### PR TITLE
feat(financeiro): Inter API v3 cobrança real + webhook receptor [E]

### DIFF
--- a/Modules/Financeiro/Console/Commands/ConfigurarContaInterCommand.php
+++ b/Modules/Financeiro/Console/Commands/ConfigurarContaInterCommand.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Modules\Financeiro\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Financeiro\Models\ContaBancaria;
+
+/**
+ * Wizard CLI pra preencher os campos da Inter API numa conta bancária.
+ *
+ * Cenário: dev faz upload do cert/key via SFTP/SSH, depois roda esse comando
+ * pra apontar client_id/client_secret/paths sem precisar mexer no DB direto
+ * ou abrir a Sheet web.
+ *
+ * Uso:
+ *   php artisan financeiro:inter:configurar-conta --conta=1
+ *   php artisan financeiro:inter:configurar-conta --conta=1 \
+ *       --client-id=abc --client-secret=xyz \
+ *       --cert=inter/cert.crt --chave=inter/cert.key
+ *
+ * Paths --cert e --chave são RELATIVOS a storage/app/private/. Coloque
+ * os arquivos lá via SFTP antes de rodar:
+ *   storage/app/private/inter/cert.crt
+ *   storage/app/private/inter/cert.key
+ *
+ * IMPORTANTE: NÃO use storage/app/ direto nem public/uploads/ — esses são
+ * servidos pela web. /private/ está fora do document root.
+ */
+class ConfigurarContaInterCommand extends Command
+{
+    protected $signature = 'financeiro:inter:configurar-conta
+                            {--conta= : ID de fin_contas_bancarias}
+                            {--client-id= : Client ID OAuth do Inter}
+                            {--client-secret= : Client Secret OAuth do Inter}
+                            {--cert= : Path do certificado (.crt) relativo a storage/app}
+                            {--chave= : Path da chave privada (.key) relativo a storage/app}
+                            {--cert-senha= : Senha do certificado (se houver)}';
+
+    protected $description = 'Configura credenciais e certificado Inter API numa conta bancária existente.';
+
+    public function handle(): int
+    {
+        $contaId = (int) $this->option('conta');
+        if (! $contaId) {
+            $this->error('--conta=<id> é obrigatório.');
+
+            return self::FAILURE;
+        }
+
+        $conta = ContaBancaria::find($contaId);
+        if (! $conta) {
+            $this->error("ContaBancaria {$contaId} não encontrada.");
+
+            return self::FAILURE;
+        }
+
+        if ($conta->banco_codigo !== '077') {
+            $this->error("Conta {$contaId} é banco {$conta->banco_codigo}, esperado 077 (Inter).");
+
+            return self::FAILURE;
+        }
+
+        $clientId = $this->option('client-id') ?: $this->secret('Client ID OAuth do Inter');
+        $clientSecret = $this->option('client-secret') ?: $this->secret('Client Secret OAuth do Inter');
+        $cert = $this->option('cert') ?: $this->ask('Path do .crt (relativo a storage/app/private/)', 'inter/cert.crt');
+        $chave = $this->option('chave') ?: $this->ask('Path do .key (relativo a storage/app/private/)', 'inter/cert.key');
+        $certSenha = $this->option('cert-senha');
+
+        $base = storage_path('app/private/');
+        if (! file_exists($base . $cert)) {
+            $this->error("Arquivo não encontrado: storage/app/private/{$cert}. Faça upload via SFTP primeiro.");
+
+            return self::FAILURE;
+        }
+        if (! file_exists($base . $chave)) {
+            $this->error("Arquivo não encontrado: storage/app/private/{$chave}. Faça upload via SFTP primeiro.");
+
+            return self::FAILURE;
+        }
+
+        $conta->inter_client_id_encrypted = $clientId;
+        $conta->inter_client_secret_encrypted = $clientSecret;
+        $conta->certificado_path = $cert;
+        $conta->certificado_chave_path = $chave;
+        if ($certSenha !== null) {
+            $conta->certificado_password_encrypted = $certSenha;
+        }
+        $conta->save();
+
+        $this->info("Conta {$contaId} configurada pra Inter API:");
+        $this->line("  client_id        : OK (encriptado)");
+        $this->line("  client_secret    : OK (encriptado)");
+        $this->line("  certificado      : storage/app/private/{$cert}");
+        $this->line("  certificado_chave: storage/app/private/{$chave}");
+        $this->line('');
+        $this->warn('Próximo passo: php artisan financeiro:inter:registrar-webhook --conta=' . $contaId);
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Financeiro/Console/Commands/RegistrarWebhookInterCommand.php
+++ b/Modules/Financeiro/Console/Commands/RegistrarWebhookInterCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Modules\Financeiro\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Strategies\InterApiStrategy;
+
+/**
+ * Gera webhook_token (se não tem), monta URL pública e chama API Inter
+ * pra registrar. Idempotente — rodar de novo sobrescreve o registro no Inter
+ * mas preserva o token (a menos que --rotate seja passado).
+ *
+ * Uso típico no Hostinger (ou CT 100):
+ *   php artisan financeiro:inter:registrar-webhook --conta=1
+ *   php artisan financeiro:inter:registrar-webhook --conta=1 --rotate
+ *   php artisan financeiro:inter:registrar-webhook --conta=1 --dry-run
+ */
+class RegistrarWebhookInterCommand extends Command
+{
+    protected $signature = 'financeiro:inter:registrar-webhook
+                            {--conta= : ID da fin_contas_bancarias}
+                            {--rotate : Gera novo webhook_token mesmo se já existe}
+                            {--dry-run : Só mostra a URL, não chama Inter}';
+
+    protected $description = 'Registra a URL do webhook de cobrança no Banco Inter pra uma conta bancária.';
+
+    public function handle(InterApiStrategy $strategy): int
+    {
+        $contaId = (int) $this->option('conta');
+        if (! $contaId) {
+            $this->error('--conta=<id> é obrigatório (id de fin_contas_bancarias).');
+
+            return self::FAILURE;
+        }
+
+        $conta = ContaBancaria::find($contaId);
+        if (! $conta) {
+            $this->error("ContaBancaria {$contaId} não encontrada.");
+
+            return self::FAILURE;
+        }
+
+        if ($conta->banco_codigo !== '077') {
+            $this->error("ContaBancaria {$contaId} é banco {$conta->banco_codigo}, não 077 (Inter).");
+
+            return self::FAILURE;
+        }
+
+        if ($this->option('rotate') || ! $conta->webhook_token) {
+            $conta->webhook_token = Str::random(64);
+            $conta->save();
+            $this->info("webhook_token " . ($this->option('rotate') ? 'rotacionado' : 'gerado') . ".");
+        }
+
+        $url = url(route('financeiro.webhook.inter', ['token' => $conta->webhook_token], false));
+        $url = rtrim(config('app.url'), '/') . '/webhook/inter/' . $conta->webhook_token;
+
+        $this->line('');
+        $this->line('URL do webhook:');
+        $this->line('  <info>' . $url . '</info>');
+        $this->line('');
+
+        if ($this->option('dry-run')) {
+            $this->warn('--dry-run: NÃO chamando Inter. Cole a URL acima manualmente no portal Inter se quiser.');
+
+            return self::SUCCESS;
+        }
+
+        $this->line('Chamando PUT /cobranca/v3/cobrancas/webhook do Inter...');
+
+        try {
+            $ok = $strategy->registrarWebhook($conta, $url);
+        } catch (\Throwable $e) {
+            $this->error('Falhou: ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if (! $ok) {
+            $this->error('Inter retornou erro (ver lib retorna false em catch interno). Verifique scopes/cert/credenciais.');
+
+            return self::FAILURE;
+        }
+
+        $this->info('Webhook registrado no Inter com sucesso.');
+        $this->line("webhook_registered_at = {$conta->fresh()->webhook_registered_at}");
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Financeiro/Database/Migrations/2026_06_03_080000_add_inter_api_fields_to_fin_contas_bancarias.php
+++ b/Modules/Financeiro/Database/Migrations/2026_06_03_080000_add_inter_api_fields_to_fin_contas_bancarias.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Campos pra integração API Inter v3 (cobrança + webhook).
+ *
+ * Decisão: ADR ARQ-0003 + memory/requisitos/Financeiro/adr/tech/0004-inter-api-v3.md
+ * (criar junto com este PR).
+ *
+ * Por que colunas dedicadas em vez de metadata JSON:
+ *  - client_id/client_secret precisam de cast 'encrypted' por LGPD/segurança
+ *  - webhook_token precisa de UNIQUE pra lookup O(1) na rota
+ *  - webhook_registered_at é auditável (LGPD Art. 37)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('fin_contas_bancarias', function (Blueprint $table) {
+            $table->string('certificado_chave_path', 255)->nullable()->after('certificado_path')
+                ->comment('Path da chave privada (.key) — Inter mTLS exige par cert+key');
+            $table->text('inter_client_id_encrypted')->nullable()->after('certificado_password_encrypted');
+            $table->text('inter_client_secret_encrypted')->nullable()->after('inter_client_id_encrypted');
+            $table->string('webhook_token', 64)->nullable()->unique()->after('inter_client_secret_encrypted')
+                ->comment('Token randômico no path da URL webhook. Sem auth — segredo é o token.');
+            $table->timestamp('webhook_registered_at')->nullable()->after('webhook_token')
+                ->comment('Quando rodou financeiro:inter:registrar-webhook com sucesso');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('fin_contas_bancarias', function (Blueprint $table) {
+            $table->dropColumn([
+                'certificado_chave_path',
+                'inter_client_id_encrypted',
+                'inter_client_secret_encrypted',
+                'webhook_token',
+                'webhook_registered_at',
+            ]);
+        });
+    }
+};

--- a/Modules/Financeiro/Database/Migrations/2026_06_03_080100_create_fin_inter_webhook_events_table.php
+++ b/Modules/Financeiro/Database/Migrations/2026_06_03_080100_create_fin_inter_webhook_events_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Log idempotente de eventos recebidos via webhook Inter.
+ *
+ * Por que idempotência: Inter pode redeliver o mesmo evento N vezes (timeout
+ * de rede, retry policy deles). UNIQUE(business_id, event_hash) garante que
+ * processamos cada notificação 1× só.
+ *
+ * event_hash = SHA-256 do JSON do item dentro do batch que o Inter manda.
+ * Inter v3 não tem um event_id estável próprio — o hash do payload é o
+ * melhor proxy.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('fin_inter_webhook_events', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedInteger('conta_bancaria_id')->index();
+            $table->unsignedBigInteger('boleto_remessa_id')->nullable()->index();
+            $table->unsignedBigInteger('titulo_baixa_id')->nullable()->index();
+
+            $table->char('event_hash', 64)->comment('SHA-256 hex do JSON do item');
+            $table->string('nosso_numero', 50)->nullable()->index();
+            $table->string('codigo_solicitacao', 50)->nullable()->index()
+                ->comment('codigoCobranca / codigoSolicitacao retornado pelo Inter v3');
+            $table->string('situacao', 30)->index()
+                ->comment('PAGO, A_RECEBER, CANCELADO, EXPIRADO, MARCADO_RECEBIDO, RECEBIDO');
+            $table->string('origem_recebimento', 20)->nullable()
+                ->comment('BOLETO ou PIX');
+            $table->decimal('valor_recebido', 15, 4)->nullable();
+            $table->timestamp('data_situacao')->nullable();
+            $table->json('payload')->comment('JSON cru do item dentro do batch');
+            $table->timestamp('processed_at')->nullable()
+                ->comment('NULL = recebido mas ainda não casou com BoletoRemessa');
+            $table->string('processed_status', 30)->nullable()
+                ->comment('ok / boleto_nao_encontrado / erro_baixa / duplicado');
+            $table->text('processed_error')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->unique(['business_id', 'event_hash'], 'uk_biz_event_hash');
+            $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
+            $table->foreign('conta_bancaria_id')->references('id')->on('fin_contas_bancarias')->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fin_inter_webhook_events');
+    }
+};

--- a/Modules/Financeiro/Http/Controllers/InterWebhookController.php
+++ b/Modules/Financeiro/Http/Controllers/InterWebhookController.php
@@ -162,10 +162,14 @@ class InterWebhookController extends Controller
                 } elseif ($situacao === InterWebhookEvent::SITUACAO_EXPIRADO) {
                     $remessa->status = BoletoRemessa::STATUS_VENCIDO;
                     $remessa->save();
+                } else {
+                    $event->processed_status = InterWebhookEvent::STATUS_IGNORADO;
                 }
 
                 $event->processed_at = now();
-                $event->processed_status = InterWebhookEvent::STATUS_OK;
+                if ($event->processed_status === null) {
+                    $event->processed_status = InterWebhookEvent::STATUS_OK;
+                }
                 $event->save();
             });
         } catch (\Throwable $e) {

--- a/Modules/Financeiro/Http/Controllers/InterWebhookController.php
+++ b/Modules/Financeiro/Http/Controllers/InterWebhookController.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace Modules\Financeiro\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Carbon\Carbon;
+use Eduardokum\LaravelBoleto\Webhook\Banco\Inter as InterWebhookParser;
+use Eduardokum\LaravelBoleto\Webhook\Boleto as WebhookBoleto;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Financeiro\Models\BoletoRemessa;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\InterWebhookEvent;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+use Modules\Financeiro\Services\TituloAutoService;
+
+/**
+ * Recebe notificações do Banco Inter (cobrança v3).
+ *
+ * URL pública: POST /financeiro/webhooks/inter/{token}
+ * Segredo: o `token` no path é o `fin_contas_bancarias.webhook_token` (64 chars).
+ *  - Token vaza → invalidar e gerar novo (re-registrar webhook no Inter).
+ *  - Sem token / token inválido → 404 silencioso.
+ *
+ * Payload (Inter v3, ver Webhook\Banco\Inter da lib eduardokum):
+ *   POST {token}
+ *   Headers: x-conta-corrente: <numero>
+ *   Body: [
+ *     {
+ *       "nossoNumero": "...",
+ *       "seuNumero": "...",
+ *       "codigoSolicitacao": "uuid-do-inter",
+ *       "situacao": "PAGO|RECEBIDO|MARCADO_RECEBIDO|A_RECEBER|CANCELADO|EXPIRADO",
+ *       "dataHoraSituacao": "2026-06-03T07:52:00-03:00",
+ *       "valorNominal": 100.00,
+ *       "valorTotalRecebimento": 100.00,
+ *       "origemRecebimento": "BOLETO|PIX",
+ *       "txid": "..."   // só se PIX
+ *     },
+ *     ...
+ *   ]
+ *
+ * Idempotência: SHA-256 do JSON do item. INSERT em fin_inter_webhook_events
+ * com UNIQUE(business_id, event_hash) — duplicado vira no-op.
+ *
+ * Resposta:
+ *  - 200 sempre que processou (ou já tinha processado) — Inter NÃO redelivera.
+ *  - 404 se token não bate (Inter loga e pára de tentar pra esse webhook).
+ *  - 500 só pra erro infra (DB down) — Inter redelivera.
+ */
+class InterWebhookController extends Controller
+{
+    public function receive(Request $request, string $token): JsonResponse
+    {
+        $conta = ContaBancaria::where('webhook_token', $token)->first();
+
+        if (! $conta) {
+            Log::warning('[InterWebhook] token desconhecido', [
+                'token_prefix' => substr($token, 0, 8),
+                'ip' => $request->ip(),
+            ]);
+
+            return response()->json(['error' => 'not_found'], 404);
+        }
+
+        $raw = $request->getContent();
+        $payload = json_decode($raw, true);
+
+        if (! is_array($payload)) {
+            Log::warning('[InterWebhook] payload não é JSON válido', [
+                'conta_id' => $conta->id,
+                'body_preview' => substr($raw, 0, 500),
+            ]);
+
+            return response()->json(['error' => 'invalid_payload'], 400);
+        }
+
+        $items = $this->normalizarItems($payload);
+
+        $stats = ['recebidos' => count($items), 'processados' => 0, 'duplicados' => 0, 'sem_boleto' => 0, 'erros' => 0];
+
+        foreach ($items as $item) {
+            $resultado = $this->processarItem($conta, $item);
+            $stats[$resultado]++;
+        }
+
+        Log::info('[InterWebhook] batch processado', [
+            'conta_id' => $conta->id,
+            'business_id' => $conta->business_id,
+            'stats' => $stats,
+        ]);
+
+        return response()->json(['status' => 'ok', 'stats' => $stats]);
+    }
+
+    private function normalizarItems(array $payload): array
+    {
+        if (isset($payload[0])) {
+            return $payload;
+        }
+        if (isset($payload['nossoNumero']) || isset($payload['codigoSolicitacao'])) {
+            return [$payload];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return string  'processados' | 'duplicados' | 'sem_boleto' | 'erros'
+     */
+    private function processarItem(ContaBancaria $conta, array $item): string
+    {
+        $eventHash = hash('sha256', json_encode($item, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        $nossoNumero = $item['nossoNumero'] ?? null;
+        $codigoSolicitacao = $item['codigoSolicitacao'] ?? null;
+        $situacao = $item['situacao'] ?? 'DESCONHECIDA';
+
+        try {
+            $event = InterWebhookEvent::create([
+                'business_id' => $conta->business_id,
+                'conta_bancaria_id' => $conta->id,
+                'event_hash' => $eventHash,
+                'nosso_numero' => $nossoNumero,
+                'codigo_solicitacao' => $codigoSolicitacao,
+                'situacao' => $situacao,
+                'origem_recebimento' => $item['origemRecebimento'] ?? null,
+                'valor_recebido' => $item['valorTotalRecebimento'] ?? $item['valorNominal'] ?? null,
+                'data_situacao' => isset($item['dataHoraSituacao']) ? Carbon::parse($item['dataHoraSituacao']) : null,
+                'payload' => $item,
+            ]);
+        } catch (\Illuminate\Database\QueryException $e) {
+            if ($e->getCode() === '23000') {
+                return 'duplicados';
+            }
+            throw $e;
+        }
+
+        $remessa = $this->localizarRemessa($conta, $codigoSolicitacao, $nossoNumero);
+
+        if (! $remessa) {
+            $event->processed_at = now();
+            $event->processed_status = InterWebhookEvent::STATUS_BOLETO_NAO_ENCONTRADO;
+            $event->processed_error = "codigo_solicitacao={$codigoSolicitacao} / nosso_numero={$nossoNumero} não encontrado em fin_boleto_remessas do business {$conta->business_id}";
+            $event->save();
+
+            return 'sem_boleto';
+        }
+
+        $event->boleto_remessa_id = $remessa->id;
+
+        try {
+            DB::transaction(function () use ($event, $remessa, $situacao, $conta) {
+                if (InterWebhookEvent::ehSituacaoPaga($situacao)) {
+                    $this->registrarBaixa($remessa, $event, $conta);
+                } elseif ($situacao === InterWebhookEvent::SITUACAO_CANCELADO) {
+                    $remessa->status = BoletoRemessa::STATUS_CANCELADO;
+                    $remessa->save();
+                } elseif ($situacao === InterWebhookEvent::SITUACAO_EXPIRADO) {
+                    $remessa->status = BoletoRemessa::STATUS_VENCIDO;
+                    $remessa->save();
+                }
+
+                $event->processed_at = now();
+                $event->processed_status = InterWebhookEvent::STATUS_OK;
+                $event->save();
+            });
+        } catch (\Throwable $e) {
+            $event->processed_at = now();
+            $event->processed_status = InterWebhookEvent::STATUS_ERRO_BAIXA;
+            $event->processed_error = $e->getMessage();
+            $event->save();
+
+            Log::error('[InterWebhook] erro processando item', [
+                'event_id' => $event->id,
+                'remessa_id' => $remessa->id,
+                'erro' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+            ]);
+
+            return 'erros';
+        }
+
+        return 'processados';
+    }
+
+    private function localizarRemessa(ContaBancaria $conta, ?string $codigoSolicitacao, ?string $nossoNumero): ?BoletoRemessa
+    {
+        $base = BoletoRemessa::where('business_id', $conta->business_id)
+            ->where('conta_bancaria_id', $conta->id);
+
+        if ($codigoSolicitacao) {
+            $r = (clone $base)
+                ->where('metadata->codigo_solicitacao', $codigoSolicitacao)
+                ->first();
+            if ($r) {
+                return $r;
+            }
+        }
+
+        if ($nossoNumero) {
+            return (clone $base)->where('nosso_numero', $nossoNumero)->first();
+        }
+
+        return null;
+    }
+
+    private function registrarBaixa(BoletoRemessa $remessa, InterWebhookEvent $event, ContaBancaria $conta): void
+    {
+        if ($remessa->status === BoletoRemessa::STATUS_PAGO) {
+            $event->processed_status = InterWebhookEvent::STATUS_DUPLICADO;
+
+            return;
+        }
+
+        $titulo = Titulo::where('business_id', $conta->business_id)
+            ->where('id', $remessa->titulo_id)
+            ->first();
+
+        if (! $titulo) {
+            throw new \RuntimeException("Titulo {$remessa->titulo_id} não existe pra remessa {$remessa->id}");
+        }
+
+        $valorPago = (float) ($event->valor_recebido ?? $remessa->valor_total);
+        $idempotencyKey = "inter_webhook:{$event->id}";
+
+        $baixa = TituloBaixa::create([
+            'business_id' => $conta->business_id,
+            'titulo_id' => $titulo->id,
+            'conta_bancaria_id' => $conta->id,
+            'valor_baixa' => $valorPago,
+            'juros' => 0,
+            'multa' => 0,
+            'desconto' => 0,
+            'data_baixa' => $event->data_situacao?->toDateString() ?? today()->toDateString(),
+            'meio_pagamento' => $event->origem_recebimento === 'PIX' ? 'pix' : 'boleto',
+            'idempotency_key' => $idempotencyKey,
+            'observacoes' => "Baixa automática via webhook Inter (event #{$event->id}).",
+            'created_by' => null,
+        ]);
+
+        $event->titulo_baixa_id = $baixa->id;
+
+        $remessa->status = BoletoRemessa::STATUS_PAGO;
+        $remessa->pago_em = $event->data_situacao ?? now();
+        $metadata = $remessa->metadata ?? [];
+        $metadata['baixa'] = [
+            'event_id' => $event->id,
+            'baixa_id' => $baixa->id,
+            'valor' => $valorPago,
+            'origem' => $event->origem_recebimento,
+            'em' => now()->toIso8601String(),
+        ];
+        $remessa->metadata = $metadata;
+        $remessa->save();
+
+        $titulo->valor_aberto = max(0, (float) $titulo->valor_aberto - $valorPago);
+        $titulo->status = $titulo->valor_aberto <= 0
+            ? 'quitado'
+            : ($titulo->valor_aberto < (float) $titulo->valor_total ? 'parcial' : $titulo->status);
+        $titulo->save();
+    }
+}

--- a/Modules/Financeiro/Models/ContaBancaria.php
+++ b/Modules/Financeiro/Models/ContaBancaria.php
@@ -34,13 +34,19 @@ class ContaBancaria extends Model
         'beneficiario_documento', 'beneficiario_razao_social',
         'beneficiario_logradouro', 'beneficiario_bairro',
         'beneficiario_cidade', 'beneficiario_uf', 'beneficiario_cep',
-        'certificado_path', 'certificado_password_encrypted',
+        'certificado_path', 'certificado_chave_path', 'certificado_password_encrypted',
+        'inter_client_id_encrypted', 'inter_client_secret_encrypted',
+        'webhook_token', 'webhook_registered_at',
         'ativo_para_boleto', 'metadata',
     ];
 
     protected $casts = [
         'ativo_para_boleto' => 'boolean',
         'metadata' => 'array',
+        'inter_client_id_encrypted' => 'encrypted',
+        'inter_client_secret_encrypted' => 'encrypted',
+        'certificado_password_encrypted' => 'encrypted',
+        'webhook_registered_at' => 'datetime',
     ];
 
     public function getActivitylogOptions(): LogOptions

--- a/Modules/Financeiro/Models/InterWebhookEvent.php
+++ b/Modules/Financeiro/Models/InterWebhookEvent.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Modules\Financeiro\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Financeiro\Models\Concerns\BusinessScope;
+
+/**
+ * Append-only log de eventos recebidos via webhook Inter.
+ * Idempotência via UNIQUE (business_id, event_hash).
+ *
+ * Não use Eloquent::delete — use soft mark via processed_status='descartado'
+ * se precisar invalidar. Não tem updated_at — auditoria preserva o original.
+ */
+class InterWebhookEvent extends Model
+{
+    use BusinessScope;
+
+    public const STATUS_OK = 'ok';
+    public const STATUS_BOLETO_NAO_ENCONTRADO = 'boleto_nao_encontrado';
+    public const STATUS_ERRO_BAIXA = 'erro_baixa';
+    public const STATUS_DUPLICADO = 'duplicado';
+    public const STATUS_IGNORADO = 'ignorado';
+
+    public const SITUACAO_PAGO = 'PAGO';
+    public const SITUACAO_RECEBIDO = 'RECEBIDO';
+    public const SITUACAO_MARCADO_RECEBIDO = 'MARCADO_RECEBIDO';
+    public const SITUACAO_A_RECEBER = 'A_RECEBER';
+    public const SITUACAO_CANCELADO = 'CANCELADO';
+    public const SITUACAO_EXPIRADO = 'EXPIRADO';
+
+    protected $table = 'fin_inter_webhook_events';
+
+    public $timestamps = false;
+
+    protected $fillable = [
+        'business_id', 'conta_bancaria_id', 'boleto_remessa_id', 'titulo_baixa_id',
+        'event_hash', 'nosso_numero', 'codigo_solicitacao',
+        'situacao', 'origem_recebimento', 'valor_recebido', 'data_situacao',
+        'payload', 'processed_at', 'processed_status', 'processed_error',
+    ];
+
+    protected $casts = [
+        'payload' => 'array',
+        'valor_recebido' => 'decimal:4',
+        'data_situacao' => 'datetime',
+        'processed_at' => 'datetime',
+        'created_at' => 'datetime',
+    ];
+
+    public function contaBancaria(): BelongsTo
+    {
+        return $this->belongsTo(ContaBancaria::class, 'conta_bancaria_id');
+    }
+
+    public function boletoRemessa(): BelongsTo
+    {
+        return $this->belongsTo(BoletoRemessa::class, 'boleto_remessa_id');
+    }
+
+    public function tituloBaixa(): BelongsTo
+    {
+        return $this->belongsTo(TituloBaixa::class, 'titulo_baixa_id');
+    }
+
+    public function delete()
+    {
+        throw new \DomainException('fin_inter_webhook_events é append-only.');
+    }
+
+    public static function ehSituacaoPaga(string $situacao): bool
+    {
+        return in_array($situacao, [
+            self::SITUACAO_PAGO,
+            self::SITUACAO_RECEBIDO,
+            self::SITUACAO_MARCADO_RECEBIDO,
+        ], true);
+    }
+}

--- a/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
+++ b/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
@@ -44,12 +44,12 @@ class FinanceiroServiceProvider extends ServiceProvider
     {
         $this->app->register(RouteServiceProvider::class);
 
-        // Default BoletoStrategy: CnabDirectStrategy via lib eduardokum/laravel-boleto.
-        // Sobrescrever via container binding em testes ou para usar GatewayStrategy
-        // (futura — ADR ARQ-0003).
+        // BoletoStrategy → Resolver: delega por ContaBancaria pra
+        // InterApiStrategy (banco 077 + credenciais) ou CnabDirectStrategy
+        // (offline mock). Ver ADR ARQ-0003 + memory/requisitos/Financeiro/adr/tech/0004.
         $this->app->bind(
             \Modules\Financeiro\Contracts\BoletoStrategy::class,
-            \Modules\Financeiro\Strategies\CnabDirectStrategy::class
+            \Modules\Financeiro\Strategies\BoletoStrategyResolver::class
         );
     }
 
@@ -61,6 +61,8 @@ class FinanceiroServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 \Modules\Financeiro\Console\Commands\InstallCommand::class,
+                \Modules\Financeiro\Console\Commands\ConfigurarContaInterCommand::class,
+                \Modules\Financeiro\Console\Commands\RegistrarWebhookInterCommand::class,
             ]);
         }
     }

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -8,6 +8,7 @@ use Modules\Financeiro\Http\Controllers\ContaPagarController;
 use Modules\Financeiro\Http\Controllers\ContaReceberController;
 use Modules\Financeiro\Http\Controllers\DashboardController;
 use Modules\Financeiro\Http\Controllers\InstallController;
+use Modules\Financeiro\Http\Controllers\InterWebhookController;
 use Modules\Financeiro\Http\Controllers\RelatoriosController;
 
 /*
@@ -79,3 +80,12 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
             ->whereNumber('id')
             ->name('categorias.toggle');
     });
+
+// Webhook Inter — público, sem auth, sem CSRF (path '/webhook/*' já está
+// no $except do VerifyCsrfToken). Segredo é o {token} de 64 chars no path,
+// resolvido contra fin_contas_bancarias.webhook_token.
+// Pra registrar a URL no Inter: php artisan financeiro:inter:registrar-webhook
+Route::post('/webhook/inter/{token}', [InterWebhookController::class, 'receive'])
+    ->where('token', '[A-Za-z0-9]{32,64}')
+    ->middleware(['throttle:60,1'])
+    ->name('financeiro.webhook.inter');

--- a/Modules/Financeiro/Strategies/BoletoStrategyResolver.php
+++ b/Modules/Financeiro/Strategies/BoletoStrategyResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Modules\Financeiro\Strategies;
+
+use Modules\Financeiro\Contracts\BoletoStrategy;
+use Modules\Financeiro\Models\BoletoRemessa;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Titulo;
+
+/**
+ * Resolver que delega pra strategy concreta com base na ContaBancaria.
+ *
+ * Regra atual:
+ *  - banco_codigo='077' + tem client_id + tem certificado_path → InterApiStrategy
+ *  - resto → CnabDirectStrategy (mock offline, status='gerado_mock')
+ *
+ * Em ondas futuras adicionar:
+ *  - GatewayStrategy (Asaas/Iugu) com discriminador metadata['gateway']
+ *  - mais bancos com API própria (Sicoob, Caixa, BB...)
+ */
+class BoletoStrategyResolver implements BoletoStrategy
+{
+    public function __construct(
+        private InterApiStrategy $inter,
+        private CnabDirectStrategy $cnab
+    ) {
+    }
+
+    public function emitir(Titulo $titulo, ContaBancaria $conta): BoletoRemessa
+    {
+        return $this->resolve($conta)->emitir($titulo, $conta);
+    }
+
+    public function cancelar(BoletoRemessa $remessa, string $motivo = ''): void
+    {
+        $this->resolveByStrategyName($remessa)->cancelar($remessa, $motivo);
+    }
+
+    public function statusAtual(BoletoRemessa $remessa): string
+    {
+        return $this->resolveByStrategyName($remessa)->statusAtual($remessa);
+    }
+
+    public function resolve(ContaBancaria $conta): BoletoStrategy
+    {
+        if ($this->ehInterApi($conta)) {
+            return $this->inter;
+        }
+
+        return $this->cnab;
+    }
+
+    private function resolveByStrategyName(BoletoRemessa $remessa): BoletoStrategy
+    {
+        if ($remessa->strategy === BoletoRemessa::STRATEGY_GATEWAY) {
+            return $this->inter;
+        }
+
+        return $this->cnab;
+    }
+
+    private function ehInterApi(ContaBancaria $conta): bool
+    {
+        return $conta->banco_codigo === '077'
+            && filled($conta->inter_client_id_encrypted)
+            && filled($conta->certificado_path)
+            && filled($conta->certificado_chave_path);
+    }
+}

--- a/Modules/Financeiro/Strategies/InterApiStrategy.php
+++ b/Modules/Financeiro/Strategies/InterApiStrategy.php
@@ -1,0 +1,243 @@
+<?php
+
+namespace Modules\Financeiro\Strategies;
+
+use Carbon\Carbon;
+use Eduardokum\LaravelBoleto\Api\Banco\Inter as InterApi;
+use Eduardokum\LaravelBoleto\Boleto\Banco\Inter as InterBoleto;
+use Eduardokum\LaravelBoleto\Pessoa;
+use Illuminate\Support\Facades\Log;
+use Modules\Financeiro\Contracts\BoletoStrategy;
+use Modules\Financeiro\Models\BoletoRemessa;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Titulo;
+
+/**
+ * Strategy real pra Banco Inter — registra cobrança via API v3.
+ *
+ * Base URL prod: https://cdpj.partners.bancointer.com.br
+ * Auth: OAuth2 client_credentials + mTLS (cert+key obrigatórios).
+ * Scopes: boleto-cobranca.read boleto-cobranca.write boleto-cobranca.webhook
+ *
+ * Decisão arquitetural: usa eduardokum/laravel-boleto Api\Banco\Inter
+ * (lib já testada em produção por terceiros, cobre auth/cert/payload).
+ * NÃO reimplementar HTTP/OAuth do zero.
+ *
+ * Pré-requisitos na ContaBancaria:
+ *  - banco_codigo = '077'
+ *  - certificado_path (relative ao storage local — .crt)
+ *  - certificado_chave_path (.key)
+ *  - inter_client_id_encrypted (cast 'encrypted' resolve)
+ *  - inter_client_secret_encrypted
+ *  - account.account_number (a conta corrente do Inter)
+ *
+ * Reaproveita CnabDirectStrategy::montarParams() pra gerar o objeto Boleto
+ * (mesmo formato, só muda quem persiste no banco do Inter).
+ */
+class InterApiStrategy implements BoletoStrategy
+{
+    public function __construct(
+        private CnabDirectStrategy $cnabHelper
+    ) {
+    }
+
+    public function emitir(Titulo $titulo, ContaBancaria $conta): BoletoRemessa
+    {
+        $this->guardConta($conta);
+
+        $idempotencyKey = sprintf('inter_api_v3:%d:%d', $titulo->id, $conta->id);
+
+        if ($existente = BoletoRemessa::where('business_id', $titulo->business_id)
+            ->where('titulo_id', $titulo->id)
+            ->where('idempotency_key', $idempotencyKey)
+            ->first()) {
+            return $existente;
+        }
+
+        $boleto = $this->cnabHelper->gerarBoleto($titulo, $conta);
+
+        $api = $this->buildApi($conta);
+        $boletoAtualizado = $api->createBoleto($boleto);
+
+        $codigoCobranca = method_exists($boletoAtualizado, 'getID')
+            ? $boletoAtualizado->getID()
+            : null;
+        $nossoNumero = $boletoAtualizado->getNossoNumero();
+        $pixCopiaECola = method_exists($boletoAtualizado, 'getPixQrCode')
+            ? $boletoAtualizado->getPixQrCode()
+            : null;
+
+        return BoletoRemessa::create([
+            'business_id' => $titulo->business_id,
+            'titulo_id' => $titulo->id,
+            'conta_bancaria_id' => $conta->id,
+            'nosso_numero' => $nossoNumero,
+            'linha_digitavel' => $boleto->getLinhaDigitavel(),
+            'codigo_barras' => $boleto->getCodigoBarras(),
+            'valor_total' => $titulo->valor_total,
+            'vencimento' => $titulo->vencimento,
+            'status' => BoletoRemessa::STATUS_REGISTRADO,
+            'strategy' => BoletoRemessa::STRATEGY_GATEWAY,
+            'idempotency_key' => $idempotencyKey,
+            'enviado_em' => now(),
+            'metadata' => [
+                'banco_codigo' => '077',
+                'api_versao' => 'v3',
+                'codigo_solicitacao' => $codigoCobranca,
+                'pix_copia_e_cola' => $pixCopiaECola,
+            ],
+        ]);
+    }
+
+    public function cancelar(BoletoRemessa $remessa, string $motivo = ''): void
+    {
+        $conta = $remessa->contaBancaria;
+        $this->guardConta($conta);
+
+        $codigo = $remessa->metadata['codigo_solicitacao'] ?? null;
+        if (! $codigo) {
+            throw new \DomainException(
+                "BoletoRemessa {$remessa->id} não tem codigo_solicitacao Inter — não foi registrado via API."
+            );
+        }
+
+        $motivoNormalizado = $motivo ?: 'APEDIDODOCLIENTE';
+
+        try {
+            $api = $this->buildApi($conta);
+            $api->cancelID($codigo, $motivoNormalizado);
+        } catch (\Throwable $e) {
+            Log::warning('[InterApiStrategy] cancelamento via API falhou', [
+                'remessa_id' => $remessa->id,
+                'codigo' => $codigo,
+                'erro' => $e->getMessage(),
+            ]);
+            throw $e;
+        }
+
+        $metadata = $remessa->metadata ?? [];
+        $metadata['cancelamento'] = [
+            'motivo' => $motivoNormalizado,
+            'em' => now()->toIso8601String(),
+            'via' => 'inter_api_v3',
+        ];
+
+        $remessa->status = BoletoRemessa::STATUS_CANCELADO;
+        $remessa->metadata = $metadata;
+        $remessa->save();
+    }
+
+    public function statusAtual(BoletoRemessa $remessa): string
+    {
+        $conta = $remessa->contaBancaria;
+        $this->guardConta($conta);
+
+        $codigo = $remessa->metadata['codigo_solicitacao'] ?? null;
+        if (! $codigo) {
+            return $remessa->status;
+        }
+
+        try {
+            $api = $this->buildApi($conta);
+            $resposta = $api->retrieveID($codigo);
+            $situacao = $resposta->cobranca->situacao ?? null;
+
+            return match ($situacao) {
+                'A_RECEBER' => BoletoRemessa::STATUS_REGISTRADO,
+                'RECEBIDO', 'MARCADO_RECEBIDO', 'PAGO' => BoletoRemessa::STATUS_PAGO,
+                'CANCELADO' => BoletoRemessa::STATUS_CANCELADO,
+                'EXPIRADO' => BoletoRemessa::STATUS_VENCIDO,
+                default => $remessa->status,
+            };
+        } catch (\Throwable $e) {
+            Log::warning('[InterApiStrategy] consulta status falhou', [
+                'remessa_id' => $remessa->id,
+                'erro' => $e->getMessage(),
+            ]);
+
+            return $remessa->status;
+        }
+    }
+
+    /**
+     * Cadastra a URL do webhook no Inter pra essa conta.
+     * Idempotente — chamar de novo sobrescreve.
+     */
+    public function registrarWebhook(ContaBancaria $conta, string $url): bool
+    {
+        $this->guardConta($conta);
+        $api = $this->buildApi($conta);
+        $ok = $api->createWebhook($url);
+
+        if ($ok) {
+            $conta->webhook_registered_at = now();
+            $conta->save();
+        }
+
+        return $ok;
+    }
+
+    private function buildApi(ContaBancaria $conta): InterApi
+    {
+        if (! $conta->certificado_path || ! $conta->certificado_chave_path) {
+            throw new \DomainException(
+                "ContaBancaria {$conta->id}: certificado_path e certificado_chave_path são obrigatórios pra Inter API."
+            );
+        }
+
+        $certPath = $this->resolverArquivo($conta->certificado_path);
+        $keyPath = $this->resolverArquivo($conta->certificado_chave_path);
+
+        $params = [
+            'versao' => 3,
+            'conta' => $conta->numero_conta ?: '0',
+            'certificado' => $certPath,
+            'certificadoChave' => $keyPath,
+            'client_id' => $conta->inter_client_id_encrypted,
+            'client_secret' => $conta->inter_client_secret_encrypted,
+        ];
+
+        if ($conta->certificado_password_encrypted) {
+            $params['certificadoSenha'] = $conta->certificado_password_encrypted;
+        }
+
+        $beneficiario = new Pessoa([
+            'nome' => $conta->beneficiario_razao_social,
+            'documento' => $conta->beneficiario_documento,
+            'endereco' => $conta->beneficiario_logradouro ?? 'Não informado',
+            'bairro' => $conta->beneficiario_bairro ?? 'Centro',
+            'cidade' => $conta->beneficiario_cidade ?? 'São Paulo',
+            'uf' => $conta->beneficiario_uf ?? 'SP',
+            'cep' => $conta->beneficiario_cep ?? '00000-000',
+        ]);
+        $params['beneficiario'] = $beneficiario;
+
+        return new InterApi($params);
+    }
+
+    /**
+     * Resolve path do certificado/chave.
+     * Aceita absoluto (POSIX ou Windows) ou relativo a storage/app/private/.
+     *
+     * IMPORTANTE: NÃO usar Storage::disk('local') — neste projeto esse disk
+     * aponta pra public/uploads/ (servido pela web). Certificados ficam em
+     * storage/app/private/ que está fora do document root.
+     */
+    private function resolverArquivo(string $path): string
+    {
+        if (str_starts_with($path, '/') || preg_match('/^[A-Z]:\\\\/i', $path)) {
+            return $path;
+        }
+
+        return storage_path('app/private/' . ltrim($path, '/'));
+    }
+
+    private function guardConta(ContaBancaria $conta): void
+    {
+        if ($conta->banco_codigo !== '077') {
+            throw new \DomainException(
+                "InterApiStrategy só atende banco 077; conta {$conta->id} tem banco {$conta->banco_codigo}."
+            );
+        }
+    }
+}

--- a/Modules/Financeiro/Strategies/InterApiStrategy.php
+++ b/Modules/Financeiro/Strategies/InterApiStrategy.php
@@ -239,5 +239,13 @@ class InterApiStrategy implements BoletoStrategy
                 "InterApiStrategy só atende banco 077; conta {$conta->id} tem banco {$conta->banco_codigo}."
             );
         }
+
+        $operacao = $conta->metadata['operacao'] ?? null;
+        if (! $operacao) {
+            throw new \DomainException(
+                "ContaBancaria {$conta->id}: metadata->operacao é obrigatório (7 dígitos do código de operação Inter). ".
+                'A lib Boleto\\Banco\\Inter exige esse campo mesmo pra API v3.'
+            );
+        }
     }
 }

--- a/memory/requisitos/Financeiro/adr/tech/0004-inter-api-v3.md
+++ b/memory/requisitos/Financeiro/adr/tech/0004-inter-api-v3.md
@@ -1,0 +1,88 @@
+# ADR TECH-0004 (Financeiro) · Inter API v3 — InterApiStrategy + Webhook
+
+- **Status**: proposed
+- **Data**: 2026-06-03
+- **Decisores**: Wagner (review), Eliana (autor)
+- **Categoria**: tech
+- **Relacionado**: ARQ-0003 (Strategy Pattern Boleto), TECH-0003 (MVP eduardokum mock)
+
+## Contexto
+
+ADR TECH-0003 entregou um `CnabDirectStrategy` em modo MOCK: gera linha digitável + PDF offline com `status='gerado_mock'`, sem nenhuma chamada bancária. Larissa (ROTA LIVRE) usa Sicoob, mas o cliente do Wagner (Office Impresso CNPJ 80281414) usa **Banco Inter (077)** e já tem **integração ativa configurada no portal** (nome "Oimpresso"/"Office Impresso", conta 219541078).
+
+Pra Eliana ter boleto Inter funcionando ponta-a-ponta — registro no banco + baixa automática quando o cliente paga — faltam 3 capacidades que o MVP TECH-0003 não tem:
+
+1. **Registro real do boleto na API Inter** (POST cobrança v3 + OAuth2 mTLS)
+2. **Webhook receptor** pra `situacao=PAGO` → `TituloBaixa` automática
+3. **Configuração persistida** das credenciais (client_id/secret/certificado) por conta bancária
+
+## Decisão
+
+**Construir `InterApiStrategy` reusando `Eduardokum\LaravelBoleto\Api\Banco\Inter` (versão 3) já presente no fork local.**
+
+3 frentes mínimas:
+
+### 1. Strategy real + Resolver
+
+- `Modules\Financeiro\Strategies\InterApiStrategy` implementa `BoletoStrategy`. Delega HTTP/OAuth/mTLS pra lib eduardokum (`Api\Banco\Inter` v3, base URL `https://cdpj.partners.bancointer.com.br`).
+- `BoletoStrategyResolver` substitui o binding direto no `FinanceiroServiceProvider`. Regra: `banco_codigo=077` + `inter_client_id_encrypted` + `certificado_path` + `certificado_chave_path` preenchidos → `InterApiStrategy`; senão → `CnabDirectStrategy` (mantém comportamento legado).
+- Reusa `CnabDirectStrategy::gerarBoleto()` pra construir o objeto `BoletoInter` (mesmo formato de Pessoa/pagador/beneficiário/numero), então só muda quem persiste no Inter vs. quem gera só o PDF.
+
+### 2. Webhook receptor com idempotência
+
+- Rota pública sem auth: `POST /webhook/inter/{token}` (path `/webhook/*` já está no `$except` do `VerifyCsrfToken`).
+- O `{token}` é o segredo. Armazenado em `fin_contas_bancarias.webhook_token` (CHAR 64 UNIQUE, gerado via `Str::random(64)`). Lookup O(1) identifica a conta e o business. Rotacionável via `--rotate` no comando.
+- Throttling: `throttle:60,1` (60 req/min/IP — Inter manda em batch, é folga).
+- Idempotência: `fin_inter_webhook_events` com `UNIQUE(business_id, event_hash)` onde `event_hash = sha256(json_encode(item))`. Inter v3 não expõe event_id estável; hash do item é o melhor proxy.
+- Append-only (`delete()` lança `DomainException`).
+- Mapeamento `situacao` → ação:
+  - `PAGO|RECEBIDO|MARCADO_RECEBIDO` → cria `TituloBaixa`, atualiza `BoletoRemessa.status=pago`, recalcula `Titulo.valor_aberto` e `Titulo.status` (parcial/quitado).
+  - `CANCELADO` → `BoletoRemessa.status=cancelado`.
+  - `EXPIRADO` → `BoletoRemessa.status=vencido`.
+  - `A_RECEBER` → só registra evento, sem mudança de estado.
+
+### 3. Persistência das credenciais
+
+- Novas colunas em `fin_contas_bancarias`:
+  - `certificado_chave_path` (path do `.key` — par com `certificado_path` que é o `.crt`)
+  - `inter_client_id_encrypted` (text, cast `encrypted`)
+  - `inter_client_secret_encrypted` (text, cast `encrypted`)
+  - `webhook_token` (char 64 UNIQUE nullable)
+  - `webhook_registered_at` (timestamp nullable, marca quando `financeiro:inter:registrar-webhook` rodou com sucesso)
+- 2 comandos artisan pra setup CLI (Sheet UI fica como follow-up):
+  - `financeiro:inter:configurar-conta --conta=<id>` — wizard interativo que recebe client_id/secret/paths e grava encriptado
+  - `financeiro:inter:registrar-webhook --conta=<id> [--rotate] [--dry-run]` — gera token, monta URL pública (`{APP_URL}/webhook/inter/{token}`), chama Inter via `PUT /cobranca/v3/cobrancas/webhook`
+
+## Por que não criar `HybridStrategy` agora
+
+ADR ARQ-0003 prevê `HybridStrategy` pra decidir banco-por-cliente. Não cabe ainda: Resolver simples por `ContaBancaria.banco_codigo` resolve nosso único cliente API real (Wagner). Quando aparecer 2° banco API (C6/Cora) o resolver vira `BancoStrategyRegistry` com map `banco_codigo → strategy class`. YAGNI no MVP.
+
+## Por que não signature HMAC no webhook
+
+A lib `Webhook\Banco\Inter` não lê nenhum header de assinatura — confirmado em `lib-custom/laravel-boleto/src/Webhook/Banco/Inter.php`. Inter v3 protege webhook por **secret no path** (modelo "URL-as-secret"). É segurança mais fraca que HMAC, mas:
+- O token tem 64 chars random (entropia ~382 bits)
+- HTTPS obrigatório protege em trânsito
+- Rotação trivial via `--rotate`
+- Vazamento detectável: logs com `token_prefix` (primeiros 8 chars) permitem auditoria
+
+Se Inter publicar HMAC no futuro, adicionar é local: middleware antes do controller, sem mudar o resto.
+
+## Riscos & open issues
+
+- **Sheet UI não atualizada**: hoje só CLI. Eliana tem CLI no Hostinger via SSH. Wagner aprova; UI vira US-FIN-NN no próximo cycle.
+- **Sem teste end-to-end automatizado**: a lib eduardokum não tem mocks pro `Api\Banco\Inter`. Smoke test manual obrigatório no deploy (ver checklist do PR).
+- **Certificado A1 expira em 1 ano**: precisa monitor + comando `financeiro:inter:check-cert-expiry` no scheduler (TODO follow-up).
+- **Hostinger não suporta workers persistentes pro Horizon** (INFRA.md §4). Baixa de boleto roda inline no webhook controller, sem fila — se ficar lento, mover pra job em CT 100 + adicionar `dispatch()`.
+
+## Alternativas descartadas
+
+- **Escrever client HTTP do zero**: rejeitada. Lib eduardokum já implementa OAuth2 + mTLS + payload v3 + retry. Reimplementar viola "não reinventar" do CLAUDE.md §5.
+- **Usar pacote oficial Inter (Java/C#)**: rejeitada. PHP não tem SDK oficial. Lib eduardokum é o padrão de fato no ecossistema PHP brasileiro.
+- **Gateway externo (Asaas/Iugu)**: descartada pra esse cenário. Cliente já tem conta Inter PJ ativa + integração registrada — passar por gateway agrega taxa sem valor.
+
+## Referências
+
+- Lib base: `lib-custom/laravel-boleto/src/Api/Banco/Inter.php` (v3 endpoints + scopes)
+- Lib webhook parser: `lib-custom/laravel-boleto/src/Webhook/Banco/Inter.php`
+- Portal Inter: `https://contadigital.inter.co/open-banking/gerenciamento-vans-apis`
+- Docs Inter: `https://developers.inter.co/references/cobranca-bolepix`


### PR DESCRIPTION
## Resumo

Substitui o modo MOCK do `CnabDirectStrategy` por integração real com Banco Inter v3 **quando a conta tem credenciais configuradas**. Contas sem API (Sicoob/Larissa, demais) continuam no fluxo offline atual; Office Impresso (CNPJ 80281414, integração "Oimpresso" já ativa no portal) passa a:

1. **Registrar boleto de verdade** na API Inter (POST `/cobranca/v3/cobrancas` com OAuth2 + mTLS).
2. **Receber baixa automática** via webhook (`POST /webhook/inter/{token}`).
3. **Persistir credenciais** encriptadas (`client_id`, `client_secret`, paths de cert/key).

ADR completa: [memory/requisitos/Financeiro/adr/tech/0004-inter-api-v3.md](memory/requisitos/Financeiro/adr/tech/0004-inter-api-v3.md)

## Arquitetura

- **`InterApiStrategy`** — usa `Eduardokum\LaravelBoleto\Api\Banco\Inter` v3 (lib fork local já presente). Reusa `CnabDirectStrategy::gerarBoleto()` pra montar o objeto Boleto; só muda quem persiste.
- **`BoletoStrategyResolver`** (novo binding do `BoletoStrategy` contract) — escolhe Inter ou Cnab por conta. Regra: `banco_codigo='077'` + `inter_client_id_encrypted` + `certificado_path` + `certificado_chave_path` → InterApi. Senão → Cnab.
- **`InterWebhookController`** — POST `/webhook/inter/{token}`. Token CHAR(64) UNIQUE no path (path `/webhook/*` já está no `\$except` do `VerifyCsrfToken`). Throttle `60/min/IP`. Idempotência via SHA-256 do JSON do item em `fin_inter_webhook_events` UNIQUE(business_id, event_hash).
- **2 artisan commands** pra setup CLI:
  - `financeiro:inter:configurar-conta --conta=<id>` (wizard interativo)
  - `financeiro:inter:registrar-webhook --conta=<id> [--rotate] [--dry-run]`

## Migrations (additivas, reversíveis)

1. `2026_06_03_080000_add_inter_api_fields_to_fin_contas_bancarias` — adiciona `certificado_chave_path`, `inter_client_id_encrypted`, `inter_client_secret_encrypted`, `webhook_token` (UNIQUE), `webhook_registered_at`.
2. `2026_06_03_080100_create_fin_inter_webhook_events_table` — log idempotente.

Nenhum DROP/ALTER destrutivo. Safe pra produção.

## Segurança

- `client_id`/`client_secret`/`certificado_password` com cast `'encrypted'` (App Key do Laravel).
- Certificados em `storage/app/private/inter/` — **NÃO** em `Storage::disk('local')` (esse disk neste projeto aponta pra `public/uploads/`, servido pelo web).
- `webhook_token` 64 chars random — entropia ~382 bits. Rotacionável via `--rotate`.
- Log de token desconhecido só armazena prefixo de 8 chars (não vaza o segredo).

## Deploy plan (Wagner)

A branch tem 2 commits, ambos passam smoke estático (PHP syntax + imports). Pra ir pra prod:

### Opção A — via `deploy.yml` (recomendado)

1. Merge este PR em `main` (botão verde).
2. Ir em [Actions → Deploy to Hostinger → Run workflow](../../actions/workflows/deploy.yml).
3. Inputs: `skip_backup=false`, `skip_migrate=false`, `extra_artisan` vazio.
4. Acompanhar a aba Actions até "Deploy SUCCESS".

### Pós-deploy (uma vez só, manual)

Em paralelo (ou depois) — **as 2 etapas abaixo precisam SSH no Hostinger**, deploy.yml não cobre:

1. SFTP upload do cert + key:
   \`\`\`
   storage/app/private/inter/cert.crt
   storage/app/private/inter/cert.key   (chmod 600)
   \`\`\`
2. SSH + 2 comandos:
   \`\`\`bash
   php artisan financeiro:inter:configurar-conta --conta=1
   php artisan financeiro:inter:registrar-webhook --conta=1
   \`\`\`
3. O 2º comando devolve a URL pública (`https://oimpresso.com/webhook/inter/<token>`) e a registra automaticamente no Inter. Se a chamada falhar, posso rodar com `--dry-run` e colar a URL manualmente no portal Inter.

## Pré-requisito que ainda precisa estar na conta

A `ContaBancaria` precisa ter `metadata->operacao` (7 dígitos do código de operação Inter — fornecido quando a integração é criada no portal Inter, **diferente** do "Operador 80281414" que aparece na tela). Sem isso, `InterApiStrategy::guardConta` lança `DomainException` claro. Adicionar via tinker ou Sheet quando souber o valor.

## Test plan

- [ ] Após deploy, `curl -X POST https://oimpresso.com/webhook/inter/INVALIDO -d '[]'` retorna **HTTP 404** `{\"error\":\"not_found\"}`.
- [ ] Após configurar conta + registrar webhook: `ContaBancaria::find(1)->webhook_registered_at` retorna timestamp recente.
- [ ] Emitir boleto via `/financeiro/contas-receber` → `fin_boleto_remessas` cria row com `strategy='gateway'`, `status='registrado'`, `metadata->codigo_solicitacao` preenchido.
- [ ] Boleto aparece no portal Inter > Cobranças.
- [ ] Pagar boleto de teste (R\$ 1 via PIX): em até 5min, `fin_inter_webhook_events` recebe row com `situacao='RECEBIDO'`/`processed_status='ok'`/`titulo_baixa_id` preenchido. `fin_titulo_baixas` cria row. `Titulo.status` vira `quitado`.

## Limitações declaradas

- **Sem UI** — só CLI nesta onda (Sheet de upload de cert + edição de campos Inter fica como US-FIN-NN no próximo cycle).
- **Sem teste automatizado E2E** — lib eduardokum não mockável; smoke manual obrigatório.
- **Sem monitor de expiração do cert A1** (~1 ano de validade) — follow-up com comando `financeiro:inter:check-cert-expiry` no scheduler.
- **Baixa roda inline no webhook controller** sem fila — se ficar lento, mover pra job (Hostinger não suporta workers persistentes, então seria CT 100).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>