### PR TITLE
feat(paymentgateway): InterDriver registerWebhook + artisan command [E]

### DIFF
--- a/Modules/PaymentGateway/Console/Commands/RegisterInterWebhookCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/RegisterInterWebhookCommand.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\InterDriver;
+
+/**
+ * Registra a URL pública do webhook de cobrança no Inter via API.
+ *
+ * Inter v3 não expõe esse cadastro no portal — `PUT /cobranca/v3/cobrancas/webhook`
+ * é a única forma. Sem ele, a infra `InterWebhookController` que recebe em
+ * `/paymentgateway/webhooks/inter/{businessId}` fica órfã — Inter não sabe
+ * pra onde mandar.
+ *
+ * Uso:
+ *   php artisan paymentgateway:inter:register-webhook --credential=12
+ *   php artisan paymentgateway:inter:register-webhook --credential=12 --dry-run
+ *   php artisan paymentgateway:inter:register-webhook --credential=12 --url=https://...
+ *
+ * --url omitido → monta automático via route('paymentgateway.webhooks.inter')
+ * usando `business_id` da credencial.
+ */
+class RegisterInterWebhookCommand extends Command
+{
+    protected $signature = 'paymentgateway:inter:register-webhook
+                            {--credential= : ID de payment_gateway_credentials}
+                            {--url= : URL pública (omitir → monta via route helper)}
+                            {--dry-run : Mostra a URL e o request sem chamar Inter}';
+
+    protected $description = 'Registra a URL do webhook de cobrança no Inter via PUT /cobranca/v3/cobrancas/webhook.';
+
+    public function handle(InterDriver $driver): int
+    {
+        $credId = (int) $this->option('credential');
+        if ($credId <= 0) {
+            $this->error('--credential=<id> é obrigatório (id de payment_gateway_credentials).');
+
+            return self::FAILURE;
+        }
+
+        $cred = PaymentGatewayCredential::query()->find($credId);
+        if (! $cred) {
+            $this->error("PaymentGatewayCredential {$credId} não encontrada.");
+
+            return self::FAILURE;
+        }
+
+        if ($cred->gateway_key !== 'inter') {
+            $this->error("Credential {$credId} tem gateway_key='{$cred->gateway_key}', esperado 'inter'.");
+
+            return self::FAILURE;
+        }
+
+        $url = (string) $this->option('url') ?: $this->montarUrlWebhook($cred);
+
+        $this->line('');
+        $this->line('Credential   : ' . ($cred->nome_display ?? "id={$cred->id}") . " (business_id={$cred->business_id}, ambiente={$cred->ambiente})");
+        $this->line('URL webhook  : ' . $url);
+        $this->line('');
+
+        if ($this->option('dry-run')) {
+            $this->warn('--dry-run: NÃO chamando Inter. Use sem a flag pra registrar de fato.');
+
+            return self::SUCCESS;
+        }
+
+        $this->line('Chamando PUT /cobranca/v3/cobrancas/webhook ...');
+
+        try {
+            $ok = $driver->registerWebhook($cred, $url);
+        } catch (\Throwable $e) {
+            $this->error('Falhou: ' . $e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        if (! $ok) {
+            $this->error('Inter retornou erro (não-2xx). Verifique scopes (boleto-cobranca.read+write), certificado mTLS e client_id/secret.');
+
+            return self::FAILURE;
+        }
+
+        $this->info('Webhook registrado no Inter com sucesso.');
+        $this->line('Pra confirmar: php artisan paymentgateway:inter:register-webhook --credential=' . $credId . ' --dry-run');
+
+        return self::SUCCESS;
+    }
+
+    private function montarUrlWebhook(PaymentGatewayCredential $cred): string
+    {
+        $base = rtrim((string) config('app.url'), '/');
+
+        return $base . '/paymentgateway/webhooks/inter/' . $cred->business_id;
+    }
+}

--- a/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
@@ -33,6 +33,7 @@ class PaymentGatewayServiceProvider extends ServiceProvider
                 \Modules\PaymentGateway\Console\Commands\EmitTrialExpiredCobrancasCommand::class,
                 \Modules\PaymentGateway\Console\Commands\RetryOrphanWebhookCommand::class,
                 \Modules\PaymentGateway\Console\Commands\RewrapCredentialsCommand::class,
+                \Modules\PaymentGateway\Console\Commands\RegisterInterWebhookCommand::class,
             ]);
         }
     }

--- a/Modules/PaymentGateway/Services/Drivers/InterDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/InterDriver.php
@@ -342,6 +342,42 @@ class InterDriver implements PaymentDriverContract
         ];
     }
 
+    /**
+     * Registra a URL pública do webhook de cobrança no Inter via API.
+     *
+     * Inter v3 não expõe esse cadastro no portal — só PUT /cobranca/v3/cobrancas/webhook
+     * com body {webhookUrl: "..."}. Sem isso, o Inter não notifica /paymentgateway/webhooks/inter/{businessId}.
+     *
+     * Idempotente — chamar de novo sobrescreve a URL anterior.
+     */
+    public function registerWebhook(object $cred, string $url): bool
+    {
+        $this->assertCredential($cred);
+
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->put('/cobranca/v3/cobrancas/webhook', ['webhookUrl' => $url]));
+
+        return $response->successful();
+    }
+
+    /**
+     * Consulta a URL atualmente registrada (pra healthcheck / UI).
+     * Retorna null se Inter responder erro ou ainda não tiver webhook registrado.
+     */
+    public function consultarWebhook(object $cred): ?string
+    {
+        $this->assertCredential($cred);
+
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->get('/cobranca/v3/cobrancas/webhook'));
+
+        if (! $response->successful()) {
+            return null;
+        }
+
+        return (string) ($response->json('webhookUrl') ?? '') ?: null;
+    }
+
     // ─── helpers ─────────────────────────────────────────────────────────
 
     private function assertCredential(object $cred): void

--- a/Modules/PaymentGateway/Tests/Feature/InterDriverRegisterWebhookTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterDriverRegisterWebhookTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\InterDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Cobertura do gap descoberto 2026-06-03 — `InterDriver` faltava método
+ * pra registrar URL do webhook no Inter (PUT /cobranca/v3/cobrancas/webhook).
+ *
+ * Sem ele, `Webhooks/InterWebhookController` ficava órfão (Inter não sabia
+ * pra onde mandar). Ver session log 2026-06-03 + ADR 0170.
+ *
+ * Pattern: Http::fake captura request, valida URL+body+headers; mTLS é bypass
+ * em test conforme convenção da Onda 4a (ver InterDriver::mtlsOptions).
+ */
+
+beforeEach(function () {
+    $this->cred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'inter',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Inter Test',
+        'config_json'  => [
+            'client_id'     => 'fake-client',
+            'client_secret' => 'fake-secret',
+        ],
+    ]);
+});
+
+it('chama PUT /cobranca/v3/cobrancas/webhook com webhookUrl no body', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'fake-token', 'expires_in' => 3600], 200),
+        '*/cobranca/v3/cobrancas/webhook' => Http::response('', 204),
+    ]);
+
+    $driver = app(InterDriver::class);
+    $url = 'https://oimpresso.com/paymentgateway/webhooks/inter/1';
+
+    $ok = $driver->registerWebhook($this->cred, $url);
+
+    expect($ok)->toBeTrue();
+    Http::assertSent(function ($request) use ($url) {
+        return $request->method() === 'PUT'
+            && str_contains($request->url(), '/cobranca/v3/cobrancas/webhook')
+            && $request->data() === ['webhookUrl' => $url];
+    });
+});
+
+it('retorna false quando Inter responde 4xx', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'fake-token', 'expires_in' => 3600], 200),
+        '*/cobranca/v3/cobrancas/webhook' => Http::response(['error' => 'invalid_scope'], 403),
+    ]);
+
+    $driver = app(InterDriver::class);
+
+    $ok = $driver->registerWebhook($this->cred, 'https://oimpresso.com/paymentgateway/webhooks/inter/1');
+
+    expect($ok)->toBeFalse();
+});
+
+it('rejeita credential de outro gateway', function () {
+    $asaasCred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'asaas',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Asaas Test',
+        'config_json'  => ['client_id' => 'x', 'client_secret' => 'y'],
+    ]);
+
+    $driver = app(InterDriver::class);
+
+    expect(fn () => $driver->registerWebhook($asaasCred, 'https://x'))
+        ->toThrow(\Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException::class);
+});
+
+it('consultarWebhook retorna URL atual quando Inter responde 200', function () {
+    $url = 'https://oimpresso.com/paymentgateway/webhooks/inter/1';
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'fake-token', 'expires_in' => 3600], 200),
+        '*/cobranca/v3/cobrancas/webhook' => Http::response(['webhookUrl' => $url], 200),
+    ]);
+
+    $driver = app(InterDriver::class);
+
+    expect($driver->consultarWebhook($this->cred))->toBe($url);
+});
+
+it('consultarWebhook retorna null quando Inter responde 404 (sem webhook registrado)', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'fake-token', 'expires_in' => 3600], 200),
+        '*/cobranca/v3/cobrancas/webhook' => Http::response('', 404),
+    ]);
+
+    $driver = app(InterDriver::class);
+
+    expect($driver->consultarWebhook($this->cred))->toBeNull();
+});


### PR DESCRIPTION
## Por que

Sessão 2026-06-03 (Eliana + [CC]): usuária Eliana observou que **o portal do Banco Inter não tem campo pra colar URL de webhook**. Verdade — Inter v3 só aceita registro via `PUT /cobranca/v3/cobrancas/webhook`. Auditando `Modules/PaymentGateway`, descobri:

- ✅ `Webhooks/InterWebhookController` recebe em `/paymentgateway/webhooks/inter/{businessId}` (Onda 3)
- ✅ `InterDriver::processWebhook` parseia o payload (Onda 4a)
- ❌ **Faltava** método pra REGISTRAR a URL no Inter

Resultado: infra de recepção orfã. Sem isso, Inter nunca sabia pra onde mandar — exatamente o sintoma da Eliana.

## O que muda

| Arquivo | Δ |
|---|---|
| `InterDriver.php` | +36 linhas — `registerWebhook(cred, url): bool` + `consultarWebhook(cred): ?string` |
| `RegisterInterWebhookCommand.php` | +99 linhas — `paymentgateway:inter:register-webhook --credential=N [--url=X] [--dry-run]` |
| `PaymentGatewayServiceProvider.php` | +1 linha — registro do command |
| `InterDriverRegisterWebhookTest.php` | +105 linhas — 5 testes Pest (Http::fake) |
| **Total** | **+241 linhas** (dentro de commit-discipline ≤300) |

## Por que escalável

`PaymentDriverContract` **não** ganha método novo — webhook registration é Inter-específico. C6/Asaas/Pagar.me têm UI no portal, BCB Pix é PSP-agnóstico. Mantém SoC.

## Test plan

- [x] Pest local: 5 specs novos (PUT correto, 4xx false, gateway errado lança, consultar 200/404)
- [ ] CI verde (PHPStan + Pest + ESLint + governance gates)
- [ ] Pós-merge: rodar `paymentgateway:inter:register-webhook --credential={id_da_cred_office_impresso} --dry-run` em prod via `deploy.yml` extra_artisan, verificar URL retornada, rodar sem `--dry-run`, conferir health do webhook no portal Inter.

## Plano de uso (Eliana)

1. Cadastra credential Inter em `/settings/payment-gateways` (SheetNovoGateway wizard 3-step)
2. Pega o ID dela
3. Roda `paymentgateway:inter:register-webhook --credential=<id>`
4. Pronto — Inter manda webhook em `/paymentgateway/webhooks/inter/<businessId>`, `processWebhook` cuida.

## Policy

Por **ADR 0241** (loop autônomo, merge sem [W2] síncrono): CI verde → merge autônomo. Não é Tier 0 (não cria ADR novo, não muda multi-tenant, não adiciona segredos novos, não muda lint/tooling, não é decisão de produto nova — implementa capability faltante de driver existente).

## Refs

- [ADR 0170](memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md) — extração PaymentGateway
- [ADR 0241](memory/decisions/0241-loop-design-cowork-code-autonomo-zero-humano.md) — autonomia
- `Modules/PaymentGateway/SCOPE.md` — InterDriver Ondas 4a-4c

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>