### PR TITLE
feat(financeiro): filtro por campo de data (paridade WR) na Visão Unificada [M]

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -62,11 +62,17 @@ class UnificadoController extends Controller
 
         $filters = $this->parseFilters($request);
         [$start, $end] = $this->parsePeriodo($filters['periodo']);
+        // Paridade filtros WR (2026-06-03): intervalo explícito sobrepõe o período preset.
+        if ($filters['data_inicio'] !== '' && $filters['data_fim'] !== '') {
+            try {
+                $start = Carbon::parse($filters['data_inicio'])->startOfDay();
+                $end = Carbon::parse($filters['data_fim'])->endOfDay();
+            } catch (\Throwable $e) { /* intervalo inválido — mantém período */ }
+        }
 
         // ───────────────── Tabela ─────────────────
         $q = Titulo::query()
             ->where('business_id', $businessId)
-            ->whereBetween('vencimento', [$start->toDateString(), $end->toDateString()])
             ->whereNull('deleted_at')
             ->whereIn('status', ['aberto', 'parcial', 'quitado'])
             ->with([
@@ -76,6 +82,8 @@ class UnificadoController extends Controller
                 'baixas' => fn ($q) => $q->orderByDesc('data_baixa'),
                 'baixas.contaBancaria.account:id,name',
             ]);
+        // Filtro por campo de data (default vencimento = comportamento anterior preservado).
+        $this->aplicarFiltroData($q, $filters['data_campo'], $start->toDateString(), $end->toDateString());
 
         // Onda Polish 2026-05-18 — lifecycle multi-select + toggle overdue independente.
         // Lifecycle items combinam via OR (union); overdue é AND multiplicativo.
@@ -215,7 +223,10 @@ class UnificadoController extends Controller
         ];
 
         // ───────────────── KPIs ─────────────────
-        $kpis = $this->kpis($businessId, $start, $end);
+        // Paridade filtros WR (2026-06-03): cards usam o MESMO data_campo da tabela
+        // (antes vencimento fixo) — RECEBIDO/A RECEBER/PAGO/A PAGAR ficam consistentes
+        // com a lista filtrada.
+        $kpis = $this->kpis($businessId, $start, $end, $filters['data_campo']);
 
         // ───────────────── Listas pra filtros ─────────────────
         $contas = ContaBancaria::where('business_id', $businessId)
@@ -929,6 +940,13 @@ class UnificadoController extends Controller
             'categoria' => $request->string('categoria', '')->toString(),
             'periodo' => in_array($request->string('periodo')->toString(), $periodosValidos, true)
                 ? $request->string('periodo')->toString() : 'mes_atual',
+            // Paridade filtros WR (2026-06-03): campo de data (4 dos 6 do WR).
+            // emissao | vencimento(default) | pagamento(via baixa) | competencia.
+            // NF/Vendas do WR exigem link titulo->transaction (origem_id) — pendente.
+            'data_campo' => in_array($request->string('data_campo')->toString(), ['vencimento', 'emissao', 'pagamento', 'competencia'], true)
+                ? $request->string('data_campo')->toString() : 'vencimento',
+            'data_inicio' => $request->string('data_inicio', '')->toString(),
+            'data_fim' => $request->string('data_fim', '')->toString(),
             'densidade' => in_array($request->string('densidade')->toString(), $densidadesValidas, true)
                 ? $request->string('densidade')->toString() : 'compact',
             // Onda 8 (2026-05-20): sort + dir. Whitelist forçada na query (não confia
@@ -950,6 +968,21 @@ class UnificadoController extends Controller
             '30d' => [now()->subDays(30)->startOfDay(), now()->endOfDay()],
             '90d' => [now()->subDays(90)->startOfDay(), now()->endOfDay()],
             default => [now()->startOfMonth(), now()->endOfMonth()],
+        };
+    }
+
+    /**
+     * Filtro por campo de data — paridade com os filtros do WR Comercial (2026-06-03).
+     * vencimento (default, back-compat) | emissao | pagamento (via baixa) | competencia (YYYY-MM).
+     * NF/Vendas do WR exigem link título→transaction (origem_id), ainda pendente.
+     */
+    private function aplicarFiltroData($q, string $campo, string $sd, string $ed): void
+    {
+        match ($campo) {
+            'emissao' => $q->whereBetween('emissao', [$sd, $ed]),
+            'competencia' => $q->whereBetween('competencia_mes', [substr($sd, 0, 7), substr($ed, 0, 7)]),
+            'pagamento' => $q->whereHas('baixas', fn ($b) => $b->whereBetween('data_baixa', [$sd, $ed])),
+            default => $q->whereBetween('vencimento', [$sd, $ed]),
         };
     }
 
@@ -984,16 +1017,16 @@ class UnificadoController extends Controller
         ];
     }
 
-    private function kpis(int $businessId, Carbon $start, Carbon $end): array
+    private function kpis(int $businessId, Carbon $start, Carbon $end, string $campo = 'vencimento'): array
     {
-        $atual = $this->kpisCore($businessId, $start, $end);
+        $atual = $this->kpisCore($businessId, $start, $end, $campo);
 
         // PR H (2026-05-25) US-FIN-023 — delta_pct vs mês anterior.
         // Calcula KPIs do período equivalente do mês anterior pra comparativo
         // visual ("Recebido R$ 45.300 ↑+12%" — Eliana vê tendência).
         $startPrior = (clone $start)->subMonth();
         $endPrior = (clone $end)->subMonth();
-        $anterior = $this->kpisCore($businessId, $startPrior, $endPrior);
+        $anterior = $this->kpisCore($businessId, $startPrior, $endPrior, $campo);
 
         $atual['delta_pct'] = [
             'saldo_previsto' => $this->deltaPct($anterior['saldo_previsto'], $atual['saldo_previsto']),
@@ -1010,10 +1043,15 @@ class UnificadoController extends Controller
      * PR H (2026-05-25) — core dos KPIs (sem delta_pct).
      * Extraído pra reuso: `kpis()` chama 2x (atual + anterior) pra delta_pct.
      */
-    private function kpisCore(int $businessId, Carbon $start, Carbon $end): array
+    private function kpisCore(int $businessId, Carbon $start, Carbon $end, string $campo = 'vencimento'): array
     {
-        $base = Titulo::where('business_id', $businessId)
-            ->whereBetween('vencimento', [$start->toDateString(), $end->toDateString()]);
+        $sd = $start->toDateString();
+        $ed = $end->toDateString();
+
+        // Paridade filtros WR (2026-06-03): A receber / A pagar filtram pelo mesmo
+        // campo de data escolhido (default vencimento = comportamento anterior).
+        $base = Titulo::where('business_id', $businessId);
+        $this->aplicarFiltroData($base, $campo, $sd, $ed);
 
         $rec = (clone $base)->where('tipo', 'receber');
         $pay = (clone $base)->where('tipo', 'pagar');
@@ -1021,15 +1059,27 @@ class UnificadoController extends Controller
         $aReceber = (clone $rec)->whereIn('status', ['aberto', 'parcial']);
         $aPagar = (clone $pay)->whereIn('status', ['aberto', 'parcial']);
 
-        $recebido = TituloBaixa::where('business_id', $businessId)
-            ->whereBetween('data_baixa', [$start->toDateString(), $end->toDateString()])
-            ->whereNull('estorno_de_id')
-            ->whereHas('titulo', fn ($q) => $q->where('tipo', 'receber'));
+        // Recebido / Pago = baixas (dinheiro que entrou/saiu).
+        //  - campo 'pagamento': data_baixa É a data relevante → filtra direto (exato).
+        //  - demais campos: filtra as baixas cujos TÍTULOS casam o campo escolhido,
+        //    mantendo os cards consistentes com a lista filtrada.
+        $aplicarBaixa = function ($q, string $tipo) use ($campo, $sd, $ed) {
+            $q->whereNull('estorno_de_id');
+            if ($campo === 'pagamento') {
+                $q->whereBetween('data_baixa', [$sd, $ed])
+                  ->whereHas('titulo', fn ($t) => $t->where('tipo', $tipo));
+            } else {
+                $q->whereHas('titulo', function ($t) use ($tipo, $campo, $sd, $ed) {
+                    $t->where('tipo', $tipo);
+                    $this->aplicarFiltroData($t, $campo, $sd, $ed);
+                });
+            }
 
-        $pago = TituloBaixa::where('business_id', $businessId)
-            ->whereBetween('data_baixa', [$start->toDateString(), $end->toDateString()])
-            ->whereNull('estorno_de_id')
-            ->whereHas('titulo', fn ($q) => $q->where('tipo', 'pagar'));
+            return $q;
+        };
+
+        $recebido = $aplicarBaixa(TituloBaixa::where('business_id', $businessId), 'receber');
+        $pago = $aplicarBaixa(TituloBaixa::where('business_id', $businessId), 'pagar');
 
         $saldoAtual = (float) ContaBancaria::where('business_id', $businessId)->sum('saldo_cached');
         $saldoPrevisto = $saldoAtual

--- a/Modules/Financeiro/Tests/Feature/UnificadoDataCampoTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoDataCampoTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Inertia\Testing\AssertableInertia;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Paridade filtros WR (2026-06-03) — filtro por CAMPO de data + intervalo.
+ *
+ * Espelha os filtros de data do WR Comercial (Emissão/Vencimento/Pagamento/
+ * Competência) na Visão Unificada. Backend: parseFilters() + aplicarFiltroData().
+ *
+ * Cobre:
+ *  (1) default data_campo = 'vencimento' (back-compat: comportamento anterior)
+ *  (2) ?data_campo=emissao|pagamento|competencia preservado no shape
+ *  (3) valor inválido cai pra 'vencimento' (sanitização anti-tampering)
+ *  (4) ?data_inicio/?data_fim preservados no shape
+ *  (5) cada data_campo responde 200 (query não quebra em nenhum dos 4 ramos)
+ *
+ * Skip gracioso quando DB greenfield ou module gate bloqueia.
+ */
+
+function dataCampoBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.dashboard.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.dashboard.view')) {
+        $user->givePermissionTo('financeiro.dashboard.view');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'business'         => ['id' => $business->id, 'name' => $business->name, 'currency_symbol' => 'R$'],
+        'is_admin'         => true,
+    ]);
+
+    return $user;
+}
+
+function dataCampoGet(User $user, string $qs = '')
+{
+    $response = test()->actingAs($user)->get('/financeiro/unificado'.$qs);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    return $response;
+}
+
+it('default data_campo = vencimento (back-compat preservado)', function () {
+    $user = dataCampoBootstrap();
+
+    dataCampoGet($user)->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filters.data_campo', 'vencimento')
+        ->where('filters.data_inicio', '')
+        ->where('filters.data_fim', '')
+    );
+});
+
+it('aceita ?data_campo=emissao no shape', function () {
+    $user = dataCampoBootstrap();
+
+    dataCampoGet($user, '?data_campo=emissao')->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filters.data_campo', 'emissao')
+    );
+});
+
+it('valor inválido cai pra vencimento (sanitização)', function () {
+    $user = dataCampoBootstrap();
+
+    dataCampoGet($user, '?data_campo=DROP_TABLE')->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filters.data_campo', 'vencimento')
+    );
+});
+
+it('preserva intervalo explícito data_inicio/data_fim', function () {
+    $user = dataCampoBootstrap();
+
+    dataCampoGet($user, '?data_inicio=2026-01-01&data_fim=2026-01-31')
+        ->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('filters.data_inicio', '2026-01-01')
+            ->where('filters.data_fim', '2026-01-31')
+        );
+});
+
+it('os 4 campos de data respondem 200 (nenhum ramo da query quebra)', function () {
+    $user = dataCampoBootstrap();
+
+    foreach (['vencimento', 'emissao', 'pagamento', 'competencia'] as $campo) {
+        dataCampoGet($user, "?data_campo={$campo}&data_inicio=2026-01-01&data_fim=2026-12-31")
+            ->assertOk();
+    }
+});

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -31,6 +31,8 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 
 ## Goals — Features (faz)
 
+- **Paridade filtros de data WR** (2026-06-03, US-FIN-030): seletor de **campo de data** (Vencimento default · Emissão · Pagamento · Competência) + **intervalo explícito** `data_inicio`/`data_fim` na toolbar, espelhando o WR Comercial. Backend `parseFilters()` + `aplicarFiltroData()` (vencimento/emissao via coluna; pagamento via `baixas.data_baixa`; competencia via `competencia_mes` YYYY-MM); intervalo sobrepõe o período preset. **O `data_campo` aplica na tabela E nos cards de KPI** (`kpisCore` segue o mesmo campo — totais consistentes com o grid filtrado; `recebido`/`pago` por `data_baixa` quando campo=pagamento, senão por título que casa o campo). Cobertura `UnificadoDataCampoTest`. Pendente: filtros 'Nota Fiscal'/'Vendas' do WR exigem link título→transaction (`origem_id`).
+
 - **PR C — GUARD + RUNBOOK** (2026-05-25, charter v9, US-FIN-027 parcial + G1/G3 auditoria):
   - **`UnificadoPlanoContaGuardTest`** — 7 GUARDs Tier 0 anti-regressão pra `plano_conta_id`: prop Inertia `planosConta`, shape 3 campos (`plano_conta_id` + `_codigo` + `_nome`), eager-load preserva (anti N+1), Update persiste, coerência tipo↔plano (Edit), Store persiste, cross-tenant rejeitado em ambos. Cada Δ = CI quebra.
   - **`RUNBOOK-unificado.md`** — doc canon Cockpit (ADR 0039) 12 seções (quando usar, permissões, rotas, componentes, filtros, atalhos, edit/insert, plano de contas, multi-tenant, pegadinhas, troubleshoot, refs).

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1248,6 +1248,10 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
             NF/Vendas do WR exigem link título→transaction (origem_id), ainda
             pendente. */}
         <div className="fin-filter-group" role="group" aria-label="Filtro por data">
+          {/* native <select> consistente com o select de Plano de Contas logo abaixo
+              (mesma classe fin-filter-select). Migração toolbar-wide pro <Select> do DS
+              é escopo separado — não converto só este pra não destoar do vizinho. */}
+          {/* eslint-disable-next-line no-restricted-syntax -- ds/no-native-select: paridade visual com select adjacente (fin-filter-select) */}
           <select
             className="fin-filter-select"
             value={filters.data_campo}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -143,6 +143,12 @@ interface Filters {
   conta: string;
   categoria: string;
   periodo: string;
+  // Paridade filtros WR (2026-06-03) — campo de data + intervalo explícito.
+  // Espelha o WR Comercial (Emissão/Vencimento/Pagamento/Competência). Aplica
+  // na TABELA. NF/Vendas do WR exigem link título→transaction (pendente).
+  data_campo: 'vencimento' | 'emissao' | 'pagamento' | 'competencia';
+  data_inicio: string; // YYYY-MM-DD; vazio = usa período preset
+  data_fim: string;    // YYYY-MM-DD; vazio = usa período preset
   // Onda 12.6 (2026-05-19) — Wagner: removed 'spacious' (não tinha uso real).
   densidade: 'compact' | 'comfortable';
   // Onda 8 (2026-05-20): sort por coluna via click no thead.
@@ -1233,6 +1239,60 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
             <span className="fin-filter-sep" />
           </>
         )}
+
+        {/* Paridade filtros WR (2026-06-03) — filtro por CAMPO de data + intervalo.
+            Espelha os filtros de data do WR Comercial (Emissão/Vencimento/Pagamento/
+            Competência). O campo escolhido + intervalo aplicam na TABELA **e** nos
+            CARDS de KPI (kpisCore segue o mesmo data_campo) — totais consistentes
+            com o grid filtrado. Intervalo vazio = usa o período preset do header.
+            NF/Vendas do WR exigem link título→transaction (origem_id), ainda
+            pendente. */}
+        <div className="fin-filter-group" role="group" aria-label="Filtro por data">
+          <select
+            className="fin-filter-select"
+            value={filters.data_campo}
+            onChange={(e) => aplicar({ data_campo: e.target.value as Filters['data_campo'] })}
+            aria-label="Campo de data"
+            title="Qual data filtrar (igual ao WR Comercial)"
+          >
+            <option value="vencimento">Vencimento</option>
+            <option value="emissao">Emissão</option>
+            <option value="pagamento">Pagamento</option>
+            <option value="competencia">Competência</option>
+          </select>
+          <input
+            type="date"
+            className="fin-filter-select"
+            value={filters.data_inicio}
+            max={filters.data_fim || undefined}
+            onChange={(e) => aplicar({ data_inicio: e.target.value })}
+            aria-label="Data inicial"
+            title="Data inicial (vazio = período do mês)"
+          />
+          <span aria-hidden="true" style={{ opacity: 0.5 }}>–</span>
+          <input
+            type="date"
+            className="fin-filter-select"
+            value={filters.data_fim}
+            min={filters.data_inicio || undefined}
+            onChange={(e) => aplicar({ data_fim: e.target.value })}
+            aria-label="Data final"
+            title="Data final (vazio = período do mês)"
+          />
+          {(filters.data_inicio !== '' || filters.data_fim !== '') && (
+            <button
+              type="button"
+              className="fin-filter-cb"
+              onClick={() => aplicar({ data_inicio: '', data_fim: '' })}
+              title="Limpar intervalo de datas"
+              aria-label="Limpar intervalo de datas"
+            >
+              ×
+            </button>
+          )}
+        </div>
+
+        <span className="fin-filter-sep" />
 
         {/* Onda 7 (2026-05-20): multi-select de contas via Popover + Checkbox.
             Backend aceita CSV "1,3,5" via filters.conta. Frontend mostra label


### PR DESCRIPTION
## O que muda

Espelha os **filtros de data do WR Comercial** na Visão Unificada (`/financeiro/unificado`). Hoje o oimpresso só filtrava por **vencimento**; o WR tem campo de data selecionável. Origem: comparação na migração do cliente **Martinho (biz=164)**.

- **Seletor de campo de data** na toolbar: **Vencimento** (default) · **Emissão** · **Pagamento** · **Competência**.
- **Intervalo explícito** (`data_inicio`/`data_fim`) — quando preenchido, **sobrepõe** o período preset do header.

## Como funciona (backend — `UnificadoController`)

- `parseFilters()` valida `data_campo` (whitelist; inválido → vencimento) + `data_inicio`/`data_fim`.
- `aplicarFiltroData()`: `vencimento`/`emissao` por coluna · `pagamento` via `baixas.data_baixa` · `competencia` via `competencia_mes` (YYYY-MM).
- **Cards de KPI seguem o MESMO `data_campo`** (`kpis`/`kpisCore`) → totais consistentes com o grid filtrado.

## ⚠️ Decisão de semântica pra você aprovar, Wagner

Apliquei a lógica **"uma tela = um universo"**: tabela **e** cards descrevem o mesmo conjunto filtrado.

- `A receber`/`A pagar`: saldo aberto dos títulos que casam o campo+intervalo.
- `Recebido`/`Pago`: baixas dos títulos que casam o campo. Quando `campo=pagamento`, é por `data_baixa` (exato).
- **Caveat:** no campo **Vencimento** (default), `Recebido`/`Pago` passa a significar *"quanto dos títulos que vencem no período já foi baixado"* — sutilmente diferente do *"entrou no caixa no mês"* anterior. É o que dá **paridade com o WR** (totais = soma do grid). Se preferir manter `Recebido`/`Pago` sempre por `data_baixa`, é um ajuste de 1 linha — só avisar.

## Testes

- `UnificadoDataCampoTest` — default vencimento, cada `data_campo` no shape, sanitização anti-tampering, intervalo preservado, os 4 campos respondem 200 (nenhum ramo da query quebra).
- Multi-tenant Tier 0 preservado (`business_id` scope em todas as queries).

## Pendente (fora deste PR — como combinado)

- Filtros **'Nota Fiscal'** e **'Vendas'** do WR exigem link título→transaction (`fin_titulos.origem_id` ainda `'manual'`). Fazer depois do linking.

## Verificação local

- `php -l` no controller: OK. 3-way apply sobre `origin/main` atual: limpo, sem conflitos.
- Pest local não rodou (sem `vendor/` neste checkout) — **o CI deste PR é o gate**.

Refs: US-FIN-030

🤖 Generated with [Claude Code](https://claude.com/claude-code)