### PR TITLE
feat(paymentgateway): reconciliacao por polling PIX Inter (fallback do webhook)

### DIFF
--- a/Modules/PaymentGateway/Console/Commands/InterReconcilePixCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/InterReconcilePixCommand.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\InterDriver;
+use Modules\PaymentGateway\Services\ReconciliarCobrancaService;
+
+/**
+ * Polling de reconciliação PIX Inter — fallback do webhook.
+ *
+ * Por que existe: o Inter NÃO empurra confirmação de pagamento sozinho. O
+ * webhook (`InterPixWebhookController`) só funciona depois de cadastrar a URL
+ * no Inter (PUT /pix/v2/webhook) + mTLS + URL pública HTTPS. Enquanto isso (e
+ * como rede de segurança permanente caso o webhook caia/atrase), este comando
+ * PERGUNTA ao Inter, de tempos em tempos, quais cobranças PIX emitidas já foram
+ * pagas — via GET /pix/v2/cob/{txid} — e reconcilia.
+ *
+ * Fluxo por credencial Inter ativa:
+ *   1. Lista Cobrancas tipo pix_cob/pix_cobv ainda 'emitida' na janela de N dias
+ *   2. Pra cada uma, consulta o status no Inter (InterDriver::consultarPixCob)
+ *   3. Se status='paga' → ReconciliarCobrancaService::marcarPaga (mesma lógica
+ *      do webhook: marca paga + quita título + dispara CobrancaPaga)
+ *
+ * Idempotência: só processa status='emitida' (já-pagas saem da query). A
+ * reconciliação em si é idempotente (listener Financeiro checa origem_id).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): console sem session() → withoutGlobalScopes +
+ * business_id explícito propagado da credencial pra reconciliação.
+ *
+ * Schedule (app/Console/Kernel.php):
+ *   $schedule->command('paymentgateway:inter-reconcile-pix')
+ *       ->everyTenMinutes()->withoutOverlapping();
+ *
+ * Uso manual:
+ *   php artisan paymentgateway:inter-reconcile-pix --dry-run
+ *   php artisan paymentgateway:inter-reconcile-pix --business=1 --days=3
+ */
+class InterReconcilePixCommand extends Command
+{
+    protected $signature = 'paymentgateway:inter-reconcile-pix
+                            {--business= : Reconcilia só este business_id (default: todos com credencial Inter ativa)}
+                            {--days=7 : Janela de cobranças emitidas a verificar (dias atrás)}
+                            {--limit=200 : Máximo de cobranças consultadas por credencial}
+                            {--dry-run : Só lista o que reconciliaria, sem marcar paga}';
+
+    protected $description = 'Polling de reconciliação: consulta o Inter pelas cobranças PIX emitidas e marca as pagas (fallback do webhook)';
+
+    public function handle(InterDriver $driver, ReconciliarCobrancaService $reconciliador): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $days = max(1, (int) $this->option('days'));
+        $limit = max(1, (int) $this->option('limit'));
+        $businessFilter = $this->option('business') !== null ? (int) $this->option('business') : null;
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhuma cobrança será marcada paga.');
+        }
+
+        $credsQuery = PaymentGatewayCredential::query()
+            ->withoutGlobalScopes()
+            ->where('gateway_key', 'inter')
+            ->where('ativo', true);
+
+        if ($businessFilter !== null) {
+            $credsQuery->where('business_id', $businessFilter);
+        }
+
+        $creds = $credsQuery->orderBy('id')->get();
+
+        if ($creds->isEmpty()) {
+            $this->warn('Nenhuma credencial Inter ativa encontrada' . ($businessFilter !== null ? " pra biz={$businessFilter}." : '.'));
+
+            return self::SUCCESS;
+        }
+
+        $checked = 0;
+        $paid = 0;
+        $errors = 0;
+
+        foreach ($creds as $cred) {
+            $cobrancas = Cobranca::query()
+                ->withoutGlobalScopes()
+                ->where('business_id', $cred->business_id)
+                ->where('payment_gateway_credential_id', $cred->id)
+                ->whereIn('tipo', ['pix_cob', 'pix_cobv'])
+                ->where('status', 'emitida')
+                ->where('created_at', '>=', now()->subDays($days))
+                ->orderBy('id')
+                ->limit($limit)
+                ->get();
+
+            if ($cobrancas->isEmpty()) {
+                continue;
+            }
+
+            $this->line(sprintf(
+                'Credencial #%d biz=%d (%s): %d cobrança(s) PIX emitida(s) na janela %dd.',
+                $cred->id,
+                $cred->business_id,
+                $cred->ambiente,
+                $cobrancas->count(),
+                $days,
+            ));
+
+            foreach ($cobrancas as $cobranca) {
+                $checked++;
+
+                try {
+                    $status = $driver->consultarPixCob($cobranca, $cred);
+                } catch (\Throwable $e) {
+                    $errors++;
+                    $this->warn(sprintf('  cobrança #%d (txid=%s): consultar falhou — %s', $cobranca->id, $cobranca->gateway_external_id, $e->getMessage()));
+                    Log::warning('paymentgateway.inter.reconcile.consultar_falhou', [
+                        'cobranca_id'   => $cobranca->id,
+                        'business_id'   => $cobranca->business_id,
+                        'credential_id' => $cred->id,
+                        'error'         => substr($e->getMessage(), 0, 200),
+                    ]);
+                    continue;
+                }
+
+                if ($status->status !== 'paga') {
+                    continue;
+                }
+
+                $valorPago = $status->valorPagoCentavos ?? (int) $cobranca->valor_centavos;
+                $pagaEm = $status->pagaEm ?? new \DateTimeImmutable();
+
+                if ($dryRun) {
+                    $paid++;
+                    $this->line(sprintf('  [dry-run] cobrança #%d biz=%d → WOULD marcar paga (R$ %s)', $cobranca->id, $cobranca->business_id, number_format($valorPago / 100, 2, ',', '.')));
+                    continue;
+                }
+
+                DB::transaction(function () use ($reconciliador, $cobranca, $cred, $valorPago, $pagaEm): void {
+                    $reconciliador->marcarPaga(
+                        cobranca: $cobranca,
+                        businessId: (int) $cred->business_id,
+                        valorPagoCentavos: (int) $valorPago,
+                        pagaEm: $pagaEm,
+                        formaPagamento: 'pix',
+                    );
+                });
+
+                $paid++;
+                $this->info(sprintf('  ✓ cobrança #%d biz=%d marcada paga (R$ %s)', $cobranca->id, $cobranca->business_id, number_format($valorPago / 100, 2, ',', '.')));
+                Log::info('paymentgateway.inter.reconcile.paga', [
+                    'cobranca_id'   => $cobranca->id,
+                    'business_id'   => $cobranca->business_id,
+                    'credential_id' => $cred->id,
+                    'valor_centavos' => $valorPago,
+                ]);
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '✓ Resumo: %d credencial(is) · %d cobrança(s) consultada(s) · %s %d paga(s) · %d erro(s)',
+            $creds->count(),
+            $checked,
+            $dryRun ? 'WOULD mark' : 'marcou',
+            $paid,
+            $errors,
+        ));
+
+        return $errors > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/Modules/PaymentGateway/Console/Commands/InterReconcilePixCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/InterReconcilePixCommand.php
@@ -119,7 +119,7 @@ class InterReconcilePixCommand extends Command
                     $this->warn(sprintf('  cobrança #%d (txid=%s): consultar falhou — %s', $cobranca->id, $cobranca->gateway_external_id, $e->getMessage()));
                     Log::warning('paymentgateway.inter.reconcile.consultar_falhou', [
                         'cobranca_id'   => $cobranca->id,
-                        'business_id'   => $cobranca->business_id,
+                        'business_id'   => $cred->business_id,
                         'credential_id' => $cred->id,
                         'error'         => substr($e->getMessage(), 0, 200),
                     ]);
@@ -135,7 +135,7 @@ class InterReconcilePixCommand extends Command
 
                 if ($dryRun) {
                     $paid++;
-                    $this->line(sprintf('  [dry-run] cobrança #%d biz=%d → WOULD marcar paga (R$ %s)', $cobranca->id, $cobranca->business_id, number_format($valorPago / 100, 2, ',', '.')));
+                    $this->line(sprintf('  [dry-run] cobrança #%d biz=%d → WOULD marcar paga (R$ %s)', $cobranca->id, $cred->business_id, number_format($valorPago / 100, 2, ',', '.')));
                     continue;
                 }
 
@@ -150,10 +150,10 @@ class InterReconcilePixCommand extends Command
                 });
 
                 $paid++;
-                $this->info(sprintf('  ✓ cobrança #%d biz=%d marcada paga (R$ %s)', $cobranca->id, $cobranca->business_id, number_format($valorPago / 100, 2, ',', '.')));
+                $this->info(sprintf('  ✓ cobrança #%d biz=%d marcada paga (R$ %s)', $cobranca->id, $cred->business_id, number_format($valorPago / 100, 2, ',', '.')));
                 Log::info('paymentgateway.inter.reconcile.paga', [
                     'cobranca_id'   => $cobranca->id,
-                    'business_id'   => $cobranca->business_id,
+                    'business_id'   => $cred->business_id,
                     'credential_id' => $cred->id,
                     'valor_centavos' => $valorPago,
                 ]);

--- a/Modules/PaymentGateway/Jobs/ProcessarWebhookPixInterJob.php
+++ b/Modules/PaymentGateway/Jobs/ProcessarWebhookPixInterJob.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Modules\PaymentGateway\Jobs;
 
-use App\Domain\Fsm\Support\FsmAuthorizationFlag;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -12,10 +11,9 @@ use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
-use Modules\Financeiro\Models\Titulo;
-use Modules\PaymentGateway\Events\CobrancaPaga;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\InterWebhookLog;
+use Modules\PaymentGateway\Services\ReconciliarCobrancaService;
 
 /**
  * US-FIN-032 (Onda 26) — Worker que processa webhook PIX Inter recebido.
@@ -66,7 +64,7 @@ class ProcessarWebhookPixInterJob implements ShouldQueue
     ) {
     }
 
-    public function handle(): void
+    public function handle(ReconciliarCobrancaService $reconciliador): void
     {
         $log = InterWebhookLog::withoutGlobalScopes()
             ->where('id', $this->interWebhookLogId)
@@ -99,41 +97,24 @@ class ProcessarWebhookPixInterJob implements ShouldQueue
                 return;
             }
 
-            DB::transaction(function () use ($log, $cobranca): void {
-                // 1. Atualiza Cobranca status='paga'
+            DB::transaction(function () use ($log, $cobranca, $reconciliador): void {
                 $valorPagoCentavos = $log->valor_centavos ?? $cobranca->valor_centavos;
                 $pagaEm = $log->data_pagamento
                     ? \DateTimeImmutable::createFromMutable($log->data_pagamento->toDateTime())
                     : new \DateTimeImmutable();
 
-                if ($cobranca->status !== 'paga') {
-                    $cobranca->update([
-                        'status'              => 'paga',
-                        'valor_pago_centavos' => $valorPagoCentavos,
-                        'paga_em'             => $pagaEm,
-                        'forma_pagamento'     => 'pix',
-                    ]);
-                }
-
-                // 2. Atualiza titulos JÁ existentes vinculados a essa cobranca
-                //    (origem='manual' + origem_id=cobranca.id — listener cria assim)
-                $this->marcarTitulosQuitados((int) $cobranca->id, $valorPagoCentavos, $pagaEm);
-
-                // 3. Dispara evento — listener OnCobrancaPagaCreateFinanceiroTitulo
-                //    cria Titulo + TituloBaixa pra biz=1 (idempotente)
-                event(new CobrancaPaga(
-                    cobrancaId: (int) $cobranca->id,
-                    businessId: (int) $cobranca->business_id,
+                // Reconciliação canônica (mesma usada pelo polling de fallback):
+                // marca Cobranca paga + quita títulos vinculados + dispara CobrancaPaga
+                // (listener OnCobrancaPagaCreateFinanceiroTitulo cria Titulo + Baixa biz=1).
+                $reconciliador->marcarPaga(
+                    cobranca: $cobranca,
+                    businessId: $this->businessId,
                     valorPagoCentavos: $valorPagoCentavos,
                     pagaEm: $pagaEm,
                     formaPagamento: 'pix',
-                    occurredAt: new \DateTimeImmutable(),
-                    payerCpfCnpj: $cobranca->payer_cpf_cnpj,
-                    origemType: $cobranca->origem_type,
-                    origemId: $cobranca->origem_id,
-                ));
+                );
 
-                // 4. Marca log processado
+                // Marca log processado
                 $log->update([
                     'cobranca_id'  => $cobranca->id,
                     'status'       => 'processed',
@@ -177,37 +158,5 @@ class ProcessarWebhookPixInterJob implements ShouldQueue
         // 200 OK pro Inter (NÃO erro — Wagner reconcilia depois).
         // Listener OnCobrancaPagaCreateFinanceiroTitulo NÃO dispara
         // (sem Cobranca ainda — pode ter chegado antes da emissão registrar).
-    }
-
-    /**
-     * Marca titulo(s) vinculado(s) à cobranca como quitado.
-     *
-     * Estado atual (Onda 26): Titulo NÃO usa trait GuardsFsmTransitions
-     * (FSM Pipeline ainda escopo Sells/Repair — ADR 0143). Update direto OK.
-     *
-     * Quando Titulo entrar no FSM Pipeline (Onda futura), trocar `update()`
-     * por `ExecuteStageActionService::execute($titulo, 'quitar_titulo', ...)`.
-     * O FsmAuthorizationFlag::mark() abaixo é defensivo — garante que
-     * mesmo se trait for adicionada antes do worker ser refatorado,
-     * a transição PRIMEIRA não barra.
-     */
-    private function marcarTitulosQuitados(int $cobrancaId, int $valorPagoCentavos, \DateTimeImmutable $pagaEm): void
-    {
-        $titulos = Titulo::withoutGlobalScopes()
-            ->where('business_id', $this->businessId)
-            ->where('origem', 'manual')
-            ->where('origem_id', $cobrancaId)
-            ->whereIn('status', ['aberto', 'parcial'])
-            ->get();
-
-        foreach ($titulos as $titulo) {
-            // Marca flag FSM defensivamente (não-op se trait não exists)
-            FsmAuthorizationFlag::mark(Titulo::class, $titulo->id);
-
-            $titulo->update([
-                'status'       => 'quitado',
-                'valor_aberto' => 0,
-            ]);
-        }
     }
 }

--- a/Modules/PaymentGateway/Models/Cobranca.php
+++ b/Modules/PaymentGateway/Models/Cobranca.php
@@ -25,22 +25,6 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * declarado em module.json.lgpd_compliance, retention 5y, redactor habilitado.
  *
  * ADR 0170 Onda 2.
- *
- * @property int $id
- * @property int $business_id
- * @property int $payment_gateway_credential_id
- * @property string|null $gateway_external_id
- * @property string|null $tipo
- * @property string $status
- * @property int $valor_centavos
- * @property int|null $valor_pago_centavos
- * @property \Illuminate\Support\Carbon|null $vencimento
- * @property \Illuminate\Support\Carbon|null $paga_em
- * @property string|null $forma_pagamento
- * @property string|null $payer_cpf_cnpj
- * @property string|null $origem_type
- * @property int|null $origem_id
- * @property array|null $payload_gateway
  */
 class Cobranca extends Model
 {

--- a/Modules/PaymentGateway/Models/Cobranca.php
+++ b/Modules/PaymentGateway/Models/Cobranca.php
@@ -25,6 +25,22 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * declarado em module.json.lgpd_compliance, retention 5y, redactor habilitado.
  *
  * ADR 0170 Onda 2.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $payment_gateway_credential_id
+ * @property string|null $gateway_external_id
+ * @property string|null $tipo
+ * @property string $status
+ * @property int $valor_centavos
+ * @property int|null $valor_pago_centavos
+ * @property \Illuminate\Support\Carbon|null $vencimento
+ * @property \Illuminate\Support\Carbon|null $paga_em
+ * @property string|null $forma_pagamento
+ * @property string|null $payer_cpf_cnpj
+ * @property string|null $origem_type
+ * @property int|null $origem_id
+ * @property array|null $payload_gateway
  */
 class Cobranca extends Model
 {

--- a/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
@@ -34,6 +34,7 @@ class PaymentGatewayServiceProvider extends ServiceProvider
                 \Modules\PaymentGateway\Console\Commands\RetryOrphanWebhookCommand::class,
                 \Modules\PaymentGateway\Console\Commands\RewrapCredentialsCommand::class,
                 \Modules\PaymentGateway\Console\Commands\RegisterInterWebhookCommand::class,
+                \Modules\PaymentGateway\Console\Commands\InterReconcilePixCommand::class,
             ]);
         }
     }

--- a/Modules/PaymentGateway/Services/Drivers/InterDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/InterDriver.php
@@ -279,6 +279,67 @@ class InterDriver implements PaymentDriverContract
         );
     }
 
+    /**
+     * Consulta status de uma cobrança PIX (cob/cobv) via API Pix v2.
+     *
+     * Usado pelo polling de reconciliação (`InterReconcilePixCommand`) — o
+     * fallback de quando o webhook não chegou (ou nem foi cadastrado no Inter).
+     *
+     *   - pix_cob  → GET /pix/v2/cob/{txid}
+     *   - pix_cobv → GET /pix/v2/cobv/{txid}
+     *
+     * Resposta BCB Pix tem `status` (ATIVA/CONCLUIDA/REMOVIDA_*) + array `pix[]`
+     * com os recebimentos (valor + horário). Quando CONCLUIDA, soma os valores
+     * recebidos e pega o horário do primeiro PIX como data de pagamento.
+     *
+     * NOTA: difere de `consultar()` (que usa a API Cobrança v3 de boleto —
+     * /cobranca/v3/cobrancas/{nossoNumero}). PIX e boleto têm APIs distintas.
+     */
+    public function consultarPixCob(object $cobranca, object $cred): CobrancaStatus
+    {
+        $this->assertCredential($cred);
+        $txid = (string) ($cobranca->gateway_external_id ?? '');
+        if ($txid === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id (txid) pra consultar PIX no Inter');
+        }
+
+        $tipo = (string) ($cobranca->tipo ?? 'pix_cob');
+        $path = $tipo === 'pix_cobv' ? "/pix/v2/cobv/{$txid}" : "/pix/v2/cob/{$txid}";
+
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->get($path));
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Inter consultar PIX falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        $data = $response->json() ?? [];
+        $situacao = (string) ($data['status'] ?? 'ATIVA');
+
+        $valorPago = null;
+        $pagaEm = null;
+        $pixList = $data['pix'] ?? [];
+        if (is_array($pixList) && $pixList !== []) {
+            $somaCentavos = 0;
+            foreach ($pixList as $pix) {
+                $somaCentavos += (int) round(((float) ($pix['valor'] ?? 0)) * 100);
+            }
+            $valorPago = $somaCentavos > 0 ? $somaCentavos : null;
+
+            $horario = $pixList[0]['horario'] ?? null;
+            $pagaEm = $horario ? new \DateTimeImmutable((string) $horario) : null;
+        }
+
+        return new CobrancaStatus(
+            status: $this->mapPixStatus($situacao),
+            pagaEm: $pagaEm,
+            valorPagoCentavos: $valorPago,
+            formaPagamento: $valorPago !== null ? 'pix' : null,
+            payloadGateway: $data,
+        );
+    }
+
     public function healthCheck(object $cred): DriverHealth
     {
         $this->assertCredential($cred);
@@ -518,6 +579,23 @@ class InterDriver implements PaymentDriverContract
             'pago_direto', 'pago_fora'                    => 'PAGODIRETOAOCLIENTE',
             'substituicao', 'substituido'                 => 'SUBSTITUICAO',
             default                                       => 'ACERTOS',
+        };
+    }
+
+    /**
+     * Mapeia `status` da cobrança PIX v2 (cob/cobv) pro status interno.
+     *
+     * Valores BCB: ATIVA (aguardando) | CONCLUIDA (paga) |
+     * REMOVIDA_PELO_USUARIO_RECEBEDOR | REMOVIDA_PELO_PSP (cancelada).
+     */
+    private function mapPixStatus(string $pixStatus): string
+    {
+        return match (strtoupper($pixStatus)) {
+            'CONCLUIDA'                       => 'paga',
+            'ATIVA'                           => 'emitida',
+            'REMOVIDA_PELO_USUARIO_RECEBEDOR',
+            'REMOVIDA_PELO_PSP'               => 'cancelada',
+            default                           => 'pending',
         };
     }
 

--- a/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
+++ b/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Services;
+
+use App\Domain\Fsm\Support\FsmAuthorizationFlag;
+use Modules\Financeiro\Models\Titulo;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Models\Cobranca;
+
+/**
+ * Reconciliação canônica "cobrança virou paga" — fonte única de verdade.
+ *
+ * Compartilhado entre os dois caminhos de confirmação de pagamento Inter:
+ *   - PUSH: `ProcessarWebhookPixInterJob` (webhook PIX recebido → US-FIN-032)
+ *   - PULL: `InterReconcilePixCommand` (polling de fallback — Inter não exige
+ *     webhook; consulta GET /pix/v2/cob/{txid} e reconcilia o que pagou)
+ *
+ * Garante que os dois caminhos façam EXATAMENTE a mesma coisa ao marcar paga:
+ *   1. Cobranca.status='paga' + valor_pago + paga_em + forma_pagamento
+ *   2. Títulos vinculados (origem='manual' + origem_id=cobranca.id) → quitado
+ *   3. Dispara evento `CobrancaPaga` (listener Financeiro cria Titulo + Baixa)
+ *
+ * NÃO abre transação — o caller (job/command) envolve em DB::transaction.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): $businessId é passado explícito pelo caller
+ * (queue worker / console não têm session()). Queries usam withoutGlobalScopes.
+ */
+class ReconciliarCobrancaService
+{
+    /**
+     * Marca a cobrança como paga + quita títulos + dispara CobrancaPaga.
+     *
+     * Idempotência: a atualização da Cobranca é guardada por `status !== 'paga'`
+     * (igual ao job original). O dispatch do evento é seguro pra re-rodar porque
+     * o listener canônico `OnCobrancaPagaCreateFinanceiroTitulo` é idempotente
+     * (checa origem_id antes de criar). Quem chama no polling já filtra
+     * status='emitida', então não há re-dispatch redundante na prática.
+     */
+    public function marcarPaga(
+        Cobranca $cobranca,
+        int $businessId,
+        int $valorPagoCentavos,
+        \DateTimeImmutable $pagaEm,
+        string $formaPagamento = 'pix',
+    ): void {
+        if ($cobranca->status !== 'paga') {
+            $cobranca->update([
+                'status'              => 'paga',
+                'valor_pago_centavos' => $valorPagoCentavos,
+                'paga_em'             => $pagaEm,
+                'forma_pagamento'     => $formaPagamento,
+            ]);
+        }
+
+        $this->marcarTitulosQuitados($businessId, (int) $cobranca->id);
+
+        event(new CobrancaPaga(
+            cobrancaId: (int) $cobranca->id,
+            businessId: (int) $cobranca->business_id,
+            valorPagoCentavos: $valorPagoCentavos,
+            pagaEm: $pagaEm,
+            formaPagamento: $formaPagamento,
+            occurredAt: new \DateTimeImmutable(),
+            payerCpfCnpj: $cobranca->payer_cpf_cnpj,
+            origemType: $cobranca->origem_type,
+            origemId: $cobranca->origem_id,
+        ));
+    }
+
+    /**
+     * Marca título(s) vinculado(s) à cobrança como quitado.
+     *
+     * Estado atual (Onda 26): Titulo NÃO usa trait GuardsFsmTransitions
+     * (FSM Pipeline ainda escopo Sells/Repair — ADR 0143). Update direto OK.
+     * O FsmAuthorizationFlag::mark() é defensivo — se a trait for adicionada
+     * antes deste worker ser refatorado, a transição PRIMEIRA não barra.
+     */
+    private function marcarTitulosQuitados(int $businessId, int $cobrancaId): void
+    {
+        $titulos = Titulo::withoutGlobalScopes()
+            ->where('business_id', $businessId)
+            ->where('origem', 'manual')
+            ->where('origem_id', $cobrancaId)
+            ->whereIn('status', ['aberto', 'parcial'])
+            ->get();
+
+        foreach ($titulos as $titulo) {
+            FsmAuthorizationFlag::mark(Titulo::class, $titulo->id);
+
+            $titulo->update([
+                'status'       => 'quitado',
+                'valor_aberto' => 0,
+            ]);
+        }
+    }
+}

--- a/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
+++ b/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
@@ -45,7 +45,7 @@ class ReconciliarCobrancaService
         \DateTimeImmutable $pagaEm,
         string $formaPagamento = 'pix',
     ): void {
-        if ($cobranca->status !== 'paga') {
+        if ($cobranca->getAttribute('status') !== 'paga') {
             $cobranca->update([
                 'status'              => 'paga',
                 'valor_pago_centavos' => $valorPagoCentavos,

--- a/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
+++ b/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
@@ -56,16 +56,22 @@ class ReconciliarCobrancaService
 
         $this->marcarTitulosQuitados($businessId, (int) $cobranca->id);
 
+        // getAttribute() em vez de propriedade mágica: o Larastan não conhece
+        // as colunas do Eloquent e o ratchet PHPStan barra acesso direto novo.
+        $payerCpfCnpj = $cobranca->getAttribute('payer_cpf_cnpj');
+        $origemType = $cobranca->getAttribute('origem_type');
+        $origemId = $cobranca->getAttribute('origem_id');
+
         event(new CobrancaPaga(
             cobrancaId: (int) $cobranca->id,
-            businessId: (int) $cobranca->business_id,
+            businessId: $businessId,
             valorPagoCentavos: $valorPagoCentavos,
             pagaEm: $pagaEm,
             formaPagamento: $formaPagamento,
             occurredAt: new \DateTimeImmutable(),
-            payerCpfCnpj: $cobranca->payer_cpf_cnpj,
-            origemType: $cobranca->origem_type,
-            origemId: $cobranca->origem_id,
+            payerCpfCnpj: $payerCpfCnpj !== null ? (string) $payerCpfCnpj : null,
+            origemType: $origemType !== null ? (string) $origemType : null,
+            origemId: $origemId !== null ? (int) $origemId : null,
         ));
     }
 

--- a/Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Polling de reconciliação PIX Inter (fallback do webhook).
+ *
+ * Comando `paymentgateway:inter-reconcile-pix` consulta o Inter (GET
+ * /pix/v2/cob/{txid}) pelas cobranças PIX emitidas e marca as pagas.
+ *
+ * Multi-tenant Tier 0 (ADR 0093/0101): biz=1 (Wagner) — nunca biz=4 cliente.
+ */
+
+beforeEach(function () {
+    $this->cred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'inter',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Inter Reconcile Test',
+        'config_json'  => [
+            'client_id'     => 'fake-client',
+            'client_secret' => 'fake-secret',
+        ],
+    ]);
+});
+
+/**
+ * Http::fake — OAuth token + GET /pix/v2/cob/{txid}.
+ * Txid contendo "paga" → CONCLUIDA; senão → ATIVA.
+ */
+function fakeInterPixConsulta(): void
+{
+    Http::fake(function ($request) {
+        $url = $request->url();
+
+        if (str_contains($url, '/oauth/v2/token')) {
+            return Http::response(['access_token' => 'fake-token', 'expires_in' => 3600], 200);
+        }
+
+        if (str_contains($url, '/pix/v2/cob/')) {
+            if (str_contains($url, 'paga')) {
+                return Http::response([
+                    'status' => 'CONCLUIDA',
+                    'valor'  => ['original' => '150.00'],
+                    'pix'    => [[
+                        'endToEndId' => 'E00000000202606011000abc',
+                        'txid'       => 'txid-paga-001',
+                        'valor'      => '150.00',
+                        'horario'    => '2026-06-01T10:00:00Z',
+                    ]],
+                ], 200);
+            }
+
+            return Http::response([
+                'status' => 'ATIVA',
+                'valor'  => ['original' => '99.00'],
+            ], 200);
+        }
+
+        return Http::response([], 404);
+    });
+}
+
+function novaCobrancaEmitida(PaymentGatewayCredential $cred, string $txid, int $valorCentavos = 15000): Cobranca
+{
+    return Cobranca::query()->create([
+        'business_id'                   => $cred->business_id,
+        'payment_gateway_credential_id' => $cred->id,
+        'gateway_external_id'           => $txid,
+        'tipo'                          => 'pix_cob',
+        'status'                        => 'emitida',
+        'valor_centavos'                => $valorCentavos,
+        'idempotency_key'               => 'idem-' . $txid,
+        'payload_gateway'               => [],
+    ]);
+}
+
+it('marca cobrança PIX paga quando Inter retorna CONCLUIDA + dispara CobrancaPaga', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+
+    $cobranca = novaCobrancaEmitida($this->cred, 'txid-paga-001');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
+        ->assertExitCode(0);
+
+    $cobranca->refresh();
+    expect($cobranca->status)->toBe('paga');
+    expect($cobranca->forma_pagamento)->toBe('pix');
+    expect($cobranca->valor_pago_centavos)->toBe(15000);
+    expect($cobranca->paga_em)->not->toBeNull();
+
+    Event::assertDispatched(CobrancaPaga::class, function (CobrancaPaga $e) use ($cobranca) {
+        return $e->cobrancaId === $cobranca->id
+            && $e->businessId === 1
+            && $e->formaPagamento === 'pix';
+    });
+});
+
+it('NÃO marca cobrança ainda ATIVA (não paga no Inter)', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+
+    $cobranca = novaCobrancaEmitida($this->cred, 'txid-ativa-002');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
+        ->assertExitCode(0);
+
+    $cobranca->refresh();
+    expect($cobranca->status)->toBe('emitida');
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('dry-run não altera nada nem dispara evento', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+
+    $cobranca = novaCobrancaEmitida($this->cred, 'txid-paga-003');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1', '--dry-run' => true])
+        ->assertExitCode(0);
+
+    $cobranca->refresh();
+    expect($cobranca->status)->toBe('emitida');
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('processa lote misto: paga a CONCLUIDA, deixa a ATIVA', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+
+    $paga = novaCobrancaEmitida($this->cred, 'txid-paga-010');
+    $ativa = novaCobrancaEmitida($this->cred, 'txid-ativa-011');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix')
+        ->assertExitCode(0);
+
+    expect($paga->fresh()->status)->toBe('paga');
+    expect($ativa->fresh()->status)->toBe('emitida');
+    Event::assertDispatchedTimes(CobrancaPaga::class, 1);
+});
+
+it('multi-tenant: --business=1 não toca cobrança de outro tenant', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+
+    $credBiz99 = PaymentGatewayCredential::query()->create([
+        'business_id'  => 99,
+        'gateway_key'  => 'inter',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Inter biz=99',
+        'config_json'  => ['client_id' => 'a', 'client_secret' => 'b'],
+    ]);
+    $cobrancaBiz99 = novaCobrancaEmitida($credBiz99, 'txid-paga-biz99');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
+        ->assertExitCode(0);
+
+    expect($cobrancaBiz99->fresh()->status)->toBe('emitida');
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('idempotente: cobrança já paga não é re-consultada nem re-dispara evento', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+
+    $cobranca = novaCobrancaEmitida($this->cred, 'txid-paga-020');
+    $cobranca->update(['status' => 'paga', 'valor_pago_centavos' => 15000, 'forma_pagamento' => 'pix', 'paga_em' => now()]);
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
+        ->assertExitCode(0);
+
+    Event::assertNotDispatched(CobrancaPaga::class);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,21 @@ class Kernel extends ConsoleKernel
 
         }
 
+        // PaymentGateway — polling de reconciliação PIX Inter (fallback do webhook).
+        // O Inter não empurra confirmação sozinho; este cron PERGUNTA ao Inter
+        // quais cobranças PIX emitidas já foram pagas e reconcilia (marca paga +
+        // quita título + dispara CobrancaPaga). Roda em local+live pra permitir
+        // teste no sandbox. withoutOverlapping evita sobreposição se um tick demorar.
+        $schedule->command('paymentgateway:inter-reconcile-pix')
+            ->everyTenMinutes()
+            ->withoutOverlapping()
+            ->environments(['local', 'live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule paymentgateway:inter-reconcile-pix FALHOU — cobranças PIX podem ficar não-reconciliadas'
+                );
+            });
+
         // SRS — sincroniza memória Claude pra dentro do repo todo dia 23:00.
         // Histórico de renames: docvault:sync-memories → memcofre:sync-memories
         // (2026-04-24, DocVault → MemCofre) → Modules/MemCofre → Modules/SRS

--- a/memory/requisitos/PaymentGateway/SPEC.md
+++ b/memory/requisitos/PaymentGateway/SPEC.md
@@ -121,6 +121,47 @@ if ($timestamp && abs(now()->timestamp - Carbon::parse($timestamp)->timestamp) >
 
 **Refs:** Audit dossier inline 2026-05-25 §PR-0 Doc-1/2/3
 
+### US-PG-005 · Registrar URL de webhook PIX no Inter (PUT /pix/v2/webhook)
+
+> owner: eliana · priority: p2 · status: todo · type: story
+> blocked_by: US-PG-006, US-PG-007
+
+**Contexto:** o webhook PIX Inter (`InterPixWebhookController`, US-FIN-032) está pronto pra RECEBER, mas ninguém cadastra a URL de callback no Inter — por isso o Inter nunca chama. Hoje a confirmação roda por polling (`paymentgateway:inter-reconcile-pix`, commit fa22d5313), que é o fallback canônico. Esta task adiciona o webhook como otimização de latência.
+
+**Aceite:**
+- Comando/serviço que chama `PUT /pix/v2/webhook/{chave}` na API Pix do Inter com a URL `/webhooks/inter/{credentialId}` (escopo OAuth `webhook.write`).
+- Botão/step no wizard `/settings/payment-gateways` pra (re)cadastrar + consultar (`GET /pix/v2/webhook/{chave}`) + remover.
+- Idempotente; loga sucesso/falha; multi-tenant Tier 0 (credencial por business).
+- Smoke no sandbox Inter validando que o callback chega.
+
+### US-PG-006 · Corrigir autenticação do webhook Inter (mTLS em vez de HMAC x-inter-signature)
+
+> owner: eliana · priority: p2 · status: todo · type: story
+> blocked_by: —
+
+**Bug latente (P0 quando o webhook entrar):** `InterPixWebhookController::validateSignature()` e `WebhookProcessor::validateInterHmac()` exigem header `x-inter-signature` (HMAC-SHA256) e são *fail-secure* (sem header → 401). Mas a doc oficial do Inter diz que o webhook PIX é autenticado por **mTLS** (certificado mútuo), NÃO por header HMAC. Do jeito atual, **todo webhook real do Inter seria rejeitado com 401**.
+
+**Aceite:**
+- Confirmar o mecanismo real contra a doc/sandbox do Inter (developers.inter.co/references/pix).
+- Validar o webhook por mTLS (fingerprint do cert do Inter no proxy/Caddy → `SSL_CLIENT_CERT`, espelhando o pattern `validateBcbPixMtls` já existente) OU pelo mecanismo que o Inter realmente usar.
+- Não quebrar os testes existentes (`InterWebhookTest`) — ajustar expectativas.
+- Documentar no SCOPE/CONTRACTS qual é o mecanismo canônico do Inter.
+
+**Nota:** enquanto não resolvido, manter o polling como caminho primário de confirmação.
+
+### US-PG-007 · Expor URL pública HTTPS do webhook Inter (deploy/proxy CT100)
+
+> owner: eliana · priority: p2 · status: todo · type: story
+> blocked_by: —
+
+**Contexto:** o Inter só entrega webhook em endpoint HTTPS público com TLS válido, e retenta 4x (20/30/60/120min) se falhar. Hoje `/webhooks/inter/{credentialId}` existe nas rotas mas precisa estar acessível da internet no ambiente de runtime correto.
+
+**Aceite:**
+- Definir e expor a URL pública (respeitando separação Hostinger ≠ CT100, ADR 0062 — Centrifugo/FrankenPHP no CT100).
+- TLS válido + roteamento do proxy/Caddy pra `/webhooks/inter/{credentialId}`.
+- Confirmar reachability externa (curl de fora) e considerar mTLS no handshake (ver US-PG-006).
+- Documentar a URL final no RUNBOOK do PaymentGateway pra cadastrar no Inter (US-PG-005).
+
 ## Referências
 
 - [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0


### PR DESCRIPTION
## O que

Adiciona **reconciliação por polling** do PIX Inter — fallback do webhook. O Inter não empurra confirmação de pagamento sozinho (o webhook exige cadastro de URL + mTLS + URL pública). Este cron pergunta ao Inter quais cobranças PIX emitidas já foram pagas e reconcilia.

Isolado de `feat/staging-ct100` (que tem 61 commits de WIP não relacionado) — só os 2 commits do Inter, pra poder ir a produção sem arrastar o resto.

## Mudanças

- **`InterReconcilePixCommand`** — `paymentgateway:inter-reconcile-pix` (`--business`/`--days`/`--limit`/`--dry-run`), agendado a cada 10min em `local`+`live`.
- **`ReconciliarCobrancaService`** — lógica canônica "virou paga" (marca paga + quita título + dispara `CobrancaPaga`), **fonte única** compartilhada entre webhook e polling.
- **`InterDriver::consultarPixCob()`** → `GET /pix/v2/cob/{txid}` + `mapPixStatus()`.
- **`ProcessarWebhookPixInterJob`** refatorado pra reusar o serviço (zero duplicação).
- 6 testes Pest (paga/ativa/dry-run/lote/multi-tenant Tier 0/idempotência).

## Por que é seguro

- Só age em cobranças `status='emitida'`; marca paga **somente** quando o Inter responde `CONCLUIDA` (impossível falso-positivo).
- Falha de consulta por cobrança é capturada/logada e segue (degrada pra no-op).
- Multi-tenant Tier 0 (ADR 0093): `business_id` explícito + `withoutGlobalScopes` no cron.
- Reusa o evento `CobrancaPaga` → mesmo downstream do webhook (título, fatura, NFSe).

## Notas

- Sem migration nova. Baseline Inter (job/controller/driver/`inter_webhook_log`) já está na `main`.
- Não validado contra Inter sandbox ainda (smoke pendente quando a credencial sandbox biz=1 estiver cadastrada). O CI deste PR é a primeira execução real dos testes.

Refs: ADR 0170 (PaymentGateway) · US-FIN-032 (webhook Inter Onda 26) · US-PG-005/006/007 (follow-up webhook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
