### PR TITLE
fix(financeiro): alinha visual do filtro de data aos chips/selects da toolbar [M]

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -550,7 +550,7 @@
   display: inline-flex; align-items: center;
   height: 26px; padding: 4px 8px;
   border-radius: 5px;
-  border: 1px solid var(--border); background: var(--surface, #fff);
+  border: 1px solid var(--border); background: var(--surface);
   font-size: 12px; font-weight: 500; color: var(--text-dim);
   font-family: inherit; line-height: 1.4;
   cursor: pointer; transition: all .12s; box-sizing: border-box;
@@ -576,5 +576,5 @@
   cursor: pointer; transition: all .12s;
 }
 .fin-cowork .fin-toolbar .fin-date-clear:hover {
-  background: var(--surface, #fff); border-color: var(--border); color: var(--text);
+  background: var(--surface); border-color: var(--border); color: var(--text);
 }

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -537,3 +537,44 @@
   color: var(--text);
 }
 .fin-cowork .fin-curadoria .fin-footer-tips .spacer { flex: 1; }
+
+/* ─── Filtro por campo de data (paridade WR · 2026-06-03) ──────────────────
+   O <select> "Vencimento ▾" usa fin-filter-select (igual ao Plano de Contas).
+   Os <input type="date"> NÃO podem usar fin-filter-select: aquela classe injeta
+   um chevron de dropdown + padding-right de 26px que não cabem num campo de data
+   (que já tem o ícone nativo de calendário) — ficava "cru"/desalinhado.
+   Esta classe replica o MESMO pill (borda/raio/altura/tipografia/tokens) dos
+   selects vizinhos, sem o chevron. Mesma família de tokens (--border/--surface/
+   --text-dim) que .fin-filter-select pra paridade exata. */
+.fin-cowork .fin-toolbar .fin-date-input {
+  display: inline-flex; align-items: center;
+  height: 26px; padding: 4px 8px;
+  border-radius: 5px;
+  border: 1px solid var(--border); background: var(--surface, #fff);
+  font-size: 12px; font-weight: 500; color: var(--text-dim);
+  font-family: inherit; line-height: 1.4;
+  cursor: pointer; transition: all .12s; box-sizing: border-box;
+}
+.fin-cowork .fin-toolbar .fin-date-input:hover {
+  border-color: var(--text-mute); color: var(--text);
+}
+.fin-cowork .fin-toolbar .fin-date-input:focus-visible {
+  outline: 2px solid oklch(0.55 0.15 295); outline-offset: 1px;
+}
+.fin-cowork .fin-toolbar .fin-date-input::-webkit-calendar-picker-indicator {
+  opacity: .5; cursor: pointer; margin-left: 2px;
+}
+.fin-cowork .fin-toolbar .fin-date-input:hover::-webkit-calendar-picker-indicator { opacity: .8; }
+.fin-cowork .fin-toolbar .fin-date-sep {
+  color: var(--text-mute); font-size: 12px; padding: 0 1px; user-select: none;
+}
+.fin-cowork .fin-toolbar .fin-date-clear {
+  display: inline-grid; place-items: center;
+  width: 24px; height: 26px; padding: 0;
+  border-radius: 5px; border: 1px solid transparent; background: transparent;
+  color: var(--text-mute); font-size: 15px; line-height: 1;
+  cursor: pointer; transition: all .12s;
+}
+.fin-cowork .fin-toolbar .fin-date-clear:hover {
+  background: var(--surface, #fff); border-color: var(--border); color: var(--text);
+}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1264,19 +1264,21 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
             <option value="pagamento">Pagamento</option>
             <option value="competencia">Competência</option>
           </select>
+          {/* date inputs: classe própria fin-date-input (pill igual aos selects,
+              sem o chevron do fin-filter-select que não cabe num input de data). */}
           <input
             type="date"
-            className="fin-filter-select"
+            className="fin-date-input"
             value={filters.data_inicio}
             max={filters.data_fim || undefined}
             onChange={(e) => aplicar({ data_inicio: e.target.value })}
             aria-label="Data inicial"
             title="Data inicial (vazio = período do mês)"
           />
-          <span aria-hidden="true" style={{ opacity: 0.5 }}>–</span>
+          <span className="fin-date-sep" aria-hidden="true">–</span>
           <input
             type="date"
-            className="fin-filter-select"
+            className="fin-date-input"
             value={filters.data_fim}
             min={filters.data_inicio || undefined}
             onChange={(e) => aplicar({ data_fim: e.target.value })}
@@ -1286,7 +1288,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
           {(filters.data_inicio !== '' || filters.data_fim !== '') && (
             <button
               type="button"
-              className="fin-filter-cb"
+              className="fin-date-clear"
               onClick={() => aplicar({ data_inicio: '', data_fim: '' })}
               title="Limpar intervalo de datas"
               aria-label="Limpar intervalo de datas"


### PR DESCRIPTION
## Problema
Os `<input type="date">` do filtro WR (PR #2157) usavam `fin-filter-select`, que injeta **chevron de dropdown + padding-right 26px** — errado pra campo de data (já tem ícone nativo de calendário). Renderizava "cru"/desalinhado vs os chips e dropdowns vizinhos da toolbar.

## Fix (frontend-only, sem mudança de comportamento)
- **`.fin-date-input`** (`fin-cowork.css`): mesmo pill que `fin-filter-select` (borda/raio/altura 26px/tipografia + tokens `--border`/`--surface`/`--text-dim`), **sem o chevron**. + `.fin-date-sep` (separador "–") e `.fin-date-clear` (botão limpar; antes usava `fin-filter-cb`, classe de checkbox-chip).
- **`Index.tsx`**: date inputs → `fin-date-input`; o `<select>` "Vencimento" **continua** em `fin-filter-select` (paridade com "Todo o plano de contas").

## Verificação
- `npm run build:inertia` local: **OK** (`fin-date-input` presente no CSS compilado).

Refs: US-FIN-030

🤖 Generated with [Claude Code](https://claude.com/claude-code)