### PR TITLE
fix(financeiro): date-input com a mesma caixa do select vizinho na toolbar [M]

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -576,7 +576,10 @@
    --text-dim) que .fin-filter-select pra paridade exata. */
 .fin-cowork .fin-toolbar .fin-date-input {
   display: inline-flex; align-items: center;
-  height: 26px; padding: 4px 8px;
+  /* Mesma caixa do fin-filter-select vizinho (vertical 5px, left 10px, altura
+     natural) — antes era height:26px/padding:4px que deixava o campo mais baixo
+     e apertado que os selects, destoando na toolbar. */
+  padding: 5px 10px;
   border-radius: 5px;
   border: 1px solid var(--border); background: var(--surface);
   font-size: 12px; font-weight: 500; color: var(--text-dim);


### PR DESCRIPTION
## Problema
O `.fin-date-input` (filtro de data WR) tinha `height:26px` + `padding:4px 8px` → renderizava **mais baixo e apertado** que os selects vizinhos (`Vencimento`/`Todas as contas`/`Todo o plano de contas`), destoando na toolbar.

## Fix
`padding: 5px 10px` + **altura natural** = caixa idêntica ao `.fin-filter-select` (mesmos border/raio/tipografia/tokens já estavam iguais).

Frontend-only, 1 arquivo, sem mudança de comportamento.

Refs: US-FIN-030

🤖 Generated with [Claude Code](https://claude.com/claude-code)