### PR TITLE
feat(paymentgateway): cert mTLS base64 inline + testes Inter polling (delta #2158)

### DIFF
--- a/Modules/PaymentGateway/Services/Drivers/InterDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/InterDriver.php
@@ -593,7 +593,7 @@ class InterDriver implements PaymentDriverContract
     public function __destruct()
     {
         foreach ($this->tempCertFiles as $file) {
-            if (is_string($file) && is_file($file)) {
+            if (is_file($file)) {
                 @unlink($file);
             }
         }

--- a/Modules/PaymentGateway/Services/Drivers/InterDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/InterDriver.php
@@ -6,6 +6,7 @@ namespace Modules\PaymentGateway\Services\Drivers;
 
 use Carbon\Carbon;
 use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Http;
 use Modules\PaymentGateway\Contracts\PaymentDriverContract;
 use Modules\PaymentGateway\Dto\CardToken;
@@ -352,7 +353,7 @@ class InterDriver implements PaymentDriverContract
                 ->timeout(10)
                 ->post($this->baseUrl($cred) . '/oauth/v2/token', [
                     'client_id'     => $config['client_id'] ?? '',
-                    'client_secret' => $config['client_secret'] ?? '',
+                    'client_secret' => $this->maybeDecrypt((string) ($config['client_secret'] ?? '')),
                     'scope'         => 'boleto-cobranca.read boleto-cobranca.write',
                     'grant_type'    => 'client_credentials',
                 ]);
@@ -489,19 +490,113 @@ class InterDriver implements PaymentDriverContract
     }
 
     /**
-     * mTLS — em prod usa cert files; em test (Http::fake) mTLS é bypass.
+     * Arquivos de certificado temporários materializados a partir de base64
+     * inline. Keyed por hash do PEM (reuso entre chamadas). Limpos em __destruct.
+     *
+     * @var array<string, string>
+     */
+    private array $tempCertFiles = [];
+
+    /**
+     * mTLS — suporta DUAS formas de armazenar o certificado:
+     *
+     *   1. **Caminho de arquivo** (`certificado_crt` / `certificado_key`) — usado
+     *      quando o cert já está no disco do servidor.
+     *   2. **Base64 inline** (`certificado_crt_b64` / `certificado_key_b64`) —
+     *      formato gravado pelo `scripts/inter-credentials/install-biz.py` em
+     *      `rb_boleto_credentials` e migrado pra cá. Pode vir Crypt-encriptado
+     *      por-campo (a key vem). Materializa em arquivo temp na hora da chamada.
+     *
+     * Em test (Http::fake) o mTLS é bypass — os arquivos só importam pro Guzzle real.
      */
     private function mtlsOptions(array $config): array
     {
         $opts = [];
-        if (! empty($config['certificado_crt']) && is_file($config['certificado_crt'])) {
-            $opts['cert'] = $config['certificado_crt'];
+
+        $crt = $this->resolveCertFile($config['certificado_crt'] ?? null, $config['certificado_crt_b64'] ?? null);
+        if ($crt !== null) {
+            $opts['cert'] = $crt;
         }
-        if (! empty($config['certificado_key']) && is_file($config['certificado_key'])) {
-            $opts['ssl_key'] = $config['certificado_key'];
+
+        $key = $this->resolveCertFile($config['certificado_key'] ?? null, $config['certificado_key_b64'] ?? null);
+        if ($key !== null) {
+            $opts['ssl_key'] = $key;
         }
 
         return $opts;
+    }
+
+    /**
+     * Resolve um arquivo de cert utilizável: caminho existente OU materializa
+     * o PEM a partir do base64 inline (cacheado por hash do conteúdo).
+     */
+    private function resolveCertFile(?string $path, ?string $b64): ?string
+    {
+        if (! empty($path) && is_file($path)) {
+            return $path;
+        }
+        if (empty($b64)) {
+            return null;
+        }
+
+        $pem = $this->decodePem((string) $b64);
+        if ($pem === null) {
+            return null;
+        }
+
+        $hash = md5($pem);
+        if (isset($this->tempCertFiles[$hash]) && is_file($this->tempCertFiles[$hash])) {
+            return $this->tempCertFiles[$hash];
+        }
+
+        $file = tempnam(sys_get_temp_dir(), 'inter_cert_');
+        file_put_contents($file, $pem);
+        @chmod($file, 0600);
+
+        return $this->tempCertFiles[$hash] = $file;
+    }
+
+    /**
+     * Normaliza um valor de cert que pode ser: PEM cru, base64(PEM), ou
+     * Crypt::encryptString(base64(PEM) | PEM). Retorna o PEM cru ou null.
+     */
+    private function decodePem(string $value): ?string
+    {
+        $v = $this->maybeDecrypt($value);
+        if (str_contains($v, '-----BEGIN')) {
+            return $v;
+        }
+        $decoded = base64_decode($v, true);
+        if ($decoded !== false && str_contains($decoded, '-----BEGIN')) {
+            return $decoded;
+        }
+
+        return null;
+    }
+
+    /**
+     * Tenta Crypt::decryptString (campo cifrado por-campo pelo install-biz.py);
+     * se não for payload Laravel-encriptado, devolve o valor original (já plano).
+     */
+    private function maybeDecrypt(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+        try {
+            return Crypt::decryptString($value);
+        } catch (\Throwable) {
+            return $value;
+        }
+    }
+
+    public function __destruct()
+    {
+        foreach ($this->tempCertFiles as $file) {
+            if (is_string($file) && is_file($file)) {
+                @unlink($file);
+            }
+        }
     }
 
     /**
@@ -524,7 +619,7 @@ class InterDriver implements PaymentDriverContract
             ->timeout(10)
             ->post($this->baseUrl($cred) . '/oauth/v2/token', [
                 'client_id'     => $config['client_id'] ?? '',
-                'client_secret' => $config['client_secret'] ?? '',
+                'client_secret' => $this->maybeDecrypt((string) ($config['client_secret'] ?? '')),
                 'scope'         => 'boleto-cobranca.read boleto-cobranca.write',
                 'grant_type'    => 'client_credentials',
             ]);

--- a/Modules/PaymentGateway/Tests/Feature/InterDriverConsultarPixCobTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterDriverConsultarPixCobTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\InterDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * InterDriver::consultarPixCob() — consulta de status PIX usada pelo polling
+ * de reconciliação (InterReconcilePixCommand). Cobre GET /pix/v2/cob|cobv/{txid}
+ * + mapPixStatus + mTLS com certificado configurado.
+ *
+ * DB-FREE: credencial não-salva (new + forceFill) + stub de cobrança + Http::fake.
+ * Roda em qualquer ambiente (inclusive CI SQLite sem migrations).
+ *
+ * Multi-tenant Tier 0: business_id=1 (ADR 0101 — nunca cliente real).
+ */
+
+/** Credencial Inter NÃO-salva (não toca DB). */
+function interCredStub(array $config = []): PaymentGatewayCredential
+{
+    $cred = new PaymentGatewayCredential();
+    $cred->forceFill([
+        'business_id'  => 1,
+        'gateway_key'  => 'inter',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Inter Driver Test',
+        'config_json'  => array_merge(['client_id' => 'cli', 'client_secret' => 'sec'], $config),
+    ]);
+    $cred->id = 1;
+
+    return $cred;
+}
+
+/** Stub de cobrança (driver só lê gateway_external_id + tipo). */
+function cobrancaStub(string $txid, string $tipo = 'pix_cob'): object
+{
+    return (object) ['gateway_external_id' => $txid, 'tipo' => $tipo];
+}
+
+function fakeOAuth(): array
+{
+    return ['*/oauth/v2/token' => Http::response(['access_token' => 'tk', 'expires_in' => 3600], 200)];
+}
+
+it('pix_cob CONCLUIDA → status paga + valor + pagaEm (GET /pix/v2/cob/{txid})', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response([
+            'status' => 'CONCLUIDA',
+            'valor'  => ['original' => '150.00'],
+            'pix'    => [[
+                'endToEndId' => 'E000202606011000',
+                'txid'       => 'tx-cob-1',
+                'valor'      => '150.00',
+                'horario'    => '2026-06-01T10:00:00Z',
+            ]],
+        ], 200),
+    ]));
+
+    $status = (new InterDriver())->consultarPixCob(cobrancaStub('tx-cob-1'), interCredStub());
+
+    expect($status)->toBeInstanceOf(CobrancaStatus::class);
+    expect($status->status)->toBe('paga');
+    expect($status->valorPagoCentavos)->toBe(15000);
+    expect($status->formaPagamento)->toBe('pix');
+    expect($status->pagaEm)->not->toBeNull();
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/pix/v2/cob/tx-cob-1'));
+});
+
+it('pix_cobv usa endpoint /pix/v2/cobv/{txid}', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cobv/*' => Http::response(['status' => 'ATIVA'], 200),
+    ]));
+
+    (new InterDriver())->consultarPixCob(cobrancaStub('tx-cobv-1', 'pix_cobv'), interCredStub());
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/pix/v2/cobv/tx-cobv-1'));
+});
+
+it('ATIVA → emitida (sem valor pago)', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response(['status' => 'ATIVA', 'valor' => ['original' => '99.00']], 200),
+    ]));
+
+    $status = (new InterDriver())->consultarPixCob(cobrancaStub('tx-ativa'), interCredStub());
+
+    expect($status->status)->toBe('emitida');
+    expect($status->valorPagoCentavos)->toBeNull();
+    expect($status->formaPagamento)->toBeNull();
+});
+
+it('REMOVIDA_PELO_USUARIO_RECEBEDOR → cancelada', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response(['status' => 'REMOVIDA_PELO_USUARIO_RECEBEDOR'], 200),
+    ]));
+
+    $status = (new InterDriver())->consultarPixCob(cobrancaStub('tx-rem-1'), interCredStub());
+    expect($status->status)->toBe('cancelada');
+});
+
+it('REMOVIDA_PELO_PSP → cancelada', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response(['status' => 'REMOVIDA_PELO_PSP'], 200),
+    ]));
+
+    $status = (new InterDriver())->consultarPixCob(cobrancaStub('tx-rem-2'), interCredStub());
+    expect($status->status)->toBe('cancelada');
+});
+
+it('status desconhecido → pending', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response(['status' => 'ALGO_NOVO'], 200),
+    ]));
+
+    $status = (new InterDriver())->consultarPixCob(cobrancaStub('tx-x'), interCredStub());
+    expect($status->status)->toBe('pending');
+});
+
+it('soma múltiplos PIX recebidos no valor pago', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response([
+            'status' => 'CONCLUIDA',
+            'pix'    => [
+                ['txid' => 't', 'valor' => '100.00', 'horario' => '2026-06-01T10:00:00Z'],
+                ['txid' => 't', 'valor' => '50.50',  'horario' => '2026-06-01T10:05:00Z'],
+            ],
+        ], 200),
+    ]));
+
+    $status = (new InterDriver())->consultarPixCob(cobrancaStub('tx-multi'), interCredStub());
+    expect($status->valorPagoCentavos)->toBe(15050);
+});
+
+it('cobrança sem gateway_external_id (txid) → InvalidPayerException', function () {
+    Http::fake(fakeOAuth());
+
+    expect(fn () => (new InterDriver())->consultarPixCob(cobrancaStub(''), interCredStub()))
+        ->toThrow(InvalidPayerException::class);
+});
+
+it('Inter responde erro (HTTP 500) → GatewayUnavailableException', function () {
+    Http::fake(array_merge(fakeOAuth(), [
+        '*/pix/v2/cob/*' => Http::response(['erro' => 'interno'], 500),
+    ]));
+
+    expect(fn () => (new InterDriver())->consultarPixCob(cobrancaStub('tx-err'), interCredStub()))
+        ->toThrow(GatewayUnavailableException::class);
+});
+
+it('credencial sem client_id/secret → CredentialMisconfiguredException', function () {
+    Http::fake(fakeOAuth());
+
+    $credSemConfig = new PaymentGatewayCredential();
+    $credSemConfig->forceFill([
+        'business_id' => 1,
+        'gateway_key' => 'inter',
+        'ambiente'    => 'sandbox',
+        'ativo'       => true,
+        'config_json' => [], // sem client_id/secret
+    ]);
+
+    expect(fn () => (new InterDriver())->consultarPixCob(cobrancaStub('tx'), $credSemConfig))
+        ->toThrow(CredentialMisconfiguredException::class);
+});
+
+it('certificado mTLS configurado: mtlsOptions inclui cert + ssl_key e a consulta funciona', function () {
+    // Cria arquivos de certificado temporários (is_file precisa existir)
+    $crt = tempnam(sys_get_temp_dir(), 'inter_crt_');
+    $key = tempnam(sys_get_temp_dir(), 'inter_key_');
+    file_put_contents($crt, "-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----");
+    file_put_contents($key, "-----BEGIN PRIVATE KEY-----\nFAKE\n-----END PRIVATE KEY-----");
+
+    try {
+        $cred = interCredStub(['certificado_crt' => $crt, 'certificado_key' => $key]);
+        $driver = new InterDriver();
+
+        // (a) mtlsOptions (private) monta cert + ssl_key a partir dos arquivos
+        $ref = new ReflectionMethod(InterDriver::class, 'mtlsOptions');
+        $ref->setAccessible(true);
+        $opts = $ref->invoke($driver, $cred->config_json);
+
+        expect($opts['cert'] ?? null)->toBe($crt);
+        expect($opts['ssl_key'] ?? null)->toBe($key);
+
+        // (b) com cert configurado, a consulta continua funcionando end-to-end
+        Http::fake(array_merge(fakeOAuth(), [
+            '*/pix/v2/cob/*' => Http::response([
+                'status' => 'CONCLUIDA',
+                'pix'    => [['txid' => 'tx-cert', 'valor' => '10.00', 'horario' => '2026-06-01T10:00:00Z']],
+            ], 200),
+        ]));
+
+        $status = $driver->consultarPixCob(cobrancaStub('tx-cert'), $cred);
+        expect($status->status)->toBe('paga');
+    } finally {
+        @unlink($crt);
+        @unlink($key);
+    }
+});
+
+it('SEM certificado configurado: mtlsOptions vazio (não quebra)', function () {
+    $driver = new InterDriver();
+    $ref = new ReflectionMethod(InterDriver::class, 'mtlsOptions');
+    $ref->setAccessible(true);
+
+    $opts = $ref->invoke($driver, ['client_id' => 'x', 'client_secret' => 'y']);
+    expect($opts)->toBe([]);
+});
+
+it('certificado via base64 inline (crt_b64/key_b64) materializa arquivos temp com o PEM', function () {
+    $crtPem = "-----BEGIN CERTIFICATE-----\nMIIBcrtFake\n-----END CERTIFICATE-----";
+    $keyPem = "-----BEGIN PRIVATE KEY-----\nMIIBkeyFake\n-----END PRIVATE KEY-----";
+
+    $driver = new InterDriver();
+    $ref = new ReflectionMethod(InterDriver::class, 'mtlsOptions');
+    $ref->setAccessible(true);
+
+    $opts = $ref->invoke($driver, [
+        'client_id'           => 'x',
+        'client_secret'       => 'y',
+        'certificado_crt_b64' => base64_encode($crtPem),
+        'certificado_key_b64' => base64_encode($keyPem),
+    ]);
+
+    expect($opts['cert'] ?? null)->not->toBeNull();
+    expect($opts['ssl_key'] ?? null)->not->toBeNull();
+    expect(is_file($opts['cert']))->toBeTrue();
+    expect(is_file($opts['ssl_key']))->toBeTrue();
+    expect(file_get_contents($opts['cert']))->toBe($crtPem);
+    expect(file_get_contents($opts['ssl_key']))->toBe($keyPem);
+});
+
+it('certificado_key_b64 cifrado por-campo (Crypt, como install-biz.py grava) é decifrado e materializado', function () {
+    $keyPem = "-----BEGIN PRIVATE KEY-----\nMIIBkeyCrypt\n-----END PRIVATE KEY-----";
+
+    $driver = new InterDriver();
+    $ref = new ReflectionMethod(InterDriver::class, 'mtlsOptions');
+    $ref->setAccessible(true);
+
+    $opts = $ref->invoke($driver, [
+        'client_id'           => 'x',
+        'client_secret'       => 'y',
+        'certificado_key_b64' => Crypt::encryptString(base64_encode($keyPem)),
+    ]);
+
+    expect($opts['ssl_key'] ?? null)->not->toBeNull();
+    expect(file_get_contents($opts['ssl_key']))->toBe($keyPem);
+});
+
+it('caminho de arquivo tem prioridade sobre base64 quando ambos presentes', function () {
+    $pathPem = "-----BEGIN CERTIFICATE-----\nDoArquivo\n-----END CERTIFICATE-----";
+    $crtFile = tempnam(sys_get_temp_dir(), 'prio_crt_');
+    file_put_contents($crtFile, $pathPem);
+
+    try {
+        $driver = new InterDriver();
+        $ref = new ReflectionMethod(InterDriver::class, 'mtlsOptions');
+        $ref->setAccessible(true);
+
+        $opts = $ref->invoke($driver, [
+            'certificado_crt'     => $crtFile,
+            'certificado_crt_b64' => base64_encode("-----BEGIN CERTIFICATE-----\nDoB64\n-----END CERTIFICATE-----"),
+        ]);
+
+        expect($opts['cert'])->toBe($crtFile);
+    } finally {
+        @unlink($crtFile);
+    }
+});
+
+it('decodePem aceita PEM cru, base64(PEM) e Crypt(base64(PEM)); rejeita lixo', function () {
+    $pem = "-----BEGIN CERTIFICATE-----\nABC\n-----END CERTIFICATE-----";
+    $driver = new InterDriver();
+    $ref = new ReflectionMethod(InterDriver::class, 'decodePem');
+    $ref->setAccessible(true);
+
+    expect($ref->invoke($driver, $pem))->toBe($pem);
+    expect($ref->invoke($driver, base64_encode($pem)))->toBe($pem);
+    expect($ref->invoke($driver, Crypt::encryptString(base64_encode($pem))))->toBe($pem);
+    expect($ref->invoke($driver, 'lixo-que-nao-eh-pem'))->toBeNull();
+});
+
+it('maybeDecrypt decifra Crypt e passa valor plano direto', function () {
+    $driver = new InterDriver();
+    $ref = new ReflectionMethod(InterDriver::class, 'maybeDecrypt');
+    $ref->setAccessible(true);
+
+    expect($ref->invoke($driver, Crypt::encryptString('segredo')))->toBe('segredo');
+    expect($ref->invoke($driver, 'ja-plano'))->toBe('ja-plano');
+    expect($ref->invoke($driver, ''))->toBe('');
+});

--- a/Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
 use Modules\PaymentGateway\Events\CobrancaPaga;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
@@ -11,31 +13,106 @@ use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 uses(Tests\TestCase::class);
 
 /**
- * Polling de reconciliação PIX Inter (fallback do webhook).
+ * paymentgateway:inter-reconcile-pix — polling de reconciliação (fallback do
+ * webhook). Consulta o Inter (GET /pix/v2/cob|cobv/{txid}) pelas cobranças PIX
+ * emitidas e marca as pagas.
  *
- * Comando `paymentgateway:inter-reconcile-pix` consulta o Inter (GET
- * /pix/v2/cob/{txid}) pelas cobranças PIX emitidas e marca as pagas.
+ * Schema mínimo via beforeEach (guardado por hasTable) pra rodar em SQLite sem
+ * migrations. Em MySQL (suite real) as tabelas já existem e o build é pulado.
  *
- * Multi-tenant Tier 0 (ADR 0093/0101): biz=1 (Wagner) — nunca biz=4 cliente.
+ * Multi-tenant Tier 0: biz=1 (ADR 0101 — nunca cliente real).
  */
 
-beforeEach(function () {
-    $this->cred = PaymentGatewayCredential::query()->create([
-        'business_id'  => 1,
-        'gateway_key'  => 'inter',
-        'ambiente'     => 'sandbox',
-        'ativo'        => true,
-        'nome_display' => 'Inter Reconcile Test',
-        'config_json'  => [
-            'client_id'     => 'fake-client',
-            'client_secret' => 'fake-secret',
-        ],
-    ]);
-});
+if (! function_exists('pgEnsureSchema')) {
+    function pgEnsureSchema(): void
+    {
+        if (! Schema::hasTable('activity_log')) {
+            Schema::create('activity_log', function ($t) {
+                $t->id();
+                $t->string('log_name')->nullable();
+                $t->text('description')->nullable();
+                $t->unsignedBigInteger('subject_id')->nullable();
+                $t->string('subject_type')->nullable();
+                $t->unsignedBigInteger('causer_id')->nullable();
+                $t->string('causer_type')->nullable();
+                $t->json('properties')->nullable();
+                $t->string('event')->nullable();
+                $t->uuid('batch_uuid')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            Schema::create('payment_gateway_credentials', function ($t) {
+                $t->id();
+                $t->unsignedInteger('business_id')->index();
+                $t->string('gateway_key');
+                $t->string('ambiente')->default('sandbox');
+                $t->boolean('ativo')->default(true);
+                $t->string('nome_display')->nullable();
+                $t->text('config_json')->nullable();
+                $t->unsignedBigInteger('conta_bancaria_id')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('cobrancas')) {
+            Schema::create('cobrancas', function ($t) {
+                $t->id();
+                $t->unsignedInteger('business_id')->index();
+                $t->unsignedBigInteger('payment_gateway_credential_id')->nullable();
+                $t->string('gateway_external_id')->nullable();
+                $t->string('tipo')->nullable();
+                $t->string('status')->default('pending');
+                $t->unsignedInteger('valor_centavos')->default(0);
+                $t->unsignedInteger('valor_pago_centavos')->nullable();
+                $t->date('vencimento')->nullable();
+                $t->timestamp('paga_em')->nullable();
+                $t->unsignedBigInteger('contact_id')->nullable();
+                $t->string('payer_cpf_cnpj')->nullable();
+                $t->string('payer_name')->nullable();
+                $t->string('payer_email')->nullable();
+                $t->text('descricao')->nullable();
+                $t->string('idempotency_key')->nullable();
+                $t->string('origem_type')->nullable();
+                $t->unsignedBigInteger('origem_id')->nullable();
+                $t->string('forma_pagamento')->nullable();
+                $t->json('payload_gateway')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('fin_titulos')) {
+            Schema::create('fin_titulos', function ($t) {
+                $t->increments('id');
+                $t->integer('business_id')->unsigned()->index();
+                $t->string('numero', 20)->nullable();
+                $t->string('tipo')->nullable();
+                $t->string('status')->default('aberto');
+                $t->integer('cliente_id')->unsigned()->nullable();
+                $t->string('cliente_descricao')->nullable();
+                $t->decimal('valor_total', 22, 4)->default(0);
+                $t->decimal('valor_aberto', 22, 4)->default(0);
+                $t->char('moeda', 3)->default('BRL');
+                $t->date('emissao')->nullable();
+                $t->date('vencimento')->nullable();
+                $t->char('competencia_mes', 7)->nullable();
+                $t->string('origem')->nullable();
+                $t->integer('origem_id')->unsigned()->nullable();
+                $t->json('metadata')->nullable();
+                $t->integer('created_by')->unsigned()->nullable();
+                $t->integer('updated_by')->unsigned()->nullable();
+                $t->timestamps();
+                $t->softDeletes();
+            });
+        }
+    }
+}
 
 /**
- * Http::fake — OAuth token + GET /pix/v2/cob/{txid}.
- * Txid contendo "paga" → CONCLUIDA; senão → ATIVA.
+ * Http::fake do Inter — OAuth + GET /pix/v2/cob|cobv/{txid}.
+ * Decide a resposta pelo txid: "paga"→CONCLUIDA, "removida"→REMOVIDA,
+ * "erro"→HTTP 500, senão→ATIVA. Valor pago fixo 150,00 (15000 centavos).
  */
 function fakeInterPixConsulta(): void
 {
@@ -43,142 +120,254 @@ function fakeInterPixConsulta(): void
         $url = $request->url();
 
         if (str_contains($url, '/oauth/v2/token')) {
-            return Http::response(['access_token' => 'fake-token', 'expires_in' => 3600], 200);
+            return Http::response(['access_token' => 'tk', 'expires_in' => 3600], 200);
         }
 
-        if (str_contains($url, '/pix/v2/cob/')) {
+        if (str_contains($url, '/pix/v2/cob/') || str_contains($url, '/pix/v2/cobv/')) {
+            if (str_contains($url, 'erro')) {
+                return Http::response(['erro' => 'interno'], 500);
+            }
+            if (str_contains($url, 'removida')) {
+                return Http::response(['status' => 'REMOVIDA_PELO_USUARIO_RECEBEDOR'], 200);
+            }
             if (str_contains($url, 'paga')) {
                 return Http::response([
                     'status' => 'CONCLUIDA',
-                    'valor'  => ['original' => '150.00'],
-                    'pix'    => [[
-                        'endToEndId' => 'E00000000202606011000abc',
-                        'txid'       => 'txid-paga-001',
-                        'valor'      => '150.00',
-                        'horario'    => '2026-06-01T10:00:00Z',
-                    ]],
+                    'pix'    => [['txid' => 'x', 'valor' => '150.00', 'horario' => '2026-06-01T10:00:00Z']],
                 ], 200);
             }
 
-            return Http::response([
-                'status' => 'ATIVA',
-                'valor'  => ['original' => '99.00'],
-            ], 200);
+            return Http::response(['status' => 'ATIVA', 'valor' => ['original' => '150.00']], 200);
         }
 
         return Http::response([], 404);
     });
 }
 
-function novaCobrancaEmitida(PaymentGatewayCredential $cred, string $txid, int $valorCentavos = 15000): Cobranca
+function credInter(array $attrs = []): PaymentGatewayCredential
 {
-    return Cobranca::query()->create([
+    return PaymentGatewayCredential::query()->create(array_merge([
+        'business_id'  => 1,
+        'gateway_key'  => 'inter',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Inter Test',
+        'config_json'  => ['client_id' => 'cli', 'client_secret' => 'sec'],
+    ], $attrs));
+}
+
+function cobEmitida(PaymentGatewayCredential $cred, string $txid, array $attrs = []): Cobranca
+{
+    return Cobranca::query()->create(array_merge([
         'business_id'                   => $cred->business_id,
         'payment_gateway_credential_id' => $cred->id,
         'gateway_external_id'           => $txid,
         'tipo'                          => 'pix_cob',
         'status'                        => 'emitida',
-        'valor_centavos'                => $valorCentavos,
+        'valor_centavos'                => 99999,
         'idempotency_key'               => 'idem-' . $txid,
+        'descricao'                     => 'Teste',
         'payload_gateway'               => [],
-    ]);
+    ], $attrs));
 }
+
+beforeEach(function () {
+    pgEnsureSchema();
+});
 
 it('marca cobrança PIX paga quando Inter retorna CONCLUIDA + dispara CobrancaPaga', function () {
     Event::fake([CobrancaPaga::class]);
     fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-001');
 
-    $cobranca = novaCobrancaEmitida($this->cred, 'txid-paga-001');
-
-    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
-        ->assertExitCode(0);
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
 
     $cobranca->refresh();
     expect($cobranca->status)->toBe('paga');
     expect($cobranca->forma_pagamento)->toBe('pix');
-    expect($cobranca->valor_pago_centavos)->toBe(15000);
     expect($cobranca->paga_em)->not->toBeNull();
 
-    Event::assertDispatched(CobrancaPaga::class, function (CobrancaPaga $e) use ($cobranca) {
-        return $e->cobrancaId === $cobranca->id
-            && $e->businessId === 1
-            && $e->formaPagamento === 'pix';
-    });
+    Event::assertDispatched(CobrancaPaga::class, fn (CobrancaPaga $e) => $e->cobrancaId === (int) $cobranca->id && $e->businessId === 1);
 });
 
-it('NÃO marca cobrança ainda ATIVA (não paga no Inter)', function () {
+it('valor pago vem do Inter (pix.valor), não do valor_centavos local', function () {
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-valor', ['valor_centavos' => 99999]);
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect($cobranca->fresh()->valor_pago_centavos)->toBe(15000);
+});
+
+it('NÃO marca cobrança ainda ATIVA', function () {
     Event::fake([CobrancaPaga::class]);
     fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-ativa-002');
 
-    $cobranca = novaCobrancaEmitida($this->cred, 'txid-ativa-002');
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
 
-    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
-        ->assertExitCode(0);
-
-    $cobranca->refresh();
-    expect($cobranca->status)->toBe('emitida');
+    expect($cobranca->fresh()->status)->toBe('emitida');
     Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('NÃO marca cobrança REMOVIDA (cancelada no Inter)', function () {
+    Event::fake([CobrancaPaga::class]);
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-removida-003');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect($cobranca->fresh()->status)->toBe('emitida');
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('erro de consulta no Inter (HTTP 500) → conta erro, exit FAILURE, cobrança intacta', function () {
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-erro-004');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(1);
+
+    expect($cobranca->fresh()->status)->toBe('emitida');
 });
 
 it('dry-run não altera nada nem dispara evento', function () {
     Event::fake([CobrancaPaga::class]);
     fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-005');
 
-    $cobranca = novaCobrancaEmitida($this->cred, 'txid-paga-003');
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1', '--dry-run' => true])->assertExitCode(0);
 
-    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1', '--dry-run' => true])
-        ->assertExitCode(0);
-
-    $cobranca->refresh();
-    expect($cobranca->status)->toBe('emitida');
+    expect($cobranca->fresh()->status)->toBe('emitida');
     Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('pix_cobv usa o endpoint cobv e marca paga', function () {
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-cobv', ['tipo' => 'pix_cobv']);
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect($cobranca->fresh()->status)->toBe('paga');
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/pix/v2/cobv/txid-paga-cobv'));
+});
+
+it('quita o título vinculado à cobrança ao reconciliar', function () {
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-titulo');
+    $titulo = \Modules\Financeiro\Models\Titulo::query()->create([
+        'business_id'     => 1,
+        'numero'          => 'T-RC-1',
+        'tipo'            => 'receber',
+        'status'          => 'aberto',
+        'valor_total'     => 150,
+        'valor_aberto'    => 150,
+        'emissao'         => now()->toDateString(),
+        'vencimento'      => now()->addDay()->toDateString(),
+        'competencia_mes' => now()->format('Y-m'),
+        'origem'          => 'manual',
+        'origem_id'       => (int) $cobranca->id,
+        'created_by'      => 1,
+    ]);
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect($titulo->fresh()->status)->toBe('quitado');
 });
 
 it('processa lote misto: paga a CONCLUIDA, deixa a ATIVA', function () {
     Event::fake([CobrancaPaga::class]);
     fakeInterPixConsulta();
+    $cred = credInter();
+    $paga = cobEmitida($cred, 'txid-paga-010');
+    $ativa = cobEmitida($cred, 'txid-ativa-011');
 
-    $paga = novaCobrancaEmitida($this->cred, 'txid-paga-010');
-    $ativa = novaCobrancaEmitida($this->cred, 'txid-ativa-011');
-
-    $this->artisan('paymentgateway:inter-reconcile-pix')
-        ->assertExitCode(0);
+    $this->artisan('paymentgateway:inter-reconcile-pix')->assertExitCode(0);
 
     expect($paga->fresh()->status)->toBe('paga');
     expect($ativa->fresh()->status)->toBe('emitida');
     Event::assertDispatchedTimes(CobrancaPaga::class, 1);
 });
 
+it('credencial inativa (ativo=false) é ignorada', function () {
+    fakeInterPixConsulta();
+    $cred = credInter(['ativo' => false]);
+    $cobranca = cobEmitida($cred, 'txid-paga-inativa');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect($cobranca->fresh()->status)->toBe('emitida');
+});
+
+it('sem credencial Inter ativa → SUCCESS no-op', function () {
+    fakeInterPixConsulta();
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect(true)->toBeTrue();
+});
+
+it('cobrança fora da janela --days não é consultada', function () {
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-velha');
+    DB::table('cobrancas')->where('id', $cobranca->id)->update(['created_at' => now()->subDays(30)]);
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1', '--days' => '7'])->assertExitCode(0);
+
+    expect($cobranca->fresh()->status)->toBe('emitida');
+});
+
+it('cobrança tipo boleto (não-pix) não é consultada', function () {
+    fakeInterPixConsulta();
+    $cred = credInter();
+    $cobranca = cobEmitida($cred, 'txid-paga-boleto', ['tipo' => 'boleto']);
+
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
+
+    expect($cobranca->fresh()->status)->toBe('emitida');
+});
+
 it('multi-tenant: --business=1 não toca cobrança de outro tenant', function () {
     Event::fake([CobrancaPaga::class]);
     fakeInterPixConsulta();
+    credInter();
+    $cred99 = credInter(['business_id' => 99]);
+    $cobranca99 = cobEmitida($cred99, 'txid-paga-biz99');
 
-    $credBiz99 = PaymentGatewayCredential::query()->create([
-        'business_id'  => 99,
-        'gateway_key'  => 'inter',
-        'ambiente'     => 'sandbox',
-        'ativo'        => true,
-        'nome_display' => 'Inter biz=99',
-        'config_json'  => ['client_id' => 'a', 'client_secret' => 'b'],
-    ]);
-    $cobrancaBiz99 = novaCobrancaEmitida($credBiz99, 'txid-paga-biz99');
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
 
-    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
-        ->assertExitCode(0);
-
-    expect($cobrancaBiz99->fresh()->status)->toBe('emitida');
+    expect($cobranca99->fresh()->status)->toBe('emitida');
     Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('sem --business: processa TODAS as credenciais Inter ativas (2 tenants)', function () {
+    fakeInterPixConsulta();
+    $cred1 = credInter(['business_id' => 1]);
+    $cred7 = credInter(['business_id' => 7]);
+    $c1 = cobEmitida($cred1, 'txid-paga-t1');
+    $c7 = cobEmitida($cred7, 'txid-paga-t7');
+
+    $this->artisan('paymentgateway:inter-reconcile-pix')->assertExitCode(0);
+
+    expect($c1->fresh()->status)->toBe('paga');
+    expect($c7->fresh()->status)->toBe('paga');
 });
 
 it('idempotente: cobrança já paga não é re-consultada nem re-dispara evento', function () {
     Event::fake([CobrancaPaga::class]);
     fakeInterPixConsulta();
+    $cred = credInter();
+    cobEmitida($cred, 'txid-paga-020', ['status' => 'paga', 'valor_pago_centavos' => 15000, 'forma_pagamento' => 'pix']);
 
-    $cobranca = novaCobrancaEmitida($this->cred, 'txid-paga-020');
-    $cobranca->update(['status' => 'paga', 'valor_pago_centavos' => 15000, 'forma_pagamento' => 'pix', 'paga_em' => now()]);
-
-    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])
-        ->assertExitCode(0);
+    $this->artisan('paymentgateway:inter-reconcile-pix', ['--business' => '1'])->assertExitCode(0);
 
     Event::assertNotDispatched(CobrancaPaga::class);
 });

--- a/Modules/PaymentGateway/Tests/Feature/ReconciliarCobrancaServiceTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/ReconciliarCobrancaServiceTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Modules\Financeiro\Models\Titulo;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Services\ReconciliarCobrancaService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * ReconciliarCobrancaService::marcarPaga() — lógica canônica "virou paga"
+ * compartilhada entre o webhook (ProcessarWebhookPixInterJob) e o polling
+ * (InterReconcilePixCommand).
+ *
+ * Schema mínimo montado em beforeEach (guardado por hasTable) pra rodar em
+ * SQLite sem migrations — as migrations UltimatePOS são MySQL-only. Em MySQL
+ * (suite local/CI real) as tabelas já existem e o build é pulado.
+ *
+ * Multi-tenant Tier 0: business_id=1 (ADR 0101).
+ */
+
+if (! function_exists('pgEnsureSchema')) {
+    function pgEnsureSchema(): void
+    {
+        if (! Schema::hasTable('activity_log')) {
+            Schema::create('activity_log', function ($t) {
+                $t->id();
+                $t->string('log_name')->nullable();
+                $t->text('description')->nullable();
+                $t->unsignedBigInteger('subject_id')->nullable();
+                $t->string('subject_type')->nullable();
+                $t->unsignedBigInteger('causer_id')->nullable();
+                $t->string('causer_type')->nullable();
+                $t->json('properties')->nullable();
+                $t->string('event')->nullable();
+                $t->uuid('batch_uuid')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('cobrancas')) {
+            Schema::create('cobrancas', function ($t) {
+                $t->id();
+                $t->unsignedInteger('business_id')->index();
+                $t->unsignedBigInteger('payment_gateway_credential_id')->nullable();
+                $t->string('gateway_external_id')->nullable();
+                $t->string('tipo')->nullable();
+                $t->string('status')->default('pending');
+                $t->unsignedInteger('valor_centavos')->default(0);
+                $t->unsignedInteger('valor_pago_centavos')->nullable();
+                $t->date('vencimento')->nullable();
+                $t->timestamp('paga_em')->nullable();
+                $t->unsignedBigInteger('contact_id')->nullable();
+                $t->string('payer_cpf_cnpj')->nullable();
+                $t->string('payer_name')->nullable();
+                $t->string('payer_email')->nullable();
+                $t->text('descricao')->nullable();
+                $t->string('idempotency_key')->nullable();
+                $t->string('origem_type')->nullable();
+                $t->unsignedBigInteger('origem_id')->nullable();
+                $t->string('forma_pagamento')->nullable();
+                $t->json('payload_gateway')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            Schema::create('payment_gateway_credentials', function ($t) {
+                $t->id();
+                $t->unsignedInteger('business_id')->index();
+                $t->string('gateway_key');
+                $t->string('ambiente')->default('sandbox');
+                $t->boolean('ativo')->default(true);
+                $t->string('nome_display')->nullable();
+                $t->text('config_json')->nullable();
+                $t->unsignedBigInteger('conta_bancaria_id')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        if (! Schema::hasTable('fin_titulos')) {
+            Schema::create('fin_titulos', function ($t) {
+                $t->increments('id');
+                $t->integer('business_id')->unsigned()->index();
+                $t->string('numero', 20)->nullable();
+                $t->string('tipo')->nullable();
+                $t->string('status')->default('aberto');
+                $t->integer('cliente_id')->unsigned()->nullable();
+                $t->string('cliente_descricao')->nullable();
+                $t->decimal('valor_total', 22, 4)->default(0);
+                $t->decimal('valor_aberto', 22, 4)->default(0);
+                $t->char('moeda', 3)->default('BRL');
+                $t->date('emissao')->nullable();
+                $t->date('vencimento')->nullable();
+                $t->char('competencia_mes', 7)->nullable();
+                $t->string('origem')->nullable();
+                $t->integer('origem_id')->unsigned()->nullable();
+                $t->json('metadata')->nullable();
+                $t->integer('created_by')->unsigned()->nullable();
+                $t->integer('updated_by')->unsigned()->nullable();
+                $t->timestamps();
+                $t->softDeletes();
+            });
+        }
+    }
+}
+
+function novoTitulo(array $attrs = []): Titulo
+{
+    return Titulo::query()->create(array_merge([
+        'business_id'       => 1,
+        'numero'            => 'T-' . random_int(1000, 999999),
+        'tipo'              => 'receber',
+        'status'            => 'aberto',
+        'valor_total'       => 100,
+        'valor_aberto'      => 100,
+        'emissao'           => now()->toDateString(),
+        'vencimento'        => now()->addDays(5)->toDateString(),
+        'competencia_mes'   => now()->format('Y-m'),
+        'origem'            => 'manual',
+        'created_by'        => 1,
+    ], $attrs));
+}
+
+function novaCobranca(array $attrs = []): Cobranca
+{
+    return Cobranca::query()->create(array_merge([
+        'business_id'     => 1,
+        'tipo'            => 'pix_cob',
+        'status'          => 'emitida',
+        'valor_centavos'  => 15000,
+        'idempotency_key' => 'idem-' . random_int(1000, 999999),
+        'descricao'       => 'Teste',
+        'payload_gateway' => [],
+    ], $attrs));
+}
+
+beforeEach(function () {
+    pgEnsureSchema();
+});
+
+it('marca cobrança paga: status + valor_pago + paga_em + forma', function () {
+    $cobranca = novaCobranca();
+    $pagaEm = new DateTimeImmutable('2026-06-01 10:00:00');
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, $pagaEm, 'pix');
+
+    $cobranca->refresh();
+    expect($cobranca->status)->toBe('paga');
+    expect($cobranca->valor_pago_centavos)->toBe(15000);
+    expect($cobranca->forma_pagamento)->toBe('pix');
+    expect($cobranca->paga_em)->not->toBeNull();
+});
+
+it('dispara CobrancaPaga com dados corretos', function () {
+    Event::fake([CobrancaPaga::class]);
+    $cobranca = novaCobranca(['payer_cpf_cnpj' => '12345678900', 'origem_type' => 'sale', 'origem_id' => 77]);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    Event::assertDispatched(CobrancaPaga::class, function (CobrancaPaga $e) use ($cobranca) {
+        return $e->cobrancaId === (int) $cobranca->id
+            && $e->businessId === 1
+            && $e->valorPagoCentavos === 15000
+            && $e->formaPagamento === 'pix'
+            && $e->payerCpfCnpj === '12345678900'
+            && $e->origemType === 'sale'
+            && $e->origemId === 77;
+    });
+});
+
+it('quita título vinculado (origem manual + origem_id) status aberto → quitado, valor_aberto 0', function () {
+    $cobranca = novaCobranca();
+    $titulo = novoTitulo(['origem' => 'manual', 'origem_id' => (int) $cobranca->id, 'status' => 'aberto', 'valor_aberto' => 100]);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    $titulo->refresh();
+    expect($titulo->status)->toBe('quitado');
+    expect((float) $titulo->valor_aberto)->toBe(0.0);
+});
+
+it('quita também título com status parcial', function () {
+    $cobranca = novaCobranca();
+    $titulo = novoTitulo(['origem' => 'manual', 'origem_id' => (int) $cobranca->id, 'status' => 'parcial', 'valor_aberto' => 50]);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    expect($titulo->fresh()->status)->toBe('quitado');
+});
+
+it('NÃO toca título de outro origem_id', function () {
+    $cobranca = novaCobranca();
+    $outro = novoTitulo(['origem' => 'manual', 'origem_id' => 999999, 'status' => 'aberto']);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    expect($outro->fresh()->status)->toBe('aberto');
+});
+
+it('NÃO toca título já quitado', function () {
+    $cobranca = novaCobranca();
+    $jaQuitado = novoTitulo(['origem' => 'manual', 'origem_id' => (int) $cobranca->id, 'status' => 'quitado', 'valor_aberto' => 0]);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    expect($jaQuitado->fresh()->status)->toBe('quitado');
+});
+
+it('multi-tenant: título de outro business NÃO é tocado', function () {
+    $cobranca = novaCobranca();
+    $tituloBiz99 = novoTitulo(['business_id' => 99, 'origem' => 'manual', 'origem_id' => (int) $cobranca->id, 'status' => 'aberto']);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    expect($tituloBiz99->fresh()->status)->toBe('aberto');
+});
+
+it('idempotente: cobrança já paga não regride/duplica (status permanece paga)', function () {
+    $cobranca = novaCobranca(['status' => 'paga', 'valor_pago_centavos' => 15000, 'forma_pagamento' => 'pix']);
+
+    app(ReconciliarCobrancaService::class)->marcarPaga($cobranca, 1, 15000, new DateTimeImmutable(), 'pix');
+
+    expect($cobranca->fresh()->status)->toBe('paga');
+});


### PR DESCRIPTION
Complemento do #2158: traz o cert mTLS base64 inline (necessario pro polling usar o cert do install-biz.py) + suite de testes completa. Delta limpo a partir da main (sem re-adicionar o que o #2158 ja mergeou).

🤖 Generated with [Claude Code](https://claude.com/claude-code)