### PR TITLE
feat(prototipo-ui): kit DS v6 — showcase + receita + gabarito-vendas

### DIFF
--- a/prototipo-ui/ds-v6/README.md
+++ b/prototipo-ui/ds-v6/README.md
@@ -1,0 +1,27 @@
+# prototipo-ui / ds-v6 — kit DS v6 (proposta)
+
+> **Origem:** handoff bundle do Claude Design (claude.ai/design) — projeto *"Oimpresso ERP Conunicação Visual."*, sessão de design **2026-06-03 [CC]**. Landado verbatim como referência canônica do DS v6 (COWORK_NOTES → Pendentes #1: *"DS v6 (aprovado [W]) — landar showcase/receita"*).
+>
+> **Natureza:** protótipos estáticos HTML/CSS (self-contained, sem build). São **referência visual e de tokens** — não código de produção. A porta pra Inertia/React segue o MWART (ADR 0104) + gate visual (ADR 0107/0114) **quando [W] liberar a tela**.
+
+## Arquivos
+
+| Arquivo | É | Pra quê |
+|---|---|---|
+| [`showcase.html`](showcase.html) | **O kit** — *"o kit que faz toda tela nascer coerente"* | Tokens DS v6 (soma do v5 + tempero da sessão) + 11 componentes canônicos: buttons · status pill · stage dots · KPI stat · segmented tabs · plate · asset card · identity header · timeline · context-rail block · next-best-action. Fundamentos (swatches) + claro/escuro. |
+| [`receita.html`](receita.html) | **A receita** — *"como nascer uma tela"* | O método em 6 passos: comece pelo shell → monte com o kit (não escreva CSS de cor) → obedeça os tokens (claro/escuro de graça) → pense em fluxo, não em tela → faltou peça é buraco do DS (proponha, não invente) → feche com o gate. |
+| [`gabarito-vendas.html`](gabarito-vendas.html) | **O gabarito** da tela Vendas/`/sells` (Index/lista) | Aplicação do kit numa tela real, grounded em `Sells/Index.charter` v6: PageHeader v3 (FOCO/Caixa/Faturamento/Comissão) · 4 KPIs (Faturado hoje · Ticket · A receber+ageing · Notas) · tabela 10 colunas (FSM dots · fiscal badge · pagamento+SLA) · status canon (Paga/Pendente/Faturada/Cancelada) · bulk emit NF-e · drawer SaleSheet 480px. **Zero `oklch` cru** — 100% kit. Tema claro/escuro no botão.
+
+## Tokens DS v6 (resumo)
+
+- **Cor:** sistema `oklch` com par claro/escuro completo (`--bg/--sunken/--surface/--raised`, `--text..--text-4`, `--accent` roxo 295 canon, `--pos/--neg/--warn`, origens `--origin-{OS,CRM,FIN}`, etapas `--stage-{slate,indigo,rose,emerald,green}`).
+- **Forma:** raios `--r-2..--r-4` + `--r-pill`; sombras `--sh-1/--sh-3`.
+- **Tipo:** IBM Plex Sans (UI) + IBM Plex Mono (números/ids/datas).
+- **Tema:** `data-theme="dark"` no `<html>`, persistido em `localStorage` (`dsv6.theme`).
+
+> Regra de ouro (da `receita.html`): **não escreva cor crua — use o token.** Faltou componente, é buraco do DS: proponha ao kit, não improvise na tela.
+
+## Mapa pra produção (quando portar)
+
+- `gabarito-vendas.html` → `resources/js/Pages/Sells/Index.tsx` (hoje vivo, KB-9.75 aprovado [W]). A porta DS v6 é **Tier 0 / MWART** — exige gate visual + [W] aprovar screenshot antes de qualquer Edit.
+- `showcase.html` → fonte dos tokens/componentes pra `prototipo-ui/tokens.css` + `design-system.css` (REGISTRY_DS_COMPONENTES).

--- a/prototipo-ui/ds-v6/gabarito-vendas.html
+++ b/prototipo-ui/ds-v6/gabarito-vendas.html
@@ -1,0 +1,302 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Vendas — Gabarito DS v6 · Oimpresso</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg: oklch(0.992 0.0015 95); --sunken: oklch(0.974 0.003 95); --surface: oklch(1 0 0); --raised: oklch(1 0 0);
+  --border: oklch(0.905 0.004 95); --border-2: oklch(0.95 0.003 95);
+  --text: oklch(0.205 0.008 90); --text-2: oklch(0.46 0.007 90); --text-3: oklch(0.63 0.006 90); --text-4: oklch(0.74 0.005 90);
+  --accent: oklch(0.55 0.15 295); --accent-soft: oklch(0.965 0.022 295); --accent-line: oklch(0.86 0.05 295); --accent-fg: #fff;
+  --pos: oklch(0.50 0.12 150); --pos-soft: oklch(0.95 0.075 150); --neg: oklch(0.55 0.18 25); --neg-soft: oklch(0.955 0.055 25); --warn: oklch(0.58 0.12 70); --warn-soft: oklch(0.955 0.072 75);
+  --origin-OS-bg: oklch(0.95 0.045 70); --origin-OS-fg: oklch(0.45 0.10 60);
+  --origin-CRM-bg: oklch(0.94 0.04 245); --origin-CRM-fg: oklch(0.45 0.11 250);
+  --origin-FIN-bg: oklch(0.95 0.05 150); --origin-FIN-fg: oklch(0.40 0.10 150);
+  --stage-slate: oklch(0.58 0.025 250); --stage-indigo: oklch(0.55 0.16 270); --stage-rose: oklch(0.62 0.16 20); --stage-emerald: oklch(0.60 0.13 155); --stage-green: oklch(0.66 0.15 145);
+  --r-2: 8px; --r-3: 11px; --r-4: 16px; --r-pill: 999px;
+  --sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif; --mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  --sh-1: 0 1px 1px oklch(0.25 0.02 280/.05), 0 2px 4px -1px oklch(0.25 0.02 280/.07);
+  --sh-3: 0 4px 9px -4px oklch(0.25 0.02 280/.08), 0 14px 32px -8px oklch(0.25 0.02 280/.14);
+}
+[data-theme="dark"]{
+  --bg: oklch(0.165 0.008 282); --sunken: oklch(0.142 0.008 282); --surface: oklch(0.205 0.009 282); --raised: oklch(0.235 0.010 282);
+  --border: oklch(0.30 0.012 282); --border-2: oklch(0.25 0.010 282);
+  --text: oklch(0.965 0.004 282); --text-2: oklch(0.74 0.008 282); --text-3: oklch(0.58 0.009 282); --text-4: oklch(0.47 0.009 282);
+  --accent: oklch(0.72 0.15 295); --accent-soft: oklch(0.30 0.07 295); --accent-line: oklch(0.42 0.10 295); --accent-fg: oklch(0.14 0.02 295);
+  --pos: oklch(0.74 0.14 150); --pos-soft: oklch(0.30 0.085 150); --neg: oklch(0.72 0.16 25); --neg-soft: oklch(0.32 0.09 25); --warn: oklch(0.80 0.13 75); --warn-soft: oklch(0.32 0.085 70);
+  --origin-OS-bg: oklch(0.32 0.06 70); --origin-OS-fg: oklch(0.85 0.10 75);
+  --origin-CRM-bg: oklch(0.30 0.06 250); --origin-CRM-fg: oklch(0.82 0.10 250);
+  --origin-FIN-bg: oklch(0.30 0.06 150); --origin-FIN-fg: oklch(0.83 0.12 150);
+  --stage-slate: oklch(0.66 0.03 250); --stage-indigo: oklch(0.66 0.16 270); --stage-rose: oklch(0.68 0.16 20); --stage-emerald: oklch(0.68 0.14 155); --stage-green: oklch(0.74 0.15 145);
+  --sh-1: 0 1px 2px oklch(0 0 0/.3); --sh-3: 0 8px 18px -8px oklch(0 0 0/.5), 0 18px 40px -12px oklch(0 0 0/.55);
+}
+*{ box-sizing: border-box; }
+html,body{ margin: 0; }
+body{ background: var(--bg); color: var(--text); font-family: var(--sans); -webkit-font-smoothing: antialiased; }
+.top{ position: sticky; top: 0; z-index: 30; display: flex; align-items: center; gap: 12px; padding: 13px 28px; background: color-mix(in oklch, var(--bg) 86%, transparent); backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+.logo{ width: 28px; height: 28px; border-radius: 8px; background: linear-gradient(135deg, var(--accent), color-mix(in oklch, var(--accent) 60%, var(--text))); display: grid; place-items: center; color: var(--accent-fg); font-weight: 700; font-size: 12px; }
+.top b{ font-size: 14px; font-weight: 600; }
+.top .ver{ font-family: var(--mono); font-size: 10.5px; color: var(--accent); background: var(--accent-soft); padding: 2px 7px; border-radius: 999px; font-weight: 600; }
+.themeBtn{ margin-left: auto; appearance: none; cursor: pointer; font: inherit; height: 32px; padding: 0 13px; border-radius: 9px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 12px; font-weight: 500; }
+.wrap{ max-width: 1280px; margin: 0 auto; padding: 22px 28px 70px; }
+
+/* PageHeader v3: h1 + sub + subnav + primary */
+.pg-head{ display: flex; align-items: flex-start; gap: 16px; flex-wrap: wrap; }
+.pg-head h1{ font-size: 23px; font-weight: 600; letter-spacing: -0.025em; margin: 0; }
+.pg-head p{ margin: 3px 0 0; font-size: 12.5px; color: var(--text-3); }
+.subnav{ display: flex; gap: 2px; margin-top: 12px; }
+.subnav a{ font-size: 13px; font-weight: 500; color: var(--text-3); padding: 7px 13px; border-radius: 8px 8px 0 0; border-bottom: 2px solid transparent; cursor: pointer; }
+.subnav a.active{ color: var(--accent); border-bottom-color: var(--accent); font-weight: 600; }
+.pg-head-r{ margin-left: auto; }
+.c-btn{ appearance: none; cursor: pointer; font: inherit; display: inline-flex; align-items: center; gap: 7px; height: 36px; padding: 0 15px; border-radius: var(--r-2); border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 12.5px; font-weight: 500; }
+.c-btn.primary{ background: var(--accent); border-color: var(--accent); color: var(--accent-fg); font-weight: 600; }
+.c-btn.sm{ height: 30px; padding: 0 11px; font-size: 12px; }
+
+/* KPIs */
+.kpis{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 18px 0; }
+.c-kpi{ background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: 14px 16px; }
+.c-kpi small{ display: block; font-size: 10px; letter-spacing: .06em; text-transform: uppercase; color: var(--text-4); }
+.c-kpi b{ display: block; font-size: 24px; font-weight: 600; font-family: var(--mono); margin-top: 5px; letter-spacing: -0.02em; }
+.c-kpi .d{ font-size: 11px; color: var(--text-3); margin-top: 3px; }
+.c-kpi.pos b{ color: var(--pos); } .c-kpi.neg b{ color: var(--neg); }
+.ageing{ display: flex; height: 5px; border-radius: 3px; overflow: hidden; margin-top: 9px; gap: 1px; }
+.ageing i{ display: block; } .ageing .a0{ background: var(--pos); } .ageing .a1{ background: var(--warn); } .ageing .a2{ background: var(--neg); }
+.ageing-lbl{ display: flex; justify-content: space-between; font-size: 9.5px; color: var(--text-4); margin-top: 4px; font-family: var(--mono); }
+.fipair{ display: flex; gap: 14px; margin-top: 7px; }
+.fipair div{ font-size: 11px; color: var(--text-3); } .fipair b{ font-family: var(--mono); font-size: 15px; display: block; margin-top: 2px; }
+.fipair .ok b{ color: var(--pos); } .fipair .pend b{ color: var(--warn); }
+
+/* toolbar linha 2 */
+.toolbar{ display: flex; align-items: center; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.visao{ display: flex; gap: 2px; }
+.visao button{ appearance: none; cursor: pointer; border: 0; background: none; font: inherit; font-size: 12.5px; font-weight: 500; color: var(--text-3); padding: 6px 11px; border-radius: 8px; }
+.visao button.active{ background: var(--accent-soft); color: var(--accent); font-weight: 600; }
+.seg{ display: inline-flex; gap: 2px; background: var(--sunken); border: 1px solid var(--border); border-radius: var(--r-pill); padding: 2px; }
+.seg button{ appearance: none; cursor: pointer; border: 0; background: none; font: inherit; font-size: 11.5px; font-weight: 500; color: var(--text-3); padding: 4px 11px; border-radius: var(--r-pill); }
+.seg button.active{ background: var(--surface); color: var(--text); font-weight: 600; box-shadow: var(--sh-1); }
+.search{ margin-left: auto; display: flex; align-items: center; gap: 6px; height: 32px; padding: 0 11px; border: 1px solid var(--border); border-radius: 999px; background: var(--surface); color: var(--text-4); font-size: 12px; }
+
+/* tabela */
+.panel{ background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-4); overflow: hidden; }
+table{ width: 100%; border-collapse: collapse; }
+thead th{ font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; color: var(--text-4); text-align: left; padding: 11px 12px; border-bottom: 1px solid var(--border); background: var(--sunken); white-space: nowrap; }
+thead th.r{ text-align: right; } th.chk, td.chk{ width: 34px; text-align: center; }
+tbody td{ padding: 11px 12px; border-bottom: 1px solid var(--border-2); font-size: 12.5px; vertical-align: middle; }
+tbody tr{ cursor: pointer; transition: background .12s; }
+tbody tr:hover{ background: var(--sunken); }
+tbody tr:last-child td{ border-bottom: 0; }
+tbody tr.sel{ background: var(--accent-soft); }
+.vid{ font-family: var(--mono); font-weight: 600; color: var(--text-2); }
+.vdate{ font-family: var(--mono); color: var(--text-3); font-size: 11.5px; white-space: nowrap; }
+.vcli b{ font-weight: 600; } .vcli small{ display: block; font-size: 10.5px; color: var(--text-4); }
+.vatt{ display: inline-flex; align-items: center; gap: 6px; color: var(--text-2); }
+.vatt .av{ width: 20px; height: 20px; border-radius: 50%; background: var(--origin-CRM-bg); color: var(--origin-CRM-fg); display: grid; place-items: center; font-size: 8.5px; font-weight: 700; }
+.c-org{ font-family: var(--mono); font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 4px; }
+.c-org.os{ background: var(--origin-OS-bg); color: var(--origin-OS-fg); }
+.c-org.balcao{ background: var(--origin-CRM-bg); color: var(--origin-CRM-fg); }
+.c-org.online{ background: var(--origin-FIN-bg); color: var(--origin-FIN-fg); }
+.fsm{ display: inline-flex; gap: 4px; align-items: center; }
+.fsm i{ width: 8px; height: 8px; border-radius: 50%; background: var(--border); }
+.fsm i.on{ background: var(--stage-emerald); } .fsm i.cur{ background: var(--stage-green); box-shadow: 0 0 0 3px color-mix(in oklch,var(--stage-green) 24%,transparent); }
+.fbadge{ display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; font-weight: 600; font-family: var(--mono); padding: 2px 7px; border-radius: 5px; }
+.fbadge.ok{ background: var(--pos-soft); color: var(--pos); } .fbadge.pend{ background: var(--warn-soft); color: var(--warn); } .fbadge.na{ color: var(--text-4); }
+.pay small{ display: block; font-size: 10px; color: var(--text-4); }
+.sla{ font-size: 9.5px; font-weight: 600; padding: 1px 5px; border-radius: 4px; }
+.sla.ok{ background: var(--pos-soft); color: var(--pos); } .sla.due{ background: var(--neg-soft); color: var(--neg); }
+.vtot{ font-family: var(--mono); font-weight: 600; text-align: right; }
+.c-pill{ display: inline-flex; align-items: center; gap: 6px; font-size: 11px; font-weight: 600; padding: 3px 10px; border-radius: var(--r-pill); white-space: nowrap; }
+.c-pill::before{ content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.c-pill.paga{ background: var(--pos-soft); color: var(--pos); }
+.c-pill.pendente{ background: var(--warn-soft); color: var(--warn); }
+.c-pill.faturada{ background: var(--accent-soft); color: var(--accent); }
+.c-pill.cancelada{ background: var(--neg-soft); color: var(--neg); }
+input[type=checkbox]{ accent-color: var(--accent); width: 15px; height: 15px; }
+
+/* BulkActionBar */
+.bulkbar{ position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(140%); z-index: 40; display: flex; align-items: center; gap: 14px; background: var(--raised); border: 1px solid var(--border); border-radius: var(--r-pill); padding: 8px 10px 8px 18px; box-shadow: var(--sh-3); transition: transform .25s cubic-bezier(.22,1,.36,1); }
+.bulkbar.on{ transform: translateX(-50%) translateY(0); }
+.bulkbar b{ font-size: 12.5px; } .bulkbar .x{ color: var(--text-4); cursor: pointer; padding: 0 4px; }
+
+/* SaleSheet drawer 480px */
+.backdrop{ position: fixed; inset: 0; background: oklch(0.2 0.02 280/.45); opacity: 0; pointer-events: none; transition: opacity .2s; z-index: 50; }
+.backdrop.on{ opacity: 1; pointer-events: auto; }
+.sheet{ position: fixed; top: 0; right: 0; bottom: 0; width: 480px; max-width: 92vw; background: var(--surface); border-left: 1px solid var(--border); box-shadow: var(--sh-3); transform: translateX(101%); transition: transform .26s cubic-bezier(.22,1,.36,1); z-index: 51; display: flex; flex-direction: column; }
+.sheet.on{ transform: translateX(0); }
+.sheet-h{ display: flex; align-items: flex-start; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--border-2); }
+.sheet-h .eyebrow{ font-family: var(--mono); font-size: 11px; color: var(--text-4); }
+.sheet-h h2{ margin: 4px 0 0; font-size: 17px; font-weight: 600; letter-spacing: -0.02em; }
+.sheet-h .x{ margin-left: auto; cursor: pointer; color: var(--text-3); font-size: 20px; line-height: 1; }
+.sheet-b{ flex: 1 1 auto; overflow-y: auto; padding: 16px 20px; }
+.sheet-sec{ margin-bottom: 18px; }
+.sheet-sec h4{ font-size: 10px; font-weight: 700; letter-spacing: .07em; text-transform: uppercase; color: var(--text-4); margin: 0 0 9px; }
+.kv{ display: grid; grid-template-columns: auto 1fr; gap: 7px 12px; font-size: 12.5px; }
+.kv dt{ color: var(--text-4); } .kv dd{ margin: 0; text-align: right; color: var(--text-2); } .kv dd.mono{ font-family: var(--mono); }
+.nba{ border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--r-3); padding: 12px; background: var(--sunken); }
+.nba b{ display: block; font-size: 12.5px; margin-bottom: 4px; } .nba p{ margin: 0 0 10px; font-size: 11.5px; line-height: 1.5; color: var(--text-2); }
+.fislist{ display: flex; flex-direction: column; gap: 7px; }
+.fisrow{ display: flex; align-items: center; gap: 10px; padding: 9px 11px; border: 1px solid var(--border-2); border-radius: 9px; background: var(--sunken); font-size: 12px; }
+.fisrow b{ flex: 1 1 auto; } .fisrow small{ font-family: var(--mono); color: var(--text-4); }
+.sheet-f{ display: flex; gap: 8px; padding: 14px 20px; border-top: 1px solid var(--border-2); }
+.note{ display: flex; gap: 9px; align-items: center; margin: 22px 0 0; padding: 11px 14px; border-radius: var(--r-3); background: var(--accent-soft); border: 1px solid var(--accent-line); font-size: 12px; color: var(--text-2); }
+.note b{ color: var(--text); } code{ font-family: var(--mono); font-size: 11.5px; }
+@media (max-width:980px){ .kpis{ grid-template-columns: repeat(2,1fr); } .vatt span, td.col-att, th.col-att{ display: none; } }
+</style>
+</head>
+<body>
+<div class="top">
+  <div class="logo">Oi</div><b>Vendas</b><span class="ver">gabarito DS v6 · grounded /sells</span>
+  <button class="themeBtn" id="themeBtn">◐ Escuro</button>
+</div>
+
+<div class="wrap">
+  <div class="pg-head">
+    <div>
+      <h1>Vendas</h1>
+      <p>Pedidos · faturamento · NF-e/NFS-e</p>
+      <nav class="subnav">
+        <a class="active" data-sn>FOCO</a><a data-sn>Caixa</a><a data-sn>Faturamento</a><a data-sn>Comissão</a>
+      </nav>
+    </div>
+    <div class="pg-head-r"><button class="c-btn primary">+ Nova venda</button></div>
+  </div>
+
+  <div class="kpis">
+    <div class="c-kpi pos"><small>Faturado hoje</small><b>R$ 8.420</b><div class="d">▲ 12% vs ontem</div></div>
+    <div class="c-kpi"><small>Ticket médio</small><b>R$ 3.150</b><div class="d">+8% na semana</div></div>
+    <div class="c-kpi neg"><small>A receber</small><b>R$ 12.400</b>
+      <div class="ageing"><i class="a0" style="flex:6"></i><i class="a1" style="flex:3"></i><i class="a2" style="flex:1"></i></div>
+      <div class="ageing-lbl"><span>0-30d</span><span>31-60d</span><span>+60d</span></div>
+    </div>
+    <div class="c-kpi"><small>Notas fiscais · hoje</small>
+      <div class="fipair"><div class="ok"><b>21</b>autorizadas</div><div class="pend"><b>3</b>pendentes</div></div>
+    </div>
+  </div>
+
+  <div class="toolbar">
+    <div class="visao">
+      <button class="active" data-v>Todas</button><button data-v>Paga</button><button data-v>Pendente</button><button data-v>Faturada</button><button data-v>Cancelada</button>
+    </div>
+    <div class="seg">
+      <button class="active" data-sg>Operacional</button><button data-sg>Financeira</button><button data-sg>Produção</button>
+    </div>
+    <span class="search">⌕ placa · cliente · #venda</span>
+  </div>
+
+  <div class="panel">
+    <table>
+      <thead>
+        <tr>
+          <th class="chk"><input type="checkbox" id="all"/></th>
+          <th>Venda</th><th>Data</th><th>Cliente</th><th class="col-att">Atendido</th><th>Origem</th><th>Pipeline</th><th>Fiscal</th><th class="r">Total</th><th>Status</th>
+        </tr>
+      </thead>
+      <tbody id="rows"></tbody>
+    </table>
+  </div>
+
+  <div class="note">⚙️ <span><b>Gabarito grounded em <code>/sells</code> (Index.charter v6):</b> PageHeader v3 (FOCO/Caixa/Faturamento/Comissão) · KPIs reais (Faturado hoje · Ticket · A receber+ageing · Notas) · 10 colunas (FSM dots · fiscal badge · pagamento+SLA) · status canon (Paga/Pendente/Faturada/Cancelada) · bulk emit · drawer SaleSheet 480px. 100% kit DS v6, zero <code>oklch</code> cru — troque o tema.</span></div>
+</div>
+
+<!-- bulk bar -->
+<div class="bulkbar" id="bulkbar"><b><span id="bulkn">0</span> selecionadas</b><button class="c-btn sm primary">Emitir NF-e em lote</button><button class="c-btn sm">Cobrar</button><span class="x" id="bulkx">✕</span></div>
+
+<!-- drawer -->
+<div class="backdrop" id="bd"></div>
+<aside class="sheet" id="sheet">
+  <div class="sheet-h"><div><div class="eyebrow" id="shId">#4471 · Paga</div><h2 id="shCli">Frota Boa Esperança</h2></div><span class="x" id="shx">✕</span></div>
+  <div class="sheet-b">
+    <div class="sheet-sec"><h4>Resumo</h4><dl class="kv">
+      <dt>Data</dt><dd class="mono" id="shDate">26/05 14:20</dd>
+      <dt>Origem</dt><dd id="shOrg">Oficina · OS #8821</dd>
+      <dt>Atendido por</dt><dd id="shAtt">Larissa</dd>
+      <dt>Pagamento</dt><dd id="shPay">PIX · à vista</dd>
+      <dt>Total</dt><dd class="mono" id="shTot">R$ 5.440,00</dd>
+    </dl></div>
+    <div class="sheet-sec"><h4>Próxima ação · pipeline</h4>
+      <div class="nba"><b id="shNbaT">Pronta — fechar fiscal</b><p id="shNbaP">Venda paga. Emita a NF-e (peças) + NFS-e (serviço) pra fechar o ciclo.</p><button class="c-btn sm primary">Emitir notas</button></div>
+    </div>
+    <div class="sheet-sec"><h4>Fiscal</h4><div class="fislist">
+      <div class="fisrow"><b>NF-e 55 · peças</b><small id="shNfe">001.214</small><span class="fbadge ok">✓ autorizada</span></div>
+      <div class="fisrow"><b>NFS-e · serviço</b><small id="shNfse">000.087</small><span class="fbadge ok">✓ autorizada</span></div>
+    </div></div>
+  </div>
+  <div class="sheet-f"><button class="c-btn">WhatsApp</button><button class="c-btn">Criar OS</button><button class="c-btn primary" style="margin-left:auto">Abrir venda</button></div>
+</aside>
+
+<script>
+(function(){
+  var root = document.documentElement, btn = document.getElementById('themeBtn');
+  try{ var s = localStorage.getItem('dsv6.theme'); if(s) root.dataset.theme = s; }catch(e){}
+  function tl(){ btn.textContent = (root.dataset.theme === 'dark' ? '◐ Escuro' : '◑ Claro'); }
+  tl(); btn.onclick = function(){ root.dataset.theme = (root.dataset.theme==='dark'?'light':'dark'); try{localStorage.setItem('dsv6.theme',root.dataset.theme);}catch(e){} tl(); };
+
+  // dados grounded no modelo /sells (origem · FSM · fiscal · pagamento · status)
+  var VENDAS = [
+    { id:"4471", date:"26/05 14:20", cli:"Frota Boa Esperança", sub:"VW Constellation · OS #8821", att:"LA", attn:"Larissa", org:"os", orgl:"OFICINA", orgf:"Oficina · OS #8821", fsm:5, fis:["ok","NF-e 001.214"], pay:"PIX · à vista", sla:"", tot:"R$ 5.440", st:"paga", nbaT:"Pronta — fechar fiscal", nbaP:"Venda paga. Emita NF-e (peças) + NFS-e (serviço)." },
+    { id:"4470", date:"26/05 11:05", cli:"Transportes Lima", sub:"4 pneus + alinhamento", att:"WR", attn:"Wagner", org:"balcao", orgl:"BALCÃO", orgf:"Balcão", fsm:3, fis:["pend","—"], pay:"Boleto · 2×", sla:"due", tot:"R$ 1.280", st:"pendente", nbaT:"Cobrar na entrega", nbaP:"Cliente retira hoje · boleto em aberto. Cobre no balcão." },
+    { id:"4468", date:"25/05 16:40", cli:"Construtora Lince", sub:"Suspensão · OS #8807", att:"LA", attn:"Larissa", org:"os", orgl:"OFICINA", orgf:"Oficina · OS #8807", fsm:2, fis:["na","—"], pay:"A definir", sla:"", tot:"R$ 2.250", st:"pendente", nbaT:"Aguardando aprovação", nbaP:"Orçamento enviado ao cliente. Sem execução até o OK." },
+    { id:"4465", date:"25/05 09:12", cli:"Auto Posto Vale", sub:"Óleo + filtros", att:"WR", attn:"Wagner", org:"balcao", orgl:"BALCÃO", orgf:"Balcão", fsm:5, fis:["ok","NFC-e 04.881"], pay:"Cartão · à vista", sla:"ok", tot:"R$ 880", st:"faturada", nbaT:"Faturada", nbaP:"NFC-e autorizada. Nada pendente." },
+    { id:"4462", date:"24/05 15:30", cli:"Frota Boa Esperança", sub:"4 pneus Iveco", att:"LA", attn:"Larissa", org:"online", orgl:"ONLINE", orgf:"Online · portal", fsm:5, fis:["ok","NF-e 001.190"], pay:"PIX · à vista", sla:"ok", tot:"R$ 3.840", st:"paga", nbaT:"Concluída", nbaP:"Pago e faturado." },
+    { id:"4459", date:"23/05 10:48", cli:"Mecânica do Zé", sub:"Cancelada pelo cliente", att:"WR", attn:"Wagner", org:"balcao", orgl:"BALCÃO", orgf:"Balcão", fsm:0, fis:["na","—"], pay:"—", sla:"", tot:"R$ 640", st:"cancelada", nbaT:"Cancelada", nbaP:"Venda cancelada · sem nota emitida." },
+  ];
+  function fsmDots(n){ var h=""; for(var i=0;i<5;i++){ h += '<i class="'+(i<n-1?'on':i===n-1&&n>0?'cur':'')+'"></i>'; } return '<span class="fsm">'+h+'</span>'; }
+  function fbadge(f){ var c=f[0]; return '<span class="fbadge '+c+'">'+(c==='ok'?'✓ '+f[1]:c==='pend'?'⧖ pendente':'—')+'</span>'; }
+  var rows = document.getElementById('rows');
+  rows.innerHTML = VENDAS.map(function(v){
+    return '<tr data-id="'+v.id+'">'
+      + '<td class="chk"><input type="checkbox" class="rc"/></td>'
+      + '<td><span class="vid">#'+v.id+'</span></td>'
+      + '<td><span class="vdate">'+v.date+'</span></td>'
+      + '<td class="vcli"><b>'+v.cli+'</b><small>'+v.sub+'</small></td>'
+      + '<td class="col-att"><span class="vatt"><span class="av">'+v.att+'</span><span>'+v.attn+'</span></span></td>'
+      + '<td><span class="c-org '+v.org+'">'+v.orgl+'</span></td>'
+      + '<td>'+fsmDots(v.fsm)+'</td>'
+      + '<td>'+fbadge(v.fis)+'</td>'
+      + '<td class="vtot">'+v.tot+'</td>'
+      + '<td><span class="c-pill '+v.st+'">'+v.st.charAt(0).toUpperCase()+v.st.slice(1)+'</span></td>'
+      + '</tr>';
+  }).join('');
+
+  // drawer
+  var bd=document.getElementById('bd'), sheet=document.getElementById('sheet');
+  function openSheet(v){
+    document.getElementById('shId').textContent='#'+v.id+' · '+v.st.charAt(0).toUpperCase()+v.st.slice(1);
+    document.getElementById('shCli').textContent=v.cli;
+    document.getElementById('shDate').textContent=v.date;
+    document.getElementById('shOrg').textContent=v.orgf;
+    document.getElementById('shAtt').textContent=v.attn;
+    document.getElementById('shPay').textContent=v.pay;
+    document.getElementById('shTot').textContent=v.tot+',00';
+    document.getElementById('shNbaT').textContent=v.nbaT;
+    document.getElementById('shNbaP').textContent=v.nbaP;
+    bd.classList.add('on'); sheet.classList.add('on');
+  }
+  function closeSheet(){ bd.classList.remove('on'); sheet.classList.remove('on'); document.querySelectorAll('#rows tr').forEach(function(r){r.classList.remove('sel');}); }
+  document.querySelectorAll('#rows tr').forEach(function(r){
+    r.addEventListener('click', function(e){
+      if(e.target.classList.contains('rc')) return;
+      document.querySelectorAll('#rows tr').forEach(function(x){x.classList.remove('sel');}); r.classList.add('sel');
+      var v=VENDAS.find(function(x){return x.id===r.dataset.id;}); openSheet(v);
+    });
+  });
+  document.getElementById('shx').onclick=closeSheet; bd.onclick=closeSheet;
+
+  // subnav / visão / segmented
+  function group(sel,attr){ document.querySelectorAll(sel).forEach(function(b){ b.addEventListener('click', function(){ document.querySelectorAll(sel).forEach(function(x){x.classList.remove('active');}); b.classList.add('active'); }); }); }
+  group('[data-sn]'); group('[data-v]'); group('[data-sg]');
+
+  // bulk
+  var bulk=document.getElementById('bulkbar'), bn=document.getElementById('bulkn');
+  function refreshBulk(){ var n=document.querySelectorAll('.rc:checked').length; bn.textContent=n; bulk.classList.toggle('on', n>0); }
+  document.querySelectorAll('.rc').forEach(function(c){ c.addEventListener('change', refreshBulk); });
+  document.getElementById('all').addEventListener('change', function(e){ document.querySelectorAll('.rc').forEach(function(c){c.checked=e.target.checked;}); refreshBulk(); });
+  document.getElementById('bulkx').onclick=function(){ document.querySelectorAll('.rc,#all').forEach(function(c){c.checked=false;}); refreshBulk(); };
+})();
+</script>
+</body>
+</html>

--- a/prototipo-ui/ds-v6/receita.html
+++ b/prototipo-ui/ds-v6/receita.html
@@ -1,0 +1,170 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Oimpresso DS · v6 — Receita de Tela</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg: oklch(0.992 0.0015 95); --sunken: oklch(0.974 0.003 95); --surface: oklch(1 0 0);
+  --border: oklch(0.905 0.004 95); --border-2: oklch(0.95 0.003 95);
+  --text: oklch(0.205 0.008 90); --text-2: oklch(0.46 0.007 90); --text-3: oklch(0.63 0.006 90); --text-4: oklch(0.74 0.005 90);
+  --accent: oklch(0.55 0.15 295); --accent-soft: oklch(0.965 0.022 295); --accent-line: oklch(0.86 0.05 295); --accent-fg: #fff;
+  --pos: oklch(0.50 0.12 150); --pos-soft: oklch(0.95 0.075 150); --neg: oklch(0.55 0.18 25); --warn: oklch(0.58 0.12 70);
+  --r-2: 8px; --r-3: 11px; --r-4: 16px;
+  --sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif; --mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+}
+[data-theme="dark"]{
+  --bg: oklch(0.165 0.008 282); --sunken: oklch(0.142 0.008 282); --surface: oklch(0.205 0.009 282);
+  --border: oklch(0.30 0.012 282); --border-2: oklch(0.25 0.010 282);
+  --text: oklch(0.965 0.004 282); --text-2: oklch(0.74 0.008 282); --text-3: oklch(0.58 0.009 282); --text-4: oklch(0.47 0.009 282);
+  --accent: oklch(0.72 0.15 295); --accent-soft: oklch(0.30 0.07 295); --accent-line: oklch(0.42 0.10 295); --accent-fg: oklch(0.14 0.02 295);
+  --pos: oklch(0.74 0.14 150); --pos-soft: oklch(0.30 0.085 150); --neg: oklch(0.72 0.16 25); --warn: oklch(0.80 0.13 75);
+}
+*{ box-sizing: border-box; }
+html,body{ margin: 0; }
+body{ background: var(--bg); color: var(--text); font-family: var(--sans); -webkit-font-smoothing: antialiased; }
+.top{ position: sticky; top: 0; z-index: 10; display: flex; align-items: center; gap: 13px; padding: 16px 32px; background: color-mix(in oklch, var(--bg) 86%, transparent); backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+.logo{ width: 30px; height: 30px; border-radius: 8px; background: linear-gradient(135deg, var(--accent), color-mix(in oklch, var(--accent) 60%, var(--text))); display: grid; place-items: center; color: var(--accent-fg); font-weight: 700; font-size: 13px; }
+.top b{ font-size: 15px; font-weight: 600; }
+.top .ver{ font-family: var(--mono); font-size: 11px; color: var(--accent); background: var(--accent-soft); padding: 2px 8px; border-radius: 999px; font-weight: 600; }
+.themeBtn{ margin-left: auto; appearance: none; cursor: pointer; font: inherit; height: 34px; padding: 0 14px; border-radius: 9px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 12.5px; font-weight: 500; }
+
+.wrap{ max-width: 880px; margin: 0 auto; padding: 40px 32px 90px; }
+h1{ font-size: 30px; font-weight: 600; letter-spacing: -0.03em; margin: 0 0 10px; }
+.lead{ font-size: 14.5px; line-height: 1.6; color: var(--text-2); margin: 0 0 8px; }
+.step{ display: flex; gap: 16px; margin: 40px 0 0; }
+.step-n{ flex: 0 0 auto; width: 34px; height: 34px; border-radius: 10px; background: var(--accent-soft); color: var(--accent); display: grid; place-items: center; font-family: var(--mono); font-weight: 700; font-size: 14px; border: 1px solid var(--accent-line); }
+.step-b{ flex: 1 1 auto; min-width: 0; }
+.step-b h2{ font-size: 18px; font-weight: 600; letter-spacing: -0.02em; margin: 4px 0 8px; }
+.step-b p{ font-size: 13.5px; line-height: 1.6; color: var(--text-2); margin: 0 0 12px; }
+.card{ background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-4); padding: 16px 18px; margin: 12px 0; }
+.chk{ list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 9px; }
+.chk li{ display: flex; align-items: flex-start; gap: 10px; font-size: 13px; line-height: 1.45; }
+.chk .tick{ flex: 0 0 auto; width: 18px; height: 18px; border-radius: 6px; background: var(--pos-soft); color: var(--pos); display: grid; place-items: center; margin-top: 1px; }
+.chk b{ color: var(--text); }
+.chk code, code.k{ font-family: var(--mono); font-size: 11.5px; color: var(--accent); background: var(--accent-soft); padding: 1px 6px; border-radius: 4px; }
+pre{ margin: 0; background: var(--sunken); border: 1px solid var(--border); border-radius: var(--r-3); padding: 15px 16px; overflow-x: auto; font-family: var(--mono); font-size: 12px; line-height: 1.65; color: var(--text-2); }
+pre .t{ color: var(--text-4); } pre .a{ color: var(--accent); } pre .c{ color: var(--pos); }
+.loop{ display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 6px; }
+.loop span{ font-size: 12px; font-weight: 500; padding: 6px 11px; border-radius: 8px; background: var(--sunken); border: 1px solid var(--border-2); }
+.loop b{ color: var(--accent); }
+.arrow{ color: var(--text-4); }
+.principios{ display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin: 12px 0; }
+.princ{ border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--r-3); padding: 12px 14px; }
+.princ b{ display: block; font-size: 13px; margin-bottom: 3px; }
+.princ small{ font-size: 11.5px; color: var(--text-3); line-height: 1.4; }
+.no{ border-left-color: var(--neg); } .no b{ color: var(--neg); }
+@media (max-width:640px){ .principios{ grid-template-columns: 1fr; } }
+</style>
+</head>
+<body>
+<div class="top">
+  <div class="logo">Oi</div><b>Receita de Tela</b><span class="ver">DS v6</span>
+  <button class="themeBtn" id="themeBtn">◐ Escuro</button>
+</div>
+
+<div class="wrap">
+  <h1>Como nascer uma tela.</h1>
+  <p class="lead">A tela não se desenha do zero — ela se <b>monta</b> do kit. Esta receita é a ordem que faz qualquer tela nova já nascer coerente, bonita e em claro/escuro. Quem segue, passa no lint e na crítica sem retrabalho.</p>
+
+  <div class="step">
+    <div class="step-n">1</div>
+    <div class="step-b">
+      <h2>Comece pelo shell, não pela tela</h2>
+      <p>Toda tela mora no <b>Cockpit V2</b>: sidebar (dark-fixo) · header · corpo · e <b>rail de contexto</b> ou drawer. Não reinvente o esqueleto — só preencha o corpo.</p>
+      <pre><span class="t">&lt;!-- corpo da tela: container + tokens, nada de cor crua --&gt;</span>
+&lt;div class="<span class="a">minha-tela</span>"&gt;
+  &lt;header&gt; <span class="c">c-id</span> (header de identidade) + ações &lt;/header&gt;
+  &lt;div class="kpis"&gt; <span class="c">c-kpi</span> × N &lt;/div&gt;
+  &lt;main&gt; conteúdo + <span class="c">c-tl</span> / <span class="c">c-asset</span> ... &lt;/main&gt;
+  &lt;aside&gt; <span class="c">c-rail</span> + <span class="c">c-nba</span> (contexto / Jana) &lt;/aside&gt;
+&lt;/div&gt;</pre>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-n">2</div>
+    <div class="step-b">
+      <h2>Monte com o kit — não escreva CSS de cor</h2>
+      <p>Pegue as peças do Showcase. Se precisa de algo que o kit não tem, é sinal de buraco no DS (passo 5), não de CSS novo.</p>
+      <div class="card"><ul class="chk">
+        <li><span class="tick">✓</span><div><b>Header de identidade</b> <code class="k">.c-id</code> — cliente/frota/OS no topo.</div></li>
+        <li><span class="tick">✓</span><div><b>KPI / stat</b> <code class="k">.c-kpi</code> — número grande, tom semântico quando importa.</div></li>
+        <li><span class="tick">✓</span><div><b>Pílula de status</b> <code class="k">.c-pill</code> + <b>etapas</b> <code class="k">.c-stage</code>.</div></li>
+        <li><span class="tick">✓</span><div><b>Timeline unificada</b> <code class="k">.c-tl</code> · <b>card de ativo</b> <code class="k">.c-asset</code>.</div></li>
+        <li><span class="tick">✓</span><div><b>Rail de contexto</b> <code class="k">.c-rail</code> + <b>próxima-ação</b> <code class="k">.c-nba</code>.</div></li>
+      </ul></div>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-n">3</div>
+    <div class="step-b">
+      <h2>Obedeça os tokens — o claro/escuro sai de graça</h2>
+      <div class="principios">
+        <div class="princ"><b>Cor = token</b><small>Só <code class="k">--accent</code>, <code class="k">--pos/neg/warn</code>, <code class="k">--origin-*</code>, <code class="k">--stage-*</code>. O roxo 295 é a marca.</small></div>
+        <div class="princ"><b>Superfície em camada</b><small><code class="k">--bg → sunken → surface → raised</code>. Borda sempre <code class="k">--border</code>.</small></div>
+        <div class="princ no"><b>Nunca oklch cru</b><small>Cor escrita à mão não flipa no tema e quebra o lint. Zero exceções.</small></div>
+        <div class="princ no"><b>Nunca modal pra detalhe</b><small>Detalhe = rail ou drawer lateral. Densidade pro 1280 da Larissa.</small></div>
+      </div>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-n">4</div>
+    <div class="step-b">
+      <h2>Pense em fluxo, não em tela</h2>
+      <p>Pergunte: <b>de onde o dado vem</b> e <b>pra onde ele vai</b>? Desenhe a <b>costura</b> (a passagem pro próximo módulo) — é onde o ERP ganha ou perde. Surfe o contexto cross-módulo no rail.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-n">5</div>
+    <div class="step-b">
+      <h2>Faltou peça? É buraco do DS — proponha, não invente</h2>
+      <p>Esse é o ciclo que mantém o sistema vivo (foi assim que a paleta <code class="k">--stage-*</code> nasceu):</p>
+      <div class="loop">
+        <span>monto a tela</span><span class="arrow">→</span>
+        <span>sobra cor/peça <b>crua</b></span><span class="arrow">→</span>
+        <span>isso é <b>buraco do DS</b></span><span class="arrow">→</span>
+        <span>vira <b>token/componente</b></span><span class="arrow">→</span>
+        <span>harmonizo</span>
+      </div>
+      <p style="margin-top:14px">Mudança no DS é <b>Tier-0</b> (decisão de [W], vira ADR). Eu <b>proponho</b>; nunca cunho versão sozinho.</p>
+    </div>
+  </div>
+
+  <div class="step">
+    <div class="step-n">6</div>
+    <div class="step-b">
+      <h2>Feche com o gate</h2>
+      <div class="card"><ul class="chk">
+        <li><span class="tick">✓</span><div>Passa nos <b>dois temas</b> (toggle claro/escuro, nada quebra).</div></li>
+        <li><span class="tick">✓</span><div><b>Zero oklch cru</b> (lint verde) · só componentes do kit.</div></li>
+        <li><span class="tick">✓</span><div>Legível e denso no <b>1280</b> (persona balcão).</div></li>
+        <li><span class="tick">✓</span><div>A <b>costura</b> pro próximo módulo está explícita.</div></li>
+        <li><span class="tick">✓</span><div>Aprovação visual de [W] (F2) → ponte pro Code.</div></li>
+      </ul></div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function(){
+  var root = document.documentElement, btn = document.getElementById('themeBtn');
+  try{ var s = localStorage.getItem('dsv6.theme'); if(s) root.dataset.theme = s; }catch(e){}
+  function label(){ btn.textContent = (root.dataset.theme === 'dark' ? '◐ Escuro' : '◑ Claro'); }
+  label();
+  btn.addEventListener('click', function(){
+    root.dataset.theme = (root.dataset.theme === 'dark' ? 'light' : 'dark');
+    try{ localStorage.setItem('dsv6.theme', root.dataset.theme); }catch(e){}
+    label();
+  });
+})();
+</script>
+</body>
+</html>

--- a/prototipo-ui/ds-v6/showcase.html
+++ b/prototipo-ui/ds-v6/showcase.html
@@ -1,0 +1,381 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Oimpresso DS · v6 — Showcase</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+/* ═══════════════ TOKENS — DS v6 (proposta · soma do v5 + tempero da sessão) ═══════════════ */
+:root{
+  --bg: oklch(0.992 0.0015 95); --sunken: oklch(0.974 0.003 95); --surface: oklch(1 0 0); --raised: oklch(1 0 0);
+  --hairline: oklch(0.935 0.003 95); --border: oklch(0.905 0.004 95); --border-2: oklch(0.95 0.003 95);
+  --text: oklch(0.205 0.008 90); --text-2: oklch(0.46 0.007 90); --text-3: oklch(0.63 0.006 90); --text-4: oklch(0.74 0.005 90);
+  --accent: oklch(0.55 0.15 295); --accent-hi: oklch(0.50 0.16 295); --accent-soft: oklch(0.965 0.022 295); --accent-line: oklch(0.86 0.05 295); --accent-fg: #fff;
+  --pos: oklch(0.50 0.12 150); --pos-soft: oklch(0.95 0.075 150);
+  --neg: oklch(0.55 0.18 25);  --neg-soft: oklch(0.955 0.055 25);
+  --warn: oklch(0.58 0.12 70); --warn-soft: oklch(0.955 0.072 75);
+  --info: var(--accent); --info-soft: var(--accent-soft);
+  --origin-OS-bg: oklch(0.95 0.045 70); --origin-OS-fg: oklch(0.45 0.10 60);
+  --origin-CRM-bg: oklch(0.94 0.04 245); --origin-CRM-fg: oklch(0.45 0.11 250);
+  --origin-FIN-bg: oklch(0.95 0.05 150); --origin-FIN-fg: oklch(0.40 0.10 150);
+  --stage-slate: oklch(0.58 0.025 250); --stage-indigo: oklch(0.55 0.16 270); --stage-rose: oklch(0.62 0.16 20); --stage-emerald: oklch(0.60 0.13 155); --stage-green: oklch(0.66 0.15 145);
+  --sh-1: 0 1px 1px oklch(0.25 0.02 280/.05), 0 2px 4px -1px oklch(0.25 0.02 280/.07);
+  --sh-2: 0 2px 4px -2px oklch(0.25 0.02 280/.06), 0 6px 16px -5px oklch(0.25 0.02 280/.11);
+  --sh-3: 0 4px 9px -4px oklch(0.25 0.02 280/.08), 0 14px 32px -8px oklch(0.25 0.02 280/.14);
+  --r-1: 5px; --r-2: 8px; --r-3: 11px; --r-4: 16px; --r-pill: 999px;
+  --sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif; --mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+}
+[data-theme="dark"]{
+  --bg: oklch(0.165 0.008 282); --sunken: oklch(0.142 0.008 282); --surface: oklch(0.205 0.009 282); --raised: oklch(0.235 0.010 282);
+  --hairline: oklch(0.27 0.010 282); --border: oklch(0.30 0.012 282); --border-2: oklch(0.25 0.010 282);
+  --text: oklch(0.965 0.004 282); --text-2: oklch(0.74 0.008 282); --text-3: oklch(0.58 0.009 282); --text-4: oklch(0.47 0.009 282);
+  --accent: oklch(0.72 0.15 295); --accent-hi: oklch(0.78 0.15 295); --accent-soft: oklch(0.30 0.07 295); --accent-line: oklch(0.42 0.10 295); --accent-fg: oklch(0.14 0.02 295);
+  --pos: oklch(0.74 0.14 150); --pos-soft: oklch(0.30 0.085 150);
+  --neg: oklch(0.72 0.16 25);  --neg-soft: oklch(0.32 0.09 25);
+  --warn: oklch(0.80 0.13 75); --warn-soft: oklch(0.32 0.085 70);
+  --origin-OS-bg: oklch(0.32 0.06 70); --origin-OS-fg: oklch(0.85 0.10 75);
+  --origin-CRM-bg: oklch(0.30 0.06 250); --origin-CRM-fg: oklch(0.82 0.10 250);
+  --origin-FIN-bg: oklch(0.30 0.06 150); --origin-FIN-fg: oklch(0.83 0.12 150);
+  --stage-slate: oklch(0.66 0.03 250); --stage-indigo: oklch(0.66 0.16 270); --stage-rose: oklch(0.68 0.16 20); --stage-emerald: oklch(0.68 0.14 155); --stage-green: oklch(0.74 0.15 145);
+  --sh-1: 0 1px 2px oklch(0 0 0/.3); --sh-2: 0 3px 8px -3px oklch(0 0 0/.42), 0 8px 20px -6px oklch(0 0 0/.4); --sh-3: 0 8px 18px -8px oklch(0 0 0/.5), 0 18px 40px -12px oklch(0 0 0/.55);
+}
+*{ box-sizing: border-box; }
+html,body{ margin: 0; }
+body{ background: var(--bg); color: var(--text); font-family: var(--sans); -webkit-font-smoothing: antialiased; }
+
+/* ── chrome ── */
+.ds-top{ position: sticky; top: 0; z-index: 10; display: flex; align-items: center; gap: 14px; padding: 16px 32px; background: color-mix(in oklch, var(--bg) 86%, transparent); backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+.ds-logo{ width: 30px; height: 30px; border-radius: 8px; background: linear-gradient(135deg, var(--accent), color-mix(in oklch, var(--accent) 60%, var(--text))); display: grid; place-items: center; color: var(--accent-fg); font-weight: 700; font-size: 13px; }
+.ds-top b{ font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
+.ds-top .ver{ font-family: var(--mono); font-size: 11px; color: var(--accent); background: var(--accent-soft); padding: 2px 8px; border-radius: 999px; font-weight: 600; }
+.ds-top .tag{ font-size: 11px; color: var(--text-3); }
+.ds-theme{ margin-left: auto; appearance: none; cursor: pointer; font: inherit; display: inline-flex; align-items: center; gap: 8px; height: 34px; padding: 0 14px; border-radius: 9px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 12.5px; font-weight: 500; }
+.ds-theme:hover{ border-color: var(--accent-line); }
+
+.ds-wrap{ max-width: 1180px; margin: 0 auto; padding: 36px 32px 80px; }
+.ds-intro{ margin-bottom: 40px; }
+.ds-intro h1{ font-size: 30px; font-weight: 600; letter-spacing: -0.03em; margin: 0 0 10px; }
+.ds-intro p{ font-size: 14.5px; line-height: 1.6; color: var(--text-2); max-width: 64ch; margin: 0; }
+.ds-group-h{ font-size: 11px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; color: var(--text-4); margin: 48px 0 18px; padding-bottom: 10px; border-bottom: 1px solid var(--border); }
+
+/* spec card: nome + uso + demo */
+.ds-grid{ display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 18px; }
+.spec{ background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-4); overflow: hidden; box-shadow: var(--sh-1); }
+.spec.wide{ grid-column: 1 / -1; }
+.spec.half{ grid-column: span 1; }
+.spec-h{ padding: 14px 18px 12px; border-bottom: 1px solid var(--border-2); }
+.spec-h b{ font-size: 13.5px; font-weight: 600; }
+.spec-h code{ font-family: var(--mono); font-size: 10.5px; color: var(--accent); background: var(--accent-soft); padding: 1px 6px; border-radius: 4px; margin-left: 7px; }
+.spec-h p{ margin: 5px 0 0; font-size: 12px; color: var(--text-3); line-height: 1.45; }
+.spec-demo{ padding: 20px 18px; background: var(--sunken); display: flex; flex-wrap: wrap; gap: 12px; align-items: center; }
+.spec-demo.col{ flex-direction: column; align-items: stretch; }
+
+/* ════════ swatches (fundamentos) ════════ */
+.sw-row{ display: flex; flex-wrap: wrap; gap: 10px; }
+.sw{ display: flex; flex-direction: column; gap: 6px; }
+.sw-chip{ width: 88px; height: 52px; border-radius: var(--r-2); border: 1px solid var(--border); }
+.sw small{ font-size: 10.5px; color: var(--text-3); font-family: var(--mono); }
+.sw b{ font-size: 11px; font-weight: 600; }
+
+/* ════════ COMPONENTES ════════ */
+/* buttons */
+.c-btn{ appearance: none; cursor: pointer; font: inherit; display: inline-flex; align-items: center; gap: 7px; height: 36px; padding: 0 16px; border-radius: var(--r-2); border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 13px; font-weight: 500; }
+.c-btn.primary{ background: var(--accent); border-color: var(--accent); color: var(--accent-fg); font-weight: 600; }
+.c-btn.danger{ background: var(--neg); border-color: var(--neg); color: #fff; font-weight: 600; }
+.c-btn.ghost{ background: transparent; border-color: transparent; color: var(--text-2); }
+
+/* status pill */
+.c-pill{ display: inline-flex; align-items: center; gap: 6px; font-size: 11.5px; font-weight: 600; padding: 3px 10px; border-radius: var(--r-pill); }
+.c-pill::before{ content: ""; width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.c-pill.pos{ background: var(--pos-soft); color: var(--pos); }
+.c-pill.neg{ background: var(--neg-soft); color: var(--neg); }
+.c-pill.warn{ background: var(--warn-soft); color: var(--warn); }
+.c-pill.info{ background: var(--accent-soft); color: var(--accent); }
+
+/* stage dots */
+.c-stage{ display: inline-flex; align-items: center; gap: 7px; font-size: 12px; color: var(--text-2); }
+.c-stage i{ width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+
+/* KPI stat */
+.c-kpi{ background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: 14px 16px; min-width: 150px; }
+.c-kpi small{ display: block; font-size: 10px; letter-spacing: .06em; text-transform: uppercase; color: var(--text-4); }
+.c-kpi b{ display: block; font-size: 24px; font-weight: 600; font-family: var(--mono); margin-top: 5px; letter-spacing: -0.02em; }
+.c-kpi.neg b{ color: var(--neg); } .c-kpi.pos b{ color: var(--pos); }
+
+/* segmented tabs */
+.c-tabs{ display: inline-flex; gap: 2px; background: var(--sunken); border: 1px solid var(--border); border-radius: var(--r-pill); padding: 2px; }
+.c-tab{ appearance: none; cursor: pointer; border: 0; background: none; font: inherit; font-size: 12px; font-weight: 500; color: var(--text-3); padding: 5px 14px; border-radius: var(--r-pill); }
+.c-tab.active{ background: var(--surface); color: var(--text); font-weight: 600; box-shadow: var(--sh-1); }
+
+/* plate */
+.c-plate{ display: inline-flex; flex-direction: column; border: 1.5px solid var(--text-3); border-radius: var(--r-1); overflow: hidden; }
+.c-plate .pt{ background: oklch(0.42 0.13 250); color: #fff; font-size: 7px; text-align: center; padding: 1px 8px; letter-spacing: .05em; font-weight: 600; }
+.c-plate .pn{ font-family: var(--mono); font-weight: 700; font-size: 16px; text-align: center; padding: 3px 0; }
+
+/* asset card */
+.c-asset{ width: 230px; background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--warn); border-radius: var(--r-3); padding: 13px 14px; }
+.c-asset-top{ display: flex; align-items: center; gap: 8px; margin-bottom: 9px; }
+.c-asset-top .ic{ color: var(--text-3); }
+.c-asset-mod{ font-size: 13.5px; font-weight: 600; margin-bottom: 9px; }
+.c-asset-foot{ display: flex; justify-content: space-between; margin-top: 10px; font-size: 11px; }
+.c-asset-foot .mono{ font-family: var(--mono); color: var(--text-3); } .c-asset-foot .rev{ color: var(--warn); font-weight: 500; }
+
+/* identity header */
+.c-id{ display: flex; align-items: center; gap: 14px; width: 100%; }
+.c-id-av{ width: 48px; height: 48px; border-radius: 13px; background: linear-gradient(135deg, var(--origin-CRM-fg), color-mix(in oklch, var(--origin-CRM-fg) 70%, var(--accent))); color: #fff; display: grid; place-items: center; font-weight: 700; font-size: 16px; flex: 0 0 auto; }
+.c-id-name{ font-size: 18px; font-weight: 600; letter-spacing: -0.02em; display: flex; align-items: center; gap: 9px; }
+.c-id-sub{ font-size: 12px; color: var(--text-3); margin-top: 2px; }
+.c-id-acts{ margin-left: auto; display: flex; gap: 7px; }
+
+/* timeline */
+.c-tl{ width: 100%; display: flex; flex-direction: column; }
+.c-tl-row{ display: grid; grid-template-columns: 10px 58px 1fr auto; gap: 11px; align-items: center; padding: 9px 2px; border-bottom: 1px solid var(--border-2); }
+.c-tl-row:last-child{ border-bottom: 0; }
+.c-tl-dot{ width: 8px; height: 8px; border-radius: 50%; background: var(--text-4); justify-self: center; }
+.c-tl-dot.pos{ background: var(--pos); } .c-tl-dot.neg{ background: var(--neg); }
+.c-org{ font-family: var(--mono); font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 4px; text-align: center; }
+.c-org.os{ background: var(--origin-OS-bg); color: var(--origin-OS-fg); }
+.c-org.fin{ background: var(--origin-FIN-bg); color: var(--origin-FIN-fg); }
+.c-org.crm{ background: var(--origin-CRM-bg); color: var(--origin-CRM-fg); }
+.c-tl-txt{ font-size: 12.5px; min-width: 0; } .c-tl-txt.neg{ color: var(--neg); font-weight: 500; }
+.c-tl-when{ font-size: 11px; color: var(--text-4); font-variant-numeric: tabular-nums; }
+
+/* context-rail block */
+.c-rail{ width: 280px; background: var(--surface); border: 1px solid var(--border); border-radius: var(--r-3); padding: 14px; }
+.c-rail-h{ display: flex; align-items: center; gap: 8px; margin-bottom: 11px; }
+.c-rail-tag{ display: inline-flex; align-items: center; gap: 4px; font-family: var(--mono); font-size: 9px; font-weight: 700; padding: 2px 6px; border-radius: 4px; background: var(--origin-CRM-bg); color: var(--origin-CRM-fg); }
+.c-rail-h b{ font-size: 13px; font-weight: 600; }
+.c-rail dl{ display: grid; grid-template-columns: auto 1fr; gap: 6px 10px; margin: 0 0 12px; font-size: 12px; }
+.c-rail dt{ color: var(--text-4); } .c-rail dd{ margin: 0; text-align: right; color: var(--text-2); } .c-rail dd.mono{ font-family: var(--mono); }
+
+/* next-best-action */
+.c-nba{ width: 300px; border: 1px solid var(--border); border-left: 3px solid var(--neg); border-radius: var(--r-3); padding: 13px; background: var(--surface); }
+.c-nba-h{ display: flex; align-items: center; gap: 8px; margin-bottom: 7px; }
+.c-nba-ic{ width: 24px; height: 24px; border-radius: 7px; background: var(--neg-soft); color: var(--neg); display: grid; place-items: center; flex: 0 0 auto; }
+.c-nba-h b{ font-size: 12.5px; font-weight: 600; }
+.c-nba p{ margin: 0 0 10px; font-size: 11.5px; line-height: 1.5; color: var(--text-2); }
+.c-jana{ display: inline-flex; align-items: center; gap: 5px; font-size: 10px; font-weight: 600; color: var(--accent); }
+
+svg{ display: block; }
+</style>
+</head>
+<body>
+<div class="ds-top">
+  <div class="ds-logo">Oi</div>
+  <b>Oimpresso Design System</b>
+  <span class="ver">v6</span>
+  <span class="tag">proposta · régua de componentes</span>
+  <button class="ds-theme" id="themeBtn">◐ Tema: Escuro</button>
+</div>
+
+<div class="ds-wrap">
+  <div class="ds-intro">
+    <h1>O kit que faz toda tela nascer coerente.</h1>
+    <p>Os componentes que se repetiram em Oficina, Fila, Norte e Ficha da Frota — agora nomeados, em tokens, e funcionando em claro e escuro de fábrica. Trocar o tema acima muda <b>tudo</b> sozinho: é a prova de que nada aqui usa cor crua. Esta é a fonte da verdade e a régua: tela nova monta daqui.</p>
+  </div>
+
+  <!-- ════════ FUNDAMENTOS ════════ -->
+  <div class="ds-group-h">Fundamentos</div>
+  <div class="ds-grid">
+    <div class="spec half">
+      <div class="spec-h"><b>Accent — roxo canônico</b><code>--accent</code><p>A cor da marca (ADR 0235). Única, universal. Muda = reindexar tudo.</p></div>
+      <div class="spec-demo">
+        <div class="sw"><div class="sw-chip" style="background:var(--accent)"></div><b>--accent</b><small>roxo 295</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--accent-soft)"></div><b>--accent-soft</b><small>fundo</small></div>
+      </div>
+    </div>
+    <div class="spec half">
+      <div class="spec-h"><b>Número semântico</b><code>--pos / --neg / --warn</code><p>Significado, não decoração: deu certo · atenção · cuidado. Sempre com <code>-soft</code> de fundo.</p></div>
+      <div class="spec-demo">
+        <div class="sw"><div class="sw-chip" style="background:var(--pos)"></div><b>--pos</b><small>150</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--warn)"></div><b>--warn</b><small>70</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--neg)"></div><b>--neg</b><small>25</small></div>
+      </div>
+    </div>
+    <div class="spec wide">
+      <div class="spec-h"><b>Paleta de etapas</b><code>--stage-*</code><p>O tempero desta sessão: a escala categórica do pipeline (Recepção→Pronto). Antes vivia crua nas telas; agora é token reusável por qualquer fluxo/kanban.</p></div>
+      <div class="spec-demo">
+        <div class="sw"><div class="sw-chip" style="background:var(--stage-slate)"></div><b>slate</b><small>recepção</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--stage-indigo)"></div><b>indigo</b><small>diagnóstico</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--stage-rose)"></div><b>rose</b><small>peças</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--stage-emerald)"></div><b>emerald</b><small>execução</small></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--stage-green)"></div><b>green</b><small>pronto</small></div>
+      </div>
+    </div>
+    <div class="spec half">
+      <div class="spec-h"><b>Superfícies</b><code>--surface / --sunken / --border</code><p>Em camadas, quentes no claro, cinza-azul no escuro. Tudo flipa junto.</p></div>
+      <div class="spec-demo">
+        <div class="sw"><div class="sw-chip" style="background:var(--bg)"></div><b>--bg</b></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--sunken)"></div><b>--sunken</b></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--surface)"></div><b>--surface</b></div>
+        <div class="sw"><div class="sw-chip" style="background:var(--raised);border-color:var(--border)"></div><b>--raised</b></div>
+      </div>
+    </div>
+    <div class="spec half">
+      <div class="spec-h"><b>Tipo &amp; forma</b><code>IBM Plex · --r-*</code><p>Plex Sans + Plex Mono p/ número/placa. Raio teto 12px (16 só drawer/modal).</p></div>
+      <div class="spec-demo col">
+        <div style="font-size:22px;font-weight:600;letter-spacing:-0.02em">Plex Sans · 600</div>
+        <div style="font-family:var(--mono);font-size:15px;color:var(--text-2)">R$ 5.440,00 · RBA-2H78</div>
+        <div style="display:flex;gap:8px;margin-top:4px">
+          <span style="width:46px;height:30px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:var(--r-1)"></span>
+          <span style="width:46px;height:30px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:var(--r-2)"></span>
+          <span style="width:46px;height:30px;background:var(--accent-soft);border:1px solid var(--accent-line);border-radius:var(--r-3)"></span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ════════ COMPONENTES ════════ -->
+  <div class="ds-group-h">Componentes — o que paramos de remontar à mão</div>
+  <div class="ds-grid">
+
+    <div class="spec half">
+      <div class="spec-h"><b>Botões</b><code>.c-btn</code><p>Primário roxo, ghost, danger. A ação primária é sempre o accent.</p></div>
+      <div class="spec-demo">
+        <button class="c-btn primary">Nova OS</button>
+        <button class="c-btn">Imprimir</button>
+        <button class="c-btn ghost">Cancelar</button>
+        <button class="c-btn danger">Cobrar</button>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Pílula de status</b><code>.c-pill</code><p>Estado por significado. Fundo <code>-soft</code> + texto semântico.</p></div>
+      <div class="spec-demo">
+        <span class="c-pill pos">em dia</span>
+        <span class="c-pill warn">em breve</span>
+        <span class="c-pill neg">vencida</span>
+        <span class="c-pill info">na oficina</span>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Etapas do pipeline</b><code>.c-stage</code><p>Pontos da esteira, consumindo <code>--stage-*</code>.</p></div>
+      <div class="spec-demo col">
+        <span class="c-stage"><i style="background:var(--stage-slate)"></i>Recepção</span>
+        <span class="c-stage"><i style="background:var(--stage-indigo)"></i>Diagnóstico</span>
+        <span class="c-stage"><i style="background:var(--stage-rose)"></i>Aguardando peças</span>
+        <span class="c-stage"><i style="background:var(--stage-emerald)"></i>Em execução</span>
+        <span class="c-stage"><i style="background:var(--stage-green)"></i>Pronto</span>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Tabs segmentadas</b><code>.c-tabs</code><p>Troca de visão dentro de uma tela. Ativo ganha surface + sombra.</p></div>
+      <div class="spec-demo">
+        <div class="c-tabs">
+          <button class="c-tab active">Visão geral</button>
+          <button class="c-tab">Veículos</button>
+          <button class="c-tab">Histórico</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>KPI / stat</b><code>.c-kpi</code><p>Número grande em mono. Tom semântico quando importa (em aberto = neg).</p></div>
+      <div class="spec-demo">
+        <div class="c-kpi neg"><small>Em aberto</small><b>R$ 4.200</b></div>
+        <div class="c-kpi"><small>Ticket médio</small><b>R$ 3.840</b></div>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Placa Mercosul</b><code>.c-plate</code><p>Identidade do veículo. Mono, sempre legível nos dois temas.</p></div>
+      <div class="spec-demo">
+        <div class="c-plate"><span class="pt">BR · MERCOSUL</span><span class="pn">RBA-2H78</span></div>
+        <div class="c-plate"><span class="pt">BR · MERCOSUL</span><span class="pn">GHS-8E22</span></div>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Card de ativo (frota)</b><code>.c-asset</code><p>Veículo/equipamento com status de revisão na borda. O grafo da frota.</p></div>
+      <div class="spec-demo">
+        <div class="c-asset">
+          <div class="c-asset-top"><span class="ic"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6h11v9H3z"/><path d="M14 9h4l3 3v3h-7z"/><circle cx="7" cy="18" r="2"/><circle cx="17" cy="18" r="2"/></svg></span><span class="c-pill warn" style="margin-left:auto">em breve</span></div>
+          <div class="c-asset-mod">Volvo FH 540</div>
+          <div class="c-plate"><span class="pt">BR · MERCOSUL</span><span class="pn">FZJ-4F12</span></div>
+          <div class="c-asset-foot"><span class="mono">388.100 km</span><span class="rev">revisão em 4.800 km</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Próxima melhor ação</b><code>.c-nba</code><p>Sugestão proativa da Jana, com tom semântico e CTA. O CRM que cutuca.</p></div>
+      <div class="spec-demo">
+        <div class="c-nba">
+          <div class="c-nba-h"><span class="c-nba-ic"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><circle cx="12" cy="12" r="2.5"/></svg></span><b>Cobrar antes de entregar</b></div>
+          <p>Boleto NF 1198 vencido (R$ 4.200). O Constellation está pronto — cobre na entrega.</p>
+          <span class="c-jana">⚡ Jana</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="spec wide">
+      <div class="spec-h"><b>Header de identidade</b><code>.c-id</code><p>O cabeçalho de qualquer ficha (cliente, frota, fornecedor): avatar + nome + saúde + ações.</p></div>
+      <div class="spec-demo">
+        <div class="c-id">
+          <div class="c-id-av">BE</div>
+          <div>
+            <div class="c-id-name">Frota Boa Esperança <span class="c-pill warn">atenção financeira</span></div>
+            <div class="c-id-sub">Cliente PJ · Frota · desde mar/2019 · LTV R$ 142.300</div>
+          </div>
+          <div class="c-id-acts">
+            <button class="c-btn">WhatsApp</button>
+            <button class="c-btn primary">Nova OS</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Linha do tempo unificada</b><code>.c-tl</code><p>Eventos de todos os módulos (OS · FIN · CRM) num scroll. Badge de origem + tom.</p></div>
+      <div class="spec-demo col">
+        <div class="c-tl">
+          <div class="c-tl-row"><span class="c-tl-dot"></span><span class="c-org os">OS</span><span class="c-tl-txt">Constellation recepcionado</span><span class="c-tl-when">Hoje</span></div>
+          <div class="c-tl-row"><span class="c-tl-dot neg"></span><span class="c-org fin">FIN</span><span class="c-tl-txt neg">Boleto NF 1198 vencido</span><span class="c-tl-when">Ontem</span></div>
+          <div class="c-tl-row"><span class="c-tl-dot pos"></span><span class="c-org crm">WA</span><span class="c-tl-txt">Cláudia confirmou retirada</span><span class="c-tl-when">03/05</span></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="spec half">
+      <div class="spec-h"><b>Bloco de contexto (rail)</b><code>.c-rail</code><p>"Apps Vinculados": o app irmão (OS, CRM) ao lado do trabalho. A espinha do ERP.</p></div>
+      <div class="spec-demo">
+        <div class="c-rail">
+          <div class="c-rail-h"><span class="c-rail-tag">CRM</span><b>Frota Boa Esperança</b></div>
+          <dl><dt>Telefone</dt><dd class="mono">(34) 9 9988-7766</dd><dt>Em aberto</dt><dd class="mono">R$ 4.200</dd><dt>Veículos</dt><dd>8</dd></dl>
+          <button class="c-btn" style="width:100%;justify-content:center">Abrir ficha ↗</button>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+<script>
+(function(){
+  var root = document.documentElement, btn = document.getElementById('themeBtn');
+  try{ var s = localStorage.getItem('dsv6.theme'); if(s) root.dataset.theme = s; }catch(e){}
+  function label(){ btn.textContent = (root.dataset.theme === 'dark' ? '◐ Tema: Escuro' : '◑ Tema: Claro'); }
+  label();
+  btn.addEventListener('click', function(){
+    root.dataset.theme = (root.dataset.theme === 'dark' ? 'light' : 'dark');
+    try{ localStorage.setItem('dsv6.theme', root.dataset.theme); }catch(e){}
+    label();
+  });
+  // demo: tabs + segmented toggle active
+  document.querySelectorAll('.c-tabs, .spec-demo').forEach(function(group){
+    group.querySelectorAll('.c-tab').forEach(function(t){
+      t.addEventListener('click', function(){
+        group.querySelectorAll('.c-tab').forEach(function(x){ x.classList.remove('active'); });
+        t.classList.add('active');
+      });
+    });
+  });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## O quê

Landa **verbatim** os 3 protótipos do **kit DS v6** vindos do handoff bundle do Claude Design (sessão de design `2026-06-03 [CC]`), em `prototipo-ui/ds-v6/`:

| Arquivo | É | Pra quê |
|---|---|---|
| `showcase.html` | **o kit** | tokens DS v6 (oklch, claro/escuro) + 11 componentes canônicos (buttons · status pill · stage dots · KPI stat · segmented tabs · plate · asset card · identity header · timeline · context-rail · next-best-action) |
| `receita.html` | **o método** | "como nascer uma tela" em 6 passos (shell-first · use o token, não CSS cru · fluxo > tela · faltou peça é buraco do DS · feche com o gate) |
| `gabarito-vendas.html` | **o gabarito** | aplicação do kit em `/sells` (Index): PageHeader v3 (FOCO/Caixa/Faturamento/Comissão), 4 KPIs (Faturado hoje · Ticket · A receber+ageing · Notas), tabela 10 col (FSM dots · fiscal badge · pagamento+SLA), status canon (Paga/Pendente/Faturada/Cancelada), bulk emit NF-e, drawer SaleSheet 480px |
| `README.md` | índice | provenance + resumo de tokens + mapa pra produção |

## Por quê

Atende `COWORK_NOTES.md` → Pendentes **#1**: *"DS v6 (aprovado [W]) — landar showcase/receita"*.

## Natureza / governança

- **Aditivo, não-Tier-0:** protótipos estáticos HTML/CSS (referência visual + tokens). **Zero toque em código de produção.**
- A porta DS v6 → `resources/js/Pages/Sells/Index.tsx` (hoje vivo, **KB-9.75** aprovado [W]) é **Tier 0 / MWART** e fica pra outra PR — exige gate visual (ADR 0107/0114) + [W] aprovar **screenshot** antes de qualquer Edit. Esta PR só estabelece a referência canônica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)