### PR TITLE
feat(sells): botão de excluir venda (tela React + fallback blade)

### DIFF
--- a/resources/views/sale_pos/show.blade.php
+++ b/resources/views/sale_pos/show.blade.php
@@ -415,6 +415,14 @@
     @can('print_invoice')
       <a href="#" class="print-invoice tw-dw-btn tw-dw-btn-primary tw-text-white" data-href="{{route('sell.printInvoice', [$sell->id])}}"><i class="fa fa-print" aria-hidden="true"></i> @lang("lang_v1.print_invoice")</a>
     @endcan
+    @if(($sell->is_direct_sale == 0 && auth()->user()->can('sell.delete')) ||
+        ($sell->type == 'sales_order' && auth()->user()->can('so.delete')) ||
+        ($sell->is_direct_sale == 1 && $sell->type != 'sales_order' && auth()->user()->can('direct_sell.delete')))
+      <a href="{{ action([\App\Http\Controllers\SellPosController::class, 'destroy'], [$sell->id]) }}"
+         class="tw-dw-btn tw-dw-btn-error tw-text-white delete-sale no-print">
+        <i class="fas fa-trash"></i> @lang('messages.delete')
+      </a>
+    @endif
       <button type="button" class="tw-dw-btn tw-dw-btn-neutral tw-text-white no-print" data-dismiss="modal">@lang( 'messages.close' )</button>
     </div>
   </div>


### PR DESCRIPTION
## O que mudou
Adiciona o botão **Excluir** na tela de detalhes da venda. A tela viva é Inertia/React (`Pages/Sells/Show.tsx`) — antes não havia nenhuma forma de excluir uma venda inteira pela UI nova.

## Por quê
Cliente **RotaLivre** reclamou que não conseguia excluir vendas. O botão só existia no blade legacy (`sale_pos/show.blade.php`), que não é mais renderizado na navegação normal (o `show()` retorna `Inertia::render('Sells/Show')` quando há header `X-Inertia`).

## Mudanças
- **resources/js/Pages/Sells/Show.tsx** — botão Excluir no cabeçalho (ao lado de Editar), gateado por `permissions.delete`. Confirmação + fetch DELETE pro `SellPosController::destroy` (mesmo padrão CSRF do FsmActionPanel), toast e redirect pra /sells no sucesso.
- **app/Http/Controllers/SellController.php** — expõe `urls.destroy` no payload Inertia do show().
- **resources/views/sale_pos/show.blade.php** — botão equivalente no fallback blade legacy.

## Validação
- `npm run typecheck`: 0 erros em Sells/Show.tsx (demais erros do repo são baseline pré-existente).

## Notas pro revisor
- Confirmação via window.confirm (MVP); AlertDialog estilizado pode ser follow-up.
- Diff enxuto: 3 arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)