### PR TITLE
feat(financeiro): forma de pagamento no lançamento unificado

### DIFF
--- a/Modules/Financeiro/Database/Migrations/2026_06_03_120000_add_forma_pagamento_to_fin_titulos.php
+++ b/Modules/Financeiro/Database/Migrations/2026_06_03_120000_add_forma_pagamento_to_fin_titulos.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 2026-06-03 — Forma de pagamento PREVISTA no título.
+ *
+ * Pedido Wagner: a tela /financeiro/unificado não mostrava como o lançamento
+ * é/será pago (boleto, dinheiro, cartão…). A forma REALIZADA já vive na baixa
+ * (fin_titulo_baixas.meio_pagamento), mas só nasce ao quitar. Esta coluna guarda
+ * a forma PREVISTA/escolhida — editável enquanto o título está em aberto.
+ *
+ * Regra de exibição na UI (UnificadoController::shapeTitulo):
+ *   forma exibida = última baixa.meio_pagamento (realizada) ?? titulo.forma_pagamento (prevista) ?? null
+ *
+ * Enum espelha fin_titulo_baixas.meio_pagamento (mesma lista canônica).
+ * Backward compat: títulos antigos têm forma_pagamento = NULL (mostra "—").
+ * Aditivo e seguro: nullable, sem default obrigatório, sem backfill.
+ */
+class AddFormaPagamentoToFinTitulos extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            $table->enum('forma_pagamento', [
+                'dinheiro',
+                'pix',
+                'boleto',
+                'cartao_credito',
+                'cartao_debito',
+                'transferencia',
+                'cheque',
+                'compensacao',
+                'outro',
+            ])->nullable()->after('vencimento');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            $table->dropColumn('forma_pagamento');
+        });
+    }
+}

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -336,6 +336,7 @@ class UnificadoController extends Controller
                 'origem_id'         => null,
                 'categoria_id'      => $request->input('categoria_id') ?: null,
                 'plano_conta_id'    => $request->input('plano_conta_id') ?: null,
+                'forma_pagamento'   => $request->input('forma_pagamento') ?: null,
                 'observacoes'       => $request->input('observacoes'),
                 'created_by'        => $userId,
                 'updated_by'        => $userId,
@@ -371,6 +372,7 @@ class UnificadoController extends Controller
             'observacoes' => $request->input('observacoes'),
             'categoria_id' => $request->input('categoria_id') ?: null,
             'plano_conta_id' => $request->input('plano_conta_id') ?: null,
+            'forma_pagamento' => $request->input('forma_pagamento') ?: null,
             'vencimento' => $request->date('vencimento')->toDateString(),
             'updated_by' => $request->user()->id,
         ];
@@ -1163,6 +1165,10 @@ class UnificadoController extends Controller
             'plano_conta_codigo' => $t->planoConta?->codigo,
             'plano_conta_nome' => $t->planoConta?->nome,
             'conta_bancaria' => $contaBancariaNome,
+            // Forma de pagamento: a REALIZADA (última baixa) manda quando existe
+            // e é read-only; senão a PREVISTA (titulo.forma_pagamento), editável.
+            'forma_pagamento' => $ultimaBaixa?->meio_pagamento ?? $t->forma_pagamento,
+            'forma_pagamento_realizada' => $ultimaBaixa?->meio_pagamento !== null,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
             'liquidacao' => $ultimaBaixa?->data_baixa?->locale('pt_BR')->isoFormat('DD MMM'),

--- a/Modules/Financeiro/Http/Requests/StoreTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/StoreTituloRequest.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\PlanoConta;
+use Modules\Financeiro\Models\Titulo;
 
 /**
  * Validação do Insert manual de título financeiro (Onda 25, 2026-05-25, US-FIN-021).
@@ -62,6 +63,7 @@ class StoreTituloRequest extends FormRequest
                     ->where('aceita_lancamento', true)
                     ->whereNull('deleted_at'),
             ],
+            'forma_pagamento' => ['nullable', Rule::in(Titulo::FORMAS_PAGAMENTO)],
         ];
     }
 
@@ -75,6 +77,7 @@ class StoreTituloRequest extends FormRequest
             'vencimento.required' => 'Vencimento obrigatório.',
             'categoria_id.exists' => 'Categoria não pertence a este negócio.',
             'plano_conta_id.exists' => 'Plano de contas inválido (inexistente, inativo ou sintético).',
+            'forma_pagamento.in' => 'Forma de pagamento inválida.',
         ];
     }
 

--- a/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
@@ -56,6 +56,7 @@ class UpdateTituloRequest extends FormRequest
             ],
             'vencimento' => ['required', 'date'],
             'valor_total' => ['sometimes', 'numeric', 'min:0.01', 'max:9999999999.99'],
+            'forma_pagamento' => ['nullable', Rule::in(Titulo::FORMAS_PAGAMENTO)],
         ];
     }
 
@@ -66,6 +67,7 @@ class UpdateTituloRequest extends FormRequest
             'plano_conta_id.exists' => 'Plano de contas inválido (inexistente, inativo ou sintético).',
             'vencimento.required' => 'Vencimento obrigatório.',
             'valor_total.min' => 'Valor deve ser positivo.',
+            'forma_pagamento.in' => 'Forma de pagamento inválida.',
         ];
     }
 

--- a/Modules/Financeiro/Models/Titulo.php
+++ b/Modules/Financeiro/Models/Titulo.php
@@ -25,6 +25,23 @@ class Titulo extends Model
 {
     use HasFactory, SoftDeletes, BusinessScope, LogsActivity;
 
+    /**
+     * Formas de pagamento canônicas — espelha o enum de
+     * fin_titulo_baixas.meio_pagamento. Reutilizado nas Requests (validação)
+     * e na migration que cria a coluna forma_pagamento. Fonte única da verdade.
+     */
+    public const FORMAS_PAGAMENTO = [
+        'dinheiro',
+        'pix',
+        'boleto',
+        'cartao_credito',
+        'cartao_debito',
+        'transferencia',
+        'cheque',
+        'compensacao',
+        'outro',
+    ];
+
     public function getActivitylogOptions(): LogOptions
     {
         return LogOptions::defaults()
@@ -43,6 +60,7 @@ class Titulo extends Model
         'emissao', 'vencimento', 'competencia_mes',
         'origem', 'origem_id', 'parcela_numero', 'parcela_total', 'titulo_pai_id',
         'plano_conta_id', 'categoria_id',
+        'forma_pagamento',
         'observacoes', 'metadata',
         'created_by', 'updated_by',
         'conferido_by', 'conferido_at',

--- a/Modules/Financeiro/Tests/Feature/UnificadoFormaPagamentoGuardTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoFormaPagamentoGuardTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * 2026-06-03 — GUARD Tier 0 anti-regressão pra forma_pagamento no
+ * /financeiro/unificado (pedido Wagner: mostrar/editar tipo de pagamento).
+ *
+ * Cobre 5 invariantes (cada Δ = CI quebra):
+ *  (G1) shapeTitulo() expõe forma_pagamento + forma_pagamento_realizada
+ *  (G2) Edit PUT persiste forma_pagamento (forma PREVISTA, título em aberto)
+ *  (G3) Store POST persiste forma_pagamento
+ *  (G4) Enum inválido rejeitado (anti tampering)
+ *  (G5) Quando há baixa, a forma REALIZADA (baixa.meio_pagamento) tem
+ *       prioridade no shape + forma_pagamento_realizada=true (read-only)
+ *
+ * Padrão graceful skip (Jana/Repair/Copiloto): pula quando DB greenfield
+ * ou subscription gate bloqueia financeiro_module no env atual.
+ */
+
+function fpBootstrap(): array
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.dashboard.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.dashboard.view')) {
+        $user->givePermissionTo('financeiro.dashboard.view');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'business'         => ['id' => $business->id, 'name' => $business->name, 'currency_symbol' => 'R$'],
+        'is_admin'         => true,
+    ]);
+
+    return [$business, $user];
+}
+
+function fpCreateTitulo(int $businessId, int $userId, ?string $forma = null): Titulo
+{
+    return Titulo::create([
+        'business_id'       => $businessId,
+        'numero'            => 'FPG-'.bin2hex(random_bytes(4)),
+        'tipo'              => 'receber',
+        'status'            => 'aberto',
+        'cliente_descricao' => 'FORMA PGTO guard',
+        'valor_total'       => 50.00,
+        'valor_aberto'      => 50.00,
+        'moeda'             => 'BRL',
+        'emissao'           => now()->toDateString(),
+        'vencimento'        => now()->addDays(15)->toDateString(),
+        'competencia_mes'   => now()->format('Y-m'),
+        'origem'            => 'manual',
+        'forma_pagamento'   => $forma,
+        'created_by'        => $userId,
+    ]);
+}
+
+// ════════════════════════════════════════════════════════════════════════
+// G1 — shapeTitulo expõe forma_pagamento + forma_pagamento_realizada
+// ════════════════════════════════════════════════════════════════════════
+it('GUARD G1: shapeTitulo expõe forma_pagamento (prevista) + flag realizada', function () {
+    [$business, $user] = fpBootstrap();
+
+    $titulo = fpCreateTitulo($business->id, $user->id, 'boleto');
+
+    $response = $this->actingAs($user)->get('/financeiro/unificado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(function (AssertableInertia $page) use ($titulo) {
+        $page->has('lancamentos');
+        $lancamentos = $page->toArray()['props']['lancamentos'] ?? [];
+        $found = collect($lancamentos)->firstWhere('id', $titulo->id);
+
+        expect($found)->not->toBeNull('título FPG não veio no payload — fora do período default?');
+        expect($found)->toHaveKeys(['forma_pagamento', 'forma_pagamento_realizada']);
+        expect($found['forma_pagamento'])->toBe('boleto');
+        expect($found['forma_pagamento_realizada'])->toBeFalse();
+    });
+
+    $titulo->forceDelete();
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// G2 — Edit PUT persiste forma_pagamento
+// ════════════════════════════════════════════════════════════════════════
+it('GUARD G2: Edit PUT /unificado/{id} persiste forma_pagamento', function () {
+    [$business, $user] = fpBootstrap();
+
+    $titulo = fpCreateTitulo($business->id, $user->id);
+
+    $response = $this->actingAs($user)->put("/financeiro/unificado/{$titulo->id}", [
+        'cliente_descricao' => $titulo->cliente_descricao,
+        'observacoes'       => null,
+        'categoria_id'      => null,
+        'vencimento'        => $titulo->vencimento->toDateString(),
+        'forma_pagamento'   => 'pix',
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertRedirect();
+    $titulo->refresh();
+    expect($titulo->forma_pagamento)->toBe('pix');
+
+    $titulo->forceDelete();
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// G3 — Store POST persiste forma_pagamento
+// ════════════════════════════════════════════════════════════════════════
+it('GUARD G3: Store POST /unificado persiste forma_pagamento', function () {
+    [$business, $user] = fpBootstrap();
+
+    $response = $this->actingAs($user)->post('/financeiro/unificado', [
+        'tipo'              => 'pagar',
+        'valor_total'       => 25.00,
+        'vencimento'        => now()->addDays(7)->toDateString(),
+        'cliente_descricao' => 'FPG G3 store',
+        'forma_pagamento'   => 'cartao_credito',
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertRedirect();
+
+    $created = Titulo::where('business_id', $business->id)
+        ->where('cliente_descricao', 'FPG G3 store')
+        ->latest('id')
+        ->first();
+
+    expect($created)->not->toBeNull();
+    expect($created->forma_pagamento)->toBe('cartao_credito');
+
+    $created->forceDelete();
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// G4 — Enum inválido rejeitado (anti tampering)
+// ════════════════════════════════════════════════════════════════════════
+it('GUARD G4: forma_pagamento fora do enum é rejeitada', function () {
+    [$business, $user] = fpBootstrap();
+
+    $titulo = fpCreateTitulo($business->id, $user->id);
+
+    $response = $this->actingAs($user)->put("/financeiro/unificado/{$titulo->id}", [
+        'cliente_descricao' => $titulo->cliente_descricao,
+        'observacoes'       => null,
+        'categoria_id'      => null,
+        'vencimento'        => $titulo->vencimento->toDateString(),
+        'forma_pagamento'   => 'bitcoin', // inválido
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    expect(in_array($response->status(), [302, 422], true))->toBeTrue();
+    $titulo->refresh();
+    expect($titulo->forma_pagamento)->toBeNull('Enum inválido foi persistido — validação furou');
+
+    $titulo->forceDelete();
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// G5 — Baixa realizada tem prioridade no shape (read-only)
+// ════════════════════════════════════════════════════════════════════════
+it('GUARD G5: baixa.meio_pagamento sobrepõe forma prevista + flag realizada', function () {
+    [$business, $user] = fpBootstrap();
+
+    // Título com forma PREVISTA = boleto, mas baixa REALIZADA = dinheiro.
+    $titulo = fpCreateTitulo($business->id, $user->id, 'boleto');
+
+    $baixa = TituloBaixa::create([
+        'business_id'     => $business->id,
+        'titulo_id'       => $titulo->id,
+        'conta_bancaria_id' => null,
+        'valor_baixa'     => 50.00,
+        'data_baixa'      => now()->toDateString(),
+        'meio_pagamento'  => 'dinheiro',
+        'idempotency_key' => (string) \Illuminate\Support\Str::uuid(),
+        'created_by'      => $user->id,
+    ]);
+
+    $response = $this->actingAs($user)->get('/financeiro/unificado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $baixa->forceDelete();
+        $titulo->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(function (AssertableInertia $page) use ($titulo) {
+        $lancamentos = $page->toArray()['props']['lancamentos'] ?? [];
+        $found = collect($lancamentos)->firstWhere('id', $titulo->id);
+
+        if ($found !== null) {
+            // Realizada (dinheiro) manda sobre prevista (boleto).
+            expect($found['forma_pagamento'])->toBe('dinheiro');
+            expect($found['forma_pagamento_realizada'])->toBeTrue();
+        }
+    });
+
+    $baixa->forceDelete();
+    $titulo->forceDelete();
+});

--- a/memory/requisitos/Financeiro/RUNBOOK-unificado.md
+++ b/memory/requisitos/Financeiro/RUNBOOK-unificado.md
@@ -131,6 +131,9 @@ Drawer Sheet abre via botão "Editar" no drawer detalhe. Campos editáveis:
 | `plano_conta_id` | **Sim (Onda 24)** | exists fin_planos_conta scoped business + ativo + aceita_lancamento + coerência tipo↔plano |
 | `vencimento` | Sim | date required |
 | `valor_total` | **Só se status aberto/parcial** (fin-tech/0002) | min 0.01, max 9999999999.99 |
+| `forma_pagamento` | **Só se NÃO-realizada** (sem baixa) | nullable, enum `Titulo::FORMAS_PAGAMENTO` |
+
+**Forma de pagamento (2026-06-03, charter v11):** coluna `fin_titulos.forma_pagamento` guarda a forma **prevista** (enum espelha `fin_titulo_baixas.meio_pagamento`). `shapeTitulo()` expõe `forma_pagamento` (exibida) + `forma_pagamento_realizada` (flag). Regra: forma **realizada** (`baixa.meio_pagamento`) tem prioridade e é read-only; senão a **prevista** (editável em aberto); senão `null` → "—". UI: coluna **Forma** na tabela + campo no drawer Detalhes + select no FinEditPanel/TituloCreateSheet. Helper `_lib/forma-pagamento.ts`. GUARD `UnificadoFormaPagamentoGuardTest` (5 casos).
 
 **Imutáveis (anti-corrupção contábil):** `tipo`, `origem`, `origem_id`, `status`, `emissao`, `competencia_mes`, `business_id`. Alterar requer cancelar+criar novo.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37316,3 +37316,13 @@ parameters:
 			identifier: property.notFound
 			count: 1
 			path: Modules/Financeiro/Models/Concerns/BusinessScope.php
+		-
+			message: '#^Access to an undefined property Modules\\Financeiro\\Models\\Titulo\:\:\$forma_pagamento\.$#'
+			identifier: property.notFound
+			count: 1
+			path: Modules/Financeiro/Http/Controllers/UnificadoController.php
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$meio_pagamento\.$#'
+			identifier: property.notFound
+			count: 2
+			path: Modules/Financeiro/Http/Controllers/UnificadoController.php

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -12,7 +12,7 @@ related_prototype: canon REAL public/cowork-preview/Oimpresso ERP - Chat.html (a
 canon_method: Bundle copy CSS 9054 LOC inteiro (regra Tier 0 feedback-cowork-bundle-aplicar-inteiro) — Ondas 12-21
 runbook: memory/requisitos/Financeiro/RUNBOOK-unificado.md
 tier: A
-charter_version: 10
+charter_version: 11
 ---
 
 # Page Charter — /financeiro/unificado
@@ -30,6 +30,8 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 ---
 
 ## Goals — Features (faz)
+
+- **Forma de pagamento no lançamento** (2026-06-03, charter v11, pedido [W]): coluna **Forma** na tabela + campo no drawer (aba Detalhes) + edição (FinEditPanel) e criação (TituloCreateSheet). Nova coluna `fin_titulos.forma_pagamento` (enum espelha `fin_titulo_baixas.meio_pagamento`). Regra de exibição: a forma **realizada** (`baixa.meio_pagamento`) tem prioridade e é **read-only** (espelha `valor_mutavel` / ADR fin-tech/0002); senão a **prevista** (`titulo.forma_pagamento`), editável em aberto; senão "—". Helper compartilhado `_lib/forma-pagamento.ts` (rótulo PT-BR + ícone). Cobertura `UnificadoFormaPagamentoGuardTest` (5 GUARDs). Títulos criados por cobrança paga (`OnCobrancaPagaCreateFinanceiroTitulo`) já exibem a forma realizada via baixa.
 
 - **Paridade filtros de data WR** (2026-06-03, US-FIN-030): seletor de **campo de data** (Vencimento default · Emissão · Pagamento · Competência) + **intervalo explícito** `data_inicio`/`data_fim` na toolbar, espelhando o WR Comercial. Backend `parseFilters()` + `aplicarFiltroData()` (vencimento/emissao via coluna; pagamento via `baixas.data_baixa`; competencia via `competencia_mes` YYYY-MM); intervalo sobrepõe o período preset. **O `data_campo` aplica na tabela E nos cards de KPI** (`kpisCore` segue o mesmo campo — totais consistentes com o grid filtrado; `recebido`/`pago` por `data_baixa` quando campo=pagamento, senão por título que casa o campo). Cobertura `UnificadoDataCampoTest`. Pendente: filtros 'Nota Fiscal'/'Vendas' do WR exigem link título→transaction (`origem_id`).
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -68,6 +68,8 @@ import { TituloCreateSheet } from './_components/TituloCreateSheet';
 import { FinAnexosPanel } from './_components/FinAnexosPanel';
 // US-FIN-029 (Onda 23) — Sheet OCR boleto (OpenAI Vision API extrai linha digitavel + valor + vencimento).
 import { FinOcrBoletoSheet } from './_components/FinOcrBoletoSheet';
+// 2026-06-03 — forma de pagamento (rótulo + ícone) compartilhada.
+import { formaPagamentoLabel, formaPagamentoIcon, type MeioPagamento } from './_lib/forma-pagamento';
 
 // ---------- Tipos ----------
 
@@ -87,6 +89,11 @@ interface Lancamento {
   plano_conta_codigo: string | null;
   plano_conta_nome: string | null;
   conta_bancaria: string;
+  // 2026-06-03 — forma de pagamento. `forma_pagamento` = exibida (baixa realizada
+  // tem prioridade, senão a prevista do título). `forma_pagamento_realizada` =
+  // true quando veio da baixa → read-only (espelha valor_mutavel).
+  forma_pagamento: MeioPagamento | null;
+  forma_pagamento_realizada: boolean;
   vencimento: string;            // ISO yyyy-mm-dd
   vencimento_label: string;      // "qua, 14 mai"
   liquidacao: string | null;
@@ -815,6 +822,19 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
           {row.categoria}
         </span>
       </td>
+      {/* 2026-06-03: forma de pagamento (ícone + rótulo compacto). */}
+      <td className="px-2 text-[11.5px] text-stone-600 whitespace-nowrap">
+        {(() => {
+          const Icon = formaPagamentoIcon(row.forma_pagamento);
+          if (!Icon) return <span className="text-stone-300">—</span>;
+          return (
+            <span className="inline-flex items-center gap-1" title={formaPagamentoLabel(row.forma_pagamento)}>
+              <Icon className="h-3.5 w-3.5 text-stone-400" aria-hidden />
+              <span className="truncate max-w-[96px]">{formaPagamentoLabel(row.forma_pagamento)}</span>
+            </span>
+          );
+        })()}
+      </td>
       <td className="px-2"><div className="flex items-center gap-1.5"><StatusPill s={row.status} /><FinPillFrescor row={frescorRow} compact /><ApprovalPill s={row.aprovacao_status} /></div></td>
       <td className={`px-2 text-right font-medium tabular-nums whitespace-nowrap ${isIn ? 'text-emerald-700' : 'text-stone-900'}`}>
         <span className="text-stone-400 mr-0.5">{isIn ? '+' : '−'}</span>{brl(row.valor).replace('R$', '').trim()}
@@ -1382,6 +1402,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 <SortableHeader k="lancamento" label="Lançamento" filters={filters} aplicar={aplicar} className="px-2 py-2 text-left font-medium" />
                 <SortableHeader k="contraparte" label="Contraparte" filters={filters} aplicar={aplicar} className="px-2 py-2 text-left font-medium" />
                 <th className="px-2 py-2 text-left font-medium">Categoria</th>
+                <th className="px-2 py-2 text-left font-medium">Forma</th>
                 <SortableHeader k="status" label="Status" filters={filters} aplicar={aplicar} className="px-2 py-2 text-left font-medium" />
                 <SortableHeader k="valor" label="Valor" filters={filters} aplicar={aplicar} className="px-2 py-2 text-right font-medium" alignRight />
                 <th className="pl-2 pr-4 py-2 w-[110px] text-right font-medium"></th>
@@ -1397,7 +1418,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 return (
                   <React.Fragment key={key}>
                     {showGroupHeader && (
-                      <tr><td colSpan={9} className="bg-stone-50/70 border-b border-stone-200">
+                      <tr><td colSpan={10} className="bg-stone-50/70 border-b border-stone-200">
                         <div className="px-4 py-1.5 flex items-center text-[11px] uppercase tracking-widest text-stone-500 font-medium">
                           <span>{label}</span>
                           <span className="ml-auto text-stone-400 normal-case tracking-normal">{rows.length} {rows.length === 1 ? 'lançamento' : 'lançamentos'}</span>
@@ -1421,7 +1442,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 );
               })}
               {grupos.length === 0 && (
-                <tr><td colSpan={9} className="py-16">
+                <tr><td colSpan={10} className="py-16">
                   <div className="flex flex-col items-center gap-3 text-center">
                     <div className="text-sm text-stone-600">
                       {filters.lifecycle.length === 0 && !filters.overdue && !filters.busca && filters.conta === '' && filters.categoria === ''
@@ -1646,6 +1667,20 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     <div>
                       <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Documento</div>
                       <div className="mt-0.5 text-stone-700 font-mono text-[12px]">{selected.nfe_numero || '—'}</div>
+                    </div>
+                    {/* 2026-06-03: forma de pagamento. Realizada (baixa) vem com hint read-only. */}
+                    <div>
+                      <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Forma de pagamento</div>
+                      <div className="mt-0.5 text-stone-700 flex items-center gap-1.5">
+                        {(() => {
+                          const Icon = formaPagamentoIcon(selected.forma_pagamento);
+                          return Icon ? <Icon className="h-4 w-4 text-stone-400" aria-hidden /> : null;
+                        })()}
+                        <span>{formaPagamentoLabel(selected.forma_pagamento)}</span>
+                        {selected.forma_pagamento_realizada && (
+                          <span className="text-[10px] text-stone-400">· da baixa</span>
+                        )}
+                      </div>
                     </div>
                     <div className="col-span-2">
                       <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Conta</div>

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinEditPanel.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinEditPanel.tsx
@@ -16,6 +16,7 @@ import { useEffect } from 'react';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@/Components/ui/select';
+import { FORMA_PAGAMENTO_OPCOES, formaPagamentoLabel } from '../_lib/forma-pagamento';
 
 interface Lancamento {
   id: number;
@@ -29,6 +30,9 @@ interface Lancamento {
   descricao: string;
   observacao: string | null;
   valor_mutavel: boolean;
+  // 2026-06-03 — forma de pagamento prevista (editável só se não-realizada).
+  forma_pagamento: string | null;
+  forma_pagamento_realizada: boolean;
 }
 
 interface Categoria {
@@ -53,6 +57,7 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
     categoria_id: lancamento.categoria_id !== null ? String(lancamento.categoria_id) : '',
     vencimento: lancamento.vencimento,
     valor_total: lancamento.valor,
+    forma_pagamento: lancamento.forma_pagamento ?? '',
   });
 
   // Reset on row change
@@ -63,6 +68,7 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
       categoria_id: lancamento.categoria_id !== null ? String(lancamento.categoria_id) : '',
       vencimento: lancamento.vencimento,
       valor_total: lancamento.valor,
+      forma_pagamento: lancamento.forma_pagamento ?? '',
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lancamento.id]);
@@ -78,6 +84,11 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
     if (lancamento.valor_mutavel) {
       data.valor_total = form.data.valor_total;
     }
+    // Forma de pagamento só é editável quando NÃO-realizada (sem baixa). Quando
+    // realizada, a forma vem da baixa (read-only) e não vai no payload.
+    if (!lancamento.forma_pagamento_realizada) {
+      data.forma_pagamento = form.data.forma_pagamento || null;
+    }
     form.put(`/financeiro/unificado/${lancamento.id}`, {
       ...({ data } as Record<string, unknown>),
       preserveScroll: true,
@@ -90,7 +101,8 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
     form.data.observacoes !== (lancamento.observacao ?? '') ||
     form.data.categoria_id !== (lancamento.categoria_id !== null ? String(lancamento.categoria_id) : '') ||
     form.data.vencimento !== lancamento.vencimento ||
-    (lancamento.valor_mutavel && form.data.valor_total !== lancamento.valor);
+    (lancamento.valor_mutavel && form.data.valor_total !== lancamento.valor) ||
+    (!lancamento.forma_pagamento_realizada && form.data.forma_pagamento !== (lancamento.forma_pagamento ?? ''));
 
   return (
     // Onda 15 (2026-05-19) — adiciona classes canon os-drawer-* sem remover fin-edit-*
@@ -154,6 +166,40 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
               ))}
             </SelectContent>
           </Select>
+        </label>
+
+        {/* 2026-06-03 — Forma de pagamento. Editável só quando não-realizada;
+            quando há baixa, mostra read-only o que realmente foi pago. */}
+        <label htmlFor="fin-edit-forma">
+          <span>Forma de pagamento</span>
+          {lancamento.forma_pagamento_realizada ? (
+            <input
+              type="text"
+              value={formaPagamentoLabel(lancamento.forma_pagamento)}
+              disabled
+              aria-label="Forma de pagamento (da baixa)"
+            />
+          ) : (
+            <Select
+              value={form.data.forma_pagamento || '__none__'}
+              onValueChange={(v) => form.setData('forma_pagamento', v === '__none__' ? '' : v)}
+            >
+              <SelectTrigger id="fin-edit-forma" aria-label="Forma de pagamento">
+                <SelectValue placeholder="— a definir —" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">— a definir —</SelectItem>
+                {FORMA_PAGAMENTO_OPCOES.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+          {lancamento.forma_pagamento_realizada && (
+            <small style={{ color: 'oklch(0.50 0 0)', fontSize: 10 }}>da baixa (read-only)</small>
+          )}
         </label>
 
         <label className="fin-edit-wide">

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloCreateSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloCreateSheet.tsx
@@ -20,6 +20,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@/Components/ui/select';
 import { PlanoContaCombobox, type PlanoConta } from './PlanoContaCombobox';
+import { FORMA_PAGAMENTO_OPCOES } from '../_lib/forma-pagamento';
 
 // PR I (2026-05-25) G5 — sugestão de valor último/médio por contraparte.
 interface ValorSugerido {
@@ -57,6 +58,7 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
     plano_conta_id: null as number | null,
     vencimento: hojeIso(),
     valor_total: 0,
+    forma_pagamento: '' as string,
   });
 
   // Reset quando trocar tipo (usuário fechou drawer e abriu outro).
@@ -69,6 +71,7 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
       plano_conta_id: null as number | null,
       vencimento: hojeIso(),
       valor_total: 0,
+      forma_pagamento: '' as string,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tipo, open]);
@@ -83,6 +86,7 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
       plano_conta_id: form.data.plano_conta_id ?? null,
       vencimento: form.data.vencimento,
       valor_total: form.data.valor_total,
+      forma_pagamento: form.data.forma_pagamento || null,
     };
     form.post('/financeiro/unificado', {
       ...({ data } as any),
@@ -211,6 +215,29 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
             </Select>
             {form.errors.categoria_id && (
               <p className="text-[11px] text-destructive">{form.errors.categoria_id}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="cr-forma" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
+              Forma de pagamento
+            </label>
+            <Select
+              value={form.data.forma_pagamento || '__none__'}
+              onValueChange={(v) => form.setData('forma_pagamento', v === '__none__' ? '' : v)}
+            >
+              <SelectTrigger id="cr-forma" aria-label="Forma de pagamento">
+                <SelectValue placeholder="— a definir —" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">— a definir —</SelectItem>
+                {FORMA_PAGAMENTO_OPCOES.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {form.errors.forma_pagamento && (
+              <p className="text-[11px] text-destructive">{form.errors.forma_pagamento}</p>
             )}
           </div>
 

--- a/resources/js/Pages/Financeiro/Unificado/_lib/forma-pagamento.ts
+++ b/resources/js/Pages/Financeiro/Unificado/_lib/forma-pagamento.ts
@@ -1,0 +1,51 @@
+// Forma de pagamento — fonte única (rótulos PT-BR + ícones) compartilhada
+// entre Index (drawer + coluna), FinEditPanel (edição) e TituloCreateSheet
+// (criação). Espelha o enum backend fin_titulos.forma_pagamento /
+// fin_titulo_baixas.meio_pagamento (Titulo::FORMAS_PAGAMENTO).
+import {
+  Banknote, QrCode, Barcode, CreditCard, ArrowLeftRight,
+  ReceiptText, Scale, Wallet,
+  type LucideIcon,
+} from 'lucide-react';
+
+export type MeioPagamento =
+  | 'dinheiro' | 'pix' | 'boleto' | 'cartao_credito' | 'cartao_debito'
+  | 'transferencia' | 'cheque' | 'compensacao' | 'outro';
+
+export const FORMA_PAGAMENTO_OPCOES: { value: MeioPagamento; label: string }[] = [
+  { value: 'dinheiro', label: 'Dinheiro' },
+  { value: 'pix', label: 'Pix' },
+  { value: 'boleto', label: 'Boleto' },
+  { value: 'cartao_credito', label: 'Cartão de crédito' },
+  { value: 'cartao_debito', label: 'Cartão de débito' },
+  { value: 'transferencia', label: 'Transferência' },
+  { value: 'cheque', label: 'Cheque' },
+  { value: 'compensacao', label: 'Compensação' },
+  { value: 'outro', label: 'Outro' },
+];
+
+const LABELS: Record<MeioPagamento, string> = Object.fromEntries(
+  FORMA_PAGAMENTO_OPCOES.map((o) => [o.value, o.label]),
+) as Record<MeioPagamento, string>;
+
+const ICONS: Record<MeioPagamento, LucideIcon> = {
+  dinheiro: Banknote,
+  pix: QrCode,
+  boleto: Barcode,
+  cartao_credito: CreditCard,
+  cartao_debito: CreditCard,
+  transferencia: ArrowLeftRight,
+  cheque: ReceiptText,
+  compensacao: Scale,
+  outro: Wallet,
+};
+
+export function formaPagamentoLabel(v: string | null | undefined): string {
+  if (!v) return '—';
+  return LABELS[v as MeioPagamento] ?? v;
+}
+
+export function formaPagamentoIcon(v: string | null | undefined): LucideIcon | null {
+  if (!v) return null;
+  return ICONS[v as MeioPagamento] ?? null;
+}


### PR DESCRIPTION
## O que muda
Mostra e permite **editar a forma de pagamento** (boleto/dinheiro/pix/cartão…) na tela `/financeiro/unificado` — pedido do Wagner.

## Por quê
A tela não exibia como o lançamento é/será pago. Além de UX, é pré-requisito da **migração OfficeImpresso** (o legacy tem `FINANCEIRO.TIPOPAGTO` — boleto domina, 55k de 103k linhas no banco do MartinhoCacamba).

## Como
- **Migration aditiva** `fin_titulos.forma_pagamento` (enum nullable, espelha `fin_titulo_baixas.meio_pagamento`). Sem tabela extra, sem backfill.
- `shapeTitulo()` expõe `forma_pagamento` + `forma_pagamento_realizada`. A forma **realizada** (última baixa) tem prioridade e é **read-only** (espelha `valor_mutavel` / ADR fin-tech/0002); senão a **prevista** (editável em aberto); senão "—".
- UI: coluna **"Forma"** na tabela + campo no drawer (aba Detalhes) + select no **FinEditPanel** (edição) e **TituloCreateSheet** (criação). Helper compartilhado `_lib/forma-pagamento.ts` (rótulo PT-BR + ícone Lucide).
- Validação enum em `Store/UpdateTituloRequest` (`Titulo::FORMAS_PAGAMENTO`).
- **GUARD** `UnificadoFormaPagamentoGuardTest` (5 casos: shape, update, store, enum inválido, baixa sobrepõe prevista).
- Charter v11 + RUNBOOK-unificado atualizados.

## Notas pro reviewer
- ⚠️ **Gate visual MWART**: mudança visível (coluna + campo) — falta aprovar **screenshot**. Não rodei smoke local (sem PHP/Herd + `node_modules` ausente na worktree); CI roda Pest/tsc.
- Bônus: títulos criados por cobrança paga (`OnCobrancaPagaCreateFinanceiroTitulo`) já exibem a forma realizada via baixa, sem código extra.
- Migration roda no deploy (coluna nullable, segura).

Refs: pedido Wagner 2026-06-03

🤖 Generated with [Claude Code](https://claude.com/claude-code)
