### PR TITLE
fix(financeiro): borda visível no filtro de data + selects da toolbar casam [M]

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -588,8 +588,8 @@
 .fin-cowork .fin-toolbar input.fin-date-input {
   -webkit-appearance: none; appearance: none;
   display: inline-flex; align-items: center;
-  height: 28px; padding: 4px 9px;
-  border: 1px solid oklch(0.84 0.006 80);
+  height: 30px; padding: 4px 10px;
+  border: 1px solid oklch(0.80 0.01 80);
   border-radius: 6px;
   background: oklch(1 0 0);
   color: oklch(0.40 0.01 80);
@@ -608,6 +608,25 @@
   opacity: .5; cursor: pointer; margin-left: 2px;
 }
 .fin-curadoria .fin-toolbar .fin-filter-group input[type="date"]:hover::-webkit-calendar-picker-indicator { opacity: .85; }
+/* Selects da toolbar (Vencimento / Todas as contas / Plano de contas). A regra
+   canônica .fin-filter-select do bundle se perdeu no build (não está no CSS
+   servido), deixando os selects SEM borda (native, 19px) — destoando do campo de
+   data. Restaura a MESMA caixa dos date inputs (borda oklch(0.80), 30px, raio 6px,
+   appearance:none) + chevron. Scope .fin-curadoria .fin-toolbar (só esta toolbar). */
+.fin-curadoria .fin-toolbar select.fin-filter-select {
+  -webkit-appearance: none; appearance: none;
+  height: 30px; padding: 4px 28px 4px 10px;
+  border: 1px solid oklch(0.80 0.01 80);
+  border-radius: 6px;
+  background-color: oklch(1 0 0);
+  color: oklch(0.40 0.01 80);
+  font-size: 12px; font-weight: 500; font-family: inherit; line-height: 1.4;
+  box-sizing: border-box; cursor: pointer; transition: border-color .12s;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='gray' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+}
+.fin-curadoria .fin-toolbar select.fin-filter-select:hover { border-color: oklch(0.70 0.01 80); }
 .fin-cowork .fin-toolbar .fin-date-sep {
   color: var(--text-mute); font-size: 12px; padding: 0 1px; user-select: none;
 }


### PR DESCRIPTION
Validado AO VIVO (Chrome MCP) + zoom: a borda do `<input type=date>` estava aplicada mas clara demais (`oklch 0.84` sub-pixel), e os selects vizinhos (Vencimento/contas/plano) estavam **sem borda** (CSS `fin-filter-select` sumiu do bundle).

Fix: date-input borda `oklch(0.80)` visível + altura 30px; `select.fin-filter-select` da toolbar ganha a MESMA caixa (borda/30px/raio/appearance:none/chevron) → linha de filtro consistente. `build:inertia` local OK. Reinspeção ao vivo pós-deploy.

(Reabertura do #2171 em branch fresca — evita o check fantasma "ADR frontmatter" travado pelo update-branch.)

Refs: US-FIN-030

🤖 Generated with [Claude Code](https://claude.com/claude-code)