### PR TITLE
fix(migracao): status WR INATIVO* → cancelado (precedência sobre datapagto) [M]

### DIFF
--- a/scripts/legacy-migration/import-financeiro.py
+++ b/scripts/legacy-migration/import-financeiro.py
@@ -152,11 +152,20 @@ def map_tipo(raw: str) -> str:
 
 
 def map_status(raw_status, datapagto, kind) -> str:
-    """FINANCEIRO.STATUS + DATAPAGTO + kind → fin_titulos.status enum."""
+    """FINANCEIRO.STATUS + DATAPAGTO + kind → fin_titulos.status enum.
+
+    Regra Wagner 2026-06-03: STATUS que começa com "INATIVO" = lançamento
+    NÃO-VÁLIDO → 'cancelado' (escondido do financeiro; só visível no filtro
+    "Arquivados"). Tem PRECEDÊNCIA sobre DATAPAGTO — um título cancelado que
+    tinha data de pagamento (pago e depois cancelado no WR) NÃO é um recebimento
+    válido e não pode somar no caixa. Bug catalogado: 2.683 títulos "INATIVO
+    CANCELADA" de biz=164 (Martinho) vinham como 'quitado' (~R$ 6,89M indevidos).
+    """
+    s = (raw_status or "").upper().strip()
+    if s.startswith("INATIVO") or kind == "real_cancelado":
+        return "cancelado"
     if datapagto is not None:
         return "quitado"
-    if kind == "real_cancelado":
-        return "cancelado"
     return "aberto"
 
 


### PR DESCRIPTION
## Bug
`import-financeiro.py` `map_status` checava `datapagto` ANTES de cancelado → títulos WR **"INATIVO CANCELADA" com data de pagamento** viravam `quitado` e somavam no caixa.

## Regra (Wagner 2026-06-03)
Status que **começa com "INATIVO"** = lançamento não-válido → `cancelado` (escondido do financeiro; só visível em "Arquivados"), com **precedência sobre `datapagto`**.

## Fix
`map_status`: `if raw.startswith("INATIVO") or kind=="real_cancelado": return "cancelado"` ANTES do check de datapagto. Cobre INATIVO CANCELADA + variantes INATIVO desconhecidas.

## Impacto + correção de dados
- Medido: **2.683 títulos** biz=164 (Martinho) somavam **R$ 6.889.888,13** indevidos (`raw=INATIVO CANCELADA`, status `quitado`).
- **Backfill já aplicado em prod** (idempotente, biz=164): `status → cancelado`. Verificado ao vivo (Chrome MCP): duplicados cancelados sumiram da lista.
- Re-rodar o import (agora corrigido) mantém o estado correto.

Refs: US-FIN-030

🤖 Generated with [Claude Code](https://claude.com/claude-code)