### PR TITLE
docs(feedback): Wagner delega aprovação de merge verde ao Claude — críticos não

### DIFF
--- a/memory/reference/feedback-auto-merge-quando-verde.md
+++ b/memory/reference/feedback-auto-merge-quando-verde.md
@@ -20,3 +20,5 @@ gh pr merge <NUM> --auto --squash --delete-branch
 - `--squash --delete-branch` é o estilo canônico do projeto (histórico limpo)
 
 **Não confundir com:** mergear sem aprovação. A aprovação ainda vem do Wagner; o auto-merge só substitui o "espera CI verde + clica botão" por "GitHub faz quando puder".
+
+> **Atualização 2026-06-03:** pra PRs **verdes em módulos não-críticos**, Wagner delegou a própria **aprovação** ao Claude — ver [[feedback-claude-aprova-merge-verde-criticos-nao]]. Este doc continua valendo pra a *mecânica* (`--auto --squash --delete-branch`) e pros módulos críticos (onde a aprovação ainda é do Wagner).

--- a/memory/reference/feedback-claude-aprova-merge-verde-criticos-nao.md
+++ b/memory/reference/feedback-claude-aprova-merge-verde-criticos-nao.md
@@ -1,0 +1,25 @@
+---
+name: Claude aprova e mergeia PR verde — críticos não
+description: Wagner delegou a APROVAÇÃO de merge ao Claude para PRs verdes (CI passando) em módulos não-críticos. Claude mergeia sozinho sem chamar Wagner. Módulos críticos (dinheiro/fiscal/LGPD) continuam exigindo OK explícito do Wagner mesmo verdes.
+type: feedback
+---
+**Regra:** PR com CI **verde** (todos os required checks passando) em área **não-crítica** → Claude **aprova e mergeia sozinho**, sem escalar pro Wagner. Se vier **vermelho**, não mergeia: conserta ou avisa.
+
+**Why:** 2026-06-03, Wagner: "*pode mergear verde, críticos não*". Contexto: ele liberou as permissões locais ("não quero ficar autorizando" / "quero trabalhar menos") e, depois de entender que (a) o time não tem acesso de escrita ao repo — só `@wagnerra23` é code owner válido — e (b) `enforce_admins: false` deixa o Claude (rodando `gh` como admin) furar a fila, decidiu **delegar a aprovação dos greens não-críticos** pro Claude em vez de ser o gargalo. Evolui [[feedback-auto-merge-quando-verde]] (que cobria só a *mecânica* `--auto` mantendo Wagner como aprovador) e fica na família [[feedback-claude-mais-autonomo-2026-05-25]] + [[feedback-ondas-multi-pr-sem-perguntar-2026-05-28]].
+
+**Como aplicar:**
+- **Verde + não-crítico → mergeia.** Comando canônico do projeto: `gh pr merge <NUM> --auto --squash --delete-branch` (`--auto` o GitHub fecha quando ficar verde; `--squash --delete-branch` é o estilo canon).
+- **Vermelho → nunca mergeia.** Conserta o que dá ou avisa o Wagner.
+- A aprovação code-owner exigida pela branch protection é satisfeita pelo Claude usando o admin do Wagner (delegação explícita desta regra). Branch protection **não se mexe** — continua de piso.
+
+**Módulos CRÍTICOS — sempre exigem OK explícito do Wagner, mesmo verdes:**
+- 💰 `Modules/Financeiro/`, `Modules/NfeBrasil/`, `Modules/RecurringBilling/` (dinheiro / fiscal / cobrança)
+- 🔒 `Modules/Copiloto/` (LGPD-crítico)
+- 🧾 qualquer coisa fiscal/SPED/NF-e
+- (espelha os owners obrigatórios do `.github/CODEOWNERS`)
+
+**Continua escalando pro Wagner (não é "merge verde"):**
+- Deploy em produção, mudança em `.env` de prod, postagem externa — `publication-policy` vale igual.
+- ADR canon (`memory/decisions/*`), mudança Tier 0 multi-tenant, `enforce_admins`/branch protection.
+
+**Anti-padrão:** mergear PR vermelho "porque o fix é óbvio"; mergear módulo crítico verde sem avisar; presumir que a delegação cobre deploy/prod. Na dúvida se a área é crítica → trata como crítica e pergunta.


### PR DESCRIPTION
Grava como feedback canônico a régua decidida por Wagner em 2026-06-03: **PR verde (CI passando) em módulo não-crítico → Claude aprova e mergeia sozinho**; módulos críticos (Financeiro/NfeBrasil/RecurringBilling/Copiloto/fiscal) continuam exigindo OK explícito.

- Novo: `memory/reference/feedback-claude-aprova-merge-verde-criticos-nao.md`
- Cross-link no `feedback-auto-merge-quando-verde.md` (que cobria só a mecânica `--auto`)

publication-policy intacta pra deploy/prod/ADR canon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)