### PR TITLE
fix(ci): quick-sync build single-thread (RAYON_NUM_THREADS=1) — evita 500 por estouro de threads [M]

### DIFF
--- a/.github/workflows/quick-sync.yml
+++ b/.github/workflows/quick-sync.yml
@@ -120,10 +120,17 @@ jobs:
         # Build sempre roda — 52s aceitável e garante manifest.json determinístico.
         # Saída em public/build-inertia/ (gitignored). Vite gera hashes novos a
         # cada build, mas o manifest.json mapeia consistente com source atual.
+        # RAYON_NUM_THREADS=1: Tailwind v4/lightningcss/oxide usam rayon (Rust) que
+        # tenta criar um thread pool grande; no shared hosting Hostinger isso estoura
+        # o limite de threads/processos → `ThreadPoolBuildError: Resource temporarily
+        # unavailable`, o build falha E esvazia public/build-inertia/ (emptyOutDir)
+        # → site 500 (manifest.json some). Single-thread evita o estouro. Catalogado
+        # 2026-06-03: incident 500 + builds quick-sync falhando. (~35s single-thread.)
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             export PATH=\"\$HOME/.nvm/versions/node/v24.15.0/bin:\$PATH\" &&
+            export RAYON_NUM_THREADS=1 &&
             npm run build:inertia 2>&1 | tail -10
           "
 
@@ -139,6 +146,7 @@ jobs:
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             export PATH=\"\$HOME/.nvm/versions/node/v24.15.0/bin:\$PATH\" &&
+            export RAYON_NUM_THREADS=1 &&
             npm run build 2>&1 | tail -10
           "
 


### PR DESCRIPTION
## Causa raiz (incident 2026-06-03)
O build do bundle no `quick-sync` (rodado no Hostinger via SSH) usa Tailwind v4 / lightningcss / oxide — todos **rayon (Rust)** com thread pool grande. No **shared hosting** o limite de threads/processos estoura → `ThreadPoolBuildError: Resource temporarily unavailable` → o build **falha E esvazia `public/build-inertia/`** (vite `emptyOutDir`) → `manifest.json` some → **site 500**.

Foi o que derrubou o auto-deploy **várias vezes hoje** e causou um 500 momentâneo (restaurado na hora rebuildando single-thread).

## Fix
`export RAYON_NUM_THREADS=1` antes dos 2 `npm run build*` (inertia + tailwind legacy). Força rayon single-thread → não estoura. Custo: ~35s (vs ~50s), aceitável.

> Commitado via Contents API (token do `git push` local não tem escopo `workflow`).