### PR TITLE
feat(ds): DS v6 PR3 slice 1 — status pills /sells → tokens semânticos [DRAFT · gate]

### DIFF
--- a/resources/js/Pages/Sells/_components/SellsTabelaUnificada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsTabelaUnificada.tsx
@@ -130,10 +130,12 @@ const fmtTime = (iso: string | null) => {
 
 const PILL_STYLE: Record<PillKey, { bg: string; fg: string; label: string }> = {
   todas: { bg: 'var(--vd-neutral-soft)', fg: 'var(--vd-neutral)', label: '—' },
-  paga: { bg: 'var(--vd-ok-soft)', fg: 'var(--vd-ok)', label: 'Paga' },
-  pendente: { bg: 'var(--vd-warn-soft)', fg: 'var(--vd-warn)', label: 'Pendente' },
+  // DS v6 (PR3 slice 1) — status pills consomem tokens semânticos canônicos
+  // (cockpit.css: --pos/--warn/--neg + -soft), espelham gabarito-vendas c-pill.
+  paga: { bg: 'var(--pos-soft)', fg: 'var(--pos)', label: 'Paga' },
+  pendente: { bg: 'var(--warn-soft)', fg: 'var(--warn)', label: 'Pendente' },
   faturada: { bg: 'var(--accent-soft)', fg: 'var(--accent)', label: 'Faturada' },
-  cancelada: { bg: 'var(--bg-2)', fg: 'var(--text-mute)', label: 'Cancelada' },
+  cancelada: { bg: 'var(--neg-soft)', fg: 'var(--neg)', label: 'Cancelada' },
 };
 
 // ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## PR3 · slice 1 — status pills do /sells consomem tokens DS v6

**DRAFT — Tier-0, gate visual (ADR 0107/0114).** Não mergear sem OK [W] no screenshot.

`PILL_STYLE` (`SellsTabelaUnificada.tsx`) passa a consumir os tokens semânticos canônicos `--pos/--warn/--neg(+soft)` (landados em #2184) em vez dos locais `--vd-ok/--vd-warn`, espelhando o `c-pill` do `gabarito-vendas.html`.

| status | antes | depois | delta visível |
|---|---|---|---|
| paga | `--vd-ok(-soft)` | `--pos(-soft)` | ~igual (verde 145→150) |
| pendente | `--vd-warn(-soft)` | `--warn(-soft)` | ~igual (âmbar 70) |
| faturada | `--accent(-soft)` | (mantido) | nenhum |
| **cancelada** | `--bg-2/--text-mute` (cinza) | `--neg(-soft)` (**vermelho**) | **único delta real** |

**1 arquivo, 3 linhas.** Gate aprovado: `sells-index-dsv6-visual-comparison.md`.

⚠️ **Decisão pendente p/ [W]:** cancelada vai pra **vermelho** (gabarito) — hoje é cinza neutro. Confirmar ou manter cinza.

🤖 Generated with [Claude Code](https://claude.com/claude-code)