### PR TITLE
feat(ds): DS v6 PR3 slice 3 — origem /sells → --origin-* (recolor gabarito)

### DIFF
--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -7403,12 +7403,15 @@
    stripe + .vd-kpi-breakdown (KPI hero quando foco=faturamento).
    ────────────────────────────────────────────────────────────── */
 .sells-cowork .vendas-aplus {
-  --vd-src-balcao:       oklch(0.50 0.13 155);
-  --vd-src-balcao-soft:  oklch(0.94 0.06 155);
-  --vd-src-oficina:      oklch(0.50 0.13 230);
-  --vd-src-oficina-soft: oklch(0.94 0.06 230);
-  --vd-src-online:       oklch(0.58 0.15 50);
-  --vd-src-online-soft:  oklch(0.94 0.07 50);
+  /* DS v6 (PR3 slice 3) — origem da venda redireciona pros tokens canônicos
+     --origin-* (cockpit.css), espelhando o c-org do gabarito:
+     balcão→CRM (azul) · oficina→OS (âmbar) · online→FIN (verde). Flip dark de fábrica. */
+  --vd-src-balcao:       var(--origin-CRM-fg);
+  --vd-src-balcao-soft:  var(--origin-CRM-bg);
+  --vd-src-oficina:      var(--origin-OS-fg);
+  --vd-src-oficina-soft: var(--origin-OS-bg);
+  --vd-src-online:       var(--origin-FIN-fg);
+  --vd-src-online-soft:  var(--origin-FIN-bg);
 }
 
 /* Source pill — célula Origem */


### PR DESCRIPTION
## PR3 · slice 3 — origem → tokens `--origin-*`

`--vd-src-balcao/oficina/online(+soft)` → pares `--origin-*` canônicos, espelhando o `c-org` do gabarito:
- **balcão** → CRM (verde→**azul**) · **oficina** → OS (azul→**âmbar**) · **online** → FIN (laranja→**verde**)

Cascateia: badge de origem na linha · dots/barras "Por origem" · border-left do breakdown KPI hero · dots da saved tree · stripe oficina. **Recolor conforme gabarito aprovado [W]** ("tudo do gabarito"). Flip dark de fábrica. -6 `oklch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)