### PR TITLE
refactor(ds): higiene token /sells — danger-red oklch → var(--neg) (-16)

### DIFF
--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -786,7 +786,7 @@
   color: var(--text-mute);
   font-variant-numeric: tabular-nums;
 }
-.sells-cowork .tk-card.urgent .tk-when { color: oklch(0.55 0.18 25); font-weight: 600; }
+.sells-cowork .tk-card.urgent .tk-when { color: var(--neg); font-weight: 600; }
 .sells-cowork .tk-title {
   font-size: 13px;
   font-weight: 600;
@@ -919,7 +919,7 @@
 }
 .sells-cowork .tk-detail-meta .t-mute { color: var(--text-mute); margin-right: 3px; }
 .sells-cowork .tk-detail-meta b { font-weight: 500; }
-.sells-cowork .tk-detail-meta .urgent b { color: oklch(0.55 0.18 25); font-weight: 600; }
+.sells-cowork .tk-detail-meta .urgent b { color: var(--neg); font-weight: 600; }
 .sells-cowork .tk-detail-body {
   flex: 1 1 auto;
   overflow-y: auto;
@@ -977,7 +977,7 @@
 .sells-cowork .vw-dl dt { color: var(--text-mute); font-weight: 500; }
 .sells-cowork .vw-dl dd { margin: 0; color: var(--text); }
 .sells-cowork .vw-dl dd.mono { font-family: var(--font-mono); }
-.sells-cowork .vw-dl dd.urgent { color: oklch(0.55 0.18 25); font-weight: 600; }
+.sells-cowork .vw-dl dd.urgent { color: var(--neg); font-weight: 600; }
 .sells-cowork .vw-stage {
   display: inline-flex;
   background: var(--origin-OS-bg);
@@ -1140,7 +1140,7 @@
   border-color: oklch(0.85 0.08 25);
   border-style: dashed;
 }
-.sells-cowork .vw-pnt-cell.miss b { color: oklch(0.55 0.18 25); }
+.sells-cowork .vw-pnt-cell.miss b { color: var(--neg); }
 .sells-cowork [data-theme="dark"] .vw-pnt-cell.miss {
   background: oklch(0.26 0.06 25);
   border-color: oklch(0.45 0.10 25);
@@ -1164,7 +1164,7 @@
   font-variant-numeric: tabular-nums;
 }
 .sells-cowork .vw-due { font-size: 12px; color: var(--text-dim); }
-.sells-cowork .vw-due.urgent { color: oklch(0.55 0.18 25); font-weight: 600; }
+.sells-cowork .vw-due.urgent { color: var(--neg); font-weight: 600; }
 /* Botões viewer */
 .sells-cowork .vw-actions {
   display: flex;
@@ -1199,9 +1199,9 @@
 }
 .sells-cowork .vw-btn.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
 .sells-cowork .vw-btn.danger {
-  background: oklch(0.55 0.18 25);
+  background: var(--neg);
   color: #fff;
-  border-color: oklch(0.55 0.18 25);
+  border-color: var(--neg);
 }
 .sells-cowork .vw-btn.danger:hover { background: oklch(0.50 0.18 25); }
 .sells-cowork .vw-btn.ghost {
@@ -1997,7 +1997,7 @@
   border-color: oklch(0.85 0.08 25);
   border-style: dashed;
 }
-.sells-cowork .lpunch-row.missing b { color: oklch(0.55 0.18 25); }
+.sells-cowork .lpunch-row.missing b { color: var(--neg); }
 .sells-cowork [data-theme="dark"] .lpunch-row.missing {
   background: oklch(0.26 0.05 25);
   border-color: oklch(0.45 0.08 25);
@@ -2133,7 +2133,7 @@
   padding: 5px 10px;
   box-shadow: 0 1px 2px rgba(0,0,0,.04);
 }
-.sells-cowork .os-tab.warn { color: oklch(0.55 0.18 25); }
+.sells-cowork .os-tab.warn { color: var(--neg); }
 .sells-cowork .os-tab.warn.active { border-color: oklch(0.85 0.08 25); }
 .sells-cowork .os-tab-n {
   font-size: 10.5px;
@@ -2212,7 +2212,7 @@
 .sells-cowork .os-btn.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
 .sells-cowork .os-btn.ghost { background: transparent; border-color: transparent; color: var(--text-dim); }
 .sells-cowork .os-btn.ghost:hover { background: var(--border-2); color: var(--text); }
-.sells-cowork .os-btn.ghost.danger { color: oklch(0.55 0.18 25); }
+.sells-cowork .os-btn.ghost.danger { color: var(--neg); }
 .sells-cowork .os-btn.ghost.danger:hover { background: oklch(0.96 0.04 25); }
 .sells-cowork .os-btn.sm { height: 26px; padding: 0 10px; font-size: 11.5px; }
 /* Table */
@@ -2312,7 +2312,7 @@
   white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
-.sells-cowork .os-cell-deadline.urgent { color: oklch(0.55 0.18 25); font-weight: 600; }
+.sells-cowork .os-cell-deadline.urgent { color: var(--neg); font-weight: 600; }
 .sells-cowork .os-cell-value {
   text-align: right;
   white-space: nowrap;
@@ -2449,7 +2449,7 @@
   font-weight: 600;
   color: var(--text);
 }
-.sells-cowork .os-drawer-meta .urgent { color: oklch(0.55 0.18 25); }
+.sells-cowork .os-drawer-meta .urgent { color: var(--neg); }
 .sells-cowork .os-drawer-meta .mono { font-family: var(--font-mono); }
 .sells-cowork .os-drawer-section {
   padding: 16px 20px;
@@ -3162,13 +3162,13 @@
 }
 .sells-cowork .os-decision.adjust.active svg { color: oklch(0.55 0.16 75); opacity: 1; }
 .sells-cowork .os-decision.reject.active {
-  border-color: oklch(0.55 0.18 25);
+  border-color: var(--neg);
   background: oklch(0.96 0.04 25);
 }
 .sells-cowork [data-theme="dark"] .os-decision.reject.active {
   background: oklch(0.30 0.06 25);
 }
-.sells-cowork .os-decision.reject.active svg { color: oklch(0.55 0.18 25); opacity: 1; }
+.sells-cowork .os-decision.reject.active svg { color: var(--neg); opacity: 1; }
 .sells-cowork .os-decision-comment {
   display: block;
   width: 100%;
@@ -3598,7 +3598,7 @@
 .sells-cowork .prod-kpi-sub {
   font-size: 11.5px; color: var(--text-mute);
 }
-.sells-cowork .prod-kpi-urgent .prod-kpi-value { color: oklch(0.55 0.18 25); }
+.sells-cowork .prod-kpi-urgent .prod-kpi-value { color: var(--neg); }
 .sells-cowork .prod-kpi-urgent { border-color: oklch(0.85 0.10 25); background: oklch(0.97 0.04 25); }
 .sells-cowork .prod-equip-filters {
   display: flex; gap: 6px; flex-wrap: wrap;
@@ -5937,7 +5937,7 @@
 .sells-cowork .vendas-aplus .vd-sla-mini .ic { font-size: 8px; line-height: 1; margin-right: 4px; }
 .sells-cowork .vendas-aplus .vd-sla-mini.fresh { color: oklch(0.45 0.13 145); }
 .sells-cowork .vendas-aplus .vd-sla-mini.warning { color: oklch(0.50 0.13 60); }
-.sells-cowork .vendas-aplus .vd-sla-mini.overdue { color: oklch(0.55 0.18 25); }
+.sells-cowork .vendas-aplus .vd-sla-mini.overdue { color: var(--neg); }
 .sells-cowork .vendas-aplus .vd-sla-mini + .vd-sla-mini::before {
   content: "·"; margin-right: 2px; color: var(--text-mute); font-weight: 400;
 }


### PR DESCRIPTION
## Higiene de token — danger-red → `var(--neg)`

16× `oklch(0.55 0.18 25)` → `var(--neg)` (urgent/overdue/reject/danger em tk-card · vw-* · os-tab.warn · os-btn.danger · prod-kpi · vd-sla). **Casa exato** com o valor light de `--neg` → zero mudança visual no claro + agora flipa no escuro. **-16 oklch crus** (526 restantes). Objetivo: token-hygiene (separado do gabarito, [W] aprovou).

🤖 Generated with [Claude Code](https://claude.com/claude-code)