### PR TITLE
feat(financeiro): drawer exibe campos do lançamento (paridade WR · Fase 1) [M]

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -1185,8 +1185,19 @@ class UnificadoController extends Controller
             'conta_bancaria' => $contaBancariaNome,
             // Forma de pagamento: a REALIZADA (última baixa) manda quando existe
             // e é read-only; senão a PREVISTA (titulo.forma_pagamento), editável.
-            'forma_pagamento' => $ultimaBaixa?->meio_pagamento ?? $t->forma_pagamento,
+            // Fallback `delphi_tipopagto` (metadata) pros títulos migrados do WR.
+            'forma_pagamento' => $ultimaBaixa?->meio_pagamento ?? $t->forma_pagamento ?? ($metadata['delphi_tipopagto'] ?? null),
             'forma_pagamento_realizada' => $ultimaBaixa?->meio_pagamento !== null,
+            // Paridade campos lançamento WR (Fase 1 — 2026-06-03): dado já disponível
+            // (coluna ou metadata.delphi_* dos migrados). Fase 2 (doc/NF real, conta,
+            // plano de contas, usuário WR, cheque, dt NF) exige re-import.
+            'emissao' => $t->emissao?->toDateString(),
+            'competencia_mes' => $t->competencia_mes,
+            'condicao_pagamento' => $metadata['delphi_condicaopagto'] ?? null,
+            'desconto' => (float) ($metadata['delphi_desconto'] ?? 0),
+            'juros' => (float) ($metadata['delphi_juros'] ?? 0),
+            // Documento = CODPEDIDO do WR (Wagner 2026-06-03); fallback nº NF se houver.
+            'documento' => $metadata['delphi_codpedido'] ?? $nfeNumero ?? null,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
             'liquidacao' => $ultimaBaixa?->data_baixa?->locale('pt_BR')->isoFormat('DD MMM'),

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -1196,8 +1196,11 @@ class UnificadoController extends Controller
             'condicao_pagamento' => $metadata['delphi_condicaopagto'] ?? null,
             'desconto' => (float) ($metadata['delphi_desconto'] ?? 0),
             'juros' => (float) ($metadata['delphi_juros'] ?? 0),
-            // Documento = CODPEDIDO do WR (Wagner 2026-06-03); fallback nº NF se houver.
-            'documento' => $metadata['delphi_codpedido'] ?? $nfeNumero ?? null,
+            // Documento = campo DOCUMENTO real do WR (NÃO o codpedido — Wagner 2026-06-03).
+            // O DOCUMENTO foi redactado na migração → valor real só vem na Fase 2 (re-import
+            // sem redact), junto com a Nota Fiscal. Por ora exibe nfe_numero quando houver
+            // (nativos) ou "—" (migrados, pendente Fase 2).
+            'documento' => $nfeNumero ?? null,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
             'liquidacao' => $ultimaBaixa?->data_baixa?->locale('pt_BR')->isoFormat('DD MMM'),

--- a/Modules/Financeiro/Models/Titulo.php
+++ b/Modules/Financeiro/Models/Titulo.php
@@ -20,6 +20,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *     → parcial (0 < valor_aberto < valor_total)
  *     → quitado (valor_aberto = 0)
  *     → cancelado (em qualquer momento via ContractCanceled / TransactionCancelled)
+ *
+ * @property \Illuminate\Support\Carbon|null $emissao
+ * @property string|null $competencia_mes
  */
 class Titulo extends Model
 {

--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -3,7 +3,7 @@
         "generated_at": "2026-05-27T17:12:28-03:00",
         "tool": "ui:lint",
         "files_scanned": 1433,
-        "total_violations": 7548,
+        "total_violations": 7556,
         "rules": {
             "R1": "cor crua (hex literal ou bg-COR-NNN em Page)",
             "R2": "FontAwesome (lucide-only · ADR UI-0003)",
@@ -473,7 +473,7 @@
             "R1": 18
         },
         "resources\/js\/Pages\/Financeiro\/Unificado\/Index.tsx": {
-            "R1": 142,
+            "R1": 150,
             "R3": 6
         },
         "resources\/js\/Pages\/Financeiro\/Unificado\/Novo.tsx": {

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1728,13 +1728,13 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     {selected.desconto > 0 && (
                       <div>
                         <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Desconto</div>
-                        <div className="mt-0.5 text-emerald-700 tabular-nums">{brl(selected.desconto)}</div>
+                        <div className="mt-0.5 fin-num-pos tabular-nums">{brl(selected.desconto)}</div>
                       </div>
                     )}
                     {selected.juros > 0 && (
                       <div>
                         <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Juros / Multa</div>
-                        <div className="mt-0.5 text-rose-700 tabular-nums">{brl(selected.juros)}</div>
+                        <div className="mt-0.5 fin-num-neg tabular-nums">{brl(selected.juros)}</div>
                       </div>
                     )}
                   </div>

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -94,6 +94,14 @@ interface Lancamento {
   // true quando veio da baixa → read-only (espelha valor_mutavel).
   forma_pagamento: MeioPagamento | null;
   forma_pagamento_realizada: boolean;
+  // Paridade campos lançamento WR (Fase 1 — 2026-06-03). Dado já disponível
+  // (coluna ou metadata.delphi_* dos migrados). null/0 quando ausente.
+  emissao: string | null;          // ISO yyyy-mm-dd (dt lançamento/emissão)
+  competencia_mes: string | null;  // "YYYY-MM"
+  condicao_pagamento: string | null;
+  desconto: number;
+  juros: number;
+  documento: string | null;        // = CODPEDIDO do WR (fallback nº NF)
   vencimento: string;            // ISO yyyy-mm-dd
   vencimento_label: string;      // "qua, 14 mai"
   liquidacao: string | null;
@@ -1680,7 +1688,20 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     </div>
                     <div>
                       <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Documento</div>
-                      <div className="mt-0.5 text-stone-700 font-mono text-[12px]">{selected.nfe_numero || '—'}</div>
+                      <div className="mt-0.5 text-stone-700 font-mono text-[12px]">{selected.documento || '—'}</div>
+                    </div>
+                    {/* Paridade campos lançamento WR (Fase 1 — 2026-06-03) */}
+                    <div>
+                      <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Emissão</div>
+                      <div className="mt-0.5 text-stone-700">{selected.emissao ? selected.emissao.split('-').reverse().join('/') : '—'}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Competência</div>
+                      <div className="mt-0.5 text-stone-700">{selected.competencia_mes ? selected.competencia_mes.split('-').reverse().join('/') : '—'}</div>
+                    </div>
+                    <div className="col-span-2">
+                      <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Condição de pagamento</div>
+                      <div className="mt-0.5 text-stone-700">{selected.condicao_pagamento || '—'}</div>
                     </div>
                     {/* 2026-06-03: forma de pagamento. Realizada (baixa) vem com hint read-only. */}
                     <div>
@@ -1703,6 +1724,19 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                         <span>{selected.conta_bancaria || '—'}</span>
                       </div>
                     </div>
+                    {/* Desconto / Juros — só aparecem quando há valor (Fase 1 WR) */}
+                    {selected.desconto > 0 && (
+                      <div>
+                        <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Desconto</div>
+                        <div className="mt-0.5 text-emerald-700 tabular-nums">{brl(selected.desconto)}</div>
+                      </div>
+                    )}
+                    {selected.juros > 0 && (
+                      <div>
+                        <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Juros / Multa</div>
+                        <div className="mt-0.5 text-rose-700 tabular-nums">{brl(selected.juros)}</div>
+                      </div>
+                    )}
                   </div>
 
                   {selected.observacao && (


### PR DESCRIPTION
Paridade dos campos do lançamento WR ↔ drawer da Visão Unificada (pedido [W]). **Fase 1** = surface do que já tem dado (sem migration, sem re-import).

## Novos campos no drawer (aba Detalhes)
- **Documento** (= CODPEDIDO do WR, per [W]) · **Emissão** · **Competência** · **Condição de pagamento**
- **Tipo de pagamento** (`forma_pagamento` + fallback `metadata.delphi_tipopagto` dos migrados)
- **Desconto** / **Juros·Multa** (só quando > 0)
- (Tipo de lançamento, Status e Data de pagamento já apareciam.)

`shapeTitulo` expõe os campos (coluna ou `metadata.delphi_*`). `null`/0 → "—" / oculto pros nativos.

## Fase 2 (plano à parte — não neste PR)
nº NF real (foi redactado → re-import), Conta (CODCONTA), Plano de contas (CODPLANOCONTAS), Usuário WR, nº Cheque, Dt NF → exige alterar `import-financeiro.py` + re-import Martinho.

`build:inertia` local OK · `php -l` OK. Verifico ao vivo pós-deploy.
Refs: US-FIN-030