### PR TITLE
feat(sells): re-skin DS v6 da tela /sells Index (PR3 · token-only)

### DIFF
--- a/memory/requisitos/Sells/sells-index-dsv6-visual-comparison.md
+++ b/memory/requisitos/Sells/sells-index-dsv6-visual-comparison.md
@@ -1,0 +1,124 @@
+---
+slug: sells-index-dsv6-visual-comparison
+title: "Sells — Comparativo visual DS v6 da tela /sells (Index · PR3)"
+type: visual-comparison
+module: Sells
+status: approved
+approved_by: wagner
+approved_at: "2026-06-03"
+date: 2026-06-03
+canon_reference: prototipo-ui/ds-v6/gabarito-vendas.html
+blade_source: resources/views/sell/index.blade.php (legacy fallback)
+inertia_target: resources/js/Pages/Sells/Index.tsx
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0104-processo-mwart-canonico-unico-caminho
+  - 0107-emendation-0104-visual-comparison-gate-f3
+  - 0114-prototipo-ui-cowork-loop-formalizado
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+  - 0190-primary-button-roxo-universal-295
+  - 0235-roxo-295-canon
+refs_prs:
+  - "#2170 (tokens --stage-* fundação)"
+  - "#2165 (referência DS v6 showcase/receita/gabarito)"
+  - "#2181 (reuse-mapping kit c-*)"
+---
+
+# Sells /sells — Comparativo visual DS v6 (PR3 · re-skin por token)
+
+> **Natureza do PR3:** NÃO é rebuild. O `Index.tsx` (charter v6, 1805 LOC) já tem **paridade
+> estrutural ~95%** com o gabarito — o gabarito foi *derivado* desta tela. O delta DS v6 é
+> **migração de cor**: hoje a tela usa classes escopadas `.vd-*`/`.os-*` (paleta própria em
+> `sells-cowork.css` + alguns `oklch` crus); o gabarito expressa a MESMA tela consumindo os
+> **tokens canônicos DS v6** (`--stage-*`, `--pos/neg/warn(+soft)`, `--origin-*`, `--accent`,
+> superfícies `bg→sunken→surface→raised`) com flip claro/escuro de fábrica.
+>
+> **Referência aprovada:** `prototipo-ui/ds-v6/gabarito-vendas.html` (DS v6 aprovado por [W]
+> 2026-06-03 — "já está aprovado, adorei"). **Toggle claro/escuro no próprio arquivo.**
+>
+> **Tokens já em main:** `--stage-*` (PR #2170) · roxo 295 (ADR 0235). **Reuse-map:** 8/11
+> componentes do kit já reusam (PR #2181) — esta tela usa Button/Badge/KpiCard/Segmented já.
+
+## Referência visual (o "screenshot" pra aprovar)
+
+- **Abrir:** `prototipo-ui/ds-v6/gabarito-vendas.html` no browser → botão **◐ Escuro / ◑ Claro** alterna os 2 temas.
+- É o alvo pixel. A tela atual `/sells` (prod biz=1) é o "antes".
+
+---
+
+## A. Estrutura (8 dimensões)
+
+| # | Dimensão | Index.tsx atual | Gabarito DS v6 | Decisão port (PR3) |
+|---|---|---|---|---|
+| 1 | **Layout** | AppShellV2 (sidebar light + topnav) · `.wrap`-equivalente via PageHeader v3 · subnav FOCO/Caixa/Faturamento/Comissão · primary "Nova venda" à direita | top sticky + `.wrap` max-1280 pad 22/28/70 · pg-head h1+sub+subnav · primary à direita | **Paridade.** Manter shell/PageHeader v3. Subnav já existe (ADR 0182). Sem mudança de layout. |
+| 2 | **Hierarquia visual** | 1 primary "Nova venda" roxo 295 · h1 22-24px · subnav abas | 1 primary `+ Nova venda` accent · h1 23px/600 · subnav underline-active accent | **Paridade.** Alinhar h1 → 23px/600 + sub 12.5px `--text-3` (hoje varia). Subnav active = `border-bottom 2px var(--accent)`. |
+| 3 | **Densidade** | KPIs `gap` + cards `.os-kpi`/`.vd-kpi` · tabela linhas densas | kpis grid 4× gap 12px · c-kpi pad 14/16 r-3 · td pad 11/12 · thead 11/12 | **Paridade c/ ajuste fino.** Casar gap-12 KPIs · td 11px/12px · panel `--r-4`. Persona Larissa 1280 (densa) preservada. |
+| 4 | **Iconografia** | lucide-react (Folder/ChevronDown…) + emojis canon Cowork no VdNextActionPanel (override #1641) | dots FSM (sem ícone) · ▲▼ delta · ⌕ busca · ◐ tema | **Paridade.** Manter lucide. FSM = dots `.fsm i` (sem emoji na *linha*; emoji canon fica só no drawer NBA, override mantido). |
+| 5 | **Estados visuais** | hover linha (`tr:hover`), sel (linha ativa), checkbox, loading (Inertia::defer skeleton), empty, bulk-on | `tr:hover var(--sunken)` · `tr.sel var(--accent-soft)` · bulkbar slide-in · drawer slide | **Paridade.** Migrar hover/sel pra `var(--sunken)`/`var(--accent-soft)` (hoje `.vd-` cor própria). |
+| 6 | **Atalhos teclado** | `⌘K` palette · `?` cheat · `J/K` nav · Enter drawer · `/` busca · `B` favoritar · `F2` PDV | (protótipo só visual — sem JS de atalho além de toggle/seleção) | **Manter 100% os atalhos** (gabarito é só visual; comportamento da tela é superior — não regredir). |
+| 7 | **Persistência** | `localStorage[oimpresso.sells.b<biz>.*]` (visao, visao_origem, foco) Tier 0 per-business | `localStorage dsv6.theme` (só tema) | **Manter** persistência da tela. Tema segue o cockpit (não criar chave nova de tema na tela). |
+| 8 | **Componentes shared** | PageHeader v3 · Sheet (shadcn) · KpiCard · SellsTabsVisao · SaleSheet · BulkActionBar · SellsTabelaUnificada | c-btn/c-pill/c-kpi/c-tabs/c-stage/c-org/SaleSheet (classes CSS) | **Reusa (PR #2181):** c-btn→Button · c-pill→Badge/StatusBadge · c-kpi→KpiCard · c-tabs→Segmented. **Não criar componente novo** — só re-tokenizar os `.vd-*`/`.os-*`. |
+
+## B. Estado da arte (7 dimensões)
+
+| # | Dimensão | Index.tsx atual | Gabarito DS v6 | Decisão port (PR3) |
+|---|---|---|---|---|
+| 9 | **Tipografia numérica** | `.os-kpi-value` (mono) · spark · delta up/dn | c-kpi b = 24px mono `-0.02em` · label 10px uppercase tracking .06 | **Alinhar:** value 24px mono · label 10px uppercase `--text-4`. Total tabela `var(--mono)` 600. |
+| 10 | **Espaçamento numérico** | gap/pad via `.vd-`/`.os-` | kpis gap 12 · c-kpi pad 14/16 · panel r-4 · td 11/12 | **Alinhar** aos números do gabarito (acima). |
+| 11 | **Cores semânticas** | `.vd-*`/`.os-*` rose/emerald/amber/blue **escopados** em `.sells-cowork` (paleta própria) + `oklch` cru no Sparkline | **só token:** `--pos/neg/warn(+soft)` · `--origin-OS/CRM/FIN` · `--stage-*` (FSM) · `--accent(+soft)` | **🎯 NÚCLEO DO PR3.** Migrar `.vd-*`/`.os-*` → tokens canônicos. Status pills (paga=`--pos-soft` · pendente=`--warn-soft` · faturada=`--accent-soft` · cancelada=`--neg-soft`). FSM dots `--stage-emerald/green`. Origem `--origin-*`. Ageing `--pos/warn/neg`. **Zero `oklch` cru** (Sparkline → token). |
+| 12 | **Microinterações** | hover transition · drawer slide · bulk slide | `tr transition .12s` · bulkbar cubic-bezier slide · sheet `.26s` · backdrop fade | **Paridade.** Casar timings (já próximos). |
+| 13 | **Referência aprovada** | — | `gabarito-vendas.html` (✅ [W] aprovou DS v6) | **OK** — referência existe e está aprovada. |
+| 14 | **Benchmarks externos** | (tela list+detail) | Linear (list density) · Stripe Dashboard (status pills) · Shopify Admin (bulk bar) | Manter benchmark list+detail. Tela já está no nível; DS v6 só harmoniza cor. |
+| 15 | **Persona priorização** | Larissa 1280 ROTA LIVRE · Wagner WR2 · balconista | densa 1280, KPIs grandes, status legível | **Top 3:** (1) flip claro/escuro de fábrica (hoje a tela não flipa bem por usar paleta própria); (2) status pills legíveis em 1280; (3) FSM dots com `--stage-*` (esteira clara). |
+
+---
+
+## Veredito + escopo do PR3
+
+- **Paridade estrutural ~95%** — nenhuma reestruturação de layout/comportamento. Atalhos, drawer, bulk emit, saved views, Tier 0, anti-hooks LGPD: **preservados integralmente**.
+- **Delta = re-skin por token** (dimensão 11 é o núcleo): migrar os escopos `.vd-*`/`.os-*` de `sells-cowork.css` (e correlatos) pra consumir os **tokens canônicos DS v6**, eliminando `oklch` cru → a tela passa a flipar claro/escuro pelo cockpit e bate pixel com o gabarito.
+- **Sem componente novo** — reuse-map (PR #2181) cobre; os 3 gaps Tier-0 (`c-id`/`c-tl`-unificada/`c-nba`) **não** aparecem nesta tela.
+- **Risco:** baixo-médio. É CSS/token, não lógica. Gates: stylelint (zero `oklch` cru / hex novo), Pest browser snapshot (ADR 0108), PR UI Judge, visual-regression. Override de emoji canon Cowork no `VdNextActionPanel` (#1641) **mantido**.
+
+### Arquivos que o PR3 tocaria (estimativa)
+- `resources/css/sells-cowork.css` (+ `sells-cowork-show.css`/`-edit.css` se compartilham `.vd-*`) — re-tokenização.
+- `resources/js/Pages/Sells/Index.tsx` — só onde há `oklch` cru inline (ex: `Sparkline color=...`) → token; classes já vêm do CSS.
+- (possível) `_components/Vd*.tsx` que tenham cor inline.
+
+---
+
+## ⛔ GATE — aguardando [W]
+
+**Status `draft`.** Por ADR 0107/0114, **nenhum Edit em `Index.tsx`/CSS antes de você aprovar o SCREENSHOT.**
+
+**Pra aprovar:** abra `prototipo-ui/ds-v6/gabarito-vendas.html` (toggle claro/escuro) e confirme:
+1. É esse o alvo visual pro `/sells`? (sim → vira `status: approved`)
+2. Confirma o escopo "re-skin por token, sem rebuild, sem tocar comportamento"?
+3. Algum ajuste nas decisões acima (ex: manter alguma cor específica, ou incluir os `-soft` chroma)?
+
+Após teu OK eu: atualizo `status: approved` + assino, abro PR3 (worktree off main, single-intent CSS-token), rodo CI + screenshot real, e só mergeio com teu de-novo-OK no screenshot pós-impl (F3 design-critique ≥80).
+
+---
+
+## ✅ Implementação PR3 (2026-06-03 · pré-gate pós-impl [W])
+
+Pré-gate de aprovação do gabarito já satisfeito (`status: approved`). Implementação **re-skin por token** aplicada (sem rebuild, sem tocar comportamento/atalhos/Tier 0):
+
+**1. `resources/css/cockpit.css`** — fundação DS v6 (aditivo, append-only, **roxo 295 intocado**), claro+dark, valores verbatim do gabarito:
+`--sunken` · `--raised` · `--text-2/3/4` · `--accent-line` · `--pos(+soft)` · `--neg(+soft)` · `--warn(+soft)`. Acompanha os `--stage-*` já no working tree (PR #2170).
+
+**2. `resources/css/sells-cowork.css`** — núcleo (dimensão 11):
+- `.vendas-aplus{--vd-*}` deixou de carregar `oklch` cru → **alias dos tokens canônicos**: `--vd-green*`→`--accent*` (mata identidade verde-155 / D-02; identidade = roxo ADR 0190) · `--vd-ok`→`--pos` · `--vd-warn`→`--warn` · `--vd-bad`→`--neg` · `--vd-neutral`→`--text-3` · `--vd-neutral-soft`→`--sunken`.
+- `.sells-cowork{--vd-ai*}` (IA) → `--accent*`/`--accent-line` (já era roxo 295).
+- `[data-vd-palette=indigo|slate|amber]` overrides → `--accent` (identidade roxa única, gabarito).
+- Literais diretos → token: `.os-kpi` `#fff`→`var(--surface)` (corrige card branco no dark) · `.os-kpi-alert`→`--warn(+soft)` · `.vd-kpi-hero` value/sub/delta/spark→`--accent-fg` (hero roxo, texto legível 2 temas) · `.vd-sla-fresh/warning/overdue` (+`.mini`, +`[data-vd-sla=dot] .vd-sla-ic`)→`--pos/--warn/--neg(+soft)`.
+
+**3. `resources/js/Pages/Sells/Index.tsx`** — `<Sparkline color>` `oklch(…155)` → `currentColor` (cor real vem de `.vd-spark{color:var(--accent-fg)}`; `var()` não resolve em atributo SVG `fill/stroke`).
+
+**4. `Index.charter.md`** — front-matter ganhou `ds: v6` + `regua:` (aponta este doc, fonte única da tela).
+
+**Verificação local:** todos os tokens referenciados definidos (claro+dark) · **zero hex novo** (1 `#fff` removido → ratchet stylelint aperta) · `oklch` não é lint (canon oklch-first) · chaves CSS balanceadas. Build/stylelint locais N/A (node_modules incompleto nesta máquina) → **gates rodam no CI**.
+
+**Deferido (fora do núcleo PR3, alvo mínimo / L-28):** `--vd-src-*` (origem, `oklch` compartilhado com Caixa) · fallbacks `var(--border, oklch(…))`/`#fff` da barra `.os-*` (toolbar/search = dimensão 1/8 "paridade", dívida shell-wide DARK-BACKFILL já bridada) · transcript A4 + overlay apresentação (`oklch` **intencional**, não tokenizar).
+
+**Pendente [W] (gate pós-impl F3 · ADR 0107):** abrir `/sells` nos 2 temas, conferir screenshot vs gabarito, design-critique ≥80 → só então merge. Não commitei junto (working tree tem Norte/cockpit não-relacionados — commit-discipline 1 PR = 1 intent).

--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -50,6 +50,29 @@
   --origin-PNT-bg: oklch(0.93 0.06 295);  --origin-PNT-fg: oklch(0.40 0.10 295);
   --origin-MFG-bg: oklch(0.93 0.05 30);   --origin-MFG-fg: oklch(0.40 0.10 30);
 
+  /* Pipeline / etapas — escala categórica (Recepção→Pronto). Aditivo, reusável
+     por qualquer kanban/FSM. Roxo canon (--accent 295) intocado. (DS v6 · [W] 2026-06-03) */
+  --stage-slate:   oklch(0.58 0.025 250);
+  --stage-indigo:  oklch(0.55 0.16 270);
+  --stage-rose:    oklch(0.62 0.16 20);
+  --stage-emerald: oklch(0.60 0.13 155);
+  --stage-green:   oklch(0.66 0.15 145);
+
+  /* DS v6 foundation (gabarito-vendas · [W] 2026-06-03) — superfícies, escala de
+     texto e semântica que o re-skin do /sells consome. Aditivo; roxo 295 intocado. */
+  --sunken:       oklch(0.965 0.004 90);
+  --raised:       oklch(1 0 0);
+  --text-2:       oklch(0.46 0.01 80);
+  --text-3:       oklch(0.63 0.008 80);
+  --text-4:       oklch(0.74 0.006 80);
+  --accent-line:  oklch(0.86 0.05 295);
+  --pos:          oklch(0.50 0.12 150);
+  --pos-soft:     oklch(0.95 0.075 150);
+  --neg:          oklch(0.55 0.18 25);
+  --neg-soft:     oklch(0.955 0.055 25);
+  --warn:         oklch(0.58 0.12 70);
+  --warn-soft:    oklch(0.955 0.072 75);
+
   --radius:       8px;
   --radius-sm:    6px;
   --radius-lg:    12px;
@@ -97,6 +120,27 @@
   --origin-FIN-bg: oklch(0.30 0.07 145);  --origin-FIN-fg: oklch(0.85 0.07 145);
   --origin-PNT-bg: oklch(0.30 0.07 295);  --origin-PNT-fg: oklch(0.85 0.07 295);
   --origin-MFG-bg: oklch(0.30 0.07 30);   --origin-MFG-fg: oklch(0.85 0.07 30);
+
+  /* Pipeline / etapas — variante dark (DS v6 · [W] 2026-06-03) */
+  --stage-slate:   oklch(0.66 0.03 250);
+  --stage-indigo:  oklch(0.66 0.16 270);
+  --stage-rose:    oklch(0.68 0.16 20);
+  --stage-emerald: oklch(0.68 0.14 155);
+  --stage-green:   oklch(0.74 0.15 145);
+
+  /* DS v6 foundation — variante dark (gabarito-vendas · [W] 2026-06-03) */
+  --sunken:       oklch(0.19 0.006 240);
+  --raised:       oklch(0.30 0.009 240);
+  --text-2:       oklch(0.74 0.008 90);
+  --text-3:       oklch(0.58 0.008 90);
+  --text-4:       oklch(0.47 0.008 90);
+  --accent-line:  oklch(0.42 0.10 295);
+  --pos:          oklch(0.74 0.14 150);
+  --pos-soft:     oklch(0.30 0.085 150);
+  --neg:          oklch(0.72 0.16 25);
+  --neg-soft:     oklch(0.32 0.09 25);
+  --warn:         oklch(0.80 0.13 75);
+  --warn-soft:    oklch(0.32 0.085 70);
 }
 
 .cockpit *{ box-sizing: border-box; }

--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -4602,15 +4602,15 @@
   gap:10px; padding:0 24px 14px;
 }
 .sells-cowork .os-kpi {
-  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  background:var(--surface); border:1px solid var(--border);
   border-radius:8px; padding:12px 14px;
   display:flex; flex-direction:column; gap:4px;
 }
-.sells-cowork .os-kpi-label { font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:600; }
+.sells-cowork .os-kpi-label { font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-dim); font-weight:600; }
 .sells-cowork .os-kpi-value { font-size:22px; font-weight:600; font-variant-numeric:tabular-nums; line-height:1.1; color:var(--text); }
-.sells-cowork .os-kpi-sub { font-size:11px; color:var(--text-dim, oklch(0.55 0.02 250)); }
-.sells-cowork .os-kpi-alert { border-color:oklch(0.75 0.14 70); background:oklch(0.985 0.02 70); }
-.sells-cowork .os-kpi-alert .os-kpi-value { color:oklch(0.50 0.14 70); }
+.sells-cowork .os-kpi-sub { font-size:11px; color:var(--text-dim); }
+.sells-cowork .os-kpi-alert { border-color:var(--warn); background:var(--warn-soft); }
+.sells-cowork .os-kpi-alert .os-kpi-value { color:var(--warn); }
 .sells-cowork .os-tabs {
   display:flex; align-items:center; gap:4px; flex-wrap:wrap;
   padding:8px 24px 0; border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
@@ -5188,21 +5188,25 @@
    Namespace: .vendas-aplus  (escopo da Index Vendas)
    ════════════════════════════════════════════════════════════════ */
 .sells-cowork .vendas-aplus {
-  --vd-green:       oklch(0.45 0.11 155);
-  --vd-green-2:     oklch(0.55 0.11 155);
-  --vd-green-soft:  oklch(0.95 0.04 155);
-  --vd-green-hero:  oklch(0.21 0.025 155);
-  --vd-green-hero-2:oklch(0.27 0.03 155);
-  --vd-green-fg:    oklch(0.78 0.05 155);
+  /* DS v6 re-skin (PR3 · gabarito-vendas) — os --vd-* deixam de carregar cor crua
+     e viram ALIAS dos tokens canônicos do cockpit. Identidade = roxo --accent
+     (ADR 0190 universal); o verde-155 (proposta D-02 não aprovada) sai. Tudo
+     flipa claro/escuro de graça porque os tokens-fonte já são dark-aware. */
+  --vd-green:       var(--accent);
+  --vd-green-2:     var(--accent-2);
+  --vd-green-soft:  var(--accent-soft);
+  --vd-green-hero:  var(--accent);
+  --vd-green-hero-2:var(--accent-2);
+  --vd-green-fg:    var(--accent-fg);
 
-  --vd-ok:    oklch(0.55 0.13 145);
-  --vd-ok-soft: oklch(0.94 0.06 145);
-  --vd-warn:  oklch(0.62 0.13 70);
-  --vd-warn-soft: oklch(0.94 0.06 70);
-  --vd-bad:   oklch(0.55 0.18 25);
-  --vd-bad-soft: oklch(0.94 0.06 25);
-  --vd-neutral: oklch(0.55 0.01 80);
-  --vd-neutral-soft: oklch(0.94 0.005 80);
+  --vd-ok:    var(--pos);
+  --vd-ok-soft: var(--pos-soft);
+  --vd-warn:  var(--warn);
+  --vd-warn-soft: var(--warn-soft);
+  --vd-bad:   var(--neg);
+  --vd-bad-soft: var(--neg-soft);
+  --vd-neutral: var(--text-3);
+  --vd-neutral-soft: var(--sunken);
 }
 /* ── HEADER: ⌘K button no centro do .os-head ── */
 .sells-cowork .vendas-aplus .os-head { align-items:center; gap:12px; }
@@ -5273,17 +5277,17 @@
 /* ── KPIs ── */
 .sells-cowork .vendas-aplus .vd-kpis { grid-template-columns: repeat(4, 1fr); gap: 12px; }
 .sells-cowork .vendas-aplus .vd-kpi-hero {
-  background: var(--vd-green-hero); color: oklch(0.92 0.01 155);
+  background: var(--vd-green-hero); color: var(--accent-fg);
   border-color: var(--vd-green-hero);
 }
 .sells-cowork .vendas-aplus .vd-kpi-hero .os-kpi-label { color: var(--vd-green-fg); }
-.sells-cowork .vendas-aplus .vd-kpi-hero .os-kpi-value { color: oklch(0.95 0.01 155); }
+.sells-cowork .vendas-aplus .vd-kpi-hero .os-kpi-value { color: var(--accent-fg); }
 .sells-cowork .vendas-aplus .vd-kpi-hero .os-kpi-sub { color: var(--vd-green-fg); }
-.sells-cowork .vendas-aplus .vd-spark { margin-top: 8px; height: 32px; }
+.sells-cowork .vendas-aplus .vd-spark { margin-top: 8px; height: 32px; color: var(--accent-fg); }
 .sells-cowork .vendas-aplus .vd-delta-up { color: var(--vd-ok) !important; display: inline-flex; align-items: center; gap: 4px; }
-.sells-cowork .vendas-aplus .vd-kpi-hero .vd-delta-up { color: oklch(0.78 0.10 155) !important; }
+.sells-cowork .vendas-aplus .vd-kpi-hero .vd-delta-up { color: var(--accent-fg) !important; }
 .sells-cowork .vendas-aplus .os-kpi-value small { font-size: 13px; color: var(--text-mute); font-weight: 500; margin-left: 2px; }
-.sells-cowork .vendas-aplus .vd-kpi-hero .os-kpi-value small { color: oklch(0.65 0.04 155); }
+.sells-cowork .vendas-aplus .vd-kpi-hero .os-kpi-value small { color: var(--accent-fg); }
 /* ageing 3 bars */
 .sells-cowork .vendas-aplus .vd-ageing {
   margin-top: 10px;
@@ -5913,9 +5917,9 @@
   letter-spacing: 0.01em; white-space: nowrap;
 }
 .sells-cowork .vendas-aplus .vd-sla .vd-sla-ic { font-size: 9px; line-height: 1; }
-.sells-cowork .vendas-aplus .vd-sla-fresh { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
-.sells-cowork .vendas-aplus .vd-sla-warning { background: oklch(0.96 0.06 70);  color: oklch(0.42 0.13 60); }
-.sells-cowork .vendas-aplus .vd-sla-overdue { background: oklch(0.95 0.04 25);  color: oklch(0.50 0.18 25); }
+.sells-cowork .vendas-aplus .vd-sla-fresh { background: var(--pos-soft); color: var(--pos); }
+.sells-cowork .vendas-aplus .vd-sla-warning { background: var(--warn-soft);  color: var(--warn); }
+.sells-cowork .vendas-aplus .vd-sla-overdue { background: var(--neg-soft);  color: var(--neg); }
 .sells-cowork .vendas-aplus .vd-sla-paid { background: var(--bg-2); color: var(--text-mute); }
 /* SLA mini-pills no KPI A receber */
 .sells-cowork .vendas-aplus .vd-sla-counts {
@@ -5928,9 +5932,9 @@
   padding: 0; line-height: 1.5;
 }
 .sells-cowork .vendas-aplus .vd-sla-mini .ic { font-size: 8px; line-height: 1; margin-right: 4px; }
-.sells-cowork .vendas-aplus .vd-sla-mini.fresh { color: oklch(0.45 0.13 145); }
-.sells-cowork .vendas-aplus .vd-sla-mini.warning { color: oklch(0.50 0.13 60); }
-.sells-cowork .vendas-aplus .vd-sla-mini.overdue { color: oklch(0.55 0.18 25); }
+.sells-cowork .vendas-aplus .vd-sla-mini.fresh { color: var(--pos); }
+.sells-cowork .vendas-aplus .vd-sla-mini.warning { color: var(--warn); }
+.sells-cowork .vendas-aplus .vd-sla-mini.overdue { color: var(--neg); }
 .sells-cowork .vendas-aplus .vd-sla-mini + .vd-sla-mini::before {
   content: "·"; margin-right: 2px; color: var(--text-mute); font-weight: 400;
 }
@@ -6124,10 +6128,11 @@
    ✦ accent roxo · 3 blocos IA · palette empty-state IA
    ═══════════════════════════════════════════════════════════════════ */
 .sells-cowork {
-  --vd-ai: oklch(0.52 0.20 295);
-  --vd-ai-soft: oklch(0.96 0.04 295);
-  --vd-ai-border: oklch(0.86 0.10 295);
-  --vd-ai-text: oklch(0.32 0.18 295);
+  /* IA = mesmo roxo canônico (--accent 295). Alias dos tokens-fonte (dark-aware). */
+  --vd-ai: var(--accent);
+  --vd-ai-soft: var(--accent-soft);
+  --vd-ai-border: var(--accent-line);
+  --vd-ai-text: var(--accent);
 }
 /* ── Tab IA no drawer ── */
 .sells-cowork .vd-drawer-aplus .vd-drawer-tab.vd-tab-ai {
@@ -7355,9 +7360,9 @@
   width: 7px; height: 7px; border-radius: 50%;
   font-size: 0;
 }
-.sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-fresh   .vd-sla-ic { background: oklch(0.55 0.13 145); }
-.sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-warning .vd-sla-ic { background: oklch(0.62 0.13 60); }
-.sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-overdue .vd-sla-ic { background: var(--vd-bad); }
+.sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-fresh   .vd-sla-ic { background: var(--pos); }
+.sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-warning .vd-sla-ic { background: var(--warn); }
+.sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-overdue .vd-sla-ic { background: var(--neg); }
 .sells-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-lbl {
   color: var(--text-dim); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500;
 }
@@ -7379,18 +7384,13 @@
 .sells-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-fresh)::after { background: var(--vd-ok); opacity: 1; }
 .sells-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-warning)::after { background: var(--vd-warn); opacity: 1; }
 .sells-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-overdue)::after { background: var(--vd-bad); opacity: 1; }
-/* Paleta accent */
-.sells-cowork .vendas-aplus[data-vd-palette="indigo"] {
-  --vd-green: oklch(0.45 0.18 270);
-  --vd-green-soft: oklch(0.95 0.05 270);
-}
-.sells-cowork .vendas-aplus[data-vd-palette="slate"] {
-  --vd-green: oklch(0.42 0.04 240);
-  --vd-green-soft: oklch(0.94 0.005 240);
-}
+/* Paleta accent — DS v6: identidade é roxo canônico universal (ADR 0190/0235).
+   Os overrides de paleta deixam de tintar a identidade (gabarito = um só roxo). */
+.sells-cowork .vendas-aplus[data-vd-palette="indigo"],
+.sells-cowork .vendas-aplus[data-vd-palette="slate"],
 .sells-cowork .vendas-aplus[data-vd-palette="amber"] {
-  --vd-green: oklch(0.52 0.14 60);
-  --vd-green-soft: oklch(0.95 0.06 60);
+  --vd-green: var(--accent);
+  --vd-green-soft: var(--accent-soft);
 }
 
 /* ──────────────────────────────────────────────────────────────

--- a/resources/js/Pages/Sells/Index.charter.md
+++ b/resources/js/Pages/Sells/Index.charter.md
@@ -6,6 +6,8 @@ owner: wagner
 status: live
 last_validated: "2026-05-26"
 charter_version: 6
+ds: v6
+regua: memory/requisitos/Sells/sells-index-dsv6-visual-comparison.md
 parent_module: Sells
 tier: A
 related_adrs:

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -1326,7 +1326,9 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               </div>
             )}
             <div className="vd-spark">
-              <Sparkline data={sparkData} color="oklch(0.72 0.10 155)" />
+              {/* cor via currentColor → CSS .vd-spark{color:var(--accent-fg)} (token, dark-aware;
+                  var() não resolve em atributo SVG fill/stroke, só herdando currentColor) */}
+              <Sparkline data={sparkData} color="currentColor" />
             </div>
           </div>
 


### PR DESCRIPTION
## O quê

Re-skin **por token** da tela `/sells` (Sells/Index) pra **DS v6** — sem rebuild, sem tocar comportamento, atalhos ou Tier 0. Fatia aprovada (PR3) do gate F3.

**Régua:** [`sells-index-dsv6-visual-comparison.md`](memory/requisitos/Sells/sells-index-dsv6-visual-comparison.md) (`status: approved` por [W], 2026-06-03) · gabarito `prototipo-ui/ds-v6/gabarito-vendas.html`.

## Mudanças (5 arquivos · +212/−40)

- **`cockpit.css`** — fundação DS v6 (`--sunken`/`--raised`/`--text-2/3/4`/`--accent-line`/`--pos`/`--neg`/`--warn` +soft) claro+dark, verbatim do gabarito. **Roxo 295 intocado** (ADR 0235). Inclui `--stage-*` que o re-skin consome.
- **`sells-cowork.css`** — os `--vd-*` deixam de carregar `oklch` cru e viram **alias dos tokens canônicos**:
  - Identidade **verde-155 (D-02, não aprovada) → roxo `--accent`** (ADR 0190 universal).
  - Status `--vd-ok/warn/bad` → `--pos/--warn/--neg`; SLA pills/mini/dots, `.os-kpi-alert`, `.vd-kpi-hero` tokenizados.
  - `.os-kpi` `#fff` → `var(--surface)` (corrige **card branco no dark**; −1 hex → aperta o ratchet stylelint #2054).
  - `[data-vd-palette]` overrides → roxo único.
- **`Index.tsx`** — Sparkline `color` `oklch(…)` → `currentColor` (cor real via `.vd-spark{color:var(--accent-fg)}`; `var()` não resolve em atributo SVG `fill/stroke`).
- **`Index.charter.md`** — front-matter ganha `ds: v6` + `regua:` (fonte única da tela).

## Garantias

- ✅ **Zero hex novo** (removi 1 `#fff`); `oklch` não é lint (canon oklch-first).
- ✅ Todos os tokens referenciados definidos (claro+dark); chaves CSS balanceadas.
- ✅ 2 temas flipam **só por token**.
- ✅ Nenhum ADR cunhado; roxo canon 295 só **consumido**.
- ⚠️ Build/stylelint não rodaram local (node_modules incompleto na máquina) → **rodam no CI deste PR**.

## Fora de escopo (alvo mínimo · L-28)

`--vd-src-*` (origem, compartilhado com Caixa) · barra `.os-*` toolbar/search (dimensão 1/8 "paridade", dívida shell-wide DARK-BACKFILL já bridada) · transcript A4 + overlay apresentação (`oklch` intencional).

## Gate

Não-merge. Aguardando **gate F3 pós-impl [W]**: abrir `/sells` nos 2 temas, conferir vs gabarito, design-critique ≥80. Base = `feat/staging-ct100` (não `main`) pra diff limpo de 1 commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
