### PR TITLE
feat(ci): gate de conformância DS — anti-regressão de cor crua (Camada 1+2+META)

### DIFF
--- a/.conformance-baseline.json
+++ b/.conformance-baseline.json
@@ -1,0 +1,12 @@
+{
+  "resources/css/sells-cowork.css": 649,
+  "resources/css/sells-cowork-show.css": 29,
+  "resources/css/sells-cowork-edit.css": 18,
+  "resources/css/sells-cowork-drafts.css": 13,
+  "resources/css/sells-cowork-quotations.css": 14,
+  "resources/css/sells-cowork-subscriptions.css": 15,
+  "resources/css/sells-cowork-curadoria.css": 38,
+  "resources/css/sells-cowork-distribuicao.css": 22,
+  "resources/css/sells-cowork-ia.css": 26,
+  "resources/css/sells-cowork-insights.css": 123
+}

--- a/.conformance-baseline.json
+++ b/.conformance-baseline.json
@@ -1,5 +1,5 @@
 {
-  "resources/css/sells-cowork.css": 649,
+  "resources/css/sells-cowork.css": 624,
   "resources/css/sells-cowork-show.css": 29,
   "resources/css/sells-cowork-edit.css": 18,
   "resources/css/sells-cowork-drafts.css": 13,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,5 +103,10 @@ jobs:
       - name: Install JS deps
         run: npm ci
 
+      - name: Conformance gate — Camada META (controle-negativo do gate de cor-crua)
+        # Prova que o gate DISCRIMINA (sensibilidade + especificidade). Gate nunca-visto-vermelho
+        # não vale (METODO_TELA_ANTI-REGRESSAO §controle-negativo). Determinístico, zero-flake.
+        run: npm run test:conformance
+
       - name: Build production bundle (Inertia/React pipeline)
         run: npm run build:inertia

--- a/.github/workflows/conformance-gate.yml
+++ b/.github/workflows/conformance-gate.yml
@@ -17,13 +17,17 @@ on:
   push:
     branches: [main, 6.7-react]
     paths:
-      - 'resources/css/sells-cowork*.css'
+      # Cor-crua (ratchet) escopa sells-cowork*; o invariante --accent varre TODO resources/css/*.css
+      # (token de marca vive em cockpit.css/fin-cowork.css/cowork-*-bundle.css) — gatilho cobre os dois.
+      - 'resources/css/**/*.css'
       - 'scripts/conformance-gate.mjs'
       - '.conformance-baseline.json'
       - '.github/workflows/conformance-gate.yml'
   pull_request:
     paths:
-      - 'resources/css/sells-cowork*.css'
+      # Cor-crua (ratchet) escopa sells-cowork*; o invariante --accent varre TODO resources/css/*.css
+      # (token de marca vive em cockpit.css/fin-cowork.css/cowork-*-bundle.css) — gatilho cobre os dois.
+      - 'resources/css/**/*.css'
       - 'scripts/conformance-gate.mjs'
       - '.conformance-baseline.json'
       - '.github/workflows/conformance-gate.yml'

--- a/.github/workflows/conformance-gate.yml
+++ b/.github/workflows/conformance-gate.yml
@@ -1,0 +1,67 @@
+name: Conformance Gate — cor-crua DS (Camada 1 · anti-regressão de contrato)
+
+# Gate de CONFORMÂNCIA DS (não só comportamento): bloqueia PR que introduza COR CRUA NOVA
+# em regras de TELA (família sells-cowork*.css). Complementa o stylelint-gate (que congela #hex
+# global) pegando o que ele não pega: oklch(<hue numérico>) cru escopado por seletor de tela —
+# inclusive o drift verde-155 × roxo-295 (ADR 0235/0190).
+#
+# Ratchet only-down: o teto (.conformance-baseline.json, versionado) só pode CAIR. Adicionou cor
+# crua = exit 1 = merge bloqueado. Determinístico, zero-dep, zero-flake.
+#
+# Camada META (controle-negativo) roda no vitest (tests/conformanceGate.spec.ts) via ci.yml.
+# Comando manual local: npm run conformance:check
+#
+# Refs: PROMPT_PARA_CODE_CONFORMANCE-GATE.md · ADR 0209 (ratchet gêmeo) · ADR 0238 (soberania, sem ADR).
+
+on:
+  push:
+    branches: [main, 6.7-react]
+    paths:
+      - 'resources/css/sells-cowork*.css'
+      - 'scripts/conformance-gate.mjs'
+      - '.conformance-baseline.json'
+      - '.github/workflows/conformance-gate.yml'
+  pull_request:
+    paths:
+      - 'resources/css/sells-cowork*.css'
+      - 'scripts/conformance-gate.mjs'
+      - '.conformance-baseline.json'
+      - '.github/workflows/conformance-gate.yml'
+
+concurrency:
+  group: conformance-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conformance:
+    name: Conformance · cor-crua ratchet vs baseline
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Conformance gate (falha só em cor crua NOVA vs baseline)
+        run: node scripts/conformance-gate.mjs --all
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "🔴 Conformance gate detectou COR CRUA NOVA numa regra de tela."
+          echo ""
+          echo "O contrato visual derivou do gabarito DS aprovado (cor fora de token voltou)."
+          echo ""
+          echo "Próximos passos:"
+          echo "  1. Local: npm run conformance:check · vê qual arquivo/seletor regrediu"
+          echo "  2. Trocar a cor crua por token DS: var(--accent)/--pos/--neg/--warn/--origin-*/--stage-*"
+          echo "     (roxo canônico = oklch(0.55 0.15 295) · ADR 0235/0190 — NUNCA verde-155)"
+          echo "  3. Se a remoção foi intencional (baixou cor crua), re-cravar o teto:"
+          echo "       npm run conformance:baseline:write   (commit separado — diff do JSON é auditável)"
+          echo ""
+          echo "Exceções declaradas (papel/transcript/apresentação): .vd-trans · .vd-pres (cor fixa proposital)."
+          echo "Refs: ADR 0209 · ADR 0235/0190 · PROMPT_PARA_CODE_CONFORMANCE-GATE.md"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,10 @@
     "design:review:check": "node prototipo-ui/audit/review-freshness.mjs",
     "design:review:baseline": "node prototipo-ui/audit/review-freshness.mjs --write-baseline",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "conformance:check": "node scripts/conformance-gate.mjs --all",
+    "conformance:baseline:write": "node scripts/conformance-gate.mjs --all --update",
+    "test:conformance": "vitest run tests/conformanceGate.spec.ts"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/resources/js/Pages/Sells/Index.charter.md
+++ b/resources/js/Pages/Sells/Index.charter.md
@@ -8,6 +8,37 @@ last_validated: "2026-05-26"
 charter_version: 6
 ds: v6
 regua: memory/requisitos/Sells/sells-index-dsv6-visual-comparison.md
+# contrato_layout — FONTE ÚNICA legível-por-máquina do gate de conformância DS (§0 PROMPT_PARA_CODE).
+# Os testes de conformância (Camada 1 estática + Camada 2 browser) são DERIVADOS daqui, não mantidos à mão.
+# Mudança de contrato visual = só Wagner edita este bloco (charter = contrato). ADR 0235/0190 · 0238 (sem ADR).
+# derivado: tests/Browser/Sells/IndexConformanceTest.php (Camada 2) + scripts/conformance-gate.mjs (Camada 1).
+contrato_layout:
+  kpis: 4            # 1-linha hero row: Faturado hoje · Ticket médio · A receber · 4º vista-dependente
+  uc:
+    UC-V09:          # accent do primary "Nova venda" == token roxo (NÃO verde) — pega o drift verde×roxo
+      alvo: primary-nova-venda
+      locator: '.os-btn.primary'   # bg=var(--accent) · sells-cowork.css:2211
+      assert: accent-token
+      hue_ok: [250, 330]     # roxo 295 canônico — oklch(0.55 0.15 295)
+      hue_proibido: [90, 165] # faixa verde-155 (D-02)
+    UC-V10:          # cor fora de token (Camada 1 estática — gate cor-crua, ratchet only-down)
+      assert: cor-crua-zero
+      gate: scripts/conformance-gate.mjs
+      escopo: ['.sells-cowork', '.vd-', '.os-', '.vendas-aplus', '.vendas-page']
+      excecao: ['.vd-trans', '.vd-pres']  # papel A4 / apresentação dark própria (cor fixa proposital)
+    UC-V11:          # detalhe abre DRAWER lateral role=dialog (NÃO modal central)
+      alvo: sale-sheet-drawer
+      locator: '[role=dialog].os-drawer'   # SaleSheet (shadcn Sheet side=right sm:max-w-xl ~576) · NÃO .vd-pal palette
+      assert: drawer-lateral
+      role: dialog
+      largura_faixa_px: [380, 600]
+      status: todo   # IndexConformanceTest UC-V11 = ->todo() (precisa venda semeada + locator do drawer)
+    UC-V12:          # 2 temas: card KPI NÃO quase-branco no dark (dívida --surface)
+      alvo: kpi-card
+      locator: '.os-kpi'
+      assert: surface-dark
+      temas: [light, dark]
+      kpi_surface_dark_L_max: 0.85   # OKLab L do bg no dark < 0.85 (card escuro legítimo vs branco vazado)
 parent_module: Sells
 tier: A
 related_adrs:
@@ -168,6 +199,7 @@ Tela cockpit central de operação comercial — lista vendas (pedidos · fatura
 
 ## v5 → v6 changelog (append-only)
 
+- v6.1 (2026-06-03 · aditivo) — `contrato_layout` (UC-V09/V10/V11/V12 + KPI 1-linha) no frontmatter = fonte única legível-por-máquina do gate de conformância DS (§0 PROMPT_PARA_CODE · ADR 0238 sem-ADR). Camada 1 (estática cor-crua) + Camada 2 (browser accent/drawer/2-temas) DERIVAM deste bloco. Sem mudança de Goals/Non-Goals — só formaliza o que já era contrato.
 - v6 (2026-05-26 · este) — backfill MWART Tier A completo · pareado com RUNBOOK-index.md (PR #1649) · consolida onda KB-9.75 P0/P1: Emit modais (#1644) + BulkActionBar fix (#1648) + VdNextActionPanel emoji override (#1641) + validações fiscais BR (#1641) + saved view "Aguardando faturamento" (#1644) · frontmatter canon strict (datas aspas, slugs literais, tier letras) · review_trigger 2026-06-15
 - v5 (2026-05-25) — Integração Vendas × Oficina (ADR 0192 Ondas 3-4) · coluna Origem + saved tree "Por origem ▾" + KPI hero breakdown + listener cross-módulo (PR #1506)
 - v4 (2026-05-21) — Unificação tabs Visão (ADR 0178 supersede ADR 0136) · `viewMode` → `visao` operacional/financeira/produção

--- a/scripts/conformance-gate.mjs
+++ b/scripts/conformance-gate.mjs
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
 /* conformance-gate.mjs — GATE de cor-crua (anti-regressão de contrato DS · Camada 1).
  * Determinístico, sem browser, sem dependência. Roda em CI (exit≠0 = bloqueia merge) E local.
- * Regra: ratchet — cor crua em REGRAS DE TELA só pode CAIR. Adicionou cor crua = 🔴.
- * Cobre a classe UC-V10 (cor fora de token). NÃO cobre accent/computed-style (= teste de browser, Camada 2 Pest).
+ * DUAS checagens determinísticas (zero browser):
+ *   (1) ratchet cor-crua — cor crua em REGRAS DE TELA só pode CAIR. Adicionou = 🔴. Cobre UC-V10.
+ *   (2) invariante --accent — todo --accent* em resources/css/*.css é roxo (hue 250–330). Fora = 🔴.
+ *       Fecha a metade do verde×roxo (UC-V09) no nível do TOKEN, que o ratchet (isenta :root) não pega.
+ * NÃO cobre só o que exige runtime: surface dark / computed cascade (= Camada 2 browser Pest, tier local).
  *
  * Por que existe ALÉM do stylelint #2054 (ADR 0209):
  *   - stylelint `color-no-hex` já congela #hex GLOBAL e barra hex novo (ratchet config/stylelint-baseline.json).
@@ -23,9 +26,41 @@
  *
  * Refs: PROMPT_PARA_CODE_CONFORMANCE-GATE.md · ADR 0209 (ratchet gêmeo) · ADR 0235/0190 (roxo 295) · ADR 0238 (soberania).
  */
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, readdirSync } from "node:fs";
 
 const BASELINE_FILE = ".conformance-baseline.json";
+
+// ── Invariante ABSOLUTO do token de marca (NÃO ratchet) ─────────────────────────────────────
+// O hue do `--accent` (e variantes --accent-soft/-line/-fg) é SEMPRE roxo (ADR 0235/0190 ·
+// oklch 0.55 0.15 295). Cor de marca não "drifta devagar" — ou é roxo, ou é bug. Fecha a metade
+// do verde×roxo que o ratchet de cor-crua NÃO pega: redefinição do TOKEN em :root (isento na
+// Camada 1) pra um oklch verde. Sem browser, determinístico. Cobre a classe UC-V09 no nível CSS.
+const ACCENT_HUE_OK = [250, 330];
+const CSS_DIR = "resources/css";
+
+// Acha `--accent[...]: oklch(L C H ...)` com 3 números crus; ignora oklch(from var(...)) (sem hue numérico).
+export function accentHueViolations(css, file = "") {
+  const out = [];
+  const re = /(--accent[\w-]*)\s*:\s*oklch\(\s*[\d.]+\s+[\d.]+\s+([\d.]+)/g;
+  let m;
+  while ((m = re.exec(css))) {
+    const hue = parseFloat(m[2]);
+    if (hue < ACCENT_HUE_OK[0] || hue > ACCENT_HUE_OK[1]) {
+      out.push(`${file} ${m[1]} hue=${hue}° (fora de roxo ${ACCENT_HUE_OK[0]}–${ACCENT_HUE_OK[1]} — drift verde×roxo no TOKEN · ADR 0235/0190)`);
+    }
+  }
+  return out;
+}
+
+// Varre todo resources/css/*.css pelo invariante do accent. Determinístico, sem baseline.
+function accentSweep() {
+  const hits = [];
+  for (const f of readdirSync(CSS_DIR).filter((n) => n.endsWith(".css"))) {
+    const path = `${CSS_DIR}/${f}`;
+    hits.push(...accentHueViolations(readFileSync(path, "utf8"), path));
+  }
+  return hits;
+}
 
 // Seletores onde cor crua é PERMITIDA (defs de token + exceções declaradas).
 const TOKEN_DEF  = /:root|\[data-theme/;
@@ -86,9 +121,17 @@ function main() {
       process.exit(0);
     }
     const failed = files.filter((f) => !checkOne(f, baseline));
+    // Invariante absoluto do token de marca (verde×roxo no nível do TOKEN — o que o ratchet não pega).
+    const accentBad = accentSweep();
+    if (accentBad.length) {
+      console.error(`\n🔴 token --accent fora do roxo canônico (${accentBad.length}):`);
+      for (const v of accentBad) console.error(`   ${v}`);
+    } else {
+      console.log(`[conformance-gate] --accent: todos os ${CSS_DIR}/*.css em roxo ${ACCENT_HUE_OK[0]}–${ACCENT_HUE_OK[1]} ✅`);
+    }
     if (failed.length) console.error(`\n🔴 ${failed.length}/${files.length} arquivo(s) com cor crua nova — merge bloqueado.`);
-    else console.log(`\n✅ ${files.length} arquivo(s) conformes (sem cor crua nova).`);
-    process.exit(failed.length ? 1 : 0);
+    if (!failed.length && !accentBad.length) console.log(`\n✅ ${files.length} arquivo(s) conformes (cor crua + token de marca).`);
+    process.exit(failed.length || accentBad.length ? 1 : 0);
   }
 
   if (!file) { console.error("uso: node scripts/conformance-gate.mjs <arquivo.css> [--update]  |  --all (modo CI)"); process.exit(2); }

--- a/scripts/conformance-gate.mjs
+++ b/scripts/conformance-gate.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+/* conformance-gate.mjs — GATE de cor-crua (anti-regressão de contrato DS · Camada 1).
+ * Determinístico, sem browser, sem dependência. Roda em CI (exit≠0 = bloqueia merge) E local.
+ * Regra: ratchet — cor crua em REGRAS DE TELA só pode CAIR. Adicionou cor crua = 🔴.
+ * Cobre a classe UC-V10 (cor fora de token). NÃO cobre accent/computed-style (= teste de browser, Camada 2 Pest).
+ *
+ * Por que existe ALÉM do stylelint #2054 (ADR 0209):
+ *   - stylelint `color-no-hex` já congela #hex GLOBAL e barra hex novo (ratchet config/stylelint-baseline.json).
+ *   - este gate pega o que o stylelint NÃO pega: `oklch(<hue numérico>)` CRU em regras de TELA
+ *     (cor fora de token sem hex), escopado por seletor de tela — precisão que o stylelint flat não dá.
+ *   Os dois são complementares (defense-in-depth). Cor crua hex aqui é dupla-rede inofensiva (ratchet only-down).
+ *
+ * Provado (vendas.css Cowork, 2026-06-03) — controle-negativo nos DOIS lados:
+ *   sensibilidade: +1 cor crua em regra de tela → conta sobe (pega o bug);
+ *   especificidade: editar doc de impressão (.vd-trans) NÃO sobe · oklch(...var()) NÃO conta (não acusa inocente).
+ *   Controle-negativo versionado em tests/js/conformance-gate.spec.mjs (Camada META — testa o teste).
+ *
+ * Uso:  node scripts/conformance-gate.mjs <arquivo.css> [--update]
+ * Baseline por arquivo em .conformance-baseline.json (versionado → ratchet auditável).
+ *
+ * AVISO HONESTO: regex ≠ parser CSS. Escopa regras flat (.sel{...}); @media/aninhado profundo pode escapar.
+ * Versão de produção: portar esta regra pro Stylelint #2054 (parser real). Esta é a rede mínima rodável já.
+ *
+ * Refs: PROMPT_PARA_CODE_CONFORMANCE-GATE.md · ADR 0209 (ratchet gêmeo) · ADR 0235/0190 (roxo 295) · ADR 0238 (soberania).
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+
+const BASELINE_FILE = ".conformance-baseline.json";
+
+// Seletores onde cor crua é PERMITIDA (defs de token + exceções declaradas).
+const TOKEN_DEF  = /:root|\[data-theme/;
+// transcript = papel A4 (cor fixa proposital) · apresentação = dark próprio (oklch intencional, régua L-122).
+const EXCEPTION  = /\.vd-trans|\.vd-pres/;
+// Regras de TELA da família Sells/Cowork. Generaliza o vocabulário vertical do repo
+// (.sells-cowork escopa tudo; .vendas-aplus/.vd-/.os- são os blocos internos; .vendas-page o legacy).
+// Ajustar/expandir por tela ao generalizar pra outros módulos (.fin-*, .repair-*, …).
+const SCREEN     = /\.sells-cowork|\.vendas-aplus|\.vendas-page|\.vd-|\.os-/;
+
+// Conta valores de cor CRUA só nas regras de tela. oklch com var() dentro = token-driven, NÃO conta.
+export function rawColorHits(css) {
+  const hits = [];
+  const re = /([.#:\[][^{}]*?)\{([^{}]*)\}/g;
+  let m;
+  while ((m = re.exec(css))) {
+    const sel = m[1].trim(), body = m[2];
+    if (TOKEN_DEF.test(sel) || EXCEPTION.test(sel) || !SCREEN.test(sel)) continue;
+    for (const h of body.match(/#[0-9a-fA-F]{3,8}\b/g) || []) hits.push(`${sel.slice(0,40)} ${h}`);
+    let i = 0;
+    while ((i = body.indexOf("oklch(", i)) !== -1) {
+      let depth = 0, j = i + 5, end = -1;
+      for (; j < body.length; j++) { if (body[j] === "(") depth++; else if (body[j] === ")") { depth--; if (depth === 0) { end = j; break; } } }
+      if (end === -1) break;
+      const chunk = body.slice(i, end + 1);
+      if (!chunk.includes("var(")) hits.push(`${sel.slice(0,40)} ${chunk}`);  // raw só se NÃO usa var
+      i = end + 1;
+    }
+  }
+  return hits;
+}
+
+function loadBaseline() { try { return existsSync(BASELINE_FILE) ? JSON.parse(readFileSync(BASELINE_FILE, "utf8")) : {}; } catch { return {}; } }
+
+function checkOne(file, baseline) {
+  const count = rawColorHits(readFileSync(file, "utf8")).length;
+  const limit = baseline[file] ?? count;     // 1ª vez adota o atual como teto
+  const pass = count <= limit;
+  console.log(`[conformance-gate] ${file}: cor-crua(regras de tela)=${count} · teto=${limit} · ${pass ? "✅ PASS" : "🔴 FAIL — cor crua nova; use token DS (--pos/--warn/--neg/--accent/--origin-*) ou baixe o teto com --update se removeu"}`);
+  return pass;
+}
+
+function main() {
+  const all = process.argv.includes("--all");
+  const update = process.argv.includes("--update");
+  const file = process.argv[2] && !process.argv[2].startsWith("--") ? process.argv[2] : null;
+  const baseline = loadBaseline();
+
+  // --all: checa TODOS os arquivos do baseline (modo CI). Falha se QUALQUER um regredir.
+  if (all) {
+    const files = Object.keys(baseline);
+    if (!files.length) { console.error("baseline vazio; rode --update primeiro"); process.exit(2); }
+    // --all --update: re-crava o teto de TODOS os arquivos já no baseline (após sweep DS intencional).
+    if (update) {
+      for (const f of files) baseline[f] = rawColorHits(readFileSync(f, "utf8")).length;
+      writeFileSync(BASELINE_FILE, JSON.stringify(baseline, null, 2) + "\n");
+      console.log(`baseline re-gravado (${files.length} arquivos):\n` + files.map((f) => `  ${f} = ${baseline[f]}`).join("\n"));
+      process.exit(0);
+    }
+    const failed = files.filter((f) => !checkOne(f, baseline));
+    if (failed.length) console.error(`\n🔴 ${failed.length}/${files.length} arquivo(s) com cor crua nova — merge bloqueado.`);
+    else console.log(`\n✅ ${files.length} arquivo(s) conformes (sem cor crua nova).`);
+    process.exit(failed.length ? 1 : 0);
+  }
+
+  if (!file) { console.error("uso: node scripts/conformance-gate.mjs <arquivo.css> [--update]  |  --all (modo CI)"); process.exit(2); }
+
+  if (update) {
+    baseline[file] = rawColorHits(readFileSync(file, "utf8")).length;
+    writeFileSync(BASELINE_FILE, JSON.stringify(baseline, null, 2) + "\n");
+    console.log(`baseline gravado: ${file} = ${baseline[file]}`);
+    process.exit(0);
+  }
+
+  process.exit(checkOne(file, baseline) ? 0 : 1);
+}
+
+// Só executa o CLI quando rodado direto (não quando importado pelo teste de controle-negativo).
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith("conformance-gate.mjs")) {
+  main();
+}

--- a/tests/Browser/Sells/IndexConformanceTest.php
+++ b/tests/Browser/Sells/IndexConformanceTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Camada 2 — Conformância de CONTRATO DS por computed-style (Pest 4 browser, determinístico).
+ *
+ * Diferente da Camada 1 (conformance-gate.mjs · cor crua estática no CSS), esta camada checa o
+ * VALOR COMPUTADO no runtime real — pega drift que o CSS estático esconde (cascade/override/tema).
+ * Asserções batem o `ds`/`regua` do charter `Pages/Sells/Index.charter.md` (ds: v6 · roxo 295).
+ *
+ * IDs estáveis (espelham memory/requisitos/Sells/sells-index-dsv6-visual-comparison.md · Vendas.casos.md):
+ *   UC-V09 — accent do primary "Nova venda" == token ROXO (oklch hue 250–330), NÃO verde. ← pega o drift verde×roxo.
+ *   UC-V12 — 2 temas: card de KPI NÃO pode ser quase-branco no dark (dívida `--surface`/`.os-kpi #fff`).
+ *   UC-V11 — detalhe abre drawer role=dialog largura canon (~480). [stub honesto — ver nota no teste]
+ *
+ * Camada META (controle-negativo · regra do MÉTODO "todo ✅ tem que ter sido visto falhar"):
+ *   UC-V09 injeta verde no botão em runtime e EXIGE que o classificador rejeite (hue fora de 250–330).
+ *   Sem isso o teste é fajuto. A classificação rgb→oklch roda no browser (porta o qa-conformance.js 1:1).
+ *
+ * Locator resiliente: classe canônica do DS (`.os-btn.primary` bg=var(--accent), sells-cowork.css:2211).
+ *
+ * Rodar:  ./vendor/bin/pest tests/Browser/Sells/IndexConformanceTest.php
+ * Pré-req local: composer install · npm install · npx playwright install chromium · DB de teste.
+ * (Em máquina sem browser bootável, os testes pulam graceful — igual CreateScreenshotTest.php.)
+ *
+ * Refs: ADR 0235/0190 (roxo 295) · ADR 0107 (gate visual F3) · ADR 0209 (ratchet) · PROMPT_PARA_CODE_CONFORMANCE-GATE.md.
+ */
+
+use App\User;
+
+// ── helpers JS (portam a lógica de classificação de cor do qa-conformance.js) ────────────────
+//
+// OKLab/OKLCH conversion (Björn Ottosson) — sRGB(0..255) → OKLCH. Roda NO BROWSER via $page->script().
+// Retorna {h, L}: h=hue OKLCH (graus 0–360), L=lightness OKLab (0–1). Mesma classe que o gabarito usa.
+function sellsConformanceColorProbeJs(string $selector): string
+{
+    return <<<JS
+    (() => {
+      const el = document.querySelector('{$selector}');
+      if (!el) return { found: false };
+      const cs = getComputedStyle(el).backgroundColor;          // "rgb(r, g, b)" | "rgba(...)"
+      const m = cs.match(/[\d.]+/g);
+      if (!m || m.length < 3) return { found: true, transparent: true, raw: cs };
+      const [r, g, b] = m.slice(0, 3).map(Number);
+      const f = (c) => { c /= 255; return c <= 0.04045 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4); };
+      const lr = f(r), lg = f(g), lb = f(b);
+      const l = 0.4122214708*lr + 0.5363325363*lg + 0.0514459929*lb;
+      const mm = 0.2119034982*lr + 0.6806995451*lg + 0.1073969566*lb;
+      const s = 0.0883024619*lr + 0.2817188376*lg + 0.6299787005*lb;
+      const l_ = Math.cbrt(l), m_ = Math.cbrt(mm), s_ = Math.cbrt(s);
+      const L = 0.2104542553*l_ + 0.7936177850*m_ - 0.0040720468*s_;
+      const A = 1.9779984951*l_ - 2.4285922050*m_ + 0.4505937099*s_;
+      const B = 0.0259040371*l_ + 0.7827717662*m_ - 0.8086757660*s_;
+      let h = Math.atan2(B, A) * 180 / Math.PI; if (h < 0) h += 360;
+      return { found: true, transparent: false, raw: cs, h, L };
+    })()
+    JS;
+}
+
+function sellsConformanceLogin(string $permission = 'sell.view'): User
+{
+    $user = User::factory()->create(['business_id' => 1]);
+    $user->givePermissionTo($permission);
+
+    return $user;
+}
+
+$browserAusente = fn () => ! class_exists(\Pest\Browser\Bootstrap::class);
+
+// ── UC-V09 — accent do primary é ROXO 295, não verde (+ controle-negativo inline) ────────────
+it('UC-V09 · accent do "Nova venda" é roxo 295 (oklch hue 250–330), não verde', function () {
+    sellsConformanceLogin();
+
+    $page = visit('/sells');
+    $page->wait('text=Nova venda', timeout: 8000);
+
+    // (a) SENSIBILIDADE/PARIDADE: o botão real tem que ser roxo.
+    $probe = (array) $page->script(sellsConformanceColorProbeJs('.os-btn.primary'));
+    expect($probe['found'] ?? false)->toBeTrue('botão .os-btn.primary "Nova venda" não encontrado');
+    expect($probe['transparent'] ?? true)->toBeFalse('accent do primary não pode ser transparente');
+    expect($probe['h'])->toBeGreaterThanOrEqual(250.0)
+        ->and($probe['h'])->toBeLessThanOrEqual(330.0, "accent fora do roxo (hue {$probe['h']}°) — drift de identidade (ADR 0190/0235)");
+
+    // (b) CONTROLE-NEGATIVO (Camada META): injeta verde em runtime → o classificador TEM que rejeitar.
+    //     Prova que a asserção (a) realmente PEGA o drift verde×roxo (gate nunca-visto-vermelho não vale).
+    $page->script("document.querySelector('.os-btn.primary').style.setProperty('background-color', 'rgb(34, 197, 94)', 'important')"); // verde tailwind-500
+    $bug = (array) $page->script(sellsConformanceColorProbeJs('.os-btn.primary'));
+    $verdeRoxo = ($bug['h'] >= 250.0 && $bug['h'] <= 330.0);
+    expect($verdeRoxo)->toBeFalse("controle-negativo falhou: verde (hue {$bug['h']}°) passou como roxo — a asserção UC-V09 não discrimina");
+})->skip($browserAusente, 'pest-plugin-browser não bootável neste ambiente');
+
+// ── UC-V12 — 2 temas: card de KPI não pode ser quase-branco no DARK ──────────────────────────
+it('UC-V12 · no tema escuro o card de KPI não fica quase-branco (dívida --surface)', function () {
+    sellsConformanceLogin();
+
+    $page = visit('/sells')->inDarkMode();
+    $page->wait('text=Nova venda', timeout: 8000);
+
+    $probe = (array) $page->script(sellsConformanceColorProbeJs('.os-kpi'));
+    expect($probe['found'] ?? false)->toBeTrue('card .os-kpi não encontrado');
+
+    // No dark, a superfície do card tem que ser ESCURA. Card quase-branco = L (OKLab) ~0.95+.
+    // Teto generoso 0.85 separa "card escuro legítimo" de "branco vazado" sem flake.
+    if (! ($probe['transparent'] ?? false)) {
+        expect($probe['L'])->toBeLessThan(0.85, "card de KPI quase-branco no dark (L={$probe['L']}) — UC-V12 / .os-kpi #fff (régua L-114)");
+    }
+})->skip($browserAusente, 'pest-plugin-browser não bootável neste ambiente');
+
+// ── UC-V11 — detalhe abre drawer role=dialog largura canon ~480 ──────────────────────────────
+// NOTA HONESTA (L-26/27): este UC exige (1) venda semeada no DB de teste pra ter linha clicável e
+// (2) o locator estável do drawer de detalhe (componente Sheet, não o `.vd-pal` da palette). Nenhum
+// dos dois foi verificável offline nesta sessão (vendor/DB ausentes). Em vez de cravar um locator
+// adivinhado que erra em CI, deixo o stub explícito com o critério de aceite pronto pra preencher
+// quando rodar com app+DB. O ratchet do método (cobertura só sobe) cobra o preenchimento.
+// Placeholder puro (sem visit/browser) — registra o UC e o critério; preencher quando rodar com app+DB.
+// TODO(camada-2): semear venda no beforeEach, clicar a 1ª linha, então:
+//   $w = $page->script("(() => { const d=document.querySelector('[role=dialog].os-drawer'); return d ? d.getBoundingClientRect().width : -1; })()");
+//   expect($w)->toBeGreaterThanOrEqual(380.0)->and($w)->toBeLessThanOrEqual(600.0);
+it('UC-V11 · detalhe abre drawer role=dialog largura ~480 (380–600)', function () {
+    expect(true)->toBeTrue();
+})->todo('precisa de venda semeada + locator do drawer de detalhe (não o .vd-pal) — preencher com app+DB');

--- a/tests/conformanceGate.spec.ts
+++ b/tests/conformanceGate.spec.ts
@@ -1,0 +1,63 @@
+// Camada META — testa o teste (controle-negativo do conformance-gate · Camada 1).
+//
+// Regra do MÉTODO (METODO_TELA_ANTI-REGRESSAO.md §controle-negativo): "todo ✅ tem que ter
+// sido visto falhar". Um gate que nunca foi visto vermelho não vale. Este suite INJETA o bug
+// (cor crua nova em regra de tela) e EXIGE que a contagem suba — e prova o lado oposto
+// (token-driven / :root / exceção / não-tela NÃO acusam inocente).
+//
+// Sensibilidade  → pega o bug (cor crua nova conta).
+// Especificidade → não acusa inocente (var()/:root/.vd-trans/não-tela não contam).
+//
+// Refs: PROMPT_PARA_CODE_CONFORMANCE-GATE.md (Camada META) · ADR 0209 (ratchet gêmeo).
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { rawColorHits } from '../scripts/conformance-gate.mjs';
+
+describe('conformance-gate — SENSIBILIDADE (injeta bug → conta sobe)', () => {
+  it('cor crua oklch(<hue numérico>) NOVA em regra de tela é contada', () => {
+    const limpo = `.sells-cowork .vd-kpi { color: var(--accent-fg); }`;
+    const comBug = `.sells-cowork .vd-kpi { color: oklch(0.72 0.18 155); }`; // verde-155 cru (drift D-02)
+    expect(rawColorHits(limpo).length).toBe(0);
+    expect(rawColorHits(comBug).length).toBeGreaterThan(rawColorHits(limpo).length);
+  });
+
+  it('#hex cru NOVO em regra de tela é contado', () => {
+    const limpo = `.sells-cowork .os-kpi { background: var(--surface); }`;
+    const comBug = `.sells-cowork .os-kpi { background: #fff; }`;
+    expect(rawColorHits(limpo).length).toBe(0);
+    expect(rawColorHits(comBug).length).toBe(1);
+  });
+});
+
+describe('conformance-gate — ESPECIFICIDADE (não acusa inocente)', () => {
+  it('oklch(...var()) token-driven NÃO conta', () => {
+    const css = `.sells-cowork .vd-pill { background: oklch(from var(--accent) l c h / 0.12); }`;
+    expect(rawColorHits(css).length).toBe(0);
+  });
+
+  it(':root / [data-theme] (defs de token) NÃO contam — é onde a cor crua mora legitimamente', () => {
+    expect(rawColorHits(`:root { --accent: oklch(0.55 0.15 295); }`).length).toBe(0);
+    expect(rawColorHits(`[data-theme="dark"] { --surface: #1a1a1a; }`).length).toBe(0);
+  });
+
+  it('exceções declaradas (.vd-trans transcript A4 · .vd-pres apresentação) NÃO contam', () => {
+    expect(rawColorHits(`.vd-trans { color: #000; background: #fff; }`).length).toBe(0);
+    expect(rawColorHits(`.vd-pres-slide { background: oklch(0.18 0.02 270); }`).length).toBe(0);
+  });
+
+  it('seletor que NÃO é de tela (fora do vocabulário Sells/Cowork) NÃO conta', () => {
+    expect(rawColorHits(`.algum-componente-generico { color: #abc; }`).length).toBe(0);
+  });
+});
+
+describe('conformance-gate — está VIVO (não passa vacuamente em 0)', () => {
+  it('o sells-cowork.css real do repo tem cor crua > 0 (senão o gate seria fajuto)', () => {
+    const css = readFileSync(
+      fileURLToPath(new URL('../resources/css/sells-cowork.css', import.meta.url)),
+      'utf8',
+    );
+    expect(rawColorHits(css).length).toBeGreaterThan(100);
+  });
+});

--- a/tests/conformanceGate.spec.ts
+++ b/tests/conformanceGate.spec.ts
@@ -12,8 +12,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { rawColorHits } from '../scripts/conformance-gate.mjs';
+import { rawColorHits, accentHueViolations } from '../scripts/conformance-gate.mjs';
 
 describe('conformance-gate — SENSIBILIDADE (injeta bug → conta sobe)', () => {
   it('cor crua oklch(<hue numérico>) NOVA em regra de tela é contada', () => {
@@ -54,10 +53,32 @@ describe('conformance-gate — ESPECIFICIDADE (não acusa inocente)', () => {
 
 describe('conformance-gate — está VIVO (não passa vacuamente em 0)', () => {
   it('o sells-cowork.css real do repo tem cor crua > 0 (senão o gate seria fajuto)', () => {
-    const css = readFileSync(
-      fileURLToPath(new URL('../resources/css/sells-cowork.css', import.meta.url)),
-      'utf8',
-    );
+    // Path relativo à raiz do repo (vitest roda de lá) — cross-platform, sem fileURLToPath
+    // (que quebra no Windows: "The URL must be of scheme file"). Bug pego no run real 2026-06-03.
+    const css = readFileSync('resources/css/sells-cowork.css', 'utf8');
     expect(rawColorHits(css).length).toBeGreaterThan(100);
+  });
+});
+
+// Invariante do TOKEN de marca (a metade do verde×roxo que o ratchet de cor-crua NÃO pega:
+// redefinição do --accent em :root pra um oklch verde). Determinístico, sem browser → fecha UC-V09 no CSS.
+describe('accent-hue guard — SENSIBILIDADE (token verde é pego)', () => {
+  it('--accent redefinido pra verde-155 é violação', () => {
+    expect(accentHueViolations(`:root { --accent: oklch(0.72 0.18 155); }`).length).toBe(1);
+  });
+  it('--accent-soft/-line verde também são pegos', () => {
+    expect(accentHueViolations(`:root { --accent-line: oklch(0.86 0.05 140); }`).length).toBe(1);
+  });
+});
+
+describe('accent-hue guard — ESPECIFICIDADE (roxo canônico não acusa)', () => {
+  it('--accent roxo 295 canônico = 0 violações', () => {
+    expect(accentHueViolations(`:root { --accent: oklch(0.55 0.15 295); --accent-soft: oklch(0.95 0.04 295); }`).length).toBe(0);
+  });
+  it('oklch(from var(--accent) ...) (sem hue numérico) NÃO é avaliado', () => {
+    expect(accentHueViolations(`.x { background: oklch(from var(--accent) l c h / 0.12); }`).length).toBe(0);
+  });
+  it('o cockpit.css real (token canônico) está em roxo — 0 violações', () => {
+    expect(accentHueViolations(readFileSync('resources/css/cockpit.css', 'utf8')).length).toBe(0);
   });
 });


### PR DESCRIPTION
Fecha o buraco que o loop deixava: protegia **comportamento** (UCs render/clique) mas não o **contrato visual/DS** (cor crua voltar, verde×roxo, dark quebrar). Gate de CI **bloqueante**, determinístico, defense-in-depth. Tier 0 tooling (autorizado [W] 2026-06-03) · §10.4 reusa trilhos existentes · sem ADR (soberania 0238).

> **Base = `feat/sells-dsv6-canon`** (não main — main está 70 commits atrás, sem vitest/DS v6). O gate viaja junto da onda DS v6 que ele protege. Origem: 3 commits da `fix/sells-dsv6-dark-flip` (PR #2199 fechada) rebaseados aqui.

## Camada 1 — estática (cor crua, ratchet only-down) ✅ provada
- `scripts/conformance-gate.mjs` (zero-dep). Conta `#hex` + `oklch(<hue numérico>)` cru **só em regras de tela** (`.sells-cowork/.vendas-aplus/.vd-/.os-`); `:root/[data-theme]` + `.vd-trans/.vd-pres` isentos. Pega o que o stylelint #2054 (ADR 0209) não pega: oklch cru escopado por seletor.
- Baseline `.conformance-baseline.json` (sells-cowork.css=624 + 9 sub-telas). `conformance-gate.yml`: exit≠0 **bloqueia merge**.
- **Invariante absoluto do token de marca** (não-ratchet): `--accent` sempre roxo `oklch 0.55 0.15 295` (250–330, ADR 0235/0190). Varre todo `resources/css/*.css`. Fecha a metade do verde×roxo no nível do **token** (que o ratchet, isentando `:root`, não pegaria).

## Camada 2 — computed-style (Pest 4 browser)
- `tests/Browser/Sells/IndexConformanceTest.php`: **UC-V09** accent "Nova venda" == roxo (rgb→OKLCH no browser, + controle-negativo inline injetando verde), **UC-V12** card KPI não quase-branco no dark, **UC-V11** stub (`todo`, precisa venda semeada + locator drawer).

## Camada META — testa o teste ✅ provada
- `tests/conformanceGate.spec.ts` (vitest): sensibilidade + especificidade do gate de cor-crua **e** do invariante accent (verde→viola, roxo→ok). Wired no `ci.yml` (`test:conformance`). "Todo ✅ tem que ter sido visto falhar."

## Fonte única (§0)
- `Pages/Sells/Index.charter.md` ganha `contrato_layout` (UC-V09..V12) — a régua que o gate deriva.

## Caveats honestos
- **UC-V12 fica vermelha até o dark-flip funcionar** — é o gate cumprindo o papel (a régua documenta a tela não-flipando hoje).
- **Camada 2 (Pest) ainda não roda em nenhum workflow** — só a META (vitest) roda em CI. Próxima onda: job Pest-browser + preencher UC-V11 + checks `jana:health-check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)