### PR TITLE
docs(designsystem): fecha reconciliacao azul-220 nos docs-ancora do Claude Design

### DIFF
--- a/memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md
@@ -164,7 +164,7 @@ Pra cada módulo, Claude Design entrega **um arquivo HTML auto-contido** + **um 
 
 HTML único auto-contido (estilo do `Oimpresso ERP - Chat.html`) usando React via CDN + Babel. Mostra a tela do módulo **dentro do Cockpit** — sidebar com Menu ativo no item correspondente, main column renderizando o template UI-0006 (PageHeader + KpiGrid + Table) ou um custom (Dashboard, gráfico), e Apps Vinculados específicos do contexto.
 
-**Reaproveita** a base do Cockpit já existente (sidebar dark, vibe workspace, accent hue 220). Não redesenha — só **encaixa** o conteúdo do módulo.
+**Reaproveita** a base do Cockpit já existente (sidebar **light** · UI-0014, vibe workspace, accent **roxo 295** · ADR 0235). Não redesenha — só **encaixa** o conteúdo do módulo.
 
 ---
 

--- a/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
@@ -3,6 +3,13 @@
 > Cole este arquivo como **primeira mensagem** numa nova sessão Claude Design.
 > Depois anexe também: `README.md`, `SKILL.md` e `colors_and_type.css` deste projeto.
 
+> ⚠️ **COR/SHELL DEFASADOS — reconciliado 2026-06-04.** Onde este briefing disser **azul**
+> (`--accent: oklch(... 220)`, "accent blue", "sidebar dark"), está **MORTO**. Canon vivo:
+> **roxo 295** `oklch(0.55 0.15 295)` ([ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md)) ·
+> **sidebar light** ([UI-0014](adr/ui/0014-sidebar-light-mantida-v2-parcial.md)) · fonte única de tokens =
+> `tokens.css`/`design-system.css` no git ([ADR 0239](../../decisions/0239-governanca-design-system-git-ssot-regressao-ia.md)).
+> Estrutura e decisões de produto abaixo seguem úteis; **a paleta não**.
+
 ---
 
 ## O que já foi feito — NÃO recriar

--- a/memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md
+++ b/memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md
@@ -4,6 +4,13 @@
 >
 > Toda alteração visual deve **referenciar este catálogo** ou abrir ADR justificando divergência.
 >
+> ⚠️ **SNAPSHOT HISTÓRICO (2026-04-27) — paleta DEFASADA · reconciliado 2026-06-04.** Este catálogo
+> retrata o `/copiloto/cockpit` quando o accent era **azul hue 220°**. A cor canon hoje é **roxo 295**
+> `oklch(0.55 0.15 295)` ([ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md); fonte única =
+> `tokens.css` no git, [ADR 0239](../../decisions/0239-governanca-design-system-git-ssot-regressao-ia.md)).
+> **Tipografia, espaçamento, sombras e estrutura seguem referência válida; a paleta (220°) NÃO** —
+> não reintroduza azul de marca (azul só semântico de status/origin-badge).
+>
 > **Última atualização**: 2026-04-27 (snapshot do PR #49 / branch `feat/copiloto-cockpit-piloto`)
 >
 > **Fonte canônica**: `resources/css/cockpit.css` no commit que essa versão do catálogo referencia. Valores cruzados com `getComputedStyle()` rodando em `https://oimpresso.com/copiloto/cockpit`.

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -143,8 +143,9 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | `HANDOFF.md` | congelado 2026-05-15 | regenerar |
 | `GLOSSARY.md` | `[M]=Manus` diverge de `[M]=Maiara` (canon) | reconciliar tabela de pessoas |
 | `MATRIZ_MIGRACAO_DS.md` §P0-3 | 3 falsos-positivos Cliente/Index | corrigir (Cliente já migrado) |
-| **`BRIEFING_CLAUDE_DESIGN.md`** ⚠️ URGENTE | doc-âncora do Claude Design, mas 2026-04-27: "sidebar dark" + accent hue 220 | reconciliar p/ sidebar light + roxo 295 + PT-01 + UI-0013 |
-| `CATALOGO_ACABAMENTOS.md` | snapshot 2026-04-27, accent hue 220 | tipografia/estrutura úteis; cor via ADR 0235 |
+| **`BRIEFING_CLAUDE_DESIGN.md`** ✅ reconciliado 2026-06-04 | doc-âncora do Claude Design; corpo "sidebar dark + hue 220" corrigido → sidebar light + roxo 295 (errata topo + linha 167) | feito |
+| `CATALOGO_ACABAMENTOS.md` ✅ reconciliado 2026-06-04 | snapshot 2026-04-27 (hue 220) — errata no topo: paleta defasada, cor via ADR 0235; tipografia/estrutura seguem | feito |
+| `BRIEFING_PROXIMA_SESSAO.md` ✅ reconciliado 2026-06-04 | briefing de sessão antiga (azul 220 + sidebar dark) — errata no topo → roxo 295 + sidebar light | feito |
 | `SPEC.md` (R-DS-002) + `ARCHITECTURE.md` + `AUTOMATION-ROADMAP.md` | exemplos `bg-blue-500` | trocar exemplo p/ roxo (confunde com primary) |
 | `GUIA-SIDEBAR-V3` + `sidebar-rail-mode` | hues divergem de `shared.ts` | validar estado real antes de seguir |
 


### PR DESCRIPTION
## Por quê

O ADR 0239 já definiu a regra única (git é fonte do DS, roxo 295, índice-mestre com teste). Mas o **enforcement de conteúdo** tinha furo: os docs-âncora que o **Claude Design lê no início de cada sessão** ainda prescreviam **azul hue 220 + sidebar dark** — fonte de drift ativa contra o canon. O próprio `INDEX-DESIGN-MEMORIAS.md` já marcava esses itens como **"⚠️ URGENTE reconciliar"**, mas ninguém tinha fechado.

Este PR fecha esse TODO — pelo mecanismo do próprio 0239 (R5 índice), sem criar canon paralelo.

## O quê

| Arquivo | Mudança |
|---|---|
| `BRIEFING_PROXIMA_SESSAO.md` | errata no topo: azul 220 + sidebar dark → **roxo 295** (ADR 0235) + **sidebar light** (UI-0014) |
| `CATALOGO_ACABAMENTOS.md` | errata no topo: é snapshot histórico (2026-04-27); paleta 220 defasada, cor via ADR 0235; tipografia/estrutura seguem válidas |
| `BRIEFING_CLAUDE_DESIGN.md` | corpo (linha 167): "sidebar dark + hue 220" → "sidebar light + roxo 295" (já tinha errata no topo) |
| `INDEX-DESIGN-MEMORIAS.md` | marca os 3 como ✅ reconciliado 2026-06-04 (fecha o TODO da própria tabela) |

## Cuidados

- **Cirúrgico:** distingue azul **de marca** (morto) de azul **semântico** (origin-badge CRM, status) que **sobrevive** — não toca esse.
- **Não mexe na fonte** (`tokens.css` já está roxo 295) — só nos docs que apontavam errado.
- **Respeita 0239:** usa o índice-mestre existente, não cria `DESIGN-CANON` paralelo.
- `DesignIndexSingleSourceTest` preservado (nenhum doc/regra canônico removido; links locais resolvem).

Refs: ADR 0239 (git SSOT + R5) · 0235 (roxo 295) · UI-0014 (sidebar light) · 0236
