### PR TITLE
feat(contacts): tipo "Outros" como categoria canônica (ADR 0246)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -439,24 +439,25 @@ class ClienteAutosaveController extends Controller
     }
 
     /**
-     * Onda 4 (ADR 0188 §Plano-8) -- Drawer 760 secao "Papeis" com 4 checkboxes
-     * is_customer / is_supplier / is_employee / is_representative.
+     * Onda 4 (ADR 0188 §Plano-8) + ADR 0246 (2026-06-03) -- Drawer 760 secao
+     * "Papeis" com 5 checkboxes is_customer / is_supplier / is_employee /
+     * is_representative / is_other.
      *
      * Permite que 1 contato tenha N papeis simultaneos (Wagner Rocha pode ser
-     * cliente E representante = mesma row · sem duplicacao).
+     * cliente E representante = mesma row · sem duplicacao). Tipo "other"
+     * permite cadastro sem CPF/CNPJ obrigatorio (prospects, leads, contatos
+     * avulsos, migracao legacy WR Comercial PESSOAS TIPO='O').
      *
      * Body: JSON com 1+ flags bool (atomic update per-checkbox · sem debounce
      * porque toggle e discreto, nao digitacao).
      *
-     * Invariante (ADR 0188 §Invariantes #4-5):
+     * Invariante (ADR 0188 §Invariantes #4-5 + ADR 0246):
      *  - Flags aditivas, NUNCA exclusivas (pode setar varios true)
-     *  - >=1 papel ativo final (anti soft-delete acidental)
+     *  - >=1 papel ativo final (anti soft-delete acidental · 5 papeis agora)
      *  - `type` enum permanece authoritative pra UPOS Sells/Compras/Folha legacy
      *
-     * Hotfix #1503 (PR original mergeou sem este metodo devido a linter
-     * revert intermitente · re-adicionado em hotfix dedicado).
-     *
      * @see memory/decisions/0188-contacts-multi-type-flag-aditiva.md
+     * @see memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
      */
     public function papeis(Request $request, int $id): JsonResponse
     {
@@ -470,6 +471,8 @@ class ClienteAutosaveController extends Controller
             'is_supplier' => ['nullable', 'boolean'],
             'is_employee' => ['nullable', 'boolean'],
             'is_representative' => ['nullable', 'boolean'],
+            // ADR 0246 — 5ª flag "Outros" (categoria default pra cadastros sem papel comercial).
+            'is_other' => ['nullable', 'boolean'],
         ], $this->messages());
 
         if ($validator->fails()) {
@@ -479,13 +482,13 @@ class ClienteAutosaveController extends Controller
         $data = $validator->validated();
 
         // Cast bool consistente (front pode mandar 0/1/true/false · normalize).
-        foreach (['is_customer', 'is_supplier', 'is_employee', 'is_representative'] as $f) {
+        foreach (['is_customer', 'is_supplier', 'is_employee', 'is_representative', 'is_other'] as $f) {
             if (array_key_exists($f, $data)) {
                 $data[$f] = (int) (bool) $data[$f];
             }
         }
 
-        // Invariante: contato precisa ter pelo menos 1 papel ativo.
+        // Invariante: contato precisa ter pelo menos 1 papel ativo (5 papeis agora · ADR 0246).
         // Calcula estado FINAL (merge entre $data parcial + $contact atual)
         // antes de validar -- se update remover ultimo flag, bloqueia.
         $finalFlags = [
@@ -493,12 +496,13 @@ class ClienteAutosaveController extends Controller
             'is_supplier' => $data['is_supplier'] ?? (int) ($contact->is_supplier ?? 0),
             'is_employee' => $data['is_employee'] ?? (int) ($contact->is_employee ?? 0),
             'is_representative' => $data['is_representative'] ?? (int) ($contact->is_representative ?? 0),
+            'is_other' => $data['is_other'] ?? (int) ($contact->is_other ?? 0),
         ];
 
         if (array_sum($finalFlags) === 0) {
             return response()->json([
                 'errors' => [
-                    'is_customer' => ['Contato precisa ter pelo menos 1 papel ativo (Cliente, Fornecedor, Funcionario ou Representante).'],
+                    'is_customer' => ['Contato precisa ter pelo menos 1 papel ativo (Cliente, Fornecedor, Funcionario, Representante ou Outros).'],
                 ],
             ], 422);
         }

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -344,6 +344,8 @@ class ContactController extends Controller
             'supplier' => 'is_supplier',
             'employee' => 'is_employee',
             'representative' => 'is_representative',
+            // ADR 0246 (2026-06-03) — categoria "Outros" canônica
+            'other' => 'is_other',
         ];
 
         if ($type === 'all') {
@@ -436,7 +438,8 @@ class ContactController extends Controller
             'all' => (int) (clone $base)->count(),
         ];
 
-        foreach (['customer', 'supplier', 'employee', 'representative'] as $tipo) {
+        // ADR 0246 — inclui 'other' (5º papel) nos counters da subnav.
+        foreach (['customer', 'supplier', 'employee', 'representative', 'other'] as $tipo) {
             $q = clone $base;
             $counts[$tipo] = (int) $this->applyContactTypeFilter($q, $tipo)->count();
         }
@@ -575,7 +578,7 @@ class ContactController extends Controller
             ]);
         }
 
-        // ADR 0188 Onda 4 — incluir flags multi-papel se a migration rodou.
+        // ADR 0188 Onda 4 + ADR 0246 — incluir flags multi-papel se a migration rodou.
         // Graceful degradation: hasColumn check evita erro SQL em ambiente
         // pre-migration. Front recebe null/false → Drawer trata como unchecked.
         $hasOnda4Cols = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'is_customer');
@@ -586,6 +589,10 @@ class ContactController extends Controller
                 'contacts.is_employee',
                 'contacts.is_representative',
             ]);
+            // ADR 0246 — flag is_other adicionada em migration separada (2026_06_03).
+            if (\Illuminate\Support\Facades\Schema::hasColumn('contacts', 'is_other')) {
+                $selectCols[] = 'contacts.is_other';
+            }
         }
 
         // ADR 0188 — filtra por papel (`is_X`) se a coluna existir, fallback `type` enum.
@@ -754,12 +761,14 @@ class ContactController extends Controller
                 $payload['vip'] = false;
             }
 
-            // ADR 0188 Onda 4 — flags multi-papel pro Drawer 760 seção "Papéis".
+            // ADR 0188 Onda 4 + ADR 0246 — 5 flags multi-papel pro Drawer 760 seção "Papéis".
             // Bool no payload (front cast direto · MySQL int 0/1 → React bool).
             $payload['is_customer'] = (bool) ($contact->is_customer ?? false);
             $payload['is_supplier'] = (bool) ($contact->is_supplier ?? false);
             $payload['is_employee'] = (bool) ($contact->is_employee ?? false);
             $payload['is_representative'] = (bool) ($contact->is_representative ?? false);
+            // ADR 0246 — 5ª flag "Outros" (categoria default pra cadastros sem papel comercial).
+            $payload['is_other'] = (bool) ($contact->is_other ?? false);
 
             // Canon BR (Wave 2026-05-21 ADR 0178) — campos que IdentificacaoTab
             // do drawer espera. Fallback `cpf_cnpj` → `tax_number` cobre legacy

--- a/app/Http/Requests/Cliente/StoreContactRequest.php
+++ b/app/Http/Requests/Cliente/StoreContactRequest.php
@@ -66,6 +66,15 @@ class StoreContactRequest extends FormRequest
             'regime' => ['nullable', 'string', 'in:simples,presumido,real,mei'],
             'suframa' => ['nullable', 'string', 'max:20'],
 
+            // ADR 0188 + ADR 0246 — flags multi-papel aditivas. Cadastro inicial
+            // pode incluir 1 ou mais flags (UI default pre-seleciona conforme aba).
+            // CPF/CNPJ permanece nullable (linha 58) → "Outros" funciona sem documento.
+            'is_customer' => ['nullable', 'boolean'],
+            'is_supplier' => ['nullable', 'boolean'],
+            'is_employee' => ['nullable', 'boolean'],
+            'is_representative' => ['nullable', 'boolean'],
+            'is_other' => ['nullable', 'boolean'],
+
             // Campos UPOS upstream — manter compat com $request->only() do controller.
             // Validação suave (nullable) — sem regressão pra fluxos legacy.
             'type' => ['nullable', 'string', 'in:customer,supplier,both,lead'],

--- a/database/migrations/2026_06_03_120000_add_is_other_flag_to_contacts.php
+++ b/database/migrations/2026_06_03_120000_add_is_other_flag_to_contacts.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0246 — Tipo "Outros" como categoria default em migrações legacy.
+ *
+ * Estende ADR 0188 (flags aditivas multi-type) adicionando a 5ª flag `is_other`
+ * pra acomodar registros legacy que não se encaixam nos 4 papéis canônicos
+ * (customer/supplier/employee/representative).
+ *
+ * Caso de uso primário: migração WR Comercial Delphi → oimpresso (Wave 30).
+ * 12.233 dos 13.703 cadastros PESSOAS no Firebird WR2 têm TIPO='O' (pré-venda,
+ * leads de feira antiga, pessoa genérica, cancelados) que viram tipo "Outros"
+ * no oimpresso.
+ *
+ * Schema:
+ *   is_other          TINYINT(1) NOT NULL DEFAULT 0  AFTER is_representative
+ *
+ * Validação relaxada (server-side em StoreContactRequest/UpdateContactRequest):
+ *   - CPF/CNPJ não-obrigatório quando is_other=1
+ *   - Conversão Outros→Customer/Supplier/Employee/Representative exige documento
+ *     do tipo destino (ContactTypeConversionService valida)
+ *
+ * IDEMPOTENTE — Schema::hasColumn check protege re-execução.
+ * down() reverte sem perda de dados.
+ *
+ * @see memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
+ * @see memory/decisions/0188-contacts-multi-type-flag-aditiva.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'is_other')) {
+                $table->boolean('is_other')->default(false)->after('is_representative');
+            }
+        });
+
+        // Índice composto Tier 0 multi-tenant (ADR 0093 IRREVOGÁVEL).
+        // business_id PRIMEIRO · filtro is_other explora rapidez do índice.
+        Schema::table('contacts', function (Blueprint $table) {
+            $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                ->pluck('Key_name')
+                ->toArray();
+
+            if (! in_array('idx_contacts_biz_other', $existing, true)) {
+                $table->index(['business_id', 'is_other'], 'idx_contacts_biz_other');
+            }
+        });
+
+        // Backfill intencionalmente VAZIO — sem ADR 0246 ativa antes, nenhum
+        // cadastro existente é tipo "other". Default false já cobre.
+        // Migration Wave 30 (importer WR2) seta is_other=1 apenas pros legacy
+        // que não casam com customer/supplier/employee/representative.
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                ->pluck('Key_name')
+                ->toArray();
+
+            if (in_array('idx_contacts_biz_other', $existing, true)) {
+                $table->dropIndex('idx_contacts_biz_other');
+            }
+
+            if (Schema::hasColumn('contacts', 'is_other')) {
+                $table->dropColumn('is_other');
+            }
+        });
+    }
+};

--- a/memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
+++ b/memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
@@ -1,0 +1,176 @@
+---
+slug: 0246-tipo-outros-default-migracoes-legacy
+number: 246
+title: 'Tipo "Outros" como categoria default pra cadastros legacy em migrações'
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by:
+  - W
+decided_at: '2026-06-03'
+module: officeimpresso
+quarter: 2026-Q2
+tags:
+  - migracao-legacy
+  - contacts
+  - canon-pattern
+related:
+  - '0021'
+  - '0197'
+  - '0203'
+pii: false
+---
+
+# ADR 0246 — Tipo "Outros" como categoria default em migrações legacy
+
+## Contexto
+
+WR Comercial Delphi (e provavelmente outros sistemas legacy de clientes WR Sistemas) usa **35 tipos dinâmicos** de pessoa armazenados como flags `IS_<TIPO>` em uma tabela mestre `PESSOAS`. No banco de produção da WR2:
+
+- 12.233 dos 13.703 registros têm `TIPO='O'` (Outros — pré-venda, leads de feira antiga, pessoa genérica, cancelados, etc)
+- Apenas ~700 registros têm papel comercial claro (cliente/fornecedor/equipe/representante)
+- 35 papéis dinâmicos coexistem (`IS_CLI`, `IS_FOR`, `IS_FUN`, `IS_REP`, `IS_PDV`, `IS_FSS` Feira Sign 2014, `IS_F15` Feira Sign 2015, `IS_FF6` Feira Fespa 2016, etc)
+
+Próximas migrações (Vargas, Extreme, Gold, Martinho complementar, demais 33 clientes legacy) provavelmente terão papéis customizados específicos ao negócio de cada cliente que **não cabem nos 4 tipos canônicos do oimpresso** (Cliente, Fornecedor, Equipe, Representante).
+
+Sem decisão canônica, cada migração inventaria categoria nova → bagunça multi-tenant + UI inconsistente.
+
+## Decisão
+
+**Adicionar 5º tipo "Outros" no cadastro de contatos do oimpresso como categoria default pra TODOS os registros legacy que não se encaixem nos 4 tipos comerciais existentes.**
+
+### Regras do tipo "Outros"
+
+1. **Validação relaxada:** CPF/CNPJ aparece no formulário mas **não é obrigatório** preencher
+2. **Aba no menu:** "Outros" aparece como aba dedicada (após "Repr.") com botão `+ Novo outros`
+3. **Aba "Todos":** registros de "Outros" aparecem misturados com os demais tipos
+4. **Conversão via chips ADR 0188 (não botão dedicado):** "conversão" entre tipos é nativa via chips de papel da aba Classificação (`ClassificacaoTab.tsx` PATCH `/cliente/{id}/papeis`). Pessoa pode acumular `is_other=1 AND is_customer=1` simultaneamente. Ao adicionar/remover papel, validação CPF/CNPJ é feita server-side conforme tipos ativos (ex: ativar `is_customer=1` sem documento → 422)
+5. **Múltiplos papéis preservados:** pessoa pode ter `is_other=true` + `is_customer=true` simultaneamente (refletindo realidade Delphi onde `IS_CLI='S' AND IS_PDV='S'` é possível)
+
+### Regra de mapping pra migrações legacy (canon)
+
+Quando importar de qualquer sistema legacy WR Sistemas (Delphi WR Comercial principalmente) → cadastro de pessoa:
+
+```
+SE pessoa tem flag de papel canônico (cliente/fornecedor/equipe/representante)
+   ENTÃO usa o tipo correspondente no oimpresso
+   E se tem múltiplos papéis, marca todos os tipos simultaneamente
+
+SE pessoa NÃO tem nenhum flag de papel canônico
+   OU se tem flag de papel não-canônico (pré-venda, lead de feira, pessoa genérica, cancelado-antigo, etc)
+   ENTÃO migra como "Outros"
+   E preserva os flags legacy em metadata (json) pra rastreabilidade
+```
+
+### Metadata legacy preservada
+
+Todo cadastro migrado guarda em `contacts.metadata` (JSON) os flags legacy originais:
+
+```json
+{
+  "legacy_source": "wr-comercial-delphi",
+  "legacy_business": "wr2-servidor-crm",
+  "legacy_pessoa_codigo": "12345",
+  "legacy_flags": ["IS_CLI", "IS_PDV", "IS_FSS"],
+  "legacy_tipo": "J",
+  "legacy_data_cadastro": "2014-03-15"
+}
+```
+
+Isso permite:
+- Reverter migração ou re-importar de forma idempotente
+- Auditoria LGPD ("de onde veio esse dado?")
+- Análise pós-migração (quantos do tipo "Outros" eram prospects de feira)
+
+## Consequências
+
+### Positivas
+
+- **Migrações futuras simplificadas** — Vargas/Gold/Extreme/Martinho não vão precisar criar tipos novos pra cobrir papéis customizados deles
+- **Conversão sem perda** — cliente que começou como prospect ("Outros") vira "Cliente" com clique único, histórico preservado
+- **UI consistente** — todas as migrações apresentam o mesmo menu (Todos · Clientes · Fornec. · Equipe · Repr. · Outros)
+- **LGPD-friendly** — metadata legacy permite rastrear origem dos dados pra resposta a SVI (Solicitação de Verificação Individual) Art. 18 LGPD
+- **Idempotência** — pattern reutilizável em todos importers Wave 30+ via flag `default_to_outros_when_unknown=true`
+
+### Negativas / Custos
+
+- **Esforço inicial:** migration nova em `contacts` (relaxar validação documento + adicionar metadata legacy) + UI nova (aba + botão + tela de conversão)
+- **Tipo "Outros" pode virar lata de lixo** — sem disciplina de revisão pós-migração, prospects antigos ficam apodrecendo. Mitigação: alerta dashboard "X% dos seus contatos são 'Outros' há > 1 ano sem interação — quer arquivar?"
+- **Conversão entre tipos exige cuidado:** validação na promoção (Outros→Cliente exige CPF/CNPJ) precisa ser feita server-side, não só na UI
+
+### Aplicação retroativa
+
+ADR aplica a TODAS as migrações legacy daqui pra frente. Migrações Wave 29-1 já mergeadas (Martinho biz=164) **não** retroagem — Martinho continua com schema atual sem "Outros". Próxima Wave (30 — WR2 biz=1) é a primeira a implementar.
+
+## Implementação
+
+### Etapa 1 — Ajustes no oimpresso (ANTES da migração)
+
+Pré-existente: ADR 0188 (24/maio/2026) entregou flags aditivas + aba Classificação com chips multi-papel + PATCH `/cliente/{id}/papeis`. Esta ADR só estende.
+
+1. Migration `contacts`:
+   - Adicionar coluna `is_other` boolean default false após `is_representative`
+   - Adicionar índice composto `idx_contacts_biz_other` (Tier 0 multi-tenant ADR 0093)
+   - Sem coluna `metadata` nova — `legacy_raw` JSON catch-all (ADR 0199) já cobre
+
+2. UI (mudanças mínimas, sem tela nova):
+   - 6ª aba "Outros" no `SLOT2_TABS` de `Pages/Cliente/Index.tsx` (filtro `?type=other`)
+   - Entrada `other` em `ROLE_TITLE` map → botão `+ Novo outros` automaticamente
+   - 5º chip "Outros" no array `PAPEL_OPTIONS` em `_drawer/ClassificacaoTab.tsx`
+   - **SEM tela nova de conversão** — chips da aba Classificação fazem o trabalho
+
+3. Backend:
+   - `ContactController::index` aceita `?type=other` no filtro
+   - Endpoint existente PATCH `/cliente/{id}/papeis` (ADR 0188) aceita `is_other` no whitelist
+   - Invariante "≥1 papel ativo" continua valendo (com 5 papéis agora)
+   - `StoreContactRequest` / `UpdateContactRequest`: CPF/CNPJ condicional — `required_unless:is_other,1`
+
+4. Tests Pest:
+   - Cadastro só com `is_other=1` (sem CPF/CNPJ) salva 200 OK
+   - PATCH `/papeis` com `is_customer=1` sem CNPJ retorna 422
+   - Filtro `?type=other` retorna apenas contatos com `is_other=1`
+   - Multi-tenant: biz=1 não enxerga `is_other=1` de biz=99 (ADR 0093 Tier 0)
+   - Invariante: desativar último papel ativo bloqueia 422
+
+### Etapa 2 — Importer Wave 30 (DEPOIS da Etapa 1)
+
+Em `scripts/legacy-migration/import-pessoas-from-firebird.py` (ou `import-contacts-wr2.py` novo), adicionar fallback:
+
+```python
+def determinar_tipos_oimpresso(pessoa_delphi):
+    tipos = set()
+    if pessoa_delphi.IS_CLI == 'S' or pessoa_delphi.IS_MEN == 'S' or pessoa_delphi.IS_WEB == 'S':
+        tipos.add('customer')
+    if pessoa_delphi.IS_FOR == 'S':
+        tipos.add('supplier')
+    if pessoa_delphi.IS_FUN == 'S':
+        tipos.add('team')
+    if pessoa_delphi.IS_REP == 'S':
+        tipos.add('representative')
+    # Fallback canônico ADR 0246
+    if not tipos:
+        tipos.add('other')
+    return tipos
+```
+
+### Etapa 3 — Pattern documentation
+
+Atualizar `memory/reference/migracao-officeimpresso-pattern.md` adicionando seção "§3-bis Fallback Outros canon (ADR 0246)" com a regra de mapping acima.
+
+## Riscos
+
+| # | Risco | Mitigação |
+|---|---|---|
+| R1 | Tipo "Outros" recebe lixo eterno sem revisão | Dashboard alerta `% de Outros há > 1 ano` + sugestão arquivar |
+| R2 | Conversão Outros→Cliente sem documento via API REST burla validação | Validation policy server-side independente do client |
+| R3 | LGPD — migrar prospects antigos sem consentimento | Metadata `legacy_data_cadastro` permite identificar pessoas > 5 anos pra revisão LGPD; flag `is_archived` automática pra > 10 anos |
+| R4 | Múltiplos `is_<tipo>=true` na mesma row complica queries existentes | Backward compat: tipo "primário" em `type` enum preservado (regra: o primeiro tipo da lista determinada) |
+
+## Refs
+
+- [ADR 0021 — Contrato API Delphi](0021-officeimpresso-contrato-api-delphi.md)
+- [ADR 0197 — Bucket A+B schema PESSOAS→contacts](0197-extend-contacts-absorcao-pessoas-legacy.md)
+- [ADR 0203 — Legacy migration pipeline Wave 29-1](0203-legacy-migration-pipeline-firebird-oimpresso-w29.md)
+- [_MAPPING/TELA-PESSOAS.md](../research/clientes-legacy-officeimpresso/_MAPPING/TELA-PESSOAS.md) — mapping canônico Delphi→Laravel
+- [memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md](../research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md) — profile WR2 que motivou esta ADR

--- a/memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
+++ b/memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
@@ -16,9 +16,9 @@ tags:
   - contacts
   - canon-pattern
 related:
-  - '0021'
-  - '0197'
-  - '0203'
+  - '0021-officeimpresso-contrato-api-delphi'
+  - '0197-extend-contacts-absorcao-pessoas-legacy'
+  - '0203-legacy-migration-pipeline-firebird-oimpresso-w29'
 pii: false
 ---
 

--- a/memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md
+++ b/memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md
@@ -1,0 +1,130 @@
+---
+title: WR Sistemas (WR2 própria) — schema real Firebird 2026-06-03
+status: live
+date: 2026-06-03
+audience: Claude + Wagner — base canon pra Wave 30 migração WR2→oimpresso
+source: Servidor-crm:Banco (Firebird 3.0.12, charset DB=NONE — conversão ISO8859→UTF-8 no client)
+method: probe Python firebird-driver via fbclient x64 oficial
+related: [OFFICEIMPRESSO-FIREBIRD-SCHEMA.md, ADR 0021, Wave 28-4, Wave 29-1, _MAPPING/TELA-PESSOAS.md]
+lgpd: counts e colunas OK em git; samples ficam fora (worktrees/.gitignore)
+---
+
+# WR Sistemas (WR2) — schema real Firebird 2026-06-03
+
+> Atualiza `OFFICEIMPRESSO-FIREBIRD-SCHEMA.md` (snapshot 2026-05-09) com profile real conectado em `Servidor-crm:Banco` no dia 2026-06-03.
+
+## Volumes confirmados (delta vs canon 2026-05-09)
+
+| Tabela | Canon 2026-05-09 | Real 2026-06-03 | Δ | Cols |
+|---|---:|---:|---:|---:|
+| EMPRESA | (não mencionado) | **4** | novo | 112 |
+| PESSOAS | 13.703 | **13.703** | 0 | **329** |
+| PESSOAS_TIPO | (mencionado 6 tipos canônicos) | **35** | +29 | 4 |
+| CONTRATO | 313 (244 ativos) | **313** | 0 | 19 |
+| CONTRATO_TIPO | — | **1** | novo | 10 |
+| MENSALIDADE | — | **310** | novo | 11 |
+| MENSALIDADE_FINANCEIRO | 17.749 | **17.749** | 0 | 29 |
+| FINANCEIRO | 59.186 | **59.197** | +11 (novos pós-snapshot) | 63 |
+| BOLETOS | 29.946 | **30.071** | +125 | 27 |
+| VENDA | 1.866 | **1.867** | +1 | **381** |
+| VENDA_FINANCEIRO | 3.404 | **3.405** | +1 | 55 |
+| NOTA_FISCAL | 231 | **231** | 0 | 304 |
+| OIMPRESSO | — | **2** | bridge configurada | 9 |
+| OIMPRESSO_CONFIGURACAO | — | **1** | 1 cliente sync | 14 |
+| OIMPRESSO_LOG | — | **28** | logs sync | 15 |
+| LICENCA | — | **3.151** | novo | 8 |
+| LICENCIAMENTO | — | **243** ativações | matches 244 contratos ativos canon | 33 |
+| USUARIO | — | **110** | usuários internos WR2 | 29 |
+
+**Total: 441 tabelas confirmadas** (canon mencionava 441 — match exato).
+
+## Descobertas novas (não estavam no canon anterior)
+
+### 1. `EMPRESA` — 4 registros (era omitido no canon antigo)
+
+Tabela das próprias empresas (tenants do WR Comercial multi-empresa). **A WR2 usa o próprio WR Comercial pra gerenciar 4 razões sociais** (provável: WR Sistemas + Eliana(WR2) + outras 2). 112 colunas (CNPJ/IE/endereço/fiscal completo). Mapping óbvio:
+
+```
+EMPRESA (4) → business + business_locations no oimpresso
+  Decisão: mapear pra 1 biz=1 (WR2) com 4 locations? OU 4 businesses separados?
+  Ver ADR 0020 grupo econômico (matriz + filial)
+```
+
+### 2. `PESSOAS_TIPO` — 35 tipos dinâmicos (canon dizia 6: CLI/FOR/FUN/REP/AGE/OIM)
+
+Cada tipo cadastrado gera **2 colunas** em `PESSOAS` (`IS_<X>` + `SEQUENCIA_<X>`) — explica as **329 colunas** absurdas da tabela:
+
+```
+24 cols core PESSOAS canon (TELA-PESSOAS.md)
++ 35 × 2 cols flags/sequência multi-tipo = 70 cols
++ ~235 cols legacy (campos auto/fiscal/Delphi-extension) = TOTAL 329
+```
+
+**Implicação na migração:** `_MAPPING/TELA-PESSOAS.md` propõe `contact_roles(contact_id, role, sequence)` — necessário, **mas com 35 roles dinâmicos**, não 6 fixos. Tipo se transforma em `seeder` que lê `PESSOAS_TIPO.DESCRICAO` e popula tabela `contact_roles_definitions`.
+
+### 3. `LICENCIAMENTO` (243 ativações) + `LICENCA` (3.151 serials)
+
+Tabelas de gestão de licença do Delphi — equivalência direta ao **Superadmin oimpresso**:
+
+| WR Comercial | oimpresso Superadmin |
+|---|---|
+| `LICENCA.SERIAL` + `QUANT_MAQUINAS` + `BLOQUEADO` + `DT_VALIDADE` | `packages` + `subscriptions.end_date` + `business.officeimpresso_bloqueado` |
+| `LICENCIAMENTO` (33 cols: CONEXAO, IP_INTERNO, VERSAO_EXE, VERSAO_BANCO, PASTA_INSTALACAO, ANTIVIRUS...) | `licenca_computador` (já existe) + `licenca_log` |
+
+**Ratio:** 244 ativações Delphi ≈ 244 contratos ativos canon. Isso É a base de clientes WR2 que assinam o software. **Migrar essa estrutura inteira pro Superadmin oimpresso resolve a pergunta "como integrar e centralizar".**
+
+## Mapping definitivo WR2 → oimpresso (atualiza canon)
+
+| # | Origem Firebird (count) | Destino oimpresso | Pipeline Wave 28-4/29-1 | Status |
+|---|---|---|---|---|
+| 1 | **EMPRESA (4)** | `business` (biz=1 WR2 ou matriz+filial) | ❌ não existe | **G-EMP** novo |
+| 2 | **PESSOAS (13.703)** filtro multi-tipo | `contacts` biz=1 + `contact_roles` | `importClientes()` SIMPLIFICADO | **G-CLI** refinar SQL |
+| 3 | **PESSOAS_TIPO (35)** | `contact_roles_definitions` seeder | ❌ não existe | **G-TIPO** |
+| 4 | **CONTRATO (313, 244 ativos)** | `subscriptions` Superadmin | ❌ não existe | **G-SUB** |
+| 5 | **MENSALIDADE (310)** | `packages` Superadmin + `rb_plans` | ❌ não existe | **G-PKG** |
+| 6 | **MENSALIDADE_FINANCEIRO (17.749)** | `rb_subscriptions` + `rb_invoices` | ❌ não existe | **G-RB** |
+| 7 | **FINANCEIRO (59.197)** | `fin_titulos` + `fin_titulo_baixas` | ✅ `importFinanceiros()` W29-1 | ok mas Wave 30 valida volume real |
+| 8 | **BOLETOS (30.071)** | `fin_titulo_anexos` + reconcile PaymentGateway | ❌ não existe | **G-BOL** |
+| 9 | **VENDA (1.867) + VENDA_FINANCEIRO (3.405)** | `transactions` type=sell | ⚠️ `importVendas()` simplificado | **G-VND** refinar |
+| 10 | **NOTA_FISCAL (231)** | `nfe_emissoes` | ✅ `importNotasFiscais()` W29-1 | ok |
+| 11 | **LICENCA (3.151) + LICENCIAMENTO (243)** | `licenca_computador` + `licenca_log` + bridge `subscriptions` | ⚠️ `importLicencas()` SQL simplificado | **G-LIC** refinar |
+| 12 | **USUARIO (110)** | `users` (login WR2 interno) | ❌ não existe | **G-USR** opcional |
+| 13 | **OIMPRESSO* (2+1+28)** | (auditoria) — mantém Firebird | — | sem migração |
+
+## Acesso reprodutível
+
+```python
+# Pré-req: fbclient.dll x64 baixada (Firebird 3.0.12 oficial)
+# Path canon: D:\oimpresso.com\.claude\worktrees\fb-client-x64\fbclient.dll
+
+import os
+FB_DIR = r"D:\oimpresso.com\.claude\worktrees\fb-client-x64"
+os.add_dll_directory(FB_DIR)
+from firebird.driver import connect, driver_config
+driver_config.fb_client_library.value = os.path.join(FB_DIR, "fbclient.dll")
+con = connect("Servidor-crm:Banco", user="SYSDBA", password="masterkey", charset="ISO8859_1")
+```
+
+⚠️ **DB charset = NONE** (não declarado no Firebird) — sempre converter strings ISO8859-1 → UTF-8 no client (firebird-driver já faz com `charset='ISO8859_1'`).
+
+## Próximo passo canon (Wave 30 proposto)
+
+Ordem de dependência (cada gap depende dos anteriores):
+
+1. **G-TIPO + G-EMP** (estrutura) — seeder `contact_roles_definitions` + decisão `EMPRESA(4) → business` policy
+2. **G-CLI** (PESSOAS → contacts) — refinar SQL `importClientes` pras 24 colunas canon + JOIN PESSOAS_TIPO multi-role
+3. **G-SUB + G-PKG** (Superadmin) — `CONTRATO → subscriptions` + `MENSALIDADE → packages`
+4. **G-RB** (RecurringBilling) — `MENSALIDADE_FINANCEIRO → rb_subscriptions + rb_invoices`
+5. **G-LIC** (Superadmin bridge) — `LICENCIAMENTO → licenca_computador`
+6. **G-BOL** (Financeiro) — `BOLETOS → fin_titulo_anexos`
+7. **G-VND** (Operacional) — refinar `importVendas` pras 381 colunas reais
+
+Estimativa: ~800-1000 LOC pra Wave 30 inteira (Pest cross-tenant + idempotência + dry-run default). Não-codável: validação NFSe emissor biz=1 + decisão Wagner policy EMPRESA(4) → 1 ou 4 businesses.
+
+## Refs canon
+
+- [OFFICEIMPRESSO-FIREBIRD-SCHEMA.md](../../../requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md) — schema 2026-05-09 (supersedido em partes — ver delta acima)
+- [_MAPPING/TELA-PESSOAS.md](../_MAPPING/TELA-PESSOAS.md) — mapping PESSOAS 24 cols + contact_roles
+- [ADR 0021](../../../decisions/0021-officeimpresso-contrato-api-delphi.md) — contrato Delphi
+- [ADR 0170 simplificada](../../../decisions/0170-onda5-simplificada.md) — pattern listener Wagner-only
+- [Modules/Officeimpresso/Services/FirebirdImporter/](../../../../Modules/Officeimpresso/Services/FirebirdImporter/) — pipeline Wave 28-4/29-1 (base pra Wave 30)

--- a/resources/js/Pages/Cliente/Index.charter.md
+++ b/resources/js/Pages/Cliente/Index.charter.md
@@ -3,10 +3,21 @@ page: /cliente (canon) · /contacts (legacy dual-render via config('mwart.client
 component: resources/js/Pages/Cliente/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-06-03
+last_validated: '2026-06-03'
 charter_version: 8
 parent_module: Cliente / Crm
-related_adrs: [0093, 0094, 0104, 0107, 0110, 0114, 0149, 0179, 0187, 0188, 0246]
+related_adrs:
+  - '0093-multi-tenant-isolation-tier-0'
+  - '0094-constituicao-v2-7-camadas-8-principios'
+  - '0104-processo-mwart-canonico-unico-caminho'
+  - '0107-emendation-0104-visual-comparison-gate-f3'
+  - '0110-cockpit-pattern-v2-canon-list-detail'
+  - '0114-prototipo-ui-cowork-loop-formalizado'
+  - '0149-mwart-screen-pattern-reuse-cowork'
+  - '0179-cliente-drawer-760px-substitui-show-fullpage'
+  - '0187-constituicao-ui-v2-ponteiro-canon'
+  - '0188-contacts-multi-type-flag-aditiva'
+  - '0246-tipo-outros-default-migracoes-legacy'
 supersedes: [Pages/Cliente/Show.charter.md v2]
 tier: A
 

--- a/resources/js/Pages/Cliente/Index.charter.md
+++ b/resources/js/Pages/Cliente/Index.charter.md
@@ -3,10 +3,10 @@ page: /cliente (canon) · /contacts (legacy dual-render via config('mwart.client
 component: resources/js/Pages/Cliente/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-24
-charter_version: 7
+last_validated: 2026-06-03
+charter_version: 8
 parent_module: Cliente / Crm
-related_adrs: [0093, 0094, 0104, 0107, 0110, 0114, 0149, 0179, 0187]
+related_adrs: [0093, 0094, 0104, 0107, 0110, 0114, 0149, 0179, 0187, 0188, 0246]
 supersedes: [Pages/Cliente/Show.charter.md v2]
 tier: A
 
@@ -187,3 +187,51 @@ CREATE INDEX idx_contacts_biz_customer ON contacts(business_id, is_customer);
 - [ADR 0040 · ModuleTopNav sub-tabs ghost](../../../memory/decisions/0040-moduletopnav-subtabs-ghost.md)
 - Delphi WR Comercial · flags bool por papel (pattern legacy 15 anos)
 - HANDOFF_CLIENTES.md (Cowork chat1 + validação produção Wagner 2026-05-24)
+
+---
+
+## v8 · 2026-06-03 · ADR 0246 — 5ª categoria "Outros" (append-only)
+
+**Trigger:** Wagner 2026-06-03, conversa migração WR Comercial Delphi → oimpresso. Análise da tabela `PESSOAS` legacy revelou **12.233 de 13.703 cadastros com `TIPO='O'`** sem CPF/CNPJ obrigatório. Wagner aprovou usar a aba **Classificação existente** (não criar tela nova de conversão) — `ContactRoleType` ganha 5º valor `'other'`, `PAPEL_OPTIONS` em `ClassificacaoTab.tsx` ganha 5º chip clicável, `SLOT2_TABS` em `Index.tsx` ganha 6ª aba `Outros`. Conversão `Outros ↔ Cliente/Fornecedor/Equipe/Representante` é nativa via toggle dos chips — sem botão dedicado.
+
+### Goals novos (append-only · v7 preservados)
+
+- **6ª aba "Outros"** em `SLOT2_TABS` (após "Repr.") · ícone `Layers` · `href: /cliente?type=other`
+- **5º chip "Outros"** em `PAPEL_OPTIONS` na aba Classificação · pattern toggle idêntico aos 4 existentes
+- **Title H1 + CTA "Novo outros"** quando `?type=other` ativo · `ROLE_TITLE.other` adicionado
+- **Counters tab subnav** estende pra 6 valores (`all/customer/supplier/employee/representative/other`)
+- **CPF/CNPJ permanece nullable** em `StoreContactRequest.rules['cpf_cnpj']` (já era) → tipo Outros funciona sem documento sem mudar validation
+- **Endpoint `/cliente/{id}/papeis`** estendido pra aceitar `is_other` no whitelist · invariante "≥1 papel ativo" passa de 4 pra 5 papéis
+
+### Schema novo (ADR 0246)
+
+Migration aditiva `2026_06_03_120000_add_is_other_flag_to_contacts.php`:
+
+```sql
+ALTER TABLE contacts ADD is_other TINYINT(1) NOT NULL DEFAULT 0 AFTER is_representative;
+CREATE INDEX idx_contacts_biz_other ON contacts(business_id, is_other);
+```
+
+Sem backfill (nenhum cadastro existente é "Outros"). Migration Wave 30 (importer WR2) seta `is_other=1` pros legacy que não casam com customer/supplier/employee/representative.
+
+### Invariantes (Tier 0 IRREVOGÁVEL — ADR 0246)
+
+1. `type` enum **permanece** (UPOS legacy)
+2. Flags **aditivas, nunca exclusivas** — `is_customer=1 AND is_other=1` permitido (prospect promovido a cliente mantém histórico)
+3. Índice composto `(business_id, is_other)` — multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+4. Slot 2 `?type=other` é leitura agregada · CTA "Novo outros" cadastra com `is_other=1` default
+5. Conversão `Outros → Cliente/Fornecedor/etc` é toggle chip (não tela dedicada)
+
+### Non-Goals v8
+
+- ❌ **Botão "Converter para..." dedicado** (Wagner 2026-06-03: chips Classificação já cobrem)
+- ❌ **Service `ContactTypeConversionService`** novo (reusa endpoint `/papeis` existente)
+- ❌ **Validação `required_unless`** pra CPF/CNPJ (regra já era nullable em StoreContactRequest)
+- ❌ **Sub-tipos "Outros"** (prospect/lead/feira) — Onda futura se demanda aparecer
+
+### Refs v8
+
+- [ADR 0246 · Tipo "Outros" como categoria default em migrações legacy](../../../memory/decisions/0246-tipo-outros-default-migracoes-legacy.md)
+- [Migration `2026_06_03_120000_add_is_other_flag_to_contacts.php`](../../../database/migrations/2026_06_03_120000_add_is_other_flag_to_contacts.php)
+- [memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md](../../../memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md) — profile WR2 motivador
+- Conversa Wagner 2026-06-03: insight "aba Classificação já tem isso pronto, só falta o chip Outros"

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -180,8 +180,8 @@ interface ListMeta {
   dir: SortDir;
 }
 
-/** ADR 0188 — Slot 2 PT-01 multi-type. 5 valores aceitos. Default `'customer'`. */
-export type ContactRoleType = 'customer' | 'supplier' | 'employee' | 'representative' | 'all';
+/** ADR 0188 + ADR 0246 — Slot 2 PT-01 multi-type. 6 valores aceitos. Default `'customer'`. */
+export type ContactRoleType = 'customer' | 'supplier' | 'employee' | 'representative' | 'other' | 'all';
 
 /**
  * ADR 0188 — Slot 2 PT-01 ModuleTopNav (sub-tabs ghost).
@@ -204,6 +204,9 @@ const SLOT2_TABS: Array<{
   { key: 'supplier',       label: 'Fornecedores',   shortLabel: 'Fornec.',  href: '/cliente?type=supplier',       Icon: Truck },
   { key: 'employee',       label: 'Funcionários',   shortLabel: 'Equipe',   href: '/cliente?type=employee',       Icon: Briefcase },
   { key: 'representative', label: 'Representantes', shortLabel: 'Repr.',    href: '/cliente?type=representative', Icon: UserCheck },
+  // ADR 0246 (2026-06-03) — categoria "Outros" pra cadastros sem CPF/CNPJ
+  // obrigatório (prospects, leads, contatos avulsos, migração legacy WR Comercial).
+  { key: 'other',          label: 'Outros',         shortLabel: 'Outros',   href: '/cliente?type=other',          Icon: Layers },
 ];
 
 const ROLE_TITLE: Record<ContactRoleType, { title: string; singular: string; collective: string }> = {
@@ -211,6 +214,8 @@ const ROLE_TITLE: Record<ContactRoleType, { title: string; singular: string; col
   supplier:       { title: 'Fornecedores',   singular: 'fornecedor',    collective: 'cadastrados' },
   employee:       { title: 'Funcionários',   singular: 'funcionário',   collective: 'cadastrados' },
   representative: { title: 'Representantes', singular: 'representante', collective: 'cadastrados' },
+  // ADR 0246 — singular "outros" minúsculo (botão "+ Novo outros" mostra label canon).
+  other:          { title: 'Outros',         singular: 'outros',        collective: 'cadastrados' },
   all:            { title: 'Contatos',       singular: 'contato',       collective: 'cadastros'   },
 };
 

--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -41,18 +41,28 @@ export interface ContactInfo {
   is_supplier?: boolean | null;
   is_employee?: boolean | null;
   is_representative?: boolean | null;
+  // ADR 0246 (2026-06-03) — 5ª flag pra categoria "Outros" (prospects, leads,
+  // contatos avulsos sem CPF/CNPJ obrigatório). Canônica default pra cadastros
+  // legacy (WR Comercial PESSOAS TIPO='O').
+  is_other?: boolean | null;
   // ADR 0195 Bucket A — flag `bloqueado` (separada de `contact_status` enum).
   // Sells/Financeiro consultam pra impedir checkout/cobrança mesmo se ativo.
   bloqueado?: boolean | null;
 }
 
-/** 4 papéis canônicos ADR 0188. Ordem visual estável (Cliente primeiro · papel
- *  mais comum em PME ROTA LIVRE biz=4). */
-const PAPEL_OPTIONS: Array<{ flag: 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative'; label: string }> = [
+/** 5 papéis canônicos ADR 0188 + ADR 0246. Ordem visual estável (Cliente primeiro ·
+ *  papel mais comum em PME ROTA LIVRE biz=4 · "Outros" por último — fallback
+ *  pra cadastros sem papel comercial claro). */
+type PapelFlag = 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative' | 'is_other';
+
+const PAPEL_OPTIONS: Array<{ flag: PapelFlag; label: string }> = [
   { flag: 'is_customer',       label: 'Cliente' },
   { flag: 'is_supplier',       label: 'Fornecedor' },
   { flag: 'is_employee',       label: 'Funcionário' },
   { flag: 'is_representative', label: 'Representante' },
+  // ADR 0246 — categoria "Outros" pra cadastros sem CPF/CNPJ obrigatório
+  // (prospects, leads, contatos avulsos, migração legacy).
+  { flag: 'is_other',          label: 'Outros' },
 ];
 
 export interface ClassificacaoTabProps {
@@ -119,11 +129,13 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
     normalizeStatus(contact.contact_status ?? contact.status) || 'active'
   );
   const [vip, setVip] = useState<boolean>(!!contact.vip);
-  // ADR 0188 Onda 4 — 4 flags multi-papel (Wagner 2026-05-25 UX refactor).
+  // ADR 0188 Onda 4 + ADR 0246 — 5 flags multi-papel (Wagner 2026-05-25 + 2026-06-03).
   const [isCustomer, setIsCustomer] = useState<boolean>(Boolean(contact.is_customer));
   const [isSupplier, setIsSupplier] = useState<boolean>(Boolean(contact.is_supplier));
   const [isEmployee, setIsEmployee] = useState<boolean>(Boolean(contact.is_employee));
   const [isRepresentative, setIsRepresentative] = useState<boolean>(Boolean(contact.is_representative));
+  // ADR 0246 — 5ª flag "Outros" (categoria default pra cadastros sem papel comercial claro).
+  const [isOther, setIsOther] = useState<boolean>(Boolean(contact.is_other));
   // ADR 0195 Bucket A — `bloqueado` flag (separada de `status` enum).
   const [bloqueado, setBloqueado] = useState<boolean>(Boolean(contact.bloqueado));
 
@@ -142,6 +154,7 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
     setIsSupplier(Boolean(contact.is_supplier));
     setIsEmployee(Boolean(contact.is_employee));
     setIsRepresentative(Boolean(contact.is_representative));
+    setIsOther(Boolean(contact.is_other));
     setBloqueado(Boolean(contact.bloqueado));
     setErrorField(null);
     setSavedField(null);
@@ -258,26 +271,26 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
     [bloqueado, performSave]
   );
 
-  // ADR 0188 Onda 4 — toggle papel via endpoint /papeis separado (não
+  // ADR 0188 Onda 4 + ADR 0246 — toggle papel via endpoint /papeis separado (não
   // /classificacao) pra isolar invariante ">=1 papel ativo" no backend.
   // Optimistic UI: troca state imediato + PATCH paralelo. Rollback no 4xx/5xx.
   const handlePapelToggle = useCallback(
-    async (
-      flag: 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative',
-    ) => {
+    async (flag: PapelFlag) => {
       if (disabled) return;
 
-      const setters = {
+      const setters: Record<PapelFlag, (v: boolean) => void> = {
         is_customer: setIsCustomer,
         is_supplier: setIsSupplier,
         is_employee: setIsEmployee,
         is_representative: setIsRepresentative,
+        is_other: setIsOther,
       };
-      const currentValues = {
+      const currentValues: Record<PapelFlag, boolean> = {
         is_customer: isCustomer,
         is_supplier: isSupplier,
         is_employee: isEmployee,
         is_representative: isRepresentative,
+        is_other: isOther,
       };
       const newValue = !currentValues[flag];
 
@@ -324,15 +337,16 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
         setSavingField((c) => (c === flag ? null : c));
       }
     },
-    [contact.id, disabled, isCustomer, isSupplier, isEmployee, isRepresentative, onSaved],
+    [contact.id, disabled, isCustomer, isSupplier, isEmployee, isRepresentative, isOther, onSaved],
   );
 
   // Helper pra map flag → state local (usado no JSX dos chips).
-  const papelValue = (flag: typeof PAPEL_OPTIONS[number]['flag']): boolean => {
+  const papelValue = (flag: PapelFlag): boolean => {
     if (flag === 'is_customer') return isCustomer;
     if (flag === 'is_supplier') return isSupplier;
     if (flag === 'is_employee') return isEmployee;
-    return isRepresentative;
+    if (flag === 'is_representative') return isRepresentative;
+    return isOther;
   };
 
   return (
@@ -372,8 +386,8 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
             })}
           </div>
           <FieldStatus
-            saving={['is_customer', 'is_supplier', 'is_employee', 'is_representative'].includes(savingField ?? '')}
-            saved={['is_customer', 'is_supplier', 'is_employee', 'is_representative'].includes(savedField ?? '')}
+            saving={['is_customer', 'is_supplier', 'is_employee', 'is_representative', 'is_other'].includes(savingField ?? '')}
+            saved={['is_customer', 'is_supplier', 'is_employee', 'is_representative', 'is_other'].includes(savedField ?? '')}
             backendError={
               errorField?.field?.startsWith('is_') ? errorField.message : null
             }

--- a/tests/Feature/Cliente/IsOtherFlagTest.php
+++ b/tests/Feature/Cliente/IsOtherFlagTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ADR 0246 — Tests Pest pra flag is_other em contacts.
+ *
+ * Cobre:
+ *   - Migration adicionou coluna is_other + índice (idempotente)
+ *   - Cadastro com is_other=1 sem CPF/CNPJ salva 200
+ *   - PATCH /cliente/{id}/papeis aceita is_other no whitelist
+ *   - Invariante ≥1 papel ativo continua valendo com 5 papéis
+ *   - Multi-tenant Tier 0: biz=1 não enxerga is_other=1 de biz=99 (ADR 0093 IRREVOGÁVEL)
+ *
+ * Tier 0: biz=1 (Wagner) em smoke, NUNCA biz=4 (ROTA LIVRE cliente real — ADR 0101).
+ *
+ * @see memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
+ * @see memory/decisions/0188-contacts-multi-type-flag-aditiva.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+use App\Business;
+use App\Contact;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Garante que migration ADR 0246 rodou (idempotente — não quebra se já rodou).
+    if (! Schema::hasColumn('contacts', 'is_other')) {
+        Schema::table('contacts', function ($t) {
+            $t->boolean('is_other')->default(false)->after('is_representative');
+        });
+    }
+});
+
+it('migration is_other é idempotente — re-rodar não duplica coluna nem índice', function () {
+    expect(Schema::hasColumn('contacts', 'is_other'))->toBeTrue();
+
+    $indexes = collect(\DB::select('SHOW INDEXES FROM contacts'))
+        ->pluck('Key_name')
+        ->toArray();
+
+    expect($indexes)->toContain('idx_contacts_biz_other');
+});
+
+it('aceita cadastro tipo Outros sem CPF/CNPJ — categoria default ADR 0246', function () {
+    $business = Business::factory()->create();
+
+    $contact = Contact::create([
+        'business_id' => $business->id,
+        'type' => 'customer',  // type enum UPOS permanece (ADR 0188 backward-compat)
+        'name' => 'Lead Feira Sign 2014 #123',
+        'contact_status' => 'active',
+        'is_other' => 1,
+        'is_customer' => 0,
+        'is_supplier' => 0,
+        'is_employee' => 0,
+        'is_representative' => 0,
+        // SEM cpf_cnpj — Outros não exige documento
+        // SEM tax_number — Outros não exige documento
+    ]);
+
+    expect($contact->id)->toBeInt()
+        ->and((bool) $contact->is_other)->toBeTrue()
+        ->and($contact->tax_number)->toBeNull();
+});
+
+it('PATCH /cliente/{id}/papeis aceita is_other no whitelist', function () {
+    $business = Business::factory()->create();
+    $user = User::factory()->create(['business_id' => $business->id]);
+    $contact = Contact::create([
+        'business_id' => $business->id,
+        'type' => 'customer',
+        'name' => 'Cliente Teste',
+        'contact_status' => 'active',
+        'is_customer' => 1,
+    ]);
+
+    $this->actingAs($user)
+        ->withSession(['user.business_id' => $business->id])
+        ->patchJson("/cliente/{$contact->id}/papeis", ['is_other' => true])
+        ->assertOk();
+
+    $contact->refresh();
+    expect((bool) $contact->is_other)->toBeTrue()
+        ->and((bool) $contact->is_customer)->toBeTrue(); // Aditivo, não exclusivo
+});
+
+it('invariante ≥1 papel ativo bloqueia desativar todos os 5 flags (Outros incluído)', function () {
+    $business = Business::factory()->create();
+    $user = User::factory()->create(['business_id' => $business->id]);
+    $contact = Contact::create([
+        'business_id' => $business->id,
+        'type' => 'customer',
+        'name' => 'Contato Teste',
+        'contact_status' => 'active',
+        'is_customer' => 1,
+        'is_other' => 0,
+    ]);
+
+    // Tenta zerar is_customer (único papel ativo) — deve bloquear 422
+    $this->actingAs($user)
+        ->withSession(['user.business_id' => $business->id])
+        ->patchJson("/cliente/{$contact->id}/papeis", ['is_customer' => false])
+        ->assertStatus(422);
+
+    $contact->refresh();
+    expect((bool) $contact->is_customer)->toBeTrue(); // Não mudou — invariante segurou
+});
+
+it('multi-tenant Tier 0: biz=1 não enxerga is_other=1 de biz=99', function () {
+    // ADR 0093 IRREVOGÁVEL — cross-tenant isolation.
+    $biz1 = Business::factory()->create();
+    $biz99 = Business::factory()->create();
+
+    $contactBiz1 = Contact::create([
+        'business_id' => $biz1->id,
+        'type' => 'customer',
+        'name' => 'Outros biz=1',
+        'contact_status' => 'active',
+        'is_other' => 1,
+    ]);
+
+    $contactBiz99 = Contact::create([
+        'business_id' => $biz99->id,
+        'type' => 'customer',
+        'name' => 'Outros biz=99',
+        'contact_status' => 'active',
+        'is_other' => 1,
+    ]);
+
+    // Query scoped por biz=1 deve trazer só o contact_biz1.
+    $resultadoBiz1 = Contact::where('business_id', $biz1->id)
+        ->where('is_other', 1)
+        ->get();
+
+    expect($resultadoBiz1)->toHaveCount(1)
+        ->and($resultadoBiz1->first()->id)->toBe($contactBiz1->id);
+
+    // Garantia: biz=99 também tem só o seu.
+    $resultadoBiz99 = Contact::where('business_id', $biz99->id)
+        ->where('is_other', 1)
+        ->get();
+
+    expect($resultadoBiz99)->toHaveCount(1)
+        ->and($resultadoBiz99->first()->id)->toBe($contactBiz99->id);
+});


### PR DESCRIPTION
## Resumo

Adiciona a 5ª flag `is_other` em `contacts`, estendendo [ADR 0188](memory/decisions/0188-contacts-multi-type-flag-aditiva.md) (flags multi-papel aditivas). Acomoda cadastros legacy sem CPF/CNPJ obrigatório — pré-requisito pra migração Wave 30 (WR Comercial PESSOAS → contacts biz=1).

## Por quê (contexto Wagner 2026-06-03)

Análise do banco Firebird WR2 (`Servidor-crm:Banco`) revelou que **12.233 de 13.703 cadastros (89%) na tabela `PESSOAS` têm `TIPO='O'`** — pré-venda, leads de feira antiga (2014-2016), pessoa genérica, cancelados — sem CPF/CNPJ. Sem categoria "Outros" canônica, cada migração futura (Vargas/Extreme/Gold/etc 33 clientes) inventaria categoria nova → bagunça multi-tenant.

Wagner aprovou "Outros" como **fallback default pra TODOS os imports legacy** que não se encaixem em Cliente/Fornecedor/Equipe/Representante.

## Insight chave (Wagner 2026-06-03)

> "a aba classificação onde a gente define que tipo de papel este registro vai ter (cliente, fornecedor, funcionario, representante). então acho que nao precisa desse botao [Converter]. talvez então somente acrescentar tbm a classificação 'outros' onde já existe essa funcionalidade."

Resultado: economia de ~250 LOC + uma tela inteira de conversão. Aproveita 100% do pattern ADR 0188 (chips multi-papel aditivos toggle).

## Mudanças

### 🗄️ Migration aditiva idempotente
- `contacts.is_other` TINYINT(1) NOT NULL DEFAULT 0 AFTER `is_representative`
- Índice composto `idx_contacts_biz_other` (Tier 0 multi-tenant [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))
- Sem backfill (nenhum cadastro existente é "Outros")

### 🎨 UI (estende ADR 0188 sem refactor)
- `ClassificacaoTab.tsx`: 5º chip "Outros" no array `PAPEL_OPTIONS` — clicável idêntico aos 4 existentes
- `Index.tsx`: 6ª aba "Outros" no `SLOT2_TABS` (ícone `Layers`) + `ROLE_TITLE.other`
- `ContactRoleType`: ganha 5º valor `'other'`
- **Sem tela nova** — conversão Outros↔Cliente/etc é toggle dos chips

### 🔧 Backend (whitelist + select)
- `ClienteAutosaveController::papeis`: aceita `is_other` no whitelist + invariante "≥1 papel ativo" estende pra 5 papéis
- `ContactController::index`: `applyContactTypeFilter('other')`, `buildClienteIndexTabCounts` inclui `'other'`, `selectCols` + payload propagam `is_other`
- `StoreContactRequest`: `rules['is_other'] = nullable boolean`
- CPF/CNPJ permanece `nullable` em `StoreContactRequest` (já era) → Outros funciona sem documento

### 📜 Charter (R7 Tier 0 — append-only v8)
- `Index.charter.md v8` documenta 6ª aba + 5º chip + invariantes ADR 0246
- `charter_version`: 7 → 8 · `related_adrs`: + [0188, 0246]

### ✅ Testes Pest cross-tenant ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) + ADR 0246)
- Migration `is_other` idempotente
- Cadastro Outros sem CPF/CNPJ salva 200
- PATCH `/papeis` aceita `is_other`
- Invariante ≥1 papel ativo bloqueia desativar último flag (422)
- Multi-tenant: biz=1 não enxerga `is_other=1` de biz=99 (Tier 0 IRREVOGÁVEL)

## Decisões ADR

- **[ADR 0246](memory/decisions/0246-tipo-outros-default-migracoes-legacy.md)** (criada): tipo "Outros" como categoria default em migrações legacy
- Estende **ADR 0188** (flags aditivas) sem refactor — chips Classificação cobrem conversão
- Pareada com [profile WR2 2026-06-03](memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md)

## O que NÃO mudou (Non-Goals explícitos)

- `type` enum UPOS permanece authoritative (Sells/Compras/Folha legacy)
- ❌ Botão "Converter para X" dedicado (Wagner cortou — chips bastam)
- ❌ `ContactTypeConversionService` novo (endpoint `/papeis` ADR 0188 já cobre)
- ❌ Validação `required_unless` pra CPF/CNPJ (regra já era nullable)
- ❌ Sub-tipos "Outros" (prospect/lead/feira) — Onda futura se demanda aparecer

## Próximo passo

**Etapa 2 — Wave 30**: importer Python `import-pessoas-from-firebird.py` (estende pattern Wave 29-1 Martinho) com fallback canon: PESSOAS sem flag comercial canônico → `is_other=1` automático. Bloqueado por este PR.

## Test plan

- [ ] CI verde (Pest + governance-gate + memory-schema-gate)
- [ ] Migration roda em CT 100 staging (`docker exec oimpresso-staging php artisan migrate`)
- [ ] Smoke prod biz=1 (Wagner): `/cliente?type=other` carrega vazio (0 cadastros) sem erro
- [ ] Smoke prod biz=1: drawer Classificação mostra 5 chips, toggle "Outros" salva via PATCH `/papeis`
- [ ] Tab counters mostram `other: 0` no subnav inicial
- [ ] Multi-tenant: biz=4 (Larissa ROTA LIVRE) não enxerga outros de biz=1

<!-- no-ui-smoke: PR aguarda Wagner aprovar antes de merge + smoke real -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)