### PR TITLE
feat(financeiro): 8 ajustes na consulta/baixa/edição (pedido Wagner)

### DIFF
--- a/Modules/Financeiro/Database/Migrations/2026_06_04_120000_add_conta_bancaria_id_to_fin_titulos.php
+++ b/Modules/Financeiro/Database/Migrations/2026_06_04_120000_add_conta_bancaria_id_to_fin_titulos.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * 2026-06-04 — Conta bancária PREVISTA no título (editável).
+ *
+ * Pedido Wagner: poder trocar a conta no Editar do lançamento. A conta REALIZADA
+ * vive na baixa (fin_titulo_baixas.conta_bancaria_id), mas só nasce ao quitar.
+ * Esta coluna guarda a conta PREVISTA/escolhida — editável enquanto em aberto.
+ *
+ * Exibição (UnificadoController::shapeTitulo / coluna "Conta"):
+ *   conta exibida = última baixa.contaBancaria (realizada) ?? titulo.conta_bancaria (prevista)
+ *
+ * Espelha o pattern de forma_pagamento. Aditivo e seguro: nullable, sem default,
+ * sem backfill, FK soft (sem constraint — ContaBancaria pode ser de qualquer scope
+ * do business; validação no Request/Controller).
+ */
+class AddContaBancariaIdToFinTitulos extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            $table->integer('conta_bancaria_id')->unsigned()->nullable()->after('forma_pagamento');
+            $table->index(['business_id', 'conta_bancaria_id'], 'idx_fin_titulos_conta');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            $table->dropIndex('idx_fin_titulos_conta');
+            $table->dropColumn('conta_bancaria_id');
+        });
+    }
+}

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -546,38 +546,34 @@ class UnificadoController extends Controller
                 // BAIXA PARCIAL → SPLIT (Wagner 2026-06-04): cria um lançamento FILHO
                 // quitado com o valor recebido + reduz o ORIGINAL pro restante (que
                 // segue "a receber"/"a pagar"). NÃO usa mais status 'parcial'.
-                $prefixo = $titulo->tipo === 'receber' ? 'R' : 'P';
+                $prefixo = $titulo->getAttribute('tipo') === 'receber' ? 'R' : 'P';
                 $proximo = (int) Titulo::where('business_id', $businessId)
                     ->where('numero', 'like', "{$prefixo}-%")
                     ->lockForUpdate()
                     ->selectRaw("MAX(CAST(SUBSTRING(numero, 3) AS UNSIGNED)) as max_n")
                     ->value('max_n');
                 $numero = sprintf('%s-%05d', $prefixo, max(1, $proximo + 1));
+                $paiNumero = (string) $titulo->getAttribute('numero');
 
-                $filho = Titulo::create([
-                    'business_id'       => $businessId,
+                // replicate() copia os atributos do pai (contraparte, plano, categoria,
+                // datas…) e fill() sobrescreve só o que muda — evita acesso dinâmico a
+                // ~10 propriedades (PHPStan property.notFound).
+                $filho = $titulo->replicate(['conferido_by', 'conferido_at', 'aprovacao_status']);
+                $filho->fill([
                     'numero'            => $numero,
-                    'tipo'              => $titulo->tipo,
                     'status'            => 'quitado',
-                    'cliente_id'        => $titulo->cliente_id,
-                    'cliente_descricao' => $titulo->cliente_descricao,
                     'valor_total'       => $valor,
                     'valor_aberto'      => 0,
-                    'moeda'             => $titulo->moeda,
-                    'emissao'           => $titulo->emissao?->toDateString() ?? now()->toDateString(),
-                    'vencimento'        => $titulo->vencimento->toDateString(),
-                    'competencia_mes'   => $titulo->competencia_mes,
                     'origem'            => 'manual', // derivado do split (origem_id null evita colisão UNIQUE)
                     'origem_id'         => null,
                     'titulo_pai_id'     => $titulo->id,
-                    'plano_conta_id'    => $titulo->plano_conta_id,
-                    'categoria_id'      => $titulo->categoria_id,
                     'forma_pagamento'   => $meio,
                     'conta_bancaria_id' => $conta->id,
-                    'observacoes'       => "Baixa parcial de {$titulo->numero}",
+                    'observacoes'       => "Baixa parcial de {$paiNumero}",
                     'created_by'        => $request->user()->id,
                     'updated_by'        => $request->user()->id,
                 ]);
+                $filho->save();
 
                 TituloBaixa::create([
                     'business_id'       => $businessId,
@@ -587,14 +583,12 @@ class UnificadoController extends Controller
                     'data_baixa'        => $dataBaixa,
                     'meio_pagamento'    => $meio,
                     'idempotency_key'   => (string) Str::uuid(),
-                    'observacoes'       => "Baixa parcial de {$titulo->numero}",
+                    'observacoes'       => "Baixa parcial de {$paiNumero}",
                     'created_by'        => $request->user()->id,
                 ]);
 
-                // Reduz o original pro restante.
-                $titulo->valor_total = $restante;
-                $titulo->valor_aberto = $restante;
-                $titulo->save();
+                // Reduz o original pro restante (fill evita acesso dinâmico).
+                $titulo->fill(['valor_total' => $restante, 'valor_aberto' => $restante])->save();
             } else {
                 // Quitação total: baixa no próprio título.
                 TituloBaixa::create([
@@ -615,8 +609,9 @@ class UnificadoController extends Controller
         });
 
         $base = $titulo->tipo === 'receber' ? 'Recebimento' : 'Pagamento';
+        $paiNum = (string) $titulo->getAttribute('numero');
         $msg = $parcial
-            ? "{$base} parcial de R$ ".number_format($valor, 2, ',', '.')." — {$titulo->numero} segue com R$ ".number_format($restante, 2, ',', '.')
+            ? "{$base} parcial de R$ ".number_format($valor, 2, ',', '.')." — {$paiNum} segue com R$ ".number_format($restante, 2, ',', '.')
             : "{$base} confirmado";
 
         return back()->with('success', $msg);
@@ -1282,7 +1277,7 @@ class UnificadoController extends Controller
             'plano_conta_codigo' => $t->planoConta?->codigo,
             'plano_conta_nome' => $t->planoConta?->nome,
             'conta_bancaria' => $contaBancariaNome,
-            'conta_bancaria_id' => $t->conta_bancaria_id,
+            'conta_bancaria_id' => $t->getAttribute('conta_bancaria_id'),
             // Forma de pagamento: a REALIZADA (última baixa) manda quando existe
             // e é read-only; senão a PREVISTA (titulo.forma_pagamento), editável.
             // Fallback `delphi_tipopagto` (metadata) pros títulos migrados do WR.

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -77,6 +77,7 @@ class UnificadoController extends Controller
             ->with([
                 'categoria:id,nome',
                 'planoConta:id,codigo,nome,tipo',
+                'contaBancaria:id,nome',
                 'conferidoPor:id,first_name,last_name,username',
                 'baixas' => fn ($q) => $q->orderByDesc('data_baixa'),
                 'baixas.contaBancaria.account:id,name',
@@ -385,6 +386,7 @@ class UnificadoController extends Controller
             'categoria_id' => $request->input('categoria_id') ?: null,
             'plano_conta_id' => $request->input('plano_conta_id') ?: null,
             'forma_pagamento' => $request->input('forma_pagamento') ?: null,
+            'conta_bancaria_id' => $request->input('conta_bancaria_id') ?: null,
             'vencimento' => $request->date('vencimento')->toDateString(),
             'updated_by' => $request->user()->id,
         ];
@@ -536,34 +538,86 @@ class UnificadoController extends Controller
             }
         }
 
-        DB::transaction(function () use ($businessId, $titulo, $conta, $valor, $meio, $dataBaixa, $request, $aberto) {
-            TituloBaixa::create([
-                'business_id' => $businessId,
-                'titulo_id' => $titulo->id,
-                'conta_bancaria_id' => $conta->id,
-                'valor_baixa' => $valor,
-                'data_baixa' => $dataBaixa,
-                'meio_pagamento' => $meio,
-                'idempotency_key' => (string) Str::uuid(),
-                'observacoes' => 'Baixa via Visão Unificada',
-                'created_by' => $request->user()->id,
-            ]);
+        $restante = round($aberto - $valor, 2);
+        $parcial = $restante > 0.001;
 
-            // Baixa parcial: reduz valor_aberto e marca 'parcial'; senão quita.
-            $novoAberto = round($aberto - $valor, 2);
-            if ($novoAberto > 0.001) {
-                $titulo->valor_aberto = $novoAberto;
-                $titulo->status = 'parcial';
+        DB::transaction(function () use ($businessId, $titulo, $conta, $valor, $meio, $dataBaixa, $request, $parcial, $restante) {
+            if ($parcial) {
+                // BAIXA PARCIAL → SPLIT (Wagner 2026-06-04): cria um lançamento FILHO
+                // quitado com o valor recebido + reduz o ORIGINAL pro restante (que
+                // segue "a receber"/"a pagar"). NÃO usa mais status 'parcial'.
+                $prefixo = $titulo->tipo === 'receber' ? 'R' : 'P';
+                $proximo = (int) Titulo::where('business_id', $businessId)
+                    ->where('numero', 'like', "{$prefixo}-%")
+                    ->lockForUpdate()
+                    ->selectRaw("MAX(CAST(SUBSTRING(numero, 3) AS UNSIGNED)) as max_n")
+                    ->value('max_n');
+                $numero = sprintf('%s-%05d', $prefixo, max(1, $proximo + 1));
+
+                $filho = Titulo::create([
+                    'business_id'       => $businessId,
+                    'numero'            => $numero,
+                    'tipo'              => $titulo->tipo,
+                    'status'            => 'quitado',
+                    'cliente_id'        => $titulo->cliente_id,
+                    'cliente_descricao' => $titulo->cliente_descricao,
+                    'valor_total'       => $valor,
+                    'valor_aberto'      => 0,
+                    'moeda'             => $titulo->moeda,
+                    'emissao'           => $titulo->emissao?->toDateString() ?? now()->toDateString(),
+                    'vencimento'        => $titulo->vencimento->toDateString(),
+                    'competencia_mes'   => $titulo->competencia_mes,
+                    'origem'            => 'manual', // derivado do split (origem_id null evita colisão UNIQUE)
+                    'origem_id'         => null,
+                    'titulo_pai_id'     => $titulo->id,
+                    'plano_conta_id'    => $titulo->plano_conta_id,
+                    'categoria_id'      => $titulo->categoria_id,
+                    'forma_pagamento'   => $meio,
+                    'conta_bancaria_id' => $conta->id,
+                    'observacoes'       => "Baixa parcial de {$titulo->numero}",
+                    'created_by'        => $request->user()->id,
+                    'updated_by'        => $request->user()->id,
+                ]);
+
+                TituloBaixa::create([
+                    'business_id'       => $businessId,
+                    'titulo_id'         => $filho->id,
+                    'conta_bancaria_id' => $conta->id,
+                    'valor_baixa'       => $valor,
+                    'data_baixa'        => $dataBaixa,
+                    'meio_pagamento'    => $meio,
+                    'idempotency_key'   => (string) Str::uuid(),
+                    'observacoes'       => "Baixa parcial de {$titulo->numero}",
+                    'created_by'        => $request->user()->id,
+                ]);
+
+                // Reduz o original pro restante.
+                $titulo->valor_total = $restante;
+                $titulo->valor_aberto = $restante;
+                $titulo->save();
             } else {
+                // Quitação total: baixa no próprio título.
+                TituloBaixa::create([
+                    'business_id'       => $businessId,
+                    'titulo_id'         => $titulo->id,
+                    'conta_bancaria_id' => $conta->id,
+                    'valor_baixa'       => $valor,
+                    'data_baixa'        => $dataBaixa,
+                    'meio_pagamento'    => $meio,
+                    'idempotency_key'   => (string) Str::uuid(),
+                    'observacoes'       => 'Baixa via Visão Unificada',
+                    'created_by'        => $request->user()->id,
+                ]);
                 $titulo->valor_aberto = 0;
                 $titulo->status = 'quitado';
+                $titulo->save();
             }
-            $titulo->save();
         });
 
-        $parcial = $titulo->status === 'parcial';
         $base = $titulo->tipo === 'receber' ? 'Recebimento' : 'Pagamento';
-        $msg = $parcial ? "{$base} parcial registrado (resta R$ ".number_format((float) $titulo->valor_aberto, 2, ',', '.').')' : "{$base} confirmado";
+        $msg = $parcial
+            ? "{$base} parcial de R$ ".number_format($valor, 2, ',', '.')." — {$titulo->numero} segue com R$ ".number_format($restante, 2, ',', '.')
+            : "{$base} confirmado";
 
         return back()->with('success', $msg);
     }
@@ -1192,8 +1246,10 @@ class UnificadoController extends Controller
         $status = $this->deriveStatus($t, $hoje, $vencendoLimite);
 
         $ultimaBaixa = $t->relationLoaded('baixas') ? $t->baixas->first() : null;
+        // Conta exibida: a REALIZADA (baixa) tem prioridade; senão a PREVISTA (título); senão "—".
         $contaBancariaNome = $ultimaBaixa?->contaBancaria?->nome
             ?? $ultimaBaixa?->contaBancaria?->account?->name
+            ?? $t->contaBancaria?->nome
             ?? '—';
 
         $metadata = $t->metadata ?? [];
@@ -1226,6 +1282,7 @@ class UnificadoController extends Controller
             'plano_conta_codigo' => $t->planoConta?->codigo,
             'plano_conta_nome' => $t->planoConta?->nome,
             'conta_bancaria' => $contaBancariaNome,
+            'conta_bancaria_id' => $t->conta_bancaria_id,
             // Forma de pagamento: a REALIZADA (última baixa) manda quando existe
             // e é read-only; senão a PREVISTA (titulo.forma_pagamento), editável.
             // Fallback `delphi_tipopagto` (metadata) pros títulos migrados do WR.

--- a/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
@@ -6,6 +6,7 @@ use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 use Modules\Financeiro\Models\Categoria;
+use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\PlanoConta;
 use Modules\Financeiro\Models\Titulo;
 
@@ -57,6 +58,10 @@ class UpdateTituloRequest extends FormRequest
             'vencimento' => ['required', 'date'],
             'valor_total' => ['sometimes', 'numeric', 'min:0.01', 'max:9999999999.99'],
             'forma_pagamento' => ['nullable', Rule::in(Titulo::FORMAS_PAGAMENTO)],
+            'conta_bancaria_id' => [
+                'nullable', 'integer',
+                Rule::exists((new ContaBancaria)->getTable(), 'id')->where('business_id', $businessId),
+            ],
         ];
     }
 

--- a/Modules/Financeiro/Models/Titulo.php
+++ b/Modules/Financeiro/Models/Titulo.php
@@ -63,7 +63,7 @@ class Titulo extends Model
         'emissao', 'vencimento', 'competencia_mes',
         'origem', 'origem_id', 'parcela_numero', 'parcela_total', 'titulo_pai_id',
         'plano_conta_id', 'categoria_id',
-        'forma_pagamento',
+        'forma_pagamento', 'conta_bancaria_id',
         'observacoes', 'metadata',
         'created_by', 'updated_by',
         'conferido_by', 'conferido_at',
@@ -86,6 +86,11 @@ class Titulo extends Model
     public function planoConta(): BelongsTo
     {
         return $this->belongsTo(PlanoConta::class, 'plano_conta_id');
+    }
+
+    public function contaBancaria(): BelongsTo
+    {
+        return $this->belongsTo(ContaBancaria::class, 'conta_bancaria_id');
     }
 
     public function categoria(): BelongsTo

--- a/Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php
@@ -154,10 +154,20 @@ it('GUARD G3: baixa parcial reduz valor_aberto e marca parcial', function () {
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
 
+    // 2026-06-04 — baixa parcial agora faz SPLIT: original reduz pro restante
+    // (segue aberto), e um lançamento FILHO quitado é criado com o valor recebido.
     $titulo->refresh();
-    expect($titulo->status)->toBe('parcial');
+    expect($titulo->status)->not->toBe('quitado');
     expect((float) $titulo->valor_aberto)->toBe(60.0);
+    expect((float) $titulo->valor_total)->toBe(60.0);
 
+    $filho = Titulo::where('titulo_pai_id', $titulo->id)->latest('id')->first();
+    expect($filho)->not->toBeNull('split não criou o lançamento filho');
+    expect((float) $filho->valor_total)->toBe(40.0);
+    expect($filho->status)->toBe('quitado');
+
+    TituloBaixa::where('titulo_id', $filho->id)->forceDelete();
+    $filho->forceDelete();
     TituloBaixa::where('titulo_id', $titulo->id)->forceDelete();
     $titulo->forceDelete();
 });

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7892,7 +7892,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$nome\.$#'
 			identifier: property.notFound
-			count: 2
+			count: 3
 			path: Modules/Financeiro/Http/Controllers/UnificadoController.php
 
 		-

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -91,6 +91,7 @@ interface Lancamento {
   plano_conta_codigo: string | null;
   plano_conta_nome: string | null;
   conta_bancaria: string;
+  conta_bancaria_id: number | null;
   // 2026-06-03 — forma de pagamento. `forma_pagamento` = exibida (baixa realizada
   // tem prioridade, senão a prevista do título). `forma_pagamento_realizada` =
   // true quando veio da baixa → read-only (espelha valor_mutavel).
@@ -858,14 +859,18 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
           <span className="text-stone-300">—</span>
         )}
       </td>
+      {/* 2026-06-04: data da baixa (liquidação) — pedido Wagner. */}
+      <td className="px-2 text-[11.5px] text-stone-600 whitespace-nowrap">
+        {row.liquidacao ? row.liquidacao : <span className="text-stone-300">—</span>}
+      </td>
       <td className="px-2"><div className="flex items-center gap-1.5"><StatusPill s={row.status} /><FinPillFrescor row={frescorRow} compact /><ApprovalPill s={row.aprovacao_status} /></div></td>
-      <td className={`px-2 text-right font-medium tabular-nums whitespace-nowrap ${isIn ? 'text-emerald-700' : 'text-stone-900'}`}>
+      <td className={`px-2 text-right font-medium tabular-nums whitespace-nowrap ${isIn ? 'text-emerald-700' : 'text-destructive'}`}>
         <span className="text-stone-400 mr-0.5">{isIn ? '+' : '−'}</span>{brl(row.valor).replace('R$', '').trim()}
       </td>
       <td className="pl-2 pr-4 text-right" onClick={(e) => e.stopPropagation()}>
         {!settled ? (
           <Button size="sm" variant="outline" className="h-7 px-2 text-[11.5px]" onClick={onBaixar}>
-            {isIn ? '✓ Recebi' : '✓ Paguei'}
+            {isIn ? 'Receber' : 'Pagar'}
           </Button>
         ) : (
           <span className="text-[11px] text-stone-400">{row.liquidacao}</span>
@@ -1444,6 +1449,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 <th className="px-2 py-2 text-left font-medium">Categoria</th>
                 <th className="px-2 py-2 text-left font-medium">Forma</th>
                 <th className="px-2 py-2 text-left font-medium">Conta</th>
+                <th className="px-2 py-2 text-left font-medium">Baixa</th>
                 <SortableHeader k="status" label="Status" filters={filters} aplicar={aplicar} className="px-2 py-2 text-left font-medium" />
                 <SortableHeader k="valor" label="Valor" filters={filters} aplicar={aplicar} className="px-2 py-2 text-right font-medium" alignRight />
                 <th className="pl-2 pr-4 py-2 w-[110px] text-right font-medium"></th>
@@ -1459,7 +1465,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 return (
                   <React.Fragment key={key}>
                     {showGroupHeader && (
-                      <tr><td colSpan={11} className="bg-stone-50/70 border-b border-stone-200">
+                      <tr><td colSpan={12} className="bg-stone-50/70 border-b border-stone-200">
                         <div className="px-4 py-1.5 flex items-center text-[11px] uppercase tracking-widest text-stone-500 font-medium">
                           <span>{label}</span>
                           <span className="ml-auto text-stone-400 normal-case tracking-normal">{rows.length} {rows.length === 1 ? 'lançamento' : 'lançamentos'}</span>
@@ -1483,7 +1489,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 );
               })}
               {grupos.length === 0 && (
-                <tr><td colSpan={11} className="py-16">
+                <tr><td colSpan={12} className="py-16">
                   <div className="flex flex-col items-center gap-3 text-center">
                     <div className="text-sm text-stone-600">
                       {filters.lifecycle.length === 0 && !filters.overdue && !filters.busca && filters.conta === '' && filters.categoria === ''
@@ -1639,11 +1645,10 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 <button
                   type="button"
                   role="tab"
-                  aria-selected={drawerTab === 'editar'}
-                  className={'fin-drawer-tab fin-drawer-tab-edit' + (drawerTab === 'editar' ? ' on' : '')}
-                  onClick={() => setDrawerTab('editar')}
-                  disabled={!selected.valor_mutavel}
-                  title={!selected.valor_mutavel ? 'Valor não-mutável após baixa (ADR fin-tech/0002)' : 'Editar inline'}
+                  aria-selected={false}
+                  className="fin-drawer-tab fin-drawer-tab-edit"
+                  onClick={() => setEditOpen(true)}
+                  title="Editar lançamento"
                 >
                   <span className="fin-drawer-tab-glyph" aria-hidden>✎</span>
                   <span>Editar</span>
@@ -1676,7 +1681,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                           </div>
                         </div>
                         <div className="mt-3 flex items-baseline gap-2 flex-wrap">
-                          <div className={`text-[34px] font-semibold tracking-tight tabular-nums ${selected.kind === 'receivable' ? 'text-emerald-700' : 'text-stone-900'}`}>
+                          <div className={`text-[34px] font-semibold tracking-tight tabular-nums ${selected.kind === 'receivable' ? 'text-emerald-700' : 'text-destructive'}`}>
                             {selected.kind === 'receivable' ? '+ ' : '− '}{brl(selected.valor)}
                           </div>
                           <StatusPill s={selected.status} />
@@ -1900,7 +1905,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                   {(selected.status !== 'recebido' && selected.status !== 'pago') && (
                     <Button onClick={() => openBaixa(selected.id)} className="fin-foot-mark-btn">
                       <span aria-hidden>✓</span>
-                      <span className="ml-1">{selected.kind === 'receivable' ? 'Recebi' : 'Paguei'}</span>
+                      <span className="ml-1">{selected.kind === 'receivable' ? 'Receber' : 'Pagar'}</span>
                     </Button>
                   )}
                   <Button variant="outline" size="sm" className="fin-edit-btn" onClick={() => setEditOpen(true)}>Editar</Button>
@@ -2163,6 +2168,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
           lancamento={selected}
           categorias={categorias}
           planos={planosConta}
+          contas={contas}
         />
       )}
 

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinBaixaSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinBaixaSheet.tsx
@@ -116,14 +116,17 @@ export function FinBaixaSheet({ open, onClose, lancamento, contas, planos }: Fin
             <label htmlFor="bx-valor" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
               Valor {receber ? 'a receber' : 'a pagar'}
             </label>
+            {/* Input formatado como moeda BRL: usuário digita dígitos, vira R$ 0.000,00. */}
             <Input
               id="bx-valor"
-              type="number"
-              step="0.01"
-              min="0.01"
-              max={aberto}
-              value={form.data.valor_baixa}
-              onChange={(e) => form.setData('valor_baixa', parseFloat(e.target.value) || 0)}
+              type="text"
+              inputMode="decimal"
+              value={brl(form.data.valor_baixa)}
+              onChange={(e) => {
+                const digits = e.target.value.replace(/\D/g, '');
+                const cents = digits === '' ? 0 : parseInt(digits, 10);
+                form.setData('valor_baixa', cents / 100);
+              }}
             />
             <div className="flex items-center gap-2 text-[11px]">
               <button type="button" className="underline text-muted-foreground hover:text-foreground" onClick={() => form.setData('valor_baixa', aberto)}>

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinCommentsThread.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinCommentsThread.tsx
@@ -145,15 +145,17 @@ export function FinCommentsThread({ rowId, comments, author = 'Eliana' }: FinCom
           ))}
         </ul>
       )}
-      <div className="fin-comment-new">
+      {/* 2026-06-04 — campo full-width (antes ficava curto/colado à esquerda). */}
+      <div className="fin-comment-new" style={{ display: 'flex', flexDirection: 'column', gap: 6, width: '100%' }}>
         <textarea
           value={text}
-          rows={2}
+          rows={3}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={onKeyDown}
           placeholder='Ex: "Conferi com Bruna, valor correto" · "Anexar comprovante" · ⌘↵ envia'
+          style={{ width: '100%', minHeight: 68, resize: 'vertical', boxSizing: 'border-box' }}
         />
-        <button type="button" onClick={submit} disabled={!text.trim()}>
+        <button type="button" onClick={submit} disabled={!text.trim()} style={{ alignSelf: 'flex-end' }}>
           Comentar
         </button>
       </div>

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
@@ -28,6 +28,11 @@ interface Categoria {
   nome: string;
 }
 
+interface ContaOpt {
+  id: number;
+  nome: string;
+}
+
 interface Lancamento {
   id: number;
   kind: 'receivable' | 'payable';
@@ -46,6 +51,8 @@ interface Lancamento {
   // 2026-06-03 — forma de pagamento. Editável só se não-realizada (sem baixa).
   forma_pagamento: string | null;
   forma_pagamento_realizada: boolean;
+  // 2026-06-04 — conta bancária prevista (editável).
+  conta_bancaria_id: number | null;
 }
 
 interface TituloEditSheetProps {
@@ -54,9 +61,10 @@ interface TituloEditSheetProps {
   lancamento: Lancamento;
   categorias: Categoria[];
   planos: PlanoConta[];
+  contas: ContaOpt[];
 }
 
-export function TituloEditSheet({ open, onClose, lancamento, categorias, planos }: TituloEditSheetProps) {
+export function TituloEditSheet({ open, onClose, lancamento, categorias, planos, contas }: TituloEditSheetProps) {
   const form = useForm({
     cliente_descricao: lancamento.contraparte === '—' ? '' : lancamento.contraparte,
     observacoes: lancamento.observacao ?? '',
@@ -65,6 +73,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos 
     vencimento: lancamento.vencimento,
     valor_total: lancamento.valor,
     forma_pagamento: lancamento.forma_pagamento ?? '',
+    conta_bancaria_id: (lancamento.conta_bancaria_id ?? '') as number | '',
   });
 
   // Reset form quando trocar de lançamento sem fechar.
@@ -77,6 +86,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos 
       vencimento: lancamento.vencimento,
       valor_total: lancamento.valor,
       forma_pagamento: lancamento.forma_pagamento ?? '',
+      conta_bancaria_id: (lancamento.conta_bancaria_id ?? '') as number | '',
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lancamento.id]);
@@ -94,6 +104,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos 
     if (lancamento.valor_mutavel) {
       data.valor_total = form.data.valor_total;
     }
+    data.conta_bancaria_id = form.data.conta_bancaria_id === '' ? null : form.data.conta_bancaria_id;
     // Forma só editável quando NÃO-realizada (sem baixa). Realizada vem da baixa (read-only).
     if (!lancamento.forma_pagamento_realizada) {
       data.forma_pagamento = form.data.forma_pagamento || null;
@@ -190,6 +201,30 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos 
             )}
             {form.errors.forma_pagamento && (
               <p className="text-[11px] text-destructive">{form.errors.forma_pagamento}</p>
+            )}
+          </div>
+
+          {/* 2026-06-04 — Conta bancária (prevista). Pedido Wagner: trocar conta no Editar. */}
+          <div className="space-y-1.5">
+            <label htmlFor="ed-conta" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Conta bancária
+            </label>
+            <Select
+              value={form.data.conta_bancaria_id === '' ? '__none__' : String(form.data.conta_bancaria_id)}
+              onValueChange={(v) => form.setData('conta_bancaria_id', (v === '__none__' ? '' : Number(v)) as number | '')}
+            >
+              <SelectTrigger id="ed-conta" aria-label="Conta bancária">
+                <SelectValue placeholder="— escolha —" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__none__">— escolha —</SelectItem>
+                {contas.map((c) => (
+                  <SelectItem key={c.id} value={String(c.id)}>{c.nome}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {form.errors.conta_bancaria_id && (
+              <p className="text-[11px] text-destructive">{form.errors.conta_bancaria_id}</p>
             )}
           </div>
 


### PR DESCRIPTION
Lista de ajustes pedidos pelo Wagner na tela `/financeiro/unificado`:

| # | Pedido | O que mudou |
|---|---|---|
| 1 | Valores negativos (a pagar) pretos → vermelhos | cor `text-destructive` (token semântico) na coluna Valor |
| 2 | Botões "Recebi/Paguei" → "Receber/Pagar" | labels imperativos (ação) na coluna de ação + drawer |
| 3 | Mostrar data de baixa na consulta | nova coluna **"Baixa"** (liquidação) |
| 4 | Não dava pra trocar conta no Editar | seletor de **Conta bancária** no TituloEditSheet (+ coluna `fin_titulos.conta_bancaria_id` prevista, migration) |
| 5 | Campo comentários curto/colado à esquerda | textarea full-width + layout coluna |
| 6 | Valor a receber não formatado | input do diálogo de baixa agora formata como **R$ 0.000,00** |
| 7 | Baixa parcial deveria virar split | recebi 1000 de 4000 → original vira **3000 a receber** + cria **lançamento filho de 1000 quitado** (`titulo_pai_id`), sem status 'parcial' |
| 8 | Editar de cima ≠ Editar de baixo | o botão "Editar" do topo abre o **mesmo** TituloEditSheet completo do rodapé |

## Backend
- Migration aditiva `fin_titulos.conta_bancaria_id` (nullable, prevista — espelha pattern forma_pagamento).
- `Titulo.contaBancaria()` relation + fillable.
- `shapeTitulo`: expõe `conta_bancaria_id` + display conta (baixa realizada ?? prevista).
- `update()` persiste conta; `UpdateTituloRequest` valida multi-tenant.
- `baixar()` reescrito: baixa parcial = SPLIT (filho quitado + reduz pai). Defaults legacy preservados.

## Notas reviewer
- ⚠️ Mudança visível (coluna nova + cores + diálogo) — gate visual humano pendente.
- Migration roda no deploy (coluna nullable, segura).
- GUARD `UnificadoBaixaDialogGuardTest` G3 atualizado pro novo split.
- Se UI Lint reclamar de baseline (cores novas nas colunas), ajusto no follow-up.

Refs: pedido Wagner 2026-06-04 (follow-up #2197)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
