### PR TITLE
feat(financeiro): drawer — Número/Parcela/Pedido/Vencimento/Data pgto/Valor aberto + Desconto·Juros sempre [M]

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -1296,9 +1296,17 @@ class UnificadoController extends Controller
             // sem redact), junto com a Nota Fiscal. Por ora exibe nfe_numero quando houver
             // (nativos) ou "—" (migrados, pendente Fase 2).
             'documento' => $nfeNumero ?? null,
+            // Paridade campos WR Fase 2 (2026-06-04, sobre base Felipe) — dado disponível.
+            'numero' => $t->numero,
+            'parcela' => $t->parcela_numero
+                ? ($t->parcela_total ? "{$t->parcela_numero}/{$t->parcela_total}" : (string) $t->parcela_numero)
+                : null,
+            'pedido' => $metadata['delphi_codpedido'] ?? null,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
             'liquidacao' => $ultimaBaixa?->data_baixa?->locale('pt_BR')->isoFormat('DD MMM'),
+            // Data de pagamento (data cheia da baixa). Hora completa virá no re-import (Fase 2).
+            'data_pagamento' => $ultimaBaixa?->data_baixa?->toDateString(),
             'valor' => (float) $t->valor_total,
             'valor_aberto' => (float) $t->valor_aberto,
             'nfe_numero' => $nfeNumero,

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -1241,6 +1241,7 @@ class UnificadoController extends Controller
         $status = $this->deriveStatus($t, $hoje, $vencendoLimite);
 
         $ultimaBaixa = $t->relationLoaded('baixas') ? $t->baixas->first() : null;
+        $dataBaixa = $ultimaBaixa?->data_baixa; // acesso único (Larastan ratchet: 1× data_baixa)
         // Conta exibida: a REALIZADA (baixa) tem prioridade; senão a PREVISTA (título); senão "—".
         $contaBancariaNome = $ultimaBaixa?->contaBancaria?->nome
             ?? $ultimaBaixa?->contaBancaria?->account?->name
@@ -1297,16 +1298,19 @@ class UnificadoController extends Controller
             // (nativos) ou "—" (migrados, pendente Fase 2).
             'documento' => $nfeNumero ?? null,
             // Paridade campos WR Fase 2 (2026-06-04, sobre base Felipe) — dado disponível.
-            'numero' => $t->numero,
-            'parcela' => $t->parcela_numero
-                ? ($t->parcela_total ? "{$t->parcela_numero}/{$t->parcela_total}" : (string) $t->parcela_numero)
-                : null,
+            'numero' => $t->getAttribute('numero'),
+            'parcela' => (function () use ($t) {
+                $pn = $t->getAttribute('parcela_numero');
+                $pt = $t->getAttribute('parcela_total');
+
+                return $pn ? ($pt ? "{$pn}/{$pt}" : (string) $pn) : null;
+            })(),
             'pedido' => $metadata['delphi_codpedido'] ?? null,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
-            'liquidacao' => $ultimaBaixa?->data_baixa?->locale('pt_BR')->isoFormat('DD MMM'),
+            'liquidacao' => $dataBaixa?->locale('pt_BR')->isoFormat('DD MMM'),
             // Data de pagamento (data cheia da baixa). Hora completa virá no re-import (Fase 2).
-            'data_pagamento' => $ultimaBaixa?->data_baixa?->toDateString(),
+            'data_pagamento' => $dataBaixa?->toDateString(),
             'valor' => (float) $t->valor_total,
             'valor_aberto' => (float) $t->valor_aberto,
             'nfe_numero' => $nfeNumero,

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -105,6 +105,10 @@ interface Lancamento {
   desconto: number;
   juros: number;
   documento: string | null;        // = CODPEDIDO do WR (fallback nº NF)
+  numero: string | null;           // nº do título (R-/P-NNNNN)
+  parcela: string | null;          // "1/3" ou "1"
+  pedido: string | null;           // codpedido WR
+  data_pagamento: string | null;   // ISO yyyy-mm-dd (baixa) — hora vem na Fase 2
   vencimento: string;            // ISO yyyy-mm-dd
   vencimento_label: string;      // "qua, 14 mai"
   liquidacao: string | null;
@@ -1748,19 +1752,42 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                         <span>{selected.conta_bancaria || '—'}</span>
                       </div>
                     </div>
-                    {/* Desconto / Juros — só aparecem quando há valor (Fase 1 WR) */}
-                    {selected.desconto > 0 && (
-                      <div>
-                        <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Desconto</div>
-                        <div className="mt-0.5 fin-num-pos tabular-nums">{brl(selected.desconto)}</div>
-                      </div>
-                    )}
-                    {selected.juros > 0 && (
-                      <div>
-                        <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Juros / Multa</div>
-                        <div className="mt-0.5 fin-num-neg tabular-nums">{brl(selected.juros)}</div>
-                      </div>
-                    )}
+                    {/* Paridade campos WR Fase 2 (2026-06-04, sobre base Felipe). Tokens
+                        semânticos (text-muted-foreground/text-foreground) p/ não disparar R1.
+                        Datas em formato data — HORA completa virá no re-import (Fase 2). */}
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Vencimento</div>
+                      <div className="mt-0.5 text-foreground">{selected.vencimento ? selected.vencimento.split('-').reverse().join('/') : '—'}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Data de pagamento</div>
+                      <div className="mt-0.5 text-foreground">{selected.data_pagamento ? selected.data_pagamento.split('-').reverse().join('/') : '—'}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Número do título</div>
+                      <div className="mt-0.5 text-foreground font-mono text-[12px]">{selected.numero || '—'}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Valor em aberto</div>
+                      <div className="mt-0.5 text-foreground tabular-nums">{brl(selected.valor_aberto)}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Parcela</div>
+                      <div className="mt-0.5 text-foreground">{selected.parcela || '—'}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Pedido</div>
+                      <div className="mt-0.5 text-foreground">{selected.pedido || '—'}</div>
+                    </div>
+                    {/* Desconto / Juros — SEMPRE visíveis (pedido Wagner; antes só >0) */}
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Desconto</div>
+                      <div className="mt-0.5 fin-num-pos tabular-nums">{brl(selected.desconto)}</div>
+                    </div>
+                    <div>
+                      <div className="text-[11px] text-muted-foreground uppercase tracking-widest font-medium">Juros / Multa</div>
+                      <div className="mt-0.5 fin-num-neg tabular-nums">{brl(selected.juros)}</div>
+                    </div>
                   </div>
 
                   {selected.observacao && (


### PR DESCRIPTION
Continuação dos campos do lançamento no drawer, **sobre a base do Felipe** (#2197/#2206 já merged — sem conflito). Só dado **já disponível** (sem re-import).

## Novos campos no drawer (aba Detalhes)
- **Número do título** (R-/P-NNNNN), **Valor em aberto** (saldo), **Parcela** (1/3), **Pedido** (codpedido WR)
- **Vencimento** e **Data de pagamento** como campos (data)
- **Desconto** e **Juros/Multa** agora **sempre visíveis** (antes só quando > 0 — erro meu da Fase 1)

Tokens semânticos (`text-muted-foreground`/`text-foreground`) → sem regressão R1 no ui:lint.

## Limite conhecido → Fase 2-data (US-FIN-051, NÃO neste PR)
**HORA** nas datas + **dia** da competência + **Documento/NF reais** + **conta populada** + **plano de contas** dependem de mudar colunas p/ `datetime` (afeta todos os business → ADR) + **re-import Firebird**. Por isso as datas aqui são date-only por enquanto.

`build:inertia` local OK · `php -l` OK. **Vou verificar ao vivo no drawer (Chrome MCP) após deploy** antes de declarar pronto.
Refs: US-FIN-030, US-FIN-051