### PR TITLE
fix(sells): data da venda automática (hoje) — venda sem data sumia da consulta

### DIFF
--- a/app/Http/Controllers/SellPosController.php
+++ b/app/Http/Controllers/SellPosController.php
@@ -447,7 +447,23 @@ class SellPosController extends Controller
                     ]);
                     $input['transaction_date'] = \Carbon::now();
                 } else {
-                    $input['transaction_date'] = $this->productUtil->uf_date($request->input('transaction_date'), true);
+                    // 2026-06-04 (Wagner) — uf_date pode devolver vazio/inválido se o valor
+                    // vier num formato que não bate com o date_format do business (bug do
+                    // campo "Data da venda" vazio no /sells/create). Sem isso, a venda grava
+                    // com transaction_date nulo/0000 e SOME da consulta (filtra por data).
+                    try {
+                        $parsedDate = $this->productUtil->uf_date($request->input('transaction_date'), true);
+                    } catch (\Throwable $e) {
+                        $parsedDate = null;
+                    }
+                    if (empty($parsedDate) || strtotime((string) $parsedDate) === false) {
+                        \Log::warning('SellPosController@store transaction_date não-parseável — fallback Carbon::now()', [
+                            'business_id' => $business_id ?? null,
+                            'raw_value' => json_encode($request->input('transaction_date')),
+                        ]);
+                        $parsedDate = \Carbon::now();
+                    }
+                    $input['transaction_date'] = $parsedDate;
                 }
                 if ($is_direct_sale) {
                     $input['is_direct_sale'] = 1;

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -159,12 +159,27 @@ function fromDatetimeLocal(val: string): string {
   return `${m[3]}/${m[2]}/${m[1]} ${m[4]}:${m[5]}`;
 }
 
+// 2026-06-04 (Wagner) — agora local em ISO "YYYY-MM-DDTHH:mm" pro datetime-local.
+function nowLocalIso(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${p(d.getMonth() + 1)}-${p(d.getDate())}T${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+// Default robusto da data da venda: usa o defaultDatetime do backend SE ele
+// parsear pro formato esperado; senão cai pra HOJE. Antes, quando o date_format
+// do business não era d/m/Y, o toDatetimeLocal retornava '' → campo vazio → venda
+// salva sem data → sumia da consulta (que filtra por data). Pedido Wagner.
+function defaultTransactionDate(backendDefault: string): string {
+  return toDatetimeLocal(backendDefault) ? backendDefault : fromDatetimeLocal(nowLocalIso());
+}
+
 export default function SellsCreate(props: SellsCreatePageProps) {
-  // Defaults conservadores ROTA LIVRE: status=final, transaction_date=format_now_local
+  // Defaults conservadores ROTA LIVRE: status=final, transaction_date=HOJE (robusto).
   const { data, setData, post, processing, errors, transform } = useForm({
     location_id: props.defaultLocation?.id ?? null,
     contact_id: props.walkInCustomer.id,
-    transaction_date: props.defaultDatetime,
+    transaction_date: defaultTransactionDate(props.defaultDatetime),
     status: 'final' as 'final' | 'quotation' | 'draft' | 'proforma',
     invoice_scheme_id: props.defaultInvoiceScheme?.id ?? null,
     invoice_no: '',
@@ -1010,7 +1025,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             <Input
               id="transaction_date"
               type="datetime-local"
-              value={toDatetimeLocal(data.transaction_date)}
+              value={toDatetimeLocal(data.transaction_date) || nowLocalIso()}
               onChange={(e) => setData('transaction_date', fromDatetimeLocal(e.target.value))}
             />
             <FieldError message={errors.transaction_date as string | undefined} />


### PR DESCRIPTION
## Bug (Wagner 2026-06-04)
Wagner fez uma venda em `/sells/create` (clicou "Nova venda", adicionou um produto de ~R$1,50, salvou) e **ela não apareceu na consulta** de Vendas.

## Causa raiz
O campo **"Data da venda"** (`<input type="datetime-local">`) nascia **VAZIO**: o conversor `toDatetimeLocal` só parseia o formato `DD/MM/YYYY HH:mm`, mas `format_now_local` retorna a data no **`date_format` do business** (que pra Martinho não é exatamente `d/m/Y`, ou usa 12h). Resultado: o default não exibia → campo vazio.

Salvando sem preencher, a venda gravava `transaction_date` nulo/inválido. A consulta filtra por `whereBetween('transaction_date', [...])` → uma venda sem data válida **fica invisível** (e não conta no "Faturado hoje"). Confirmado: status default = `final` (não era rascunho), e não estava em rascunhos/cotações.

## Fix
- **Frontend** (`Create.tsx`): `defaultTransactionDate()` — usa o `defaultDatetime` do backend **se** ele parsear, senão cai pra **HOJE** (`nowLocalIso`). O `value` do input também cai pra hoje se o estado ficar inválido. O campo agora **vem preenchido com hoje** automaticamente.
- **Backend** (`SellPosController@store`): além do fallback de data vazia (já existia desde 2026-05-27), agora também trata `uf_date()` **vazio/não-parseável** → `Carbon::now()`. Defesa em profundidade — **nenhuma venda grava sem data**, de qualquer fluxo (Inertia, legacy POS, API).

## Notas reviewer
- ⚠️ Mudança visível (campo de data pré-preenchido) — gate visual humano pendente.
- A venda de R$1,50 do Wagner provavelmente está no banco com data nula (invisível). Pós-fix: ele pode refazer (vai gravar certo) OU localizar/corrigir a data dela depois.
- Frontend-only + backend defensivo, sem migration.

Refs: pedido Wagner 2026-06-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)
