### PR TITLE
fix(financeiro): hero KPI legível no dark — eleva .fin-stat-hero

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -167,6 +167,17 @@
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-stat-hint { color: oklch(0.72 0.01 80); opacity: 0.85; }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-num-neg { color: oklch(0.78 0.14 25); }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-num-pos { color: oklch(0.78 0.14 145); }
+/* DARK-BACKFILL (2026-06-04 · DARK-BACKFILL-SWEEP #1) — o hero charcoal
+   `oklch(0.22 0.01 80)` (warm "documento contábil") tem a MESMA luminosidade do
+   page-bg dark (`oklch(0.22 …)`), então no escuro o card SOME (perde a borda e
+   funde no fundo). Eleva pra uma superfície warm-raised distinta + borda sutil,
+   preservando a identidade quente e o texto branco. Escopo `.dark` (classe no
+   <html>, ADR foundations) porque o hero renderiza tanto in-page quanto no Sheet
+   portalizado fora de `.cockpit`. ADITIVO: o claro fica 100% intocado (L-28). */
+.dark .fin-cowork .fin-curadoria .fin-stat-hero {
+  background: oklch(0.30 0.012 80);
+  border: 1px solid oklch(0.40 0.012 80);
+}
 .fin-cowork .fin-curadoria .fin-spark {
   margin-top: 8px;
   width: 100%;


### PR DESCRIPTION
## O que / Por quê

O hero card de KPI do Financeiro (`.fin-cowork .fin-curadoria .fin-stat-hero`) usa fundo charcoal warm `oklch(0.22 0.01 80)` + texto branco — ótimo no **claro** (card escuro destaca no fundo claro), mas no **escuro** o page-bg também é `~oklch(0.22)`, então o card **funde no fundo e some** (perde borda e contraste). É o "card sumido/branco" recorrente do Financeiro no dark (DARK-BACKFILL #1 — maior alavancagem).

## Como

Override **aditivo** escopado em `.dark` (classe no `<html>`, cobre tanto o uso in-page quanto o `Sheet` portalizado fora de `.cockpit`): eleva o hero pra uma superfície warm-raised distinta (`0.30`) + borda sutil (`0.40`), preservando a identidade quente "documento contábil" e o texto branco.

```css
.dark .fin-cowork .fin-curadoria .fin-stat-hero {
  background: oklch(0.30 0.012 80);
  border: 1px solid oklch(0.40 0.012 80);
}
```

## Garantias

- **Claro 100% intocado** (L-28 — não mexer no que está ótimo): o bloco só adiciona regra `.dark`, nenhuma regra existente é alterada.
- **Stylelint baseline:** delta 0 (só adiciona `oklch`, sem hex/`!important` novo).
- 1 arquivo, 11 linhas, single-intent (commit-discipline).

## Gate antes do merge

⏸️ **Não mergear sem o screenshot do dark** (gate visual F3 · ADR 0107) — [W] aprova a tela escura. CI (PR UI Judge + visual-regression) é a prova adicional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)