### PR TITLE
feat(recurringbilling): re-skin DS v6 — stone+roxo canon (charter Cobrança Recorrente)

### DIFF
--- a/resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx
@@ -123,7 +123,7 @@ const SEVERITY_TOKENS: Record<
 
 const BANCO_BG: Record<Banco, string> = {
   inter: 'bg-orange-100 text-orange-800 ring-orange-200',
-  c6: 'bg-zinc-900 text-white ring-zinc-700',
+  c6: 'bg-stone-900 text-white ring-stone-700',
   asaas: 'bg-emerald-100 text-emerald-800 ring-emerald-200',
 };
 
@@ -172,19 +172,19 @@ export default function ConfiguracoesIndex(props: PageProps) {
     <>
       <Head title="Configurações · Cobrança Recorrente" />
 
-      <div className="min-h-screen bg-zinc-50 p-4 md:p-6">
+      <div className="min-h-screen bg-stone-50 p-4 md:p-6">
         {/* ── HEADER ── */}
         <header className="mb-6">
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-center gap-3">
-              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-violet-100 text-violet-700">
+              <span className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-primary/10 text-primary">
                 <Settings size={20} />
               </span>
               <div>
-                <h1 className="text-2xl font-bold tracking-tight text-zinc-900">
+                <h1 className="text-2xl font-semibold tracking-tight text-stone-900">
                   Configurações · cobrança recorrente
                 </h1>
-                <div className="mt-0.5 text-sm text-zinc-500">
+                <div className="mt-0.5 text-sm text-stone-500">
                   Gateways de pagamento, régua de dunning, NFe automática e webhooks por gateway.
                 </div>
               </div>
@@ -194,10 +194,10 @@ export default function ConfiguracoesIndex(props: PageProps) {
               type="button"
               onClick={() => setShowCheatsheet(true)}
               title="Ver atalhos de teclado"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-2.5 py-1.5 text-xs font-medium text-zinc-600 hover:bg-zinc-50"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-stone-200 bg-white px-2.5 py-1.5 text-xs font-medium text-stone-600 hover:bg-stone-50"
             >
               atalhos
-              <kbd className="rounded bg-zinc-100 px-1.5 py-0.5 font-mono text-[10px] text-zinc-700 ring-1 ring-zinc-200">?</kbd>
+              <kbd className="rounded bg-stone-100 px-1.5 py-0.5 font-mono text-[10px] text-stone-700 ring-1 ring-stone-200">?</kbd>
             </button>
           </div>
         </header>
@@ -221,7 +221,7 @@ export default function ConfiguracoesIndex(props: PageProps) {
             title="Régua de dunning (cobrança)"
             subtitle="Cronograma de retentativas quando uma fatura falha no pagamento."
           >
-            <p className="mb-4 text-sm leading-relaxed text-zinc-600">
+            <p className="mb-4 text-sm leading-relaxed text-stone-600">
               {regua_dunning.descricao}
             </p>
 
@@ -251,7 +251,7 @@ export default function ConfiguracoesIndex(props: PageProps) {
               })}
             </div>
 
-            <div className="mt-3 rounded-lg bg-zinc-50 px-3 py-2 text-[11px] italic text-zinc-500 ring-1 ring-zinc-100">
+            <div className="mt-3 rounded-lg bg-stone-50 px-3 py-2 text-[11px] italic text-stone-500 ring-1 ring-stone-100">
               {regua_dunning.editavel_em}
             </div>
           </SectionCard>
@@ -262,11 +262,11 @@ export default function ConfiguracoesIndex(props: PageProps) {
             title="NFe-de-boleto-pago automática"
             subtitle="Emissão fiscal disparada automaticamente ao receber pagamento."
           >
-            <div className="mb-4 flex items-center justify-between rounded-xl bg-zinc-50 px-4 py-3 ring-1 ring-zinc-200">
+            <div className="mb-4 flex items-center justify-between rounded-xl bg-stone-50 px-4 py-3 ring-1 ring-stone-200">
               <div className="flex items-center gap-3">
                 <span
                   className={`inline-flex h-6 w-11 items-center rounded-full p-0.5 transition-colors ${
-                    nfe_auto.ativo ? 'bg-emerald-500' : 'bg-zinc-300'
+                    nfe_auto.ativo ? 'bg-emerald-500' : 'bg-stone-300'
                   }`}
                 >
                   <span
@@ -276,22 +276,22 @@ export default function ConfiguracoesIndex(props: PageProps) {
                   />
                 </span>
                 <div>
-                  <div className="text-sm font-medium text-zinc-800">
+                  <div className="text-sm font-medium text-stone-800">
                     {nfe_auto.ativo ? 'Ativada' : 'Desativada'}
                   </div>
-                  <div className="text-[11px] text-zinc-500">
-                    Ref. <code className="rounded bg-white px-1.5 py-0.5 font-mono text-[10px] ring-1 ring-zinc-200">{nfe_auto.us_ref}</code>
+                  <div className="text-[11px] text-stone-500">
+                    Ref. <code className="rounded bg-white px-1.5 py-0.5 font-mono text-[10px] ring-1 ring-stone-200">{nfe_auto.us_ref}</code>
                   </div>
                 </div>
               </div>
-              <span className="rounded-full bg-zinc-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-500 ring-1 ring-zinc-200">
+              <span className="rounded-full bg-stone-100 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-stone-500 ring-1 ring-stone-200">
                 Em breve
               </span>
             </div>
 
-            <p className="text-sm leading-relaxed text-zinc-600">{nfe_auto.descricao}</p>
+            <p className="text-sm leading-relaxed text-stone-600">{nfe_auto.descricao}</p>
 
-            <div className="mt-3 rounded-lg bg-zinc-50 px-3 py-2 text-[11px] italic text-zinc-500 ring-1 ring-zinc-100">
+            <div className="mt-3 rounded-lg bg-stone-50 px-3 py-2 text-[11px] italic text-stone-500 ring-1 ring-stone-100">
               {nfe_auto.editavel_em}
             </div>
           </SectionCard>
@@ -375,12 +375,12 @@ function TourConfiguracoes({ onClose }: { onClose: () => void }) {
     <div
       role="dialog"
       aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/30 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/30 backdrop-blur-sm"
     >
-      <div className="w-full max-w-md rounded-2xl bg-white shadow-2xl ring-1 ring-zinc-200">
-        <header className="flex items-center justify-between border-b border-zinc-100 px-4 py-3">
-          <div className="flex items-center gap-2 text-xs text-zinc-500">
-            <span className="rounded bg-violet-100 px-2 py-0.5 font-semibold text-violet-700">
+      <div className="w-full max-w-md rounded-lg bg-white shadow-2xl ring-1 ring-stone-200">
+        <header className="flex items-center justify-between border-b border-stone-100 px-4 py-3">
+          <div className="flex items-center gap-2 text-xs text-stone-500">
+            <span className="rounded bg-primary/10 px-2 py-0.5 font-semibold text-primary">
               {step + 1}/{TOUR_STEPS_CONFIG.length}
             </span>
             <span>Tour · Configurações</span>
@@ -389,20 +389,20 @@ function TourConfiguracoes({ onClose }: { onClose: () => void }) {
             type="button"
             onClick={() => close(false)}
             aria-label="Fechar"
-            className="rounded p-1 hover:bg-zinc-100"
+            className="rounded p-1 hover:bg-stone-100"
           >
-            <X size={14} className="text-zinc-500" />
+            <X size={14} className="text-stone-500" />
           </button>
         </header>
         <div className="px-6 py-6">
-          <h3 className="text-lg font-bold text-zinc-900">{cur.title}</h3>
-          <p className="mt-2 text-sm text-zinc-600">{cur.body}</p>
+          <h3 className="text-lg font-bold text-stone-900">{cur.title}</h3>
+          <p className="mt-2 text-sm text-stone-600">{cur.body}</p>
         </div>
-        <footer className="flex items-center justify-between gap-2 border-t border-zinc-100 px-4 py-3">
+        <footer className="flex items-center justify-between gap-2 border-t border-stone-100 px-4 py-3">
           <button
             type="button"
             onClick={() => close(true)}
-            className="text-xs text-zinc-500 hover:text-zinc-700"
+            className="text-xs text-stone-500 hover:text-stone-700"
           >
             Não mostrar mais
           </button>
@@ -411,7 +411,7 @@ function TourConfiguracoes({ onClose }: { onClose: () => void }) {
               type="button"
               onClick={() => setStep(Math.max(0, step - 1))}
               disabled={step === 0}
-              className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-3 py-1.5 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-40"
+              className="inline-flex items-center gap-1 rounded-lg border border-stone-200 px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 disabled:opacity-40"
             >
               <ChevronLeft size={12} /> Anterior
             </button>
@@ -419,7 +419,7 @@ function TourConfiguracoes({ onClose }: { onClose: () => void }) {
               <button
                 type="button"
                 onClick={() => setStep(step + 1)}
-                className="inline-flex items-center gap-1 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700"
+                className="inline-flex items-center gap-1 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-primary"
               >
                 Próximo <ChevronRight size={12} />
               </button>
@@ -428,7 +428,7 @@ function TourConfiguracoes({ onClose }: { onClose: () => void }) {
               <button
                 type="button"
                 onClick={() => close(true)}
-                className="rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700"
+                className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:bg-primary"
               >
                 Começar
               </button>
@@ -456,14 +456,14 @@ function SectionCard({
   children: ReactNode;
 }) {
   return (
-    <section className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-zinc-200">
-      <header className="flex items-start gap-3 border-b border-zinc-100 px-5 py-4">
-        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-700">
+    <section className="overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-stone-200">
+      <header className="flex items-start gap-3 border-b border-stone-100 px-5 py-4">
+        <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
           <Icon size={16} />
         </span>
         <div className="min-w-0 flex-1">
-          <h2 className="text-base font-semibold text-zinc-900">{title}</h2>
-          {subtitle && <p className="mt-0.5 text-xs text-zinc-500">{subtitle}</p>}
+          <h2 className="text-base font-semibold text-stone-900">{title}</h2>
+          {subtitle && <p className="mt-0.5 text-xs text-stone-500">{subtitle}</p>}
         </div>
       </header>
       <div className="p-5">{children}</div>
@@ -474,17 +474,17 @@ function SectionCard({
 function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
   if (gateways.length === 0) {
     return (
-      <div className="rounded-xl border-2 border-dashed border-zinc-200 p-8 text-center">
-        <Banknote size={28} className="mx-auto text-zinc-300" />
-        <div className="mt-2 text-sm font-medium text-zinc-700">
+      <div className="rounded-xl border-2 border-dashed border-stone-200 p-8 text-center">
+        <Banknote size={28} className="mx-auto text-stone-300" />
+        <div className="mt-2 text-sm font-medium text-stone-700">
           Nenhum gateway cadastrado
         </div>
-        <div className="mt-1 text-xs text-zinc-500">
+        <div className="mt-1 text-xs text-stone-500">
           Cadastre uma credencial Inter PJ, C6 ou Asaas para começar a cobrar.
         </div>
         <a
           href="/financeiro/contas-bancarias"
-          className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-violet-700"
+          className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary"
         >
           <Plus size={14} />
           Adicionar gateway
@@ -499,7 +499,7 @@ function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
         {gateways.map((g) => (
           <li
             key={g.id}
-            className="flex items-center gap-3 rounded-xl border border-zinc-200 px-3 py-2.5"
+            className="flex items-center gap-3 rounded-xl border border-stone-200 px-3 py-2.5"
           >
             <span
               className={`inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-xs font-bold ring-1 ${BANCO_BG[g.banco]}`}
@@ -509,7 +509,7 @@ function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
             </span>
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
-                <div className="truncate text-sm font-semibold text-zinc-900">
+                <div className="truncate text-sm font-semibold text-stone-900">
                   {g.nome_display || g.banco_label}
                 </div>
                 {g.ambiente === 'sandbox' && (
@@ -518,7 +518,7 @@ function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
                   </span>
                 )}
               </div>
-              <div className="mt-0.5 truncate text-[11px] text-zinc-500">
+              <div className="mt-0.5 truncate text-[11px] text-stone-500">
                 {g.banco_label} · {g.ambiente_label}
               </div>
             </div>
@@ -528,7 +528,7 @@ function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
                 ativo
               </span>
             ) : (
-              <span className="inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-500 ring-1 ring-zinc-200">
+              <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-500 ring-1 ring-stone-200">
                 <XCircle size={11} />
                 inativo
               </span>
@@ -539,12 +539,12 @@ function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
 
       <a
         href="/financeiro/contas-bancarias"
-        className="mt-4 inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-50"
+        className="mt-4 inline-flex items-center gap-1.5 rounded-lg border border-stone-200 bg-white px-3 py-1.5 text-sm font-medium text-stone-700 hover:bg-stone-50"
         title="Cadastro fica em Contas Bancárias (Onda futura move pra cá)"
       >
         <Plus size={14} />
         Adicionar gateway
-        <span className="ml-1 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] text-zinc-500">em breve aqui</span>
+        <span className="ml-1 rounded bg-stone-100 px-1.5 py-0.5 text-[10px] text-stone-500">em breve aqui</span>
       </a>
     </div>
   );
@@ -568,29 +568,29 @@ function WebhookCard({ webhook }: { webhook: WebhookRow }) {
   }
 
   return (
-    <div className="rounded-xl border border-zinc-200 p-3">
+    <div className="rounded-xl border border-stone-200 p-3">
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <span className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-zinc-600 ring-1 ring-zinc-200">
+          <span className="rounded bg-stone-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-stone-600 ring-1 ring-stone-200">
             {webhook.metodo}
           </span>
-          <span className="text-sm font-semibold text-zinc-900">{webhook.gateway_label}</span>
+          <span className="text-sm font-semibold text-stone-900">{webhook.gateway_label}</span>
         </div>
         <a
           href={webhook.docs_link}
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 text-[11px] font-medium text-violet-700 hover:underline"
+          className="inline-flex items-center gap-1 text-[11px] font-medium text-primary hover:underline"
         >
           docs
           <ExternalLink size={10} />
         </a>
       </div>
 
-      <div className="mt-1 text-xs text-zinc-500">{webhook.rotulo}</div>
+      <div className="mt-1 text-xs text-stone-500">{webhook.rotulo}</div>
 
       <div className="mt-2 flex items-center gap-2">
-        <code className="flex-1 truncate rounded-lg bg-zinc-50 px-3 py-2 font-mono text-xs text-zinc-700 ring-1 ring-zinc-200">
+        <code className="flex-1 truncate rounded-lg bg-stone-50 px-3 py-2 font-mono text-xs text-stone-700 ring-1 ring-stone-200">
           {webhook.url}
         </code>
         <button
@@ -599,7 +599,7 @@ function WebhookCard({ webhook }: { webhook: WebhookRow }) {
           className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition ${
             copied
               ? 'bg-emerald-600 text-white'
-              : 'bg-white text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50'
+              : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50'
           }`}
           title="Copiar URL pra área de transferência"
         >
@@ -608,8 +608,8 @@ function WebhookCard({ webhook }: { webhook: WebhookRow }) {
         </button>
       </div>
 
-      <div className="mt-2 rounded-lg bg-zinc-50 px-3 py-2 text-[11px] leading-relaxed text-zinc-500 ring-1 ring-zinc-100">
-        <span className="font-semibold text-zinc-600">Autenticação:</span> {webhook.auth}
+      <div className="mt-2 rounded-lg bg-stone-50 px-3 py-2 text-[11px] leading-relaxed text-stone-500 ring-1 ring-stone-100">
+        <span className="font-semibold text-stone-600">Autenticação:</span> {webhook.auth}
       </div>
     </div>
   );
@@ -623,13 +623,13 @@ function GatewaysSkeleton() {
   return (
     <ul className="space-y-2">
       {Array.from({ length: 3 }).map((_, i) => (
-        <li key={i} className="flex items-center gap-3 rounded-xl border border-zinc-200 px-3 py-2.5">
-          <div className="h-8 w-8 animate-pulse rounded-lg bg-zinc-200" />
+        <li key={i} className="flex items-center gap-3 rounded-xl border border-stone-200 px-3 py-2.5">
+          <div className="h-8 w-8 animate-pulse rounded-lg bg-stone-200" />
           <div className="flex-1 space-y-1">
-            <div className="h-3 w-32 animate-pulse rounded bg-zinc-200" />
-            <div className="h-2 w-48 animate-pulse rounded bg-zinc-100" />
+            <div className="h-3 w-32 animate-pulse rounded bg-stone-200" />
+            <div className="h-2 w-48 animate-pulse rounded bg-stone-100" />
           </div>
-          <div className="h-5 w-14 animate-pulse rounded-full bg-zinc-100" />
+          <div className="h-5 w-14 animate-pulse rounded-full bg-stone-100" />
         </li>
       ))}
     </ul>

--- a/resources/js/Pages/RecurringBilling/Faturas/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Faturas/Index.tsx
@@ -123,26 +123,26 @@ const STATUS_STYLES: Record<InvoiceStatus, { label: string; classes: string }> =
   },
   canceled: {
     label: 'cancelada',
-    classes: 'bg-zinc-100 text-zinc-400 ring-zinc-200 line-through',
+    classes: 'bg-stone-100 text-stone-400 ring-stone-200 line-through',
   },
   refunded: {
     label: 'reembolsada',
-    classes: 'bg-zinc-100 text-zinc-600 ring-zinc-200',
+    classes: 'bg-stone-100 text-stone-600 ring-stone-200',
   },
 };
 
 const GATEWAY_STYLES: Record<Gateway, { label: string; classes: string }> = {
   inter: { label: 'Inter', classes: 'bg-orange-50 text-orange-700 ring-orange-200' },
-  c6: { label: 'C6', classes: 'bg-zinc-900 text-white ring-zinc-700' },
+  c6: { label: 'C6', classes: 'bg-stone-900 text-white ring-stone-700' },
   asaas: { label: 'Asaas', classes: 'bg-sky-50 text-sky-700 ring-sky-200' },
 };
 
 const STATUS_PILLS: Array<{ key: StatusFilter; label: string; dot: string }> = [
-  { key: 'all', label: 'Todas', dot: 'bg-zinc-300' },
+  { key: 'all', label: 'Todas', dot: 'bg-stone-300' },
   { key: 'paid', label: 'Pagas', dot: 'bg-emerald-500' },
   { key: 'open', label: 'Pendentes', dot: 'bg-amber-500' },
   { key: 'overdue', label: 'Atrasadas', dot: 'bg-rose-500' },
-  { key: 'canceled', label: 'Canceladas', dot: 'bg-zinc-400' },
+  { key: 'canceled', label: 'Canceladas', dot: 'bg-stone-400' },
 ];
 
 const GATEWAY_OPTIONS: Array<{ key: GatewayFilter; label: string }> = [
@@ -175,7 +175,7 @@ function StatusBadge({ status }: { status: InvoiceStatus }) {
 function GatewayBadge({ gateway }: { gateway: Gateway | null }) {
   if (!gateway) {
     return (
-      <span className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium text-zinc-400 ring-1 ring-zinc-200">
+      <span className="inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium text-stone-400 ring-1 ring-stone-200">
         —
       </span>
     );
@@ -209,18 +209,18 @@ function KpiCard({
     ok: 'bg-emerald-700',
     warn: 'bg-amber-700',
     bad: 'bg-rose-700',
-    neutral: 'bg-zinc-900',
+    neutral: 'bg-stone-900',
   }[tone];
   const lightDelta = {
     ok: 'text-emerald-700',
     warn: 'text-amber-700',
     bad: 'text-rose-700',
-    neutral: 'text-zinc-500',
+    neutral: 'text-stone-500',
   }[tone];
 
   if (hero) {
     return (
-      <div className={`rounded-2xl ${heroTone} p-4 text-white shadow-sm ring-1 ring-zinc-800`}>
+      <div className={`rounded-lg ${heroTone} p-4 text-white shadow-sm ring-1 ring-stone-800`}>
         <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-white/70">
           <span>{label}</span>
           {sparkline && sparkline.length > 0 ? (
@@ -237,12 +237,12 @@ function KpiCard({
     );
   }
   return (
-    <div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-zinc-200">
-      <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+    <div className="rounded-lg bg-white p-4 shadow-sm ring-1 ring-stone-200">
+      <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-stone-500">
         <span>{label}</span>
-        {Icon && <Icon size={14} className="text-zinc-400" />}
+        {Icon && <Icon size={14} className="text-stone-400" />}
       </div>
-      <div className="mt-2 text-2xl font-bold text-zinc-900 tabular-nums">{value}</div>
+      <div className="mt-2 text-2xl font-bold text-stone-900 tabular-nums">{value}</div>
       {delta && <div className={`mt-1 text-xs font-medium ${lightDelta}`}>{delta}</div>}
     </div>
   );
@@ -252,7 +252,7 @@ function KpiSkeleton() {
   return (
     <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="h-24 animate-pulse rounded-2xl bg-zinc-100" />
+        <div key={i} className="h-24 animate-pulse rounded-lg bg-stone-100" />
       ))}
     </div>
   );
@@ -260,16 +260,16 @@ function KpiSkeleton() {
 
 function TableSkeleton() {
   return (
-    <div className="divide-y divide-zinc-100">
+    <div className="divide-y divide-stone-100">
       {Array.from({ length: 8 }).map((_, i) => (
         <div key={i} className="flex items-center gap-3 px-4 py-3">
-          <div className="h-4 w-24 animate-pulse rounded bg-zinc-100" />
+          <div className="h-4 w-24 animate-pulse rounded bg-stone-100" />
           <div className="flex-1 space-y-1">
-            <div className="h-3 w-48 animate-pulse rounded bg-zinc-200" />
-            <div className="h-2 w-32 animate-pulse rounded bg-zinc-100" />
+            <div className="h-3 w-48 animate-pulse rounded bg-stone-200" />
+            <div className="h-2 w-32 animate-pulse rounded bg-stone-100" />
           </div>
-          <div className="h-4 w-20 animate-pulse rounded bg-zinc-100" />
-          <div className="h-4 w-16 animate-pulse rounded-full bg-zinc-100" />
+          <div className="h-4 w-20 animate-pulse rounded bg-stone-100" />
+          <div className="h-4 w-16 animate-pulse rounded-full bg-stone-100" />
         </div>
       ))}
     </div>
@@ -294,9 +294,9 @@ function CancelDialog({
   const [motivo, setMotivo] = useState('ACERTOS');
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/50 p-4" onClick={onClose}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/50 p-4" onClick={onClose}>
       <div
-        className="w-full max-w-md rounded-2xl bg-white p-6 shadow-2xl ring-1 ring-zinc-200"
+        className="w-full max-w-md rounded-lg bg-white p-6 shadow-2xl ring-1 ring-stone-200"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start gap-3">
@@ -304,29 +304,29 @@ function CancelDialog({
             <AlertCircle size={20} />
           </div>
           <div className="min-w-0 flex-1">
-            <h3 className="text-base font-semibold text-zinc-900">Cancelar fatura</h3>
-            <p className="mt-1 text-sm text-zinc-600">
+            <h3 className="text-base font-semibold text-stone-900">Cancelar fatura</h3>
+            <p className="mt-1 text-sm text-stone-600">
               Você vai cancelar a fatura{' '}
-              <span className="font-mono font-semibold text-zinc-900">
+              <span className="font-mono font-semibold text-stone-900">
                 {invoice.numero_documento || `#${invoice.id}`}
               </span>{' '}
               de <strong>{invoice.cliente_nome}</strong> ({BRL(invoice.valor)}).
             </p>
-            <p className="mt-2 text-xs text-zinc-500">
+            <p className="mt-2 text-xs text-stone-500">
               Se a fatura está num gateway (Inter/C6/Asaas), o cancelamento é propagado.
               Ação registrada em audit log (LGPD).
             </p>
           </div>
         </div>
 
-        <label className="mt-4 block text-xs font-medium text-zinc-700">
+        <label className="mt-4 block text-xs font-medium text-stone-700">
           Motivo (opcional)
           <input
             type="text"
             value={motivo}
             onChange={(e) => setMotivo(e.target.value)}
             placeholder="Ex: ACERTOS, duplicidade, solicitação cliente"
-            className="mt-1 w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-rose-400 focus:ring-2 focus:ring-rose-100"
+            className="mt-1 w-full rounded-lg border border-stone-300 px-3 py-2 text-sm outline-none focus:border-rose-400 focus:ring-2 focus:ring-rose-100"
             disabled={busy}
           />
         </label>
@@ -336,7 +336,7 @@ function CancelDialog({
             type="button"
             onClick={onClose}
             disabled={busy}
-            className="rounded-lg px-3 py-2 text-sm font-medium text-zinc-600 hover:bg-zinc-100 disabled:opacity-50"
+            className="rounded-lg px-3 py-2 text-sm font-medium text-stone-600 hover:bg-stone-100 disabled:opacity-50"
           >
             Voltar
           </button>
@@ -440,15 +440,15 @@ export default function FaturasIndex(props: PageProps) {
     <>
       <Head title="Faturas · cobrança recorrente" />
 
-      <div className="min-h-screen bg-zinc-50 p-4 md:p-6">
+      <div className="min-h-screen bg-stone-50 p-4 md:p-6">
         {/* ── HEADER ── */}
         <header className="mb-4">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-bold tracking-tight text-zinc-900">
+              <h1 className="text-2xl font-semibold tracking-tight text-stone-900">
                 Faturas · cobrança recorrente
               </h1>
-              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-zinc-500">
+              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-stone-500">
                 {kpis ? (
                   <>
                     {kpis.total_faturas} FATURAS · ATRASADAS {kpis.count_overdue}
@@ -462,12 +462,12 @@ export default function FaturasIndex(props: PageProps) {
               <button
                 type="button"
                 disabled
-                className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-lg bg-zinc-200 px-3 py-2 text-sm font-medium text-zinc-500 shadow-sm"
+                className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-lg bg-stone-200 px-3 py-2 text-sm font-medium text-stone-500 shadow-sm"
                 title="Nova fatura — em breve"
               >
                 <Plus size={14} />
                 Nova fatura
-                <span className="ml-1 rounded bg-zinc-300 px-1.5 py-0.5 text-[9px] uppercase tracking-wider">
+                <span className="ml-1 rounded bg-stone-300 px-1.5 py-0.5 text-[9px] uppercase tracking-wider">
                   em breve
                 </span>
               </button>
@@ -519,10 +519,10 @@ export default function FaturasIndex(props: PageProps) {
         </Deferred>
 
         {/* ── FILTER BAR ── */}
-        <div className="mb-4 rounded-2xl bg-white p-3 shadow-sm ring-1 ring-zinc-200">
+        <div className="mb-4 rounded-lg bg-white p-3 shadow-sm ring-1 ring-stone-200">
           <div className="flex flex-wrap items-center gap-2">
             {/* Status pills */}
-            <div className="flex items-center gap-1 rounded-lg bg-zinc-100 p-1">
+            <div className="flex items-center gap-1 rounded-lg bg-stone-100 p-1">
               {STATUS_PILLS.map((p) => (
                 <button
                   key={p.key}
@@ -533,8 +533,8 @@ export default function FaturasIndex(props: PageProps) {
                   }}
                   className={`flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition ${
                     statusFilter === p.key
-                      ? 'bg-white text-zinc-900 shadow-sm ring-1 ring-zinc-200'
-                      : 'text-zinc-600 hover:text-zinc-900'
+                      ? 'bg-white text-stone-900 shadow-sm ring-1 ring-stone-200'
+                      : 'text-stone-600 hover:text-stone-900'
                   }`}
                 >
                   <span className={`h-1.5 w-1.5 rounded-full ${p.dot}`} />
@@ -580,8 +580,8 @@ export default function FaturasIndex(props: PageProps) {
             </Select>
 
             {/* Search */}
-            <div className="flex flex-1 items-center gap-2 rounded-lg bg-zinc-100 px-3 py-1.5">
-              <Search size={14} className="text-zinc-400" />
+            <div className="flex flex-1 items-center gap-2 rounded-lg bg-stone-100 px-3 py-1.5">
+              <Search size={14} className="text-stone-400" />
               <input
                 ref={searchRef}
                 type="text"
@@ -591,15 +591,15 @@ export default function FaturasIndex(props: PageProps) {
                   if (e.key === 'Enter') applyFilters({ q: search });
                 }}
                 placeholder="Buscar (/) — cliente, CNPJ, número da fatura"
-                className="flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-400"
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-stone-400"
               />
-              <kbd className="rounded bg-white px-1.5 py-0.5 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">
+              <kbd className="rounded bg-white px-1.5 py-0.5 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">
                 /
               </kbd>
             </div>
 
             {invoices?.meta && (
-              <span className="text-xs text-zinc-500 tabular-nums">
+              <span className="text-xs text-stone-500 tabular-nums">
                 {rows.length} / {invoices.meta.total}
               </span>
             )}
@@ -607,22 +607,22 @@ export default function FaturasIndex(props: PageProps) {
         </div>
 
         {/* ── TABELA ── */}
-        <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-zinc-200">
+        <div className="overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-stone-200">
           <Deferred data="invoices" fallback={<TableSkeleton />}>
             {rows.length === 0 ? (
               <div className="flex flex-col items-center justify-center p-12 text-center">
-                <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-zinc-100 text-zinc-400">
+                <div className="mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-stone-100 text-stone-400">
                   <Banknote size={22} />
                 </div>
-                <div className="font-medium text-zinc-700">Nenhuma fatura encontrada.</div>
-                <div className="mt-1 text-sm text-zinc-500">
+                <div className="font-medium text-stone-700">Nenhuma fatura encontrada.</div>
+                <div className="mt-1 text-sm text-stone-500">
                   Ajuste os filtros ou crie uma nova fatura.
                 </div>
               </div>
             ) : (
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
-                  <thead className="border-b border-zinc-200 bg-zinc-50 text-[11px] uppercase tracking-wider text-zinc-500">
+                  <thead className="border-b border-stone-200 bg-stone-50 text-[11px] uppercase tracking-wider text-stone-500">
                     <tr>
                       <th className="px-4 py-2.5 text-left font-medium">Número</th>
                       <th className="px-4 py-2.5 text-left font-medium">Cliente</th>
@@ -634,33 +634,33 @@ export default function FaturasIndex(props: PageProps) {
                       <th className="px-4 py-2.5 text-right font-medium">Ações</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-zinc-100">
+                  <tbody className="divide-y divide-stone-100">
                     {rows.map((inv) => (
-                      <tr key={inv.id} className="hover:bg-zinc-50">
-                        <td className="px-4 py-3 font-mono text-xs text-zinc-700">
+                      <tr key={inv.id} className="hover:bg-stone-50">
+                        <td className="px-4 py-3 font-mono text-xs text-stone-700">
                           {inv.numero_documento || (
-                            <span className="text-zinc-400">#{inv.id}</span>
+                            <span className="text-stone-400">#{inv.id}</span>
                           )}
                         </td>
                         <td className="max-w-[220px] px-4 py-3">
-                          <div className="truncate font-medium text-zinc-900">{inv.cliente_nome}</div>
+                          <div className="truncate font-medium text-stone-900">{inv.cliente_nome}</div>
                           {inv.cliente_cnpj && (
-                            <div className="truncate font-mono text-[11px] text-zinc-500">
+                            <div className="truncate font-mono text-[11px] text-stone-500">
                               {inv.cliente_cnpj}
                             </div>
                           )}
                         </td>
-                        <td className="max-w-[180px] truncate px-4 py-3 text-xs text-zinc-600">
-                          {inv.plano_nome || <span className="italic text-zinc-400">avulsa</span>}
+                        <td className="max-w-[180px] truncate px-4 py-3 text-xs text-stone-600">
+                          {inv.plano_nome || <span className="italic text-stone-400">avulsa</span>}
                         </td>
-                        <td className="px-4 py-3 text-right font-mono font-semibold tabular-nums text-zinc-900">
+                        <td className="px-4 py-3 text-right font-mono font-semibold tabular-nums text-stone-900">
                           {BRL(inv.valor)}
                         </td>
-                        <td className="px-4 py-3 text-xs text-zinc-700">
+                        <td className="px-4 py-3 text-xs text-stone-700">
                           <div>{dateBR(inv.vencimento)}</div>
                           <div
                             className={`mt-0.5 text-[11px] ${
-                              inv.is_overdue ? 'font-medium text-rose-600' : 'text-zinc-500'
+                              inv.is_overdue ? 'font-medium text-rose-600' : 'text-stone-500'
                             }`}
                           >
                             {dueLabel(inv.dias_delta_venc)}
@@ -685,7 +685,7 @@ export default function FaturasIndex(props: PageProps) {
                             </button>
                           )}
                           {!inv.is_cancelavel && (
-                            <span className="text-[11px] italic text-zinc-400">—</span>
+                            <span className="text-[11px] italic text-stone-400">—</span>
                           )}
                         </td>
                       </tr>
@@ -698,7 +698,7 @@ export default function FaturasIndex(props: PageProps) {
 
           {/* Pagination footer */}
           {invoices?.meta && invoices.meta.last_page > 1 && (
-            <div className="flex items-center justify-between border-t border-zinc-200 bg-zinc-50/50 px-4 py-2.5 text-xs text-zinc-600">
+            <div className="flex items-center justify-between border-t border-stone-200 bg-stone-50/50 px-4 py-2.5 text-xs text-stone-600">
               <span>
                 Página <strong className="tabular-nums">{invoices.meta.current_page}</strong> de{' '}
                 <strong className="tabular-nums">{invoices.meta.last_page}</strong> ·{' '}
@@ -714,7 +714,7 @@ export default function FaturasIndex(props: PageProps) {
                       only: ['invoices'],
                     })
                   }
-                  className="rounded px-2 py-1 hover:bg-zinc-200 disabled:opacity-30"
+                  className="rounded px-2 py-1 hover:bg-stone-200 disabled:opacity-30"
                 >
                   ← Anterior
                 </button>
@@ -727,7 +727,7 @@ export default function FaturasIndex(props: PageProps) {
                       only: ['invoices'],
                     })
                   }
-                  className="rounded px-2 py-1 hover:bg-zinc-200 disabled:opacity-30"
+                  className="rounded px-2 py-1 hover:bg-stone-200 disabled:opacity-30"
                 >
                   Próxima →
                 </button>
@@ -737,10 +737,10 @@ export default function FaturasIndex(props: PageProps) {
         </div>
 
         {/* Footer note */}
-        <div className="mt-3 text-[11px] italic text-zinc-400">
+        <div className="mt-3 text-[11px] italic text-stone-400">
           Cancelar dispara <code className="font-mono">POST /financeiro/rb-invoices/&#123;id&#125;/cancelar</code>{' '}
           (US-RB-042). Cancelamento propagado ao gateway + audit log Spatie.
-          <CreditCard size={11} className="ml-1 inline align-text-bottom text-zinc-400" />
+          <CreditCard size={11} className="ml-1 inline align-text-bottom text-stone-400" />
         </div>
       </div>
 

--- a/resources/js/Pages/RecurringBilling/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Index.tsx
@@ -191,13 +191,13 @@ const STATUS_STYLES: Record<VisualStatus, { label: string; classes: string; dot:
   },
   pausada: {
     label: 'pausada',
-    classes: 'bg-zinc-100 text-zinc-600 ring-zinc-200',
-    dot: 'bg-zinc-400',
+    classes: 'bg-stone-100 text-stone-600 ring-stone-200',
+    dot: 'bg-stone-400',
   },
   cancelada: {
     label: 'cancelada',
-    classes: 'bg-zinc-100 text-zinc-400 ring-zinc-200 line-through',
-    dot: 'bg-zinc-300',
+    classes: 'bg-stone-100 text-stone-400 ring-stone-200 line-through',
+    dot: 'bg-stone-300',
   },
 };
 
@@ -262,7 +262,7 @@ function StatusBadge({ status, retry, retryMax }: { status: VisualStatus; retry?
 
 function MethodIcon({ method, size = 12 }: { method: PaymentMethod; size?: number }) {
   const Icon = METHOD_ICONS[method];
-  return <Icon size={size} className="text-zinc-500" />;
+  return <Icon size={size} className="text-stone-500" />;
 }
 
 // Onda 11 v9,75 — sparkline SVG real (substituiu TrendingUp icon estático).
@@ -319,19 +319,19 @@ function KpiCard({ label, value, delta, deltaTone = 'neutral', hero = false, spa
     ok: 'text-emerald-300',
     warn: 'text-amber-400',
     bad: 'text-rose-400',
-    neutral: 'text-zinc-400',
+    neutral: 'text-stone-400',
   }[deltaTone];
   const deltaClsLight = {
     ok: 'text-emerald-700',
     warn: 'text-amber-700',
     bad: 'text-rose-700',
-    neutral: 'text-zinc-500',
+    neutral: 'text-stone-500',
   }[deltaTone];
 
   if (hero) {
     return (
-      <div className="rounded-2xl bg-zinc-900 p-4 text-white shadow-sm ring-1 ring-zinc-800">
-        <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+      <div className="rounded-lg bg-stone-900 p-4 text-white shadow-sm ring-1 ring-stone-800">
+        <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-stone-400">
           <span>{label}</span>
           {sparkline && sparkline.length > 0 ? (
             <Sparkline points={sparkline} color="oklch(0.75 0.13 145)" />
@@ -345,9 +345,9 @@ function KpiCard({ label, value, delta, deltaTone = 'neutral', hero = false, spa
     );
   }
   return (
-    <div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-zinc-200">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">{label}</div>
-      <div className="mt-2 text-2xl font-bold text-zinc-900 tabular-nums">{value}</div>
+    <div className="rounded-lg bg-white p-4 shadow-sm ring-1 ring-stone-200">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-stone-500">{label}</div>
+      <div className="mt-2 text-2xl font-bold text-stone-900 tabular-nums">{value}</div>
       {delta && <div className={`mt-1 text-xs font-medium ${deltaClsLight}`}>{delta}</div>}
     </div>
   );
@@ -478,25 +478,25 @@ export default function RecurringBillingIndex(props: PageProps) {
 
   // ── Filtros status
   const STATUS_FILTERS: Array<{ key: string; label: string; dot: string }> = [
-    { key: 'all', label: 'Todas', dot: 'bg-zinc-300' },
+    { key: 'all', label: 'Todas', dot: 'bg-stone-300' },
     { key: 'em_dia', label: 'Em dia', dot: 'bg-emerald-500' },
     { key: 'retentando', label: 'Retentando', dot: 'bg-amber-500' },
     { key: 'falhou', label: 'Falharam', dot: 'bg-rose-500' },
-    { key: 'pausada', label: 'Pausadas', dot: 'bg-zinc-400' },
-    { key: 'cancelada', label: 'Canceladas', dot: 'bg-zinc-300' },
+    { key: 'pausada', label: 'Pausadas', dot: 'bg-stone-400' },
+    { key: 'cancelada', label: 'Canceladas', dot: 'bg-stone-300' },
   ];
 
   return (
     <>
       <Head title="Cobrança Recorrente" />
 
-      <div className="min-h-screen bg-zinc-50 p-4 md:p-6">
+      <div className="min-h-screen bg-stone-50 p-4 md:p-6">
         {/* ── HEADER ── */}
         <header className="mb-4">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-bold tracking-tight text-zinc-900">Cobrança recorrente</h1>
-              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-zinc-500">
+              <h1 className="text-2xl font-semibold tracking-tight text-stone-900">Cobrança recorrente</h1>
+              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-stone-500">
                 {kpis ? (
                   <>
                     {kpis.active_count} ATIVAS · MRR {BRL(kpis.mrr)} · CHURN {kpis.churn_rate}%
@@ -507,7 +507,7 @@ export default function RecurringBillingIndex(props: PageProps) {
               </div>
             </div>
             <div className="flex items-center gap-2">
-              <nav className="flex gap-1 rounded-lg bg-white p-1 shadow-sm ring-1 ring-zinc-200">
+              <nav className="flex gap-1 rounded-lg bg-white p-1 shadow-sm ring-1 ring-stone-200">
                 {TABS.map((t) => (
                   <button
                     key={t.key}
@@ -526,13 +526,13 @@ export default function RecurringBillingIndex(props: PageProps) {
                     }}
                     className={`flex items-center gap-1.5 rounded px-3 py-1.5 text-sm font-medium transition ${
                       tab === t.key
-                        ? 'bg-violet-100 text-violet-900'
-                        : 'text-zinc-600 hover:bg-zinc-100'
+                        ? 'bg-primary/10 text-primary'
+                        : 'text-stone-600 hover:bg-stone-100'
                     }`}
                   >
                     {t.label}
                     {t.count !== undefined && (
-                      <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-zinc-700">
+                      <span className="rounded bg-stone-200 px-1.5 py-0.5 text-[10px] font-semibold tabular-nums text-stone-700">
                         {t.count}
                       </span>
                     )}
@@ -541,12 +541,12 @@ export default function RecurringBillingIndex(props: PageProps) {
               </nav>
               <button
                 type="button"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-violet-700"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white shadow-sm hover:opacity-90"
                 title="Nova assinatura (em breve)"
               >
                 <Plus size={14} />
                 Nova assinatura
-                <kbd className="ml-1 rounded bg-violet-700 px-1 text-[10px] font-mono">N</kbd>
+                <kbd className="ml-1 rounded bg-primary px-1 text-[10px] font-mono">N</kbd>
               </button>
             </div>
           </div>
@@ -594,17 +594,17 @@ export default function RecurringBillingIndex(props: PageProps) {
 
         {/* ── Placeholder pras outras 3 tabs ── */}
         {tab !== 'assinaturas' && (
-          <div className="rounded-2xl bg-white p-12 text-center shadow-sm ring-1 ring-zinc-200">
-            <div className="text-lg font-medium text-zinc-700">
-              Aba <strong className="text-violet-700">{TABS.find((t) => t.key === tab)?.label}</strong> em construção
+          <div className="rounded-lg bg-white p-12 text-center shadow-sm ring-1 ring-stone-200">
+            <div className="text-lg font-medium text-stone-700">
+              Aba <strong className="text-primary">{TABS.find((t) => t.key === tab)?.label}</strong> em construção
             </div>
-            <div className="mt-2 text-sm text-zinc-500">
+            <div className="mt-2 text-sm text-stone-500">
               Próximas ondas: Planos · Faturas · Configurações. Por ora use a aba Assinaturas.
             </div>
             <button
               type="button"
               onClick={() => setTab('assinaturas')}
-              className="mt-4 inline-flex rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+              className="mt-4 inline-flex rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:opacity-90"
             >
               Voltar a Assinaturas
             </button>
@@ -615,26 +615,26 @@ export default function RecurringBillingIndex(props: PageProps) {
         {tab === 'assinaturas' && (
           <div className="grid grid-cols-1 gap-3 lg:grid-cols-[220px_1fr_340px]">
             {/* COL 1 · FILTROS */}
-            <aside className="rounded-2xl bg-white p-3 shadow-sm ring-1 ring-zinc-200">
+            <aside className="rounded-lg bg-white p-3 shadow-sm ring-1 ring-stone-200">
               <button
                 type="button"
                 onClick={() => setOnlyPinned((p) => !p)}
                 className={`mb-3 flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-sm font-medium transition ${
                   onlyPinned
                     ? 'bg-amber-50 text-amber-800 ring-1 ring-amber-200'
-                    : 'text-zinc-700 hover:bg-zinc-50'
+                    : 'text-stone-700 hover:bg-stone-50'
                 }`}
               >
                 <Star size={14} className={onlyPinned ? 'fill-amber-500 text-amber-500' : ''} />
                 <span className="flex-1 text-left">
                   {onlyPinned ? 'Mostrando favoritos' : 'Mostrar só favoritos'}
                 </span>
-                <span className="rounded bg-zinc-200 px-1.5 py-0.5 text-[10px] tabular-nums">
+                <span className="rounded bg-stone-200 px-1.5 py-0.5 text-[10px] tabular-nums">
                   {subsData.filter((s) => s.is_pinned).length}
                 </span>
               </button>
 
-              <div className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+              <div className="mt-3 text-[11px] font-semibold uppercase tracking-wider text-stone-400">
                 Próxima cobrança
               </div>
               <ul className="mt-1">
@@ -647,8 +647,8 @@ export default function RecurringBillingIndex(props: PageProps) {
                     }}
                     className={`flex cursor-pointer items-center justify-between rounded-lg px-2 py-1.5 text-sm transition ${
                       whenFilter === f.key
-                        ? 'bg-violet-50 font-medium text-violet-900'
-                        : 'text-zinc-700 hover:bg-zinc-50'
+                        ? 'bg-primary/10 font-medium text-primary'
+                        : 'text-stone-700 hover:bg-stone-50'
                     }`}
                   >
                     <span>{f.label}</span>
@@ -656,7 +656,7 @@ export default function RecurringBillingIndex(props: PageProps) {
                 ))}
               </ul>
 
-              <div className="mt-4 text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+              <div className="mt-4 text-[11px] font-semibold uppercase tracking-wider text-stone-400">
                 Status
               </div>
               <ul className="mt-1">
@@ -669,8 +669,8 @@ export default function RecurringBillingIndex(props: PageProps) {
                     }}
                     className={`flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition ${
                       statusFilter === f.key
-                        ? 'bg-violet-50 font-medium text-violet-900'
-                        : 'text-zinc-700 hover:bg-zinc-50'
+                        ? 'bg-primary/10 font-medium text-primary'
+                        : 'text-stone-700 hover:bg-stone-50'
                     }`}
                   >
                     <span className={`h-2 w-2 rounded-full ${f.dot}`} />
@@ -681,16 +681,16 @@ export default function RecurringBillingIndex(props: PageProps) {
 
               {plans && plans.length > 0 && (
                 <>
-                  <div className="mt-4 text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+                  <div className="mt-4 text-[11px] font-semibold uppercase tracking-wider text-stone-400">
                     Plano
                   </div>
                   <ul className="mt-1 space-y-1">
                     {plans.map((p) => {
                       const n = subsData.filter((s) => s.plan_id === p.id && s.status !== 'cancelada').length;
                       return (
-                        <li key={p.id} className="rounded-lg px-2 py-1.5 text-xs text-zinc-700">
+                        <li key={p.id} className="rounded-lg px-2 py-1.5 text-xs text-stone-700">
                           <div className="font-medium">{p.name}</div>
-                          <div className="text-zinc-500 tabular-nums">
+                          <div className="text-stone-500 tabular-nums">
                             {BRL(p.price)} · {n} ativ.
                           </div>
                         </li>
@@ -700,24 +700,24 @@ export default function RecurringBillingIndex(props: PageProps) {
                 </>
               )}
 
-              <div className="mt-4 border-t border-zinc-200 pt-3">
-                <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-400">
+              <div className="mt-4 border-t border-stone-200 pt-3">
+                <div className="text-[11px] font-semibold uppercase tracking-wider text-stone-400">
                   MRR filtrado
                 </div>
-                <div className="mt-1 font-mono text-base font-bold text-zinc-900 tabular-nums">
+                <div className="mt-1 font-mono text-base font-bold text-stone-900 tabular-nums">
                   {BRL(filteredMrr)}
                 </div>
-                <div className="text-[11px] text-zinc-500">
+                <div className="text-[11px] text-stone-500">
                   {filtered.filter((s) => s.status !== 'cancelada').length} ativ. de {subsData.length}
                 </div>
               </div>
             </aside>
 
             {/* COL 2 · LISTA */}
-            <section className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-zinc-200">
-              <div className="flex items-center gap-2 border-b border-zinc-200 p-2.5">
-                <div className="flex flex-1 items-center gap-2 rounded-lg bg-zinc-100 px-3 py-1.5">
-                  <Search size={14} className="text-zinc-400" />
+            <section className="overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-stone-200">
+              <div className="flex items-center gap-2 border-b border-stone-200 p-2.5">
+                <div className="flex flex-1 items-center gap-2 rounded-lg bg-stone-100 px-3 py-1.5">
+                  <Search size={14} className="text-stone-400" />
                   <input
                     ref={searchRef}
                     type="text"
@@ -727,13 +727,13 @@ export default function RecurringBillingIndex(props: PageProps) {
                       if (e.key === 'Enter') applyFilters({ q: search });
                     }}
                     placeholder="Buscar (/) — cliente, CNPJ, OS"
-                    className="flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-400"
+                    className="flex-1 bg-transparent text-sm outline-none placeholder:text-stone-400"
                   />
-                  <kbd className="rounded bg-white px-1.5 py-0.5 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">
+                  <kbd className="rounded bg-white px-1.5 py-0.5 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">
                     /
                   </kbd>
                 </div>
-                <span className="text-xs text-zinc-500 tabular-nums">
+                <span className="text-xs text-stone-500 tabular-nums">
                   {filtered.length} / {subsData.length}
                 </span>
               </div>
@@ -742,8 +742,8 @@ export default function RecurringBillingIndex(props: PageProps) {
                 <div className="max-h-[calc(100vh-360px)] overflow-y-auto">
                   {filtered.length === 0 && (
                     <div className="p-8 text-center">
-                      <div className="font-medium text-zinc-700">Nada por aqui.</div>
-                      <div className="mt-1 text-sm text-zinc-500">
+                      <div className="font-medium text-stone-700">Nada por aqui.</div>
+                      <div className="mt-1 text-sm text-stone-500">
                         Nenhuma assinatura com este filtro + busca.
                       </div>
                     </div>
@@ -754,10 +754,10 @@ export default function RecurringBillingIndex(props: PageProps) {
                       <div
                         key={s.id}
                         onClick={() => setActiveId(s.id)}
-                        className={`flex cursor-pointer items-center gap-3 border-b border-zinc-100 px-3 py-2.5 transition ${
+                        className={`flex cursor-pointer items-center gap-3 border-b border-stone-100 px-3 py-2.5 transition ${
                           isActive
-                            ? 'border-l-2 border-l-violet-500 bg-violet-50/50'
-                            : 'hover:bg-zinc-50'
+                            ? 'border-l-2 border-l-primary bg-primary/5'
+                            : 'hover:bg-stone-50'
                         }`}
                       >
                         {/* Onda 19 v9,75 — ★ favorite toggle persistente (POST backend). */}
@@ -775,22 +775,22 @@ export default function RecurringBillingIndex(props: PageProps) {
                         >
                           <Star
                             size={14}
-                            className={s.is_pinned ? 'fill-amber-500 text-amber-500' : 'text-zinc-300 hover:text-amber-400'}
+                            className={s.is_pinned ? 'fill-amber-500 text-amber-500' : 'text-stone-300 hover:text-amber-400'}
                           />
                         </button>
                         <Avatar name={s.client} />
                         <div className="min-w-0 flex-1">
-                          <div className="flex items-center gap-1.5 truncate text-sm font-semibold text-zinc-900">
+                          <div className="flex items-center gap-1.5 truncate text-sm font-semibold text-stone-900">
                             <span className="truncate">{s.client}</span>
                           </div>
-                          <div className="truncate text-xs text-zinc-500">
+                          <div className="truncate text-xs text-stone-500">
                             {s.plan_name} · {s.plan_cycle} · desde {daysAgoLabel(s.since) || '—'}
                           </div>
                         </div>
                         <div className="flex flex-col items-end gap-1">
                           <StatusBadge status={s.status} retry={s.retry} retryMax={s.retry_max} />
                           {s.status !== 'cancelada' && (
-                            <span className="inline-flex items-center gap-1 text-xs font-medium tabular-nums text-zinc-700">
+                            <span className="inline-flex items-center gap-1 text-xs font-medium tabular-nums text-stone-700">
                               <MethodIcon method={s.method} size={11} />
                               {BRL(s.next_value)}
                             </span>
@@ -804,9 +804,9 @@ export default function RecurringBillingIndex(props: PageProps) {
             </section>
 
             {/* COL 3 · DETAIL DRAWER */}
-            <aside className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-zinc-200">
+            <aside className="rounded-lg bg-white p-4 shadow-sm ring-1 ring-stone-200">
               {!active && (
-                <div className="flex h-full items-center justify-center text-sm text-zinc-400">
+                <div className="flex h-full items-center justify-center text-sm text-stone-400">
                   Selecione uma assinatura
                 </div>
               )}
@@ -887,17 +887,17 @@ function DetailDrawer({ sub, onTrouble }: { sub: SubRow; onTrouble?: (t: Trouble
   return (
     <div className="space-y-4">
       {/* Header — Onda 13 v9,75 add botão PDF (print extrato) */}
-      <div className="flex items-start gap-3 border-b border-zinc-100 pb-3">
+      <div className="flex items-start gap-3 border-b border-stone-100 pb-3">
         <Avatar name={sub.client} size={40} />
         <div className="min-w-0 flex-1">
-          <h3 className="truncate text-base font-semibold text-zinc-900">{sub.client}</h3>
-          <div className="truncate text-xs text-zinc-500">{sub.cnpj || '—'}</div>
+          <h3 className="truncate text-base font-semibold text-stone-900">{sub.client}</h3>
+          <div className="truncate text-xs text-stone-500">{sub.cnpj || '—'}</div>
         </div>
         <button
           type="button"
           title="Imprimir extrato (⇧E)"
           onClick={() => printSubDetail(sub.id)}
-          className="inline-flex items-center gap-1 rounded border border-zinc-300 px-2 py-1 text-[10px] text-zinc-600 hover:bg-zinc-50"
+          className="inline-flex items-center gap-1 rounded border border-stone-300 px-2 py-1 text-[10px] text-stone-600 hover:bg-stone-50"
         >
           PDF
         </button>
@@ -911,23 +911,23 @@ function DetailDrawer({ sub, onTrouble }: { sub: SubRow; onTrouble?: (t: Trouble
             ? 'bg-rose-50 ring-1 ring-rose-200'
             : sub.status === 'retentando'
               ? 'bg-amber-50 ring-1 ring-amber-200'
-              : 'bg-violet-50 ring-1 ring-violet-200'
+              : 'bg-primary/10 ring-1 ring-primary/30'
         }`}>
-          <div className="text-[11px] font-semibold uppercase tracking-wider text-zinc-600">
+          <div className="text-[11px] font-semibold uppercase tracking-wider text-stone-600">
             {sub.status === 'falhou' ? 'Ação manual' : 'Próxima cobrança'}
           </div>
           <div className="mt-1 flex items-end justify-between">
             <div>
-              <div className="text-lg font-bold text-zinc-900">{nextLabel(sub.next_at)}</div>
-              <div className="text-xs text-zinc-600">
+              <div className="text-lg font-bold text-stone-900">{nextLabel(sub.next_at)}</div>
+              <div className="text-xs text-stone-600">
                 {nextDateBR(sub.next_at)} · ciclo {sub.plan_cycle}
               </div>
             </div>
             <div className="text-right">
-              <div className="font-mono text-base font-semibold tabular-nums text-zinc-900">
+              <div className="font-mono text-base font-semibold tabular-nums text-stone-900">
                 {BRL(sub.next_value)}
               </div>
-              <div className="mt-0.5 inline-flex items-center gap-1 text-[11px] text-zinc-600">
+              <div className="mt-0.5 inline-flex items-center gap-1 text-[11px] text-stone-600">
                 <MethodIcon method={sub.method} size={10} />
                 {sub.method === 'pix' ? 'Pix' : sub.method === 'boleto' ? 'Boleto' : 'Cartão'}
               </div>
@@ -938,34 +938,34 @@ function DetailDrawer({ sub, onTrouble }: { sub: SubRow; onTrouble?: (t: Trouble
 
       {/* KV grid */}
       <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
-        <dt className="text-zinc-500">Plano</dt>
-        <dd className="font-medium text-zinc-800">{sub.plan_name}</dd>
-        <dt className="text-zinc-500">Ciclo</dt>
-        <dd className="text-zinc-800">{sub.plan_cycle}</dd>
-        <dt className="text-zinc-500">Desde</dt>
-        <dd className="text-zinc-800">{daysAgoLabel(sub.since) || '—'}</dd>
-        <dt className="text-zinc-500">Cobranças pagas</dt>
-        <dd className="font-mono tabular-nums text-zinc-800">{sub.paid}</dd>
-        <dt className="text-zinc-500">Falhas</dt>
-        <dd className={`font-mono tabular-nums ${sub.missed > 0 ? 'text-rose-600 font-semibold' : 'text-zinc-800'}`}>
+        <dt className="text-stone-500">Plano</dt>
+        <dd className="font-medium text-stone-800">{sub.plan_name}</dd>
+        <dt className="text-stone-500">Ciclo</dt>
+        <dd className="text-stone-800">{sub.plan_cycle}</dd>
+        <dt className="text-stone-500">Desde</dt>
+        <dd className="text-stone-800">{daysAgoLabel(sub.since) || '—'}</dd>
+        <dt className="text-stone-500">Cobranças pagas</dt>
+        <dd className="font-mono tabular-nums text-stone-800">{sub.paid}</dd>
+        <dt className="text-stone-500">Falhas</dt>
+        <dd className={`font-mono tabular-nums ${sub.missed > 0 ? 'text-rose-600 font-semibold' : 'text-stone-800'}`}>
           {sub.missed}
         </dd>
-        <dt className="text-zinc-500">LTV</dt>
-        <dd className="font-mono tabular-nums text-zinc-800">{BRL(sub.ltv)}</dd>
-        <dt className="text-zinc-500">Contato</dt>
-        <dd className="truncate text-zinc-800">
+        <dt className="text-stone-500">LTV</dt>
+        <dd className="font-mono tabular-nums text-stone-800">{BRL(sub.ltv)}</dd>
+        <dt className="text-stone-500">Contato</dt>
+        <dd className="truncate text-stone-800">
           {sub.contact.name} · <span className="font-mono">{sub.contact.phone}</span>
         </dd>
         {sub.os && (
           <>
-            <dt className="text-zinc-500">OS recente</dt>
-            <dd className="font-mono text-zinc-800">{sub.os}</dd>
+            <dt className="text-stone-500">OS recente</dt>
+            <dd className="font-mono text-stone-800">{sub.os}</dd>
           </>
         )}
         {sub.churn_reason && (
           <>
-            <dt className="text-zinc-500">Motivo cancelamento</dt>
-            <dd className="text-zinc-800">{sub.churn_reason}</dd>
+            <dt className="text-stone-500">Motivo cancelamento</dt>
+            <dd className="text-stone-800">{sub.churn_reason}</dd>
           </>
         )}
       </dl>
@@ -979,7 +979,7 @@ function DetailDrawer({ sub, onTrouble }: { sub: SubRow; onTrouble?: (t: Trouble
       )}
 
       {/* Bloco Fiscal */}
-      <div className="rounded-lg border border-zinc-200 p-3">
+      <div className="rounded-lg border border-stone-200 p-3">
         <div className="flex items-center justify-between">
           <div>
             <span className={`inline-flex rounded px-1.5 py-0.5 text-[10px] font-semibold ${
@@ -987,17 +987,17 @@ function DetailDrawer({ sub, onTrouble }: { sub: SubRow; onTrouble?: (t: Trouble
                 ? 'bg-blue-100 text-blue-700'
                 : sub.fiscal?.type === 'nfse'
                   ? 'bg-emerald-100 text-emerald-700'
-                  : 'bg-zinc-100 text-zinc-500'
+                  : 'bg-stone-100 text-stone-500'
             }`}>
               {fiscal.label}
             </span>
-            <div className="mt-1 text-[10px] text-zinc-500">{fiscal.long}</div>
+            <div className="mt-1 text-[10px] text-stone-500">{fiscal.long}</div>
           </div>
           {sub.fiscal?.last_nf && (
             <button
               type="button"
               onClick={() => postAction(`/recurring-billing/${sub.id}/reenviar-nfe`, {}, `Reenviar ${sub.fiscal?.last_nf}?`)}
-              className="inline-flex items-center gap-1 rounded border border-zinc-300 px-2 py-1 text-[11px] text-zinc-600 hover:bg-zinc-50"
+              className="inline-flex items-center gap-1 rounded border border-stone-300 px-2 py-1 text-[11px] text-stone-600 hover:bg-stone-50"
               title="Reenviar última NFe por e-mail/WhatsApp"
             >
               <RefreshCw size={10} />
@@ -1107,8 +1107,8 @@ function PaymentHistory({ paid, missed }: { paid: number; missed: number }) {
   }, []);
 
   return (
-    <div className="rounded-lg border border-zinc-200 p-3">
-      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+    <div className="rounded-lg border border-stone-200 p-3">
+      <div className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-stone-500">
         Histórico de pagamentos
       </div>
       <div className="flex gap-1">
@@ -1120,14 +1120,14 @@ function PaymentHistory({ paid, missed }: { paid: number; missed: number }) {
                   ? 'bg-emerald-400'
                   : c === 'missed'
                     ? 'bg-rose-400'
-                    : 'bg-zinc-100 ring-1 ring-zinc-200'
+                    : 'bg-stone-100 ring-1 ring-stone-200'
               }`}
             />
-            <div className="mt-0.5 text-[9px] text-zinc-400">{months[i]?.slice(0, 1) || ''}</div>
+            <div className="mt-0.5 text-[9px] text-stone-400">{months[i]?.slice(0, 1) || ''}</div>
           </div>
         ))}
       </div>
-      <div className="mt-2 flex items-center gap-3 text-[10px] text-zinc-500">
+      <div className="mt-2 flex items-center gap-3 text-[10px] text-stone-500">
         <span className="inline-flex items-center gap-1">
           <span className="inline-block h-2 w-2 rounded-sm bg-emerald-400" /> pago ({paid})
         </span>
@@ -1135,7 +1135,7 @@ function PaymentHistory({ paid, missed }: { paid: number; missed: number }) {
           <span className="inline-block h-2 w-2 rounded-sm bg-rose-400" /> falhou ({missed})
         </span>
         <span className="inline-flex items-center gap-1">
-          <span className="inline-block h-2 w-2 rounded-sm bg-zinc-100 ring-1 ring-zinc-200" /> futuro
+          <span className="inline-block h-2 w-2 rounded-sm bg-stone-100 ring-1 ring-stone-200" /> futuro
         </span>
       </div>
     </div>
@@ -1201,8 +1201,8 @@ function SubscriptionTimeline({ subId, subStatus }: { subId: number; subStatus: 
 
   const kindStyle: Record<string, { dot: string; label: string }> = {
     note: { dot: 'bg-amber-400', label: 'nota' },
-    'event-create': { dot: 'bg-violet-400', label: 'criou' },
-    'event-status': { dot: 'bg-zinc-400', label: 'status' },
+    'event-create': { dot: 'bg-primary', label: 'criou' },
+    'event-status': { dot: 'bg-stone-400', label: 'status' },
     'event-plan': { dot: 'bg-blue-400', label: 'plano' },
     'event-charge': { dot: 'bg-emerald-400', label: 'cobrança' },
     'event-retry': { dot: 'bg-amber-500', label: 'retry' },
@@ -1210,9 +1210,9 @@ function SubscriptionTimeline({ subId, subStatus }: { subId: number; subStatus: 
   };
 
   return (
-    <div className="rounded-lg border border-zinc-200 p-3">
+    <div className="rounded-lg border border-stone-200 p-3">
       <div className="mb-2 flex items-center justify-between">
-        <div className="text-[10px] font-semibold uppercase tracking-wider text-zinc-500">
+        <div className="text-[10px] font-semibold uppercase tracking-wider text-stone-500">
           Notas & Eventos {events.length > 0 ? `· ${events.length}` : ''}
         </div>
       </div>
@@ -1230,14 +1230,14 @@ function SubscriptionTimeline({ subId, subStatus }: { subId: number; subStatus: 
               }
             }}
             placeholder="Anotar internamente…"
-            className="flex-1 rounded border border-zinc-200 bg-white px-2 py-1 text-xs outline-none focus:border-violet-400 focus:ring-1 focus:ring-violet-200"
+            className="flex-1 rounded border border-stone-200 bg-white px-2 py-1 text-xs outline-none focus:border-primary focus:ring-1 focus:ring-primary/30"
             maxLength={5000}
           />
           <button
             type="button"
             onClick={submitNote}
             disabled={submitting || !noteText.trim()}
-            className="rounded-lg bg-violet-600 px-3 py-1 text-xs font-medium text-white hover:bg-violet-700 disabled:bg-zinc-300"
+            className="rounded-lg bg-primary px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:bg-stone-300"
           >
             Anotar
           </button>
@@ -1247,13 +1247,13 @@ function SubscriptionTimeline({ subId, subStatus }: { subId: number; subStatus: 
       {loading && (
         <div className="space-y-1.5">
           {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="h-8 animate-pulse rounded bg-zinc-100" />
+            <div key={i} className="h-8 animate-pulse rounded bg-stone-100" />
           ))}
         </div>
       )}
 
       {!loading && events.length === 0 && (
-        <div className="py-3 text-center text-[11px] text-zinc-400">
+        <div className="py-3 text-center text-[11px] text-stone-400">
           Nenhum evento registrado.
         </div>
       )}
@@ -1261,7 +1261,7 @@ function SubscriptionTimeline({ subId, subStatus }: { subId: number; subStatus: 
       {!loading && events.length > 0 && (
         <ul className="space-y-2 max-h-64 overflow-y-auto">
           {events.map((ev) => {
-            const ks = kindStyle[ev.kind] || { dot: 'bg-zinc-300', label: ev.kind };
+            const ks = kindStyle[ev.kind] || { dot: 'bg-stone-300', label: ev.kind };
             const when = new Date(ev.occurred_at).toLocaleString('pt-BR', {
               day: '2-digit',
               month: 'short',
@@ -1272,14 +1272,14 @@ function SubscriptionTimeline({ subId, subStatus }: { subId: number; subStatus: 
               <li key={ev.id} className="flex gap-2 text-xs">
                 <span className={`mt-1 h-2 w-2 shrink-0 rounded-full ${ks.dot}`} />
                 <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-1.5 text-[10px] text-zinc-500">
+                  <div className="flex items-center gap-1.5 text-[10px] text-stone-500">
                     <span className="font-semibold uppercase">{ks.label}</span>
                     <span>·</span>
                     <span>{ev.by_actor}</span>
                     <span>·</span>
                     <span>{when}</span>
                   </div>
-                  <div className="text-zinc-800">{ev.body}</div>
+                  <div className="text-stone-800">{ev.body}</div>
                 </div>
               </li>
             );
@@ -1298,8 +1298,8 @@ function ActionBtn({ icon: Icon, label, hint, primary = false, onClick }: {
   onClick?: () => void;
 }) {
   const cls = primary
-    ? 'bg-violet-600 text-white hover:bg-violet-700'
-    : 'bg-white text-zinc-700 ring-1 ring-zinc-200 hover:bg-zinc-50';
+    ? 'bg-primary text-white hover:opacity-90'
+    : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50';
   return (
     <button
       type="button"
@@ -1310,7 +1310,7 @@ function ActionBtn({ icon: Icon, label, hint, primary = false, onClick }: {
       {label}
       {hint && (
         <kbd className={`rounded px-1 text-[10px] font-mono ${
-          primary ? 'bg-violet-700' : 'bg-zinc-100 text-zinc-500 ring-1 ring-zinc-200'
+          primary ? 'bg-primary' : 'bg-stone-100 text-stone-500 ring-1 ring-stone-200'
         }`}>{hint}</kbd>
       )}
     </button>
@@ -1325,7 +1325,7 @@ function KpiSkeleton() {
   return (
     <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="h-24 animate-pulse rounded-2xl bg-zinc-100" />
+        <div key={i} className="h-24 animate-pulse rounded-lg bg-stone-100" />
       ))}
     </div>
   );
@@ -1333,15 +1333,15 @@ function KpiSkeleton() {
 
 function ListSkeleton() {
   return (
-    <div className="divide-y divide-zinc-100">
+    <div className="divide-y divide-stone-100">
       {Array.from({ length: 6 }).map((_, i) => (
         <div key={i} className="flex items-center gap-3 px-3 py-2.5">
-          <div className="h-7 w-7 animate-pulse rounded-full bg-zinc-200" />
+          <div className="h-7 w-7 animate-pulse rounded-full bg-stone-200" />
           <div className="flex-1 space-y-1">
-            <div className="h-3 w-32 animate-pulse rounded bg-zinc-200" />
-            <div className="h-2 w-48 animate-pulse rounded bg-zinc-100" />
+            <div className="h-3 w-32 animate-pulse rounded bg-stone-200" />
+            <div className="h-2 w-48 animate-pulse rounded bg-stone-100" />
           </div>
-          <div className="h-4 w-16 animate-pulse rounded-full bg-zinc-100" />
+          <div className="h-4 w-16 animate-pulse rounded-full bg-stone-100" />
         </div>
       ))}
     </div>

--- a/resources/js/Pages/RecurringBilling/Planos/Create.tsx
+++ b/resources/js/Pages/RecurringBilling/Planos/Create.tsx
@@ -97,22 +97,22 @@ export default function PlanosCreate({ defaults }: PageProps) {
     <>
       <Head title="Novo plano · Cobrança Recorrente" />
 
-      <div className="min-h-screen bg-zinc-50 p-4 md:p-6">
+      <div className="min-h-screen bg-stone-50 p-4 md:p-6">
         {/* HEADER */}
         <header className="mb-4">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
               <Link
                 href="/recurring-billing/planos"
-                className="inline-flex items-center gap-1 text-xs font-medium text-violet-700 hover:text-violet-900"
+                className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:text-primary"
               >
                 <ArrowLeft size={12} />
                 Voltar pra Planos
               </Link>
-              <h1 className="mt-1 text-2xl font-bold tracking-tight text-zinc-900">
+              <h1 className="mt-1 text-2xl font-semibold tracking-tight text-stone-900">
                 Novo plano
               </h1>
-              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-zinc-500">
+              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-stone-500">
                 CADASTRAR · COBRANÇA RECORRENTE
               </div>
             </div>
@@ -126,8 +126,8 @@ export default function PlanosCreate({ defaults }: PageProps) {
           className="space-y-4"
         >
           {/* Card 1 — Identificação */}
-          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-zinc-200">
-            <h2 className="mb-3 text-sm font-semibold text-zinc-900">Identificação</h2>
+          <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-stone-200">
+            <h2 className="mb-3 text-sm font-semibold text-stone-900">Identificação</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <Field
                 label="Nome do plano"
@@ -139,7 +139,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   type="text"
                   value={form.data.name}
                   onChange={(e) => form.setData('name', e.target.value)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   required
                   maxLength={150}
                 />
@@ -154,7 +154,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   type="text"
                   value={form.data.slug}
                   onChange={(e) => form.setData('slug', e.target.value.toLowerCase())}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   maxLength={80}
                   placeholder="plano-anual-pro"
                 />
@@ -169,7 +169,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   type="text"
                   value={form.data.descricao_curta}
                   onChange={(e) => form.setData('descricao_curta', e.target.value)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   maxLength={200}
                 />
               </Field>
@@ -183,7 +183,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   value={form.data.description}
                   onChange={(e) => form.setData('description', e.target.value)}
                   rows={2}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   maxLength={2000}
                 />
               </Field>
@@ -191,8 +191,8 @@ export default function PlanosCreate({ defaults }: PageProps) {
           </section>
 
           {/* Card 2 — Cobrança */}
-          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-zinc-200">
-            <h2 className="mb-3 text-sm font-semibold text-zinc-900">Cobrança</h2>
+          <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-stone-200">
+            <h2 className="mb-3 text-sm font-semibold text-stone-900">Cobrança</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               <Field
                 label="Valor (R$)"
@@ -206,7 +206,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   min="0"
                   value={form.data.valor}
                   onChange={(e) => form.setData('valor', parseFloat(e.target.value) || 0)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   required
                 />
               </Field>
@@ -244,7 +244,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                     max="365"
                     value={form.data.ciclo_dias}
                     onChange={(e) => form.setData('ciclo_dias', parseInt(e.target.value, 10) || 0)}
-                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   />
                 </Field>
               )}
@@ -260,7 +260,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   max="90"
                   value={form.data.trial_days}
                   onChange={(e) => form.setData('trial_days', parseInt(e.target.value, 10) || 0)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 />
               </Field>
             </div>
@@ -272,7 +272,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                   checked={form.data.ativo}
                   onCheckedChange={(c) => form.setData('ativo', c === true)}
                 />
-                <Label htmlFor="ativo" className="cursor-pointer text-sm text-zinc-700">
+                <Label htmlFor="ativo" className="cursor-pointer text-sm text-stone-700">
                   Plano ativo (disponível pra novas assinaturas)
                 </Label>
               </div>
@@ -280,8 +280,8 @@ export default function PlanosCreate({ defaults }: PageProps) {
           </section>
 
           {/* Card 3 — Fiscal */}
-          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-zinc-200">
-            <h2 className="mb-3 text-sm font-semibold text-zinc-900">Emissão fiscal</h2>
+          <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-stone-200">
+            <h2 className="mb-3 text-sm font-semibold text-stone-900">Emissão fiscal</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               <Field
                 label="Tipo"
@@ -313,7 +313,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                     type="text"
                     value={form.data.fiscal_cfop}
                     onChange={(e) => form.setData('fiscal_cfop', e.target.value)}
-                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     maxLength={8}
                   />
                 </Field>
@@ -330,7 +330,7 @@ export default function PlanosCreate({ defaults }: PageProps) {
                     type="text"
                     value={form.data.fiscal_servico}
                     onChange={(e) => form.setData('fiscal_servico', e.target.value)}
-                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     maxLength={8}
                   />
                 </Field>
@@ -342,19 +342,19 @@ export default function PlanosCreate({ defaults }: PageProps) {
           <div className="flex items-center justify-end gap-2 pt-2">
             <Link
               href="/recurring-billing/planos"
-              className="inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm ring-1 ring-zinc-200 hover:bg-zinc-50"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 shadow-sm ring-1 ring-stone-200 hover:bg-stone-50"
             >
               Cancelar
-              <kbd className="rounded bg-zinc-100 px-1 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">Esc</kbd>
+              <kbd className="rounded bg-stone-100 px-1 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">Esc</kbd>
             </Link>
             <button
               type="submit"
               disabled={form.processing}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-violet-700 disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary disabled:opacity-50"
             >
               <Save size={14} />
               {form.processing ? 'Salvando…' : 'Salvar plano'}
-              <kbd className="ml-1 rounded bg-violet-700 px-1 text-[10px] font-mono">⌘↵</kbd>
+              <kbd className="ml-1 rounded bg-primary px-1 text-[10px] font-mono">⌘↵</kbd>
             </button>
           </div>
         </form>
@@ -382,11 +382,11 @@ function Field({
 }) {
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium text-zinc-700">
+      <label className="mb-1 block text-xs font-medium text-stone-700">
         {label} {required && <span className="text-rose-600">*</span>}
       </label>
       {children}
-      {hint && !error && <div className="mt-1 text-[11px] text-zinc-500">{hint}</div>}
+      {hint && !error && <div className="mt-1 text-[11px] text-stone-500">{hint}</div>}
       {error && <div className="mt-1 text-[11px] font-medium text-rose-600">{error}</div>}
     </div>
   );

--- a/resources/js/Pages/RecurringBilling/Planos/Edit.tsx
+++ b/resources/js/Pages/RecurringBilling/Planos/Edit.tsx
@@ -106,22 +106,22 @@ export default function PlanosEdit({ plan }: PageProps) {
     <>
       <Head title={`Editar ${plan.name} · Planos`} />
 
-      <div className="min-h-screen bg-zinc-50 p-4 md:p-6">
+      <div className="min-h-screen bg-stone-50 p-4 md:p-6">
         {/* HEADER */}
         <header className="mb-4">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
               <Link
                 href="/recurring-billing/planos"
-                className="inline-flex items-center gap-1 text-xs font-medium text-violet-700 hover:text-violet-900"
+                className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:text-primary"
               >
                 <ArrowLeft size={12} />
                 Voltar pra Planos
               </Link>
-              <h1 className="mt-1 text-2xl font-bold tracking-tight text-zinc-900">
+              <h1 className="mt-1 text-2xl font-semibold tracking-tight text-stone-900">
                 Editar plano
               </h1>
-              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-zinc-500">
+              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-stone-500">
                 {plan.name} · #{plan.id}
               </div>
             </div>
@@ -135,8 +135,8 @@ export default function PlanosEdit({ plan }: PageProps) {
           className="space-y-4"
         >
           {/* Card 1 — Identificação */}
-          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-zinc-200">
-            <h2 className="mb-3 text-sm font-semibold text-zinc-900">Identificação</h2>
+          <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-stone-200">
+            <h2 className="mb-3 text-sm font-semibold text-stone-900">Identificação</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <Field
                 label="Nome do plano"
@@ -147,7 +147,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   type="text"
                   value={form.data.name}
                   onChange={(e) => form.setData('name', e.target.value)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   required
                   maxLength={150}
                 />
@@ -169,7 +169,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   className={`w-full rounded-lg border px-3 py-2 font-mono text-sm focus:outline-none focus:ring-1 ${
                     slugChanged
                       ? 'border-amber-400 focus:border-amber-500 focus:ring-amber-500'
-                      : 'border-zinc-300 focus:border-violet-500 focus:ring-violet-500'
+                      : 'border-stone-300 focus:border-primary focus:ring-primary'
                   }`}
                   maxLength={80}
                 />
@@ -183,7 +183,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   type="text"
                   value={form.data.descricao_curta}
                   onChange={(e) => form.setData('descricao_curta', e.target.value)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   maxLength={200}
                 />
               </Field>
@@ -196,7 +196,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   value={form.data.description}
                   onChange={(e) => form.setData('description', e.target.value)}
                   rows={2}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 text-sm focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   maxLength={2000}
                 />
               </Field>
@@ -204,8 +204,8 @@ export default function PlanosEdit({ plan }: PageProps) {
           </section>
 
           {/* Card 2 — Cobrança */}
-          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-zinc-200">
-            <h2 className="mb-3 text-sm font-semibold text-zinc-900">Cobrança</h2>
+          <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-stone-200">
+            <h2 className="mb-3 text-sm font-semibold text-stone-900">Cobrança</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               <Field
                 label="Valor (R$)"
@@ -218,7 +218,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   min="0"
                   value={form.data.valor}
                   onChange={(e) => form.setData('valor', parseFloat(e.target.value) || 0)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   required
                 />
               </Field>
@@ -256,7 +256,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                     max="365"
                     value={form.data.ciclo_dias}
                     onChange={(e) => form.setData('ciclo_dias', parseInt(e.target.value, 10) || 0)}
-                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                   />
                 </Field>
               )}
@@ -272,7 +272,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   max="90"
                   value={form.data.trial_days}
                   onChange={(e) => form.setData('trial_days', parseInt(e.target.value, 10) || 0)}
-                  className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                  className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                 />
               </Field>
             </div>
@@ -284,7 +284,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                   checked={form.data.ativo}
                   onCheckedChange={(c) => form.setData('ativo', c === true)}
                 />
-                <Label htmlFor="ativo" className="cursor-pointer text-sm text-zinc-700">
+                <Label htmlFor="ativo" className="cursor-pointer text-sm text-stone-700">
                   Plano ativo (disponível pra novas assinaturas)
                 </Label>
               </div>
@@ -292,8 +292,8 @@ export default function PlanosEdit({ plan }: PageProps) {
           </section>
 
           {/* Card 3 — Fiscal */}
-          <section className="rounded-2xl bg-white p-5 shadow-sm ring-1 ring-zinc-200">
-            <h2 className="mb-3 text-sm font-semibold text-zinc-900">Emissão fiscal</h2>
+          <section className="rounded-lg bg-white p-5 shadow-sm ring-1 ring-stone-200">
+            <h2 className="mb-3 text-sm font-semibold text-stone-900">Emissão fiscal</h2>
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
               <Field
                 label="Tipo"
@@ -325,7 +325,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                     type="text"
                     value={form.data.fiscal_cfop}
                     onChange={(e) => form.setData('fiscal_cfop', e.target.value)}
-                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     maxLength={8}
                   />
                 </Field>
@@ -342,7 +342,7 @@ export default function PlanosEdit({ plan }: PageProps) {
                     type="text"
                     value={form.data.fiscal_servico}
                     onChange={(e) => form.setData('fiscal_servico', e.target.value)}
-                    className="w-full rounded-lg border border-zinc-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-violet-500 focus:outline-none focus:ring-1 focus:ring-violet-500"
+                    className="w-full rounded-lg border border-stone-300 px-3 py-2 font-mono text-sm tabular-nums focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary"
                     maxLength={8}
                   />
                 </Field>
@@ -354,19 +354,19 @@ export default function PlanosEdit({ plan }: PageProps) {
           <div className="flex items-center justify-end gap-2 pt-2">
             <Link
               href="/recurring-billing/planos"
-              className="inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-sm font-medium text-zinc-700 shadow-sm ring-1 ring-zinc-200 hover:bg-zinc-50"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-white px-4 py-2 text-sm font-medium text-stone-700 shadow-sm ring-1 ring-stone-200 hover:bg-stone-50"
             >
               Cancelar
-              <kbd className="rounded bg-zinc-100 px-1 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">Esc</kbd>
+              <kbd className="rounded bg-stone-100 px-1 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">Esc</kbd>
             </Link>
             <button
               type="submit"
               disabled={form.processing}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-violet-700 disabled:opacity-50"
+              className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary disabled:opacity-50"
             >
               <Save size={14} />
               {form.processing ? 'Salvando…' : 'Salvar alterações'}
-              <kbd className="ml-1 rounded bg-violet-700 px-1 text-[10px] font-mono">⌘↵</kbd>
+              <kbd className="ml-1 rounded bg-primary px-1 text-[10px] font-mono">⌘↵</kbd>
             </button>
           </div>
         </form>
@@ -394,11 +394,11 @@ function Field({
 }) {
   return (
     <div>
-      <label className="mb-1 block text-xs font-medium text-zinc-700">
+      <label className="mb-1 block text-xs font-medium text-stone-700">
         {label} {required && <span className="text-rose-600">*</span>}
       </label>
       {children}
-      {hint && !error && <div className="mt-1 text-[11px] text-zinc-500">{hint}</div>}
+      {hint && !error && <div className="mt-1 text-[11px] text-stone-500">{hint}</div>}
       {error && <div className="mt-1 text-[11px] font-medium text-rose-600">{error}</div>}
     </div>
   );

--- a/resources/js/Pages/RecurringBilling/Planos/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Planos/Index.tsx
@@ -100,7 +100,7 @@ const BRLshort = (n: number) =>
 const FISCAL_LABEL: Record<FiscalType, { label: string; classes: string }> = {
   nfe:  { label: 'NFe',        classes: 'bg-blue-100 text-blue-700 ring-blue-200' },
   nfse: { label: 'NFS-e',      classes: 'bg-emerald-100 text-emerald-700 ring-emerald-200' },
-  none: { label: 'Não emite',  classes: 'bg-zinc-100 text-zinc-500 ring-zinc-200' },
+  none: { label: 'Não emite',  classes: 'bg-stone-100 text-stone-500 ring-stone-200' },
 };
 
 const CICLO_LABEL: Record<Ciclo, string> = {
@@ -135,19 +135,19 @@ function KpiCard({
     ok: 'text-emerald-300',
     warn: 'text-amber-400',
     bad: 'text-rose-400',
-    neutral: 'text-zinc-400',
+    neutral: 'text-stone-400',
   }[deltaTone];
   const deltaClsLight = {
     ok: 'text-emerald-700',
     warn: 'text-amber-700',
     bad: 'text-rose-700',
-    neutral: 'text-zinc-500',
+    neutral: 'text-stone-500',
   }[deltaTone];
 
   if (hero) {
     return (
-      <div className="rounded-2xl bg-zinc-900 p-4 text-white shadow-sm ring-1 ring-zinc-800">
-        <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-zinc-400">
+      <div className="rounded-lg bg-stone-900 p-4 text-white shadow-sm ring-1 ring-stone-800">
+        <div className="flex items-center justify-between text-[11px] font-medium uppercase tracking-wider text-stone-400">
           <span>{label}</span>
           {sparkline && sparkline.length > 0 ? (
             <Sparkline points={sparkline} color="oklch(0.75 0.13 145)" />
@@ -161,9 +161,9 @@ function KpiCard({
     );
   }
   return (
-    <div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-zinc-200">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">{label}</div>
-      <div className="mt-2 text-2xl font-bold text-zinc-900 tabular-nums">{value}</div>
+    <div className="rounded-lg bg-white p-4 shadow-sm ring-1 ring-stone-200">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-stone-500">{label}</div>
+      <div className="mt-2 text-2xl font-bold text-stone-900 tabular-nums">{value}</div>
       {delta && <div className={`mt-1 text-xs font-medium ${deltaClsLight}`}>{delta}</div>}
     </div>
   );
@@ -171,7 +171,7 @@ function KpiCard({
 
 function CicloDistribuicao({ kpis }: { kpis: KpisPayload }) {
   const totals: Array<{ key: Ciclo; label: string; count: number; color: string }> = [
-    { key: 'monthly',    label: 'mensal',      count: kpis.distribuicao.monthly,    color: 'bg-violet-500' },
+    { key: 'monthly',    label: 'mensal',      count: kpis.distribuicao.monthly,    color: 'bg-primary' },
     { key: 'quarterly',  label: 'trimestral',  count: kpis.distribuicao.quarterly,  color: 'bg-blue-500' },
     { key: 'semiannual', label: 'semestral',   count: kpis.distribuicao.semiannual, color: 'bg-cyan-500' },
     { key: 'yearly',     label: 'anual',       count: kpis.distribuicao.yearly,     color: 'bg-emerald-500' },
@@ -180,21 +180,21 @@ function CicloDistribuicao({ kpis }: { kpis: KpisPayload }) {
   const max = Math.max(...totals.map((t) => t.count), 1);
 
   return (
-    <div className="rounded-2xl bg-white p-4 shadow-sm ring-1 ring-zinc-200">
-      <div className="text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+    <div className="rounded-lg bg-white p-4 shadow-sm ring-1 ring-stone-200">
+      <div className="text-[11px] font-medium uppercase tracking-wider text-stone-500">
         Distribuição ciclos
       </div>
       <ul className="mt-3 space-y-1.5">
         {totals.map((t) => (
           <li key={t.key} className="flex items-center gap-2 text-xs">
-            <span className="w-20 text-zinc-600">{t.label}</span>
-            <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-zinc-100">
+            <span className="w-20 text-stone-600">{t.label}</span>
+            <div className="relative h-3 flex-1 overflow-hidden rounded-full bg-stone-100">
               <div
                 className={`absolute inset-y-0 left-0 ${t.color}`}
                 style={{ width: `${(t.count / max) * 100}%` }}
               />
             </div>
-            <span className="w-6 text-right font-mono tabular-nums text-zinc-700">{t.count}</span>
+            <span className="w-6 text-right font-mono tabular-nums text-stone-700">{t.count}</span>
           </li>
         ))}
       </ul>
@@ -209,7 +209,7 @@ function StatusBadge({ ativo }: { ativo: boolean }) {
       ativo
     </span>
   ) : (
-    <span className="inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] font-medium text-zinc-500 ring-1 ring-zinc-200">
+    <span className="inline-flex items-center gap-1 rounded-full bg-stone-100 px-2 py-0.5 text-[11px] font-medium text-stone-500 ring-1 ring-stone-200">
       <XCircle size={11} />
       inativo
     </span>
@@ -356,15 +356,15 @@ export default function PlanosIndex(props: PageProps) {
     <>
       <Head title="Planos · Cobrança Recorrente" />
 
-      <div className="min-h-screen bg-zinc-50 p-4 md:p-6">
+      <div className="min-h-screen bg-stone-50 p-4 md:p-6">
         {/* HEADER */}
         <header className="mb-4">
           <div className="flex flex-wrap items-end justify-between gap-4">
             <div>
-              <h1 className="text-2xl font-bold tracking-tight text-zinc-900">
+              <h1 className="text-2xl font-semibold tracking-tight text-stone-900">
                 Planos · cobrança recorrente
               </h1>
-              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-zinc-500">
+              <div className="mt-1 font-mono text-[11px] uppercase tracking-wider text-stone-500">
                 {kpis ? (
                   <>
                     {kpis.total_planos} PLANOS · {kpis.total_ativos} ATIVOS · MRR potencial {BRL(kpis.mrr_potencial)}
@@ -377,7 +377,7 @@ export default function PlanosIndex(props: PageProps) {
             <div className="flex items-center gap-2">
               <Link
                 href="/recurring-billing"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-2 text-sm font-medium text-zinc-700 shadow-sm ring-1 ring-zinc-200 hover:bg-zinc-50"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-2 text-sm font-medium text-stone-700 shadow-sm ring-1 ring-stone-200 hover:bg-stone-50"
               >
                 Voltar
               </Link>
@@ -385,17 +385,17 @@ export default function PlanosIndex(props: PageProps) {
                 type="button"
                 onClick={() => setShowCheatsheet(true)}
                 title="Atalhos teclado (?)"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-2 text-sm font-medium text-zinc-700 shadow-sm ring-1 ring-zinc-200 hover:bg-zinc-50"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-white px-3 py-2 text-sm font-medium text-stone-700 shadow-sm ring-1 ring-stone-200 hover:bg-stone-50"
               >
-                <kbd className="rounded bg-zinc-100 px-1 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">?</kbd>
+                <kbd className="rounded bg-stone-100 px-1 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">?</kbd>
               </button>
               <Link
                 href="/recurring-billing/planos/novo"
-                className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-violet-700"
+                className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-primary"
               >
                 <Plus size={14} />
                 Novo plano
-                <kbd className="ml-1 rounded bg-violet-700 px-1 text-[10px] font-mono">N</kbd>
+                <kbd className="ml-1 rounded bg-primary px-1 text-[10px] font-mono">N</kbd>
               </Link>
             </div>
           </div>
@@ -452,29 +452,29 @@ export default function PlanosIndex(props: PageProps) {
         </Deferred>
 
         {/* Tabela */}
-        <section className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-zinc-200">
+        <section className="overflow-hidden rounded-lg bg-white shadow-sm ring-1 ring-stone-200">
           {/* Toolbar */}
           <form
             onSubmit={handleSearch}
-            className="flex items-center gap-2 border-b border-zinc-200 p-2.5"
+            className="flex items-center gap-2 border-b border-stone-200 p-2.5"
           >
-            <div className="flex flex-1 items-center gap-2 rounded-lg bg-zinc-100 px-3 py-1.5">
-              <Search size={14} className="text-zinc-400" />
+            <div className="flex flex-1 items-center gap-2 rounded-lg bg-stone-100 px-3 py-1.5">
+              <Search size={14} className="text-stone-400" />
               <input
                 ref={searchRef}
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Buscar (/) — nome ou slug"
-                className="flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-400"
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-stone-400"
               />
-              <kbd className="rounded bg-white px-1.5 py-0.5 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">
+              <kbd className="rounded bg-white px-1.5 py-0.5 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">
                 /
               </kbd>
             </div>
             <button
               type="submit"
-              className="rounded-lg bg-zinc-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-zinc-800"
+              className="rounded-lg bg-stone-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-stone-800"
             >
               Buscar
             </button>
@@ -486,7 +486,7 @@ export default function PlanosIndex(props: PageProps) {
             ) : (
               <div className="overflow-x-auto">
                 <table className="w-full text-sm">
-                  <thead className="bg-zinc-50 text-[11px] font-semibold uppercase tracking-wider text-zinc-500">
+                  <thead className="bg-stone-50 text-[11px] font-semibold uppercase tracking-wider text-stone-500">
                     <tr>
                       <th className="px-4 py-2 text-left">Plano</th>
                       <th className="px-4 py-2 text-left">Ciclo</th>
@@ -497,34 +497,34 @@ export default function PlanosIndex(props: PageProps) {
                       <th className="px-4 py-2 text-right">Ações</th>
                     </tr>
                   </thead>
-                  <tbody className="divide-y divide-zinc-100">
+                  <tbody className="divide-y divide-stone-100">
                     {rows.map((p) => (
                       <tr
                         key={p.id}
                         onClick={() => setActiveId(p.id)}
                         className={`cursor-pointer transition ${
                           activeId === p.id
-                            ? 'border-l-2 border-l-violet-500 bg-violet-50/50'
-                            : 'hover:bg-zinc-50'
+                            ? 'border-l-2 border-l-primary bg-primary/50'
+                            : 'hover:bg-stone-50'
                         }`}
                       >
                         <td className="px-4 py-2.5">
-                          <div className="font-medium text-zinc-900">{p.name}</div>
-                          <div className="font-mono text-[11px] text-zinc-500">{p.slug}</div>
+                          <div className="font-medium text-stone-900">{p.name}</div>
+                          <div className="font-mono text-[11px] text-stone-500">{p.slug}</div>
                           {p.descricao_curta && (
-                            <div className="mt-0.5 text-[11px] text-zinc-500">{p.descricao_curta}</div>
+                            <div className="mt-0.5 text-[11px] text-stone-500">{p.descricao_curta}</div>
                           )}
                         </td>
-                        <td className="px-4 py-2.5 text-zinc-700">
+                        <td className="px-4 py-2.5 text-stone-700">
                           {CICLO_LABEL[p.ciclo] ?? p.ciclo_label}
                           {p.ciclo === 'custom' && p.ciclo_dias && (
-                            <span className="ml-1 text-[11px] text-zinc-500">({p.ciclo_dias}d)</span>
+                            <span className="ml-1 text-[11px] text-stone-500">({p.ciclo_dias}d)</span>
                           )}
                         </td>
-                        <td className="px-4 py-2.5 text-right font-mono tabular-nums text-zinc-900">
+                        <td className="px-4 py-2.5 text-right font-mono tabular-nums text-stone-900">
                           {BRLshort(p.valor)}
                         </td>
-                        <td className="px-4 py-2.5 text-center font-mono tabular-nums text-zinc-700">
+                        <td className="px-4 py-2.5 text-center font-mono tabular-nums text-stone-700">
                           {p.assinaturas_ativas_count}
                         </td>
                         <td className="px-4 py-2.5 text-center">
@@ -537,7 +537,7 @@ export default function PlanosIndex(props: PageProps) {
                           <div className="inline-flex items-center gap-1">
                             <Link
                               href={`/recurring-billing/planos/${p.id}/editar`}
-                              className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-100"
+                              className="inline-flex items-center gap-1 rounded px-2 py-1 text-xs text-stone-700 hover:bg-stone-100"
                               title="Editar"
                             >
                               <Pencil size={12} />
@@ -564,7 +564,7 @@ export default function PlanosIndex(props: PageProps) {
 
           {/* Footer paginação */}
           {plans && plans.meta.total > 0 && (
-            <div className="flex items-center justify-between border-t border-zinc-200 px-4 py-2 text-xs text-zinc-500">
+            <div className="flex items-center justify-between border-t border-stone-200 px-4 py-2 text-xs text-stone-500">
               <span>
                 {plans.meta.total} {plans.meta.total === 1 ? 'plano' : 'planos'} no total
               </span>
@@ -612,16 +612,16 @@ export default function PlanosIndex(props: PageProps) {
 function EmptyState() {
   return (
     <div className="p-12 text-center">
-      <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-violet-100">
-        <Plus size={20} className="text-violet-600" />
+      <div className="mx-auto mb-3 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
+        <Plus size={20} className="text-primary" />
       </div>
-      <div className="text-lg font-medium text-zinc-700">Nenhum plano cadastrado.</div>
-      <div className="mt-1 text-sm text-zinc-500">
+      <div className="text-lg font-medium text-stone-700">Nenhum plano cadastrado.</div>
+      <div className="mt-1 text-sm text-stone-500">
         Crie o primeiro plano pra começar a vincular assinaturas.
       </div>
       <Link
         href="/recurring-billing/planos/novo"
-        className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-700"
+        className="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-primary px-4 py-2 text-sm font-medium text-white hover:bg-primary"
       >
         <Plus size={14} />
         Criar primeiro plano
@@ -634,7 +634,7 @@ function KpiSkeleton() {
   return (
     <div className="mb-4 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
       {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="h-24 animate-pulse rounded-2xl bg-zinc-100" />
+        <div key={i} className="h-24 animate-pulse rounded-lg bg-stone-100" />
       ))}
     </div>
   );
@@ -642,15 +642,15 @@ function KpiSkeleton() {
 
 function ListSkeleton() {
   return (
-    <div className="divide-y divide-zinc-100">
+    <div className="divide-y divide-stone-100">
       {Array.from({ length: 5 }).map((_, i) => (
         <div key={i} className="flex items-center gap-3 px-4 py-3">
           <div className="flex-1 space-y-1">
-            <div className="h-3 w-40 animate-pulse rounded bg-zinc-200" />
-            <div className="h-2 w-24 animate-pulse rounded bg-zinc-100" />
+            <div className="h-3 w-40 animate-pulse rounded bg-stone-200" />
+            <div className="h-2 w-24 animate-pulse rounded bg-stone-100" />
           </div>
-          <div className="h-4 w-16 animate-pulse rounded-full bg-zinc-100" />
-          <div className="h-4 w-12 animate-pulse rounded bg-zinc-100" />
+          <div className="h-4 w-16 animate-pulse rounded-full bg-stone-100" />
+          <div className="h-4 w-12 animate-pulse rounded bg-stone-100" />
         </div>
       ))}
     </div>

--- a/resources/js/Pages/RecurringBilling/_components/CheatSheet.tsx
+++ b/resources/js/Pages/RecurringBilling/_components/CheatSheet.tsx
@@ -32,29 +32,29 @@ export default function CheatSheet({ onClose }: Props) {
       role="dialog"
       aria-modal="true"
       onClick={onClose}
-      className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/40 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/40 backdrop-blur-sm"
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="w-full max-w-sm rounded-2xl bg-white shadow-xl ring-1 ring-zinc-200"
+        className="w-full max-w-sm rounded-lg bg-white shadow-xl ring-1 ring-stone-200"
       >
-        <header className="flex items-center gap-2 border-b border-zinc-100 px-4 py-3">
-          <Keyboard size={14} className="text-zinc-600" />
-          <b className="flex-1 text-sm text-zinc-900">Atalhos · Cobrança recorrente</b>
-          <button type="button" onClick={onClose} aria-label="Fechar" className="rounded p-1 hover:bg-zinc-100">
-            <X size={14} className="text-zinc-500" />
+        <header className="flex items-center gap-2 border-b border-stone-100 px-4 py-3">
+          <Keyboard size={14} className="text-stone-600" />
+          <b className="flex-1 text-sm text-stone-900">Atalhos · Cobrança recorrente</b>
+          <button type="button" onClick={onClose} aria-label="Fechar" className="rounded p-1 hover:bg-stone-100">
+            <X size={14} className="text-stone-500" />
           </button>
         </header>
-        <ul className="grid grid-cols-1 divide-y divide-zinc-100">
+        <ul className="grid grid-cols-1 divide-y divide-stone-100">
           {SHORTCUTS.map(([k, l]) => (
             <li key={k} className="flex items-center justify-between px-4 py-2 text-xs">
-              <kbd className="rounded bg-zinc-100 px-2 py-0.5 font-mono text-[11px] text-zinc-700 ring-1 ring-zinc-200">{k}</kbd>
-              <span className="text-zinc-700">{l}</span>
+              <kbd className="rounded bg-stone-100 px-2 py-0.5 font-mono text-[11px] text-stone-700 ring-1 ring-stone-200">{k}</kbd>
+              <span className="text-stone-700">{l}</span>
             </li>
           ))}
         </ul>
-        <footer className="border-t border-zinc-100 px-4 py-2 text-center text-[10px] text-zinc-400">
-          Pressione <kbd className="rounded bg-zinc-100 px-1 ring-1 ring-zinc-200">?</kbd> para abrir · <kbd className="rounded bg-zinc-100 px-1 ring-1 ring-zinc-200">Esc</kbd> para fechar
+        <footer className="border-t border-stone-100 px-4 py-2 text-center text-[10px] text-stone-400">
+          Pressione <kbd className="rounded bg-stone-100 px-1 ring-1 ring-stone-200">?</kbd> para abrir · <kbd className="rounded bg-stone-100 px-1 ring-1 ring-stone-200">Esc</kbd> para fechar
         </footer>
       </div>
     </div>

--- a/resources/js/Pages/RecurringBilling/_components/CmdPalette.tsx
+++ b/resources/js/Pages/RecurringBilling/_components/CmdPalette.tsx
@@ -78,36 +78,36 @@ export default function CmdPalette({ subs, plans, onClose, onPick }: Props) {
   }, [results, sel, q, iaText, iaLoading]);
 
   return (
-    <div role="dialog" aria-modal="true" onClick={onClose} className="fixed inset-0 z-50 flex items-start justify-center bg-zinc-900/50 backdrop-blur-sm pt-32">
-      <div onClick={(e) => e.stopPropagation()} className="w-full max-w-2xl rounded-2xl bg-white shadow-2xl ring-1 ring-zinc-200 overflow-hidden">
-        <div className="flex items-center gap-2 border-b border-zinc-100 px-3 py-2.5">
-          <Search size={16} className="text-zinc-400" />
+    <div role="dialog" aria-modal="true" onClick={onClose} className="fixed inset-0 z-50 flex items-start justify-center bg-stone-900/50 backdrop-blur-sm pt-32">
+      <div onClick={(e) => e.stopPropagation()} className="w-full max-w-2xl rounded-lg bg-white shadow-2xl ring-1 ring-stone-200 overflow-hidden">
+        <div className="flex items-center gap-2 border-b border-stone-100 px-3 py-2.5">
+          <Search size={16} className="text-stone-400" />
           <input
             ref={inputRef}
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Buscar assinante, CNPJ, OS — ou perguntar à Jana"
-            className="flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-400"
+            className="flex-1 bg-transparent text-sm outline-none placeholder:text-stone-400"
           />
-          <kbd className="rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-mono text-zinc-500 ring-1 ring-zinc-200">Esc</kbd>
+          <kbd className="rounded bg-stone-100 px-1.5 py-0.5 text-[10px] font-mono text-stone-500 ring-1 ring-stone-200">Esc</kbd>
         </div>
         <ul className="max-h-96 overflow-y-auto py-1">
           {results.length === 0 && q.trim() && !iaText && !iaLoading && (
             <li className="p-4 text-center">
-              <p className="mb-2 text-sm text-zinc-500">Nada encontrado para "<b>{q}</b>".</p>
-              <button type="button" onClick={askIa} className="inline-flex items-center gap-1.5 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700">
+              <p className="mb-2 text-sm text-stone-500">Nada encontrado para "<b>{q}</b>".</p>
+              <button type="button" onClick={askIa} className="inline-flex items-center gap-1.5 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90">
                 <Sparkles size={12} /> Perguntar à Jana →
               </button>
             </li>
           )}
           {iaLoading && (
-            <li className="px-4 py-3 text-xs text-zinc-500">
+            <li className="px-4 py-3 text-xs text-stone-500">
               <Sparkles size={12} className="inline animate-pulse" /> Jana pensando…
             </li>
           )}
           {iaText && (
-            <li className="border-y border-violet-100 bg-violet-50/50 px-4 py-3 text-sm text-zinc-800">
-              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-violet-700">
+            <li className="border-y border-primary/20 bg-primary/5 px-4 py-3 text-sm text-stone-800">
+              <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-primary">
                 <Sparkles size={10} className="inline" /> Jana
               </div>
               <div className="whitespace-pre-wrap text-xs">{iaText}</div>
@@ -118,20 +118,20 @@ export default function CmdPalette({ subs, plans, onClose, onPick }: Props) {
               key={`${r.kind}-${r.id}`}
               onMouseEnter={() => setSel(i)}
               onClick={() => onPick(r)}
-              className={`flex cursor-pointer items-center gap-3 px-4 py-2 text-sm ${i === sel ? 'bg-violet-50' : 'hover:bg-zinc-50'}`}
+              className={`flex cursor-pointer items-center gap-3 px-4 py-2 text-sm ${i === sel ? 'bg-primary/10' : 'hover:bg-stone-50'}`}
             >
-              <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${r.kind === 'sub' ? 'bg-zinc-200 text-zinc-700' : 'bg-blue-200 text-blue-800'}`}>
+              <span className={`rounded px-1.5 py-0.5 text-[10px] font-semibold ${r.kind === 'sub' ? 'bg-stone-200 text-stone-700' : 'bg-blue-200 text-blue-800'}`}>
                 {r.kind === 'sub' ? 'assin.' : 'plano'}
               </span>
-              <b className="flex-1 truncate text-zinc-900">{r.label}</b>
-              <small className="truncate text-xs text-zinc-500">{(r as { sub: string }).sub}</small>
+              <b className="flex-1 truncate text-stone-900">{r.label}</b>
+              <small className="truncate text-xs text-stone-500">{(r as { sub: string }).sub}</small>
             </li>
           ))}
         </ul>
-        <footer className="flex items-center justify-between gap-2 border-t border-zinc-100 px-3 py-2 text-[10px] text-zinc-500">
-          <span><kbd className="rounded bg-zinc-100 px-1 ring-1 ring-zinc-200">↑↓</kbd> navegar</span>
-          <span><kbd className="rounded bg-zinc-100 px-1 ring-1 ring-zinc-200">↵</kbd> selecionar</span>
-          <span><kbd className="rounded bg-zinc-100 px-1 ring-1 ring-zinc-200">Esc</kbd> fechar</span>
+        <footer className="flex items-center justify-between gap-2 border-t border-stone-100 px-3 py-2 text-[10px] text-stone-500">
+          <span><kbd className="rounded bg-stone-100 px-1 ring-1 ring-stone-200">↑↓</kbd> navegar</span>
+          <span><kbd className="rounded bg-stone-100 px-1 ring-1 ring-stone-200">↵</kbd> selecionar</span>
+          <span><kbd className="rounded bg-stone-100 px-1 ring-1 ring-stone-200">Esc</kbd> fechar</span>
         </footer>
       </div>
     </div>

--- a/resources/js/Pages/RecurringBilling/_components/JanaPanel.tsx
+++ b/resources/js/Pages/RecurringBilling/_components/JanaPanel.tsx
@@ -54,9 +54,9 @@ export default function JanaPanel({ sub }: Props) {
   if (sub.status === 'cancelada') return null;
 
   return (
-    <div className="rounded-lg border border-violet-200 bg-gradient-to-br from-violet-50 to-white p-3">
+    <div className="rounded-lg border border-primary/30 bg-gradient-to-br from-primary/10 to-white p-3">
       <header className="mb-2 flex items-center gap-2">
-        <span className="inline-flex items-center gap-1 rounded bg-violet-200 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-violet-800">
+        <span className="inline-flex items-center gap-1 rounded bg-primary/20 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
           <Sparkles size={10} /> Jana · IA
         </span>
         <nav className="flex gap-1">
@@ -66,7 +66,7 @@ export default function JanaPanel({ sub }: Props) {
               type="button"
               onClick={() => setTab(t)}
               className={`rounded px-2 py-0.5 text-[11px] font-medium transition ${
-                tab === t ? 'bg-violet-600 text-white' : 'text-violet-700 hover:bg-violet-100'
+                tab === t ? 'bg-primary text-white' : 'text-primary hover:bg-primary/10'
               }`}
             >
               {t === 'sugerir' && isCritical && '⚠ '}
@@ -78,8 +78,8 @@ export default function JanaPanel({ sub }: Props) {
 
       {tab === 'sugerir' && (
         <div>
-          <div className="text-xs text-zinc-700">{clientDiagnostic(sub)}</div>
-          <button type="button" disabled title="Em breve" className="mt-2 rounded-lg bg-zinc-200 px-2 py-1 text-[11px] text-zinc-500">
+          <div className="text-xs text-stone-700">{clientDiagnostic(sub)}</div>
+          <button type="button" disabled title="Em breve" className="mt-2 rounded-lg bg-stone-200 px-2 py-1 text-[11px] text-stone-500">
             Aplicar sugestão (em breve)
           </button>
         </div>
@@ -87,7 +87,7 @@ export default function JanaPanel({ sub }: Props) {
 
       {tab === 'resumir' && (
         <div>
-          <pre className="whitespace-pre-wrap rounded bg-white p-2 text-[11px] text-zinc-700 ring-1 ring-zinc-200">{clientSummary(sub)}</pre>
+          <pre className="whitespace-pre-wrap rounded bg-white p-2 text-[11px] text-stone-700 ring-1 ring-stone-200">{clientSummary(sub)}</pre>
         </div>
       )}
 
@@ -100,19 +100,19 @@ export default function JanaPanel({ sub }: Props) {
               onChange={(e) => setIaQ(e.target.value)}
               onKeyDown={(e) => { if (e.key === 'Enter') ask(); }}
               placeholder="Pergunte sobre esta assinatura…"
-              className="flex-1 rounded border border-zinc-200 bg-white px-2 py-1 text-xs outline-none focus:border-violet-400"
+              className="flex-1 rounded border border-stone-200 bg-white px-2 py-1 text-xs outline-none focus:border-primary"
             />
             <button
               type="button"
               onClick={ask}
               disabled={iaLoading || !iaQ.trim()}
-              className="rounded-lg bg-violet-600 px-3 py-1 text-xs font-medium text-white hover:bg-violet-700 disabled:bg-zinc-300"
+              className="rounded-lg bg-primary px-3 py-1 text-xs font-medium text-white hover:opacity-90 disabled:bg-stone-300"
             >
               {iaLoading ? '…' : 'Enviar'}
             </button>
           </div>
           {iaResp && (
-            <div className="mt-2 whitespace-pre-wrap rounded bg-white p-2 text-xs text-zinc-700 ring-1 ring-violet-200">{iaResp}</div>
+            <div className="mt-2 whitespace-pre-wrap rounded bg-white p-2 text-xs text-stone-700 ring-1 ring-primary/30">{iaResp}</div>
           )}
         </div>
       )}

--- a/resources/js/Pages/RecurringBilling/_components/PresentationMode.tsx
+++ b/resources/js/Pages/RecurringBilling/_components/PresentationMode.tsx
@@ -36,52 +36,52 @@ export default function PresentationMode({ kpis, subs, plans, onClose }: Props) 
   const deltaPct = kpis.mrr_delta && kpis.mrr ? ((kpis.mrr_delta / Math.max(kpis.mrr - kpis.mrr_delta, 1)) * 100).toFixed(1) : '0';
 
   return (
-    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 overflow-y-auto bg-gradient-to-br from-zinc-900 via-zinc-950 to-zinc-900 text-white">
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 overflow-y-auto bg-gradient-to-br from-stone-900 via-stone-950 to-stone-900 text-white">
       <button type="button" onClick={onClose} className="fixed top-4 right-4 rounded-lg bg-white/10 px-3 py-1.5 text-xs hover:bg-white/20">
         Sair · Esc
       </button>
       <div className="mx-auto max-w-6xl px-8 py-12">
         <header className="mb-10 flex items-end justify-between">
           <div>
-            <h1 className="text-4xl font-bold tracking-tight">Oimpresso</h1>
-            <p className="text-sm text-zinc-400">Cobrança Recorrente · {new Date().toLocaleDateString('pt-BR', { day: '2-digit', month: 'long', year: 'numeric' })}</p>
+            <h1 className="text-4xl font-semibold tracking-tight">Oimpresso</h1>
+            <p className="text-sm text-stone-400">Cobrança Recorrente · {new Date().toLocaleDateString('pt-BR', { day: '2-digit', month: 'long', year: 'numeric' })}</p>
           </div>
         </header>
         <div className="grid grid-cols-4 gap-6">
-          <div className="col-span-2 rounded-2xl bg-emerald-500/10 p-6 ring-1 ring-emerald-500/30">
+          <div className="col-span-2 rounded-lg bg-emerald-500/10 p-6 ring-1 ring-emerald-500/30">
             <div className="text-[11px] uppercase tracking-wider text-emerald-300">MRR · receita recorrente mensal</div>
             <div className="mt-2 text-5xl font-bold tabular-nums">{BRL(kpis.mrr)}</div>
             <div className="mt-2 text-sm text-emerald-400">↑ {BRL(kpis.mrr_delta)} vs mês anterior · +{deltaPct}%</div>
           </div>
-          <div className="rounded-2xl bg-white/5 p-6 ring-1 ring-white/10">
-            <div className="text-[11px] uppercase tracking-wider text-zinc-400">Ativas</div>
+          <div className="rounded-lg bg-white/5 p-6 ring-1 ring-white/10">
+            <div className="text-[11px] uppercase tracking-wider text-stone-400">Ativas</div>
             <div className="mt-2 text-4xl font-bold tabular-nums">{kpis.active_count}</div>
           </div>
-          <div className="rounded-2xl bg-white/5 p-6 ring-1 ring-white/10">
-            <div className="text-[11px] uppercase tracking-wider text-zinc-400">Churn mês</div>
+          <div className="rounded-lg bg-white/5 p-6 ring-1 ring-white/10">
+            <div className="text-[11px] uppercase tracking-wider text-stone-400">Churn mês</div>
             <div className="mt-2 text-4xl font-bold tabular-nums text-amber-400">{kpis.churn_count}</div>
-            <div className="text-xs text-zinc-400">taxa {kpis.churn_rate}%</div>
+            <div className="text-xs text-stone-400">taxa {kpis.churn_rate}%</div>
           </div>
         </div>
         <section className="mt-10">
-          <h2 className="mb-4 text-xs uppercase tracking-wider text-zinc-400">Distribuição por plano</h2>
+          <h2 className="mb-4 text-xs uppercase tracking-wider text-stone-400">Distribuição por plano</h2>
           <ul className="space-y-3">
             {byPlan.map((p, i) => {
               const hue = PLAN_HUES[i % PLAN_HUES.length];
               return (
                 <li key={p.id} className="grid grid-cols-[200px_60px_1fr_120px] items-center gap-4 text-sm">
                   <span className="font-medium">{p.name}</span>
-                  <span className="text-zinc-400">{p.count} assin.</span>
+                  <span className="text-stone-400">{p.count} assin.</span>
                   <div className="h-2 overflow-hidden rounded-full bg-white/10">
                     <div className="h-full rounded-full" style={{ width: `${(p.mrr / maxMrr) * 100}%`, background: `oklch(0.65 0.15 ${hue})` }} />
                   </div>
-                  <span className="text-right font-mono tabular-nums">{BRL(p.mrr)}<small className="text-zinc-500">/mês</small></span>
+                  <span className="text-right font-mono tabular-nums">{BRL(p.mrr)}<small className="text-stone-500">/mês</small></span>
                 </li>
               );
             })}
           </ul>
         </section>
-        <footer className="mt-12 border-t border-white/10 pt-4 text-center text-xs text-zinc-500">
+        <footer className="mt-12 border-t border-white/10 pt-4 text-center text-xs text-stone-500">
           Modo apresentação · dados sensíveis ocultos · LTV total {BRLshort(kpis.total_ltv)}
         </footer>
       </div>

--- a/resources/js/Pages/RecurringBilling/_components/TourOnboarding.tsx
+++ b/resources/js/Pages/RecurringBilling/_components/TourOnboarding.tsx
@@ -38,36 +38,36 @@ export default function TourOnboarding({ onClose }: Props) {
   const isLast = step === STEPS.length - 1;
 
   return (
-    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-900/30 backdrop-blur-sm">
-      <div className="w-full max-w-md rounded-2xl bg-white shadow-2xl ring-1 ring-zinc-200">
-        <header className="flex items-center justify-between border-b border-zinc-100 px-4 py-3">
-          <div className="flex items-center gap-2 text-xs text-zinc-500">
-            <span className="rounded bg-violet-100 px-2 py-0.5 font-semibold text-violet-700">{step + 1}/{STEPS.length}</span>
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 flex items-center justify-center bg-stone-900/30 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-lg bg-white shadow-2xl ring-1 ring-stone-200">
+        <header className="flex items-center justify-between border-b border-stone-100 px-4 py-3">
+          <div className="flex items-center gap-2 text-xs text-stone-500">
+            <span className="rounded bg-primary/10 px-2 py-0.5 font-semibold text-primary">{step + 1}/{STEPS.length}</span>
             <span>Tour rápido</span>
           </div>
-          <button type="button" onClick={() => close(false)} aria-label="Fechar" className="rounded p-1 hover:bg-zinc-100">
-            <X size={14} className="text-zinc-500" />
+          <button type="button" onClick={() => close(false)} aria-label="Fechar" className="rounded p-1 hover:bg-stone-100">
+            <X size={14} className="text-stone-500" />
           </button>
         </header>
         <div className="px-6 py-6">
-          <h3 className="text-lg font-bold text-zinc-900">{cur.title}</h3>
-          <p className="mt-2 text-sm text-zinc-600">{cur.body}</p>
+          <h3 className="text-lg font-bold text-stone-900">{cur.title}</h3>
+          <p className="mt-2 text-sm text-stone-600">{cur.body}</p>
         </div>
-        <footer className="flex items-center justify-between gap-2 border-t border-zinc-100 px-4 py-3">
-          <button type="button" onClick={() => close(true)} className="text-xs text-zinc-500 hover:text-zinc-700">
+        <footer className="flex items-center justify-between gap-2 border-t border-stone-100 px-4 py-3">
+          <button type="button" onClick={() => close(true)} className="text-xs text-stone-500 hover:text-stone-700">
             Não mostrar mais
           </button>
           <div className="flex items-center gap-2">
-            <button type="button" onClick={() => setStep(Math.max(0, step - 1))} disabled={step === 0} className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-3 py-1.5 text-xs text-zinc-700 hover:bg-zinc-50 disabled:opacity-40">
+            <button type="button" onClick={() => setStep(Math.max(0, step - 1))} disabled={step === 0} className="inline-flex items-center gap-1 rounded-lg border border-stone-200 px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 disabled:opacity-40">
               <ChevronLeft size={12} /> Anterior
             </button>
             {!isLast && (
-              <button type="button" onClick={() => setStep(step + 1)} className="inline-flex items-center gap-1 rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700">
+              <button type="button" onClick={() => setStep(step + 1)} className="inline-flex items-center gap-1 rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90">
                 Próximo <ChevronRight size={12} />
               </button>
             )}
             {isLast && (
-              <button type="button" onClick={() => close(true)} className="rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700">
+              <button type="button" onClick={() => close(true)} className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90">
                 Começar
               </button>
             )}

--- a/resources/js/Pages/RecurringBilling/_components/TroubleshooterOverlay.tsx
+++ b/resources/js/Pages/RecurringBilling/_components/TroubleshooterOverlay.tsx
@@ -34,8 +34,8 @@ export default function TroubleshooterOverlay({ troubleId, onClose }: Props) {
 
   const step = trouble.steps[stepIdx];
   const Icon = ICONS[trouble.icon as TroubleshooterIcon] ?? User;
-  const barCls = HUE_BAR[trouble.hue] ?? 'bg-zinc-300';
-  const tagCls = HUE_TAG[trouble.hue] ?? 'bg-zinc-100 text-zinc-700';
+  const barCls = HUE_BAR[trouble.hue] ?? 'bg-stone-300';
+  const tagCls = HUE_TAG[trouble.hue] ?? 'bg-stone-100 text-stone-700';
 
   function pick(opt: { label: string; next: number }) {
     if (!step) return;
@@ -53,44 +53,44 @@ export default function TroubleshooterOverlay({ troubleId, onClose }: Props) {
       role="dialog"
       aria-modal="true"
       onClick={onClose}
-      className="fixed inset-0 z-50 flex items-start justify-center bg-zinc-900/60 backdrop-blur-sm pt-20"
+      className="fixed inset-0 z-50 flex items-start justify-center bg-stone-900/60 backdrop-blur-sm pt-20"
     >
       <div
         onClick={(e) => e.stopPropagation()}
-        className="relative w-full max-w-md max-h-[85vh] overflow-hidden rounded-2xl bg-white shadow-xl ring-1 ring-zinc-200 flex flex-col"
+        className="relative w-full max-w-md max-h-[85vh] overflow-hidden rounded-lg bg-white shadow-xl ring-1 ring-stone-200 flex flex-col"
       >
-        <header className="flex items-center gap-3 border-b border-zinc-100 px-4 py-3">
-          <Icon size={18} className="text-zinc-700" />
-          <h2 className="flex-1 text-sm font-semibold text-zinc-900">{trouble.title}</h2>
-          <button type="button" onClick={onClose} aria-label="Fechar" className="rounded p-1 hover:bg-zinc-100">
-            <X size={16} className="text-zinc-500" />
+        <header className="flex items-center gap-3 border-b border-stone-100 px-4 py-3">
+          <Icon size={18} className="text-stone-700" />
+          <h2 className="flex-1 text-sm font-semibold text-stone-900">{trouble.title}</h2>
+          <button type="button" onClick={onClose} aria-label="Fechar" className="rounded p-1 hover:bg-stone-100">
+            <X size={16} className="text-stone-500" />
           </button>
         </header>
         <div className={`h-1 w-full ${barCls}`} aria-hidden="true" />
         <div className="flex-1 overflow-y-auto px-4 py-4">
           {path.length > 0 && (
-            <ol className="mb-4 space-y-1.5 text-xs text-zinc-500">
+            <ol className="mb-4 space-y-1.5 text-xs text-stone-500">
               {path.map((p, i) => (
                 <li key={i} className="flex gap-2">
-                  <span className="text-zinc-400">{i + 1}.</span>
-                  <span><b className="text-zinc-700">{p.q}</b> → {p.answer}</span>
+                  <span className="text-stone-400">{i + 1}.</span>
+                  <span><b className="text-stone-700">{p.q}</b> → {p.answer}</span>
                 </li>
               ))}
             </ol>
           )}
           {step && step.opts && (
             <>
-              <div className="mb-3 text-sm font-medium text-zinc-900">{step.q}</div>
+              <div className="mb-3 text-sm font-medium text-stone-900">{step.q}</div>
               <ul className="space-y-2">
                 {step.opts.map((opt) => (
                   <li key={opt.label}>
                     <button
                       type="button"
                       onClick={() => pick(opt)}
-                      className="flex w-full items-center justify-between gap-2 rounded-lg border border-zinc-200 px-3 py-2 text-left text-sm text-zinc-700 hover:bg-violet-50 hover:border-violet-300"
+                      className="flex w-full items-center justify-between gap-2 rounded-lg border border-stone-200 px-3 py-2 text-left text-sm text-stone-700 hover:bg-primary/10 hover:border-primary/40"
                     >
                       {opt.label}
-                      <ChevronRight size={14} className="text-zinc-400" />
+                      <ChevronRight size={14} className="text-stone-400" />
                     </button>
                   </li>
                 ))}
@@ -102,19 +102,19 @@ export default function TroubleshooterOverlay({ troubleId, onClose }: Props) {
               <div className={`mb-2 inline-block rounded-md px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${tagCls}`}>
                 Ação recomendada
               </div>
-              <p className="text-sm leading-relaxed text-zinc-800">{step.final}</p>
+              <p className="text-sm leading-relaxed text-stone-800">{step.final}</p>
               <div className="mt-4 flex gap-2">
                 <button
                   type="button"
                   onClick={restart}
-                  className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-3 py-1.5 text-xs text-zinc-700 hover:bg-zinc-50"
+                  className="inline-flex items-center gap-1 rounded-lg border border-stone-200 px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50"
                 >
                   <RefreshCcw size={12} /> Recomeçar
                 </button>
                 <button
                   type="button"
                   onClick={onClose}
-                  className="rounded-lg bg-violet-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-violet-700"
+                  className="rounded-lg bg-primary px-3 py-1.5 text-xs font-medium text-white hover:opacity-90"
                 >
                   Concluído
                 </button>
@@ -122,7 +122,7 @@ export default function TroubleshooterOverlay({ troubleId, onClose }: Props) {
             </div>
           )}
         </div>
-        <footer className="border-t border-zinc-100 px-4 py-2 text-[10px] text-zinc-400">
+        <footer className="border-t border-stone-100 px-4 py-2 text-[10px] text-stone-400">
           Esc fecha
         </footer>
       </div>


### PR DESCRIPTION
## O que / Por quê

Conforma a **RecurringBilling** ao charter aprovado por [W] (`CobrancaRecorrente`, F2 2026-06-03) e ao **gabarito ds-v6** — **não copia o host**. A tela já tinha a estrutura certa (3 colunas filtros·lista·drawer lateral · sub-nav ao lado do primary · KPI hero · **sem page-header**); o gap era só a linguagem visual em **Tailwind cru**.

## Mata as 6 proibições do charter

| Proibição | Antes | Depois |
|---|---|---|
| cinza frio | `zinc-*` (132+) | `stone-*` (warm) |
| roxo errado | `violet-*` (38+) | `var(--accent)`/`primary` (foundations @theme) — alpha por shade (50/100→/10, 200/300→/20-/30, ≥400 sólido) |
| raio | `rounded-2xl` | `rounded-lg` (canon) |
| h1 | `font-bold` | `font-semibold` (peso normal, molde Financeiro) |
| hero | `bg-zinc-900` (cool) | `bg-stone-900` (warm) |

## Escopo

Index (hub Assinaturas) + sub-telas Planos/Faturas/Configurações + 6 overlays (`_components`) = **módulo inteiro consistente** (sem half-roxo/half-violet). **Token-only**: zero mudança de layout/lógica (alvo mínimo, L-28).

## Garantias

- **ESLint baseline: delta −92** (token utilities substituem arbitrary violet; 0 regressão).
- 0 resíduo `violet`/`zinc-`/`rounded-2xl` no módulo · 0 token malformado.

## Gate antes do merge

⏸️ **Aguarda screenshot (claro + dark) pra [W] aprovar** (gate F3 · ADR 0107). O visual-regression do CI gera o comparativo. Não mergear sem o OK visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)