### PR TITLE
fix(sells): parsear transaction_date d/m/Y do Inertia (venda sumia da consulta)

### DIFF
--- a/app/Http/Controllers/SellPosController.php
+++ b/app/Http/Controllers/SellPosController.php
@@ -447,19 +447,37 @@ class SellPosController extends Controller
                     ]);
                     $input['transaction_date'] = \Carbon::now();
                 } else {
-                    // 2026-06-04 (Wagner) — uf_date pode devolver vazio/inválido se o valor
-                    // vier num formato que não bate com o date_format do business (bug do
-                    // campo "Data da venda" vazio no /sells/create). Sem isso, a venda grava
-                    // com transaction_date nulo/0000 e SOME da consulta (filtra por data).
-                    try {
-                        $parsedDate = $this->productUtil->uf_date($request->input('transaction_date'), true);
-                    } catch (\Throwable $e) {
-                        $parsedDate = null;
+                    // 2026-06-04 (Wagner) — a venda gravava com transaction_date inválido e
+                    // SUMIA da consulta (que filtra por data). Causa: o form Inertia
+                    // (/sells/create) envia SEMPRE "d/m/Y H:i" (guard R9), mas uf_date()
+                    // parseia com o date_format do business — se o business usa OUTRO
+                    // formato (ex: Martinho), o uf_date mis-parseia / devolve vazio e a
+                    // data grava nula/0000.
+                    // Fix: quando o valor bate o padrão d/m/Y H:i do Inertia, parsear
+                    // explícito com Carbon (independente do date_format). Só cai no uf_date
+                    // legacy (POS Blade) quando NÃO é o formato do Inertia.
+                    $rawDate = (string) $request->input('transaction_date');
+                    $parsedDate = null;
+                    if (preg_match('#^(\d{2})/(\d{2})/(\d{4})\s+(\d{2}):(\d{2})#', $rawDate, $m)) {
+                        try {
+                            $parsedDate = \Carbon::createFromFormat(
+                                'd/m/Y H:i',
+                                "{$m[1]}/{$m[2]}/{$m[3]} {$m[4]}:{$m[5]}"
+                            );
+                        } catch (\Throwable $e) {
+                            $parsedDate = null;
+                        }
+                    } else {
+                        try {
+                            $parsedDate = $this->productUtil->uf_date($rawDate, true);
+                        } catch (\Throwable $e) {
+                            $parsedDate = null;
+                        }
                     }
                     if (empty($parsedDate) || strtotime((string) $parsedDate) === false) {
                         \Log::warning('SellPosController@store transaction_date não-parseável — fallback Carbon::now()', [
                             'business_id' => $business_id ?? null,
-                            'raw_value' => json_encode($request->input('transaction_date')),
+                            'raw_value' => json_encode($rawDate),
                         ]);
                         $parsedDate = \Carbon::now();
                     }


### PR DESCRIPTION
## Problema (prod, biz Martinho)
Wagner: *"fiz uma venda e nao apareceu na consulta"* — reproduzido: ao salvar pelo `/sells/create`, o POST redireciona pra `/sells` (sucesso, sem erro de validação), **mas a venda nunca aparece** na lista (conta segue estável; topo continua em datas antigas; "faturado hoje: 0 vendas").

## Causa-raiz
A venda **é criada**, mas com `transaction_date` inválido → some da consulta, que filtra `whereBetween(transaction_date, ...)`.

O form Inertia (`Sells/Create.tsx`) envia `transaction_date` SEMPRE no formato `d/m/Y H:i` (garantido pelo guard R9). Mas o backend chamava `uf_date()`, que parseia usando o **date_format do business**. Quando o business usa outro formato, `uf_date` mis-parseia ou devolve vazio → data nula/0000 → venda invisível. O PR anterior (#2208) corrigiu só o **display** do campo (mostrar hoje) e o caso vazio — não o mis-parse.

## Fix
`SellPosController@store`: quando `transaction_date` bate o padrão `d/m/Y H:i` do Inertia, parsear **explícito** com `Carbon::createFromFormat('d/m/Y H:i', ...)`, independente do `date_format`. Fallback `uf_date` legacy só pro POS Blade (valores fora desse padrão). Mantém o net final `Carbon::now()` se nada parsear.

## Escopo
- Backend-only (1 arquivo PHP). Sem mudança de frontend, schema ou migration.
- Não toca multi-tenant (business_id intacto).

## Validação pós-merge
1. `/sells/create` → adicionar produto → Salvar.
2. Conferir que a venda aparece no topo de `/sells` com a data de hoje.
3. Regressão: venda via POS Blade (`/pos/create`) continua gravando data correta.

## Follow-up (não neste PR)
Vendas órfãs já criadas com data inválida (tentativas do Wagner + 1 de teste "pistao R$1,25") seguem invisíveis — precisam de backfill da data. Proponho comando idempotente `sells:fix-null-dates {biz}` em PR separado.

<!-- no-ui-smoke: mudança backend-only (parse de data); validação é via consulta /sells, screenshot incluído no follow-up de verificação -->