### PR TITLE
feat(qa): especialista de tela + catraca de cobertura sustentável (proposta)

### DIFF
--- a/.claude/agents/screen-qa-specialist.md
+++ b/.claude/agents/screen-qa-specialist.md
@@ -1,0 +1,58 @@
+---
+name: screen-qa-specialist
+description: ATIVAR quando Wagner pedir "garantir QA da tela X", "testar a tela Y de ponta a ponta", "cobrir a tela Z", "/screen-qa <Mod>/<Tela>", "especialista de teste na tela W", "subir a cobertura de telas", OU como passo de QA antes de marcar uma US de tela como done. Especialista Full Tester + QA que pega UMA tela Inertia e a leva à cobertura sustentável — nota (screen-grade 16-dim por persona) + E2E (Pest 4 Browser) + acessibilidade (axe) + regressão visual + smoke prod — e deixa cada ganho TRAVADO por catraca (impossível regredir sem decisão consciente). Espelha o ciclo agentic Planner→Automator→Maintainer (estado-da-arte 2026) adaptado às regras Tier 0 do oimpresso. NÃO commita, NÃO roda teste local (CT 100 only), NÃO edita a Page sem charter + gate visual Wagner.\n\n<example>\nContext: Wagner quer garantir a tela de venda end-to-end antes de fechar o cycle.\nuser: "/screen-qa Sells/Create"\nassistant: "Spawn screen-qa-specialist — roda o Pré-Flight + screen-grade (nota/persona Larissa), deriva os casos E2E do charter, gera o Pest Browser test com viewports 1280/1440, injeta axe, captura baseline visual, e entrega scorecard YAML + gaps rankeados. Wagner aprova o screenshot antes de qualquer Edit."\n</example>\n\n<example>\nContext: tela nova entrou sem cobertura.\nuser: "cobre a tela nova de Financeiro/Conciliacao"\nassistant: "Spawn screen-qa-specialist — se faltar charter, PARA e chama charter-write; depois nota + E2E + axe + visual + smoke, e atualiza o baseline da catraca."\n</example>\n\nNÃO usar pra: bug tático numa tela já coberta (Edit direto), auditoria de módulo inteiro (use capterra-senior), ou pesquisa genérica (use estado-da-arte).
+model: opus
+color: green
+tools: Read, Grep, Glob, Bash, Write, Edit
+---
+
+Você é o `screen-qa-specialist` do Wagner — o especialista Full Tester + QA **por tela** do oimpresso (ERP modular Laravel 13.6 + Inertia v3 + React 19, multi-tenant `business_id`, persona-aware). Você não "acha que testou": você deixa prova versionada e travada.
+
+> **Princípio-mãe:** cobertura não é um número que você atinge — é um equilíbrio contra a entropia. Toda passagem sua deve deixar a tela **mais coberta e impossível de regredir sem alguém decidir**. Se o seu trabalho pode apodrecer sozinho, você não terminou.
+
+## Entrada
+Um caminho de tela `<Mod>/<Tela>` (ex: `Sells/Create`). Se vier vago, resolva via `screen-coverage-baseline.json` (telas com menor cobertura primeiro) e confirme com Wagner.
+
+## Ciclo agentic (Planner → Automator → Maintainer), ordem fixa
+
+### 0 · PRÉ-FLIGHT (read-only) — não inventar, não repetir erro
+Rode o resolvedor da skill [`screen-grade`](../skills/screen-grade/SKILL.md) (4 blocos do `prototipo-ui/PRE-FLIGHT-TELA.md`): arquétipo + persona (de `personas-por-modulo.yml`) + charter + golden + tokens DS v4 + injeção dos anti-padrões (`LICOES_F3_FINANCEIRO_REJEITADO.md`, `PRE-MERGE-UI.md`, `proibicoes.md §UI`).
+- **Sem charter → PARE** e chame `charter-write`. Charter é o oráculo: sem ele, o teste não sabe o que é "correto".
+
+### 1 · NOTA (screen-grade 16-dim) — onde estamos
+Aplique o método `SCREEN-GRADE-METODO.md` ponderado pela persona. Persista o **scorecard YAML** em `memory/governance/scorecards/screens/<modulo>-<tela>.yaml` (hoje esse diretório está VAZIO — 0/275). Cada dimensão fraca cita ≥1 best-of-class **com o mecanismo** (não basta nomear Linear/Stripe).
+
+### 2 · PLANNER — derivar os casos do charter
+Leia o charter (Mission/Goals/Non-Goals/Anti-hooks) e o Controller real (`Inertia::render` props). Derive a lista mínima de **fluxos críticos** da persona (caminho feliz + 2-3 bordas que importam pra ela). Não invente fluxo que a tela não tem.
+
+### 3 · AUTOMATOR — gerar o E2E (Pest 4 Browser)
+Escreva/atualize `tests/Browser/<Mod>/<Tela>Test.php`:
+- viewports **1280** (Larissa/ROTA LIVRE) **e 1440**;
+- asserções vindas do charter, não de chute;
+- **smoke biz=1** ([ADR 0101](../../memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md)) — NUNCA biz=4;
+- baseline visual via `toHaveScreenshot`/snapshot (a atualização de baseline exige aprovação humana — anti-drift);
+- injete **axe** (`@axe-core` / accessibility) e asserte zero violação crítica WCAG.
+- ⛔ **Você NÃO roda o teste local** (Pest/PHPStan são CT 100 only — `memory/proibicoes.md`). Você gera o arquivo; a catraca/CI roda no CT 100. Se precisar de execução, instrua o comando `tailscale ssh root@ct100-mcp "docker exec ... pest tests/Browser/<...>"`.
+
+### 4 · SMOKE PROD (runtime real) — claim com evidência
+Via browser MCP (Claude_in_Chrome / computer-use), abra a rota em prod, screenshot 1280+1440, console errors, perf. Cole a evidência (status HTTP literal — `memory/proibicoes.md §Claim sem evidência`). Opcional: `php artisan ui:judge-pr <PR>` (LLM 9-dim semântico).
+
+### 5 · ENTREGA
+Scorecard YAML + tabela 16-dim + gaps por impacto×esforço (ondas) + **diff dos testes gerados**. Atualize o baseline: `node scripts/qa/screen-coverage-map.mjs --json`. Proponha o batch `tasks-create` dos gaps — **Wagner aprova 1×** (publication-policy). Você **não cria tasks nem commita** sozinho.
+
+## Sobrevivência (os 4 anéis que você SEMPRE deixa armados)
+Sua entrega só conta se estes quatro estiverem ativos pra a tela:
+1. **Catraca de nota** — o scorecard YAML versionado é o baseline; `module-grades-gate` (espelhado para telas) bloqueia PR que derrube a nota.
+2. **Catraca de cobertura** — `scripts/qa/screen-coverage-map.mjs --check` falha o CI se telas-com-E2E/charter/a11y/scorecard regredirem. Tela nova sem teste = PR vermelho.
+3. **Sentinela de freshness** — charter/baseline/teste com idade > limiar acende flag no Daily Brief ("CHARTERS APODRECENDO" já existe; estenda pra "TELAS SEM RE-SMOKE"). Cron daily 09:00 BRT re-smoka telas live ≥7d.
+4. **Self-healing (Maintainer)** — quando o `.tsx` muda, você é re-disparado pra **regenerar** o E2E e propor o novo baseline visual, em vez de deixar o teste quebrar e esperar um humano.
+
+> Sem os 4 anéis, você entregou cobertura que apodrece. Com eles, a nota agregada do sistema **sobe sozinha** porque regredir exige decisão consciente.
+
+## Guardrails Tier 0
+- ⛔ Não rodar Pest/PHPStan local nem Hostinger — **CT 100 only**.
+- ⛔ Não editar a Page (`.tsx`) sem charter + **gate visual Wagner aprova screenshot** (R2/R7). Você é QA, não refator visual.
+- ⛔ Smoke sempre **biz=1**, nunca biz=4 (Larissa) — ADR 0101.
+- ⛔ Zero git ops (commit/push/branch). Você só Read/Grep/Glob/Bash/Write/Edit; o parent consolida.
+- ⛔ Não auto-aprovar baseline visual — drift de baseline mata o gate.
+- ⛔ Não inventar token/Model/componente — só o que o Pré-Flight materializou.

--- a/memory/decisions/proposals/screen-qa-specialist-sustentavel.md
+++ b/memory/decisions/proposals/screen-qa-specialist-sustentavel.md
@@ -1,0 +1,79 @@
+---
+slug: screen-qa-specialist-sustentavel
+title: "Especialista Full Tester + QA por tela com sobrevivência embutida (catraca + sentinela + dono + self-healing)"
+type: adr
+status: proposed
+authority: canonical
+lifecycle: proposta
+decided_by:
+  - W
+quarter: 2026-Q2
+related:
+  - '0108'
+  - '0101'
+  - '0230'
+  - '0231'
+  - '0232'
+pii: false
+---
+
+# ADR (proposta) — QA-de-tela sustentável: especialista por tela + 4 anéis de sobrevivência
+
+**Status:** 🟡 Proposta (aguarda aceite Wagner)
+**Complementa:** [0108](../0108-regressao-visual-pest-browser-tier-2.md) (visual regression Tier 2), [0101](../0101-sistema-charter-capterra-governanca-escopo.md) (smoke biz=1), [0230](../0230-metodo-governance-scorecard.md)/[0231](../0231-processo-trabalho-canonico-especialista-por-area.md)/[0232](../0232-modelo-peso-real-classificacao-por-meta.md) (scorecard/especialista/peso real)
+
+---
+
+## Contexto
+
+Pedido do Wagner (2026-06-04): garantir cobertura de QA das telas com um "especialista Full Tester + QA" por tela, comparado ao estado-da-arte, e — crucial — **que sobreviva e evolua no tempo**.
+
+Baseline factual medido (`scripts/qa/screen-coverage-map.mjs`, 2026-06-04):
+
+| Camada | Cobertura | Leitura |
+|---|---|---|
+| Telas Inertia | 275 | universo |
+| Charter (contrato) | 132/275 (48%) | metade tem oráculo |
+| E2E (Pest Browser) | **3/275 (1,1%)** | buraco crítico |
+| A11Y (axe) | **0/275 (0%)** | inexistente |
+| Scorecard (nota persistida) | **0/275 (0%)** | método existe, nunca persistido |
+
+O paradoxo: o oimpresso **já desenhou** a camada de QA-de-tela (skills `screen-grade` 16-dim, `pr-ui-judge`, `tela-smoke-pos-merge`; ADR 0108; runner Pest Browser/Playwright instalado) mas a **execução está off/manual**: `visual-regression.yml` em `continue-on-error` (não bloqueia), `pr-ui-judge.yml` com kill-switch OFF, smoke pós-merge semi-manual. QA de **backend** é forte (1.177 testes, multi-tenant-gate); QA de **tela** está em ~34/100.
+
+**O problema central não é atingir 100% — é não regredir depois.** Cobertura sem mecanismo apodrece pelos 4 modos: cobertura regride (tela nova sem teste), flakiness (gate é desligado), baseline drift (snapshot vira carimbo), oráculo stale (charter desatualizado). Entropia ganha por padrão.
+
+## Decisão
+
+1. **Agente `screen-qa-specialist`** (`.claude/agents/`) — especialista Opus por tela, ciclo agentic **Planner → Automator → Maintainer** (estado-da-arte 2026: QA Wolf/Autonoma) adaptado às regras Tier 0: Pré-Flight → nota (screen-grade) → derivar casos do charter → gerar Pest Browser (viewports 1280/1440, biz=1) → axe + baseline visual → smoke prod com evidência → scorecard YAML + gaps. Não commita, não roda teste local (CT 100 only), não edita Page sem gate visual.
+
+2. **Catraca de cobertura** (`scripts/qa/screen-coverage-map.mjs`) — `--json` grava `memory/governance/screen-coverage-baseline.json`; `--check` falha o CI se charter/e2e/a11y/scorecard agregados regredirem. **Telas cobertas só sobem.**
+
+3. **Sobrevivência embutida** (seção abaixo) — não é promessa, é mecanismo, espelhando o `module-grades-gate` que o time já confia.
+
+## Sobrevivência — os 4 anéis (o coração desta ADR)
+
+| Anel | Mecanismo | Espelha o que já existe | Estado |
+|---|---|---|---|
+| **1. Catraca de nota** | scorecard YAML versionado vira baseline; gate bloqueia PR que derrube a nota da tela | `module-grades-gate.yml` | a criar (`screen-grades-gate`) |
+| **2. Catraca de cobertura** | `screen-coverage-map.mjs --check` no CI; tela nova sem teste = PR vermelho | governance append-only / drift gate | ✅ script entregue, falta wire no CI |
+| **3. Sentinela de freshness** | charter/baseline/teste > limiar → flag no Daily Brief; cron 09:00 re-smoka telas live ≥7d | seção "CHARTERS APODRECENDO" do brief + cron `tela-smoke` | parcial (estender pra "TELAS SEM RE-SMOKE") |
+| **4. Self-healing (Maintainer)** | `.tsx` muda → agente re-disparado regenera E2E + propõe novo baseline visual | `screen-smoke-after-merge.yml` (detecta diff) | a ligar (hoje só comenta "pendente") |
+
+**Métrica-mãe** (no Daily Brief, igual cycle goals): **`% de telas ≥ nota 70` e `% de telas com E2E`** — trackadas no tempo. Evolução do critério é versionada: quando o estado-da-arte mudar (ex: Visual-AI virar padrão), adiciona-se uma dimensão ao método 16-dim → a catraca recalibra → todas as telas reavaliadas. O QA acompanha o estado-da-arte porque o critério é doc vivo (score-as-code), não número congelado.
+
+## Roadmap de ativação (ondas, por impacto×esforço)
+
+- **Onda 0 (feito nesta proposta):** script de cobertura + baseline + agente + esta ADR.
+- **Onda 1:** wire `screen-coverage-map.mjs --check` no CI (anel 2) + desbloquear `visual-regression.yml` (tirar `continue-on-error`, resolver migration-order legacy).
+- **Onda 2:** piloto end-to-end numa tela P0 (`Sells/Create`, tela-ouro) — primeiro scorecard YAML + primeiro E2E com axe → prova o fluxo do agente.
+- **Onda 3:** `screen-grades-gate` (anel 1) + métrica-mãe no brief (anel 3 estendido).
+- **Onda 4:** self-healing — ligar `screen-smoke-after-merge` pra invocar o agente (anel 4).
+- **Onda 5+:** rolar agente por módulos P0 (Sells → Financeiro → NfeBrasil → Ponto), catraca subindo a cada PR.
+
+## Consequências
+
+**Positivas:** cobertura passa a ser monotônica (só sobe); QA-de-tela vira ativo durável, não esforço heróico; reusa 80% do que já existe (não reinventa); especialista por tela operacionaliza a filosofia ADR 0231.
+
+**Custos/riscos:** Pest Browser roda só no CT 100 (CI já está lá); baseline visual exige curadoria humana (anti-drift = atrito intencional); a11y automatizado pega só ~30-40% das violações WCAG (não substitui revisão humana — apenas trava o piso).
+
+**Não-objetivos:** substituir QA humano de exploração; rodar testes na máquina local; tornar a catraca um número congelado.

--- a/memory/governance/screen-coverage-baseline.json
+++ b/memory/governance/screen-coverage-baseline.json
@@ -1,0 +1,285 @@
+{
+  "generated_note": "baseline da catraca de cobertura — NÃO editar à mão",
+  "aggregates": {
+    "total": 275,
+    "charter": 132,
+    "e2e": 3,
+    "a11y": 0,
+    "scorecard": 0
+  },
+  "by_module": {
+    "Admin": {
+      "total": 8,
+      "charter": 8,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "ads": {
+      "total": 19,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Atendimento": {
+      "total": 9,
+      "charter": 6,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Auditoria": {
+      "total": 2,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Cliente": {
+      "total": 34,
+      "charter": 7,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Compras": {
+      "total": 5,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "ComunicacaoVisual": {
+      "total": 1,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "ConsultaOs": {
+      "total": 1,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Essentials": {
+      "total": 13,
+      "charter": 3,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Financeiro": {
+      "total": 23,
+      "charter": 12,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Fiscal": {
+      "total": 8,
+      "charter": 7,
+      "e2e": 1,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "governance": {
+      "total": 6,
+      "charter": 6,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Home": {
+      "total": 1,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Jana": {
+      "total": 17,
+      "charter": 8,
+      "e2e": 1,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "kb": {
+      "total": 3,
+      "charter": 3,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Manufacturing": {
+      "total": 1,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "MemCofre": {
+      "total": 6,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Modules": {
+      "total": 1,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "NfeBrasil": {
+      "total": 6,
+      "charter": 4,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Nfse": {
+      "total": 3,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "OficinaAuto": {
+      "total": 11,
+      "charter": 11,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Ponto": {
+      "total": 22,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Produto": {
+      "total": 8,
+      "charter": 8,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "ProjectMgmt": {
+      "total": 9,
+      "charter": 3,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Purchase": {
+      "total": 4,
+      "charter": 2,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "RecurringBilling": {
+      "total": 6,
+      "charter": 6,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Repair": {
+      "total": 13,
+      "charter": 12,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Sells": {
+      "total": 8,
+      "charter": 8,
+      "e2e": 1,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Settings": {
+      "total": 2,
+      "charter": 2,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Site": {
+      "total": 7,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "StockAdjustment": {
+      "total": 2,
+      "charter": 2,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "StockTransfer": {
+      "total": 2,
+      "charter": 2,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "superadmin": {
+      "total": 2,
+      "charter": 2,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Tarefas": {
+      "total": 1,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "team-mcp": {
+      "total": 3,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "TransactionPayment": {
+      "total": 3,
+      "charter": 3,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Vestuario": {
+      "total": 1,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "Whatsapp": {
+      "total": 2,
+      "charter": 1,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    },
+    "_Showcase": {
+      "total": 2,
+      "charter": 0,
+      "e2e": 0,
+      "a11y": 0,
+      "scorecard": 0
+    }
+  }
+}

--- a/scripts/qa/screen-coverage-map.mjs
+++ b/scripts/qa/screen-coverage-map.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * screen-coverage-map.mjs — mapa de cobertura de QA por tela + baseline da catraca.
+ *
+ * Cruza as 4 camadas de garantia que uma tela Inertia pode ter:
+ *   1. CHARTER   — contrato vivo (<Tela>.charter.md ao lado do .tsx)
+ *   2. E2E       — referência da tela em tests/Browser/**.php (Pest 4 Browser/Playwright)
+ *   3. SCORECARD — nota persistida (memory/governance/scorecards/screens/*.yaml)
+ *   4. A11Y      — referência da tela em teste que injeta axe (heurística: "axe" no arquivo E2E)
+ *
+ * Saídas:
+ *   - stdout: resumo por módulo + agregados (read-only, sem efeito colateral)
+ *   - --json: escreve memory/governance/screen-coverage-baseline.json (o que a CATRACA lê)
+ *
+ * É o Passo 0 da sobrevivência (ADR proposto screen-qa-specialist-sustentavel):
+ * a catraca de cobertura compara o estado de um PR contra este baseline e
+ * BLOQUEIA se qualquer agregado regredir (telas cobertas só sobem).
+ *
+ * Uso:
+ *   node scripts/qa/screen-coverage-map.mjs            # só relatório
+ *   node scripts/qa/screen-coverage-map.mjs --json     # + grava baseline
+ *   node scripts/qa/screen-coverage-map.mjs --check    # falha (exit 1) se regrediu vs baseline
+ */
+
+import { readFileSync, readdirSync, statSync, writeFileSync, existsSync } from 'node:fs';
+import { join, relative, sep, basename } from 'node:path';
+
+const ROOT = process.cwd();
+const PAGES_DIR = join(ROOT, 'resources', 'js', 'Pages');
+const BROWSER_DIR = join(ROOT, 'tests', 'Browser');
+const SCORECARD_DIR = join(ROOT, 'memory', 'governance', 'scorecards', 'screens');
+const BASELINE = join(ROOT, 'memory', 'governance', 'screen-coverage-baseline.json');
+
+const flags = new Set(process.argv.slice(2));
+
+/** Lista recursiva de arquivos sob `dir` cujo nome casa `match`. */
+function walk(dir, match, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) walk(full, match, acc);
+    else if (match(full)) acc.push(full);
+  }
+  return acc;
+}
+
+// 1. Universo de telas: Pages/**/*.tsx, exceto _components/ e *.charter.* e *.test.*
+const isScreen = (f) =>
+  f.endsWith('.tsx') &&
+  !f.includes(`${sep}_components${sep}`) &&
+  !f.includes(`${sep}Partials${sep}`) &&
+  !f.endsWith('.charter.tsx') &&
+  !f.includes('.test.');
+const screens = walk(PAGES_DIR, isScreen);
+
+// 2. Corpus de E2E (conteúdo concatenado pra busca de referência).
+const browserFiles = walk(BROWSER_DIR, (f) => f.endsWith('.php'));
+const browserCorpus = browserFiles
+  .map((f) => ({ file: f, body: readFileSync(f, 'utf8') }))
+  .map((x) => ({ ...x, hasAxe: /axe|accessibilit/i.test(x.body) }));
+
+// 3. Scorecards existentes (slug modulo-tela).
+const scorecards = new Set(
+  walk(SCORECARD_DIR, (f) => f.endsWith('.yaml') || f.endsWith('.yml')).map((f) =>
+    basename(f).replace(/\.(ya?ml)$/, '').toLowerCase(),
+  ),
+);
+
+/** Uma tela é "referenciada" por um E2E se o caminho relativo do Page (Mod/Tela) aparece no body. */
+function e2eFor(relTsx) {
+  const key = relTsx.replace(/\.tsx$/, ''); // ex: Sells/Create
+  const keyAlt = key.replace(/\//g, '\\');
+  const name = basename(key); // ex: Create
+  return browserCorpus.filter(
+    (b) => b.body.includes(key) || b.body.includes(keyAlt) || new RegExp(`['"\`/]${name}['"\`]`).test(b.body),
+  );
+}
+
+const rows = screens.map((abs) => {
+  const relTsx = relative(PAGES_DIR, abs).split(sep).join('/');
+  const mod = relTsx.split('/')[0];
+  const charter = existsSync(abs.replace(/\.tsx$/, '.charter.md'));
+  const e2e = e2eFor(relTsx);
+  const slug = relTsx.replace(/\.tsx$/, '').replace(/\//g, '-').toLowerCase();
+  return {
+    screen: relTsx,
+    module: mod,
+    charter,
+    e2e: e2e.length > 0,
+    a11y: e2e.some((b) => b.hasAxe),
+    scorecard: scorecards.has(slug),
+  };
+});
+
+// Agregados.
+const total = rows.length;
+const pct = (n) => (total ? Math.round((n / total) * 1000) / 10 : 0);
+const agg = {
+  total,
+  charter: rows.filter((r) => r.charter).length,
+  e2e: rows.filter((r) => r.e2e).length,
+  a11y: rows.filter((r) => r.a11y).length,
+  scorecard: rows.filter((r) => r.scorecard).length,
+};
+
+// Por módulo.
+const byModule = {};
+for (const r of rows) {
+  const m = (byModule[r.module] ??= { total: 0, charter: 0, e2e: 0, a11y: 0, scorecard: 0 });
+  m.total++;
+  if (r.charter) m.charter++;
+  if (r.e2e) m.e2e++;
+  if (r.a11y) m.a11y++;
+  if (r.scorecard) m.scorecard++;
+}
+
+// --- Relatório stdout ---
+console.log(`\n=== Mapa de cobertura QA-de-tela · ${total} telas ===\n`);
+console.log(`  CHARTER (contrato)   : ${agg.charter}/${total}  (${pct(agg.charter)}%)`);
+console.log(`  E2E (Pest Browser)   : ${agg.e2e}/${total}  (${pct(agg.e2e)}%)`);
+console.log(`  A11Y (axe no E2E)    : ${agg.a11y}/${total}  (${pct(agg.a11y)}%)`);
+console.log(`  SCORECARD (nota)     : ${agg.scorecard}/${total}  (${pct(agg.scorecard)}%)\n`);
+
+const mods = Object.entries(byModule).sort((a, b) => b[1].total - a[1].total);
+console.log('  Módulo'.padEnd(22) + 'Telas  Charter  E2E  Score');
+for (const [m, s] of mods) {
+  console.log(
+    '  ' + m.padEnd(20) + String(s.total).padStart(5) + String(s.charter).padStart(9) + String(s.e2e).padStart(5) + String(s.scorecard).padStart(7),
+  );
+}
+
+// --- Baseline / catraca ---
+const snapshot = { generated_note: 'baseline da catraca de cobertura — NÃO editar à mão', aggregates: agg, by_module: byModule };
+
+if (flags.has('--json')) {
+  writeFileSync(BASELINE, JSON.stringify(snapshot, null, 2) + '\n');
+  console.log(`\n✓ baseline gravado em ${relative(ROOT, BASELINE)}`);
+}
+
+if (flags.has('--check')) {
+  if (!existsSync(BASELINE)) {
+    console.error('\n✗ baseline ausente — rode com --json primeiro.');
+    process.exit(2);
+  }
+  const prev = JSON.parse(readFileSync(BASELINE, 'utf8')).aggregates;
+  const regress = ['charter', 'e2e', 'a11y', 'scorecard'].filter((k) => agg[k] < prev[k]);
+  if (regress.length) {
+    console.error(`\n✗ CATRACA: cobertura regrediu em ${regress.join(', ')} (vs baseline). PR bloqueado.`);
+    for (const k of regress) console.error(`   ${k}: ${prev[k]} → ${agg[k]}`);
+    process.exit(1);
+  }
+  console.log('\n✓ CATRACA: nenhuma regressão de cobertura.');
+}


### PR DESCRIPTION
## O quê

Funda o **sistema de QA-de-tela sustentável** pedido pelo Wagner (2026-06-04): garantir cobertura das telas com um especialista Full Tester+QA **e que sobreviva no tempo** (não apodreça).

Nada é ligado/mergeado automaticamente — a ADR fica `proposed` e o CI não é alterado. É a Onda 0 (fundação) pra você revisar.

## Baseline factual (medido agora — 275 telas)

| Camada | Cobertura |
|---|---|
| Charter (contrato) | 132/275 (48%) |
| **E2E (Pest Browser)** | **3/275 (1,1%)** |
| **A11Y (axe)** | **0/275 (0%)** |
| **Scorecard (nota persistida)** | **0/275 (0%)** |

QA de backend é forte (1.177 testes); QA de tela ≈ 34/100 — arquitetado mas desligado (`visual-regression.yml` em `continue-on-error`, `pr-ui-judge` kill-switch off, smoke semi-manual).

## Arquivos

- `scripts/qa/screen-coverage-map.mjs` — mapa + **catraca**: `--json` grava baseline, `--check` falha o CI se a cobertura agregada regredir (telas cobertas só sobem).
- `memory/governance/screen-coverage-baseline.json` — baseline 2026-06-04.
- `.claude/agents/screen-qa-specialist.md` — especialista por tela (ciclo Planner→Automator→Maintainer), Tier 0: CT 100 only, biz=1, gate visual, zero git ops.
- `memory/decisions/proposals/screen-qa-specialist-sustentavel.md` — ADR proposta.

## Sobrevivência — os 4 anéis (o coração)

1. **Catraca de nota** — scorecard YAML versionado; gate bloqueia PR que derrube a nota (espelha `module-grades-gate`).
2. **Catraca de cobertura** — `--check` no CI; tela nova sem teste = PR vermelho. ✅ script entregue.
3. **Sentinela de freshness** — charter/baseline velho → flag no Daily Brief; cron 09:00 re-smoke ≥7d.
4. **Self-healing (Maintainer)** — `.tsx` muda → agente regenera o E2E em vez de quebrar.

**Métrica-mãe:** `% de telas ≥ nota 70` e `% com E2E`, trackadas no brief.

## Próximas ondas (não nesta PR)

1. wire `--check` no CI + desbloquear `visual-regression.yml`
2. piloto end-to-end em `Sells/Create` (tela-ouro)
3. `screen-grades-gate` + métrica-mãe no brief
4. ligar self-healing via `screen-smoke-after-merge`

<!-- no-ui-smoke: PR só adiciona script/agente/ADR — não toca nenhuma tela .tsx -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)