### PR TITLE
fix(nfse): FK nfse_emissao_id INT casa com nfse_emissoes (erro 3780, destrava suíte MySQL)

### DIFF
--- a/Modules/NfeBrasil/Database/Migrations/2026_05_12_120000_create_nfse_eventos_cancelamento_table.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_12_120000_create_nfse_eventos_cancelamento_table.php
@@ -49,7 +49,10 @@ return new class extends Migration
         Schema::create('nfse_eventos_cancelamento', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('business_id')->index();
-            $table->unsignedBigInteger('nfse_emissao_id');
+            // INT (não BIGINT): casa com nfse_emissoes.id que é criado via
+            // increments() (INT UNSIGNED) pela migration NFSe 2026_05_01.
+            // unsignedBigInteger aqui gera FK incompatível (MySQL erro 3780).
+            $table->unsignedInteger('nfse_emissao_id');
             $table->string('driver_key', 32)
                 ->comment('ABRASF_V1, ABRASF_V2.04, GINFES, IPM, TIPLAN, NFSE_GOV_BR');
             $table->text('motivo')


### PR DESCRIPTION
## Problema

A suíte Pest com MySQL (job `PHP / Pest (Financeiro · MySQL)`) falha em **todo** PR — inclusive PRs que não tocam NFSe (ex: #2211, Financeiro). Erro:

```
2026_05_12_120000_create_nfse_eventos_cancelamento_table ... FAIL
General error: 3780 — Referencing column 'nfse_emissao_id' and referenced column 'id'
in foreign key 'nfse_eventos_canc_emi_fk' are incompatible.
```

## Causa-raiz

`nfse_emissoes` é criada por **duas** migrations com `id` de tipos diferentes:
- NFSe `2026_05_01_000003` → `increments('id')` = **INT UNSIGNED** (roda primeiro, vence)
- NfeBrasil `2026_05_11_150001` → `$table->id()` = BIGINT (tem guard `hasTable`, **pula**)

A tabela real fica **INT**. Mas a migration de cancelamento declarava `nfse_emissao_id` como `unsignedBigInteger` (**BIGINT**). MySQL exige tipos idênticos em FK → erro 3780.

**Não é regressão de nenhum PR** — é bug pré-existente em `main`.

## Fix (1 linha)

`unsignedBigInteger('nfse_emissao_id')` → `unsignedInteger(...)`, casando com o `increments` legado. Comentário inline explica o porquê.

## Impacto

Destrava: o #2211, **todo** PR que roda a suíte com MySQL, e a Onda 1 do gate `visual-regression` (que esbarra nesse mesmo drift).

## Follow-up (separado)

Duas migrations criando `nfse_emissoes` com `id` divergente (INT vs BIGINT) é drift entre módulos NFSe e NfeBrasil — vale unificar numa próxima passada.

<!-- no-ui-smoke: mudança backend-only (migration), não toca tela -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)