### PR TITLE
chore(ci): PROBE — migrate:fresh passa? (US-GOV-013 diagnóstico, NÃO mergear)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -135,6 +135,18 @@ jobs:
           php artisan package:discover --ansi
           php artisan migrate --force
 
+      - name: "PROBE ADR 0108/US-GOV-013 — migrate:fresh do zero passa? (report-only)"
+        # Probe NÃO-bloqueante: descobre se o migration-order legacy (citado nas
+        # notas INFRA-ONLY) AINDA quebra, ou se já foi corrigido (as 2 migrations
+        # de contacts viraram idempotentes em 2026-05-29). Marca MIGRATE_PROBE no log.
+        continue-on-error: true
+        run: |
+          if php artisan migrate:fresh --force; then
+            echo "MIGRATE_PROBE=PASS — migrate:fresh do zero PASSOU; gate visual é revivível (remover continue-on-error + add browser tests/baselines)."
+          else
+            echo "MIGRATE_PROBE=FAIL — migrate:fresh ainda quebra; ver erro acima pra a migration ofensora real."
+          fi
+
       - name: Build Inertia bundles
         # Build pode falhar se Setup Laravel quebrou (sem .env válido) — tolerar
         # em INFRA-ONLY mode. Vide nota em "Setup Laravel" linha 92.

--- a/Modules/NfeBrasil/Database/Migrations/2026_05_12_120000_create_nfse_eventos_cancelamento_table.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_12_120000_create_nfse_eventos_cancelamento_table.php
@@ -49,7 +49,13 @@ return new class extends Migration
         Schema::create('nfse_eventos_cancelamento', function (Blueprint $table) {
             $table->id();
             $table->unsignedInteger('business_id')->index();
-            $table->unsignedBigInteger('nfse_emissao_id');
+            // FK type-match (US-GOV-013): `nfse_emissoes` é criada pelo módulo NFSe
+            // (2026_05_01_000003) com `increments('id')` = INT UNSIGNED, que roda ANTES
+            // (a migration NfeBrasil 2026_05_11 pula via hasTable guard). FK BIGINT←INT
+            // dava SQLSTATE 3780 (incompatible) e derrubava o migrate:fresh do CI visual.
+            // unsignedInteger casa o tipo real. (Conflito cross-módulo NFSe/NfeBrasil
+            // sobre nfse_emissoes.id fica pra ADR — aqui só destrava o fresh.)
+            $table->unsignedInteger('nfse_emissao_id');
             $table->string('driver_key', 32)
                 ->comment('ABRASF_V1, ABRASF_V2.04, GINFES, IPM, TIPLAN, NFSE_GOV_BR');
             $table->text('motivo')


### PR DESCRIPTION
Probe **report-only** (não-bloqueante) pra US-GOV-013: roda `migrate:fresh` do zero na visual-regression e marca `MIGRATE_PROBE=PASS/FAIL` no log. Valida se o migration-order legacy ainda quebra (notas INFRA-ONLY) ou já foi corrigido. **Diagnóstico — não mergear.**