### PR TITLE
fix(featureflag): GrowthBook vazio/down cai no fallback (tela de venda revertia pro Blade)

### DIFF
--- a/app/Services/FeatureFlagService.php
+++ b/app/Services/FeatureFlagService.php
@@ -49,7 +49,17 @@ class FeatureFlagService
     {
         try {
             $features = $this->getFeatures();
-            if ($features === null) {
+
+            // Fallback offline-safe: usar o default seguro quando o GrowthBook
+            // está inacessível (null) OU quando ele NÃO conhece esta flag
+            // (features vazio / flag ausente). Sem o `array_key_exists`, quando
+            // o GrowthBook do CT 100 cai / responde non-2xx / não tem a flag
+            // definida, getFeatures() devolve [] (não null) e $gb->isOn()
+            // retorna false silenciosamente — derrubando v2 (tela React de
+            // venda) pro Blade legado pra TODOS os business, ignorando o
+            // fallbackDefaults=true. Catalogado 2026-06-04 (tela /sells/create
+            // do Martinho reverteu pro layout antigo).
+            if ($features === null || ! array_key_exists($flag, $features)) {
                 return $this->fallback($flag);
             }
 

--- a/tests/Feature/Services/FeatureFlagServiceTest.php
+++ b/tests/Feature/Services/FeatureFlagServiceTest.php
@@ -48,7 +48,11 @@ it('retorna fallback default quando GrowthBook API responde 5xx', function () {
 
     $service = new FeatureFlagService();
 
-    expect($service->isOn('useV2SellsCreate'))->toBeFalse();
+    // 2026-06-04 — GrowthBook inacessível (5xx) DEVE cair no fallback default
+    // (offline-safe). useV2SellsCreate=true. Antes este teste afirmava false,
+    // encodando o bug que derrubava a tela React de venda pro Blade quando o
+    // GrowthBook do CT 100 caía. Ver FeatureFlagService::isOn (array_key_exists).
+    expect($service->isOn('useV2SellsCreate'))->toBeTrue();
 });
 
 it('retorna ON quando GrowthBook fornece flag habilitada', function () {
@@ -124,6 +128,6 @@ it('flag ausente nos features retornados retorna fallback', function () {
 
     $service = new FeatureFlagService();
 
-    expect($service->isOn('useV2SellsCreate'))->toBeFalse(); // fallback default
+    expect($service->isOn('useV2SellsCreate'))->toBeTrue(); // flag ausente nos features → fallback default TRUE
     expect($service->isOn('flagDesconhecida'))->toBeFalse(); // sem fallback explícito → false
 });


### PR DESCRIPTION
## Problema (prod, Martinho)
A tela **/sells/create voltou pro layout Blade antigo** — antes era a tela React v2. Regressão reportada por Wagner 2026-06-04.

## Causa-raiz
`SellController@create` decide React v2 vs Blade legado por uma feature flag:
```php
$useV2 = app(FeatureFlagService::class)->isOn('useV2SellsCreate', ['business_id' => $business_id]);
if ($useV2) return Inertia::render('Sells/Create', ...);   // React
return view('sell.create');                                 // Blade antigo
```

`FeatureFlagService::isOn()` tinha um buraco no fallback offline-safe:
- env GrowthBook **ausente** → `getFeatures()` devolve `null` → usa `fallbackDefaults['useV2SellsCreate'] = true` ✅
- GrowthBook **configurado mas falho** (CT 100 fora / non-2xx / flag não definida lá) → `getFeatures()` devolve `[]` (array vazio, **≠ null**) → o código pulava o fallback e ia pro `$gb->isOn('useV2SellsCreate')`, que retorna **false** pra flag desconhecida → **Blade pra todos os business**, ignorando o default `true`.

Ou seja: bastava o GrowthBook do CT 100 ficar indisponível (ou um deploy ligar o env do GrowthBook) pra a tela inteira reverter.

## Fix
Usar o fallback também quando a flag **não está presente** nos features retornados:
```php
if ($features === null || ! array_key_exists($flag, $features)) {
    return $this->fallback($flag);
}
```
- GrowthBook indisponível/vazio → default seguro (v2 **ON**), respeitando o intent documentado ("defaults seguros se GrowthBook inacessível").
- GrowthBook que **define** a flag continua no controle (override real preservado).
- `flagDesconhecida` (sem default explícito) segue `false`.

## Testes
Corrigidos 2 casos que **encodavam o bug** — o caso 5xx e o caso "features vazio" tinham comentário `// fallback default` mas afirmavam `toBeFalse()` (o oposto do default, que é `true`). Agora afirmam o default correto. Demais casos (env ausente, GrowthBook habilita, cache, clearCache) intactos.

## Validação pós-merge
1. Abrir `/sells/create` no Martinho → deve renderizar a **tela React v2** (não o Blade antigo). Screenshot incluído após deploy.
2. Regressão: telas que dependem de flags realmente definidas no GrowthBook continuam respeitando o valor de lá.