### PR TITLE
feat(qa): screen-grade enforcement — seed 222 scorecards + catraca anti-regressão

### DIFF
--- a/memory/governance/scorecards/screens/admin-featureflags-index.yaml
+++ b/memory/governance/scorecards/screens/admin-featureflags-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/FeatureFlags/Index
+path: resources/js/Pages/Admin/FeatureFlags/Index.tsx
+archetype: config
+persona: wagner
+nota: 64
+nivel: "Developing"
+baseline_anterior: 64   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Painel GrowthBook funcional com audit log, mas tabelas hand-rolled e cores cruas amber/red sem token, sem charter nem estados defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe Dashboard usa design tokens semanticos (warning/danger) sem hex cru"
+    fix: "Trocar bg-amber-100/bg-red-100/bg-green por <Alert variant> + tokens DS v4; criar charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear reusa DataTable em vez de <table> manual por tela"
+    fix: "Migrar as 2 <table> pro componente de tabela DS / PT-01"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Notion mostra skeleton enquanto carrega listas"
+    fix: "Adicionar Inertia::defer + fallback skeleton nas features/audits"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-featureflags-show.yaml
+++ b/memory/governance/scorecards/screens/admin-featureflags-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/FeatureFlags/Show
+path: resources/js/Pages/Admin/FeatureFlags/Show.tsx
+archetype: config
+persona: wagner
+nota: 66
+nivel: "Developing"
+baseline_anterior: 66   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de flag com mata-switch e CRUD de rule biz via useForm; bom error-recovery por confirm, mas <select> nativo, cores cruas e zero charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe usa Select do DS + Alert tokenizado"
+    fix: "Trocar <select> nativo por @/Components/ui/select e bg-red-100 por Alert variant; criar charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Vercel usa modal de confirmacao com input de typed-confirm pra acao destrutiva"
+    fix: "Substituir window.confirm do mata-switch por Dialog com double-confirm visual"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear evita emoji 🟢🔴 inline, usa Badge com dot"
+    fix: "Trocar emojis de status por Badge/Circle tokenizado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-governancev4.yaml
+++ b/memory/governance/scorecards/screens/admin-governancev4.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/GovernanceV4
+path: resources/js/Pages/Admin/GovernanceV4.tsx
+archetype: dashboard
+persona: wagner
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tri-pane estado-da-arte com ⌘K, localStorage, Deferred granular, KpiGrid e charter+review; mancha sao os window.prompt/confirm pra initiative/override."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Linear cria via dialog inline com campos validados, nunca prompt do browser"
+    fix: "Substituir window.prompt de Initiative/Override pelo InitiativeComposerDialog (W29-D pendente)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe rotula estado MOCK como banner explicito de ambiente"
+    fix: "Promover aviso 'MOCK v4_enabled=false' a banner persistente em vez de so no description"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Height-cockpit tri-pane do Linear colapsa em tabs no mobile"
+    fix: "Garantir data-mobile-view alterna panes (sidebar/list/reader) em <lg"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-governancev4dashboard.yaml
+++ b/memory/governance/scorecards/screens/admin-governancev4dashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/GovernanceV4Dashboard
+path: resources/js/Pages/Admin/GovernanceV4Dashboard.tsx
+archetype: dashboard
+persona: wagner
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Dashboard intra-bucket com sparkline SVG, drift banner e Deferred; cores cruas zinc/emerald e hex inline (#dc2626) + filtros bg-zinc-900 fora do primary roxo derrubam Pre-Flight."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 primary roxo pra chip ativo, zero hex literal"
+    fix: "Trocar bg-zinc-900 dos filtros por primary; remover style borderLeftColor #dc2626/#059669 por classe token"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "GovernanceV4 (irma) ja usa KpiCard+filter chips DS"
+    fix: "Alinhar filtros e cards com os _components do GovernanceV4 tri-pane"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe da aria-pressed nos toggles de filtro e foco visivel"
+    fix: "Adicionar aria-pressed/role nos botoes de bucket/status e label no checkbox drift"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-index.yaml
+++ b/memory/governance/scorecards/screens/admin-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/Index
+path: resources/js/Pages/Admin/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Centro de Operacoes agrega 10 widgets em Card grid com charter; mas zero Inertia::defer (tudo eager) e badges de status com cores cruas green/amber/red repetidas inline."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Performance-perceived"
+    best_of_class: "Vercel dashboard defer cada widget caro com skeleton independente"
+    fix: "Aplicar skill inertia-defer-default nos 10 widgets (infra ping, mcp, vault) com fallback"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Token semantico de status em vez de bg-green-100/bg-red-100 repetido 6x"
+    fix: "Extrair StatusBadge tokenizado e reusar nos CardTitle"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Datadog agrupa widgets por severidade com a critica no topo fixa"
+    fix: "Promover Tier-0/Health pro topo e usar KpiGrid pros numericos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-ragqualitydashboard.yaml
+++ b/memory/governance/scorecards/screens/admin-ragqualitydashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/RagQualityDashboard
+path: resources/js/Pages/Admin/RagQualityDashboard.tsx
+archetype: dashboard
+persona: wagner
+nota: 69
+nivel: "Developing"
+baseline_anterior: 69   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Observability RAG com 3 sparklines p99, nDCG/recall e Deferred bem aplicado; perde por cores cruas zinc/emerald/indigo, sem charter e thresholds hardcoded sem token."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 com escala de cor semantica + charter ao lado"
+    fix: "Tokenizar text-emerald/amber/red de p99Color/pctColor; criar RagQualityDashboard.charter.md"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Grafana sparkline com eixo/tooltip de valor no hover"
+    fix: "Adicionar tooltip/ultimo-ponto destacado no Sparkline SVG"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Reusar 1 Sparkline compartilhado (GovernanceV4Dashboard tem copia)"
+    fix: "Extrair Sparkline pra @/Components/shared e dedupe"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-screenreview.yaml
+++ b/memory/governance/scorecards/screens/admin-screenreview.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/ScreenReview
+path: resources/js/Pages/Admin/ScreenReview.tsx
+archetype: dashboard
+persona: wagner
+nota: 83
+nivel: "Advanced"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tri-pane PDCA bem montado: Deferred por pane, localStorage, PageHeaderActions, toast e charter+review; falta dialog real pra notes/initiative e re-smoke ainda e placeholder toast."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "GitHub review usa textarea inline com submit pra notes, nao toast placeholder"
+    fix: "Implementar input de notes + create_initiative no ReviewReader (hoje handleResmoke so toast)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Notion colapsa 3 panes em stack navegavel no mobile"
+    fix: "Validar data-mobile-view=list alterna sidebar/list/reader em telas pequenas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear mantem selecao apos erro de POST com retry visivel"
+    fix: "Tratar onError mostrando retry/estado da tela alem do toast"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/admin-screenreviewdashboard.yaml
+++ b/memory/governance/scorecards/screens/admin-screenreviewdashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Admin/ScreenReviewDashboard
+path: resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+archetype: dashboard
+persona: wagner
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Landing PDCA enxuta e limpa: KpiGrid 5 cards tonalizados, alert role=alert com dark mode e charter; escopo pequeno mas conforme DS, so falta tendencia/contexto alem dos numeros."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe KPI mostra delta vs periodo anterior"
+    fix: "Adicionar trend/sparkline ou variacao 7d nos KpiCard alem do valor cru"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear KPI clicavel filtra a lista correspondente"
+    fix: "Tornar cards (Pendentes/Rejeitadas) clicaveis levando a Triagem ja filtrada"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Atalho de teclado pra pular pro item critico"
+    fix: "Linkar 'pending_over_7d' direto pra lista filtrada >7d"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-confidence.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-confidence.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Confidence
+path: resources/js/Pages/ads/Admin/Confidence.tsx
+archetype: dashboard
+persona: wagner
+nota: 69
+nivel: "Developing"
+baseline_anterior: 69   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tabela score×HiTL limpa com KpiGrid e EmptyState pedagogico, mas cor crua como unico sinal e zero charter puxam pra Developing."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "scoreColor/hitlBadge hardcodam emerald/blue/amber/red/zinc cru; migrar pra tokens semanticos + primary roxo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe Dashboard"
+    fix: "<table> sem <caption>/scope=col; cor unica como sinal de score (falha daltonismo) — add icone/label"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Notion"
+    fix: "tabela 7 colunas so com overflow-x; em mobile vira scroll horizontal cego — considerar card-stack <md"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-conflicts.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-conflicts.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Conflicts
+path: resources/js/Pages/ads/Admin/Conflicts.tsx
+archetype: dashboard
+persona: wagner
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detector 3-tipos bem estruturado com KPIs, empty-state e links de drill-down; cor crua e falta de nav inter-secoes limitam."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "cards amber/destructive/blue cru + bg-zinc-100 em code; tokenizar e usar primary roxo onde for acao"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Datadog"
+    fix: "3 secoes de conflito sem ancora/jump nav; add tabs ou sticky filter por tipo quando total alto"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GOV.UK"
+    fix: "icone-cor por severidade sem texto alternativo redundante; '⟷' decorativo sem aria-hidden"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-decisaoshow.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-decisaoshow.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/DecisaoShow
+path: resources/js/Pages/ads/Admin/DecisaoShow.tsx
+archetype: detail
+persona: wagner
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe rico: drill-down chain, review G-Eval, KV tecnico, StatusBadge canon; window.prompt e cores cruas seguram a nota."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Linear"
+    fix: "reject/dismiss usam window.prompt() nativo (sem validacao, sem cancel limpo); trocar por Dialog DS com Textarea"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "border-blue-500/20, bg-emerald-600, text-red-700, bg-zinc-100 cru espalhados; tokenizar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Stripe"
+    fix: "acoes Aprovar/Rejeitar so no header; em pagina longa somem no scroll — sticky action bar ou repetir no rodape"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-decisoes.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-decisoes.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Decisoes
+path: resources/js/Pages/ads/Admin/Decisoes.tsx
+archetype: list
+persona: wagner
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Inbox operacional forte: KPIs-como-filtro, live-polling cortes, rows densas, empty por aba; cor crua e window.prompt limitam."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "toggle Live e KPI selected usam emerald/zinc cru; badge Brain-B blue/5 cru; mapear tokens + primary roxo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear"
+    fix: "reject via window.prompt nativo; substituir por modal DS com motivo obrigatorio opcional"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion"
+    fix: "auto-refresh 10s sem aria-live region anunciando atualizacao; KPI-filtro clicavel ok mas sem role/aria-pressed"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-graph.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-graph.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Graph
+path: resources/js/Pages/ads/Admin/Graph.tsx
+archetype: other
+persona: wagner
+nota: 60
+nivel: "Developing"
+baseline_anterior: 60   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Knowledge-graph ReactFlow util mas e o pior em Pre-Flight: HEX cru em inline-style, canvas fixo nao-responsivo, zero a11y."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "nodeStyle/MiniMap/Legend cravam HEX cru (#3b82f6,#fef3c7,#ef4444...) em inline style — violacao dura AP hex; extrair pra tokens CSS vars"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Miro"
+    fix: "canvas fixo height:700 + layout absoluto cx600/cy350 nao responsivo; sem fallback lista <md"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "ReactFlow a11y"
+    fix: "grafo so-visual sem alternativa textual/tabela equivalente; nodes nao focaveis por teclado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-learning.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-learning.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Learning
+path: resources/js/Pages/ads/Admin/Learning.tsx
+archetype: dashboard
+persona: wagner
+nota: 67
+nivel: "Developing"
+baseline_anterior: 67   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Pipeline-loop didatico com stages clicaveis e diagrama de fluxo; colorMap cru de 9 cores e chart hand-roll sem eixos puxam pra baixo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "colorMap com 9 cores Tailwind cruas (zinc..green) pros stages; throughput bars emerald/red/zinc cru; tokenizar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Amplitude"
+    fix: "ThroughputChart custom div-bar sem eixo/tooltip/legenda de valor; usar componente chart DS com hover"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GOV.UK"
+    fix: "barras coloridas (sucesso/rejeitada) sem rotulo textual por segmento; add title/aria nos segmentos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-metaskills.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-metaskills.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/MetaSkills
+path: resources/js/Pages/ads/Admin/MetaSkills.tsx
+archetype: config
+persona: wagner
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Editor de regras SOFT robusto (condition-builder, validate-against-data, versao, switch); select nativo, JSON cru e cores cruas limitam."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "<select> HTML cru (categoria/condition builder) em vez de @/Components/ui/select; bg-zinc-50/blue-600 cru; padronizar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe rules"
+    fix: "Action e JSON cru em Textarea com try/catch silencioso — erro de parse some sem feedback; add validacao visivel"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Zapier editor"
+    fix: "condition-builder bom mas action so JSON raw; oferecer dropdown de tipos + params guiados"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-metricas.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-metricas.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Metricas
+path: resources/js/Pages/ads/Admin/Metricas.tsx
+archetype: dashboard
+persona: wagner
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Metricas de adocao com KPIs duplos, stacked-bar e top-10; boa microcopy (peso 3x modificadas) mas cor crua e sem defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "StackedBar segs emerald/blue/red/amber cru; so TopList usa bg-primary roxo; unificar paleta em tokens"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Stripe"
+    fix: "sem Inertia::defer nem skeleton — pagina agregada (custo/tokens/top10) bloqueia render ate query pesada"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Datadog"
+    fix: "StackedBar so com title (hover) — invisivel teclado/mobile; add legenda ja existe mas sem associacao aria"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-patterns.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-patterns.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Patterns
+path: resources/js/Pages/ads/Admin/Patterns.tsx
+archetype: dashboard
+persona: wagner
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Padroes com Wilson-Score bem explicado, secoes candidatos/drifts em cards + tabela; cor crua como sinal e a11y de tabela limitam."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "lbColor emerald/blue/amber/zinc cru + bg-zinc-700; cor unica como sinal de Wilson LB; tokenizar + icone"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe"
+    fix: "tabela sem caption/scope; status Hardcoded/Pronto/Aprendendo ok com label, mas LB so cor"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Notion"
+    fix: "tabela 6-col overflow-x cego em mobile; candidatos/drifts ja sao cards (bom) — espelhar tabela em card-stack"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-policy.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-policy.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Policy
+path: resources/js/Pages/ads/Admin/Policy.tsx
+archetype: list
+persona: wagner
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Firewall read-only claro: aviso imutabilidade, 4 categorias com icone/cor, copy honesta; cor parcialmente crua e sem filtro."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "categoryConfig amber/blue/emerald/5 cru (destructive ok); banner Lock amber-600 cru; tokenizar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Stripe"
+    fix: "read-only firewall sem busca/filtro por event_type; com muitas regras vira scroll — add filtro client-side"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "GOV.UK"
+    fix: "4 categorias em grid 2-col sem ordem de severidade explicita (BLOCK→ALLOW); fixar ordem semantica"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-projects.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-projects.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Projects
+path: resources/js/Pages/ads/Admin/Projects.tsx
+archetype: list
+persona: wagner
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista+create inline limpa com progress roxo, mas sem filtro/busca e paleta de status crua (blue presente)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "statusColor map bg-blue/amber/emerald/red-100 cru + zero primary roxo -> tokens semanticos, badge variant"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Bling filtro"
+    fix: "lista sem busca/filtro/sort (so KPIs) -> add Input filtro client-side como em Skills/Index"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Shopify inline create"
+    fix: "create inline OK mas sem skeleton/defer; progress bar usa bg-primary (bom) -> manter, add empty da busca"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-projectshow.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-projectshow.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/ProjectShow
+path: resources/js/Pages/ads/Admin/ProjectShow.tsx
+archetype: detail
+persona: wagner
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de project bem estruturado (KpiGrid+parts ordenadas+deps), mas cores cruas com blue e confirm() nativo derrubam Pre-Flight."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear status tokens"
+    fix: "viabilityColor/statusBadge usam bg-blue/emerald/amber/red-100 crus -> mapear pra tokens semanticos v4 (primary roxo/destructive/muted), zerar blue"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe modal"
+    fix: "decompose() usa window.confirm nativo -> trocar por AlertDialog @/Components/ui com custo/tokens explicitos"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion"
+    fix: "emoji inline (clock/dollar/depende) sem aria -> usar lucide icons com aria-label + sem charter ao lado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-skills-edit.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-skills-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Skills/Edit
+path: resources/js/Pages/ads/Admin/Skills/Edit.tsx
+archetype: form
+persona: wagner
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de edicao forte: rationale 4-campos obrigatorio, dirty-state visual, tokens majoritariamente semanticos; so falta guard de saida e amber cru."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe dirty-state"
+    fix: "alerta de frontmatter modificado usa border-amber-300/bg-amber-50 cru -> token warning semantico + sem charter"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear unsaved guard"
+    fix: "sem beforeunload/guard ao sair com draft sujo; rationale obrigatorio so valida no server -> add validacao client"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Notion editor"
+    fix: "Textarea rows=24 mono em max-w-5xl ok desktop; em mobile fica gigante -> altura responsiva"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-skills-index.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-skills-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Skills/Index
+path: resources/js/Pages/ads/Admin/Skills/Index.tsx
+archetype: list
+persona: wagner
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista read-only exemplar: busca useMemo, empty contextual, tabela densa com source badge; pequenos gaps a11y e marca roxa ausente."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear DS"
+    fix: "tokens bons (text-primary/muted) mas zero roxo de marca em superficie + sem charter ao lado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GitHub table"
+    fix: "Input busca sem label/aria-label; table sem caption/scope -> add aria + scope=col"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear"
+    fix: "filtro client em lista potencialmente grande sem virtualizacao/defer -> defer + paginacao se >200"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-skills-review.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-skills-review.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Skills/Review
+path: resources/js/Pages/ads/Admin/Skills/Review.tsx
+archetype: list
+persona: wagner
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Approval queue clara com gating de comentario e cards de draft, mas valida via alert() nativo e cores de status cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe inline error"
+    fix: "reject usa alert() nativo pra validar comment<5 -> erro inline sob Textarea + foco"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "flash usa border-emerald-200/bg-emerald-50 cru + warning '⚠️ sem test runs' text-amber-600 -> tokens semanticos"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "GitHub PR review"
+    fix: "approve/reject sem diff do que mudou (so problema+hipotese) -> link/preview do diff de version"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-skills-show.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-skills-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Skills/Show
+path: resources/js/Pages/ads/Admin/Skills/Show.tsx
+archetype: detail
+persona: wagner
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe rico: timeline de versions com acoes contextuais (promover/publish), markdown prose, dl frontmatter; confirm() nativo e zinc-900 cru sao os furos."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe confirm"
+    fix: "move-label e publish-to-git usam confirm() nativo p/ acoes destrutivas/PR -> AlertDialog com detalhe da consequencia"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "prose-pre:bg-zinc-900 hardcoded + sem charter ao lado; resto tokenizado bem -> token surface"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GitHub"
+    fix: "table de versions sem scope/caption; botoes h-6 text-xs alvo <44px touch -> ampliar/aria"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-skills-test.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-skills-test.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Skills/Test
+path: resources/js/Pages/ads/Admin/Skills/Test.tsx
+archetype: form
+persona: wagner
+nota: 77
+nivel: "Advanced"
+baseline_anterior: 77   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tela de teste completa (manual vs conversas reais, PII, dry-run badge, runs com metricas), mas mistura inputs nativos hand-rolled e a11y de label fraca."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear segmented"
+    fix: "source toggle usa <button> hand-rolled (bg-foreground/background) + inputs number/text nativos com border cru -> usar Tabs/ToggleGroup + Input @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe"
+    fix: "labels nao associados (htmlFor) nos inputs number/text; segmented sem role=tablist/aria-selected"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear async run"
+    fix: "rodar teste real (latencia/API) sem skeleton/progress alem de 'Rodando...' -> estado de loading no painel de runs"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-teamscopes.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-teamscopes.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/TeamScopes
+path: resources/js/Pages/ads/Admin/TeamScopes.tsx
+archetype: config
+persona: wagner
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Matriz user×modulo com Switch granular e explicacao do enforcement server-side; densa e poderosa mas desktop-only e cores de estado cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe permissions"
+    fix: "matriz de Switch 4-col + sidebar lg:col-span depende de viewport largo; em mobile colapsa mal -> stack/accordion por modulo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "linha com acesso usa bg-emerald-50/30 cru + Card border-amber-300 cru -> tokens semanticos (success/warning)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GitHub settings"
+    fix: "Switch headers so icon com title= (Read/Write/Exec/Commit) sem th scope/aria; revoke via confirm() nativo"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ads-admin-tools.yaml
+++ b/memory/governance/scorecards/screens/ads-admin-tools.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ads/Admin/Tools
+path: resources/js/Pages/ads/Admin/Tools.tsx
+archetype: config
+persona: wagner
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Catalogo de tools com try-it inline e audit de execucoes; util mas paleta crua (emerald/amber/zinc), confirm() nativo e input JSON manual elevam carga."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear badges"
+    fix: "badges bg-emerald-600/bg-amber-600 text-white + code bg-zinc-100 + Card border-zinc-200 cru, zero primary roxo -> tokens v4"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Postman try-it"
+    fix: "ToolCard 'Try it' executa write tools com so confirm() nativo + fetch manual sem retry/timeout UI -> AlertDialog + estado de erro tipado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Stripe API ref"
+    fix: "schema em <pre> JSON [10px] + input JSON livre exige conhecer shape -> form gerado do input_schema"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-caixaunificada-index.yaml
+++ b/memory/governance/scorecards/screens/atendimento-caixaunificada-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/CaixaUnificada/Index
+path: resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+archetype: chat
+persona: larissa
+nota: 88
+nivel: "Leader"
+baseline_anterior: 88   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Inbox omnichannel madura: Centrifugo+polling fallback, atalhos J/K/E/A + /, Deferred granular, EmptyState, tokens primary e charter+review; pesa header hand-rolled e 3 acoes topnav disabled."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Intercom nao mostra botoes desabilitados permanentes (Filas/Broadcast/Nova)"
+    fix: "Esconder ou habilitar os 3 placeholders TODO em vez de deixar disabled visivel"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Demais telas Atendimento usam <PageHeader>"
+    fix: "Trocar header custom (div+h1) por PageHeader/PageHeaderActions pra alinhar shell"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "WhatsApp Web alterna lista/thread/contexto em mobile"
+    fix: "Confirmar grid lg:[320_1fr_300] colapsa pra navegacao single-pane <lg"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-channels-index.yaml
+++ b/memory/governance/scorecards/screens/atendimento-channels-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Channels/Index
+path: resources/js/Pages/Atendimento/Channels/Index.tsx
+archetype: list
+persona: larissa
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "CRUD de canais rico: cards com health, dialogs DS, fluxo QR/pairing com poll, EmptyState e charter+review; perde por alert()/confirm() nativos, emoji 📥 e cores emerald/amber cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe usa toast/Dialog DS, nunca window.alert pra resultado de acao"
+    fix: "Trocar alert()/confirm() de import-history pelo Dialog + toast (sonner ja no projeto)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Bling usa icone do set, sem emoji literal e cor tokenizada"
+    fix: "Trocar 📥 por Lucide + tokenizar healthColor emerald/amber/red"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Shopify mostra filtro/busca quando lista de canais cresce"
+    fix: "Adicionar busca/filtro por status/health quando N canais"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-channels-show.yaml
+++ b/memory/governance/scorecards/screens/atendimento-channels-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Channels/Show
+path: resources/js/Pages/Atendimento/Channels/Show.tsx
+archetype: detail
+persona: larissa
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe com tabs role-tab acessiveis, Deferred por aba, re-parear com poll e PageHeader; mas sem componente Tabs do DS, confirm() nativo e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "shadcn Tabs canonico + charter ao lado"
+    fix: "Criar Components/ui/tabs e charter; migrar TabButton hand-rolled"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Vercel re-pair em Dialog com confirm tipado"
+    fix: "Substituir window.confirm do re-parear por Dialog DS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Twilio detail mostra metricas do canal (msgs 24h) alem de config estatica"
+    fix: "Enriquecer ConfigTab com saude/uso recente do canal"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-csat-index.yaml
+++ b/memory/governance/scorecards/screens/atendimento-csat-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Csat/Index
+path: resources/js/Pages/Atendimento/Csat/Index.tsx
+archetype: dashboard
+persona: larissa
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "CSAT limpo: KpiGrid 4 cards tonalizados, distribuicao em barras, tabela com Deferred, EmptyState e StarRow a11y; perde por cores cruas emerald/amber, prop 'actions' fora do padrao e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "PageHeader canon usa prop 'action' (singular) como nas outras telas"
+    fix: "Alinhar prop actions->action do PageHeader; criar charter CSAT"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 escala semantica de cor nas barras de distribuicao"
+    fix: "Tokenizar bg-emerald-500/amber-500 das barras e thresholds de tone"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Zendesk CSAT permite filtrar por canal/atendente alem do range"
+    fix: "Adicionar filtros canal/atendente ao lado do range selector"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-inbox-index.yaml
+++ b/memory/governance/scorecards/screens/atendimento-inbox-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Inbox/Index
+path: resources/js/Pages/Atendimento/Inbox/Index.tsx
+archetype: chat
+persona: misto
+nota: 91
+nivel: "Leader"
+baseline_anterior: 91   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit 3-paineis estado-da-arte: charter, Deferred+skeletons, J/K/E/A, Centrifugo+polling fallback, tokens primary — falta polish mobile/a11y real-time."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Front/Intercom (handles de colapso nativos, tooltip rico)"
+    fix: "Botoes de colapso hand-rolled (div+button); extrair pra <CollapseHandle> de @/Components/ui c/ tooltip token"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Crisp omnichannel (sidebar contexto vira bottom-sheet no mobile)"
+    fix: "Painel direito so aparece em lg+; no mobile o contexto/acoes da conversa some — adicionar drawer mobile"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear (live region anuncia msg nova)"
+    fix: "Real-time reload nao tem aria-live; leitor de tela nao percebe msg chegando — add role=status"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-janatemplates.yaml
+++ b/memory/governance/scorecards/screens/atendimento-janatemplates.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/JanaTemplates
+path: resources/js/Pages/Atendimento/JanaTemplates.tsx
+archetype: config
+persona: misto
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form config limpo c/ charter, PageHeader canon e @/Components/ui — simples demais, sem render de erros de validacao inline."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (erro de validacao inline por campo)"
+    fix: "useForm errors nao renderizados nos Inputs; so spinner no submit — exibir errors.template_* abaixo de cada campo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Notion (helper text explica o que e template HSM)"
+    fix: "Campos de template pedem nome exato sem link/ajuda do que e HSM; add hint ou link doc Meta"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Linear settings (agrupa toggle+campos relacionados)"
+    fix: "4 campos soltos num grid; agrupar Repair vs Cobranca em sub-secoes rotuladas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-macros-index.yaml
+++ b/memory/governance/scorecards/screens/atendimento-macros-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Macros/Index
+path: resources/js/Pages/Atendimento/Macros/Index.tsx
+archetype: list
+persona: misto
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de macros completa (Deferred+skeleton+empty+a11y labels), mas table hand-rolled, confirm() nativo e vermelho cru."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Linear (modal de confirmacao com undo, nao window.confirm)"
+    fix: "destroy() usa confirm() nativo; trocar por AlertDialog de @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (tokens semanticos destrutivos)"
+    fix: "text-red-600/red-700 cru no botao excluir; usar token destructive"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Shopify (DataTable unica reutilizada)"
+    fix: "Tabela hand-rolled <table> em vez de componente lista compartilhado; alinhar c/ pattern PT-01"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-macros-variants.yaml
+++ b/memory/governance/scorecards/screens/atendimento-macros-variants.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Macros/Variants
+path: resources/js/Pages/Atendimento/Macros/Variants.tsx
+archetype: list
+persona: misto
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "A/B testing rico (peso/taxa/vencedora) mas falta charter, tem bug filter pre-guard e usa confirm() + cores cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "React defensive (guard antes de .filter)"
+    fix: "Linha 159 variants.filter() roda ANTES do Deferred guard — crash quando variants undefined no 1o paint; usar (variants??[]).filter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Charter-first (todo .tsx tem .charter.md)"
+    fix: "Sem Variants.charter.md ao lado (so review.md) — criar charter contrato"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Optimizely (vencedora destacada visualmente na linha)"
+    fix: "Trophy so muda cor; destacar linha vencedora c/ bg/badge + barra de taxa de resposta"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/atendimento-metricas-index.yaml
+++ b/memory/governance/scorecards/screens/atendimento-metricas-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Atendimento/Metricas/Index
+path: resources/js/Pages/Atendimento/Metricas/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Dashboard metricas solido (KpiCard reuse, Deferred, snapshot pre-agregado) mas chart com hex/blue cru e SVG hand-rolled."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (zero hex/blue cru, tokens roxo)"
+    fix: "Chart usa #3b82f6 / #10b981 / bg-blue-500 hardcoded — violacao blue/hex; mapear pra tokens chart DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Recharts/lib unica"
+    fix: "Grafico SVG hand-rolled + AppShellV2 dupla (layout method + wrapper inline na linha 132); remover wrap duplicado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Stripe (hover tooltip no ponto da serie)"
+    fix: "Linha sem tooltip/hover por dia — usuario nao le valor exato; add pontos interativos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/auditoria-detail.yaml
+++ b/memory/governance/scorecards/screens/auditoria-detail.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Auditoria/Detail
+path: resources/js/Pages/Auditoria/Detail.tsx
+archetype: detail
+persona: wagner
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de auditoria funcional mas thin: azul sky cru, JSON dump bruto, sem header roxo canon nem links navegaveis."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (text-sky-700 -> token primary roxo)"
+    fix: "Links text-sky-700 (azul) + zinc-* cru + sem PageHeader primary roxo; trocar por tokens DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear (diff visual key/value, nao JSON dump)"
+    fix: "properties renderizado como <pre>JSON.stringify</pre> bruto; render diff antes/depois formatado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe audit (timeline + entidade clicavel)"
+    fix: "Entidade/causer texto morto; tornar subject e causer links navegaveis"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/auditoria-index.yaml
+++ b/memory/governance/scorecards/screens/auditoria-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Auditoria/Index
+path: resources/js/Pages/Auditoria/Index.tsx
+archetype: list
+persona: wagner
+nota: 57
+nivel: "Developing"
+baseline_anterior: 57   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Log de atividades legivel mas Developing: cores sky/zinc cruas, filtros sem UI, sem Deferred/skeleton nem header canon."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (zero sky/zinc cru)"
+    fix: "hover:bg-sky-50, text-sky-700, badges bg-emerald/sky/amber-100 crus; migrar pra tokens semanticos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Datadog logs (filtros por log/causer/periodo na UI)"
+    fix: "Filters existe no payload mas sem UI de filtro — so badge readonly; add barra de filtros"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear (Deferred + skeleton)"
+    fix: "Sem Inertia::defer nem skeleton; lista grande bloqueia paint — adicionar Deferred"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-create.yaml
+++ b/memory/governance/scorecards/screens/cliente-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Create
+path: resources/js/Pages/Cliente/Create.tsx
+archetype: form
+persona: larissa
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cadastro limpo c/ useForm + ClienteForm compartilhado + lookup CNPJ BrasilAPI, mas header sem canon roxo e nav <a> full-reload."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PageHeader canon modo FOCO roxo"
+    fix: "Header so h1 cru, sem PageHeader/primary roxo canon (ADR 0190); padronizar header de form"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Inertia SPA (Link em vez de <a>)"
+    fix: "Voltar usa <a href> = full reload; trocar por <Link> Inertia pra preservar SPA"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe (CTA primario na cor da marca)"
+    fix: "submitLabel padrao no ClienteForm; garantir CTA roxo cowork-primary consistente c/ Import"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-edit.yaml
+++ b/memory/governance/scorecards/screens/cliente-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Edit
+path: resources/js/Pages/Cliente/Edit.tsx
+archetype: form
+persona: larissa
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Espelho do Create (ClienteForm reuso, useForm put), mesma qualidade — falta header canon roxo, Link SPA e dirty-guard."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PageHeader canon modo FOCO roxo"
+    fix: "Header h1 cru sem PageHeader/primary roxo canon; alinhar c/ ADR 0190"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Inertia SPA (Link)"
+    fix: "Voltar <a href> full-reload; usar <Link>"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Notion (aviso de alteracoes nao salvas ao sair)"
+    fix: "Sem dirty-guard; sair perde edicoes silenciosamente — add confirm on unsaved"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-import.yaml
+++ b/memory/governance/scorecards/screens/cliente-import.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Import
+path: resources/js/Pages/Cliente/Import.tsx
+archetype: form
+persona: larissa
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Wizard import bom: 2 passos, progress bar, estado zip-indisponivel, variants cowork — mas cores rose/emerald cruas e sem preview de linhas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (tokens success/danger, nao rose/emerald cru)"
+    fix: "Notification e erro-zip usam rose-/emerald-100/700 crus; trocar por tokens semanticos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Flatfile (preview + relatorio de linhas com erro)"
+    fix: "Sem preview de linhas nem mapeamento de colunas; so sucesso/falha agregado — add preview pre-commit"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Dropzone (drag real, nao so onClick)"
+    fix: "Dropzone tem texto 'arraste' mas so onClick dispara; implementar onDrop real"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-index.yaml
+++ b/memory/governance/scorecards/screens/cliente-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Index
+path: resources/js/Pages/Cliente/Index.tsx
+archetype: list
+persona: larissa
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Flagship denso (KB ⌘K/J/K, KPI strip clicavel, 6 filtros, drawer 5 tabs, avatar HSL) — execucao Leader mas paleta inline oklch/sky-rose fora dos tokens e header nao-canon."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (token --primary, nao oklch inline nem sky/rose/stone cru)"
+    fix: "PRIMARY_HUE 295 via oklch() inline + paleta sky/rose/stone/amber crua; promover pra tokens DS e componente PageHeader canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "PT-01 Lista (header/toolbar componentizados)"
+    fix: "Header+toolbar reconstruidos inline com comentarios de iteracao Wagner; extrair pra PageHeader/Toolbar canon reutilizavel"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Linear (estado derivado enxuto)"
+    fix: "~10 useState de filtro + KPI + KB num so componente 2486 linhas; extrair hooks/subcomponentes"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-ledger.yaml
+++ b/memory/governance/scorecards/screens/cliente-ledger.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Ledger
+path: resources/js/Pages/Cliente/Ledger.tsx
+archetype: detail
+persona: eliana
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Extrato financeiro denso e legivel (KpiCard, debito/credito/saldo, PDF/Excel) mas usa window.location full-reload, cores cruas e sem Deferred."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Inertia SPA (router.get em vez de window.location)"
+    fix: "applyFilters/printPdf usam window.location.href/open = full reload; migrar pra router.get partial"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (tokens debit/credit, nao rose/emerald-700 cru)"
+    fix: "Debito rose-700 / credito emerald-700 / KpiCard rose crus; usar tokens financeiros semanticos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Stripe (Deferred + skeleton em extrato pesado)"
+    fix: "Sem Inertia::defer; extrato grande bloqueia render — add Deferred + skeleton de linhas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-map.yaml
+++ b/memory/governance/scorecards/screens/cliente-map.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Map
+path: resources/js/Pages/Cliente/Map.tsx
+archetype: detail
+persona: larissa
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Split-screen mapa de clientes limpo com tokens, mas mapa via iframe Google hardcoded e lista hand-rolled sem defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Shopify Maps usa lib nativa + tokens"
+    fix: "Trocar iframe maps.google.com hardcoded e text-emerald-600 raw por componente de mapa tokenizado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear vira lista grande sem travar"
+    fix: "Inertia::defer em all_contacts + virtualizar lista quando >100 itens"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe marca item selecionado com aria"
+    fix: "Adicionar aria-pressed/aria-current no botao de cliente selecionado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/cliente-show.yaml
+++ b/memory/governance/scorecards/screens/cliente-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Cliente/Show
+path: resources/js/Pages/Cliente/Show.tsx
+archetype: detail
+persona: larissa
+nota: 86
+nivel: "Leader"
+baseline_anterior: 86   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de cliente maduro: 9 tabs, Deferred em tudo, cowork-primary, CPF mascarado LGPD, frota condicional."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "Bling padroniza paleta de status"
+    fix: "Consolidar cores cruas sky/amber/rose/stone em tokens semanticos de status v4"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion tabs com role=tablist + setas"
+    fix: "Envolver tabs em role=tablist e suportar navegacao por seta/Home/End"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe colapsa sidebar em sheet no mobile"
+    fix: "No mobile mover aside de contato/fiscal pra accordion acima das tabs"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/compras-index.yaml
+++ b/memory/governance/scorecards/screens/compras-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Compras/Index
+path: resources/js/Pages/Compras/Index.tsx
+archetype: list
+persona: larissa
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit denso com drawer, KPIs, defer e visibilidade de colunas, mas CSS bundle proprio fora do DS v4 e tabela hand-rolled."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear usa um unico DS tokenizado"
+    fix: "Migrar cowork-compras-bundle.css e tokens --cmp-* pro primary roxo v4 + @/Components/ui; remover hex crus (#fff,#fbf9f3,#c9d6e8)"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe nunca usa <a> sem href pra tab"
+    fix: "Trocar <a onClick> de tabs/ordenacao por <button> (teclado + foco)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling tem filtro server-side real"
+    fix: "Entregar Importar XML e Filtros (hoje 'Em breve' desabilitado) ou esconder ate existir"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/comunicacaovisual-index.yaml
+++ b/memory/governance/scorecards/screens/comunicacaovisual-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ComunicacaoVisual/Index
+path: resources/js/Pages/ComunicacaoVisual/Index.tsx
+archetype: other
+persona: larissa
+nota: 54
+nivel: "Developing"
+baseline_anterior: 54   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Hub stub honesto de 4 cards 'em breve', mas cores zinc cruas, sem AppShellV2 e sem funcionalidade real."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo + AppShellV2 padrao"
+    fix: "Trocar paleta zinc/amber crua por tokens v4 e montar via AppShellV2 como as demais telas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Shopify entrega valor minimo na v1"
+    fix: "Substituir cards 'em breve' por ao menos a calculadora de m2 (API ja existe na Sprint 1)"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Notion linka a acao real"
+    fix: "Cards com api_hint tecnico nao ajudam Larissa; trocar por CTA util ou status claro"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/consultaos-index.yaml
+++ b/memory/governance/scorecards/screens/consultaos-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ConsultaOs/Index
+path: resources/js/Pages/ConsultaOs/Index.tsx
+archetype: form
+persona: misto
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Consulta publica de OS limpa com 3 estados (busca/resultado/nao-encontrado) e @/Components/ui, mas gradiente blue/violet fora do brand."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe logo coerente com a marca"
+    fix: "Trocar gradiente from-blue-500 to-violet-600 pelo roxo primary v4 (zero blue)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Charter vivo ao lado do tsx"
+    fix: "Criar Index.charter.md (so existe Index.review.md) com Mission/Non-Goals"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Shopify anuncia loading em aria-live"
+    fix: "Adicionar aria-live no bloco de erro/resultado e aria-busy no submit"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-documents-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-documents-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Documents/Index
+path: resources/js/Pages/Essentials/Documents/Index.tsx
+archetype: list
+persona: misto
+nota: 83
+nivel: "Developing"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "CRUD de docs/memos forte: tabs, upload com progresso, share dialog, AlertDialog e toasts, tudo tokenizado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Charter vivo ao lado do tsx"
+    fix: "Criar Index.charter.md (so existe .review.md)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion mostra tipo/tamanho do arquivo"
+    fix: "Adicionar coluna de tipo/tamanho do arquivo e icone por extensao"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Linear vira tabela em cards no mobile"
+    fix: "Colapsar a tabela em lista de cards <640px (hoje so overflow-x)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-holidays-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-holidays-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Holidays/Index
+path: resources/js/Pages/Essentials/Holidays/Index.tsx
+archetype: list
+persona: misto
+nota: 84
+nivel: "Developing"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de feriados solida: filtros por localidade/data, dialog create/edit, badge de dias, empty state, full DS."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Mobile-fit"
+    best_of_class: "Linear converte tabela em cards no mobile"
+    fix: "Colapsar tabela em cards <640px em vez de overflow horizontal"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Bling lista feriados em calendario"
+    fix: "Oferecer toggle visao calendario/lista pra leitura rapida do mes"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe explica escopo do filtro"
+    fix: "Hint de que feriado sem localidade vale pra todas as lojas"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-knowledge-create.yaml
+++ b/memory/governance/scorecards/screens/essentials-knowledge-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Knowledge/Create
+path: resources/js/Pages/Essentials/Knowledge/Create.tsx
+archetype: form
+persona: misto
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de criacao coeso (tipo derivado do pai, compartilhamento, autoFocus), mas conteudo HTML em textarea cru sem editor."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Notion edita rich-text WYSIWYG"
+    fix: "Trocar Textarea 'HTML permitido' por editor rich-text (ou markdown) com preview"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear avisa antes de descartar"
+    fix: "Guardar dirty state e confirmar ao sair/cancelar com texto digitado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Charter vivo ao lado do tsx"
+    fix: "Criar Create.charter.md (so existe .review.md)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-knowledge-edit.yaml
+++ b/memory/governance/scorecards/screens/essentials-knowledge-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Knowledge/Edit
+path: resources/js/Pages/Essentials/Knowledge/Edit.tsx
+archetype: form
+persona: misto
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edicao espelha o Create com mesmos campos e DS limpo; mesma lacuna de editor rich-text e charter ausente."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Notion edita rich-text WYSIWYG"
+    fix: "Trocar Textarea de conteudo por editor rich-text com preview"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear protege edicao nao salva"
+    fix: "Detectar dirty e confirmar antes de sair/cancelar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Stripe extrai form compartilhado"
+    fix: "Extrair form compartilhado Create/Edit pra um KbForm unico (DRY)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-knowledge-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-knowledge-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Knowledge/Index
+path: resources/js/Pages/Essentials/Knowledge/Index.tsx
+archetype: list
+persona: misto
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Arvore livro/secao/artigo em cards com expand/collapse e delete confirmado, mas innerHTML cru e botoes-icone minusculos."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion alvos de toque >=24px"
+    fix: "Botoes-icone de 0.5/1px de padding violam alvo minimo; subir pra h-7 w-7 + aria-label"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Conteudo sanitizado server-side"
+    fix: "dangerouslySetInnerHTML em book.content exige sanitizacao (XSS) antes de render"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Notion tem busca global no topo"
+    fix: "Adicionar campo de busca por titulo/conteudo no header da base"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-knowledge-show.yaml
+++ b/memory/governance/scorecards/screens/essentials-knowledge-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Knowledge/Show
+path: resources/js/Pages/Essentials/Knowledge/Show.tsx
+archetype: detail
+persona: misto
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Leitor de artigo com nav lateral em arvore, prose e badge de tipo, mas innerHTML cru e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Conteudo sanitizado server-side"
+    fix: "Sanitizar item.content antes de dangerouslySetInnerHTML (XSS)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Notion mostra breadcrumb do caminho"
+    fix: "Breadcrumb Livro > Secao > Artigo acima do titulo alem da nav lateral"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe vira nav em drawer no mobile"
+    fix: "Colapsar aside de arvore em drawer/accordion <1024px"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-messages-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-messages-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Messages/Index
+path: resources/js/Pages/Essentials/Messages/Index.tsx
+archetype: chat
+persona: misto
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Mural chat com polling, auto-scroll, Enter-envia e bolhas mine/theirs tokenizadas, mas innerHTML stored-XSS e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Slack escapa msg do usuario"
+    fix: "m.message via dangerouslySetInnerHTML e XSS armazenado; escapar/sanitizar texto do usuario"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Slack usa websocket nao polling"
+    fix: "Trocar polling por Centrifugo (CT100) ou ao menos pausar polling em aba inativa"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Slack mostra estado offline/reenviar"
+    fix: "Indicar falha de polling/conexao e botao reenviar em vez de silenciar"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-reminders-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-reminders-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Reminders/Index
+path: resources/js/Pages/Essentials/Reminders/Index.tsx
+archetype: list
+persona: misto
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista pessoal limpa com Dialog+AlertDialog, @/ui, charter live; falta PageHeader canon, tokens v4 (usa default) e loading state."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: PageHeader canon v3 + tokens"
+    fix: "Trocar <header> hand-roll por <PageHeader> canon; charter existe e está bom"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Stripe: skeleton + defer"
+    fix: "Sem Inertia::defer/Deferred nem skeleton; lista eager (ok p/ <50 itens mas sem loading state)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Notion: atalhos teclado + bulk"
+    fix: "Sem atalho 'n' p/ novo nem busca/filtro por nome; só lista linear"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-settings-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-settings-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Settings/Index
+path: resources/js/Pages/Essentials/Settings/Index.tsx
+archetype: config
+persona: misto
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de config bem cardificado com Switch/Textarea/@ui; falha em inputs numéricos crus, breadcrumb HRM≠Essentials e ausência de charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe: validação numérica inline"
+    fix: "Grace periods são Input string sem type=number/min; sem form.errors render nos campos de tolerância"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: PageHeader + breadcrumb coerente"
+    fix: "Header hand-roll; breadcrumb diz 'HRM' mas módulo é Essentials (inconsistência); sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion settings: grupos colapsáveis + dirty-state"
+    fix: "Sem indicador de campo alterado nem sticky save; 4 cards planos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-todo-create.yaml
+++ b/memory/governance/scorecards/screens/essentials-todo-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Todo/Create
+path: resources/js/Pages/Essentials/Todo/Create.tsx
+archetype: form
+persona: misto
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de criação sólido (@ui, Sonner, validação inline em task/date); falta PageHeader canon, charter e multiselect com busca."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: modo FOCO PageHeader sem distração"
+    fix: "Header hand-roll em vez de PageHeader modo-foco; sem charter (só Reminders tem)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Shopify: multiselect com search/chips removíveis"
+    fix: "Picker de usuários é botões toggle sem busca; ruim com muitos users"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe: estimated_hours numérico validado"
+    fix: "estimated_hours é Input string livre, sem type=number/máscara"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-todo-edit.yaml
+++ b/memory/governance/scorecards/screens/essentials-todo-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Todo/Edit
+path: resources/js/Pages/Essentials/Todo/Edit.tsx
+archetype: form
+persona: misto
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit consistente com Create (Head dinâmico, @ui, validação); mesmos gaps: sem PageHeader canon, charter, busca no multiselect, nem dirty-guard."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: PageHeader modo FOCO"
+    fix: "Header hand-roll; sem charter; espelha Create sem dirty-guard ao sair"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Shopify: multiselect search"
+    fix: "Mesmo picker toggle sem busca do Create"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Notion: aviso de mudanças não salvas"
+    fix: "Sem unsaved-changes guard; Cancelar descarta sem confirmar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-todo-index.yaml
+++ b/memory/governance/scorecards/screens/essentials-todo-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Todo/Index
+path: resources/js/Pages/Essentials/Todo/Index.tsx
+archetype: list
+persona: misto
+nota: 77
+nivel: "Advanced"
+baseline_anterior: 77   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista com filtros, troca rápida de status e paginação funcionais; perde em cores cruas (sem tokens v4), tabela hand-roll e ausência de defer/skeleton."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4: status via tokens, não cores cruas"
+    fix: "statusTone/priorityTone hardcodam bg-amber/sky/emerald/rose; trocar por Badge variantes/tokens v4 (zero roxo na tela)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear: defer + skeleton tabela"
+    fix: "Paginated eager sem Inertia::defer/Deferred nem skeleton; filtros disparam router.get full"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Bling: DataTable compartilhada"
+    fix: "Tabela hand-roll em vez de PT-01/DataTable; sem PageHeader canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/essentials-todo-show.yaml
+++ b/memory/governance/scorecards/screens/essentials-todo-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Essentials/Todo/Show
+path: resources/js/Pages/Essentials/Todo/Show.tsx
+archetype: detail
+persona: misto
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe rico (tabs comentários/anexos/atividades, upload com progress, fetch async); arranha em GET-deleta, cores cruas e dangerouslySetInnerHTML."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe: DELETE verbo correto"
+    fix: "Delete de comentário/anexo via router.get (GET muta estado); migrar p/ DELETE + AlertDialog (já usa dialog, mas verbo GET é frágil)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4: tokens"
+    fix: "statusTone/priorityTone cores cruas; dangerouslySetInnerHTML na descrição (XSS se backend não sanear)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear: Tabs do DS"
+    fix: "Tabs hand-roll (TabButton) em vez de @/ui Tabs; sem PageHeader canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-advisor-dashboard.yaml
+++ b/memory/governance/scorecards/screens/financeiro-advisor-dashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Advisor/Dashboard
+path: resources/js/Pages/Financeiro/Advisor/Dashboard.tsx
+archetype: dashboard
+persona: eliana
+nota: 52
+nivel: "Developing"
+baseline_anterior: 52   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Portal contador read-only funcional com grid de clientes e aviso LGPD; estética crua (os-btn legacy, cores hand-roll, zero DS v4/roxo) e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4: @/ui + tokens roxo"
+    fix: "Tudo hand-roll: bg-slate/white/amber/emerald cruas, os-btn legacy em vez de @/ui Button, zero token v4, zero roxo, sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe portal: identidade forte"
+    fix: "Portal genérico cinza; sem logo/brand roxo, parece scaffold"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear: foco/landmark"
+    fix: "Cards <div> sem role/heading semântico consistente; botão Sair sem aria; links read-only sem indicação de estado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-advisor-login.yaml
+++ b/memory/governance/scorecards/screens/financeiro-advisor-login.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Advisor/Login
+path: resources/js/Pages/Financeiro/Advisor/Login.tsx
+archetype: form
+persona: eliana
+nota: 50
+nivel: "Developing"
+baseline_anterior: 50   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Login isolado do portal contador (justificadamente fora do AppShell) com flash success/error; inputs/botões crus, cores hand-roll, zero DS v4 e sem recuperação de senha."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4: @/ui Input/Button"
+    fix: "<input> e os-btn crus (só Checkbox/Label do @/ui); cores slate/emerald/red hand-roll, zero token v4/roxo, sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe login: marca + trust"
+    fix: "Gradiente slate genérico sem logo oimpresso roxo; baixa confiança"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Auth0: lockout/forgot"
+    fix: "Sem 'esqueci a senha', sem rate-limit hint; só reset de password no erro"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-assinaturaatualizar.yaml
+++ b/memory/governance/scorecards/screens/financeiro-assinaturaatualizar.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/AssinaturaAtualizar
+path: resources/js/Pages/Financeiro/AssinaturaAtualizar.tsx
+archetype: form
+persona: eliana
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form propositalmente minimal (HITL pending Wagner) p/ alterar cobrança recorrente; @/ui + useMemo ok, mas header legacy, sem tabela de assinaturas, sem charter nem preview de impacto."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PageHeader canon v3.8"
+    fix: "header usa os-page-h/fin-page-h/fin-cowork/vendas-aplus legacy em vez de <PageHeader>; sem charter (arquivo se diz 'UI minimal HITL pending')"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Stripe billing: lista + edição contextual"
+    fix: "Só um Select p/ escolher assinatura; sem tabela das assinaturas ativas com estado visível"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe: preview do impacto antes de salvar"
+    fix: "Patch parcial sem confirmação/preview (biz=4 prod ROTA LIVRE); sem diff valor antigo→novo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-caixa-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-caixa-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Caixa/Index
+path: resources/js/Pages/Financeiro/Caixa/Index.tsx
+archetype: list
+persona: eliana
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Wrapper read-only maduro: charter excelente, PageHeader v3.8, SubNav, KPIs, fmtMoney pt-BR e badge integração; perde em cores cruas/emerald-primary, confirm() nativo e tabela hand-roll."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4: tokens roxo, zero cor crua"
+    fix: "PageHeader canon ok, mas bg-emerald/stone/blue/red/amber + bg-white hardcoded (sem dark), emerald como primary (não roxo), emojis ℹ️⚠️✅💡 na UI"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear: AlertDialog confirm"
+    fix: "native confirm() p/ lançar fin_titulo retroativo; trocar por AlertDialog do @/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Bling: DataTable + export"
+    fix: "Tabela hand-roll (charter mira PT-01); sem export (backlog conhecido)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-categorias-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-categorias-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Categorias/Index
+path: resources/js/Pages/Financeiro/Categorias/Index.tsx
+archetype: list
+persona: eliana
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista CRUD com PageHeader canon, FinanceiroPrimaryButton, drawer CategoriaSheet e toasts; arranha em confirm() nativo, cores cruas de tipo e ausência de charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Linear: AlertDialog confirm"
+    fix: "native confirm() p/ excluir/soft-delete; migrar p/ AlertDialog do @/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4: tokens semânticos"
+    fix: "TIPO_LABELS hardcodam bg-emerald/rose/slate; sem charter; classes legacy fin-curadoria/vendas-aplus/fin-cowork"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Bling: DataTable compartilhada"
+    fix: "Tabela hand-roll em vez de PT-01/DataTable padrão"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-cobranca-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-cobranca-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Cobranca/Index
+path: resources/js/Pages/Financeiro/Cobranca/Index.tsx
+archetype: list
+persona: eliana
+nota: 94
+nivel: "Leader"
+baseline_anterior: 94   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Port Cowork F1.5 96/100: charter live, defer+Deferred, KB-9.75, localStorage, PII mask, primary roxo 295 - referencia de excelencia do modulo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "Stripe (1 atoms lib pro modulo todo)"
+    fix: "Atoms locais (_components/atoms) divergem do DS shadcn das telas irmas; consolidar StatusBadge/KpiCard em @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Linear (cards stack <768px)"
+    fix: "Charter assume desktop-only; filtros em 2 linhas + tabela 8col estouram mobile - sem fallback responsivo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion (sort clicavel)"
+    fix: "Sort de coluna e export sao no-op (backlog Onda 5); botoes sugerem acao que nao existe"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-conciliacao-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-conciliacao-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Conciliacao/Index
+path: resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+archetype: list
+persona: eliana
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Fluxo OFX upload->match->aprovar funcional e claro, mas oklch cru inline nos botoes, sem defer, sem charter e file input nao estilizado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Cobranca (token primary roxo)"
+    fix: "Botao Importar/Confirmar/Ignorar usam style inline oklch(0.55 0.15 145/25) cru; trocar por token DS / variant"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred+skeleton)"
+    fix: "linhas/stats eager sem Inertia::defer nem skeleton; OFX grande trava first paint"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Stripe (dropzone)"
+    fix: "input type=file nativo sem estilo; usar dropzone shadcn + nome do arquivo + progresso"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-configuracoes-contador.yaml
+++ b/memory/governance/scorecards/screens/financeiro-configuracoes-contador.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Configuracoes/Contador
+path: resources/js/Pages/Financeiro/Configuracoes/Contador.tsx
+archetype: config
+persona: eliana
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "MVP F0 stub (charter pendente): consent LGPD bem feito, mas inputs hand-rolled, flash bg-blue cru, confirm() nativo e sem PageHeader/SubNav/defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "ContasPagar (shadcn Input/Sheet)"
+    fix: "Inputs CNPJ/email/nome sao <input> hand-rolled com classes cruas; migrar pra @/Components/ui/input + flash bg-blue-300/50 viola zero-blue"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear (modal confirm)"
+    fix: "revoke usa window.confirm() nativo; trocar por AlertDialog shadcn com consequencia explicita"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Cobranca (PageHeader+SubNav)"
+    fix: "Usa os-page-h inline sem PageHeader canon nem FinanceiroSubNav; tela orfa da navegacao do modulo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-contasbancarias-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-contasbancarias-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/ContasBancarias/Index
+path: resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+archetype: list
+persona: eliana
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista shadcn limpa com StatusBadge semantico e Sheet de config boleto; charter live, mas primary oklch inline (TODO Wave5) e sem defer/skeleton."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Cobranca (FinanceiroPrimaryButton)"
+    fix: "Primary 'Nova conta' com style inline oklch 295 cru (TODO assumido); trocar pelo FinanceiroPrimaryButton shim"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred)"
+    fix: "accounts eager sem defer/skeleton; lista carrega sincrona"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe (CTA pra acao)"
+    fix: "Empty state 'Cadastre primeiro no POS' sem link/botao acionavel pro POS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-contaspagar-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-contaspagar-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/ContasPagar/Index
+path: resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+archetype: list
+persona: eliana
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista titulos + Sheet de baixa shadcn com toast e validacao; solido, mas status bg-blue-100 nao-token, sem defer/skeleton e empty state minimo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PlanoContas (tipo tokens fin)"
+    fix: "STATUS_LABELS aberto usa bg-blue-100 text-blue-900 cru; mapear pra cor semantica DS (sky/stone token)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred+skeleton)"
+    fix: "titulos eager sem defer; sem skeleton de tabela enquanto filtro recarrega"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Cobranca (KB-9.75 / + Enter)"
+    fix: "Zero atalhos teclado; Eliana navega so com mouse - sem busca, sem foco /"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-contasreceber-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-contasreceber-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/ContasReceber/Index
+path: resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+archetype: list
+persona: eliana
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Gemea de ContasPagar com coluna boleto + emitir-boleto via toast; mesmos pontos fortes e fracos: bg-blue-100 cru, sem defer, sem atalhos."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PlanoContas (tipo tokens fin)"
+    fix: "STATUS_LABELS aberto bg-blue-100 text-blue-900 cru viola zero-blue; trocar por token semantico"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred+skeleton)"
+    fix: "titulos eager sem Inertia::defer nem skeleton de tabela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (estado loading por linha)"
+    fix: "emitirForm.processing desabilita TODOS os botoes Emitir simultaneamente (form global), nao so a linha clicada"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-dashboard-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-dashboard-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Dashboard/Index
+path: resources/js/Pages/Financeiro/Dashboard/Index.tsx
+archetype: dashboard
+persona: eliana
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Defer+skeletons com aria em todos os blocos, KPI clicaveis pra filtrar; forte, mas cores bg-blue/purple/green cruas, dangerouslySetInnerHTML na paginacao e 'Novo titulo' no-op."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PlanoContas (fin tokens)"
+    fix: "Badges conta usam bg-blue-100/bg-purple-100/bg-green-100 cruas; consolidar em tokens semanticos roxo/stone"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe (CTA real)"
+    fix: "Botao primary 'Novo titulo' sem onClick (no-op); ou liga em /unificado/novo ou remove"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear (markup seguro)"
+    fix: "Paginacao via dangerouslySetInnerHTML(link.label); render texto direto evita XSS e melhora SR"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-dre-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-dre-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Dre/Index
+path: resources/js/Pages/Financeiro/Dre/Index.tsx
+archetype: detail
+persona: eliana
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "DRE hierarquico denso classe-Cowork com tabs Balanco/Balancete, charter+visual-comparison approved; mas 5 botoes feature sao no-op F1, banner oklch cru e sem defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Notion (sem botao morto)"
+    fix: "Buscar/Resumir/Fechamento/Apresentar/Exportar no overflow sao stubs vazios (onClick comentado); esconder ate F2 ou marcar 'em breve'"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Cobranca (sem style inline)"
+    fix: "Banner aviso_sem_mapping com style inline oklch 70 cru; extrair pra componente Alert DS com token amber"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred)"
+    fix: "linhas/balanco/balancete eager sem defer; DRE pesado bloqueia first paint"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-extrato-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-extrato-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Extrato/Index
+path: resources/js/Pages/Financeiro/Extrato/Index.tsx
+archetype: detail
+persona: eliana
+nota: 67
+nivel: "Developing"
+baseline_anterior: 67   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Extrato bancario shadcn com 4 cards-resumo e filtro periodo; charter live, mas header os-page-h inline sem PageHeader/SubNav, text-red cru e doc da contraparte exposto sem mascara (PII)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe (PII mascarada)"
+    fix: "contraparte_documento renderizado em plain text; aplicar piiMask como em Cobranca (LGPD)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Cobranca (PageHeader+SubNav)"
+    fix: "Header os-page-h inline sem PageHeader canon nem FinanceiroSubNav; rompe navegacao do modulo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Fluxo (rose token)"
+    fix: "Debitos usam text-red-600 cru; padronizar pra rose semantico do modulo"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-fluxo-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-fluxo-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Fluxo/Index
+path: resources/js/Pages/Financeiro/Fluxo/Index.tsx
+archetype: dashboard
+persona: eliana
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Fluxo de caixa projetado+realizado com graficos de barra inline, tabs deep-link, charter+visual-comparison approved e tokens fin consistentes; banner oklch cru e sem defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Cobranca (componente Alert)"
+    fix: "Banner 'sem conta cadastrada' com style inline oklch 70 cru; extrair pra Alert DS token amber"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred+skeleton)"
+    fix: "RealizadoView so tem texto 'Carregando…'; dias/realizado sem Inertia::defer real nem skeleton de grafico"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Stripe charts (Recharts/SVG)"
+    fix: "Grafico de barras div-based artesanal sem eixo-Y/gridlines/tooltip acessivel; considerar lib de chart"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-planocontas-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-planocontas-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/PlanoContas/Index
+path: resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+archetype: list
+persona: eliana
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Plano de contas hierarquico denso com tokens fin-*, filtro radiogroup a11y e indentacao por nivel; mas microcopy de empty vaza comando tinker SSH e hue 240 (blue) no CSS var."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Microcopy"
+    best_of_class: "Bling (empty amigavel)"
+    fix: "Empty state mostra comando `php artisan tinker --execute=...` pro usuario final; trocar por CTA/instrucao de negocio"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DRE (delta tokens)"
+    fix: "--cb-hue 240 (azul) pra ativo/passivo viola zero-blue; usar hues semanticos do DS (stone/violet)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred)"
+    fix: "planos eager sem defer/skeleton; plano BR cheio (centenas de linhas) carrega sincrono"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-relatorios-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-relatorios-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Relatorios/Index
+path: resources/js/Pages/Financeiro/Relatorios/Index.tsx
+archetype: dashboard
+persona: eliana
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Relatorios com tabs Fluxo/Resumo, KPI fin-stats, export CSV e card-alerta de vencidos; solido mas banner DRE oklch cru, sem defer e graficos div artesanais."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Cobranca (Alert DS)"
+    fix: "Banner 'DRE virou tela dedicada' com style inline oklch 70 cru; extrair pra Alert token amber"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Dashboard (Deferred+skeleton)"
+    fix: "fluxo/resumo eager sem Inertia::defer; relatorio de periodo longo bloqueia paint"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe (tabela ou chart, nao ambos crus)"
+    fix: "FluxoBars 4 barras empilhadas por linha sem legenda inline/eixo dificultam leitura proj-vs-real"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-unificado-index.yaml
+++ b/memory/governance/scorecards/screens/financeiro-unificado-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Unificado/Index
+path: resources/js/Pages/Financeiro/Unificado/Index.tsx
+archetype: list
+persona: eliana
+nota: 90
+nivel: "Leader"
+baseline_anterior: 90   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit financeiro denso estado-da-arte (KPI hero+sparkline, multi-filtro, bulk, drawer 3-abas, atalhos J/K/space/B, OCR boleto) — top do batch, so peca mistura emoji+oklch cru vs DS."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "Stripe/Linear: 1 sistema de cor/icone"
+    fix: "Trocar emoji cru (🔍🏦📷👁✉☆) por lucide-react ja importado; unificar fin-* CSS vs @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Shopify Polaris tokens"
+    fix: "Migrar inline oklch hardcoded e classes fin-num-* pra tokens DS v4 primary roxo (zero hue 145/25/240 cru)"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear keyboard map visivel"
+    fix: "Sparkline tooltip via <title> nao e a11y; status so por cor em pills — adicionar texto/aria-live nos baixar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/financeiro-unificado-novo.yaml
+++ b/memory/governance/scorecards/screens/financeiro-unificado-novo.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Financeiro/Unificado/Novo
+path: resources/js/Pages/Financeiro/Unificado/Novo.tsx
+archetype: form
+persona: eliana
+nota: 52
+nivel: "Developing"
+baseline_anterior: 52   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Stub-ponte provisorio (2 cards picker receber/pagar) auto-declarado status=stub — funcional mas sem form real nem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Bling: form unico inline"
+    fix: "E stub picker (2 cards) que so redireciona pra contas-receber/pagar — entregar form unificado real"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS shadcn Button"
+    fix: "Sem charter; usa os-btn cru e nao @/Components/ui; sem estados loading/error"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion empty-action"
+    fix: "Cards div role=button com hover-cor crua; usar Card + Button DS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-cockpit.yaml
+++ b/memory/governance/scorecards/screens/fiscal-cockpit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Cockpit
+path: resources/js/Pages/Fiscal/Cockpit.tsx
+archetype: dashboard
+persona: eliana
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit fiscal unificado rico (ribbon KPI, saved-views chips, bulk, drawers NFe/NFSe/Eventos, density) — charter ok, mas layer fx-* fora do DS e dados mock eager."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 @/Components/ui + primary roxo"
+    fix: "FxShell usa --fx-* / fx-btn / <input> cru + 6-KPI ribbon fora do DS shadcn; alinhar com tokens DS"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Inertia::defer (ver Nfe.tsx)"
+    fix: "notasMock vem eager no controller (sem Deferred como nas irmas Nfe/Nfse/Dfe)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear single-source filter"
+    fix: "Filtro client-side local (TODO sync URL) diverge do server-side filter das sub-paginas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-config.yaml
+++ b/memory/governance/scorecards/screens/fiscal-config.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Config
+path: resources/js/Pages/Fiscal/Config.tsx
+archetype: config
+persona: eliana
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Config fiscal unificada solida (cert A1 upload+ambiente+testar SEFAZ live+series+SPED, 4 tabs, useForm+toast) — UX completa, mas forms 100% inline-style fora do DS."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "shadcn Form + Input"
+    fix: "Inputs/radio 100% hand-rolled com inline style; usar @/Components/ui/input + form DS"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe field-level errors"
+    fix: "Bom (toast+errors inline+teste SEFAZ live) — falta aria-invalid nos campos pfx/senha"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Notion 1-col foco"
+    fix: "Muito inline-style verboso (style={{display:grid...}}) repetido; extrair pra classes"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-dfe.yaml
+++ b/memory/governance/scorecards/screens/fiscal-dfe.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Dfe
+path: resources/js/Pages/Fiscal/Dfe.tsx
+archetype: list
+persona: eliana
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Manifestacao DF-e bem-feita (callout legal, 4 acoes SEFAZ com modal justificativa min-15char validado, Deferred, historico) — gaps: modal inline-style e bulk pendente."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS Dialog + tokens"
+    fix: "Modal justificativa 100% inline-style (rgba(0,0,0,.2), width 460) em vez de @/Components/ui/dialog; AP hex cru"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Gmail bulk archive"
+    fix: "Botao 'Manifestar selecionadas' disabled (PR seguinte) — sem bulk real ainda"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Linear icon+label"
+    fix: "Acoes manifestacao so icon (Check/Eye/X) — label so no title; ambiguo entre confirmar/nao-realizada"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-eventos.yaml
+++ b/memory/governance/scorecards/screens/fiscal-eventos.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Eventos
+path: resources/js/Pages/Fiscal/Eventos.tsx
+archetype: list
+persona: eliana
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Timeline append-only de eventos fiscais (CC-e/cancel/EPEC/manifesto) com callout janelas legais + Deferred + link cross pra NFe — correta e enxuta, layer fx-* fora do DS."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS tokens + Select"
+    fix: "Timeline fx-tl-* + <select> cru fora do DS; sem @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear filtro persistente"
+    fix: "Filtro tipo+dias nao reflete em URL bookmark alem do server-roundtrip; sem busca textual"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe stacked timeline"
+    fix: "fx-tl-h horizontal (badge+link+cstat+when) sem wrap testado em mobile"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-nfe.yaml
+++ b/memory/governance/scorecards/screens/fiscal-nfe.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Nfe
+path: resources/js/Pages/Fiscal/Nfe.tsx
+archetype: list
+persona: eliana
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit NF-e/NFC-e exemplar de perf (Inertia Deferred + only:[] partial reload, J/K/Enter nav, chips status server-side, drawer SEFAZ) — melhor padrao tecnico do batch; acoes write ainda stub."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 primary + @/Components/ui"
+    fix: "fx-btn/fx-chip/<input> hand-rolled + var(--fis) rosa fora do DS roxo; migrar pra tokens DS"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling emissao 1-click"
+    fix: "Botoes Emitir/Importar XML disabled (PR seguinte); R/X atalhos 'em breve' — leitura-only hoje"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe status hints"
+    fix: "Bom (cstat+hint SEFAZ+prazo 24h pill) — entrada XML hardcoded count 0"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-nfse.yaml
+++ b/memory/governance/scorecards/screens/fiscal-nfse.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Nfse
+path: resources/js/Pages/Fiscal/Nfse.tsx
+archetype: list
+persona: eliana
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista NFS-e nacional (status+ISS+competencia month-picker, Deferred, chips) — consistente com irmas mas mais rasa: sem drawer detalhe nem acoes por linha."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS tokens + @/Components/ui"
+    fix: "fx-chip/fx-search/<input month> cru fora do DS; sem charter-fetch no fluxo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Linear row-click drawer"
+    fix: "Linhas sem onClick/drawer (so title=errorMsg) — NFSe nao tem detalhe vs NFe que tem"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe inline retry"
+    fix: "Rejeitadas so mostram errorMsg via title hover; sem acao reenviar/corrigir na linha"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/fiscal-sped.yaml
+++ b/memory/governance/scorecards/screens/fiscal-sped.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Fiscal/Sped
+path: resources/js/Pages/Fiscal/Sped.tsx
+archetype: list
+persona: eliana
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "SPED MVP parcial (tabela competencias + export EFD-ICMS/IPI .txt funcional, resto placeholder 'em dev') — funcional no core mas imaturo e com hex cru de fallback."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS tokens (zero hex)"
+    fix: "Hex cru em fallback gradient (#d4f4dd, #2da764) + inline-style pesado; usar var DS sem fallback hardcoded"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Notion progressive disclosure"
+    fix: "Tela maioria placeholder/callout 'em desenvolvimento'; so 1 export EFD real funciona"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear status-driven actions"
+    fix: "Sem filtro/busca; export so .txt por linha — sem preview do conteudo SPED"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/governance-audit.yaml
+++ b/memory/governance/scorecards/screens/governance-audit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: governance/Audit
+path: resources/js/Pages/governance/Audit.tsx
+archetype: list
+persona: wagner
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Audit forense com 4 filtros server-side e charter ao lado, mas selects/tabela hand-rolled com zinc/emerald crus e sem paginacao real."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear filters"
+    fix: "selects nativos com border-zinc-300/bg-white crus + statusColor bg-emerald/red-100 + text-zinc-500 cru por toda parte -> Select @/Components/ui + tokens"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GitHub audit"
+    fix: "labels de filtro sem htmlFor; table sem scope/caption; sort ausente -> associar labels + th scope=col"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Datadog logs"
+    fix: "limit 200 fixo sem paginacao/load-more nem busca textual em endpoint -> paginacao + free-text"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/governance-dashboard.yaml
+++ b/memory/governance/scorecards/screens/governance-dashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: governance/Dashboard
+path: resources/js/Pages/governance/Dashboard.tsx
+archetype: dashboard
+persona: wagner
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit de governanca rico (KPIs constituicao+saude, 3 paineis, atalhos, links canon) com charter, mas emojis e paleta crua afastam do DS roxo estado-da-arte."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear dashboard"
+    fix: "blue/rose/amber/emerald-50 em severityBadgeClass+modeBadge + emoji 📋📊🤖⚙️ como icones de secao + atalhos bg-zinc-50 cru -> tokens v4 + lucide"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Stripe home"
+    fix: "secoes-titulo uppercase + emojis dao ar improvisado vs cockpit roxo; KpiGrid cols=6 aperta -> hierarquia com PageHeader/icones consistentes"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Notion"
+    fix: "KpiGrid cols=6 e cols=3 + grid lg:3 cards quebram cedo; emojis nao escalam -> breakpoints e densidade mobile"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/governance-driftalerts.yaml
+++ b/memory/governance/scorecards/screens/governance-driftalerts.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: governance/DriftAlerts
+path: resources/js/Pages/governance/DriftAlerts.tsx
+archetype: list
+persona: wagner
+nota: 69
+nivel: "Developing"
+baseline_anterior: 69   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de drift funcional com KPIs e historico, mas quase toda em amber cru e divs hand-rolled (sem CardTitle), read-only sem acao e fora do DS roxo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "tudo em amber-50/100/200/950 + zinc cru hand-rolled, h3 hand-rolled em vez de CardTitle, zero primary roxo + charter existe mas UI nao herda DS -> tokens v4 + Card components"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Datadog monitors"
+    fix: "3 secoes (runtime/sem-scope/historico) achatadas sem severidade visual nem agrupamento; '→ ctrl' como bullet -> severidade por cor token + counts no header"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Linear"
+    fix: "drift listado mas sem acao inline (add ao SCOPE, ir pro modulo) -> CTA por item ligando ao fix descrito no texto"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/governance-modulegrades-index.yaml
+++ b/memory/governance/scorecards/screens/governance-modulegrades-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: governance/ModuleGrades/Index
+path: resources/js/Pages/governance/ModuleGrades/Index.tsx
+archetype: list
+persona: wagner
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tabela densa 13-col com filtros/KPIs/Deferred/skeletons e charter — mas paleta sky/emerald em vez de primary roxo v4 e header de cores cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (1 accent token consistente)"
+    fix: "Trocar focus:ring-sky-500, chip ativo zinc-900 e header D6-D9 (purple/pink/indigo/cyan literais) por tokens primary/ring v4 roxo 295"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify (cards stacked < md)"
+    fix: "Tabela 13col só faz overflow-x; abaixo de sm virar lista de cards key-value"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe"
+    fix: "Empty 'Nenhum módulo combina' poderia oferecer ação 'limpar filtros'"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/governance-modulegrades-show.yaml
+++ b/memory/governance/scorecards/screens/governance-modulegrades-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: governance/ModuleGrades/Show
+path: resources/js/Pages/governance/ModuleGrades/Show.tsx
+archetype: detail
+persona: wagner
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe rico: sparkline a11y, dossier markdown deferred, modal Evoluir, gaps ordenados — porém botão Evoluir verde hardcoded e accents per-dim em cores cruas, não tokens v4."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Notion (system tokens)"
+    fix: "Substituir bg-emerald-600 do CTA e DIM_ACCENT purple/pink/indigo/cyan por variantes de Button + tokens roxo/semânticos v4"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe"
+    fix: "Score raw /118 + 3 badges no header competem; agrupar metadados secundários e dar 1 ponto focal"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear"
+    fix: "Subtitle diz 'module-grade-v1' mas resto é v3; alinhar versionamento no copy"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/governance-policies.yaml
+++ b/memory/governance/scorecards/screens/governance-policies.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: governance/Policies
+path: resources/js/Pages/governance/Policies.tsx
+archetype: config
+persona: wagner
+nota: 66
+nivel: "Developing"
+baseline_anterior: 66   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Toggle de rules limpo com KpiGrid/EmptyState e dark-mode, mas toggle hand-rolled (emerald cru), sem loading/optimistic e sem token roxo v4."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Stripe (Switch component)"
+    fix: "Trocar botão toggle artesanal por @/Components/ui/switch com estado pending/disabled durante router.post"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear (optimistic + rollback)"
+    fix: "toggle não trata erro/loading; adicionar onError toast + estado otimista"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "bg-emerald-500 do switch e ausência de wrapper max-w consistente; usar tokens primary/success v4"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/home-index.yaml
+++ b/memory/governance/scorecards/screens/home-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Home/Index
+path: resources/js/Pages/Home/Index.tsx
+archetype: dashboard
+persona: misto
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Landing pos-login limpa e WCAG-AA (8 KPI Vendas/Compras agrupados, accent-map JIT-safe, primary roxo, permission gate, fallback legacy) — solido mas KPIs estaticos sem drill."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "shadcn Select"
+    fix: "<select> location nativo cru em vez de @/Components/ui/select (resto e 100% DS + primary roxo)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe dashboard drill"
+    fix: "8 KPI cards estaticos sem click-through/drill nem sparkline; valor so leitura"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Shopify home quick-actions"
+    fix: "Landing sem atalhos/quick-actions; depende de banner legacy pra graficos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-admin-custos-index.yaml
+++ b/memory/governance/scorecards/screens/jana-admin-custos-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Admin/Custos/Index
+path: resources/js/Pages/Jana/Admin/Custos/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Dashboard custos IA bem-feito (4 KPI + SVG area chart inline + tabela por-usuario com tfoot total, primary roxo, @/Components/ui) — DS-clean, so falta charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "charter-fetch obrigatorio"
+    fix: "Falta Index.charter.md ao lado (unica admin Jana sem charter); resto e DS-clean exemplar"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe responsive table"
+    fix: "Tabela por-usuario so overflow-x-auto; SVG chart 800w fixo escala mas tabela larga em mobile"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "shared SubNav (ver Governanca)"
+    fix: "Title local hand-roll + JanaAreaHeader; Governanca irma usa SubNav/EmptyState shared — alinhar"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-admin-governanca-index.yaml
+++ b/memory/governance/scorecards/screens/jana-admin-governanca-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Admin/Governanca/Index
+path: resources/js/Pages/Jana/Admin/Governanca/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 86
+nivel: "Leader"
+baseline_anterior: 86   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Governanca MCP estado-da-arte interno (3 secoes SubNav+persist LS, KPI taxa-sucesso/p95, chart calls/custo toggle, RBAC denied, EmptyState/StatusBadge shared) — melhor conformance DS do batch."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Performance-perceived"
+    best_of_class: "Inertia::defer charts"
+    fix: "6 datasets (status/latency/tools/users/denied/serie) eager no router.get sem Deferred/skeleton"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe responsive"
+    fix: "Grids md:grid-cols-2 ok mas charts 800w + tabelas truncate-200 apertados em mobile"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Linear focused views"
+    fix: "3 secoes x multiplos cards densos; persist localStorage ajuda mas onboard inicial pesado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-admin-qualidade-index.yaml
+++ b/memory/governance/scorecards/screens/jana-admin-qualidade-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Admin/Qualidade/Index
+path: resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Dashboard de métricas IA denso e competente (sparklines SVG, gates, KpiCard reuse, empty state com comando), mas cores cruas hex e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe (tokens semânticos)"
+    fix: "Trocar hex sparkline (#3b82f6 etc) por tokens v4 / CSS vars"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Linear"
+    fix: "Substituir emoji ✅🔴 por Badge/ícone DS com aria-label de status"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Bling"
+    fix: "Tabela trend larga sem scroll-x dedicado nem stack mobile"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-admin-roadmap.yaml
+++ b/memory/governance/scorecards/screens/jana-admin-roadmap.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Admin/Roadmap
+path: resources/js/Pages/Jana/Admin/Roadmap.tsx
+archetype: dashboard
+persona: wagner
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Gantt de tasks MCP bem estruturado (Sheet detalhe, useMemo/useCallback, filtros, empty states, charter), porém tons de prioridade hardcoded e a11y fraca no canvas Gantt."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "priorityTone usa rose/amber/sky/hex — mapear pra tokens v4 primary/semantic"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion"
+    fix: "Gantt SVAR sem navegação teclado/aria; expor lista acessível alternativa"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify"
+    fix: "Gantt 600px fixo não responsivo; fallback lista em viewport pequena"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-brief-index.yaml
+++ b/memory/governance/scorecards/screens/jana-brief-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Brief/Index
+path: resources/js/Pages/Jana/Brief/Index.tsx
+archetype: other
+persona: misto
+nota: 52
+nivel: "Developing"
+baseline_anterior: 52   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Stub explícito 'UI em construção' com 2 CTAs e dot oklch azul cru; correto mas sem conteúdo real."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Notion"
+    fix: "Renderizar brief real (brief-fetch) inline em vez de redirecionar pro chat"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Cor inline oklch(0.62 0.13 220) azul + violet-500 fora do roxo primary v4"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Linear"
+    fix: "Stub não comunica valor; adicionar preview/skeleton do brief"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-chat.yaml
+++ b/memory/governance/scorecards/screens/jana-chat.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Chat
+path: resources/js/Pages/Jana/Chat.tsx
+archetype: chat
+persona: misto
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Chat master/detail maduro com busca acento-insensitive, tabs a11y (role/aria/teclado) e charter, mas CSS hand-rolled .cs-/.sb- fora do DS e tabs 'Em breve' são afford. morta."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "Sidebar conversas usa classes CSS próprias + var(--text-mute) em vez de @/Components/ui + tokens"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Slack"
+    fix: "Tabs Minhas/Compartilhadas/Arquivadas clicáveis mas só mostram 'Em breve' — desabilitar/ocultar"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Notion"
+    fix: "Atalhos ⌘K/⌘N exibidos mas não wired no front; implementar ou remover"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-cockpit.yaml
+++ b/memory/governance/scorecards/screens/jana-cockpit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Cockpit
+path: resources/js/Pages/Jana/Cockpit.tsx
+archetype: dashboard
+persona: misto
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit Analista IA rico (KPIs, análises donut/spark/bars, 4 kinds de bubble, stream mock, PII detector, atalhos) porém 100% hand-rolled sem @/Components/ui, emoji-ícones e cores cruas — Pre-Flight fraco."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Zero uso de @/Components/ui; botões/cards raw + hex/oklch/violet/rose hardcoded"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Linear"
+    fix: "Ícones emoji (⚙⬇📊🤖) em vez de lucide; padronizar iconografia DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion"
+    fix: "Vários botões sem aria-label/foco visível; tab nav sem role tablist completo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-dashboard.yaml
+++ b/memory/governance/scorecards/screens/jana-dashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Dashboard
+path: resources/js/Pages/Jana/Dashboard.tsx
+archetype: dashboard
+persona: misto
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Dashboard de metas com farol, sparkline e empty states sólidos via DS, mas KpiStrip é mock '—' e badges gradiente violet/fuchsia/pink desviam do roxo primary."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe"
+    fix: "Badge gradient violet→fuchsia→pink foge do primary roxo v4; usar primary sólido"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear"
+    fix: "JanaKpiStrip/ProximaAcao são mocks fixos; usar Inertia::defer com skeleton real"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Bling"
+    fix: "Cores CATEGORIA/tones raw (blue/purple/red-100) em vez de tokens semânticos"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-memoria.yaml
+++ b/memory/governance/scorecards/screens/jana-memoria.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Memoria
+path: resources/js/Pages/Jana/Memoria.tsx
+archetype: list
+persona: misto
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de fatos LGPD com edição inline e copy clara, reuso DS bom, mas confirm() nativo, categorias com bg cru e label de edição sem a11y."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Notion"
+    fix: "Usar AlertDialog do DS em vez de window.confirm pra 'esquecer'"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "CATEGORIA_LABELS bg-blue/purple/red-100 hardcoded — migrar pra tokens"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear"
+    fix: "Textarea de edição sem label/aria; foco não gerido ao entrar em edição"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-painel.yaml
+++ b/memory/governance/scorecards/screens/jana-painel.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Painel
+path: resources/js/Pages/Jana/Painel.tsx
+archetype: dashboard
+persona: misto
+nota: 55
+nivel: "Developing"
+baseline_anterior: 55   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Esqueleto Onda A1 com placeholders '[kind] sub-component virá', classes .jc-* cruas e zero @/Components/ui — HTML cru declarado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Substituir markup .jc-* hand-rolled por @/Components/ui + tokens v4"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear"
+    fix: "Cards de análise mostram placeholder textual; implementar sub-components reais"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Notion"
+    fix: "Duplica conceito do Cockpit.tsx com outra implementação; unificar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/jana-regras-index.yaml
+++ b/memory/governance/scorecards/screens/jana-regras-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Jana/Regras/Index
+path: resources/js/Pages/Jana/Regras/Index.tsx
+archetype: other
+persona: wagner
+nota: 52
+nivel: "Developing"
+baseline_anterior: 52   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Stub 'UI em construção' apontando pra Governança; correto e a11y básica ok, mas sem conteúdo e cor oklch azul/violet cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Notion"
+    fix: "Listar policies do PolicyEngine (4 outcomes) read-only em vez de só redirecionar"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "oklch(0.62 0.13 220) + violet-500 inline fora do primary roxo v4"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Linear"
+    fix: "Sem preview de regras; agregar contagem/estado das políticas ativas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/kb-graph.yaml
+++ b/memory/governance/scorecards/screens/kb-graph.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: kb/Graph
+path: resources/js/Pages/kb/Graph.tsx
+archetype: dashboard
+persona: wagner
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tri-pane grafo Reactflow com filtros, KPIs, atalhos / e Esc, empty state e a11y — mas roda em modo MOCK (sem backend) e usa amber/muted em vez de roxo v4."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Performance-perceived"
+    best_of_class: "Bling (dados reais)"
+    fix: "Remover fallback MOCK_NODES e ligar KbGraphController com Inertia::defer + skeleton no canvas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "Badge 'modo mock' amber-100 e tons muted/border — mapear pra tokens semânticos e accent roxo 295"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion"
+    fix: "Canvas de grafo sem alternativa textual/teclado pra navegar nós; adicionar lista acessível ou aria-describedby"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/kb-index.yaml
+++ b/memory/governance/scorecards/screens/kb-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: kb/Index
+path: resources/js/Pages/kb/Index.tsx
+archetype: list
+persona: wagner
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Browser KB master-detail denso: j/k/Enter/Esc, debounce, soft-delete LGPD com confirm, markdown rico — mas usa bg-blue-100 (azul proibido), emojis como ícones e prose-blockquote azul."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "typeBadge adr usa bg-blue-100; prose-a/blockquote azul — trocar azul por roxo/primary v4 (zero blue é regra dura)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear (icon set)"
+    fix: "Substituir emojis 📋✕🗑️📂📜♻️ por ícones lucide consistentes com o DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe"
+    fix: "Botão '📜 N versões' disabled sem tooltip claro de 'em breve' visível; usar Tooltip do DS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/manufacturing-index.yaml
+++ b/memory/governance/scorecards/screens/manufacturing-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Manufacturing/Index
+path: resources/js/Pages/Manufacturing/Index.tsx
+archetype: list
+persona: misto
+nota: 50
+nivel: "Developing"
+baseline_anterior: 50   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Esqueleto MWART de produções com tabela hand-rolled, paleta gray/green/yellow-100 fora do DS, sem AppShellV2 nem dark mode e CTA desabilitado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Cores gray-50/500/900 + green/yellow-100 cruas; sem AppShellV2 nem @/Components/ui (só table raw)"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling"
+    fix: "CTA 'Nova produção' disabled e sem filtros (location/data); habilitar fluxo"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Shopify"
+    fix: "Não segue PT-01 Lista (DataTable/TanStack + drawer); alinhar ao padrão de tela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/memcofre-chat.yaml
+++ b/memory/governance/scorecards/screens/memcofre-chat.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: MemCofre/Chat
+path: resources/js/Pages/MemCofre/Chat.tsx
+archetype: chat
+persona: wagner
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Chat do Cofre sólido com reuso DS (Card/Textarea/Button/Badge), envio otimista, estado de erro e sessões recentes, mas select nativo, sem charter e a11y de inputs fraca."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "<select> nativo de escopo — trocar por Select do DS; sem charter ao lado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe"
+    fix: "Erro de fetch genérico sem retry; adicionar ação de reenviar + toast"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion"
+    fix: "Select/Textarea sem label associado; aria-live na resposta streaming"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/memcofre-dashboard.yaml
+++ b/memory/governance/scorecards/screens/memcofre-dashboard.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: MemCofre/Dashboard
+path: resources/js/Pages/MemCofre/Dashboard.tsx
+archetype: dashboard
+persona: wagner
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Dashboard de cobertura documental rico (KPIs, dots, barras trace/audit/DoD, empty guards) com bom reuso DS, mas tabela densa sem mobile e tons semânticos hardcoded; sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify"
+    fix: "Tabela de 11 colunas só com overflow-x; oferecer stack/cards em mobile"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Barras emerald/amber/red inline repetidas; extrair helper tokenizado + charter"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion"
+    fix: "4 cards-resumo competem com a tabela; priorizar 1 visão principal"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/memcofre-inbox.yaml
+++ b/memory/governance/scorecards/screens/memcofre-inbox.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: MemCofre/Inbox
+path: resources/js/Pages/MemCofre/Inbox.tsx
+archetype: list
+persona: wagner
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Inbox de triagem solido com shadcn/ui, busca debounce+Scout, tabs por status, dialog editar e AlertDialog deletar; perde por cores raw e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (tokens semanticos unicos, zero charter-less ship)"
+    fix: "Trocar tones amber/sky/emerald hard nos statusTabs por tokens v4 e criar Inbox.charter.md."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe (tablist com roles ARIA + foco visivel)"
+    fix: "Adicionar role=tablist/tab/aria-selected nas tabs de status (hoje sao <button> nus)."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion (densidade de badges controlada)"
+    fix: "Reduzir empilhamento de badges [10px] na linha; agrupar meta secundaria sob disclosure."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/memcofre-ingest.yaml
+++ b/memory/governance/scorecards/screens/memcofre-ingest.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: MemCofre/Ingest
+path: resources/js/Pages/MemCofre/Ingest.tsx
+archetype: form
+persona: wagner
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de captura limpo com tipo-condicional (upload/url/text), progress bar de upload e evidencia opt-in via Switch; falta charter e a11y de erro agregado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (resumo de erros no topo + scroll-to-field)"
+    fix: "Adicionar bloco de erro agregado e aria-describedby ligando input ao <p> de erro."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (charter por tela)"
+    fix: "Criar Ingest.charter.md (Mission/Non-Goals) — tela shipada sem contrato."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify (form full-width em mobile com toolbar sticky)"
+    fix: "Acoes Cancelar/Registrar viram barra sticky no rodape em telas pequenas."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/memcofre-memoria.yaml
+++ b/memory/governance/scorecards/screens/memcofre-memoria.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: MemCofre/Memoria
+path: resources/js/Pages/MemCofre/Memoria.tsx
+archetype: detail
+persona: wagner
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Explorador arvore+preview de 3 roots com filtro recursivo e markdown render; bom UX mas usa <input> hand-rolled, fetch manual sem error state e cores raw amber/sky/emerald."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (so @/Components/ui + tokens)"
+    fix: "Trocar <input> cru por @/Components/ui/input e icones text-amber/sky/emerald-500 por tokens."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Notion (estado de falha de carregamento com retry)"
+    fix: "openFile() faz fetch sem tratar res !ok — adicionar toast/erro + botao tentar de novo."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "VS Code web (treeview com role=tree/treeitem + navegacao por seta)"
+    fix: "Anotar arvore com role=tree/treeitem/aria-expanded e suporte a setas teclado."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/memcofre-modulo.yaml
+++ b/memory/governance/scorecards/screens/memcofre-modulo.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: MemCofre/Modulo
+path: resources/js/Pages/MemCofre/Modulo.tsx
+archetype: detail
+persona: wagner
+nota: 69
+nivel: "Developing"
+baseline_anterior: 69   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Hub de requisitos com 12 tabs, KPIs e filtro ADR — completo mas pesado (623 linhas) e despeja conteudo em <pre> font-mono cru sem markdown nem virtualizacao."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Aesthetic-usability"
+    best_of_class: "Notion (markdown render em vez de <pre> dump)"
+    fix: "Renderizar architecture/glossary/runbook via SimpleMarkdown (ja usado na Memoria), nao <pre>."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Stripe Docs (tabs com overflow controlado)"
+    fix: "12 tabs estouram em mobile; agrupar secundarias num menu 'Mais' / overflow."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear (status colors via token unico)"
+    fix: "Status ADR usa emerald/amber/muted inline; unificar com mesmo mapa de tones do resto do app."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/modules-index.yaml
+++ b/memory/governance/scorecards/screens/modules-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Modules/Index
+path: resources/js/Pages/Modules/Index.tsx
+archetype: list
+persona: wagner
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tabela admin polida espelhando Cliente/Index: StatCards, FilterDropdown acessivel, chips de filtro ativo, ActionsMenu; perde por confirm() nativo e paleta stone/emerald/rose raw."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (modal de confirmacao destrutiva, nao window.confirm)"
+    fix: "Trocar confirm() de Install/Uninstall por AlertDialog @/Components/ui (acao roda migrations)."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (tokens semanticos + charter)"
+    fix: "STATUS_STYLE usa emerald/stone/rose/amber-50 hardcoded; mapear pra tokens v4 e add charter."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify (tabela densa colapsa em cards no mobile)"
+    fix: "overflow-x-auto resolve, mas oferecer layout card empilhado abaixo de sm pra densidade."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfebrasil-manifestacao-index.yaml
+++ b/memory/governance/scorecards/screens/nfebrasil-manifestacao-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: NfeBrasil/Manifestacao/Index
+path: resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx
+archetype: list
+persona: eliana
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit fiscal forte: master/detail, atalhos J/K/C/D/R, bulk toolbar sticky, KPIs, PrazoBadge, localStorage; charter+visual-comparison aprovados. Perde por confirm()/prompt() e cores raw."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (dialog com textarea de justificativa validada inline)"
+    fix: "desconhecer/naoRealizada usam prompt() nativo p/ justificativa ≥15ch — virar Dialog com Textarea + contador."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (zero hex/cor crua, so token)"
+    fix: "Substituir bg-emerald-600/amber-50/red-50 e bg-accent-soft por tokens v4 primary roxo."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify POS (tabela fiscal reflow em mobile)"
+    fix: "Coluna detail e tabela 6-col nao colapsam <xl; oferecer cards/stack abaixo de md."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfebrasil-transactions-nfcestatus.yaml
+++ b/memory/governance/scorecards/screens/nfebrasil-transactions-nfcestatus.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: NfeBrasil/Transactions/NfceStatus
+path: resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx
+archetype: detail
+persona: eliana
+nota: 38
+nivel: "Beginner"
+baseline_anterior: 38   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Page demo de 1 badge de status com polling; tem charter mas e stub com inline style={{}} e oklch(...240) azul hardcoded — viola Pre-Flight, sem componentes DS nem estados ricos."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (zero inline-style, zero cor crua)"
+    fix: "Eliminar todos style={{}} inline e oklch(0.55 0.05 240) azul; reescrever com Tailwind+tokens v4 roxo."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe (status page com timeline + acao reemitir)"
+    fix: "Adicionar acoes contextuais (reemitir/baixar DANFE) e link de volta como Button DS, nao <a> inline."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Bling (status fiscal com identidade visual consistente)"
+    fix: "Usar Card/Badge do DS em vez de div com background light-dark() ad-hoc."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfebrasil-tributacao-configdefault.yaml
+++ b/memory/governance/scorecards/screens/nfebrasil-tributacao-configdefault.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: NfeBrasil/Tributacao/ConfigDefault
+path: resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx
+archetype: config
+persona: eliana
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de defaults fiscais Nivel 4 muito bom: wizard 'Aplicar pelo regime', toggle CSOSN/CST, mascaras numericas, hints por regime; charter presente. Perde em a11y de erro e cascade discoverability."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Discoverability"
+    best_of_class: "Bling (mostra onde esse default cai no cascade)"
+    fix: "Indicar visualmente que e Nivel 4 do cascade (badge/diagrama) — hoje so texto na descricao."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe (input numerico com aria-describedby pro hint decimal)"
+    fix: "Ligar hints 'decimal 0.18=18%' aos inputs via aria-describedby; toggle CSOSN/CST sem label htmlFor."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe (rotulos sem jargao cru)"
+    fix: "Explicar CSOSN/CST/NCM com tooltip pra usuario nao-fiscal; hoje assume vocabulario."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfebrasil-tributacao-importcsv.yaml
+++ b/memory/governance/scorecards/screens/nfebrasil-tributacao-importcsv.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: NfeBrasil/Tributacao/ImportCsv
+path: resources/js/Pages/NfeBrasil/Tributacao/ImportCsv.tsx
+archetype: form
+persona: eliana
+nota: 77
+nivel: "Advanced"
+baseline_anterior: 77   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Fluxo import 2-step (upload->preview->aplicar) exemplar: amostra em tabela sticky, erros em <details>, idempotencia explicita; sem charter e usa confirm() nativo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (confirm de aplicar via Dialog DS)"
+    fix: "Trocar confirm() de aplicar regras por AlertDialog; mostrar diff (novas vs atualizadas)."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Shopify (import com download de template CSV)"
+    fix: "Adicionar botao 'Baixar modelo CSV' alem do cabecalho mostrado em <code>."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (charter por tela + tokens)"
+    fix: "Criar ImportCsv.charter.md; trocar bg-emerald-50 raw do success por token."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfebrasil-tributacao-index.yaml
+++ b/memory/governance/scorecards/screens/nfebrasil-tributacao-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: NfeBrasil/Tributacao/Index
+path: resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
+archetype: list
+persona: eliana
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Hub tributacao bem orquestrado: templates por setor, config pendente em destaque, gate emissao-automatica com Switch, tabela regras NCM, diagrama de prioridade cascade; charter ok."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (acao destrutiva/substituir via Dialog)"
+    fix: "aplicarTemplate e remover usam confirm() nativo — migrar pra AlertDialog DS."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (so token, zero cor crua)"
+    fix: "Banner success/error usa bg-emerald-50/destructive raw; padronizar via tokens v4."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify (tabela regras vira cards no mobile)"
+    fix: "Tabela 9-col com overflow-x; oferecer layout empilhado e acoes acessiveis abaixo de md."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfebrasil-tributacao-regraform.yaml
+++ b/memory/governance/scorecards/screens/nfebrasil-tributacao-regraform.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: NfeBrasil/Tributacao/RegraForm
+path: resources/js/Pages/NfeBrasil/Tributacao/RegraForm.tsx
+archetype: form
+persona: eliana
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form criar/editar regra NCM limpo: subcomponente FieldDecimal reusado, toggle CSOSN/CST, selects UF, mascaras; consistente com ConfigDefault. Sem charter e microcopy fiscal cru."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (charter por tela)"
+    fix: "Criar RegraForm.charter.md — form fiscal shipado sem contrato (Non-Goals importam aqui)."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Bling (campos fiscais com ajuda contextual)"
+    fix: "MVA/FCP/CFOP sem explicacao; add tooltip/hint pra quem nao domina termo fiscal."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (erro agregado + foco no 1o invalido)"
+    fix: "Erros so aparecem por campo; add sumario topo e scroll-to-first-error no submit."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfse-emitir.yaml
+++ b/memory/governance/scorecards/screens/nfse-emitir.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Nfse/Emitir
+path: resources/js/Pages/Nfse/Emitir.tsx
+archetype: form
+persona: eliana
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form emissao NFSe robusto: calculo ISS/liquido ao vivo, painel venda vinculada, alertas cert/config, contador de chars, PageHeader DS. Usa tokens CSS-var legacy (--accent) nao primary roxo v4 e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (camada de token unica v4)"
+    fix: "Migrar var(--accent)/var(--text-mute)/var(--panel) pro token v4 primary roxo; envolve via .layout nao AppShellV2 inline."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (resumo de erros + foco)"
+    fix: "Erros por-campo sem sumario; certAlerta bloqueia submit mas falta CTA claro de como resolver cert."
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear (1 sistema de cor)"
+    fix: "Mistura amber-200/emerald-500 raw com CSS-vars legacy — unificar numa camada de token so."
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfse-index.yaml
+++ b/memory/governance/scorecards/screens/nfse-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Nfse/Index
+path: resources/js/Pages/Nfse/Index.tsx
+archetype: list
+persona: eliana
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista madura com atalhos J/K/N//, filtros persistidos e tooltips; perde no token roxo e Select value vazio (bug Radix)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear (1 primary accent token)"
+    fix: "Trocar var(--accent)/accent-soft pelo primary roxo 295 (ADR 0190) nos realces de valor/flash success"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Radix Select"
+    fix: "SelectItem value=\"\" e proibido no Radix (crasha) — usar sentinel 'todos' e mapear pra undefined no filtro"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Stripe (defer skeleton)"
+    fix: "Inertia::defer no paginate + <Deferred> com skeleton da tabela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/nfse-show.yaml
+++ b/memory/governance/scorecards/screens/nfse-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Nfse/Show
+path: resources/js/Pages/Nfse/Show.tsx
+archetype: detail
+persona: eliana
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe limpo com AlertDialog de cancelamento (contador+minLength) e aside de venda; falta token roxo e auto-refresh no processando."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear"
+    fix: "var(--accent) no total da venda/icone -> primary roxo 295 (ADR 0190)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe invoice"
+    fix: "aside w-72 fixo: empilhar abaixo do conteudo em <lg (flex-col) em vez de side-by-side forcado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Stripe (polling)"
+    fix: "status processando pede 'atualize a pagina' — auto-poll/reload only:[nfse] a cada 5s"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-aprovacaopublica.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-aprovacaopublica.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/AprovacaoPublica
+path: resources/js/Pages/OficinaAuto/AprovacaoPublica.tsx
+archetype: form
+persona: tecnico
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Aprovacao publica mobile-first com PIN OTP e lockout; cores cruas green/blue violam Pre-Flight e flash sem aria-live."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "bg-green-50/blue-50/border-green-200 sao cores cruas — trocar por tokens success/info (zero hex/raw Tailwind palette e regra dura)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe Checkout"
+    fix: "flash success/erro sem role=status/alert + aria-live; lockout sem anuncio pra leitor de tela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Shopify"
+    fix: "PIN 4-digit: usar OTP slots separados (melhor toque) e foco automatico ao montar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-producaooficina-index.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-producaooficina-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/ProducaoOficina/Index
+path: resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+archetype: kanban
+persona: tecnico
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Kanban rico com DnD-FSM, 6 KPIs e confirm dialog; densamente hand-rolled em slate/raw colors fora do DS e DnD sem fallback teclado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (AppShell tokens)"
+    fix: "header/KPIs/pills hand-rolled em slate-50/900/white + amber/rose/emerald cruas — migrar pra tokens DS e primary roxo (zero raw palette)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Linear board"
+    fix: "toggle Kanban e 'Imprimir fila' disabled sem dica do porque (so title) — usar tooltip 'V2' visivel ou esconder"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion DnD"
+    fix: "drag-drop FSM sem alternativa teclado/aria-grabbed; confirmar transicao so via mouse"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-serviceorders-create.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-serviceorders-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/ServiceOrders/Create
+path: resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
+archetype: form
+persona: tecnico
+nota: 66
+nivel: "Developing"
+baseline_anterior: 66   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de OS em Sheet 720 funcional com referer-close, mas selects/textarea nativos e erros parciais o deixam scaffold."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "@/Components/ui"
+    fix: "<select> e <textarea> nativos hand-rolled — usar Select/Textarea do DS (Edit usa mesmo padrao raw; padronizar)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe forms"
+    fix: "so vehicle_id mostra erro; status/datas sem render de errors[]; sem foco no 1o campo invalido"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Linear quick-create"
+    fix: "selecao de veiculo por <option> texto plano — combobox com busca de placa (lista grande trava)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-serviceorders-edit.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-serviceorders-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/ServiceOrders/Edit
+path: resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx
+archetype: form
+persona: tecnico
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit com secao Itens inline (optimistic+toast+roxo) supera Create, mas mantem selects nativos e window.confirm fora do DS."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "@/Components/ui"
+    fix: "select/textarea nativos (vs Input/Label do DS); padronizar com Select/Textarea shadcn"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Notion"
+    fix: "delete de item usa window.confirm() nativo — trocar por AlertDialog do DS (consistente com optimistic toast)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Linear"
+    fix: "4 campos datetime-local lado a lado (entrada/previsao/concluida/entregue) sem agrupamento visual — agrupar em fieldset 'Datas'"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-serviceorders-index.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-serviceorders-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/ServiceOrders/Index
+path: resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+archetype: list
+persona: eliana
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de OS rica com KPIs, chips FSM e defer + drawer; tabela/ cores hand-rolled fora do DS e sem atalhos de teclado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 StatusBadge"
+    fix: "mapa de cores blue/amber/rose/violet/indigo cru por stage + tabela hand-rolled (nao DataTable shared) — tokenizar e reusar DataTable"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe table"
+    fix: "paginacao via dangerouslySetInnerHTML do label — render seguro do texto; checkboxes disabled sem proposito visivel"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear"
+    fix: "sem atalhos de teclado (J/K/Enter/N) ao contrario do Nfse/Index irmao — padronizar navegacao por teclado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-serviceorders-show.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-serviceorders-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/ServiceOrders/Show
+path: resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de OS com Itens optimistic + imprimir A4 e CTA roxo; status plano (sem badge canon) e cores slate cruas na lista."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "lista de itens em slate-100/slate-200/white + total emerald cru — usar tokens border/divide e primary roxo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe"
+    fix: "status renderizado como bg-muted plano (nao ServiceOrderStatusBadge usado no Index) — reusar o badge canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Notion"
+    fix: "delete item via window.confirm nativo; alinhar com AlertDialog DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-vehicles-create.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-vehicles-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/Vehicles/Create
+path: resources/js/Pages/OficinaAuto/Vehicles/Create.tsx
+archetype: form
+persona: tecnico
+nota: 64
+nivel: "Developing"
+baseline_anterior: 64   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cadastro de veiculo completo porem scaffold: selects nativos, erros so na placa, sem charter e divergente do Edit."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Charter + DS"
+    fix: "sem Create.charter.md (irmaos tem) + select/textarea nativos — criar charter e usar Select/Textarea DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Notion form"
+    fix: "Create tem 13 campos mas Edit so expoe ~7 — alinhar conjunto de campos entre Create/Edit"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe"
+    fix: "so plate renderiza erro; demais campos sem errors[]; sem scroll/foco no 1o invalido"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-vehicles-edit.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-vehicles-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/Vehicles/Edit
+path: resources/js/Pages/OficinaAuto/Vehicles/Edit.tsx
+archetype: form
+persona: tecnico
+nota: 62
+nivel: "Developing"
+baseline_anterior: 62   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit minimo (so 6 campos) diverge do Create completo, selects nativos e erros parciais — scaffold incompleto."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "Notion"
+    fix: "Edit omite chassi/renavam/ano/motor/combustivel/KM que existem no Create — restaurar paridade de campos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "@/Components/ui"
+    fix: "select/textarea nativos vs DS Select/Textarea"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe"
+    fix: "errors so na placa; sem feedback nos demais campos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-vehicles-index.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-vehicles-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/Vehicles/Index
+path: resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
+archetype: list
+persona: tecnico
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de caçambas rica (KPIs, pills c/ contagem, tfoot totais, paginacao, dark-mode); cores cruas e toggle Grade sem efeito real."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 (roxo primary)"
+    fix: "KPIs/status em emerald/blue/amber/rose cru — manter tokens border/muted ja usados e levar realce ao primary roxo 295"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Linear"
+    fix: "header h1 + toolbar + table + tfoot + pagination hand-rolled — extrair pra PageHeader/DataTable shared (consistencia c/ Nfse)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear"
+    fix: "toggle Lista/Grade existe mas 'Grade Avancada' renderiza a mesma tabela; sem atalhos teclado — implementar grade real ou remover toggle"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/oficinaauto-vehicles-show.yaml
+++ b/memory/governance/scorecards/screens/oficinaauto-vehicles-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: OficinaAuto/Vehicles/Show
+path: resources/js/Pages/OficinaAuto/Vehicles/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de veiculo limpo (dados + historico OS) porem estatico: sem charter, status plano e sem acao/estado FSM no topo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Charter"
+    fix: "sem Show.charter.md (irmaos OficinaAuto tem) — criar charter da tela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe"
+    fix: "status da OS no historico so bg-muted plano (nao VehicleStatusBadge/ServiceOrderStatusBadge) — reusar badge canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Linear"
+    fix: "Show estatico sem KPI/acao FSM nem status atual do veiculo no topo; adicionar badge de current_status + CTA nova OS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-aprovacoes-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-aprovacoes-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Aprovacoes/Index
+path: resources/js/Pages/Ponto/Aprovacoes/Index.tsx
+archetype: list
+persona: tecnico
+nota: 86
+nivel: "Leader"
+baseline_anterior: 86   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista densa estado-da-arte (KPI-filtro, bulk, dialogs, empty/search, toasts); peca por cores cruas, confirm() nativo e zero charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe (tokens semanticos only)"
+    fix: "Trocar bg-emerald-600/text-amber-600/text-destructive cru por tokens v4 (success/warning); sem charter.md ao lado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear (undo dialog)"
+    fix: "Bulk usa window.confirm() nativo — substituir por AlertDialog igual ao aprovar single"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Shopify Polaris"
+    fix: "th sem scope=col; linha clicavel so via botoes — add scope + foco visivel"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-bancohoras-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-bancohoras-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/BancoHoras/Index
+path: resources/js/Pages/Ponto/BancoHoras/Index.tsx
+archetype: list
+persona: tecnico
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Ledger limpo com KPIs e saldo colorido; falta busca/sort, reflow mobile e tokens no lugar de emerald/destructive crus."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe tokens"
+    fix: "text-emerald-600/text-destructive cru no saldo -> token success/danger; criar charter.md"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling (filtro+busca)"
+    fix: "Sem busca/filtro por colaborador nem ordenacao de coluna; add search debounced + sort saldo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Linear cards"
+    fix: "So overflow-x; em touch reflow tabela->cards p/ tecnico"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-bancohoras-show.yaml
+++ b/memory/governance/scorecards/screens/ponto-bancohoras-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/BancoHoras/Show
+path: resources/js/Pages/Ponto/BancoHoras/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe append-only solido (saldo hero, ajuste, historico, useForm) — limitado por cores cruas e validacao so-toast."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe tokens"
+    fix: "text-emerald-600/text-red-600 cru em saldo+movimentos -> tokens; sem charter"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Notion (validacao inline)"
+    fix: "Validacao minutos!=0/obs<5 so via toast; mostrar erro inline no campo antes do submit"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Linear"
+    fix: "Saldo gigante + form + alert + tabela competem; mover Alert append-only p/ tooltip do titulo"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-colaboradores-edit.yaml
+++ b/memory/governance/scorecards/screens/ponto-colaboradores-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Colaboradores/Edit
+path: resources/js/Pages/Ponto/Colaboradores/Edit.tsx
+archetype: form
+persona: tecnico
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de config de ponto bem estruturado (Switch+Select+useForm) mas pagina vs drawer-PT, sem mascara CPF/PIS e charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PT drawer 760 cadastral"
+    fix: "PT cadastral pede drawer, nao pagina max-w-3xl; e sem charter.md"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (mascara)"
+    fix: "CPF/PIS/matricula sem mascara nem validacao client; add input mask + erro inline"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion"
+    fix: "Switch 'usa banco horas' nao desabilita quando escala sem BH (regra citada no hint mas nao aplicada)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-colaboradores-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-colaboradores-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Colaboradores/Index
+path: resources/js/Pages/Ponto/Colaboradores/Index.tsx
+archetype: list
+persona: tecnico
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista limpa com busca debounced 350ms e empty/search states; falta filtros, reuso de SearchInput e reflow mobile."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS shared"
+    fix: "Busca hand-rolled (div+border+Input) em vez de SearchInput shared; sem charter"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Bling (filtros)"
+    fix: "So busca texto; add filtro controla_ponto/usa_bh/escala como KpiCard ou chips"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Linear cards"
+    fix: "Tabela 7 col so overflow-x; reflow cards no touch"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-configuracoes-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-configuracoes-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Configuracoes/Index
+path: resources/js/Pages/Ponto/Configuracoes/Index.tsx
+archetype: config
+persona: wagner
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Painel CLT bem organizado em 4 cards, mas read-only, usa azul proibido na borda e cores cruas — baixa o Pre-Flight."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS roxo 295"
+    fix: "border-t-blue-500 (AZUL proibido!) + emerald/violet/amber crus nos cards -> tokens v4; sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Stripe settings"
+    fix: "Read-only ('edite config/pontowr2.php') — sem editar na UI quebra task principal de config"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion"
+    fix: "Cards parecem editaveis mas nao sao; add badge 'somente leitura' explicito por card"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-configuracoes-reps.yaml
+++ b/memory/governance/scorecards/screens/ponto-configuracoes-reps.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Configuracoes/Reps
+path: resources/js/Pages/Ponto/Configuracoes/Reps.tsx
+archetype: form
+persona: wagner
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Split form+lista bom para REPs (Portaria 671) mas CRUD incompleto (so create), validacao fraca do identificador e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe"
+    fix: "Identificador 17ch sem validacao de formato CNPJ+seq inline; valida client antes do post"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "charter live"
+    fix: "Sem charter.md; lista REPs sem empty-state component (div hand-roll)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Bling CRUD"
+    fix: "Lista nao permite editar/desativar REP (so cadastra) — add acao por linha"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-dashboard-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-dashboard-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Dashboard/Index
+path: resources/js/Pages/Ponto/Dashboard/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit rico (KPIs clicaveis, presenca ao vivo, chart 7d, polling only:[]) — peca skeleton, a11y do chart e charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS tokens"
+    fix: "bg-primary/80 ok mas bg-amber-500 cru no chart + sem charter.md"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear (skeleton)"
+    fix: "Polling 30s sem skeleton no 1o load; envolver chart/feeds em Deferred+skeleton"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe charts"
+    fix: "BarChart canvas-div sem aria-label/tabela alt; add descricao textual da serie"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-escalas-form.yaml
+++ b/memory/governance/scorecards/screens/ponto-escalas-form.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Escalas/Form
+path: resources/js/Pages/Ponto/Escalas/Form.tsx
+archetype: form
+persona: tecnico
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form create/edit de escala correto (useForm dual), mas turnos so leitura, checkbox nativo inconsistente com Switch e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Shopify"
+    fix: "Checkbox BH usa input nativo hand-roll em vez do Switch usado no Colaboradores/Edit (inconsistente)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Notion inline"
+    fix: "Turnos read-only ('iteracao futura') — CRUD de turno e o core da escala, falta"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "charter"
+    fix: "Sem charter.md; checkbox nativo size-4 fora do DS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-escalas-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-escalas-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Escalas/Index
+path: resources/js/Pages/Ponto/Escalas/Index.tsx
+archetype: list
+persona: tecnico
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de escalas enxuta e conforme DS (primary, empty, tabular-nums); falta filtro/busca e reflow mobile."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Discoverability"
+    best_of_class: "Bling"
+    fix: "Sem busca/filtro por tipo nem KPIs; add filtro tipo (FIXA/12x36...)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "charter"
+    fix: "Sem charter.md (resto conforme: PontoPrimaryButton, EmptyState, tokens)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Linear cards"
+    fix: "Tabela 8 col so overflow-x; reflow no touch"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-espelho-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-espelho-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Espelho/Index
+path: resources/js/Pages/Ponto/Espelho/Index.tsx
+archetype: list
+persona: tecnico
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Seletor de colaborador p/ espelho com filtro de mes ok, mas tem input de busca falso 'em breve', empty cru e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Stripe"
+    fix: "Campo busca disabled placeholder 'em breve' — esconder ou habilitar; input morto confunde"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Bling"
+    fix: "Sem busca real nem empty-state component (div p-12); usar SearchInput+EmptyState shared"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS shared"
+    fix: "Busca/empty hand-rolled fora do DS; sem charter.md"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-espelho-show.yaml
+++ b/memory/governance/scorecards/screens/ponto-espelho-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Espelho/Show
+path: resources/js/Pages/Ponto/Espelho/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Espelho mensal forte (heatmap clicavel->scroll, totalizadores, imprimir PDF, nav mes) — limitado por paleta crua com azul e cor-unica."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS tokens"
+    fix: "Totalizador hardcoda paleta 6 tons incl text-blue-700 (azul) + amber/red/violet crus -> tokens v4; sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe"
+    fix: "Heatmap+divergencia so por cor (amber); add icone/label nao-cor p/ daltonico"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Linear"
+    fix: "Espelho dia-a-dia 6 col so overflow-x; denso demais no touch do tecnico"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-importacoes-create.yaml
+++ b/memory/governance/scorecards/screens/ponto-importacoes-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Importacoes/Create
+path: resources/js/Pages/Ponto/Importacoes/Create.tsx
+archetype: form
+persona: tecnico
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de upload AFD enxuto, DS v4 + toast, mas header canon nao estilizado (os-page-h orfao) e sem charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe/Linear scoped tokens render reliably"
+    fix: "Header usa classe os-page-h que so existe sob .fin-cowork/.sells-cowork; sem wrapper ponto fica sem estilo canon — envolver em scope ou migrar p/ PageHeader component"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Shopify mostra erro de upload por campo + retry inline"
+    fix: "Falta estado de erro de servidor visivel alem do toast (ex arquivo duplicado SHA-256) e drag-and-drop"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear barra progresso com aria-valuenow"
+    fix: "Barra de progresso sem role=progressbar/aria-valuenow"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-importacoes-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-importacoes-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Importacoes/Index
+path: resources/js/Pages/Ponto/Importacoes/Index.tsx
+archetype: list
+persona: tecnico
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista AFD limpa com StatusBadge/EmptyState/paginacao, falta filtro+busca e header canon nao renderiza estilizado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PT-01 Lista canon estilizada"
+    fix: "os-page-h sem scope ponto = header sem estilo; alinhar ao PageHeader/PT-01"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Bling lista de importacoes com filtro estado/tipo + busca"
+    fix: "Tabela sem filtros nem busca (so paginacao) apesar de poder crescer"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Linear sticky thead + zebra em listas longas"
+    fix: "thead nao sticky; linhas/criadas em coluna unica confunde"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-importacoes-show.yaml
+++ b/memory/governance/scorecards/screens/ponto-importacoes-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Importacoes/Show
+path: resources/js/Pages/Ponto/Importacoes/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe solido com polling de job e bloco de erro, mas header canon nao estilizado e polling sem backoff/aria-live."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Detalhe canon estilizado"
+    fix: "os-page-h orfao (sem scope ponto) — header sem estilo canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear usa websocket/SSE p/ status de job"
+    fix: "Polling setInterval 3s fixo; preferir backoff ou Centrifugo (ja na stack)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "aria-live em status que muda sozinho"
+    fix: "Auto-refresh sem aria-live; leitor de tela nao anuncia mudanca de estado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-intercorrencias-create.yaml
+++ b/memory/governance/scorecards/screens/ponto-intercorrencias-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Intercorrencias/Create
+path: resources/js/Pages/Ponto/Intercorrencias/Create.tsx
+archetype: form
+persona: tecnico
+nota: 83
+nivel: "Advanced"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form rico com classificacao IA (texto livre->preenche campos), bom estado loading/erro; perde em checkbox nativo + header canon orfao."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Header canon estilizado"
+    fix: "os-page-h orfao sem scope ponto; checkboxes hand-rolled (input nativo) em vez de @/Components/ui/checkbox"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear usa cor de marca (roxo) p/ acento de IA"
+    fix: "Bloco de sucesso IA usa emerald cru (border-emerald-500/bg-emerald-500); preferir token"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe associa contador de chars via aria-describedby"
+    fix: "Contador 'x/2000' e dica IA sem aria-describedby no textarea"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-intercorrencias-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-intercorrencias-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Intercorrencias/Index
+path: resources/js/Pages/Ponto/Intercorrencias/Index.tsx
+archetype: list
+persona: tecnico
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista madura: PageFilters+chips+EmptyState contextual (search vs vazio)+StatusBadge; falta busca textual e header canon orfao."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PT-01 Lista canon estilizada"
+    fix: "os-page-h orfao (sem scope ponto) — header sem estilo canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear filtro por texto/colaborador + atalho teclado"
+    fix: "Filtra so por estado/tipo; falta busca por colaborador/codigo e atalhos"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Notion sticky header + acoes em hover"
+    fix: "thead nao sticky; coluna acao so 'Ver' (sem submeter/cancelar inline)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-intercorrencias-show.yaml
+++ b/memory/governance/scorecards/screens/ponto-intercorrencias-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Intercorrencias/Show
+path: resources/js/Pages/Ponto/Intercorrencias/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe com maquina de estados (canEdit/Submit/Cancel) e alerts de aprovacao/rejeicao; usa confirm() nativo e header canon orfao."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Linear usa modal/dialog com motivo em vez de window.confirm"
+    fix: "Submeter/cancelar usam confirm() nativo; trocar por AlertDialog @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Header canon estilizado"
+    fix: "os-page-h orfao sem scope ponto — header sem estilo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe agrupa acao destrutiva separada com confirmacao tipada"
+    fix: "Cancelar (irreversivel) so com text-destructive em botao outline; pouco peso visual"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-relatorios-index.yaml
+++ b/memory/governance/scorecards/screens/ponto-relatorios-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Relatorios/Index
+path: resources/js/Pages/Ponto/Relatorios/Index.tsx
+archetype: dashboard
+persona: tecnico
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Galeria de relatorios em cards com estado disponivel/em-breve, mas cores cruas (blue/violet/amber proibidos no DS roxo) e zero parametrizacao."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo zero blue cru"
+    fix: "corClasses usa bg-blue-100/text-blue-700 + violet/amber/red crus (anti-padrao DS roxo, blue proibido) — trocar por tokens"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling relatorio abre com filtro periodo/colaborador inline"
+    fix: "Cards so linkam p/ /gerar sem parametros (periodo/escopo); zero config antes de emitir"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion agrupa por categoria com secoes"
+    fix: "Grid plano de cards sem agrupamento; metade 'Em breve' polui"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/ponto-welcome.yaml
+++ b/memory/governance/scorecards/screens/ponto-welcome.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Ponto/Welcome
+path: resources/js/Pages/Ponto/Welcome.tsx
+archetype: other
+persona: tecnico
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Stub de boas-vindas (business+usuario), copy dev-facing e sem valor operacional — placeholder, nao dashboard."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Linear home com atalhos p/ acoes-chave"
+    fix: "Pagina piloto so mostra business/usuario; sem navegacao util nem KPIs do modulo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Header canon estilizado"
+    fix: "os-page-h orfao sem scope ponto; copy 'renderizada via Inertia+React' e dev-facing, nao usuario"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Shopify dashboard com cards acionaveis"
+    fix: "2 cards estaticos sem CTA; deveria ser dashboard de ponto (pendencias/aprovacoes)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-bulkedit.yaml
+++ b/memory/governance/scorecards/screens/produto-bulkedit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/BulkEdit
+path: resources/js/Pages/Produto/BulkEdit.tsx
+archetype: form
+persona: larissa
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edicao em massa com banner destrutivo + confirm 2-passos e charter; perde em paleta crua e ausencia de preview/diff de mudancas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo + tokens"
+    fix: "Paleta stone/rose/amber crua + header proprio (nao AppShellV2 PageHeader/os canon); botao confirm bg-rose-700 em vez de token destructive"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear bulk com diff/preview do que muda + undo"
+    fix: "Confirma via 2-clique no botao mas sem preview de quais campos mudaram; aviso diz 'sem desfazer'"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Notion bulk sticky header + col fixa"
+    fix: "Tabela larga sem sticky thead/coluna produto fixa em scroll horizontal"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-create.yaml
+++ b/memory/governance/scorecards/screens/produto-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/Create
+path: resources/js/Pages/Produto/Create.tsx
+archetype: form
+persona: larissa
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cadastro Cowork com avancado colapsavel persistido + dedup; usa Deferred? nao, e perde em tokens crus + feedback de erro so no nome."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens + AppShellV2 PageHeader"
+    fix: "Header sticky proprio em stone + rose-700 cru em erros; nao usa os-page-h/PageHeader canon nem tokens DS roxo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe rola ate 1o erro + resumo no topo"
+    fix: "So errors.name renderizado inline; demais campos (unit/tax) sem feedback de erro nem scroll-to-error"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Shopify salva e mostra toast/redireciona claro"
+    fix: "post('/products') sem onSuccess/onError (sem toast); sem 'salvar e novo'"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-edit.yaml
+++ b/memory/governance/scorecards/screens/produto-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/Edit
+path: resources/js/Pages/Produto/Edit.tsx
+archetype: form
+persona: larissa
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edicao espelha Create (consistencia boa), tipo travado bem comunicado; perde em tokens crus, feedback de erro parcial e sem dirty-guard."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens + PageHeader canon"
+    fix: "Paleta stone/rose crua + header proprio (nao AppShellV2/os-page-h); fora do padrao drawer-760 p/ cadastro"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe valida todos campos + dirty-guard ao sair"
+    fix: "So errors.name inline; sem aviso de alteracoes nao salvas ao navegar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear Cmd+S salva"
+    fix: "put sem onSuccess toast; sem atalho salvar nem delete acessivel (permissao existe nos props)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-index.yaml
+++ b/memory/governance/scorecards/screens/produto-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/Index
+path: resources/js/Pages/Produto/Index.tsx
+archetype: list
+persona: larissa
+nota: 83
+nivel: "Advanced"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Catalogo Cowork forte: Inertia Deferred+skeletons, KPIs, tabs categoria, localStorage de prefs; perde em tokens crus e densidade card vs tabela p/ balcao."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo + tokens"
+    fix: "Header sticky + KPIs em paleta stone/emerald/rose crua (zero token DS, primary roxo ausente); blueprint Cowork mas fora da Constituicao UI v2"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Bling/Linear lista densa em tabela p/ balcao (scan rapido SKU/preco/estoque)"
+    fix: "Cards 4-col gastam espaco vertical p/ persona Larissa; oferecer toggle tabela densa"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Shopify busca server-side + atalhos"
+    fix: "Busca/filtro so client-side sobre rows ja carregadas (nao escala catalogo grande); sem atalho foco busca"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-sellingprices.yaml
+++ b/memory/governance/scorecards/screens/produto-sellingprices.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/SellingPrices
+path: resources/js/Pages/Produto/SellingPrices.tsx
+archetype: form
+persona: larissa
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Matriz preço grupo×variação funcional com @/Components/ui e empty-states, mas paleta stone crua + header hand-rolled fora do PageHeader/token roxo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe Dashboard usa um único token de marca em toda superfície"
+    fix: "Trocar stone-900/stone-* por tokens v4 (primary roxo, bg-card, border) e migrar header pro PageHeader canon"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling: salvar célula com Enter/Tab sem percorrer toda a matriz"
+    fix: "Adicionar dirty-state, atalho salvar (Cmd+S) e navegação por teclado entre células"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear mostra erro de validação inline por campo"
+    fix: "Exibir erros do useForm por célula + confirmação de salvo (toast/banner)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-show.yaml
+++ b/memory/governance/scorecards/screens/produto-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/Show
+path: resources/js/Pages/Produto/Show.tsx
+archetype: detail
+persona: larissa
+nota: 70
+nivel: "Advanced"
+baseline_anterior: 70   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe com tabs + Deferred/skeleton e bons empty-states, porém tabs e header hand-rolled com bg-stone-900 em vez do PageHeader e token roxo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Shopify: header de produto padronizado e reutilizado"
+    fix: "Substituir header/tabs stone por PageHeader canon + tokens roxo; tab ativa via primary"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion: detalhe traz métricas-chave (estoque, preço) acima da dobra"
+    fix: "Adicionar KpiStrip/KpiCard de estoque e preço no topo do Resumo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Linear sincroniza tab ativa com a URL (deep-link)"
+    fix: "Persistir activeTab na querystring pra deep-link e back-button"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-stockhistory.yaml
+++ b/memory/governance/scorecards/screens/produto-stockhistory.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/StockHistory
+path: resources/js/Pages/Produto/StockHistory.tsx
+archetype: detail
+persona: larissa
+nota: 47
+nivel: "Beginner"
+baseline_anterior: 47   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Placeholder: filtros variação/local com persist localStorage, mas timeline só linka pro Blade legacy (admite migração Wave 3) — feature incompleta."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Bling: timeline de movimentação renderizada inline com entrada/saída/ajuste"
+    fix: "Migrar endpoint pra JSON e renderizar timeline real em vez de link 'ver legacy'"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe usa header/tokens consistentes em toda tela"
+    fix: "Adotar PageHeader + tokens roxo; remover paleta stone crua"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear mostra skeleton enquanto carrega dados"
+    fix: "Carregar série via Inertia::defer com skeleton em vez de iframe/link externo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/produto-unificado-index.yaml
+++ b/memory/governance/scorecards/screens/produto-unificado-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Produto/Unificado/Index
+path: resources/js/Pages/Produto/Unificado/Index.tsx
+archetype: list
+persona: larissa
+nota: 56
+nivel: "Developing"
+baseline_anterior: 56   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Catálogo denso 5-sub-telas density-first (bom pra Larissa), mas zero @/Components/ui (native select/input), text-sky-700 blue-leak, bg-stone-900 e TODOs por todo lado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Shopify Polaris: nenhum input nativo, tudo via design system"
+    fix: "Trocar <select>/<input>/TweaksPanel nativos pelos @/Components/ui; remover sky-700 e stone-900 por tokens roxo"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Notion reusa o mesmo shell em todas as views"
+    fix: "Extrair CockpitShell/KpiStrip compartilhados (TODOs declarados) e alinhar com PageHeader das telas PM"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear: linhas de tabela navegáveis por teclado com foco visível"
+    fix: "Adicionar role/aria nas linhas clicáveis + foco teclado + atalhos (a tela não tem nenhum)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-activity-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-activity-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Activity/Index
+path: resources/js/Pages/ProjectMgmt/Activity/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Feed timeline agrupado por dia com PageHeader+KpiGrid, filtros, auto-refresh 30s e i18n PT-BR sólido; falta charter e tem leve dependência de cor emerald hardcoded."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: toda tela tem contrato/charter versionado"
+    fix: "Criar Activity/Index.charter.md (Mission/Goals/Non-Goals)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe events: agrupa e permite expandir/colapsar dias"
+    fix: "Tornar grupos de dia colapsáveis + sticky day-header ao rolar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion timeline navegável por teclado"
+    fix: "Adicionar navegação J/K (consistente com Board/Inbox) e foco nos itens"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-backlog-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-backlog-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Backlog/Index
+path: resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
+archetype: list
+persona: wagner
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista densa com filtros multi + bulk-edit sticky + defer-guard + persist localStorage e badges canônicos; falta charter e atalhos de teclado (J/K) que o resto do módulo tem."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Linear: J/K + X seleciona, atalhos de bulk sem mouse"
+    fix: "Adicionar navegação J/K + tecla pra (de)selecionar linha, alinhando com Board"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear charter por tela"
+    fix: "Criar Backlog/Index.charter.md"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe: bulk action mostra resultado/falhas parciais e permite undo"
+    fix: "bulk() deve tratar erro do fetch (banner) e oferecer desfazer"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-board-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-board-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Board/Index
+path: resources/js/Pages/ProjectMgmt/Board/Index.tsx
+archetype: kanban
+persona: wagner
+nota: 89
+nivel: "Leader"
+baseline_anterior: 89   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Kanban estado-da-arte: drag-drop otimista com optimistic-lock 409/403, atalhos J/K/E/A, polling+on-focus, DetailSheet via URL, charter presente; só leves blue-leaks (border-l-blue-500)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: zero cor hardcoded fora do token"
+    fix: "Trocar border-l-blue-500 do goal-card por token (primary/accent)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Trello: colunas viram swimlanes roláveis no mobile"
+    fix: "grid de N colunas fixas quebra em telas estreitas; tornar scroll-x/responsivo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear vira realtime via websocket em vez de polling"
+    fix: "Migrar polling 10s pra Centrifugo (já no stack) reduzindo jitter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-burndown-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-burndown-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Burndown/Index
+path: resources/js/Pages/ProjectMgmt/Burndown/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Burndown SVG ideal-vs-real hand-rolled com KPIs de pace/forecast e empty-state sem-cycle; usa stroke-blue-500 cru e não tem charter nem tooltip/hover no gráfico."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe charts usam tokens do tema"
+    fix: "Trocar stroke-blue-500/fill-blue-500 por token (primary roxo)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear cycle chart: hover mostra valor do dia (tooltip)"
+    fix: "Adicionar tooltip por ponto (data, ideal, real) no SVG"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "charter por tela"
+    fix: "Criar Burndown/Index.charter.md"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-inbox-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-inbox-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Inbox/Index
+path: resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
+archetype: list
+persona: wagner
+nota: 86
+nivel: "Leader"
+baseline_anterior: 86   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Caixa de entrada agrupada por tipo com marca-lido otimista, deep-link pro Board, J/K/Enter/R, banner erro role=alert, empty-state e charter; tokens limpos. Marcada DRAFT aguardando screenshot Wagner."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Brand-confidence"
+    best_of_class: "Linear inbox: superfície aprovada e estável"
+    fix: "Concluir gate F3 (screenshot Wagner ADR 0107/0114) e remover header DRAFT"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Superhuman: snooze/arquivar por item além de marcar lido"
+    fix: "Adicionar ação snooze/dispensar por item e undo do marcar-lido"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Gmail prioritário: bloco 'acionáveis' destacado no topo"
+    fix: "Separar visualmente menções/atribuições (acionáveis) do ruído de status_changed"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-mywork-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-mywork-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/MyWork/Index
+path: resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 83
+nivel: "Advanced"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Painel duplo My Work + Inbox com foco alternável (Tab), J/K/E/R, defer-guard, ring de foco via primary; falta charter e tem blue-500 cru no dot de não-lida."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear: zero cor hardcoded"
+    fix: "Trocar bg-blue-500 (dot não-lida) por token; criar MyWork/Index.charter.md"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear avisa quando ação de status falha"
+    fix: "bumpStatus/markAllRead engolem erro silenciosamente — adicionar banner role=alert como Board/Inbox"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Notion: deep-link de notificação igual em toda parte"
+    fix: "Inbox aqui usa ?focus=ID mas Inbox/Triage usam ?task=ID — unificar param do Board"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-roadmap-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-roadmap-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Roadmap/Index
+path: resources/js/Pages/ProjectMgmt/Roadmap/Index.tsx
+archetype: dashboard
+persona: wagner
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Roadmap epics×quarter em colunas roláveis com progress-bar e KPIs; bom empty-state, mas várias cores cruas (blue-100, slate, #3b82f6 fallback) e sem charter nem interação de mover epic na UI."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear roadmap: paleta 100% tokenizada"
+    fix: "Trocar STATUS_BADGE blue/slate e borderLeft #3b82f6 por tokens; emerald da barra idem"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear: arrastar epic entre quarters direto na UI"
+    fix: "Permitir mudar target_quarter via drag/menu em vez de só instruir comando MCP"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion: card de epic abre detalhe ao clicar"
+    fix: "EpicCard não é clicável — linkar pro Backlog filtrado pelo epic"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/projectmgmt-triage-index.yaml
+++ b/memory/governance/scorecards/screens/projectmgmt-triage-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: ProjectMgmt/Triage/Index
+path: resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+archetype: list
+persona: wagner
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Fila de triagem com atribuição inline otimista (owner/prio/cycle/epic), rollback+banner erro, chips de motivo, J/K/Enter, responsivo grid→stack e charter; só falta confirmar gate F3 (DRAFT)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Brand-confidence"
+    best_of_class: "Linear: tela aprovada e fora de DRAFT"
+    fix: "Fechar gate screenshot Wagner (ADR 0107/0114) e remover banner DRAFT"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe: badges de aviso via token semântico"
+    fix: "amber-100/slate-100 dos chips de motivo poderiam usar tokens warning/muted do DS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear: triagem em lote (selecionar várias + aplicar)"
+    fix: "Adicionar seleção múltipla + atribuição bulk pra filas grandes"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/purchase-create.yaml
+++ b/memory/governance/scorecards/screens/purchase-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Purchase/Create
+path: resources/js/Pages/Purchase/Create.tsx
+archetype: form
+persona: misto
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form linear denso e consistente (Card/PageHeader/AppShellV2 + totais reativos), mas fornecedor/produto como texto livre e <select> cru limitam affordance."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Stripe/Bling — combobox de fornecedor com busca + criar inline"
+    fix: "Trocar Input 'ID do fornecedor' por Combobox @/Components/ui com busca async; idem produto na linha (hoje texto livre)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — Select primitive @/Components/ui, zero <select> cru"
+    fix: "Migrar os 3 <select> hand-roll pra Select do DS (tokens/foco/a11y consistentes)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear — validação inline + bloqueio de submit vazio"
+    fix: "Validar ≥1 item e fornecedor client-side antes do POST; hoje só backend, form pode enviar vazio"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/purchase-edit.yaml
+++ b/memory/governance/scorecards/screens/purchase-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Purchase/Edit
+path: resources/js/Pages/Purchase/Edit.tsx
+archetype: form
+persona: misto
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Clone fiel do Create com PUT e pré-popula; herda as mesmas forças e o mesmo gap de affordance (IDs textuais)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Bling — fornecedor/produto via combobox, não ID textual"
+    fix: "Mesma combobox do Create; reaproveita pattern (já compartilha ~80%)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe — avisar campos travados quando fora do período editável (R-PUR-005)"
+    fix: "Exibir banner/disabled quando canBeEdited=false em vez de só depender do 403 backend"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Notion — mostrar pagamentos já lançados no Edit"
+    fix: "Edit não expõe payment_lines; adicionar bloco read-only de pagamentos existentes"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/purchase-index.yaml
+++ b/memory/governance/scorecards/screens/purchase-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Purchase/Index
+path: resources/js/Pages/Purchase/Index.tsx
+archetype: list
+persona: misto
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista densa com filtros sticky, pills de status/pagamento e empty state bom; pena o azul cru no pill 'ordered' e ausência de defer/paginação."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — zero azul cru, status via token roxo/neutro"
+    fix: "STATUS_PILL.ordered usa bg-blue-50/text-blue-700; trocar por token DS (amber/stone/violet) — viola regra anti-blue"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear — defer + skeleton da tabela; paginação server"
+    fix: "rows vêm eager sem Inertia::defer nem paginação; envolver tabela em <Deferred> + skeleton e paginar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling — busca server-side + atalho '/'"
+    fix: "Busca é só client-side sobre rows carregadas; ligar ao filtro server e atalho '/' p/ foco"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/purchase-show.yaml
+++ b/memory/governance/scorecards/screens/purchase-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Purchase/Show
+path: resources/js/Pages/Purchase/Show.tsx
+archetype: detail
+persona: misto
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe completo (fornecedor/empresa/itens/pagamentos/totais) bem hierarquizado e fiscal-aware; falta CTA de pagamento e ajuste do azul cru."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — paleta sem azul cru"
+    fix: "STATUS_PILL.ordered = blue-*; alinhar ao token DS como no Index"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Stripe — ações de pagamento no detalhe (registrar pagamento)"
+    fix: "Show só lê pagamentos; adicionar 'Registrar pagamento' quando permissions.payments e há saldo"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify — tabela vira cards/scroll em <640px"
+    fix: "Tabela de itens sem overflow-x wrapper; adicionar overflow-x-auto ou layout card mobile"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/recurringbilling-configuracoes-index.yaml
+++ b/memory/governance/scorecards/screens/recurringbilling-configuracoes-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: RecurringBilling/Configuracoes/Index
+path: resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx
+archetype: config
+persona: eliana
+nota: 83
+nivel: "Advanced"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Config rica (gateways/dunning/NFe/webhooks com copiar+docs+tour) mas majoritariamente read-only/'em breve' e fora do shell canon."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — shell PageHeader/AppShellV2 + @/Components/ui"
+    fix: "Header e cards hand-roll com bg-sky/orange (badges banco); padronizar com SectionCard do DS e remover sky/orange crus"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe — toggle NFe e régua editáveis in-place"
+    fix: "NFe-auto é toggle decorativo 'em breve' e régua é read-only; tornar régua/NFe editáveis (PUT) ou marcar claramente disabled"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Notion — gateway gerido aqui, não em outra rota"
+    fix: "Adicionar gateway redireciona pra /contas-bancarias ('em breve aqui'); fechar o loop no próprio config"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/recurringbilling-faturas-index.yaml
+++ b/memory/governance/scorecards/screens/recurringbilling-faturas-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: RecurringBilling/Faturas/Index
+path: resources/js/Pages/RecurringBilling/Faturas/Index.tsx
+archetype: list
+persona: eliana
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de faturas estado-da-arte (KPIs hero+sparkline, filtros pill, defer+skeleton, cancel dialog LGPD-aware), limitada por divergência do shell/DS e criação ainda bloqueada."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — @/Components/ui + shell + zero azul/sky/orange cru"
+    fix: "Tudo hand-roll; gateway badges usam orange/sky/zinc-900. Migrar p/ primitives DS e tokens roxo/neutro"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear — dialog com foco-trap e botões nativos"
+    fix: "CancelDialog não tem role=dialog/aria-modal nem focus-trap (só Esc no Index não fecha o dialog); adicionar"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Stripe — ação 'Nova fatura' funcional + reenviar cobrança"
+    fix: "Botão 'Nova fatura' está disabled 'em breve'; habilitar criação avulsa e ação reenviar boleto/pix por linha"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/recurringbilling-index.yaml
+++ b/memory/governance/scorecards/screens/recurringbilling-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: RecurringBilling/Index
+path: resources/js/Pages/RecurringBilling/Index.tsx
+archetype: dashboard
+persona: eliana
+nota: 88
+nivel: "Leader"
+baseline_anterior: 88   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit 3-col de altíssimo craft (defer, ⌘K palette, Jana IA, troubleshooters, timeline, atalhos) — teto puxado por mock client-side, a11y de itens clicáveis e fuga do shell/DS canon."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — shell canon (PageHeader/AppShellV2) + @/Components/ui + sem azul cru"
+    fix: "Header/colunas/badges hand-roll com bg-zinc-900 hero e blue-* no fiscal; alinhar ao DS roxo e ao shell sem duplicar min-h-screen"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear — itens de lista são button/[role=option] navegáveis por teclado"
+    fix: "Linhas e filtros são <div>/<li> onClick sem role/tabindex/foco visível; promover a button/listbox (j/k existe mas mouse-only no DOM)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe — métricas reais, sem mock client-side"
+    fix: "Sparkline e PaymentHistory são mock heurístico no front (marcado em código); puxar histórico real do backend"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/recurringbilling-planos-create.yaml
+++ b/memory/governance/scorecards/screens/recurringbilling-planos-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: RecurringBilling/Planos/Create
+path: resources/js/Pages/RecurringBilling/Planos/Create.tsx
+archetype: form
+persona: eliana
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de plano limpo com campos condicionais (custom/CFOP/NFS-e), kbd ⌘↵/Esc e validação por campo; pena estar fora do shell/DS e sem máscara de valor."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — Input/Select/Button @/Components/ui + shell"
+    fix: "Form 100% hand-roll (inputs/selects/checkbox crus) fora do shell; migrar pro DS mantendo o Field wrapper"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe — slug auto-preview e máscara de moeda em valor"
+    fix: "Slug não mostra preview auto a partir do nome; valor é number cru sem máscara R$ (usar input monetário)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear — preview do plano (ciclo/trial/valor) ao lado do form"
+    fix: "Adicionar painel preview do plano em construção (campo condicional já existe p/ custom/CFOP)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/recurringbilling-planos-edit.yaml
+++ b/memory/governance/scorecards/screens/recurringbilling-planos-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: RecurringBilling/Planos/Edit
+path: resources/js/Pages/RecurringBilling/Planos/Edit.tsx
+archetype: form
+persona: eliana
+nota: 83
+nivel: "Advanced"
+baseline_anterior: 83   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit espelha o Create com aviso inteligente de slug alterado; falta guarda em ciclo/valor com assinaturas ativas e alinhamento ao DS/shell."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — primitives @/Components/ui + shell"
+    fix: "Inputs/selects/checkbox crus; migrar ao DS (mesmo Field). Reaproveita 1:1 do Create"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe — bloquear troca de ciclo/slug com assinaturas ativas"
+    fix: "Só avisa slug por cor amber; ciclo/valor sem guarda quando há assinaturas vinculadas (impacto cobrança)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Bling — valor com máscara monetária"
+    fix: "valor number cru; usar input R$ formatado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/recurringbilling-planos-index.yaml
+++ b/memory/governance/scorecards/screens/recurringbilling-planos-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: RecurringBilling/Planos/Index
+path: resources/js/Pages/RecurringBilling/Planos/Index.tsx
+archetype: list
+persona: eliana
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de planos forte (KPIs hero+distribuição de ciclos, defer+skeleton, flash, ⌘K, atalhos N/J/K) limitada por cores cruas, a11y de linha e métricas aproximadas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — @/Components/ui + shell + sem azul/cyan cru"
+    fix: "Tudo hand-roll; CicloDistribuicao usa blue-500/cyan-500 e FiscalBadge blue-*. Trocar por tokens DS e primitives"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear — linha selecionável é button/option com teclado"
+    fix: "<tr onClick> sem role/tabindex; j/k move activeId mas linha não é focável p/ leitor de tela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Stripe — sparkline derivado de dado real"
+    fix: "Ticket médio = MRR/total (aprox) e sparkline mock; rotular como estimativa ou puxar real"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-dashboard-index.yaml
+++ b/memory/governance/scorecards/screens/repair-dashboard-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/Dashboard/Index
+path: resources/js/Pages/Repair/Dashboard/Index.tsx
+archetype: dashboard
+persona: tecnico
+nota: 62
+nivel: "Developing"
+baseline_anterior: 62   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Port honesto do dashboard Repair com tokens semânticos corretos, mas raso: 2 KPIs, 'gráficos' são listas de texto e um chart foi dropado (FIXME)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion/Linear — gráficos reais (barras/donut), não listas chave-valor"
+    fix: "job_sheets_by_status e trending viram <SimpleListCard> de texto; usar gráfico (recharts/sparkbar) e expor trending_devices (hoje voided com FIXME)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Shopify — dashboard com 4-6 KPIs + drill-down"
+    fix: "Só 2 KPIs (status únicos, staff); adicionar OS abertas/atrasadas/ticket médio/receita e links de drill"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear — defer + skeleton dos painéis"
+    fix: "Sem Inertia::defer nem loading; envolver painéis em <Deferred> com skeleton"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-devicemodels-create.yaml
+++ b/memory/governance/scorecards/screens/repair-devicemodels-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/DeviceModels/Create
+path: resources/js/Pages/Repair/DeviceModels/Create.tsx
+archetype: form
+persona: tecnico
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form pequeno e correto (DS primitives, PageHeader, autoFocus, foco max-w-3xl, errors), limitado pelo checklist via '|' e selects crus pouco touch."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Linear — checklist como tag/chips, não texto com '|'"
+    fix: "repair_checklist é Textarea separada por '|'; trocar por input de chips/lista editável (touch-friendly p/ técnico)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 — Select primitive @/Components/ui"
+    fix: "brand_id/device_id são <select> cru; usar Select do DS p/ tokens/foco consistentes"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify — alvos de toque ≥44px no balcão/oficina"
+    fix: "Inputs/selects em densidade desktop; aumentar área de toque e usar combobox de marca pesquisável"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-devicemodels-edit.yaml
+++ b/memory/governance/scorecards/screens/repair-devicemodels-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/DeviceModels/Edit
+path: resources/js/Pages/Repair/DeviceModels/Edit.tsx
+archetype: form
+persona: misto
+nota: 76
+nivel: "Advanced"
+baseline_anterior: 76   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form de modelo limpo com useForm/charter/AppShellV2, mas cores cruas rose e selects nativos fora do DS."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe (semantic tokens)"
+    fix: "Trocar text-rose-600 por text-destructive; usar Select de @/Components/ui no lugar de <select> hand-roll"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Notion drawer cadastral"
+    fix: "PT cadastral pede drawer-760, nao container max-w-3xl full-page"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear"
+    fix: "Sem estado processing visivel alem do disabled; add inline saving spinner"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-devicemodels-index.yaml
+++ b/memory/governance/scorecards/screens/repair-devicemodels-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/DeviceModels/Index
+path: resources/js/Pages/Repair/DeviceModels/Index.tsx
+archetype: list
+persona: misto
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista madura com Deferred+skeleton, persist localStorage e EmptyState; perde por KpiCard duplicado e selects nativos."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "Shopify"
+    fix: "KpiCard local duplica o shared KpiCard; consolidar no componente compartilhado"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Selects nativos hand-roll; migrar pra Select DS; tabela sem paginacao visivel"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear"
+    fix: "Filtro exige clique em Filtrar; aplicar on-change ou Enter pra fluidez"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-index.yaml
+++ b/memory/governance/scorecards/screens/repair-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/Index
+path: resources/js/Pages/Repair/Index.tsx
+archetype: list
+persona: misto
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Listagem OS rica (KPI toggle, chips status, atalhos Enter/Esc) mas sem charter, cores cruas e sem defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "Sem .charter.md (so .review.md); cor crua #6b7280 e palettes rose/emerald/amber raw em vez de tokens"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear"
+    fix: "Tabela sem Inertia::defer/skeleton; eager render trava em listas grandes"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Bling OS"
+    fix: "10 colunas sem sticky header nem sort clicavel no thead"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-jobsheet-addparts.yaml
+++ b/memory/governance/scorecards/screens/repair-jobsheet-addparts.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/JobSheet/AddParts
+path: resources/js/Pages/Repair/JobSheet/AddParts.tsx
+archetype: form
+persona: tecnico
+nota: 61
+nivel: "Developing"
+baseline_anterior: 61   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Tabela de pecas editavel funcional mas pede Variation ID numerico cru — affordance fraca e sem totais."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Bling (busca produto)"
+    fix: "Campo Variation ID e input numerico cru; trocar por autocomplete de produto com nome/SKU"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear"
+    fix: "Sem exibicao de errors por campo nem validacao de qtd/preco; add feedback inline"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Cognitive-load"
+    best_of_class: "Shopify line items"
+    fix: "Sem subtotal/preco por linha nem total; tecnico nao ve impacto financeiro"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-jobsheet-create.yaml
+++ b/memory/governance/scorecards/screens/repair-jobsheet-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/JobSheet/Create
+path: resources/js/Pages/Repair/JobSheet/Create.tsx
+archetype: form
+persona: tecnico
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Create com Deferred options + skeleton e secoes claras, mas cliente por ID numerico e validacao incompleta."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Bling"
+    fix: "contact_id e input number; substituir por busca de cliente (nome/telefone) com autocomplete"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe forms"
+    fix: "errors so renderizados em contact_id; propagar inline a todos os campos obrigatorios"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Notion"
+    fix: "Selects nativos; sem marcadores de campo obrigatorio; migrar pra Select DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-jobsheet-edit.yaml
+++ b/memory/governance/scorecards/screens/repair-jobsheet-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/JobSheet/Edit
+path: resources/js/Pages/Repair/JobSheet/Edit.tsx
+archetype: form
+persona: tecnico
+nota: 71
+nivel: "Advanced"
+baseline_anterior: 71   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit com tabs e indicador de erro por aba (bom), mas checklist readOnly inativo e cliente por ID."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Affordance"
+    best_of_class: "Shopify"
+    fix: "Checklist usa checkbox readOnly (nao salva estado); tornar editavel e persistir"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Bling"
+    fix: "contact_id input number; trocar por busca de cliente"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Linear tabs"
+    fix: "Tabs hand-roll + selects nativos; usar Tabs/Select do DS (tokens v4)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-jobsheet-index.yaml
+++ b/memory/governance/scorecards/screens/repair-jobsheet-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/JobSheet/Index
+path: resources/js/Pages/Repair/JobSheet/Index.tsx
+archetype: list
+persona: tecnico
+nota: 52
+nivel: "Developing"
+baseline_anterior: 52   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Shell React limpo mas e stub — lista real e placeholder de DataTables legacy e cards so contam filtros."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Linear"
+    fix: "Tabela e placeholder (div explicando DataTables legacy); migrar pra TanStack/tabela real com dados"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Bling"
+    fix: "Cards mostram CONTAGEM de filtros, nao a lista de OS; substituir por tabela acionavel"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Shopify filters"
+    fix: "Filtros existem so como numeros; expor selects funcionais que filtram a lista"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-jobsheet-show.yaml
+++ b/memory/governance/scorecards/screens/repair-jobsheet-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/JobSheet/Show
+path: resources/js/Pages/Repair/JobSheet/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Melhor da leva: painel FSM completo (fetch, confirm, motivo, toast, side-effect, permissao) mas cores cruas e modal hand-roll."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "STAGE_COLOR_MAP usa palette tailwind crua (gray/blue/red); mapear pra tokens DS v4"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Linear modal"
+    fix: "Modal de confirmacao FSM hand-roll (fixed inset-0); usar Dialog de @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Notion"
+    fix: "Deferred parts/anexos/activities sempre caem em EmptyState (defer nao wired pro render real)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-producaooficina-index.yaml
+++ b/memory/governance/scorecards/screens/repair-producaooficina-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/ProducaoOficina/Index
+path: resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+archetype: kanban
+persona: tecnico
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Kanban F3 com DnD otimista e filtros dinamicos por vertical, mas palette crua fora do DS e drawer totalmente mockado."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Constituicao UI v2 (roxo 295)"
+    fix: "100% palette slate/blue/amber cruas, zero token DS, zero primary roxo; nao herda Fundacoes"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Linear board"
+    fix: "Conteudo do drawer 100% MOCKADO (barulho suspensao, fotos fake, timeline fake); ligar dados reais do card"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion DnD"
+    fix: "Drag-drop HTML5 sem fallback teclado nem aria-grabbed; inacessivel a teclado"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-show.yaml
+++ b/memory/governance/scorecards/screens/repair-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/Show
+path: resources/js/Pages/Repair/Show.tsx
+archetype: detail
+persona: tecnico
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe de venda-reparo limpo (dl grid, aside pagamentos, defer timeline) mas FSM e placeholder e cores cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Linear"
+    fix: "Painel FSM e stub textual (Importar FsmActionPanel em iteracao futura); ligar painel real ou ocultar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe"
+    fix: "STAGE_COLOR_MAP palette crua; sem charter usado no header; mapear tokens DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion"
+    fix: "Timeline e EmptyState fixo (ActivitiesList hardcoded vazio) apesar do Deferred"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/repair-status-index.yaml
+++ b/memory/governance/scorecards/screens/repair-status-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Repair/Status/Index
+path: resources/js/Pages/Repair/Status/Index.tsx
+archetype: config
+persona: misto
+nota: 77
+nivel: "Advanced"
+baseline_anterior: 77   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "CRUD de status enxuto e completo pro escopo (swatch cor, EmptyState, a11y) mas create/edit ainda em Blade legacy."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Linear inline edit"
+    fix: "Create/edit saem pra modal Blade legacy; trazer pra drawer Inertia mantendo contexto"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Notion sortable"
+    fix: "sort_order so exibido; permitir reordenar por drag em vez de editar numero no Blade"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Density"
+    best_of_class: "Stripe settings"
+    fix: "Tabela de config poderia mostrar contagem de OS por status pra contexto"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-caixa-index.yaml
+++ b/memory/governance/scorecards/screens/sells-caixa-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Caixa/Index
+path: resources/js/Pages/Sells/Caixa/Index.tsx
+archetype: dashboard
+persona: larissa
+nota: 75
+nivel: "Advanced"
+baseline_anterior: 75   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Caixa do dia KB-9.75 com KPI hero e barras por-origem, mas metade e placeholder legacy e usa CSS cru com emoji."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Constituicao UI v2"
+    fix: "Usa classes CSS cockpit cruas (os-*, vc-*) e oklch inline, nao @/Components/ui; emoji como icone de pagamento"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Brand-confidence"
+    best_of_class: "Stripe dashboard"
+    fix: "2 de 4 secoes sao placeholders apontando pro /cash-register legacy; completar movimentos+conferencia"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Bling caixa"
+    fix: "Fechar caixa faz window.location pra modal legacy; trazer pra drawer Inertia"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-create.yaml
+++ b/memory/governance/scorecards/screens/sells-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Create
+path: resources/js/Pages/Sells/Create.tsx
+archetype: form
+persona: larissa
+nota: 88
+nivel: "Leader"
+baseline_anterior: 88   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form POS denso e maduro (1647 linhas, charter): autosave multi-tenant, atalhos /, Cmd+Enter, error-scroll, NumericInputPtBR; perde por cores cruas nos cards e header fora do canon."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "Stripe/Linear: 100% design tokens semanticos"
+    fix: "Trocar amber/blue/emerald-50/700 hardcoded dos KPI/status cards por tokens (--warning/--info/--success) ou data-attrs"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "Shopify: 1 header canon em todas telas"
+    fix: "Usar PageHeader canon (ja importado mas nao usado) em vez do header sticky hand-roll"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear: zero N+1 no client"
+    fix: "handlePriceGroupChange faz 1 fetch/linha; batchar endpoint /products/list pra 1 request"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-drafts.yaml
+++ b/memory/governance/scorecards/screens/sells-drafts.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Drafts
+path: resources/js/Pages/Sells/Drafts.tsx
+archetype: list
+persona: larissa
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de rascunhos limpa com badge idade/CTA continuar e atalhos N/Esc; raso em a11y de tabela, sem skeleton nem paginacao server."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Performance-perceived"
+    best_of_class: "Linear: skeleton rows"
+    fix: "Trocar 'Carregando…' por skeleton de tabela; busca/filtro so client-side (sem paginacao server)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Notion: header sortable com aria-sort"
+    fix: "Tabela sem sort nem aria-sort/scope nos th; adicionar role + foco de teclado nas linhas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Bling: filtro local/vendedor"
+    fix: "filters.businessLocations/customers carregados mas nao expostos como filtro UI"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-edit.yaml
+++ b/memory/governance/scorecards/screens/sells-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Edit
+path: resources/js/Pages/Sells/Edit.tsx
+archetype: form
+persona: larissa
+nota: 79
+nivel: "Advanced"
+baseline_anterior: 79   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit deferred com skeleton, autosave per-venda, FSM-safe e paridade Create; cai por selects nativos, confirm()/alert() nativos e cores cruas."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Aesthetic-usability"
+    best_of_class: "Stripe: Select estilizado consistente"
+    fix: "Status/desconto/responsavel usam <select> nativo hand-roll em vez do componente Select @/Components/ui"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear: dialog in-app"
+    fix: "Substituir confirm() e alert() nativos (recover draft, >5MB) por AlertDialog shadcn (Create ja fez)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "tokens semanticos"
+    fix: "amber/emerald hardcoded nos KPI; alinhar com tokens como na pendencia do Create"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-index.yaml
+++ b/memory/governance/scorecards/screens/sells-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Index
+path: resources/js/Pages/Sells/Index.tsx
+archetype: list
+persona: larissa
+nota: 90
+nivel: "Leader"
+baseline_anterior: 90   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cockpit de vendas estado-da-arte (1806 linhas, charter, score 9.75): SLA pills, pipeline FSM, ⌘K, saved views, bulk emit, sparkline deferred; desvia do DS por CSS Cowork scoped."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "DS unico (@/Components/ui)"
+    fix: "Tela usa familia .sells-cowork + classes os-btn/vd-* hand-roll em vez de Button/Input canon (port Cowork intencional, mas diverge do DS)"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "tokens v4 primary roxo"
+    fix: "Paleta Cowork via CSS bundle proprio; auditar que mapeia em tokens oklch e nao hex/blue cru"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "Linear: roving tabindex anunciado"
+    fix: "J/K/⌘K ricos mas faltam aria-live no foco de linha e aria-sort nos headers clicaveis"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-quotations.yaml
+++ b/memory/governance/scorecards/screens/sells-quotations.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Quotations
+path: resources/js/Pages/Sells/Quotations.tsx
+archetype: list
+persona: larissa
+nota: 73
+nivel: "Advanced"
+baseline_anterior: 73   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de cotacoes irma de Drafts (badge orcamento, enviar/editar); mesma divida: sem skeleton/paginacao/a11y e CTA 'Enviar' enganoso."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Performance-perceived"
+    best_of_class: "skeleton + paginacao server"
+    fix: "'Carregando…' textual, busca so client-side, sem paginacao; clonar pattern do Index"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "tabela acessivel"
+    fix: "th sem scope/aria-sort, linhas sem foco teclado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Microcopy"
+    best_of_class: "Stripe: acao clara"
+    fix: "Botao 'Enviar' abre /print?quotation=1 em nova aba (imprime, nao envia) — rotular 'Imprimir/PDF' ou wirar envio real"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-show.yaml
+++ b/memory/governance/scorecards/screens/sells-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Show
+path: resources/js/Pages/Sells/Show.tsx
+archetype: detail
+persona: larissa
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe 8/4 deferred com proxima-acao FSM, emit NF-e/NFS-e, timeline unificada, multi-modo print e cheat-sheet; perde por tones crus e alert() nativo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "tokens semanticos"
+    fix: "PAYMENT_STATUS_TONE com emerald/amber/blue-50/700 hardcoded; mover pra tokens"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear: toast nao-bloqueante"
+    fix: "Falha de impressao usa window.alert() nativo; trocar por toast sonner"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe: detail 1-col fluido"
+    fix: "Grid 8/4 colapsa mas painel FSM/timeline lateral fica longe no mobile; validar ordem"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/sells-subscriptions.yaml
+++ b/memory/governance/scorecards/screens/sells-subscriptions.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Sells/Subscriptions
+path: resources/js/Pages/Sells/Subscriptions.tsx
+archetype: list
+persona: larissa
+nota: 72
+nivel: "Advanced"
+baseline_anterior: 72   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de assinaturas com start/stop inline, badges freq/proxima-fatura/status; fragil em feedback de erro (catch mudo) e a11y."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe: feedback de mutacao"
+    fix: "toggleRecurring falha em silencio (catch vazio) e nao confirma pausa/retomada; adicionar toast + estado erro"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "skeleton"
+    fix: "'Carregando…' textual, refetch full apos toggle (sem optimistic update)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "tabela acessivel"
+    fix: "th sem scope/aria-sort; toggle sem aria-pressed/estado anunciado"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/settings-paymentgateways-cnabretorno.yaml
+++ b/memory/governance/scorecards/screens/settings-paymentgateways-cnabretorno.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Settings/PaymentGateways/CnabRetorno
+path: resources/js/Pages/Settings/PaymentGateways/CnabRetorno.tsx
+archetype: config
+persona: wagner
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Fundacao tecnica de upload CNAB retorno (sem charter, declarado): form file + tabela deferred funcional mas plano, paleta stone fora do DS v4."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "tokens v4 + charter"
+    fix: "Sem charter (assumido), paleta stone/emerald/rose/amber crua, PageHeader importado de Financeiro/atoms (nao canon shared)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe/Shopify: dropzone drag&drop"
+    fix: "Input file nativo cru; adicionar dropzone + preview nome/tamanho antes de enviar"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear: empty/erro ricos"
+    fix: "Empty e erros de upload minimalistas (icone+texto inline); usar EmptyState canon + lista de erros expandivel"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/settings-paymentgateways-index.yaml
+++ b/memory/governance/scorecards/screens/settings-paymentgateways-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Settings/PaymentGateways/Index
+path: resources/js/Pages/Settings/PaymentGateways/Index.tsx
+archetype: config
+persona: wagner
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Console de gateways (charter, Cowork F1.5 93/100, persona Wagner): KPIs+tabela deferred, J/K, cheat-sheet, drawer; desvia do DS v4 (paleta stone + atoms locais)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 primary roxo + tokens"
+    fix: "bg-stone-50/text-stone-* e emerald/amber/rose hardcoded em toda tela; primary roxo so num ring. Migrar pra tokens v4"
+    esforco: alto
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Internal-consistency"
+    best_of_class: "componentes shared canon"
+    fix: "Btn/KpiCard/PageHeader importados de Financeiro/Cobranca/_components/atoms (DS local) em vez de @/Components/ui shared"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Stripe: acoes-linha rotuladas"
+    fix: "Botoes RefreshCw/MoreHorizontal por linha sem handler/menu real (so o Settings abre drawer); wirar ou remover"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-blogpost.yaml
+++ b/memory/governance/scorecards/screens/site-blogpost.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/BlogPost
+path: resources/js/Pages/Site/BlogPost.tsx
+archetype: detail
+persona: misto
+nota: 55
+nivel: "Developing"
+baseline_anterior: 55   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Pagina de post marketing tokenizada (prose, tags, meta-desc); fina e com dangerouslySetInnerHTML sem sanitizacao e img hero sem lazy/dimensoes."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Next/Stripe blog: HTML sanitizado"
+    fix: "content via dangerouslySetInnerHTML sem sanitizacao (risco XSS se CMS aceitar HTML nao-confiavel); sanitizar server/client"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "feature_image com width/height + lazy"
+    fix: "img hero sem loading/lazy nem dimensoes (CLS); adicionar"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Medium: meta autor/data/tempo leitura"
+    fix: "Falta data publicacao, autor e tempo de leitura no topo do post"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-blogs.yaml
+++ b/memory/governance/scorecards/screens/site-blogs.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/Blogs
+path: resources/js/Pages/Site/Blogs.tsx
+archetype: list
+persona: misto
+nota: 68
+nivel: "Developing"
+baseline_anterior: 68   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Indice de blog marketing tokenizado com cards hover/line-clamp/lazy-img e empty state; faltam paginacao, busca/tags e data nos cards."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Discoverability"
+    best_of_class: "Ghost/Stripe: paginacao + tags/busca"
+    fix: "Grid sem paginacao, busca ou filtro por tag/categoria"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "i18n-PT-BR"
+    best_of_class: "Medium: data + tempo leitura por card"
+    fix: "created_at existe no tipo mas nao e exibido; adicionar data formatada pt-BR no card"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Next: skeleton de cards"
+    fix: "Sem estado loading/skeleton (posts via prop direta); ok se SSR, mas sem fallback de erro"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-home.yaml
+++ b/memory/governance/scorecards/screens/site-home.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/Home
+path: resources/js/Pages/Site/Home.tsx
+archetype: dashboard
+persona: misto
+nota: 78
+nivel: "Advanced"
+baseline_anterior: 78   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Landing marketing composicional com Inertia::defer per-prop, CTA final em bg-primary roxo e componentes Site reusados; perde so por tipos any e fallbacks que piscam."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "tipagem estrita"
+    fix: "Props page/testimonials/faqs/statistics tipadas como any/any[]; definir interfaces reais do CMS"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe landing: secoes com IDs/anchor nav"
+    fix: "Composicao linear de secoes sem ancoras/nav interna; ok pra landing curta, revisar se crescer"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Linear: skeleton fiel por secao"
+    fix: "Deferred per-prop bom, mas fallbacks renderizam componente com null (pode piscar copy hardcoded vs DB)"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-login.yaml
+++ b/memory/governance/scorecards/screens/site-login.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/Login
+path: resources/js/Pages/Site/Login.tsx
+archetype: form
+persona: misto
+nota: 88
+nivel: "Leader"
+baseline_anterior: 88   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Login estado-da-arte: token-puro, floating-label, social IdP, show/hide, flash error, copy PT-BR caloroso; falta wiring a11y de erro de campo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "A11y-WCAG"
+    best_of_class: "Stripe/Linear auth"
+    fix: "Mover errors.username/password de status flash p/ aria-describedby+aria-invalid no input; remember tem id mas label so no inline"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Affordance"
+    best_of_class: "Shopify floating-label"
+    fix: "Floating label hand-rolled (peer) em vez de @/Components/ui — toggle Mostrar/Ocultar sem aria-pressed"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "Sem .charter.md (so .review.md); social IdP redirect sem estado loading"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-page.yaml
+++ b/memory/governance/scorecards/screens/site-page.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/Page
+path: resources/js/Pages/Site/Page.tsx
+archetype: other
+persona: misto
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Renderizador CMS enxuto (prose + dangerouslySetInnerHTML); correto e tokenizado mas sem estados de erro/vazio nem sanitize — baixa maturidade por escopo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Notion public page"
+    fix: "Sem fallback p/ page null/404 nem estado vazio de content; dangerouslySetInnerHTML sem sanitize visivel"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "WCAG img"
+    fix: "feature_image alt='' fixo (decorativo assumido) mesmo quando e conteudo; prose sem landmark heading skip"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "Renderer CMS minimo 49 linhas, sem charter, sem PageHeader — stub legitimo mas raso"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-pricing.yaml
+++ b/memory/governance/scorecards/screens/site-pricing.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/Pricing
+path: resources/js/Pages/Site/Pricing.tsx
+archetype: other
+persona: misto
+nota: 84
+nivel: "Advanced"
+baseline_anterior: 84   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Landing de preços convincente: billing toggle, tiers/FAQ extraidos, confidence row, CTA final roxo; falha em token success cru e a11y do toggle."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Internal-consistency"
+    best_of_class: "Stripe pricing"
+    fix: "Toggle mensal/anual sem role=tablist/aria-pressed; desconto −20% em bg-green-500/20 cru em vez de token success"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "i18n-PT-BR"
+    best_of_class: "DS tokens"
+    fix: "Emojis 🇧🇷🔒↩️ como icones (sem fallback semantico/aria-hidden ok mas fragil) — preferir lucide"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "packages:any[] (sem tipo); green-500 hardcoded fora do token set; sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/site-register.yaml
+++ b/memory/governance/scorecards/screens/site-register.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Site/Register
+path: resources/js/Pages/Site/Register.tsx
+archetype: form
+persona: misto
+nota: 86
+nivel: "Leader"
+baseline_anterior: 86   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Cadastro espelha Login com mesma qualidade: social, gate allowRegistration, copy '30s sem cartao'; falta strength meter e validacao client de match."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe signup"
+    fix: "Sem strength meter nem validacao client de senha>=8/match; password_confirmation sem error inline (so server)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "WCAG forms"
+    fix: "Mesmo padrao Login: errors via prop, falta aria-invalid/describedby; toggle senha sem aria-pressed"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "Field hand-rolled duplicado de Login (DRY p/ @/Components/ui/FloatingField); sem charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/stockadjustment-create.yaml
+++ b/memory/governance/scorecards/screens/stockadjustment-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: StockAdjustment/Create
+path: resources/js/Pages/StockAdjustment/Create.tsx
+archetype: form
+persona: eliana
+nota: 80
+nivel: "Advanced"
+baseline_anterior: 80   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Form denso forte: validacao live recuperado<=total, perda liquida ao vivo, perm-gate preco, empty states; trava em product-picker fake e paleta stone fora do token v4."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Bling/Linear combobox"
+    fix: "'Buscar produto' e Input texto puro — product_id fica null, sem autocomplete real (Command/combobox)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "<select> nativo + cores stone-*/rose-* hardcoded em vez de @/Components/ui/select + tokens muted/destructive"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Stripe"
+    fix: "Validacao so recuperado<=total; sem erro client p/ filial/linhas vazias antes do submit"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/stockadjustment-index.yaml
+++ b/memory/governance/scorecards/screens/stockadjustment-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: StockAdjustment/Index
+path: resources/js/Pages/StockAdjustment/Index.tsx
+archetype: list
+persona: eliana
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista densa exemplar: filtro sticky filial/data, pills tipo, perm-gate preco, empty dual (busca vs zero), tabular-nums; perde em tokens stone crus e confirm() nativo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "Tabela hand-roll com stone-*/rose-*/emerald-* cru; <select> nativo no filtro; confirm() em vez de alert-dialog DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Error-recovery"
+    best_of_class: "Linear"
+    fix: "Delete via window.confirm nativo (sem undo/AlertDialog acessivel); sem estado error/loading da lista"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Inertia defer"
+    fix: "rows eager (sem Inertia::defer/Skeleton) e busca client-only — escala mal sem paginacao server"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/stocktransfer-create.yaml
+++ b/memory/governance/scorecards/screens/stocktransfer-create.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: StockTransfer/Create
+path: resources/js/Pages/StockTransfer/Create.tsx
+archetype: form
+persona: eliana
+nota: 81
+nivel: "Advanced"
+baseline_anterior: 81   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Transfer com guard origem≠destino (bloqueia submit + filtra destino), total+frete ao vivo, charter presente; mesmas pendencias: product-picker fake e cores stone."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Bling combobox"
+    fix: "Produto e Input texto puro (product_id null) — sem autocomplete real nem validacao de estoque na origem"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "<select> nativo + paleta stone/emerald/rose hardcoded fora do token roxo v4"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Aesthetic-usability"
+    best_of_class: "Linear"
+    fix: "Bloco DE→PARA bom, mas badges DE/PARA com bg-stone-200/emerald-100 cru; preferir token + Badge DS"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/stocktransfer-index.yaml
+++ b/memory/governance/scorecards/screens/stocktransfer-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: StockTransfer/Index
+path: resources/js/Pages/StockTransfer/Index.tsx
+archetype: list
+persona: eliana
+nota: 82
+nivel: "Advanced"
+baseline_anterior: 82   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista transfer solida com filtro status+filial+data, origem→destino inline, pills status, print/ver/excluir; mesmos gaps de tokens stone e ausencia de defer."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "stone-*/rose-*/amber-*/emerald-* hardcoded; 2 <select> nativos; confirm() nativo no delete"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Inertia defer"
+    fix: "rows eager sem defer/Skeleton; busca client-only sem paginacao server (vs TxPayment/Index que faz)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear"
+    fix: "Print abre window.open novo tab sem aria/feedback; status pill pending=rose pode confundir com erro"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/superadmin-usuario360-index.yaml
+++ b/memory/governance/scorecards/screens/superadmin-usuario360-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: superadmin/Usuario360/Index
+path: resources/js/Pages/superadmin/Usuario360/Index.tsx
+archetype: list
+persona: wagner
+nota: 58
+nivel: "Developing"
+baseline_anterior: 58   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista de busca enxuta com tabela responsiva e empty state, mas sem charter, botão submit hand-rolled, sem paginação/loading e busca só por submit (sem debounce)."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Linear (busca instantânea)"
+    fix: "Busca exige submit; adicionar debounce + only:['users'] partial reload"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "Sem .charter.md ao lado e <button> primário cru; usar @/Components/ui/button e criar charter"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Performance-perceived"
+    best_of_class: "Shopify"
+    fix: "users[] sem paginação nem skeleton; paginar server-side + estado loading"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/superadmin-usuario360-show.yaml
+++ b/memory/governance/scorecards/screens/superadmin-usuario360-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: superadmin/Usuario360/Show
+path: resources/js/Pages/superadmin/Usuario360/Show.tsx
+archetype: detail
+persona: wagner
+nota: 64
+nivel: "Developing"
+baseline_anterior: 64   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Painel 360 abrangente (roles/perms/tokens/sessions/audit/lockouts) com graceful-degradation de tabelas ausentes, mas sem charter, emoji-heavy, RISK_STYLES em cores cruas e window.confirm nativo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe (dialog tipado)"
+    fix: "submitUnlock usa window.confirm nativo; trocar por Dialog do DS com motivo/nota igual ao lock"
+    esforco: baixo
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 tokens"
+    fix: "RISK_STYLES (gray/yellow/orange/red literais) e emojis 🔒✅⏸; mapear risk pra tokens semânticos + ícones lucide; criar charter"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Notion"
+    fix: "9 blocos empilhados sem âncoras/tabs; adicionar nav lateral ou tabs pra navegar seções longas"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/transactionpayment-edit.yaml
+++ b/memory/governance/scorecards/screens/transactionpayment-edit.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: TransactionPayment/Edit
+path: resources/js/Pages/TransactionPayment/Edit.tsx
+archetype: form
+persona: eliana
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Edit token-puro forte: Select DS, campos condicionais por metodo, toast validation+onError, contexto da transacao; falha em mask de cartao e red-600 cru."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Error-recovery"
+    best_of_class: "Stripe"
+    fix: "Validacao client via toast (bom) mas amount<=0/method dup com server; sem aria-live no toast p/ leitor de tela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "PCI/WCAG"
+    fix: "card_number/cheque em Input texto puro sem mask/inputmode; erros usam text-red-600 cru em vez de destructive"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4"
+    fix: "Header h1 hand-roll em vez de PageHeader; PUT reusa /payments legacy (acoplamento controlado mas fragil)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/transactionpayment-index.yaml
+++ b/memory/governance/scorecards/screens/transactionpayment-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: TransactionPayment/Index
+path: resources/js/Pages/TransactionPayment/Index.tsx
+archetype: list
+persona: eliana
+nota: 87
+nivel: "Leader"
+baseline_anterior: 87   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Melhor lista do lote: Inertia::defer+Skeleton nos KPIs, filtros persistidos em localStorage, paginacao server real, Badge/token puro; falta PageHeader e date-range UI."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PageHeader canon"
+    fix: "h1 hand-roll em vez de PageHeader (AppShellV2 ok); filtros como chips Button (bom) mas sem date range UI"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Linear filters"
+    fix: "Filtros from/to existem no tipo mas sem controle de data na UI — so tipo/status clicaveis"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "WCAG table"
+    fix: "Paginacao via dangerouslySetInnerHTML no Button (label '&laquo;'); table sem scope/caption"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/transactionpayment-show.yaml
+++ b/memory/governance/scorecards/screens/transactionpayment-show.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: TransactionPayment/Show
+path: resources/js/Pages/TransactionPayment/Show.tsx
+archetype: detail
+persona: eliana
+nota: 85
+nivel: "Leader"
+baseline_anterior: 85   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Detalhe/recibo token-puro elegante: amount destacado, campos condicionais por metodo, print (no-print), download anexo, badges status; falta sanitize e PageHeader."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "A11y-WCAG"
+    best_of_class: "WCAG"
+    fix: "contact_address via dangerouslySetInnerHTML sem sanitize; print usa window.print sem media-query visivel alem de no-print"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "PageHeader canon"
+    fix: "Header h1+acoes hand-roll em vez de PageHeader; audit trail e placeholder textual ('v2.1')"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Information-hierarchy"
+    best_of_class: "Stripe receipt"
+    fix: "Amount 3xl bom, mas cards contato/pagamento 50/50 sem enfase no status; doc anexo so se existir"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/vestuario-etiquetas-index.yaml
+++ b/memory/governance/scorecards/screens/vestuario-etiquetas-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Vestuario/Etiquetas/Index
+path: resources/js/Pages/Vestuario/Etiquetas/Index.tsx
+archetype: form
+persona: larissa
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Gerador de etiquetas ZPL/PDF funcional: lote multi-item, cópias, config badges, download blob, error inline; trava em entrada manual de Produto ID e grid-12 nao responsivo."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Speed-to-task"
+    best_of_class: "Bling label batch"
+    fix: "'Produto ID' digitado a mao (sem lookup de produto/variation) — fricção alta no balcao; SKU/EAN manuais"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Mobile-fit"
+    best_of_class: "Shopify"
+    fix: "grid-cols-12 por linha colapsa mal em telas estreitas; sem responsivo p/ os 8 campos inline"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 + charter"
+    fix: "Sem .charter.md; fetch manual+CSRF em vez de useForm/router; emerald-100 cru; PageHeader subtitle prop (canon usa description)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/whatsapp-settings.yaml
+++ b/memory/governance/scorecards/screens/whatsapp-settings.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Whatsapp/Settings
+path: resources/js/Pages/Whatsapp/Settings.tsx
+archetype: config
+persona: misto
+nota: 86
+nivel: "Leader"
+baseline_anterior: 86   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Wizard OAuth Meta exemplar: charter live v2, tokens semanticos, Esc/autofocus/aria, empty-state honesto, error-recovery solido — melhor da leva."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Mobile-fit"
+    best_of_class: "Stripe Connect onboarding"
+    fix: "max-w-3xl + p-6 ok, mas popup 600x750 e cards nao testados <400px; validar stack vertical"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "A11y-WCAG"
+    best_of_class: "GOV.UK"
+    fix: "<details> Z-API sem aria-expanded explicito; errorMessage card sem role=alert pra leitor de tela"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Discoverability"
+    best_of_class: "Shopify"
+    fix: "estado degraded/disconnected so mostra link 'Reconectar' inline; promover a CTA visivel igual ao empty state"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/memory/governance/scorecards/screens/whatsapp-templates-index.yaml
+++ b/memory/governance/scorecards/screens/whatsapp-templates-index.yaml
@@ -1,0 +1,32 @@
+# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico
+# screen-grades-baseline-2026-05-30.json (método "SCREEN-GRADE-9.75").
+# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.
+# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.
+screen: Whatsapp/Templates/Index
+path: resources/js/Pages/Whatsapp/Templates/Index.tsx
+archetype: list
+persona: misto
+nota: 74
+nivel: "Advanced"
+baseline_anterior: 74   # ratchet — nota não cai abaixo disto sem aprovação
+peso_real: 1.0
+source: screen-grades-baseline-2026-05-30
+graded_at: "2026-05-30"
+resumo: "Lista HSM madura com Deferred+skeleton, EmptyState, form criar e alerta orfaos; perde em cores cruas nos badges e ausencia de charter."
+dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)
+gaps:
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "DS v4 roxo"
+    fix: "badges provider/status usam Tailwind cru (blue/purple/orange/pink/slate) sob 'R-DS-002 excecao'; mapear pra tokens semanticos data-viz"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Pre-Flight-conformance"
+    best_of_class: "charter-first"
+    fix: "so existe Index.review.md; criar Index.charter.md (Mission/Non-Goals/Anti-hooks)"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30
+  - dim: "Speed-to-task"
+    best_of_class: "Linear"
+    fix: "filtros Provider/Status sem busca textual por nome nem contador de resultados; add Input search + count"
+    esforco: medio
+    origin: screen-grades-baseline-2026-05-30

--- a/scripts/qa/screen-grade-seed.mjs
+++ b/scripts/qa/screen-grade-seed.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * screen-grade-seed.mjs — materializa os scorecards YAML por tela a partir do
+ * baseline canônico screen-grades-baseline-2026-05-30.json (método SCREEN-GRADE,
+ * SCREEN-GRADE-METODO.md §5).
+ *
+ * Por quê: o método prevê 1 YAML por tela em scorecards/screens/<modulo>-<tela>.yaml
+ * (com `baseline_anterior` pro ratchet), mas só existe o JSON agregado de 30/mai.
+ * Sem os YAMLs individuais, o ratchet (screen-grades-ratchet.mjs) não tem o que
+ * comparar. Este seed transforma o agregado → individuais, SEM inventar nota
+ * (usa a que o agente LLM-as-judge já produziu).
+ *
+ * Determinístico: mesma entrada → mesma saída. Idempotente: re-rodar sobrescreve.
+ * NÃO recomputa a nota (16 dims subjetivas são do agente, não deste script).
+ *
+ * Uso:
+ *   node scripts/qa/screen-grade-seed.mjs            # gera os YAMLs
+ *   node scripts/qa/screen-grade-seed.mjs --dry-run  # só conta, não escreve
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const BASELINE = join(ROOT, 'memory', 'governance', 'scorecards', 'screen-grades-baseline-2026-05-30.json');
+const OUT_DIR = join(ROOT, 'memory', 'governance', 'scorecards', 'screens');
+const DRY = process.argv.includes('--dry-run');
+
+const ESFORCO = { S: 'baixo', M: 'medio', L: 'alto' };
+const q = (s) => JSON.stringify(s ?? ''); // string YAML-safe (aspas duplas escapadas, válido em YAML)
+
+if (!existsSync(BASELINE)) {
+  console.error(`✗ baseline não encontrado: ${BASELINE}`);
+  process.exit(2);
+}
+
+const baseline = JSON.parse(readFileSync(BASELINE, 'utf8'));
+const grades = baseline.grades ?? [];
+if (!DRY) mkdirSync(OUT_DIR, { recursive: true });
+
+let written = 0;
+for (const g of grades) {
+  const screen = g.screen;
+  const slug = screen.replace(/\//g, '-').toLowerCase();
+  const path = `resources/js/Pages/${screen}.tsx`;
+  const gaps = (g.top_gaps ?? [])
+    .map(
+      (gap) =>
+        `  - dim: ${q(gap.dim)}\n` +
+        `    best_of_class: ${q(gap.best_of_class)}\n` +
+        `    fix: ${q(gap.fix)}\n` +
+        `    esforco: ${ESFORCO[gap.esforco] ?? 'medio'}\n` +
+        `    origin: screen-grades-baseline-2026-05-30`,
+    )
+    .join('\n');
+
+  const yaml =
+    `# Gerado por scripts/qa/screen-grade-seed.mjs a partir do baseline canônico\n` +
+    `# screen-grades-baseline-2026-05-30.json (método ${q(baseline.metodo)}).\n` +
+    `# A nota 16-dim é LLM-as-judge (agente screen-qa) — NÃO editar à mão.\n` +
+    `# Este YAML é o ponto de partida do ratchet: a nota não pode cair abaixo de baseline_anterior.\n` +
+    `screen: ${screen}\n` +
+    `path: ${path}\n` +
+    `archetype: ${g.archetype ?? 'unknown'}\n` +
+    `persona: ${g.persona ?? 'unknown'}\n` +
+    `nota: ${g.nota}\n` +
+    `nivel: ${q(g.nivel)}\n` +
+    `baseline_anterior: ${g.nota}   # ratchet — nota não cai abaixo disto sem aprovação\n` +
+    `peso_real: 1.0\n` +
+    `source: screen-grades-baseline-2026-05-30\n` +
+    `graded_at: ${q(baseline.data)}\n` +
+    `resumo: ${q(g.resumo)}\n` +
+    `dimensoes: {}   # 16 dims individuais: a regradeação pelo agente preenche (baseline só tem agregado)\n` +
+    `gaps:\n${gaps || '  []'}\n`;
+
+  if (!DRY) writeFileSync(join(OUT_DIR, `${slug}.yaml`), yaml);
+  written++;
+}
+
+console.log(`\n${DRY ? '[dry-run] ' : ''}${written} scorecards de tela ${DRY ? 'seriam gerados' : 'gerados'} em memory/governance/scorecards/screens/`);
+console.log(`Fonte: baseline ${baseline.data} · método ${baseline.metodo} · média ${baseline.media}`);
+console.log(`Distribuição: ${Object.entries(baseline.distribuicao).map(([k, v]) => `${k}=${v}`).join(' · ')}`);

--- a/scripts/qa/screen-grades-ratchet.mjs
+++ b/scripts/qa/screen-grades-ratchet.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * screen-grades-ratchet.mjs — catraca anti-regressão da nota por tela.
+ *
+ * Espelha o `module-grades-gate` (ADR 0155): compara a nota de cada scorecard de
+ * tela no PR contra a nota em `origin/main` e BLOQUEIA (exit 1) se alguma cair.
+ * Robusto contra burla: compara sempre vs `origin/main` (não vs o `baseline_anterior`
+ * do próprio arquivo, que o PR poderia baixar junto).
+ *
+ * Regra (catraca = nota só sobe):
+ *   - nota(PR) <  nota(main)   → REGRESSÃO → bloqueia
+ *   - nota(PR) >= nota(main)   → ok (subiu ou estável)
+ *   - tela nova (ausente em main) → ok, vira o novo baseline
+ *
+ * Override (Wagner aprova regressão consciente): variável de ambiente
+ *   SCREEN_RATCHET_ALLOW_REGRESSION=1  (espelha o label do module-grades-gate).
+ *
+ * Pré-req no CI: actions/checkout fetch-depth: 0 (precisa de origin/main).
+ *
+ * Uso:
+ *   node scripts/qa/screen-grades-ratchet.mjs
+ */
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const DIR = join(ROOT, 'memory', 'governance', 'scorecards', 'screens');
+const REL = 'memory/governance/scorecards/screens';
+const ALLOW = process.env.SCREEN_RATCHET_ALLOW_REGRESSION === '1';
+// Ref de baseline (default origin/main). Configurável pra teste local.
+const BASE_REF = process.env.SCREEN_RATCHET_BASE_REF || 'origin/main';
+
+/** Lê `nota:` de um YAML de scorecard (formato controlado pelo seed). */
+const parseNota = (text) => {
+  const m = text.match(/^nota:\s*(\d+)/m);
+  return m ? parseInt(m[1], 10) : null;
+};
+
+/** Nota da versão em origin/main, ou null se a tela é nova. */
+function notaInMain(relPath) {
+  try {
+    const out = execSync(`git show ${BASE_REF}:${relPath}`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return parseNota(out);
+  } catch {
+    return null; // ausente em main → tela nova
+  }
+}
+
+if (!existsSync(DIR)) {
+  console.error(`✗ ${REL} não existe — rode screen-grade-seed.mjs primeiro.`);
+  process.exit(2);
+}
+
+const files = readdirSync(DIR).filter((f) => f.endsWith('.yaml'));
+const regress = [];
+let novas = 0,
+  ok = 0;
+
+for (const f of files) {
+  const cur = parseNota(readFileSync(join(DIR, f), 'utf8'));
+  if (cur === null) continue;
+  const base = notaInMain(`${REL}/${f}`);
+  if (base === null) {
+    novas++;
+    continue;
+  }
+  if (cur < base) regress.push({ file: f, base, cur, delta: cur - base });
+  else ok++;
+}
+
+console.log(`\nCatraca screen-grade · ${files.length} telas · ✅ ${ok} ok/subiu · ✨ ${novas} novas · 🔻 ${regress.length} regrediram`);
+
+if (regress.length) {
+  console.log('\nRegressões (nota caiu vs origin/main):');
+  for (const r of regress.sort((a, b) => a.delta - b.delta)) {
+    console.log(`  🔻 ${r.file}: ${r.base} → ${r.cur} (${r.delta})`);
+  }
+  if (ALLOW) {
+    console.log('\n⚠️  SCREEN_RATCHET_ALLOW_REGRESSION=1 — regressão consciente autorizada. PASS.');
+    process.exit(0);
+  }
+  console.error('\n✗ CATRACA: nota de tela caiu. PR bloqueado. (override: SCREEN_RATCHET_ALLOW_REGRESSION=1)');
+  process.exit(1);
+}
+
+console.log('\n✓ CATRACA: nenhuma tela regrediu.');


### PR DESCRIPTION
## Contexto (pós-reavaliação)

Ao estudar as rotinas internas, descobri que **o método screen-grade e o baseline de 222 telas já existem** (`SCREEN-GRADE-METODO.md` + `screen-grades-baseline-2026-05-30.json`, 30/mai). A nota é **LLM-as-judge** (16 dims subjetivas vs Stripe/Linear/Bling) — então **não** dá pra "espelhar o `module:grade`" como command determinístico sem inventar heurística.

O que o próprio método aponta como gap (§6): *"enforcement (ratchet+GovernanceV4): **ligar**"*. Esta PR liga o enforcement — a parte **determinística** em volta da grade.

## O que entra

- **`scripts/qa/screen-grade-seed.mjs`** — transforma o baseline agregado 30/mai em **222 scorecards individuais** `memory/governance/scorecards/screens/<modulo>-<tela>.yaml` (template `SCREEN-GRADE-METODO §5`). **Não inventa nota** — usa a que o agente já produziu; `dimensoes: {}` fica pro agente preencher na regradeação.
- **`scripts/qa/screen-grades-ratchet.mjs`** — catraca espelhando o `module-grades-gate`: compara a nota de cada tela vs `origin/main` e **bloqueia se cair**. Override consciente via `SCREEN_RATCHET_ALLOW_REGRESSION=1`.
- **222 `scorecards/screens/*.yaml`** — move o coverage de scorecard de **0 → 222** (o `screen-coverage-map.mjs` do #2215 passa a detectá-los).

## Smoke real da catraca (não narração)

```
# baixei sells-create de 88 → 10 e rodei vs o baseline:
exit com regressão        = 1   ← bloqueia
exit com override (=1)    = 0   ← libera regressão consciente
exit após restaurar (88)  = 0   ← volta a passar
```

## Natureza (honestidade)

| Parte | Quem faz |
|---|---|
| Nota 16-dim (subjetiva, vs best-of-class) | **agente** screen-qa (LLM-as-judge) |
| Catraca / seed / freshness (determinístico) | **estes scripts / CI** |

CI vigia; agente julga. Não há command que "finge computar" dimensões subjetivas.

## Fora desta PR (próximos)

- Wire do `screen-grades-ratchet.mjs` num workflow CI (`pull_request`, `fetch-depth: 0`).
- Dim-16 mecânica (charter? `@/ui`? tokens v4? zero inline-style?) como piso grep no PR.
- Re-seed quando o agente regradear (a nota sobe → novo baseline).

<!-- no-ui-smoke: scripts + dados YAML, não toca nenhuma tela .tsx -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)