### PR TITLE
ci(qa): Onda 2 — ligar catraca de cobertura no CI (anel 2 da ADR 0249)

### DIFF
--- a/.github/workflows/screen-coverage-gate.yml
+++ b/.github/workflows/screen-coverage-gate.yml
@@ -1,0 +1,37 @@
+name: Screen Coverage Gate (catraca de cobertura)
+
+# Catraca de cobertura de QA-de-tela (ADR 0249, anel 2). Bloqueia merge se a
+# cobertura agregada (charter / E2E / a11y / scorecard) cair vs o baseline
+# commitado memory/governance/screen-coverage-baseline.json.
+# Leve (Node puro). Telas cobertas só sobem.
+#
+# Pra subir o piso conscientemente: rode `node scripts/qa/screen-coverage-map.mjs --json`
+# e commite o baseline atualizado junto.
+
+on:
+  pull_request:
+    paths:
+      - 'resources/js/Pages/**/*.tsx'
+      - 'resources/js/Pages/**/*.charter.md'
+      - 'tests/Browser/**/*.php'
+      - 'memory/governance/scorecards/screens/**'
+      - 'memory/governance/screen-coverage-baseline.json'
+      - 'scripts/qa/screen-coverage-map.mjs'
+      - '.github/workflows/screen-coverage-gate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  screen-coverage-gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Catraca de cobertura (telas cobertas só sobem)
+        run: node scripts/qa/screen-coverage-map.mjs --check

--- a/memory/governance/screen-coverage-baseline.json
+++ b/memory/governance/screen-coverage-baseline.json
@@ -5,7 +5,7 @@
     "charter": 132,
     "e2e": 3,
     "a11y": 0,
-    "scorecard": 0
+    "scorecard": 222
   },
   "by_module": {
     "Admin": {
@@ -13,231 +13,231 @@
       "charter": 8,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 8
     },
     "ads": {
       "total": 19,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 19
     },
     "Atendimento": {
       "total": 9,
       "charter": 6,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 9
     },
     "Auditoria": {
       "total": 2,
       "charter": 1,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "Cliente": {
       "total": 34,
       "charter": 7,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 7
     },
     "Compras": {
       "total": 5,
       "charter": 1,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "ComunicacaoVisual": {
       "total": 1,
       "charter": 1,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "ConsultaOs": {
       "total": 1,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "Essentials": {
       "total": 13,
       "charter": 3,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 13
     },
     "Financeiro": {
       "total": 23,
       "charter": 12,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 19
     },
     "Fiscal": {
       "total": 8,
       "charter": 7,
       "e2e": 1,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 7
     },
     "governance": {
       "total": 6,
       "charter": 6,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 6
     },
     "Home": {
       "total": 1,
       "charter": 1,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "Jana": {
       "total": 17,
       "charter": 8,
       "e2e": 1,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 11
     },
     "kb": {
       "total": 3,
       "charter": 3,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "Manufacturing": {
       "total": 1,
       "charter": 1,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "MemCofre": {
       "total": 6,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 6
     },
     "Modules": {
       "total": 1,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "NfeBrasil": {
       "total": 6,
       "charter": 4,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 6
     },
     "Nfse": {
       "total": 3,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 3
     },
     "OficinaAuto": {
       "total": 11,
       "charter": 11,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 10
     },
     "Ponto": {
       "total": 22,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 20
     },
     "Produto": {
       "total": 8,
       "charter": 8,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 8
     },
     "ProjectMgmt": {
       "total": 9,
       "charter": 3,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 8
     },
     "Purchase": {
       "total": 4,
       "charter": 2,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 4
     },
     "RecurringBilling": {
       "total": 6,
       "charter": 6,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 6
     },
     "Repair": {
       "total": 13,
       "charter": 12,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 13
     },
     "Sells": {
       "total": 8,
       "charter": 8,
       "e2e": 1,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 8
     },
     "Settings": {
       "total": 2,
       "charter": 2,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "Site": {
       "total": 7,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 7
     },
     "StockAdjustment": {
       "total": 2,
       "charter": 2,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "StockTransfer": {
       "total": 2,
       "charter": 2,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "superadmin": {
       "total": 2,
       "charter": 2,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "Tarefas": {
       "total": 1,
@@ -258,21 +258,21 @@
       "charter": 3,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 3
     },
     "Vestuario": {
       "total": 1,
       "charter": 0,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 1
     },
     "Whatsapp": {
       "total": 2,
       "charter": 1,
       "e2e": 0,
       "a11y": 0,
-      "scorecard": 0
+      "scorecard": 2
     },
     "_Showcase": {
       "total": 2,


### PR DESCRIPTION
## Onda 2 da ADR 0249 — fecha o anel 2 (catraca de cobertura)

- **`screen-coverage-gate.yml`** — roda `screen-coverage-map.mjs --check` em PR; bloqueia se charter/E2E/a11y/scorecard agregados caírem vs o baseline commitado. Trigger amplo (pages tsx, charters, tests/Browser, scorecards).
- **baseline atualizado** — scorecard de tela **0 → 222** (efeito do seed do #2223).

## Smoke real

```
exit normal              = 0   ← cobertura estável
exit apagando 1 scorecard = 1   ← bloqueia queda
exit restaurado          = 0
```

## Estado dos 4 anéis (ADR 0249) após esta PR

| Anel | Estado |
|---|---|
| 1. Catraca de nota (`screen-grades-gate`) | ✅ no ar (#2223) |
| 2. Catraca de cobertura (`screen-coverage-gate`) | ✅ **esta PR** |
| 3. Sentinela de freshness (`charter:health` + "TELAS SEM RE-SMOKE") | parcial |
| 4. Self-healing | a ligar |

## Próximo (Onda 2b/3)

- **Dim-16 mecânica** (charter? `@/ui`? tokens v4? zero inline-style?) como piso grep por tela do diff.
- Sentinela "TELAS SEM RE-SMOKE" no Daily Brief.

<!-- no-ui-smoke: workflow + baseline JSON, não toca nenhuma tela .tsx -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)