### PR TITLE
feat(oficina): handoff design Produção — charter v3 + drawer Vendas×Oficina + arrasto preditivo

### DIFF
--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md
@@ -1,0 +1,80 @@
+---
+casos: Produção / Kanban da Oficina · /oficina-auto/producao
+irmaos: Index.charter.md (lei) · Index.decisoes.md (debate)
+tecnica: Caso de uso = narrativa do cliente + critério de aceite verificável (Dado/Quando/Então)
+por_que: comportamento é durável — não muda no refactor; é teste E explicação de uso E material de treino.
+owner: wagner
+last_run: "2026-06-02"
+---
+
+# Casos de Uso & Aceite — Produção / Kanban da Oficina
+
+> **Importado do handoff de design (Cowork) 2026-06-04.** Os checks `live` foram escritos contra o protótipo de design (`oficina-page.jsx`); ao virar teste real, mapear pro código de produção [`Index.tsx`](Index.tsx). Estados refletem o **modelo (A) reparo** travado no charter, não as colunas caçamba do código atual (dívida F3).
+>
+> **Como roda:** `live` = checável no protótipo · `static` = wiring no código (grep) · `manual` = [W]/usuário confirma visual.
+> **Status:** ✅ passa · 🧪 em teste · ⬜ não verificado · ❌ quebrou (regressão → vira lição).
+
+---
+
+## UC-01 · Ver o pátio num relance
+- **Persona:** Larissa (balcão, 1280px), 8h da manhã.
+- **Como usa:** abre Oficina e vê todas as OS organizadas por etapa, sem rolar, pra saber o que está pegando.
+- **Aceite:** Dado a tela carregada · Quando foco=Etapa · Então **5 colunas** (Recepção → Diagnóstico → Aguardando peças → Em execução → Pronto), cada uma com a contagem de OS.
+- **Status: ✅**
+
+## UC-02 · Os números do dia
+- **Persona:** Larissa / Wagner (governança).
+- **Aceite:** Então **6 KPIs** com valor numérico (Recepção · Diagnóstico · Aguardando peças · Execução · Urgentes · Valor em curso).
+- **Status: ✅**
+
+## UC-03 · Achar uma OS na hora
+- **Persona:** Larissa (cliente ligou citando a placa).
+- **Aceite:** Quando digita na busca (placa/nome/sintoma/#OS) · Então o kanban mostra só as OS que casam + contador de resultados.
+- **Status: ✅**
+
+## UC-04 · Reorganizar por box ou mecânico
+- **Persona:** gestor de oficina.
+- **Aceite:** Quando foco=Mecânico · Então as colunas viram os mecânicos (não as etapas).
+- **Status: ✅** (design validado 2026-06-02: 5 colunas João/Pedro/Carlos/Diego + Sem mecânico).
+
+## UC-05 · Abrir a OS como documento vivo
+- **Persona:** Larissa / mecânico (tablet).
+- **Aceite:** Quando clica no card · Então abre o **drawer** com as **11 seções na ordem travada** do charter (🔒). Fecha no backdrop/✕.
+- **Status: ✅ (drawer travado)**
+
+## UC-06 · Avançar de etapa sem furar a regra (D-01)
+- **Persona:** mecânico.
+- **Como usa:** arrasta o card pra próxima coluna (ou clica o botão "Triagem→/Iniciar→/Entregar→"); só avança se o gate da etapa estiver completo. Se faltar algo, o drawer abre no que falta.
+- **Aceite:** Dado gate completo · Quando solta/clica · Então avança (toast verde). Dado gate incompleto · Então não avança, abre o drawer no checklist (toast âmbar).
+- **Status: 🧪 (aguarda veredito [W] — ver D-01)**
+
+## UC-07 · Cadastrar um carro que chegou
+- **Persona:** Larissa (veículo no balcão).
+- **Aceite:** Quando clica "Nova OS" · Então abre o drawer de criação; salvar adiciona o card em Recepção.
+- **Status: ✅**
+
+## UC-08 · Ver o que vira nota quando o carro fica pronto
+- **Persona:** Larissa (entrega).
+- **Aceite:** Dado stage=pronto + venda derivada · Então o drawer mostra o card Vendas×Oficina com Total · Peças(NF-e) · MO(NFS-e) + badges fiscais.
+- **Status: ⬜** (depende de venda derivada + impl da seção 2 do drawer — ver D-09).
+
+## UC-09 · Ritmo de balcão sem pensar em imposto
+- **Persona:** Larissa (1280px, fila no balcão).
+- **Aceite:** Dado viewport 1280px · Então **sem scroll horizontal**; colunas rolam internamente.
+- **Status: ✅** (design validado 2026-06-02: overflow 0px).
+
+## UC-10 · Trabalhar do jeito que prefere
+- **Persona:** Larissa (calmo) vs. dia de pico (pressão).
+- **Aceite:** Quando muda Pressão=calmo · Então a tira de urgente some; Pressão=pressão · Então urgentes pulsam.
+- **Status: ✅** (design validado 2026-06-02: `ofc-mood-calmo`).
+
+---
+
+## Como rodar a suíte
+1. **Static:** grep do componente — o wiring de cada UC existe? (pega regressão de "sumiu a função").
+2. **Live:** rota Produção → checar os asserts `live`.
+3. **Cadência:** rodar ao fim de toda mexida na Oficina. UC que vira ❌ = regressão → lição + conserto antes de seguir.
+
+## Trilha do tempo
+- 2026-06-02 · [CC] criou a suíte (10 UCs) a partir do inventário aprovado do charter (design).
+- 2026-06-04 · [CC] importado pro repo via handoff. Pointers `Index.*`; nota de mapeamento design→produção adicionada.

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/producao
 component: resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
 owner: wagner
 status: live
-last_validated: "2026-05-26"
+last_validated: "2026-06-02"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada
@@ -14,61 +14,139 @@ related_adrs:
   - 0192-auto-faturar-os-venda-jobsheet-observer
   - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: A
-charter_version: 2
+charter_version: 3
 ---
 
-# Page Charter — /oficina-auto/producao
+# Page Charter — /oficina-auto/producao (Produção / Kanban da Oficina)
 
-> **Status:** live (V0). Kanban operacional drag-drop de OS em produção — replica pré-arte Delphi WR_KANBAN.
+> **Status:** live (V2 rica). Painel vivo do pátio — todos os veículos em produção num relance — com um **drawer que é o documento vivo da OS**, do check-in à entrega.
+> **Personas:** Larissa (balcão, 1280px) · mecânico (tablet) · Wagner (governança).
+> **Referência travada (design):** Shopmonkey (calma/polish) × Tekmetric (densidade/fluxo) × Linear (kanban) × Stripe Tax (split fiscal invisível). Nota [W] do design: **9.5**.
 >
-> **Sub-vertical 4 ([ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) — 2026-05-26):** Martinho biz=164 LIVE prod usa sub-vertical 4 (mecânica pesada caminhão basculante) com fluxo Simples 3-estado. **Feedback Martinho 2026-05-26 "placa Mercosul + design Oficina ficou top"** — diferencial UX. Flag `is_overdue` aplica primariamente pra schema sub-vertical 3 hipotético (locação container) preservado nullable; em OS de mecânica pesada o conceito é `expected_completion > now()`.
+> **charter_version 3 (2026-06-02):** backfill de design [CC] que **trava o conceito** (drawer + modelo). Versão 2 (2026-05-26) pré-data a trava do drawer e a decisão de modelo abaixo. Co-vive com o Decision Register irmão [`Index.decisoes.md`](Index.decisoes.md) (o que está em movimento) e os casos de uso [`Index.casos.md`](Index.casos.md) (comportamento durável + aceite).
+>
+> ⚠️ **Divergência conhecida (dívida F3):** o código de produção hoje espelha o protótipo **caçamba** antigo (colunas `disponivel/locada/aguardando/manutencao/pronta`, vocabulário sub-vertical 4 mecânica pesada — Martinho biz=164 LIVE prod, [ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md)). A **verdade de design** é o modelo **(A) reparo** (ver decisão abaixo). Convergir é tarefa **F3** — não regredir o existente até lá.
 
 ## Mission
 
-Visão Kanban tempo-real pro gerente de produção movimentar OS entre estágios (`aberta` → `em_servico` → `concluida` Simples; ou pipeline Complexa Vargas) via drag-drop, com confirmação em transições críticas e placa Mercosul visual.
+Dar à oficina um painel Kanban tempo-real pra o gerente movimentar OS entre estágios via drag-drop (confirmação em transições críticas, [ADR 0143](../../../../../memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) `is_critical`), com placa Mercosul visual e um drawer que concentra todo o documento da OS.
+
+## ⚠️ Modelo decidido por [W] 2026-06-02 — referência (A) reparo automotivo
+
+> [W] 2026-06-02: **"referência é a A".** Decisão cravada — o kanban segue o modelo de **oficina de reparo automotivo** (boxes/elevadores, mecânico, diagnóstico, ETA, partsStatus). Não é mais default provisório. Opções B/C descartadas.
+
+- Modelo canônico do kanban + drawer = **reparo**. Colunas-alvo: **Recepção → Diagnóstico → Aguardando peças → Em execução → Pronto p/ retirar**.
+- A produção real caçamba (Martinho · biz 164, CNAE 4520) roda hoje colunas `disponivel · locada · aguardando · manutencao · pronta`. **Consequência (A):** a caçamba **sobe** pro nível do protótipo de reparo na F3 — NÃO o contrário. Quando a F3 chegar, `ProducaoOficina/Index` adota colunas/cards/drawer de reparo; locação vira caso particular.
+- [ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) marca a dívida técnica (`cacamba_locacao` legado → `mecanica_pesada_basculante`).
+
+## 🔒 DRAWER — TRAVADO (canônico · anti-regressão · não redesenhar)
+
+> [W] 2026-06-02: "Drawer está com os conteúdos perfeitos, trave nisso." A ORDEM e a PRESENÇA das seções abaixo são **contrato**. Mudanças só por novo OK explícito de [W] (registrar na trilha do tempo). Implementação atual: [`_components/ServiceOrderRichSheet.tsx`](_components/ServiceOrderRichSheet.tsx).
+
+Ordem canônica das seções do `Drawer`:
+
+1. **Header** — `OS #id · <etapa>` · modelo do veículo · cliente · botão **Editar** · fechar.
+2. **Card Vendas×Oficina** *(só etapa = `pronto` E existe venda derivada)* — "esta OS gerou a venda #id"; grid **Total · Peças (NF-e) · Mão-de-obra (NFS-e)**; badges fiscais NF-e / NFS-e (ok/aguarda/erro); ações **Abrir venda ↗ · DANFE · DANFS-e · Ver no Caixa do dia**. Ponte oficial Oficina→Vendas (origin:"oficina" + osRef). _Impl 2026-06-04 (D-09): reuso do shared `VendaDerivadaCard`; acende com `venda_derivada != null`. Breakdown fiscal completo = wave futura._
+3. **Hero do veículo** — Placa Mercosul · KM · Box · Mecânico · Valor.
+4. **Sintoma reportado.**
+5. **Vistoria Digital · DVI** — editor item a item, semáforo ok/atenção/reprovado, + "aprovar por WhatsApp". _Gap atual: existe `DviPhotoGrid` parcial; editor inline pendente._
+6. **Aviso de aprovação** *(só etapa `pecas` + `approval`)* — "aguardando aprovação do cliente", botão Cobrar.
+7. **Fotos & Laudo** — thumbs de entrada + adicionar foto.
+8. **Peças & Mão de obra** — `ItemsEditor` (peça / mão de obra / terceiro), split por natureza.
+9. **Checklist de etapa** — `StageGate`: bloqueia avanço enquanto a etapa não fecha (hoje via `ServiceOrderFsmActionPanel`).
+10. **Linha do tempo** — eventos da OS com status done/now.
+11. **Ações de rodapé** — Conversa cliente · Imprimir OS.
+
+**Regras travadas:** seções acendem por contexto (não mostrar vazio); fiscal é split peça→NF-e / mão de obra→NFS-e e a tela **prepara**, não emite; abre por clique no card e fecha por backdrop/✕; scroll interno (header da OS fixo).
+
+## 📋 Inventário de funções — placar [W]
+
+> **Legenda:** ✅ aprovado (fica como está) · ⬜ a decidir/melhorar · 💡 ideia nova [CC] (proposta, ainda não no build). O debate de cada ⬜/💡 vive no Register [`Index.decisoes.md`](Index.decisoes.md) (anéis Avaliar→Testar→Adotar→Descartar). Item aprovado lá **grada pra cá como ✅**. IDs `D-NN` referenciam o Register.
+
+### A. Quadro / Kanban
+- [x] ✅ Colunas por etapa · [x] ✅ Card contextual por etapa · [x] ✅ Realce de OS urgente
+- [ ] ⬜ Capacidade visível por coluna `D-03`
+- [ ] 💡 Arrastar card entre colunas (drag-and-drop) `D-01` · 💡 Avançar etapa direto no card `D-02` · 💡 Alerta de prazo no topo da coluna `D-04`
+
+### B. Cards
+- [x] ✅ Placa Mercosul + veículo + KM + cliente + sintoma · [x] ✅ Mecânico · prazo · valor · countdown · [x] ✅ foto-tag + última atividade + StageGate mini
+- [ ] ⬜ Foto real de entrada no card `D-08` · 💡 Cor da borda por SLA `D-04`
+
+### C. KPIs
+- [x] ✅ 6 KPIs (Recepção · Diagnóstico · Aguardando peças · Execução · Urgentes · Valor em curso)
+- [ ] ⬜ KPI clicável = filtra o quadro `D-05` · 💡 Mini-tendência ↑/↓ vs. ontem
+
+### D. Visões & Foco
+- [x] ✅ 3 visões (Kanban · Lista · Grade) · [x] ✅ 3 focos (Etapa · Box · Mecânico)
+- [ ] ⬜ Persistir visão/foco escolhido `D-06` · 💡 Visão Linha do tempo do dia
+
+### E. Toolbar & Busca
+- [x] ✅ Busca livre (placa/veículo/cliente/sintoma/#OS) + contador · [x] ✅ Filtro por box/elevador
+- [ ] ⬜ Filtros combinados salvos como "vistas"
+
+### F. Tweaks inline
+- [x] ✅ Foco · Densidade · Pressão
+- [ ] ⬜ Densidade "detalhe" revisada
+
+### G. Ações de topo
+- [x] ✅ Nova OS · Editar · Imprimir fila
+- [ ] 💡 Atalhos de teclado (`N` nova OS · `/` busca · setas) `D-07`
+
+### H. Drawer
+- [x] ✅ **TRAVADO** — ver seção "🔒 DRAWER" acima (nota 9.5). Não redesenhar.
 
 ## Goals — Features (faz)
 
-- AppShellV2 + topnav
-- `<PageHeader>` "Produção Oficina" + filtros (mecânico, order_type, prioridade)
-- Colunas Kanban por stage FSM (CacambaKanbanColumn) — heading + count + total valor coluna
-- Cards arrastáveis (CacambaCard) — placa Mercosul visual + vehicle + cliente + tempo em estágio + flag overdue (locação)
-- Drag-drop @dnd-kit → ConfirmDialog em transições críticas (cancelar, voltar estágio) — ADR 0143 `is_critical`
-- Drag-drop em transição padrão → ação imediata via `ExecuteStageActionService` (sem confirm)
-- KanbanDndProvider isola contexto drag (não afeta outros componentes da página)
-- Drawer detail (CacambaProducaoSheet) ao clicar card — FSM action panel completo
-- Multi-tenant Tier 0 — colunas scopadas business_id
-- Refresh manual (sem WebSocket no MVP V0) — Wagner pode chamar polling ou reload
+- AppShellV2 + topnav + `<PageHeader>` "Produção Oficina" + filtros.
+- Kanban por stage FSM (`CacambaKanbanColumn`) — heading + count + total valor da coluna.
+- Cards arrastáveis (`CacambaCard`) — placa Mercosul + veículo + cliente + tempo em estágio + flag overdue.
+- Drag-drop @dnd-kit → `DragConfirmDialog` em transições críticas; transição padrão → ação imediata via `ExecuteStageActionService`.
+- `KanbanDndProvider` isola contexto drag.
+- Drawer detail (`ServiceOrderRichSheet`) ao clicar card — drawer travado (11 seções).
+- Faixa de 6 KPIs.
+- Busca livre + contador de resultados.
+- Multi-tenant Tier 0 — colunas scopadas `business_id` ([ADR 0093](../../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)).
 
 ## Non-Goals — Features (NÃO faz)
 
-- Real-time WebSocket Centrifugo (futuro V1 — ADR 0058)
-- Edição de campos via Kanban (drawer ou navegar pra Edit)
-- Bulk drag-drop (1 card por vez — drag múltiplo confunde gerente)
-- Histórico/audit log inline (vai pro drawer)
+- **NÃO emite nota** — split fiscal é preparado; emissão é listener backend.
+- **NÃO é a Nova OS** (`ServiceOrders/Create`) — esta é a visão de pátio.
+- **NÃO é POS / venda comercial** — sem bipe-código, sem Consumidor Final default, sem NFC-e.
+- Real-time WebSocket Centrifugo (futuro V1 — [ADR 0058](../../../../../memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md)).
+- Edição de campos via Kanban (drawer ou navegar pra Edit). Bulk drag-drop (1 card por vez).
 
-## UX Targets
+## UX Targets + Tests
 
-- p95 first-paint < 1.2s (até 100 cards distribuídos em 5 colunas)
-- Drag responsivo < 16ms por frame (60fps)
-- Drop → status update < 300ms (otimista UI + reconcile)
-- Placa Mercosul reconhecível < 50ms render
+- 1280px sem overflow horizontal; colunas rolam internamente.
+- Drawer abre/fecha sem layout shift; seções na ordem canônica travada.
+- p95 first-paint < 1.2s (até 100 cards / 5 colunas); drag < 16ms/frame (60fps); drop→update < 300ms.
+- Placa Mercosul reconhecível < 50ms render.
+- `valor em curso` = soma consistente (não parse frágil de string `R$` no destino real).
+- Foco=Box mostra capacidade ocupada por box; Foco=Mecânico agrupa por responsável.
+- design-critique ≥ 80 (F1.5) antes de F2.
 
-## UX Anti-patterns
-
-- Drag sem feedback visual (canon = shadow + ghost card)
-- Drop em coluna inválida sem mensagem (canon = toast explicativo + revert otimista)
-- Polling agressivo < 5s (DDoS próprio backend)
-- Card overflow text (canon = truncate + tooltip placa completa)
+### Anti-patterns
+- Drag sem feedback visual (canon = shadow + ghost card).
+- Drop em coluna inválida sem mensagem (canon = toast + revert otimista).
+- Polling agressivo < 5s. Card overflow text (canon = truncate + tooltip placa completa).
 
 ## Tests anti-regressão
 
 - [Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php](../../../../../Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php)
 - [Modules/OficinaAuto/Tests/Feature/ServiceOrderCrudTest.php](../../../../../Modules/OficinaAuto/Tests/Feature/ServiceOrderCrudTest.php)
+- Casos de uso UC-01..UC-10 em [`Index.casos.md`](Index.casos.md).
 
 ## Refs
 
+- Design (Cowork): `oficina-page.{jsx,css}` · `oficina-forms.jsx` · `Oficina - Benchmark Estado da Arte.html`
+- Irmãos no repo: [`Index.decisoes.md`](Index.decisoes.md) (Decision Register) · [`Index.casos.md`](Index.casos.md) (casos & aceite)
 - [SPEC.md US-OFICINA-004 Kanban OS multi-item](../../../../../memory/requisitos/OficinaAuto/SPEC.md)
 - [producao-oficina-cacamba-visual-comparison.md](../../../../../memory/requisitos/OficinaAuto/producao-oficina-cacamba-visual-comparison.md)
-- [ADR 0143 FSM pipeline LIVE](../../../../../memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
-- Pré-arte Delphi: research/clientes-legacy-officeimpresso/_MAPPING/TELA-PRODUCAO-KANBAN.md
+- Irmão de tela: `Oficina.charter.md` (Nova OS · `ServiceOrders/Create`) — NÃO confundir; este é a PRODUÇÃO/kanban.
+
+## Evolução / trilha do tempo
+
+- 2026-05-26 · charter_version 2 — live V0 caçamba (Martinho biz=164, sub-vertical 4 ADR 0194).
+- 2026-06-02 · [CC] backfill de design (charter_version 3). **DRAWER travado por [W]** (nota 9.5). **[W] decidiu modelo (A) reparo automotivo** como referência; B/C descartadas; convergência caçamba→reparo é dívida F3.
+- 2026-06-04 · [CC] sync do handoff de design → repo: charter v2→v3 alinhado ao design travado; Decision Register + casos importados como irmãos. Deltas de código (⬜/💡) permanecem gated por [W] no Register.
+- 2026-06-04 · [CC] implementou (greenlight [W]) **D-09** (drawer §2 Vendas×Oficina via reuso `VendaDerivadaCard`) + **D-01/D-02** (feedback preditivo de arrasto + drawer-on-block + avançar pelo card). tsc/eslint sem erro novo. **Aguarda veredito VISUAL [W]** (gate MWART) pra os checkboxes 💡 D-01/D-02 e ✅ D-09 graduarem oficialmente. Full migração modelo-(A) segue F3.

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.decisoes.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.decisoes.md
@@ -1,0 +1,90 @@
+---
+register: Produção / Kanban da Oficina · /oficina-auto/producao
+irmao_charter: Index.charter.md
+tecnica: Decision Register (anéis estilo Technology Radar — Avaliar/Testar/Adotar/Descartar)
+owner: wagner
+last_update: "2026-06-02"
+---
+
+# Decision Register — Produção / Kanban da Oficina
+
+> **Importado do handoff de design (Cowork) 2026-06-04.** Refs de build (`oficina-page.jsx`/`.css`) são do **protótipo de design**, não do código de produção — o código real vive em [`Index.tsx`](Index.tsx) + [`_components/`](_components). Nada aqui está graduado: deltas seguem **gated por [W]**.
+
+> **O chão de debate da tela.** Aqui vivem as opções ainda sendo discutidas/testadas. O **charter** guarda só o que já fechou; este arquivo guarda o que está **em movimento**.
+>
+> **Ciclo de vida (anéis):**
+> - 🔍 **AVALIAR** — ideia levantada, ainda não testada.
+> - 🧪 **TESTAR** — [CC] protótipou; [W] está experimentando/decidindo.
+> - ✅ **ADOTAR** — [W] aprovou → **grada pro charter** como ✅ e sai daqui.
+> - ⛔ **DESCARTAR** — reprovado → vira anti-pattern no charter.
+>
+> **Como [W] usa:** mexe no campo `estado:` de cada item, ou escreve em `nota [W]:`.
+
+---
+
+## D-01 · Arrastar para avançar, com o gate como guarda
+- **estado:** 🧪 TESTAR — **portado pra produção 2026-06-04** (`Index.tsx` + `KanbanDndProvider`/`CacambaKanbanColumn`); aguarda **veredito visual [W]** (gate MWART) pra graduar ✅.
+- **impl produção 2026-06-04:** feedback preditivo na coluna sob o cursor (verde "solte p/ avançar" / âmbar "abre detalhes") via `useKanbanDragState` + `evaluateDrop` (reusa `resolveDragMapping` — mesma máquina do drop) · em drop **bloqueado** o drawer abre no documento da OS (em vez de só toast). Confirm dialog mantido em transições críticas (ADR 0143 `is_critical`) — não removi a rede de segurança em LIVE prod (Martinho biz=164).
+- **prioridade:** alta (é a "ideia melhor de interação" 2026-06-02)
+- **contexto:** hoje avançar etapa = clicar card → abrir drawer → usar StageGate. Lento pro caminho feliz.
+- **opção proposta:** arrastar o card pra próxima coluna = intenção de avançar; no *drop*, o StageGate valida. Gate ok → avança sem abrir nada. Gate falha → card volta e o drawer abre já no checklist do que falta.
+- **escopo travado:** só ativo no **foco=Etapa**. **Drawer travado intacto** — só abre quando o gate barra.
+- **TESTE FUNCIONAL (painel [W], 2026-06-02):** ✅ render 5 colunas, 12 cards arrastáveis · ✅ roteamento gate.next correto · ✅ caminho bloqueado (OS 8804 gate 3/4 → abre drawer no checklist) · ✅ caminho feliz (4/4 → avança) · ✅ zero regressão no drawer travado.
+- **nota:** 1ª passada 8/10 → REFINO 2ª passada 9/10 (extraído `tryAdvance(os)`: arrasto E botões do card usam a MESMA porta gate-guardada — funde D-02; feedback preditivo na coluna-alvo verde/âmbar).
+- **achados (refino antes de ✅):** (1) etapa terminal "Pronto" → "Entregar" é botão, não coluna; (2) touch/tablet: D-02 deixa de ser opcional; (3) verificação limitada ao painel [W] (iframe não roda host).
+- **nota [W]:** _(vazio — veredito: ✅ adotar / 🧪 continuar / ⛔)_
+
+## D-02 · Botão "→ próxima etapa" no próprio card
+- **estado:** 🧪 TESTAR — **portado pra produção 2026-06-04** (junto com D-01); aguarda veredito visual [W].
+- **contexto:** obrigatório pra touch (mecânico no tablet, onde arrasto falha).
+- **impl produção 2026-06-04:** "uma máquina, duas portas" — os botões de ação do `CacambaCard` (Iniciar/Recolher/Concluir/Entregar) disparam o MESMO `handleDragMove` do arrasto via `onAdvance` + mapa `NEXT_COLUMN_FOR`. "Acompanhar" (locada) segue abrindo o drawer (é ver, não avançar).
+- **nota [W]:** _(vazio — junto com D-01)_
+
+## D-03 · Capacidade visível em todas as colunas
+- **estado:** 🔍 AVALIAR
+- **contexto:** hoje só "Em execução" mostra X/5 boxes. Estender? Dúvida: Recepção/Pronto não têm capacidade física.
+- **nota [W]:** _(vazio)_
+
+## D-04 · Borda do card por SLA (verde/âmbar/vermelho)
+- **estado:** 🔍 AVALIAR
+- **contexto:** hoje urgência é booleano (tira vermelha). Trocar por gradiente de prazo? Risco: ruído visual vs. calma "Shopmonkey". Testar no modo Pressão.
+- **nota [W]:** _(vazio)_
+
+## D-05 · KPI clicável filtra o quadro
+- **estado:** 🔍 AVALIAR
+- **contexto:** os 6 KPIs são só leitura. KPI vira filtro de 1 clique (toggle)?
+- **nota [W]:** _(vazio)_
+
+## D-06 · Persistir visão/foco escolhido
+- **estado:** 🔍 AVALIAR
+- **contexto:** ao voltar volta no default (Etapa/Kanban). Lembrar a última escolha? localStorage no protótipo; preferência de usuário no real.
+- **nota [W]:** _(vazio)_
+
+## D-07 · Atalhos de teclado (N / barra / setas)
+- **estado:** 🔍 AVALIAR
+- **contexto:** Larissa é teclado-first. `N` nova OS · `/` foca busca · setas navegam · Enter abre.
+- **nota [W]:** _(vazio)_
+
+## D-08 · Foto real de entrada no card
+- **estado:** 🔍 AVALIAR
+- **contexto:** card mostra tag textual. Trocar por thumbnail real do check-in? Risco: densidade a 1280px; talvez só no modo "Detalhe".
+- **nota [W]:** _(vazio)_
+
+## D-09 · Card Vendas×Oficina no drawer (seção 2 travada — gap de impl)
+- **estado:** ✅ **RESOLVIDO 2026-06-04** (lacuna de implementação fechada · aguarda veredito visual [W]).
+- **contexto:** drawer travado prevê o card Vendas×Oficina quando etapa=pronto + venda derivada (split NF-e/NFS-e + ações fiscais). `ServiceOrderRichSheet` não renderizava.
+- **impl produção 2026-06-04:** **reuso** do componente shared órfão `resources/js/Components/shared/VendaDerivadaCard.tsx` (Total · Data · breakdown peças/serviços · badge fiscal NF-e · CTAs Abrir/Imprimir/Compartilhar). Backend já servia `venda_derivada` (`ServiceOrderController::show` → `shapeVendaDerivada`, ADR 0192) — só faltava plugar no drawer. Renderiza como §2 (ordem travada), acende só quando `venda_derivada != null`. Sem backend novo. Empty-states fiscais/breakdown tolerantes (Fase B opcional).
+- **dep:** venda derivada (origin:"oficina" + osRef · [ADR 0192](../../../../../memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)). Breakdown items_list/fiscal NF-e completo = wave futura (paridade `Modules/Repair buildVendaDerivadaPayload`).
+- **nota [W]:** _(vazio — confirmar visual numa OS pronta com venda)_
+
+---
+
+## Graduados (saíram daqui → viraram ✅ no charter)
+- _(nenhum ainda — primeiro ciclo)_
+
+## Descartados (viraram anti-pattern no charter)
+- _(nenhum ainda)_
+
+## Trilha do tempo
+- 2026-06-02 · [CC] criou o Register (anéis Radar). Semeado com D-01…D-08 do inventário ⬜/💡 do charter.
+- 2026-06-04 · [CC] importado pro repo via handoff de design. Pointers ajustados pra `Index.*`. D-09 adicionado (gap de impl da seção 2 travada do drawer).

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
@@ -235,6 +235,17 @@ function resolveDragMapping(
   };
 }
 
+// D-02 — coluna-alvo do "avançar direto pelo card" por estado de origem (o botão do
+// card dispara a MESMA porta gate-guardada do arrasto · resolveDragMapping). `locada`
+// = "Acompanhar" (ver, não avançar) → tratado no card via onClick, fica null aqui.
+const NEXT_COLUMN_FOR: Record<CacambaStatus, CacambaStatus | null> = {
+  disponivel: 'locada',     // Iniciar locação → redirect criar OS
+  locada:     null,         // Acompanhar → abre drawer (não avança)
+  aguardando: 'disponivel', // Recolher → encerrar OS
+  manutencao: 'pronta',     // Concluir → pronto p/ entrega
+  pronta:     'disponivel', // Entregar → volta ao pátio
+};
+
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
@@ -309,6 +320,11 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
         } else {
           toast.info(result.reason);
         }
+        // D-01 — "gate falha → o drawer abre já no que falta": em vez de só toast,
+        // abre o documento da OS pra o usuário ver o estado (quando há OS ativa).
+        if (cacamba.current_rental_id) {
+          setOpenOsId(cacamba.current_rental_id);
+        }
         return;
       }
 
@@ -330,6 +346,32 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
       });
     },
     [],
+  );
+
+  // D-01 — veredito preditivo síncrono pra pintar as colunas durante o arrasto.
+  // Reusa resolveDragMapping (mesma máquina do drop real) — verde se avança, âmbar se barra.
+  const evaluateDrop = useCallback(
+    (from: CacambaStatus, to: CacambaStatus, cacamba: CacambaCardData) => {
+      const r = resolveDragMapping(from, to, cacamba);
+      if (r.kind === 'allowed') return r.isCritical ? 'confirm' : 'advance';
+      return 'blocked'; // redirect_sells + blocked: não avança soltando aqui
+    },
+    [],
+  );
+
+  // D-02 — "avançar etapa direto no card": o botão dispara a MESMA porta do arrasto
+  // (handleDragMove → resolveDragMapping → confirm/toast). Touch-friendly (tablet do mecânico).
+  const handleCardAdvance = useCallback(
+    (cacamba: CacambaCardData, from: CacambaStatus) => {
+      const to = NEXT_COLUMN_FOR[from];
+      if (!to) {
+        // Estado sem avanço definido (ex.: locada "Acompanhar") — abre o drawer.
+        handleCardClick(cacamba);
+        return;
+      }
+      handleDragMove(cacamba.id, from, to, cacamba);
+    },
+    [handleDragMove, handleCardClick],
   );
 
   const handleConfirmTransition = useCallback(async () => {
@@ -599,7 +641,7 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
 
         {/* ─── Kanban 5 colunas (drag-drop entre colunas) ─── */}
         <div className="p-6">
-          <KanbanDndProvider onMove={handleDragMove}>
+          <KanbanDndProvider onMove={handleDragMove} evaluateDrop={evaluateDrop}>
             <div className="grid grid-cols-5 gap-4">
               {columnsData.map((col) => (
                 <CacambaKanbanColumn
@@ -608,6 +650,7 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
                   label={col.label}
                   cards={col.cards}
                   onCardClick={handleCardClick}
+                  onCardAdvance={handleCardAdvance}
                 />
               ))}
             </div>

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
@@ -19,7 +19,7 @@
 // Lição PR #717 — useMemo/useCallback nos handlers descendentes pra evitar re-render loop
 // quando hierarquia profunda (Index → Coluna → Card × N).
 
-import { memo, type CSSProperties } from 'react';
+import { memo, type CSSProperties, type MouseEvent } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import {
@@ -59,6 +59,13 @@ interface Props {
   cacamba: CacambaCardData;
   variant: CacambaStatus;
   onClick: (cacamba: CacambaCardData) => void;
+  /**
+   * D-02 — "avançar etapa direto no card". Quando presente, o botão de ação dos
+   * estados de avanço (Iniciar/Recolher/Concluir/Entregar) dispara a MESMA porta do
+   * arrasto (gate-guardada · resolveDragMapping no Index) em vez de só abrir o drawer.
+   * "Acompanhar" (locada) segue abrindo o drawer (é ver, não avançar).
+   */
+  onAdvance?: (cacamba: CacambaCardData) => void;
 }
 
 const formatBRL = (value: number | null | undefined) =>
@@ -145,7 +152,18 @@ function actionLabelFor(variant: CacambaStatus): string | null {
   }
 }
 
-function CacambaCardImpl({ cacamba, variant, onClick }: Props) {
+function CacambaCardImpl({ cacamba, variant, onClick, onAdvance }: Props) {
+  // D-02 — estados de avanço usam a porta gate-guardada (onAdvance); "Acompanhar"
+  // (locada) é ver, não avançar → segue abrindo o drawer (onClick).
+  const canAdvance = onAdvance != null && variant !== 'locada';
+  const triggerAction = (e: MouseEvent) => {
+    e.stopPropagation();
+    if (canAdvance) {
+      onAdvance!(cacamba);
+    } else {
+      onClick(cacamba);
+    }
+  };
   // Drag handle — distance:8 no PointerSensor (KanbanDndProvider) evita drag acidental
   // em onClick "abrir drawer". Card inteiro é o drag handle (UX padrão Kanban).
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
@@ -415,10 +433,7 @@ function CacambaCardImpl({ cacamba, variant, onClick }: Props) {
           <button
             type="button"
             className="text-[10.5px] px-2 py-1 bg-slate-900 text-white rounded font-medium hover:bg-slate-700 inline-flex items-center gap-1 transition-colors"
-            onClick={(e) => {
-              e.stopPropagation();
-              onClick(cacamba);
-            }}
+            onClick={triggerAction}
             aria-label="Entregar caçamba"
           >
             Entregar
@@ -440,10 +455,7 @@ function CacambaCardImpl({ cacamba, variant, onClick }: Props) {
                   ? 'bg-slate-100 text-slate-700 hover:bg-slate-200 border border-slate-200'
                   : 'bg-slate-900 text-white hover:bg-slate-700')
             }
-            onClick={(e) => {
-              e.stopPropagation();
-              onClick(cacamba);
-            }}
+            onClick={triggerAction}
             aria-label={actionLabel}
           >
             {actionLabel}

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaKanbanColumn.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaKanbanColumn.tsx
@@ -17,12 +17,15 @@
 import { memo, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
 import CacambaCard, { type CacambaCardData, type CacambaStatus } from './CacambaCard';
+import { useKanbanDragState } from './kanbanDrag';
 
 interface Props {
   status: CacambaStatus;
   label: string;
   cards: CacambaCardData[];
   onCardClick: (cacamba: CacambaCardData) => void;
+  /** D-02 — avançar etapa direto pelo botão do card (mesma porta do arrasto). */
+  onCardAdvance?: (cacamba: CacambaCardData, from: CacambaStatus) => void;
 }
 
 const dotColorMap: Record<CacambaStatus, string> = {
@@ -42,11 +45,16 @@ const topBorderMap: Record<CacambaStatus, string> = {
   pronta:     'border-t-emerald-400',
 };
 
-function CacambaKanbanColumnImpl({ status, label, cards, onCardClick }: Props) {
+function CacambaKanbanColumnImpl({ status, label, cards, onCardClick, onCardAdvance }: Props) {
   // Handler estável — Card memo recebe sempre mesma referência
   const handleClick = useCallback(
     (c: CacambaCardData) => onCardClick(c),
     [onCardClick]
+  );
+
+  const handleAdvance = useCallback(
+    (c: CacambaCardData) => onCardAdvance?.(c, status),
+    [onCardAdvance, status]
   );
 
   // Drop zone — id = status (disponivel/locada/aguardando/manutencao/pronta)
@@ -57,10 +65,29 @@ function CacambaKanbanColumnImpl({ status, label, cards, onCardClick }: Props) {
 
   const isAguardando = status === 'aguardando';
 
-  // Visual feedback quando algo está sendo arrastado sobre a coluna
-  const overClasses = isOver
-    ? 'ring-2 ring-primary/60 ring-offset-2 bg-primary/5'
-    : '';
+  // D-01 — feedback preditivo: durante o arrasto a coluna mostra o desfecho de soltar
+  // aqui (verde "solte p/ avançar" se o gate libera · âmbar "abre detalhes" se barra).
+  const { activeFromColumn, verdictFor } = useKanbanDragState();
+  const isDragging = activeFromColumn != null;
+  const verdict = isDragging ? verdictFor(status) : null; // null = origem ou mesma coluna
+  const isValidTarget = verdict === 'advance' || verdict === 'confirm';
+
+  // Realce: coluna sob o cursor (isOver) ganha realce forte; alvos válidos não-sob-cursor
+  // ganham dica sutil; bloqueado fica âmbar discreto. Sem arrasto = neutro (comportamento antigo).
+  let overClasses = '';
+  if (verdict) {
+    if (isOver) {
+      // Tokens semânticos success/warning (ADR UI-0013 · não-flagados R1) — verde=avança, âmbar=barra.
+      overClasses = isValidTarget
+        ? 'ring-2 ring-success/70 ring-offset-2 bg-success/10'
+        : 'ring-2 ring-warning/70 ring-offset-2 bg-warning/10';
+    } else if (isValidTarget) {
+      overClasses = 'ring-1 ring-success/40';
+    }
+  } else if (isOver) {
+    // Sem evaluateDrop (fallback) — realce neutro antigo.
+    overClasses = 'ring-2 ring-primary/60 ring-offset-2 bg-primary/5';
+  }
 
   return (
     <section
@@ -94,6 +121,25 @@ function CacambaKanbanColumnImpl({ status, label, cards, onCardClick }: Props) {
         </span>
       </header>
 
+      {/* D-01 — dica preditiva na coluna sob o cursor (Linear/Stripe: sem bounce-surpresa) */}
+      {isOver && verdict && (
+        <div
+          className={
+            'px-3 py-1 text-[11px] font-medium border-b ' +
+            (isValidTarget
+              ? 'bg-success/10 text-success-foreground border-success/30'
+              : 'bg-warning/10 text-warning-foreground border-warning/30')
+          }
+          aria-live="polite"
+        >
+          {verdict === 'advance'
+            ? 'Solte p/ avançar'
+            : verdict === 'confirm'
+              ? 'Solte p/ confirmar avanço'
+              : 'Abre os detalhes (não avança aqui)'}
+        </div>
+      )}
+
       <div
         className="p-2 space-y-2 max-h-[calc(100vh-220px)] overflow-y-auto"
         style={{ scrollbarWidth: 'thin' }}
@@ -109,6 +155,7 @@ function CacambaKanbanColumnImpl({ status, label, cards, onCardClick }: Props) {
               cacamba={c}
               variant={status}
               onClick={handleClick}
+              onAdvance={onCardAdvance ? handleAdvance : undefined}
             />
           ))
         )}

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx
@@ -25,8 +25,20 @@ import {
   type DragEndEvent,
   type DragOverEvent,
 } from '@dnd-kit/core';
-import { useCallback, useState, type ReactNode } from 'react';
+import {
+  useCallback,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
 import type { CacambaCardData, CacambaStatus } from './CacambaCard';
+// D-01 — context/hook/tipos do feedback preditivo moram em módulo sem componente
+// (Fast Refresh feliz: este arquivo exporta só o componente default).
+import {
+  KanbanDragContext,
+  type DropVerdict,
+  type KanbanDragState,
+} from './kanbanDrag';
 
 // Genérico (2026-06-02 · port Kanban do carro): o provider DnD canon é reusado por
 // múltiplas verticais (caçamba ProducaoOficina + OS de mecânica ServiceOrders/Board).
@@ -48,6 +60,12 @@ interface KanbanDndProviderProps<T, C extends string> {
   ) => void;
   /** Preview flutuante durante o drag. Default = preview da caçamba (compat). */
   renderPreview?: (cacamba: T) => ReactNode;
+  /**
+   * D-01 — avalia (puro/síncrono) o desfecho de soltar `cacamba` de `from` em `to`.
+   * Reusa a máquina de mapping do consumidor (ex.: resolveDragMapping do Index) pra
+   * pintar verde/âmbar nas colunas. Opcional: sem ele o feedback preditivo desliga.
+   */
+  evaluateDrop?: (from: C, to: C, cacamba: T) => DropVerdict;
 }
 
 /**
@@ -89,8 +107,10 @@ export default function KanbanDndProvider<
   children,
   onMove,
   renderPreview,
+  evaluateDrop,
 }: KanbanDndProviderProps<T, C>) {
   const [activeData, setActiveData] = useState<DraggedData<T, C> | null>(null);
+  const [overColumn, setOverColumn] = useState<C | null>(null);
 
   // Sensors — PointerSensor com distance:8 evita drag acidental em click-pra-abrir
   const sensors = useSensors(
@@ -107,30 +127,32 @@ export default function KanbanDndProvider<
     }
   }, []);
 
-  const handleDragOver = useCallback((_event: DragOverEvent) => {
-    // No-op por ora — visual feedback de "sobre coluna" fica em CacambaKanbanColumn
-    // via useDroppable.isOver (já implementado lá)
+  const handleDragOver = useCallback((event: DragOverEvent) => {
+    // D-01 — rastreia coluna sob o cursor pro feedback preditivo das colunas.
+    const over = event.over?.data.current as { columnStatus?: C } | undefined;
+    setOverColumn(over?.columnStatus ?? null);
   }, []);
 
   const handleDragEnd = useCallback(
     (event: DragEndEvent) => {
       const { active, over } = event;
       setActiveData(null);
+      setOverColumn(null);
 
       if (!over) return; // Drop fora de qualquer coluna
 
       const dragData = active.data.current as DraggedData<T, C> | undefined;
-      const overColumn = over.data.current as { columnStatus?: C } | undefined;
+      const overData = over.data.current as { columnStatus?: C } | undefined;
 
-      if (!dragData || !overColumn?.columnStatus) return;
+      if (!dragData || !overData?.columnStatus) return;
 
       // Drop na mesma coluna — no-op
-      if (dragData.currentColumn === overColumn.columnStatus) return;
+      if (dragData.currentColumn === overData.columnStatus) return;
 
       onMove(
         dragData.cacambaId,
         dragData.currentColumn,
-        overColumn.columnStatus,
+        overData.columnStatus,
         dragData.cacamba,
       );
     },
@@ -139,7 +161,22 @@ export default function KanbanDndProvider<
 
   const handleDragCancel = useCallback(() => {
     setActiveData(null);
+    setOverColumn(null);
   }, []);
+
+  // D-01 — estado de arrasto exposto às colunas via context (feedback preditivo).
+  const dragState = useMemo<KanbanDragState>(() => {
+    const activeFromColumn = activeData?.currentColumn ?? null;
+    return {
+      activeFromColumn,
+      overColumn,
+      verdictFor: (to: string) => {
+        if (!activeData || !evaluateDrop) return null;
+        if (activeData.currentColumn === to) return null; // origem = destino
+        return evaluateDrop(activeData.currentColumn, to as C, activeData.cacamba);
+      },
+    };
+  }, [activeData, overColumn, evaluateDrop]);
 
   return (
     <DndContext
@@ -149,7 +186,9 @@ export default function KanbanDndProvider<
       onDragEnd={handleDragEnd}
       onDragCancel={handleDragCancel}
     >
-      {children}
+      <KanbanDragContext.Provider value={dragState}>
+        {children}
+      </KanbanDragContext.Provider>
       <DragOverlay dropAnimation={null}>
         {activeData
           ? renderPreview

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -49,6 +49,7 @@ import {
 import { Button } from '@/Components/ui/button';
 import MercosulPlate from './MercosulPlate';
 import ServiceOrderFsmActionPanel from '../../ServiceOrders/_components/ServiceOrderFsmActionPanel';
+import VendaDerivadaCard, { type VendaDerivada } from '@/Components/shared/VendaDerivadaCard';
 import { MessageCircle, Printer, Wrench, Package, UserCog } from 'lucide-react';
 import { toast } from 'sonner';
 import { printServiceOrder } from '@/Lib/printServiceOrder';
@@ -116,6 +117,10 @@ interface ServiceOrderDetail {
   // Wave 2.3 US-OFICINA-027 — items lançados (peças + mão-de-obra + terceiros)
   items?: ServiceOrderItemRel[];
   items_total?: number | string;
+  // D-09 (charter §2 TRAVADO) — venda derivada da OS (origem oficina · ADR 0192).
+  // Backend ServiceOrderController::show() popula via shapeVendaDerivada() só quando
+  // a OS já gerou Transaction (transição → concluída/pronto). null no resto.
+  venda_derivada?: VendaDerivada | null;
   urls?: {
     edit?: string | null;
     show?: string | null;
@@ -293,10 +298,22 @@ export default function ServiceOrderRichSheet({
               </SheetDescription>
             </SheetHeader>
 
-            {/* Conteúdo scroll — 5 sections empilhadas */}
+            {/* Conteúdo scroll — sections empilhadas (ordem TRAVADA · charter §1-§11) */}
             <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
 
-              {/* ─── SEÇÃO 1: Veículo + KV grid polimórfico (Wave 2.2 US-OFICINA-027) ───
+              {/* ─── SEÇÃO 2 (TRAVADA): Card Vendas×Oficina (D-09) ───
+                  Acende só quando a OS gerou venda (etapa pronto/concluída + Transaction
+                  derivada · ADR 0192). Reusa o componente shared VendaDerivadaCard (Total ·
+                  Data · breakdown peças/serviços · badge fiscal NF-e · CTAs Abrir/Imprimir/
+                  Compartilhar). -mx-6 cancela o px-6 do scroll pra a margem mx-5 própria do
+                  card render como desenhado. "Seções acendem por contexto" (regra travada). */}
+              {data.venda_derivada && (
+                <div className="-mx-6">
+                  <VendaDerivadaCard venda={data.venda_derivada} />
+                </div>
+              )}
+
+              {/* ─── SEÇÃO 3 (Hero): Veículo + KV grid polimórfico (Wave 2.2 US-OFICINA-027) ───
                   - manutenção (Martinho sub-vertical 4 CNAE 4520): KM / Box / Mecânico / Valor (items_total)
                   - locação    (sub-vertical 3 hipotético CNAE 4581): Cliente / Capacidade / Endereço / Diárias / Valor */}
               {data.vehicle && (

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/kanbanDrag.ts
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/kanbanDrag.ts
@@ -1,0 +1,35 @@
+// Estado de arrasto do Kanban Produção · Oficina (D-01 — feedback preditivo).
+//
+// Mora num módulo SEM componente (só context + hook + tipos) pra o KanbanDndProvider
+// continuar exportando só o componente default — Fast Refresh feliz
+// (react-refresh/only-export-components). Consumido por CacambaKanbanColumn.
+
+import { createContext, useContext } from 'react';
+
+// Veredito preditivo do drop, calculado durante o drag (feedback Linear/Stripe):
+//   'advance' → gate ok, solta e avança · 'confirm' → avança mas pede confirmação
+//   (transição crítica ADR 0143) · 'blocked' → não avança, abre o drawer no que falta.
+export type DropVerdict = 'advance' | 'confirm' | 'blocked';
+
+// Colunas tipadas como `string` pra manter o provider genérico — consumidores
+// concretos (ex.: CacambaStatus) são subtipos de string. Consumidores que não usam
+// o feedback (ex.: ServiceOrders/Board) ignoram o context (verdictFor → null).
+export interface KanbanDragState {
+  /** Coluna de origem do card em arrasto (null quando nada arrastando). */
+  activeFromColumn: string | null;
+  /** Coluna sob o cursor agora (null fora de coluna). */
+  overColumn: string | null;
+  /** Veredito preditivo de soltar o card ativo na coluna `to` (null se origem=destino ou sem arrasto/evaluateDrop). */
+  verdictFor: (to: string) => DropVerdict | null;
+}
+
+export const KanbanDragContext = createContext<KanbanDragState>({
+  activeFromColumn: null,
+  overColumn: null,
+  verdictFor: () => null,
+});
+
+/** Hook pras colunas lerem o estado de arrasto e pintarem o feedback preditivo (D-01). */
+export function useKanbanDragState(): KanbanDragState {
+  return useContext(KanbanDragContext);
+}


### PR DESCRIPTION
Implementa o handoff de design (Claude Design → Claude Code) da tela **Produção / Kanban da Oficina** (`OficinaProducao.charter.md`).

## Commits
1. **docs** — sync do charter `Index.charter.md` v2→v3: drawer **TRAVADO** (11 seções), decisão **modelo (A) reparo** [W] 2026-06-02, inventário, flag divergência F3. Importa irmãos canônicos `Index.decisoes.md` (Decision Register D-01..D-09) + `Index.casos.md` (UC-01..UC-10).
2. **feat** — 3 deltas greenlit por [W]:
   - **D-09** — drawer §2 *Card Vendas×Oficina*: reusa o componente shared órfão `VendaDerivadaCard` (Total · breakdown peças/serviços · badge NF-e · CTAs). Zero backend (`venda_derivada` já servido · ADR 0192). Acende só com venda derivada.
   - **D-01** — feedback preditivo de arrasto (verde "solte p/ avançar" / âmbar "abre detalhes") + drop bloqueado abre o drawer. Context novo em `KanbanDndProvider` reusando `resolveDragMapping`. Generics `<T,C>`+`renderPreview` preservados (compat ServiceOrders/Board).
   - **D-02** — botões do card avançam pela MESMA porta gate-guardada do arrasto (touch-friendly). Confirm dialog mantido em transições críticas (ADR 0143).

## Qualidade
- tsc/eslint: **zero erro novo** nos arquivos tocados (erros restantes são pré-existentes no origin/main).
- Drawer travado intacto; rede de segurança (confirm) preservada no LIVE prod (Martinho biz=164).

## Gate pendente
Aguarda **veredito visual [W]** (gate MWART) numa OS pronta-com-venda + drag — então os checkboxes D-01/D-02/D-09 graduam no Register.

Refs: handoff design 2026-06-04 · ADR 0114 · 0143 · 0192 · 0194

🤖 Generated with [Claude Code](https://claude.com/claude-code)