### PR TITLE
docs(oficina): gradua D-09/D-01/D-02 (veredito visual delegado)

### DIFF
--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
@@ -65,8 +65,8 @@ Ordem canônica das seções do `Drawer`:
 
 ### A. Quadro / Kanban
 - [x] ✅ Colunas por etapa · [x] ✅ Card contextual por etapa · [x] ✅ Realce de OS urgente
-- [ ] ⬜ Capacidade visível por coluna `D-03`
-- [ ] 💡 Arrastar card entre colunas (drag-and-drop) `D-01` · 💡 Avançar etapa direto no card `D-02` · 💡 Alerta de prazo no topo da coluna `D-04`
+- [x] ✅ Arrastar card entre colunas + feedback preditivo `D-01` (adotado 2026-06-04) · [x] ✅ Avançar etapa direto no card `D-02` (adotado 2026-06-04)
+- [ ] ⬜ Capacidade visível por coluna `D-03` · 💡 Alerta de prazo no topo da coluna `D-04`
 
 ### B. Cards
 - [x] ✅ Placa Mercosul + veículo + KM + cliente + sintoma · [x] ✅ Mecânico · prazo · valor · countdown · [x] ✅ foto-tag + última atividade + StageGate mini
@@ -149,4 +149,5 @@ Ordem canônica das seções do `Drawer`:
 - 2026-05-26 · charter_version 2 — live V0 caçamba (Martinho biz=164, sub-vertical 4 ADR 0194).
 - 2026-06-02 · [CC] backfill de design (charter_version 3). **DRAWER travado por [W]** (nota 9.5). **[W] decidiu modelo (A) reparo automotivo** como referência; B/C descartadas; convergência caçamba→reparo é dívida F3.
 - 2026-06-04 · [CC] sync do handoff de design → repo: charter v2→v3 alinhado ao design travado; Decision Register + casos importados como irmãos. Deltas de código (⬜/💡) permanecem gated por [W] no Register.
-- 2026-06-04 · [CC] implementou (greenlight [W]) **D-09** (drawer §2 Vendas×Oficina via reuso `VendaDerivadaCard`) + **D-01/D-02** (feedback preditivo de arrasto + drawer-on-block + avançar pelo card). tsc/eslint sem erro novo. **Aguarda veredito VISUAL [W]** (gate MWART) pra os checkboxes 💡 D-01/D-02 e ✅ D-09 graduarem oficialmente. Full migração modelo-(A) segue F3.
+- 2026-06-04 · [CC] implementou (greenlight [W]) **D-09** (drawer §2 Vendas×Oficina via reuso `VendaDerivadaCard`) + **D-01/D-02** (feedback preditivo de arrasto + drawer-on-block + avançar pelo card). tsc/eslint sem erro novo. Mergeado PR #2228.
+- 2026-06-04 · **D-09/D-01/D-02 GRADUADOS ✅.** Veredito visual delegado a [CC] por [W] ("resolva, não é pergunta pra mim") → confirmado via render fiel (`_preview/oficina-veredito.html` + screenshot) + CI visual verde (PR UI Judge + visual-regression). Conferência no app LIVE com dado real = follow-up pós-deploy. Full migração modelo-(A) segue F3.

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.decisoes.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.decisoes.md
@@ -23,7 +23,7 @@ last_update: "2026-06-02"
 ---
 
 ## D-01 · Arrastar para avançar, com o gate como guarda
-- **estado:** 🧪 TESTAR — **portado pra produção 2026-06-04** (`Index.tsx` + `KanbanDndProvider`/`CacambaKanbanColumn`); aguarda **veredito visual [W]** (gate MWART) pra graduar ✅.
+- **estado:** ✅ **ADOTADO 2026-06-04** — portado pra produção (`Index.tsx` + `KanbanDndProvider`/`CacambaKanbanColumn`), mergeado (PR #2228 · aabe70f4b). Veredito visual **delegado a [CC] por [W]** ("resolva, não é pergunta pra mim" 2026-06-04) → confirmado via render fiel dos componentes (`_preview/oficina-veredito.html` + screenshot) + gates visuais de CI verdes (PR UI Judge + visual-regression). Pendência menor: conferir no app LIVE com dado real quando deployar.
 - **impl produção 2026-06-04:** feedback preditivo na coluna sob o cursor (verde "solte p/ avançar" / âmbar "abre detalhes") via `useKanbanDragState` + `evaluateDrop` (reusa `resolveDragMapping` — mesma máquina do drop) · em drop **bloqueado** o drawer abre no documento da OS (em vez de só toast). Confirm dialog mantido em transições críticas (ADR 0143 `is_critical`) — não removi a rede de segurança em LIVE prod (Martinho biz=164).
 - **prioridade:** alta (é a "ideia melhor de interação" 2026-06-02)
 - **contexto:** hoje avançar etapa = clicar card → abrir drawer → usar StageGate. Lento pro caminho feliz.
@@ -35,7 +35,7 @@ last_update: "2026-06-02"
 - **nota [W]:** _(vazio — veredito: ✅ adotar / 🧪 continuar / ⛔)_
 
 ## D-02 · Botão "→ próxima etapa" no próprio card
-- **estado:** 🧪 TESTAR — **portado pra produção 2026-06-04** (junto com D-01); aguarda veredito visual [W].
+- **estado:** ✅ **ADOTADO 2026-06-04** (junto com D-01) — veredito visual delegado a [CC] por [W], confirmado via render + CI verde.
 - **contexto:** obrigatório pra touch (mecânico no tablet, onde arrasto falha).
 - **impl produção 2026-06-04:** "uma máquina, duas portas" — os botões de ação do `CacambaCard` (Iniciar/Recolher/Concluir/Entregar) disparam o MESMO `handleDragMove` do arrasto via `onAdvance` + mapa `NEXT_COLUMN_FOR`. "Acompanhar" (locada) segue abrindo o drawer (é ver, não avançar).
 - **nota [W]:** _(vazio — junto com D-01)_
@@ -80,7 +80,10 @@ last_update: "2026-06-02"
 ---
 
 ## Graduados (saíram daqui → viraram ✅ no charter)
-- _(nenhum ainda — primeiro ciclo)_
+- **2026-06-04 · D-09** Card Vendas×Oficina no drawer (reuso `VendaDerivadaCard`). PR #2228.
+- **2026-06-04 · D-01** Arrasto preditivo + drawer-on-block. PR #2228.
+- **2026-06-04 · D-02** Avançar pelo card (mesma porta gate-guardada). PR #2228.
+- _Veredito delegado a [CC] por [W] 2026-06-04; método: render fiel + CI visual verde. Conferência LIVE pós-deploy é follow-up._
 
 ## Descartados (viraram anti-pattern no charter)
 - _(nenhum ainda)_


### PR DESCRIPTION
Fecha o loop do handoff de design da Produção/Oficina (PR #2228): grada **D-09 + D-01 + D-02** no Decision Register + charter.

Veredito visual **delegado a [CC] por [W]** ("resolva, não é pergunta pra mim" 2026-06-04) — confirmado via **render fiel dos componentes** (`_preview/oficina-veredito.html`, tokens/markup 1:1) + **CI visual verde** no #2228 (PR UI Judge Sonnet + visual-regression). Conferência no app LIVE com dado real = follow-up pós-deploy.

- D-01/D-02 inventário 💡→✅ · D-09 ✅ · os 3 em "Graduados" no Register.
- Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)