### PR TITLE
feat(sells): confirmar Cancelar quando há venda montada (não perde o carrinho)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -766,6 +766,10 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   // achou estranho — UI inconsistente). Mantém mesma semântica: OK→recupera, Cancelar→descarta.
   const recoveredRef = useRef(false);
   const [draftRecover, setDraftRecover] = useState<{ data: typeof data; savedAt: number; time: string } | null>(null);
+  // 2026-06-04 (Wagner) — Cancelar com confirmação: se há venda montada
+  // (produtos ou notas), pede confirmação antes de sair pra não perder tudo
+  // num clique acidental. Carrinho vazio sai direto (sem fricção).
+  const [cancelConfirm, setCancelConfirm] = useState(false);
   useEffect(() => {
     if (!draftKey || recoveredRef.current) return;
     recoveredRef.current = true;
@@ -803,6 +807,15 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       try { localStorage.removeItem(draftKey); } catch { /* ignore */ }
     }
     setDraftRecover(null);
+  };
+
+  // Cancelar: confirma se há trabalho a perder (produtos ou notas), senão sai direto.
+  const handleCancelClick = () => {
+    if (data.products.length > 0 || (data.notes ?? '').trim() !== '') {
+      setCancelConfirm(true);
+      return;
+    }
+    router.visit('/sells');
   };
 
   // Auto-save debounced 500ms quando data mudar (após mount).
@@ -1626,7 +1639,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             )}
           </div>
           <div className="flex items-center gap-2 shrink-0">
-            <Button variant="outline" onClick={() => router.visit('/sells')}>
+            <Button variant="outline" onClick={handleCancelClick}>
               Cancelar
             </Button>
             <Button variant="outline" onClick={() => handleSubmit(true)} disabled={!canSubmit}>
@@ -1657,6 +1670,27 @@ export default function SellsCreate(props: SellsCreatePageProps) {
           <AlertDialogFooter>
             <AlertDialogCancel onClick={handleDraftDiscard}>Descartar</AlertDialogCancel>
             <AlertDialogAction onClick={handleDraftRecover}>Recuperar</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* 2026-06-04 (Wagner) — confirmar Cancelar quando há venda montada, pra
+          o operador não perder tudo num clique acidental (autosave cobre F5,
+          não navegação forçada). */}
+      <AlertDialog open={cancelConfirm} onOpenChange={setCancelConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Descartar esta venda?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Você montou produtos/observações nesta venda. Se sair agora, perde o
+              que foi preenchido. Deseja realmente descartar e voltar pra lista?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Continuar editando</AlertDialogCancel>
+            <AlertDialogAction onClick={() => { router.visit('/sells'); }}>
+              Descartar e sair
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/tests/Feature/Sells/CreateCancelConfirmTest.php
+++ b/tests/Feature/Sells/CreateCancelConfirmTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test estrutural — Sells/Create.tsx confirmação ao Cancelar com carrinho
+ * cheio (feature "cancel-confirm").
+ *
+ * Dor: o botão "Cancelar" hoje chama `router.visit('/sells')` direto (linha ~1629),
+ *   saindo da tela e PERDENDO tudo o que já foi montado no carrinho (itens/notas)
+ *   sem avisar. Larissa monta venda longa ao telefone — um clique errado em
+ *   Cancelar joga fora o trabalho sem pergunta.
+ *
+ * Estado-alvo (o "pronto"):
+ *   1. Novo handler `handleCancelClick` decide:
+ *      - se `data.products.length > 0` → abre AlertDialog de confirmação
+ *        (NÃO navega direto)
+ *      - se carrinho vazio → navega direto pra /sells (sem fricção)
+ *   2. Estado `cancelConfirm` (useState boolean) controla a abertura do dialog.
+ *   3. AlertDialog shadcn (mesmo pattern do draft-recover já existente nesta tela)
+ *      com 2 ações: ficar na tela (AlertDialogCancel) e descartar+sair
+ *      (AlertDialogAction → router.visit('/sells')).
+ *   4. O botão Cancelar do footer passa a usar `handleCancelClick`, NÃO mais o
+ *      inline `() => router.visit('/sells')`.
+ *
+ * Como a feature ainda NÃO foi implementada, os it() abaixo ficam VERMELHOS agora
+ * (test-first / TDD). Passam quando a feature existir.
+ *
+ * Padrão estrutural (igual SaleSheetComponentTest + CustomerAutoApplyOnSelectTest):
+ *   lê o source com file_get_contents(base_path(...)) e faz expect()->toContain/toMatch.
+ *   Não toca DB — mas vale a regra Tier 0: smoke real roda biz=1 (ADR 0101), nunca
+ *   biz=4 (cliente ROTA LIVRE).
+ */
+
+const PAGE_PATH_CANCEL = 'resources/js/Pages/Sells/Create.tsx';
+
+function readPageCancel(): string
+{
+    return file_get_contents(base_path(PAGE_PATH_CANCEL));
+}
+
+// === Handler de cancelar ===
+
+it('cancel-confirm — Create.tsx tem handler handleCancelClick', function () {
+    $src = readPageCancel();
+    expect($src)->toContain('handleCancelClick');
+    expect($src)->toMatch('/const\s+handleCancelClick\s*=/');
+});
+
+it('cancel-confirm — handleCancelClick checa data.products.length > 0', function () {
+    $src = readPageCancel();
+    $start = strpos($src, 'const handleCancelClick');
+    expect($start)->not->toBeFalse();
+    $body = substr($src, $start, 700);
+    expect($body)->toMatch('/data\.products\.length\s*>\s*0/');
+});
+
+it('cancel-confirm — handleCancelClick abre confirmação quando há itens (set state)', function () {
+    $src = readPageCancel();
+    $start = strpos($src, 'const handleCancelClick');
+    $body = substr($src, $start, 700);
+    // abre o dialog em vez de navegar direto
+    expect($body)->toContain('setCancelConfirm(true)');
+});
+
+it('cancel-confirm — handleCancelClick navega direto pra /sells quando carrinho vazio', function () {
+    $src = readPageCancel();
+    $start = strpos($src, 'const handleCancelClick');
+    $body = substr($src, $start, 700);
+    expect($body)->toMatch("/router\.visit\(['\"]\/sells['\"]\)/");
+});
+
+// === Estado do dialog ===
+
+it('cancel-confirm — Create.tsx declara estado cancelConfirm useState boolean', function () {
+    $src = readPageCancel();
+    expect($src)->toContain('cancelConfirm');
+    expect($src)->toContain('setCancelConfirm');
+    expect($src)->toMatch('/useState(<boolean>)?\(false\)/');
+});
+
+// === AlertDialog de confirmação ===
+
+it('cancel-confirm — existe AlertDialog controlado por cancelConfirm', function () {
+    $src = readPageCancel();
+    expect($src)->toMatch('/<AlertDialog\s+open=\{cancelConfirm\}/');
+    expect($src)->toContain('onOpenChange={setCancelConfirm}');
+});
+
+it('cancel-confirm — dialog tem ação destrutiva que descarta e sai pra /sells', function () {
+    $src = readPageCancel();
+    $start = strpos($src, 'open={cancelConfirm}');
+    expect($start)->not->toBeFalse();
+    $body = substr($src, $start, 900);
+    expect($body)->toContain('AlertDialogAction');
+    expect($body)->toMatch("/router\.visit\(['\"]\/sells['\"]\)/");
+});
+
+it('cancel-confirm — dialog tem opção de ficar na tela (AlertDialogCancel)', function () {
+    $src = readPageCancel();
+    $start = strpos($src, 'open={cancelConfirm}');
+    $body = substr($src, $start, 900);
+    expect($body)->toContain('AlertDialogCancel');
+});
+
+// === Wiring no botão do footer ===
+
+it('cancel-confirm — botão Cancelar do footer usa handleCancelClick', function () {
+    $src = readPageCancel();
+    expect($src)->toContain('onClick={handleCancelClick}');
+});
+
+it('cancel-confirm — botão Cancelar NÃO navega mais inline direto pra /sells', function () {
+    $src = readPageCancel();
+    // versão antiga inline (perde o carrinho sem perguntar) deve sumir
+    expect($src)->not->toMatch("/onClick=\{\(\)\s*=>\s*router\.visit\(['\"]\/sells['\"]\)\}/");
+});


### PR DESCRIPTION
## Test-first
`tests/Feature/Sells/CreateCancelConfirmTest.php` (10 `it()`) foi escrito ANTES (definindo o "pronto"), estava vermelho, e este PR deixa verde.

## Problema
Larissa monta venda longa atendendo ao telefone. O botão **"Cancelar"** chamava `router.visit('/sells')` direto — um clique acidental **jogava fora tudo** que foi montado (itens/notas), sem perguntar. O autosave de rascunho cobre F5, mas não navegação forçada.

## Fix (mesmo pattern do draft-recover que já existe na tela)
- `handleCancelClick`: se há **produtos ou notas** → abre `AlertDialog` de confirmação (não navega direto); carrinho **vazio** → sai direto (sem fricção).
- `AlertDialog` "Descartar esta venda?" com **"Continuar editando"** / **"Descartar e sair"**.
- Botão Cancelar do footer passa a usar `handleCancelClick`.

## Validação pós-merge
1. `/sells/create` com produtos → clicar Cancelar → aparece a confirmação (não sai).
2. "Continuar editando" → fica na tela com tudo. "Descartar e sair" → vai pra /sells.
3. Tela vazia → Cancelar sai direto.

<!-- mwart-override: 1 confirmação de cancelar em tela existente (Create) — não é tela nova nem refator visual; UX de proteção de dados. -->
<!-- no-ui-smoke: adição de AlertDialog (mesmo pattern já existente na tela); smoke real pós-deploy. -->