### PR TITLE
feat(design): crava DS v6 como nome canonico unico (ADR 0249) — fecha GAP-A

### DIFF
--- a/memory/decisions/0249-ds-v6-naming-amends-0235.md
+++ b/memory/decisions/0249-ds-v6-naming-amends-0235.md
@@ -1,0 +1,59 @@
+---
+slug: 0249-ds-v6-naming-amends-0235
+number: 249
+title: "DS v6 — nome canônico único da camada de tokens semânticos (resolve divergência v4×v5×v6); amends 0235 (roxo 295 permanece âncora)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-06-04"
+accepted_at: "2026-06-04"
+accepted_via: "Wagner 2026-06-04 — 'merge' (Opção A do draft 2026-06-04-ds-v6-naming-amends-0235): nome oficial DS v6, amends 0235, não supersede."
+module: _DesignSystem
+quarter: 2026-Q2
+tags: [design-system, ds-v6, naming, semantic-tokens, amends-0235, gap-a, governanca-ui]
+supersedes: []
+amends:
+  - "0235-ds-v4-accent-roxo-universal"
+superseded_by: []
+related:
+  - "0013-constituicao-ui-v2-camadas"
+  - "0235-ds-v4-accent-roxo-universal"
+  - "0244-ds-v5-canon-oficina-padrao"
+  - "0246-sessao-2026-05-30-ds-harmonizacao"
+  - "0247-ratificacao-constituicao-design"
+pii: false
+---
+
+# ADR 0249 — Um nome só pro Design System: **DS v6**
+
+> Fecha o **GAP-A** do [plano de design 2026-06-04](../sessions/2026-06-04-plano-design-canon-um-estilo-grounded-main.md).
+> `amends 0235` (append-only · Art. 3) — **não** supersede: o roxo `oklch(0.55 0.15 295)` continua a âncora de cor.
+
+## Contexto
+
+A camada de tokens semânticos (`--pos/--neg/--warn/--stage-*/--origin-*`) já está no `main`
+(PRs #2128–#2200) e já é cobrada por máquina (`conformance-gate`). Faltava **nome único**.
+A mesma coisa tinha 4 nomes: `INDEX` dizia "DS v4", ADR 0244 "DS v5", ADR 0246 "v4.2",
+os protótipos Cowork (`prototipo-ui/ds-v6/`) "v6". Divergência de nome = a doença
+"diferente = errado" no nível do próprio padrão.
+
+## Decisão ([W], 2026-06-04 — "merge")
+
+1. **Nome oficial = "DS v6"** — designa a camada de tokens semânticos que assenta **sobre**
+   a cor roxa do ADR 0235.
+2. Esta ADR **`amends 0235`**, não supersede. **Cor canon permanece** `primary` roxo
+   `oklch(0.55 0.15 295)`; azul de marca = débito a migrar.
+3. `INDEX-DESIGN-MEMORIAS.md` (§4 regra de ouro #2 + §5 hierarquia) passa a dizer **DS v6**,
+   citando 0235 como fonte da cor e 0249 como o nome da camada.
+4. Cowork e repo canon usam **um nome só: DS v6**. `DesignIndexSingleSourceTest` segue a polícia.
+
+## Não-decidido aqui (decisão própria do [W], se/quando)
+- **5 origins → 11 hues**: UI-0013 lista como lacuna ("abrir ADR se decidido"). **Não** entra
+  nesta ADR — abrir ADR à parte se sim.
+
+## Consequências
+- ✅ Para a divergência de nome na fonte (repo = Cowork = "DS v6").
+- ✅ Append-only respeitado (0235 intacto; este estende).
+- 🔜 Lápides nos docs stale (§6) = **GAP-C**, fase VARRER (ADR separada/PR seguinte).

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -10,7 +10,7 @@
 Quando duas memórias divergem, vence nesta ordem:
 
 1. **ADR canon mais recente com `supersedes`** (memórias são append-only — o aposentado vira histórico, NÃO se usa).
-2. **DS v4 roxo (ADR 0235) > DS v3 > v2.** Cor canon = `primary` roxo `oklch(0.55 0.15 295)`. Azul em tela = **débito a migrar**, nunca padrão novo.
+2. **DS v6 (nome canônico — ADR 0249) sobre o roxo do ADR 0235 > DS v3 > v2.** Cor canon = `primary` roxo `oklch(0.55 0.15 295)` (0235, âncora de cor); "DS v6" é o nome único da camada de tokens semânticos (`--pos/--neg/--warn/--stage-*/--origin-*`). Azul em tela = **débito a migrar**, nunca padrão novo. *(v4/v4.2/v5 = nomes antigos da mesma coisa — usar só "DS v6".)*
 3. **Código real > documento.** Se a doc diz "tela X tem drift Y" e o código não tem mais, o código vence (a MATRIZ_MIGRACAO_DS tem falsos-positivos confirmados — ver §4).
 4. **Constituição UI v2 (ADR UI-0013):** Fundações → Shell → Padrão de Tela → Módulo. Camada superior herda e **nunca contradiz** a inferior.
 5. **Data mais recente** vence em docs operacionais (briefings, handoffs, notes).
@@ -128,7 +128,7 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 
 ## 5 · HIERARQUIA CANÔNICA HOJE (estado final)
 
-**Fundações** (tokens DS v3, accent **roxo 295** via DS v4/ADR 0235) → **Shell** (AppShellV2/Cockpit, sidebar **light** single-pane) → **Padrão de Tela** (PT-01 Lista / Cockpit Pattern V2 / `os-page.jsx`) → **Módulo**. Owner da UI = **Claude Design plugin** (ADR 0235 §3), dentro do loop MWART (0104→0114) + persona (UI-0016).
+**Fundações** (tokens DS v3 + camada semântica **DS v6**/ADR 0249, accent **roxo 295** via ADR 0235) → **Shell** (AppShellV2/Cockpit, sidebar **light** single-pane) → **Padrão de Tela** (PT-01 Lista / Cockpit Pattern V2 / `os-page.jsx`) → **Módulo**. Owner da UI = **Claude Design plugin** (ADR 0235 §3), dentro do loop MWART (0104→0114) + persona (UI-0016).
 
 ---
 
@@ -166,7 +166,8 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 
 | ADR | Regra |
 |---|---|
-| [ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md) | DS v4 — tokens + `primary` roxo `oklch(0.55 0.15 295)` universal; Claude Design plugin dono da interface |
+| [ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md) | Cor canon — tokens + `primary` roxo `oklch(0.55 0.15 295)` universal; Claude Design plugin dono da interface (âncora de cor do DS v6) |
+| [ADR 0249](../../decisions/0249-ds-v6-naming-amends-0235.md) | **DS v6** — nome canônico único da camada de tokens semânticos; amends 0235 (roxo permanece); resolve divergência v4×v5×v6 |
 | [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md) | Evolução da doc de design — append-only + índice fonte-única + ratchet + freshness + reprocesso |
 | [ADR 0238](../../decisions/0238-soberania-constituicao-wagner.md) | Soberania de [W] sobre a constituição (memória/numeração) |
 | [ADR 0239](../../decisions/0239-governanca-design-system-git-ssot-regressao-ia.md) | Governança do DS — git SSOT · Cowork→Code · regressão-IA · 1 spec vigente na raiz |


### PR DESCRIPTION
## O que

Fecha o **GAP-A** do [plano de design 2026-06-04](memory/sessions/2026-06-04-plano-design-canon-um-estilo-grounded-main.md): o Design System tinha 4 nomes pra mesma coisa (repo "DS v4", ADR 0244 "v5", ADR 0246 "v4.2", Cowork "v6"). Esta é a divergência "diferente = errado" no nível do próprio nome do padrão.

## Decisão (Wagner 2026-06-04 — "merge", Opção A)

- **Nome oficial único = "DS v6"** (camada de tokens semânticos `--pos/--neg/--warn/--stage-*/--origin-*`).
- **ADR 0249 `amends 0235`** — NÃO supersede. Roxo `oklch(0.55 0.15 295)` continua a âncora de cor.
- `INDEX-DESIGN-MEMORIAS` §4 (regra de ouro #2) + §5 (hierarquia) + tabela de ADRs apontam pro nome novo.

## Arquivos
- `memory/decisions/0249-ds-v6-naming-amends-0235.md` (novo · status aceito)
- `memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md` (naming v4→v6)

## Gates verificados (sem pest local — validado por leitura)
- ✅ AdrNumberCollisionTest: 0249 livre, sem colisão.
- ✅ DesignIndexSingleSourceTest: link novo `../../decisions/0249-...md` resolve (arquivo existe).
- ✅ memory-schema-gate: frontmatter ADR completo (slug/number/title/type/status/authority/lifecycle/decided_by/decided_at).

## Fora de escopo (próximo PR)
- **GAP-C** (lápides nos 4 docs stale do §6) — fase VARRER, ordem do próprio plano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)