### PR TITLE
docs(design): errata canon nos docs stale restantes — fecha GAP-C

### DIFF
--- a/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
+++ b/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
@@ -2,6 +2,15 @@
 
 > **Pra quem está se perguntando "como faço pra arrumar a bagunça do sidebar?"** — este guia é seu roteiro executável. Passo a passo, com comandos prontos pra copiar, ordem de execução, e validação visual a cada onda.
 
+> ⚠️ **ERRATA (2026-06-04) — valide os HUES contra o código antes de seguir.** Os valores de hue
+> por grupo deste guia **divergem do canon vivo**, que é o código `cockpit/shared.ts` →
+> `SIDEBAR_GROUP_HUE` (reconciliado em [`INDEX-DESIGN-MEMORIAS §4`](INDEX-DESIGN-MEMORIAS.md), R3).
+> Regra de ouro: **código real > documento**. Cor de marca = roxo `oklch(0.55 0.15 295)`
+> ([ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md)); nome do DS = **DS v6**
+> ([ADR 0249](../../decisions/0249-ds-v6-naming-amends-0235.md)); **sidebar LIGHT** por padrão
+> (UI-0009 + UI-0014). A **estrutura/ordem de passos** deste guia segue útil; só **não copie hue
+> daqui** — pegue do `shared.ts`.
+
 **Última atualização:** 2026-05-21 · Wagner solicitou guia executável pós-sessão Financeiro
 
 ---

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -137,8 +137,8 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | Doc | Problema | Ação |
 |---|---|---|
 | `CLAUDE_COWORK_PRIMER.md` | `last_sync 2026-05-09` — não conhece DS v4/GOLDEN/PRE-FLIGHT | **header canon adicionado 2026-05-30** (aponta pra este índice) |
-| `CLAUDE_DESIGN_BRIEFING.md` | §2 "só comunicação visual" (errado) · §4 tokens azul/shadcn genérico | refresh: posicionamento multi-vertical + token roxo |
-| `CODE_DESIGN_CONTRACT.md` | versão para em DS v3.1, cita "Design System.html" | bump v4 + apontar `Design System v4.html` |
+| `CLAUDE_DESIGN_BRIEFING.md` ✅ reconciliado 2026-06-04 | §2 "só comunicação visual" + §4 azul/shadcn — errata "CANON ATUAL" no topo (roxo 295 + multi-vertical + DS v6/ADR 0249) | feito |
+| `CODE_DESIGN_CONTRACT.md` ✅ reconciliado 2026-06-04 | citava "DS v3.1"/"Design System.html" como SoT — errata no topo: DS v6 (ADR 0249) + fonte `tokens.css` git (ADR 0239); regra-única segue válida | feito |
 | `PROTOCOL.md` | v1.0, F3 "1 linha" (já estendido por PROTOCOL-F3) | costurar GOLDEN/PRE-FLIGHT como gate |
 | `HANDOFF.md` | congelado 2026-05-15 | regenerar |
 | `GLOSSARY.md` | `[M]=Manus` diverge de `[M]=Maiara` (canon) | reconciliar tabela de pessoas |
@@ -147,7 +147,7 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | `CATALOGO_ACABAMENTOS.md` ✅ reconciliado 2026-06-04 | snapshot 2026-04-27 (hue 220) — errata no topo: paleta defasada, cor via ADR 0235; tipografia/estrutura seguem | feito |
 | `BRIEFING_PROXIMA_SESSAO.md` ✅ reconciliado 2026-06-04 | briefing de sessão antiga (azul 220 + sidebar dark) — errata no topo → roxo 295 + sidebar light | feito |
 | `SPEC.md` (R-DS-002) + `ARCHITECTURE.md` + `AUTOMATION-ROADMAP.md` | exemplos `bg-blue-500` | trocar exemplo p/ roxo (confunde com primary) |
-| `GUIA-SIDEBAR-V3` + `sidebar-rail-mode` | hues divergem de `shared.ts` | validar estado real antes de seguir |
+| `GUIA-SIDEBAR-V3-PASSO-A-PASSO.md` ✅ reconciliado 2026-06-04 | hues divergem de `shared.ts` — errata no topo: código real > doc, não copiar hue daqui (pegar do `SIDEBAR_GROUP_HUE`); estrutura segue útil. `sidebar-rail-mode` idem | feito |
 
 ---
 

--- a/prototipo-ui/CODE_DESIGN_CONTRACT.md
+++ b/prototipo-ui/CODE_DESIGN_CONTRACT.md
@@ -1,5 +1,12 @@
 # CODE_DESIGN_CONTRACT.md
 
+> ## ⚠️ CANON ATUAL (2026-06-04) — corrige a referência de versão abaixo
+> Onde divergir, vence isto:
+> 1. **Entrada única:** **[`memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md`](../memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md)** — índice mestre + regra de ouro.
+> 2. **Nome do DS = "DS v6"** ([ADR 0249](../memory/decisions/0249-ds-v6-naming-amends-0235.md)). Onde o corpo citar "DS v3.1" / "Design System.html" como source-of-truth, está **defasado** — a fonte é `tokens.css` no git ([ADR 0239](../memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md)).
+> 3. **Cor = roxo** `primary` `oklch(0.55 0.15 295)` ([ADR 0235](../memory/decisions/0235-ds-v4-accent-roxo-universal.md)) — zero `blue-*` de marca.
+> 4. **A "regra única" abaixo (Code PARA e atualiza o DS primeiro) permanece VÁLIDA** — só a referência de versão/arquivo é que envelheceu.
+
 > Contrato visual entre **Cowork [CC]** e **Claude Code [CL]**.
 > Vigente desde: **2026-05-27**.
 > Source of truth: **`Design System.html`** (na raiz do projeto Cowork) + `tokens.css` / `design-system.css` no repo.


### PR DESCRIPTION
## O que

Fecha o **GAP-C** do [plano de design 2026-06-04](memory/sessions/2026-06-04-plano-design-canon-um-estilo-grounded-main.md). Ao revisar o §6 do INDEX, vários docs stale **já tinham sido reconciliados** em 2026-06-04 (CATALOGO, BRIEFING_CLAUDE_DESIGN, BRIEFING_PROXIMA_SESSAO, CLAUDE_DESIGN_BRIEFING). Sobravam **2** docs de cor/sidebar sem errata.

## Mudança
- `prototipo-ui/CODE_DESIGN_CONTRACT.md` — errata "CANON ATUAL" no topo (DS v6/ADR 0249 + fonte `tokens.css` git/ADR 0239 + roxo 295/ADR 0235). Regra-única do contrato **segue válida**.
- `memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md` — errata: hues divergem do código `SIDEBAR_GROUP_HUE` → **código real > doc**; estrutura/passos seguem úteis.
- `INDEX-DESIGN-MEMORIAS §6` — marca os 3 (`CLAUDE_DESIGN_BRIEFING`, `CODE_DESIGN_CONTRACT`, `GUIA-SIDEBAR-V3`) como ✅ reconciliado 2026-06-04.

## Decisão de design
**Sem `⚰️ NÃO USE` cego.** Os docs têm conteúdo válido (regra-única, tipografia, estrutura). A errata **marca, não deleta** (append-only · Constituição Art. 3) — mesmo padrão já usado no CATALOGO.

## Gates
- Append-only: nenhum conteúdo removido, só errata prepended + status em §6.
- DesignIndexSingleSourceTest: nenhum link novo no INDEX; docs continuam referenciados por nome; links das erratas (nos docs) resolvem (verificado).

Fecha a lista dos 5 gaps do plano (A,B,D,E já fechados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)