### PR TITLE
feat(sells/create): paridade Edit — nota interna (staff_note) + assinatura recorrente (is_recurring)

### DIFF
--- a/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
+++ b/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
@@ -2,6 +2,15 @@
 
 > **Pra quem está se perguntando "como faço pra arrumar a bagunça do sidebar?"** — este guia é seu roteiro executável. Passo a passo, com comandos prontos pra copiar, ordem de execução, e validação visual a cada onda.
 
+> ⚠️ **ERRATA (2026-06-04) — valide os HUES contra o código antes de seguir.** Os valores de hue
+> por grupo deste guia **divergem do canon vivo**, que é o código `cockpit/shared.ts` →
+> `SIDEBAR_GROUP_HUE` (reconciliado em [`INDEX-DESIGN-MEMORIAS §4`](INDEX-DESIGN-MEMORIAS.md), R3).
+> Regra de ouro: **código real > documento**. Cor de marca = roxo `oklch(0.55 0.15 295)`
+> ([ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md)); nome do DS = **DS v6**
+> ([ADR 0249](../../decisions/0249-ds-v6-naming-amends-0235.md)); **sidebar LIGHT** por padrão
+> (UI-0009 + UI-0014). A **estrutura/ordem de passos** deste guia segue útil; só **não copie hue
+> daqui** — pegue do `shared.ts`.
+
 **Última atualização:** 2026-05-21 · Wagner solicitou guia executável pós-sessão Financeiro
 
 ---

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -137,8 +137,8 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | Doc | Problema | Ação |
 |---|---|---|
 | `CLAUDE_COWORK_PRIMER.md` | `last_sync 2026-05-09` — não conhece DS v4/GOLDEN/PRE-FLIGHT | **header canon adicionado 2026-05-30** (aponta pra este índice) |
-| `CLAUDE_DESIGN_BRIEFING.md` | §2 "só comunicação visual" (errado) · §4 tokens azul/shadcn genérico | refresh: posicionamento multi-vertical + token roxo |
-| `CODE_DESIGN_CONTRACT.md` | versão para em DS v3.1, cita "Design System.html" | bump v4 + apontar `Design System v4.html` |
+| `CLAUDE_DESIGN_BRIEFING.md` ✅ reconciliado 2026-06-04 | §2 "só comunicação visual" + §4 azul/shadcn — errata "CANON ATUAL" no topo (roxo 295 + multi-vertical + DS v6/ADR 0249) | feito |
+| `CODE_DESIGN_CONTRACT.md` ✅ reconciliado 2026-06-04 | citava "DS v3.1"/"Design System.html" como SoT — errata no topo: DS v6 (ADR 0249) + fonte `tokens.css` git (ADR 0239); regra-única segue válida | feito |
 | `PROTOCOL.md` | v1.0, F3 "1 linha" (já estendido por PROTOCOL-F3) | costurar GOLDEN/PRE-FLIGHT como gate |
 | `HANDOFF.md` | congelado 2026-05-15 | regenerar |
 | `GLOSSARY.md` | `[M]=Manus` diverge de `[M]=Maiara` (canon) | reconciliar tabela de pessoas |
@@ -147,7 +147,7 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | `CATALOGO_ACABAMENTOS.md` ✅ reconciliado 2026-06-04 | snapshot 2026-04-27 (hue 220) — errata no topo: paleta defasada, cor via ADR 0235; tipografia/estrutura seguem | feito |
 | `BRIEFING_PROXIMA_SESSAO.md` ✅ reconciliado 2026-06-04 | briefing de sessão antiga (azul 220 + sidebar dark) — errata no topo → roxo 295 + sidebar light | feito |
 | `SPEC.md` (R-DS-002) + `ARCHITECTURE.md` + `AUTOMATION-ROADMAP.md` | exemplos `bg-blue-500` | trocar exemplo p/ roxo (confunde com primary) |
-| `GUIA-SIDEBAR-V3` + `sidebar-rail-mode` | hues divergem de `shared.ts` | validar estado real antes de seguir |
+| `GUIA-SIDEBAR-V3-PASSO-A-PASSO.md` ✅ reconciliado 2026-06-04 | hues divergem de `shared.ts` — errata no topo: código real > doc, não copiar hue daqui (pegar do `SIDEBAR_GROUP_HUE`); estrutura segue útil. `sidebar-rail-mode` idem | feito |
 
 ---
 

--- a/prototipo-ui/CODE_DESIGN_CONTRACT.md
+++ b/prototipo-ui/CODE_DESIGN_CONTRACT.md
@@ -1,5 +1,12 @@
 # CODE_DESIGN_CONTRACT.md
 
+> ## ⚠️ CANON ATUAL (2026-06-04) — corrige a referência de versão abaixo
+> Onde divergir, vence isto:
+> 1. **Entrada única:** **[`memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md`](../memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md)** — índice mestre + regra de ouro.
+> 2. **Nome do DS = "DS v6"** ([ADR 0249](../memory/decisions/0249-ds-v6-naming-amends-0235.md)). Onde o corpo citar "DS v3.1" / "Design System.html" como source-of-truth, está **defasado** — a fonte é `tokens.css` no git ([ADR 0239](../memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md)).
+> 3. **Cor = roxo** `primary` `oklch(0.55 0.15 295)` ([ADR 0235](../memory/decisions/0235-ds-v4-accent-roxo-universal.md)) — zero `blue-*` de marca.
+> 4. **A "regra única" abaixo (Code PARA e atualiza o DS primeiro) permanece VÁLIDA** — só a referência de versão/arquivo é que envelheceu.
+
 > Contrato visual entre **Cowork [CC]** e **Claude Code [CL]**.
 > Vigente desde: **2026-05-27**.
 > Source of truth: **`Design System.html`** (na raiz do projeto Cowork) + `tokens.css` / `design-system.css` no repo.

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -20,6 +20,7 @@ import { useAuth, useBusiness } from '@/Hooks/usePageProps';
 import { AlertTriangle, CreditCard, FileText, Loader2, Package, Plus, Printer, Receipt, Search, Settings2, Trash2 } from 'lucide-react';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
+import { Checkbox } from '@/Components/ui/checkbox';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Textarea } from '@/Components/ui/textarea';
@@ -213,6 +214,10 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     discount_type: 'percentage' as 'percentage' | 'fixed',
     discount_amount: 0,
     notes: '',
+    /** Nota interna pra equipe (separada de notes/additional_notes). Backend: TransactionUtil staff_note. */
+    staff_note: '',
+    /** Assinatura recorrente (Blade legacy is_recurring). Paridade com Edit.tsx. */
+    is_recurring: 0 as 0 | 1,
     shipping: {
       details: '',
       address: '',
@@ -606,6 +611,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       price_group: d.price_group_id,
       sale_note: d.notes,
       additional_notes: d.notes,
+      // Paridade Edit — nota interna equipe + assinatura recorrente (Blade legacy).
+      staff_note: d.staff_note,
+      is_recurring: d.is_recurring ? 1 : 0,
       // Flatten shipping object pra campos top-level
       shipping_details: d.shipping.details,
       shipping_address: d.shipping.address,
@@ -1573,6 +1581,36 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                 </Select>
               </div>
             )}
+          </div>
+
+          {/* Paridade Edit — Nota interna (equipe) + Assinatura recorrente */}
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="staff_note">Nota interna (equipe)</Label>
+              <Textarea
+                id="staff_note"
+                value={data.staff_note}
+                onChange={(e) => setData('staff_note', e.target.value)}
+                placeholder="Observação visível só pra equipe — não aparece no recibo."
+                rows={2}
+              />
+            </div>
+            <div className="flex items-start gap-2 pt-7">
+              <Checkbox
+                id="is_recurring"
+                checked={data.is_recurring === 1}
+                onCheckedChange={(c) => setData('is_recurring', c === true ? 1 : 0)}
+                className="mt-1"
+              />
+              <div className="flex-1">
+                <Label htmlFor="is_recurring" className="cursor-pointer">
+                  Assinatura recorrente
+                </Label>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Marca esta venda como recorrente (gera próxima fatura automática).
+                </p>
+              </div>
+            </div>
           </div>
 
           {/* Bloco frete colapsável dentro de Mais opções (5 campos juntos) */}

--- a/tests/Feature/Sells/SellsCreateParkingLotP1Test.php
+++ b/tests/Feature/Sells/SellsCreateParkingLotP1Test.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — Sells/Create Parity Parking-Lot P1 (mirror do Edit.tsx).
+ *
+ * Felipe abriu a trilha "produzir as 8 features reais (mirror do Edit)" test-first.
+ * Este é o PR #1 da trilha: paridade Create←Edit para os 2 campos avançados
+ * mais simples, que vivem em "Mais opções":
+ *
+ *   - is_recurring  → checkbox "Assinatura recorrente" (Blade legacy is_recurring)
+ *   - staff_note    → textarea "Nota interna (equipe)" (separada de additional_notes)
+ *
+ * Backend já aceita ambos no store (SellPosController@store linha 379
+ * `$request->except('_token')` + TransactionUtil:79/106 lê staff_note/is_recurring).
+ * Logo este PR é PURAMENTE frontend — wire-up no Create.tsx + payload transform.
+ *
+ * Pattern espelha SellsEditParkingLotP1P2P3Test.php (assertions estruturais via
+ * file_get_contents — não bootam o container, compatível com worktrees).
+ *
+ * Refs:
+ *  - resources/js/Pages/Sells/Create.tsx
+ *  - resources/js/Pages/Sells/Edit.tsx (fonte do pattern: linhas 922-953)
+ *  - app/Utils/TransactionUtil.php@createSellTransaction (staff_note + is_recurring)
+ */
+
+const CREATE_TSX = 'resources/js/Pages/Sells/Create.tsx';
+
+function plCreateRoot(): string
+{
+    // Sobe 3 níveis de tests/Feature/Sells → repo root. Compatível com worktrees.
+    return dirname(__DIR__, 3);
+}
+
+function plCreateRead(string $rel): string
+{
+    return file_get_contents(plCreateRoot() . DIRECTORY_SEPARATOR . $rel);
+}
+
+// ─── is_recurring (Assinatura recorrente) ──────────────────────────
+
+it('Create.tsx declara is_recurring no useForm (0/1 paridade backend)', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)
+        ->toContain('is_recurring: 0 as 0 | 1');
+});
+
+it('Create.tsx adiciona checkbox is_recurring (Assinatura recorrente)', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)
+        ->toContain('is_recurring')
+        ->toContain('Assinatura recorrente')
+        ->toContain('checked={data.is_recurring === 1}');
+});
+
+it('Create.tsx importa Checkbox (necessário pro is_recurring)', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)->toContain("import { Checkbox } from '@/Components/ui/checkbox'");
+});
+
+it('Create.tsx envia is_recurring no payload transform (0/1)', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)->toContain('is_recurring: d.is_recurring ? 1 : 0');
+});
+
+// ─── staff_note (Nota interna equipe) ──────────────────────────
+
+it('Create.tsx declara staff_note no useForm', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)->toContain("staff_note: ''");
+});
+
+it('Create.tsx adiciona textarea staff_note separada de additional_notes', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)
+        ->toContain('staff_note')
+        ->toContain('Nota interna')
+        ->toContain('visível só pra equipe');
+});
+
+it('Create.tsx envia staff_note no payload transform', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)->toContain('staff_note: d.staff_note');
+});
+
+// ─── Tier 0 IRREVOGÁVEL — não regredir invariantes do Create ──────────
+
+it('Create.tsx PRESERVA is_direct_sale=1 no payload (não cai em cashRegister)', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)->toContain('is_direct_sale: 1');
+});
+
+it('Create.tsx PRESERVA FSM safety (NUNCA seta current_stage_id — ADR 0143)', function () {
+    $src = plCreateRead(CREATE_TSX);
+    expect($src)->not->toContain("setData('current_stage_id'");
+});


### PR DESCRIPTION
## Contexto
PR #1 da trilha **"8 features reais — mirror do Edit"** (assumida do Felipe). Create.tsx ganha paridade com Edit.tsx para os 2 campos avançados mais simples, que vivem em **"Mais opções"**.

## Test-first
`tests/Feature/Sells/SellsCreateParkingLotP1Test.php` (9 `it()` estruturais via `file_get_contents`, espelhando `SellsEditParkingLotP1P2P3Test`) foi escrito ANTES e define o "pronto".

## O que entra
- **useForm**: `staff_note: ''` + `is_recurring: 0 as 0|1`
- **payload transform**: `staff_note` + `is_recurring` (0/1)
- **UI** em "Mais opções": `Textarea` "Nota interna (equipe)" + `Checkbox` "Assinatura recorrente"
- import `Checkbox`

## Backend
Sem mudança — `SellPosController@store:379` faz `$request->except('_token')` e `TransactionUtil:79/106` já lê `staff_note`/`is_recurring`. Puramente frontend.

## Tier 0 preservado
- ✅ `is_direct_sale: 1` (não cai em cashRegister)
- ✅ FSM safety — nunca seta `current_stage_id` (ADR 0143)

Espelha `Edit.tsx:922-953`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)