### PR TITLE
feat(sells): re-do CU-11 frete/entrega 1ª classe + CU-G4 tipo de serviço (paridade Blade↔V2)

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -150,20 +150,34 @@ class Contact extends Authenticatable
      *
      * @see app/ContactAddress.php
      * @see memory/requisitos/Cliente/SPEC.md §US-CRM-078
+     *
+     * Return types tipados: o eager-load `Contact::with(['addresses' => ...])` no
+     * getCustomers (Sells/Create CU-11) exige que o Larastan resolva a relação —
+     * sem o hint dá "Relation 'addresses' is not found" (regressão pega no revert #2107).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany<ContactAddress, $this>
      */
-    public function addresses()
+    public function addresses(): \Illuminate\Database\Eloquent\Relations\HasMany
     {
         return $this->hasMany(ContactAddress::class, 'contact_id');
     }
 
-    /** Endereço marcado como principal/cobrança (espelha os campos inline). */
-    public function defaultAddress()
+    /**
+     * Endereço marcado como principal/cobrança (espelha os campos inline).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne<ContactAddress, $this>
+     */
+    public function defaultAddress(): \Illuminate\Database\Eloquent\Relations\HasOne
     {
         return $this->hasOne(ContactAddress::class, 'contact_id')->where('is_default', true);
     }
 
-    /** Endereço default de entrega (pré-seleção do shipping_address na venda). */
-    public function shippingAddress()
+    /**
+     * Endereço default de entrega (pré-seleção do shipping_address na venda).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne<ContactAddress, $this>
+     */
+    public function shippingAddress(): \Illuminate\Database\Eloquent\Relations\HasOne
     {
         return $this->hasOne(ContactAddress::class, 'contact_id')->where('is_shipping', true);
     }

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -2415,6 +2415,28 @@ class ContactController extends Controller
             if (request()->session()->get('business.enable_rp') == 1) {
                 $contacts->addSelect('total_rp');
             }
+
+            // US-CRM-078 PR2 (re-do) — catálogo de endereços do cliente p/ o seletor
+            // de entrega na venda (Sells/Create). HasBusinessScope no model
+            // App\ContactAddress garante Tier 0 (ADR 0093): só endereços do mesmo
+            // business. city_code (IBGE/cMun) alimenta destinatário ↔ local de
+            // entrega + gatilho MDF-e na NF-e. Ordena: entrega > default > resto.
+            //
+            // BLINDAGEM (lição do revert #2107): este endpoint é COMPARTILHADO com o
+            // Blade legado. Se a migration `contact_addresses` (US-CRM-078 PR1) ainda
+            // não rodou no ambiente, eager-load cego dá 500 e derruba a busca de
+            // cliente do POS inteiro. Guard Schema::hasTable degrada gracioso (sem
+            // catálogo, o seletor cai no fallback one-line) em vez de quebrar.
+            if (\Illuminate\Support\Facades\Schema::hasTable('contact_addresses')) {
+                $contacts->with(['addresses' => function ($query) {
+                    $query->select([
+                        'id', 'contact_id', 'label', 'zip_code', 'address_line_1',
+                        'numero', 'address_line_2', 'neighborhood', 'city', 'state',
+                        'city_code', 'is_default', 'is_shipping',
+                    ])->orderByDesc('is_shipping')->orderByDesc('is_default');
+                }]);
+            }
+
             $contacts = $contacts->get();
 
             return json_encode($contacts);

--- a/memory/requisitos/Sells/CASOS-USO-CREATE-VENDA.md
+++ b/memory/requisitos/Sells/CASOS-USO-CREATE-VENDA.md
@@ -30,7 +30,7 @@ updated: "2026-06-02"
 | CU-08 | Status da venda (final/rascunho/cotação/proforma) | must | ✅ | `SellsCreatePageTest` (8 campos + status) | 🟢 |
 | CU-09 | Prazo de pagamento + comissionista | should | ✅ | `SellsCreatePageTest` (condicional) · `CommissionSplitEditorTest` | 🟢 |
 | CU-10 | Esquema/nº fatura + imposto do pedido | should | ✅ | `SellsCreatePageTest` ("Mais opções") | 🟢 |
-| CU-11 | Frete/entrega (endereço + custo + status remessa) | must | ⚠️ básico | `SellsCreatePageTest` (bloco frete) | 🟡 |
+| CU-11 | Frete/entrega (endereço 1ª classe + custo + status remessa) | must | ✅ | `SellsCreatePageTest` (sec-entrega + catálogo) | 🟢 |
 | CU-12 | Notas + despesas adicionais | should | ✅ | `SellsCreatePageTest` | 🟢 |
 | CU-13 | Salvar / Salvar e imprimir + **auto-save draft** (biz.user) | must | ✅ | `SellsCreatePageTest` (useForm + draft localStorage) | 🟢 |
 | CU-14 | Criar OS a partir da venda (comvis/oficina) | should | ✅ | `CriarOsPorVendaTest` | 🟢 |
@@ -38,10 +38,10 @@ updated: "2026-06-02"
 | CU-G1 | Venda recorrente / assinatura | — | ❌ | — | ⚪ Non-Goal (tela `Sells/Subscriptions`) |
 | CU-G2 | Resgate de pontos (reward) | could | ❌ | — | ⚪ gap (Blade-only) |
 | CU-G3 | Anexar documento à venda | could | ❌ | — | ⚪ gap (Blade-only) |
-| CU-G4 | Tipos de serviço (multi-select) | should | ⚠️ | — | 🔴 gap a avaliar |
+| CU-G4 | Tipo de serviço (`types_of_service_id`, select único) | should | ✅ | `SellsCreatePageTest` (select condicional) | 🟢 |
 | CU-G5 | Devolução (esquema Venda/Devolução + fluxo) | — | ❌ | — | ⚪ Non-Goal (fluxo separado) |
 
-**Veredito de paridade:** núcleo da venda ✅ coberto + testado. Pendências reais: **CU-11** (frete estruturado de 1ª classe — era o PR2 revertido #2104, **re-fazer com smoke**) e **CU-G4** (tipos de serviço). O resto dos gaps é Non-Goal documentado.
+**Veredito de paridade:** núcleo da venda ✅ coberto + testado. **CU-11** (frete estruturado de 1ª classe) e **CU-G4** (tipo de serviço) re-feitos em 2026-06-04 (re-do do PR2 revertido #2104, agora com a migration `contact_addresses` já em main + blindagem `Schema::hasTable` no `getCustomers` compartilhado — causa raiz do revert). Pendente apenas o **smoke visual CT 100** antes do merge. O resto dos gaps é Non-Goal documentado.
 
 ---
 
@@ -98,13 +98,14 @@ updated: "2026-06-02"
 **Then** payload reflete o status (cotação/proforma → FSM stage inicial)
 - **V2:** `status` select · **Pest:** `SellsCreatePageTest.php`
 
-## CU-11 · Frete / entrega · `must` · 🟡 parcial
+## CU-11 · Frete / entrega · `must` · ✅ (re-do 2026-06-04)
 **Given** venda com entrega
-**When** preenche endereço de entrega + custo + status da remessa + entregue a
-**Then** persiste em `transactions.shipping_*`
-- **V2 (atual):** bloco frete free-text dentro de "Mais opções" — ✅ funcional, ⚠️ **não estruturado**
-- **Pendente (PR2 #2104, revertido):** endereço de **1ª classe** lendo `contact.addresses[]` (Destinatário ↔ Local de entrega) + gatilho MDF-e por `city_code`. **Re-fazer com smoke biz=4 antes de religar.** Ver US-SELL-044 (PR3 fiscal).
-- **Pest:** `SellsCreatePageTest.php` (bloco frete)
+**When** escolhe modo Entrega → seleciona endereço do catálogo do cliente (Destinatário ↔ Local de entrega) ou "Outro" + custo + status da remessa + entregue a
+**Then** persiste o one-line derivado em `transactions.shipping_address` (compat UPOS/NFe) + `shipping_*`
+- **V2 (atual):** seção própria `sec-entrega` de **1ª classe** (entre Produtos e Pagamento) — toggle Retirada × Entrega, consome `contact.addresses[]` (eager-load `getCustomers`), pré-seleciona `is_shipping > is_default > 1º`, "Outro" estruturado, hint MDF-e por divergência de cidade. Frete saiu de "Mais opções".
+- **Causa raiz do revert #2107 corrigida:** PR2 fazia `->with(['addresses'])` cego no endpoint **compartilhado** com Blade → 500 quando a migration não estava em prod. Re-do guarda com `Schema::hasTable('contact_addresses')` (degrada gracioso pro fallback one-line). Dependência PR1 (`efc31745a`) já em main.
+- **Gatilho fiscal real** (`<entrega>`/cMun via `city_code` no NfeService) fica pro PR3 — US-SELL-044.
+- **Pest:** `SellsCreatePageTest.php` (sec-entrega + catálogo + MDF-e hint)
 
 ## CU-13 · Salvar + auto-save draft · `must`
 **Given** venda em preenchimento
@@ -128,7 +129,7 @@ updated: "2026-06-02"
 | CU-G1 | Assinatura/recorrência | ⚪ Non-Goal | Vive na tela `Sells/Subscriptions` (separada) |
 | CU-G2 | Resgate de pontos | ⚪ gap | UPOS legado; sem sinal de cliente (ADR 0105) |
 | CU-G3 | Anexar documento à venda | ⚪ gap | Idem — avaliar se algum cliente usa |
-| CU-G4 | Tipos de serviço (multi-select) | 🔴 a avaliar | Prop existe (`typesOfService`), sem UI na V2 — confirmar se comvis/oficina precisa |
+| CU-G4 | Tipo de serviço (`types_of_service_id`) | ✅ feito 2026-06-04 | Select único na sec-dados, gated por `hasTypesOfService` (some em vestuário). Era impreciso chamar de "multi-select" — UPOS usa FK único |
 | CU-G5 | Devolução (Venda/Devolução) | ⚪ Non-Goal | Fluxo de retorno é separado, não o "adicionar venda" |
 
 > Marcar um item como Non-Goal aqui é **decisão de produto** (Wagner) — o teste não cobra, e ninguém chama de "regressão". Se um cliente reclamar de um destes, vira US com sinal qualificado (ADR 0105).

--- a/resources/js/Pages/Sells/Create.charter.md
+++ b/resources/js/Pages/Sells/Create.charter.md
@@ -25,12 +25,13 @@ Cadastrar venda completa (cliente + produtos + pagamento + frete + impostos) num
 ## Goals — Features (faz)
 
 - AppShellV2 + topnav inline com breadcrumb
-- Header sticky no topo: h1 "Adicionar venda" + subtitle + 5 filter pills `rounded-full` (Dados / Produtos / Pagamento / Resumo / Mais opções)
-- Pills com ícones lucide (FileText / Package / CreditCard / Receipt / Settings2) + counter Produtos quando > 0
+- Header sticky no topo: h1 "Adicionar venda" + subtitle + 6 filter pills `rounded-full` (Dados / Produtos / Entrega / Pagamento / Resumo / Mais opções)
+- Pills com ícones lucide (FileText / Package / Truck / CreditCard / Receipt / Settings2) + counter Produtos quando > 0
 - Click pill faz `scrollToSection(id)` smooth scroll + scroll-spy via IntersectionObserver marca pill ativa
 - 4 KPIs gigantes (Itens / Total venda / Pago / Status pgto) com tone semântico rose/emerald/amber
 - 8 campos sempre visíveis: Cliente / Data / Status / Local + Produtos + Pagamentos + Desconto + Notas
-- 10 campos colapsáveis em `<details>` "Mais opções" com persist localStorage `oimpresso.sells.create.advanced.open`
+- Campos avançados colapsáveis em `<details>` "Mais opções" (fatura / nº fatura / imposto / prazo / comissão / grupo de preço) com persist localStorage `oimpresso.sells.create.advanced.open`
+- **Seção Entrega de 1ª classe** (`sec-entrega`, US-CRM-078 PR2 · ADR 0093): toggle Retirada/Entrega; seletor lê o catálogo `contact.addresses[]` do cliente — **Destinatário** (cadastro `is_default`) ↔ **Local de entrega** (`is_shipping`) — + opção "Outro endereço" avulso estruturado (CEP/logradouro/nº/compl/bairro/cidade/UF); hint de **MDF-e** quando a cidade de entrega ≠ cidade da loja. Persiste one-line em `shipping_address` (compat). Gatilho fiscal real (`<entrega>`/cMun via `city_code`) fica no `NfeService` — **PR3** follow-up.
 - ProductSearchAutocomplete (debounce + min query) + tabela editável produtos (5 cols)
 - PaymentRow split de pagamento + indicador saldo (falta/troco/exato)
 - Footer sticky no bottom: Cancelar + Salvar venda (sempre visíveis em form longo)

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -17,7 +17,7 @@ import { router, useForm } from '@inertiajs/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useAuth, useBusiness } from '@/Hooks/usePageProps';
-import { AlertTriangle, CreditCard, FileText, Loader2, Package, Plus, Printer, Receipt, Search, Settings2, Trash2 } from 'lucide-react';
+import { AlertTriangle, Building2, CreditCard, FileText, Loader2, MapPin, Package, Plus, Printer, Receipt, Search, Settings2, Store, Trash2, Truck } from 'lucide-react';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
 import { Checkbox } from '@/Components/ui/checkbox';
@@ -30,6 +30,7 @@ import ProductSearchAutocomplete, {
 } from './_components/ProductSearchAutocomplete';
 import CustomerSearchAutocomplete, {
   type CustomerSearchResult,
+  type ContactAddressOption,
 } from './_components/CustomerSearchAutocomplete';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
 import NumericInputPtBR from './_components/NumericInputPtBR';
@@ -61,6 +62,10 @@ interface Location {
   id: number;
   name: string;
   selling_price_group_id: number | null;
+  // US-CRM-078 PR2 — cidade da loja (origem). Origem do comparativo de município
+  // que sugere MDF-e quando a entrega sai pra outra cidade. defaultLocation já vem
+  // como model BusinessLocation completo do controller (inclui city).
+  city?: string | null;
 }
 
 interface Contact {
@@ -117,6 +122,9 @@ const DRAFT_TTL_MS = 24 * 60 * 60 * 1000;
 // US-SELL-010 — campos dentro do <details> "Mais opções". Se erro cair em algum
 // destes, o details abre automaticamente pra Larissa achar o campo (gap UX
 // detectado pelo design-arte agent 2026-05-13).
+// US-CRM-078 PR2 — frete/entrega SAIU de "Mais opções" pra seção própria
+// `sec-entrega` (endereço de 1ª classe). Por isso as chaves shipping_* não
+// estão mais aqui: erro de shipping abre/rola a seção Entrega, não o <details>.
 const COLLAPSED_FIELD_KEYS = [
   'invoice_scheme_id',
   'invoice_no',
@@ -126,12 +134,69 @@ const COLLAPSED_FIELD_KEYS = [
   'price_group_id',
   'commission_agent_id',
   'tax_rate_id',
-  'shipping_details',
-  'shipping_address',
-  'shipping_charges',
-  'shipping_status',
-  'delivered_to',
 ];
+
+// US-CRM-078 PR2 — campos estruturados de um endereço de entrega "Outro" (avulso),
+// espelhando o schema `contact_addresses`. Mesmos nomes do model pra 1 helper só.
+interface DeliveryAddressFields {
+  zip_code: string;
+  address_line_1: string;
+  numero: string;
+  address_line_2: string;
+  neighborhood: string;
+  city: string;
+  state: string;
+  city_code: string;
+}
+
+const EMPTY_DELIVERY_ADDRESS: DeliveryAddressFields = {
+  zip_code: '',
+  address_line_1: '',
+  numero: '',
+  address_line_2: '',
+  neighborhood: '',
+  city: '',
+  state: '',
+  city_code: '',
+};
+
+// Endereço em 1 linha — espelha App\ContactAddress::getOneLineAttribute (PHP) pra
+// o texto persistir igual no `transactions.shipping_address` (compat UPOS/NFe).
+// Ex.: "Av. Paulista, 1578 — Bela Vista — São Paulo/SP · 01310-100".
+function buildAddressOneLine(a: {
+  address_line_1?: string | null;
+  numero?: string | null;
+  neighborhood?: string | null;
+  city?: string | null;
+  state?: string | null;
+  zip_code?: string | null;
+}): string {
+  let rua = (a.address_line_1 ?? '').trim();
+  const numero = (a.numero ?? '').trim();
+  if (numero !== '') rua = rua !== '' ? `${rua}, ${numero}` : numero;
+
+  const city = (a.city ?? '').trim();
+  const state = (a.state ?? '').trim();
+  const cidadeUf = city && state ? `${city}/${state}` : city || state;
+
+  const line = [rua, (a.neighborhood ?? '').trim(), cidadeUf]
+    .filter((p) => p !== '')
+    .join(' — ');
+
+  const zip = (a.zip_code ?? '').trim();
+  if (zip) return line !== '' ? `${line} · ${zip}` : zip;
+  return line;
+}
+
+// Normaliza nome de cidade pra comparar origem (loja) × destino (entrega) sem
+// falso-positivo por acento/caixa. Base do hint de MDF-e (gatilho real fica no
+// NfeService via city_code — PR3).
+const normalizeCity = (c?: string | null): string =>
+  (c ?? '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .trim()
+    .toLowerCase();
 
 // FieldError — exibe erro de validação por campo. Inline (canon: componente
 // reusável só ao 2º uso; aqui é local). role="alert" pra screen reader.
@@ -189,6 +254,10 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     price_group_id: props.defaultPriceGroupId,
     commission_agent_id: null as number | null,
     tax_rate_id: null as number | null,
+    // CU-G4 — Tipo de serviço (FK único transactions.types_of_service_id). Só
+    // relevante quando o módulo `types_of_service` está habilitado pro business
+    // (oficina/comunicação visual). '' = nenhum (vira null no TransactionUtil).
+    types_of_service_id: '' as string,
     products: [] as Array<{
       product_id: number;
       variation_id: number | null;
@@ -226,7 +295,14 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     customer_secondary_address: '',
     /** Documento anexo (file upload Blade legacy sell_document). Paridade Edit. */
     sell_document: null as File | null,
+    // US-CRM-078 PR2 — entrega de 1ª classe. `mode` retirada|entrega, `address_id`
+    // = endereço escolhido do catálogo do cliente (null = "Outro" avulso). Campos
+    // estruturados espelham `contact_addresses`; `address` (one-line) é DERIVADO no
+    // submit e persiste em `transactions.shipping_address` (compat UPOS/NFe).
     shipping: {
+      mode: 'retirada' as 'retirada' | 'entrega',
+      address_id: null as number | null,
+      ...EMPTY_DELIVERY_ADDRESS,
       details: '',
       address: '',
       cost: 0,
@@ -240,6 +316,12 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       { key: '', value: 0 },
     ] as Array<{ key: string; value: number }>,
   });
+
+  // US-CRM-078 PR2 — endereços do cliente selecionado (opções do seletor de
+  // entrega). Vêm do payload /contacts/customers (getCustomers eager-load
+  // `addresses`). NÃO entram no draft (dados de referência do cadastro): no
+  // recover o endereço escolhido sobrevive via data.shipping.* já persistido.
+  const [customerAddresses, setCustomerAddresses] = useState<ContactAddressOption[]>([]);
 
   // Persistir <details> open state em localStorage (DESIGN.md §12)
   const [advancedOpen, setAdvancedOpen] = useState<boolean>(false);
@@ -304,6 +386,48 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
   const formatBRL = (value: number) =>
     value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  // Hint de MDF-e: entrega sai pra município diferente do da loja (origem).
+  // Gatilho fiscal real (cMun via city_code) fica no NfeService — PR3. Aqui é só UX.
+  const originCity = props.defaultLocation?.city ?? null;
+  const mdfeHint = useMemo(() => {
+    if (data.shipping.mode !== 'entrega') return false;
+    const dest = normalizeCity(data.shipping.city);
+    const orig = normalizeCity(originCity);
+    if (!dest || !orig) return false;
+    return dest !== orig;
+  }, [data.shipping.mode, data.shipping.city, originCity]);
+
+  // US-CRM-078 PR2 — Destinatário fiscal = endereço de cadastro (is_default) do
+  // cliente. Mostrado como contexto; o "Local de entrega" pode diferir dele.
+  const destinatarioAddr = customerAddresses.find((a) => a.is_default) ?? customerAddresses[0] ?? null;
+  const isRealCustomer = data.contact_id !== props.walkInCustomer.id;
+
+  // Handlers do seletor de entrega.
+  const setDeliveryMode = (mode: 'retirada' | 'entrega') =>
+    setData('shipping', { ...data.shipping, mode });
+
+  const selectSavedAddress = (a: ContactAddressOption) =>
+    setData('shipping', {
+      ...data.shipping,
+      address_id: a.id,
+      zip_code: a.zip_code ?? '',
+      address_line_1: a.address_line_1 ?? '',
+      numero: a.numero ?? '',
+      address_line_2: a.address_line_2 ?? '',
+      neighborhood: a.neighborhood ?? '',
+      city: a.city ?? '',
+      state: a.state ?? '',
+      city_code: a.city_code ?? '',
+      address: buildAddressOneLine(a),
+    });
+
+  // "Outro endereço" — solta o vínculo com o catálogo e zera os campos pra digitar.
+  const selectOutroAddress = () =>
+    setData('shipping', { ...data.shipping, address_id: null, ...EMPTY_DELIVERY_ADDRESS, address: '' });
+
+  const setOutroField = (field: keyof DeliveryAddressFields, value: string) =>
+    setData('shipping', { ...data.shipping, [field]: value, address_id: null });
 
   const validateDiscount = (type: string, amount: number) => {
     if (maxDiscount == null || maxDiscount <= 0) { setDiscountError(null); return; }
@@ -471,11 +595,33 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     if (c.pay_term_type === 'days' || c.pay_term_type === 'months') {
       setData('pay_term_type', c.pay_term_type);
     }
-    // Shipping address — `data.shipping.address` é nested. Usa spread pra preservar
-    // outros campos (details, cost, status, deliver_to) que user pode ter editado.
-    if (c.shipping_address && c.shipping_address !== '') {
-      setData('shipping', { ...data.shipping, address: c.shipping_address });
+    // US-CRM-078 PR2 — catálogo de endereços do cliente alimenta o seletor de
+    // entrega. Pré-seleciona o de entrega (is_shipping) > default > 1º, mas NÃO
+    // liga o modo "entrega" sozinho (Larissa decide retirada vs entrega).
+    const addrs = c.addresses ?? [];
+    setCustomerAddresses(addrs);
+    const preferred =
+      addrs.find((a) => a.is_shipping) ?? addrs.find((a) => a.is_default) ?? addrs[0] ?? null;
+    if (preferred) {
+      setData('shipping', {
+        ...data.shipping,
+        address_id: preferred.id,
+        zip_code: preferred.zip_code ?? '',
+        address_line_1: preferred.address_line_1 ?? '',
+        numero: preferred.numero ?? '',
+        address_line_2: preferred.address_line_2 ?? '',
+        neighborhood: preferred.neighborhood ?? '',
+        city: preferred.city ?? '',
+        state: preferred.state ?? '',
+        city_code: preferred.city_code ?? '',
+        address: buildAddressOneLine(preferred),
+      });
+    } else if (c.shipping_address && c.shipping_address !== '') {
+      // Fallback legacy: cliente sem catálogo estruturado (pré-backfill) — mantém
+      // o one-line do cadastro como endereço de entrega "Outro".
+      setData('shipping', { ...data.shipping, address_id: null, address: c.shipping_address });
     }
+
     // Grupo de preço — `handlePriceGroupChange` já existe (R3) e recalcula linhas.
     // null/undefined → não muda (preserva default já aplicado).
     if (c.selling_price_group_id !== null && c.selling_price_group_id !== undefined) {
@@ -488,6 +634,10 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     setData('contact_id', props.walkInCustomer.id);
     setData('pay_term_number', '');
     setData('pay_term_type', 'days');
+    // US-CRM-078 PR2 — sem cliente, não há catálogo de endereços. Limpa as opções
+    // e solta o vínculo (address_id) — o que estiver digitado vira "Outro" avulso.
+    setCustomerAddresses([]);
+    setData('shipping', { ...data.shipping, address_id: null });
     // shipping fica como user editou — não auto-limpa (pode ser endereço manual)
     // price_group volta ao default do business
     if (props.defaultPriceGroupId !== data.price_group_id) {
@@ -642,12 +792,14 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       // FormData só quando há anexo (caminho JSON comum intacto sem documento).
       // Backend: SellPosController@store:586 uploadFile($request,'sell_document').
       sell_document: d.sell_document,
-      // Flatten shipping object pra campos top-level
-      shipping_details: d.shipping.details,
-      shipping_address: d.shipping.address,
-      shipping_charges: d.shipping.cost,
-      shipping_status: d.shipping.status,
-      delivered_to: d.shipping.deliver_to,
+      // Flatten shipping object pra campos top-level. US-CRM-078 PR2 — shipping_address
+      // é o endereço estruturado em 1 linha quando há entrega; vazio em retirada.
+      // Recalcula de `d` (não do useMemo) por defesa contra race do setData/post.
+      shipping_details: d.shipping.mode === 'entrega' ? d.shipping.details : '',
+      shipping_address: d.shipping.mode === 'entrega' ? buildAddressOneLine(d.shipping) : '',
+      shipping_charges: d.shipping.mode === 'entrega' ? d.shipping.cost : 0,
+      shipping_status: d.shipping.mode === 'entrega' ? d.shipping.status : '',
+      delivered_to: d.shipping.mode === 'entrega' ? d.shipping.deliver_to : '',
       // Despesas adicionais (Blade: additional_expense_key_N + additional_expense_value_N)
       additional_expense_key_1: d.additional_expenses[0]?.key ?? '',
       additional_expense_value_1: d.additional_expenses[0]?.value ?? '',
@@ -719,6 +871,8 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             transaction_date: 'sec-dados',
             products: 'sec-produtos',
             payments: 'sec-pagamento',
+            shipping_address: 'sec-entrega',
+            shipping_charges: 'sec-entrega',
             invoice_no: 'sec-mais-opcoes',
           };
           const section = sectionMap[firstErrorKey] ?? 'sec-dados';
@@ -850,8 +1004,17 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   }, [draftKey]);
 
   const handleDraftRecover = () => {
-    // Draft não guarda File — restaura preservando sell_document=null.
-    if (draftRecover) setData({ ...draftRecover.data, sell_document: null });
+    if (draftRecover) {
+      // Draft não guarda File — restaura preservando sell_document=null.
+      // US-CRM-078 PR2 — drafts antigos (pré-feature) não têm os campos novos de
+      // shipping (mode/address_id/estruturados). Mescla com a forma atual pra não
+      // deixar undefined e quebrar o seletor de entrega.
+      setData({
+        ...draftRecover.data,
+        sell_document: null,
+        shipping: { ...data.shipping, ...draftRecover.data.shipping },
+      });
+    }
     setDraftRecover(null);
   };
 
@@ -907,7 +1070,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
   // Scroll-spy: detecta qual aba está visível e marca como ativa (pattern Cockpit canon).
   // Ref: Pages/ProjectMgmt/Board/DetailSheet.tsx — abas com border-b-2 border-primary -mb-px no estado ativo.
-  const sectionIds = ['sec-dados', 'sec-produtos', 'sec-pagamento', 'sec-resumo', 'sec-mais-opcoes'];
+  const sectionIds = ['sec-dados', 'sec-produtos', 'sec-entrega', 'sec-pagamento', 'sec-resumo', 'sec-mais-opcoes'];
   const [activeSection, setActiveSection] = useState<string>('sec-dados');
   useEffect(() => {
     const observer = new IntersectionObserver(
@@ -956,6 +1119,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             {[
               { id: 'sec-dados', label: 'Dados', icon: FileText, count: undefined as number | undefined },
               { id: 'sec-produtos', label: 'Produtos', icon: Package, count: itensCount > 0 ? itensCount : undefined },
+              { id: 'sec-entrega', label: 'Entrega', icon: Truck, count: undefined },
               { id: 'sec-pagamento', label: 'Pagamento', icon: CreditCard, count: undefined },
               { id: 'sec-resumo', label: 'Resumo', icon: Receipt, count: undefined },
               { id: 'sec-mais-opcoes', label: 'Mais opções', icon: Settings2, count: undefined },
@@ -1136,6 +1300,31 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             </Select>
             <FieldError message={errors.location_id as string | undefined} />
           </div>
+
+          {/* CU-G4 — Tipo de serviço. Só aparece quando o módulo types_of_service
+              está habilitado pro business (oficina/comunicação visual). Em vestuário
+              (ROTA LIVRE) a prop vem vazia → seção some, zero ruído. FK único. */}
+          {hasTypesOfService && (
+            <div className="space-y-1.5">
+              <Label htmlFor="types_of_service_id">Tipo de serviço</Label>
+              <Select
+                value={data.types_of_service_id || ''}
+                onValueChange={(v) => setData('types_of_service_id', v)}
+              >
+                <SelectTrigger id="types_of_service_id">
+                  <SelectValue placeholder="Selecionar tipo" />
+                </SelectTrigger>
+                <SelectContent>
+                  {dropdownEntries(props.typesOfService).map(([id, name]) => (
+                    <SelectItem key={id} value={id}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError message={errors.types_of_service_id as string | undefined} />
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -1309,6 +1498,285 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                   </tr>
                 </tfoot>
               </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* US-CRM-078 PR2 — Entrega de 1ª classe: destinatário (cadastro) ↔ local de
+          entrega (catálogo do cliente ou "Outro" avulso). Saiu de "Mais opções". */}
+      <Card id="sec-entrega" className="shadow-sm bg-background border-border scroll-mt-32">
+        <CardHeader>
+          <CardTitle className="text-base">Entrega</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Retirada na loja ou entrega num endereço do cliente — entrega pra outra
+            cidade sugere emissão de MDF-e.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Modo: retirada × entrega */}
+          <div
+            role="radiogroup"
+            aria-label="Modo de entrega"
+            className="grid grid-cols-2 gap-2 max-w-md"
+          >
+            <button
+              type="button"
+              role="radio"
+              aria-checked={data.shipping.mode === 'retirada'}
+              onClick={() => setDeliveryMode('retirada')}
+              className={
+                'flex items-start gap-2 rounded-md border p-3 text-left text-sm transition-colors ' +
+                (data.shipping.mode === 'retirada'
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : 'border-border hover:bg-muted/50')
+              }
+            >
+              <Store className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+              <span>
+                <span className="block font-medium text-foreground">Retirada na loja</span>
+                <span className="block text-xs text-muted-foreground">Cliente busca · sem frete</span>
+              </span>
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={data.shipping.mode === 'entrega'}
+              onClick={() => setDeliveryMode('entrega')}
+              className={
+                'flex items-start gap-2 rounded-md border p-3 text-left text-sm transition-colors ' +
+                (data.shipping.mode === 'entrega'
+                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                  : 'border-border hover:bg-muted/50')
+              }
+            >
+              <Truck className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+              <span>
+                <span className="block font-medium text-foreground">Entrega</span>
+                <span className="block text-xs text-muted-foreground">Endereço do cliente · frete</span>
+              </span>
+            </button>
+          </div>
+
+          {data.shipping.mode === 'entrega' && (
+            <div className="space-y-4">
+              {/* Destinatário fiscal (cadastro is_default) — contexto read-only */}
+              {isRealCustomer && destinatarioAddr && (
+                <div className="flex items-start gap-2 rounded-md border border-border bg-muted/30 p-3 text-sm">
+                  <Building2 className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      Destinatário (cadastro)
+                    </div>
+                    <div className="text-foreground">{buildAddressOneLine(destinatarioAddr)}</div>
+                  </div>
+                </div>
+              )}
+
+              {/* Local de entrega — catálogo do cliente + "Outro" */}
+              <div className="space-y-2">
+                <Label>Local de entrega</Label>
+
+                {customerAddresses.length > 0 ? (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                    {customerAddresses.map((a) => {
+                      const selected = data.shipping.address_id === a.id;
+                      return (
+                        <button
+                          key={a.id}
+                          type="button"
+                          onClick={() => selectSavedAddress(a)}
+                          aria-pressed={selected}
+                          className={
+                            'flex flex-col items-start gap-0.5 rounded-md border p-3 text-left text-sm transition-colors ' +
+                            (selected
+                              ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                              : 'border-border hover:bg-muted/50')
+                          }
+                        >
+                          <span className="flex items-center gap-1.5 font-medium text-foreground">
+                            <MapPin className="h-3.5 w-3.5 text-muted-foreground" />
+                            {a.label || 'Endereço'}
+                            {a.is_shipping && (
+                              <span className="rounded bg-muted px-1 text-[10px] font-normal text-muted-foreground">
+                                padrão entrega
+                              </span>
+                            )}
+                          </span>
+                          <span className="text-xs text-muted-foreground">{buildAddressOneLine(a)}</span>
+                        </button>
+                      );
+                    })}
+                    <button
+                      type="button"
+                      onClick={selectOutroAddress}
+                      aria-pressed={data.shipping.address_id === null}
+                      className={
+                        'flex items-center gap-1.5 rounded-md border border-dashed p-3 text-left text-sm transition-colors ' +
+                        (data.shipping.address_id === null
+                          ? 'border-primary bg-primary/5 text-primary ring-1 ring-primary'
+                          : 'border-border text-muted-foreground hover:bg-muted/50')
+                      }
+                    >
+                      <Plus className="h-4 w-4" />
+                      Outro endereço
+                    </button>
+                  </div>
+                ) : (
+                  isRealCustomer && (
+                    <p className="text-xs text-muted-foreground">
+                      Cliente sem endereço cadastrado — informe o endereço de entrega abaixo.
+                    </p>
+                  )
+                )}
+
+                {/* Form estruturado "Outro"/avulso (quando nenhum endereço salvo está escolhido) */}
+                {data.shipping.address_id === null && (
+                  <div className="grid grid-cols-2 gap-3 sm:grid-cols-6 pt-1">
+                    <div className="space-y-1.5 col-span-1 sm:col-span-2">
+                      <Label htmlFor="shipping_zip_code">CEP</Label>
+                      <Input
+                        id="shipping_zip_code"
+                        value={data.shipping.zip_code}
+                        onChange={(e) => setOutroField('zip_code', e.target.value)}
+                        placeholder="00000-000"
+                      />
+                    </div>
+                    <div className="space-y-1.5 col-span-2 sm:col-span-3">
+                      <Label htmlFor="shipping_address_line_1">Logradouro</Label>
+                      <Input
+                        id="shipping_address_line_1"
+                        value={data.shipping.address_line_1}
+                        onChange={(e) => setOutroField('address_line_1', e.target.value)}
+                        placeholder="Rua / Avenida"
+                      />
+                    </div>
+                    <div className="space-y-1.5 col-span-1">
+                      <Label htmlFor="shipping_numero">Número</Label>
+                      <Input
+                        id="shipping_numero"
+                        value={data.shipping.numero}
+                        onChange={(e) => setOutroField('numero', e.target.value)}
+                        placeholder="nº"
+                      />
+                    </div>
+                    <div className="space-y-1.5 col-span-2">
+                      <Label htmlFor="shipping_address_line_2">Complemento</Label>
+                      <Input
+                        id="shipping_address_line_2"
+                        value={data.shipping.address_line_2}
+                        onChange={(e) => setOutroField('address_line_2', e.target.value)}
+                        placeholder="Sala, bloco…"
+                      />
+                    </div>
+                    <div className="space-y-1.5 col-span-2">
+                      <Label htmlFor="shipping_neighborhood">Bairro</Label>
+                      <Input
+                        id="shipping_neighborhood"
+                        value={data.shipping.neighborhood}
+                        onChange={(e) => setOutroField('neighborhood', e.target.value)}
+                        placeholder="Bairro"
+                      />
+                    </div>
+                    <div className="space-y-1.5 col-span-1">
+                      <Label htmlFor="shipping_city">Cidade</Label>
+                      <Input
+                        id="shipping_city"
+                        value={data.shipping.city}
+                        onChange={(e) => setOutroField('city', e.target.value)}
+                        placeholder="Cidade"
+                      />
+                    </div>
+                    <div className="space-y-1.5 col-span-1">
+                      <Label htmlFor="shipping_state">UF</Label>
+                      <Input
+                        id="shipping_state"
+                        maxLength={2}
+                        value={data.shipping.state}
+                        onChange={(e) => setOutroField('state', e.target.value.toUpperCase())}
+                        placeholder="UF"
+                      />
+                    </div>
+                  </div>
+                )}
+
+                <FieldError
+                  message={(errors as Record<string, string | undefined>).shipping_address}
+                />
+              </div>
+
+              {/* Hint de MDF-e — token semântico de atenção (text-warning), sem cor crua
+                  pra não regredir o ui:lint ratchet. Gatilho fiscal real fica no NfeService (PR3). */}
+              {mdfeHint && (
+                <div className="flex items-start gap-2 rounded-md border border-border bg-muted/40 p-3 text-sm text-warning">
+                  <Truck className="h-4 w-4 mt-0.5 shrink-0" />
+                  <span>
+                    Entrega em{' '}
+                    <strong>
+                      {data.shipping.city}
+                      {data.shipping.state ? `/${data.shipping.state}` : ''}
+                    </strong>{' '}
+                    — município diferente da loja{originCity ? ` (${originCity})` : ''}. Sugere emissão de{' '}
+                    <strong>MDF-e</strong> no faturamento.
+                  </span>
+                </div>
+              )}
+
+              {/* Logística: frete, status, entregar a, detalhes */}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="space-y-1.5">
+                  <Label htmlFor="shipping_cost">Valor do frete</Label>
+                  <Input
+                    id="shipping_cost"
+                    type="number"
+                    inputMode="decimal"
+                    step="0.01"
+                    value={data.shipping.cost}
+                    onChange={(e) =>
+                      setData('shipping', { ...data.shipping, cost: Number(e.target.value) })
+                    }
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="shipping_status">Status da remessa</Label>
+                  <Select
+                    value={data.shipping.status}
+                    onValueChange={(v) => setData('shipping', { ...data.shipping, status: v })}
+                  >
+                    <SelectTrigger id="shipping_status">
+                      <SelectValue placeholder="Selecionar" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {dropdownEntries(props.shippingStatuses).map(([k, label]) => (
+                        <SelectItem key={k} value={k}>
+                          {label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="shipping_deliver_to">Entregar a / transportadora</Label>
+                  <Input
+                    id="shipping_deliver_to"
+                    value={data.shipping.deliver_to}
+                    onChange={(e) =>
+                      setData('shipping', { ...data.shipping, deliver_to: e.target.value })
+                    }
+                    placeholder="Nome de quem recebe ou transportadora"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="shipping_details">Detalhes de envio</Label>
+                  <Input
+                    id="shipping_details"
+                    value={data.shipping.details}
+                    onChange={(e) =>
+                      setData('shipping', { ...data.shipping, details: e.target.value })
+                    }
+                  />
+                </div>
+              </div>
             </div>
           )}
         </CardContent>
@@ -1521,7 +1989,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
         className="rounded-lg border border-border bg-card scroll-mt-32"
       >
         <summary className="cursor-pointer px-6 py-4 font-medium text-foreground hover:bg-muted/50 select-none">
-          Mais opções (frete, fatura, comissão, prazo, imposto)
+          Mais opções (fatura, comissão, prazo, imposto)
         </summary>
         <div className="px-6 pb-6 space-y-6 border-t border-border pt-4">
           {/* Linha colapsável 1: invoice + faturamento */}
@@ -1726,73 +2194,8 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             )}
           </div>
 
-          {/* Bloco frete colapsável dentro de Mais opções (5 campos juntos) */}
-          <div className="rounded-md border border-border p-4 space-y-4">
-            <h3 className="text-sm font-semibold text-foreground">Entrega / Frete</h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div className="space-y-1.5">
-                <Label htmlFor="shipping_details">Detalhes de envio</Label>
-                <Input
-                  id="shipping_details"
-                  value={data.shipping.details}
-                  onChange={(e) =>
-                    setData('shipping', { ...data.shipping, details: e.target.value })
-                  }
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="shipping_address">Endereço de entrega</Label>
-                <Input
-                  id="shipping_address"
-                  value={data.shipping.address}
-                  onChange={(e) =>
-                    setData('shipping', { ...data.shipping, address: e.target.value })
-                  }
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="shipping_cost">Custo de envio</Label>
-                <Input
-                  id="shipping_cost"
-                  type="number"
-                  inputMode="decimal"
-                  step="0.01"
-                  value={data.shipping.cost}
-                  onChange={(e) =>
-                    setData('shipping', { ...data.shipping, cost: Number(e.target.value) })
-                  }
-                />
-              </div>
-              <div className="space-y-1.5">
-                <Label htmlFor="shipping_status">Status da remessa</Label>
-                <Select
-                  value={data.shipping.status}
-                  onValueChange={(v) => setData('shipping', { ...data.shipping, status: v })}
-                >
-                  <SelectTrigger id="shipping_status">
-                    <SelectValue placeholder="Selecionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {dropdownEntries(props.shippingStatuses).map(([k, label]) => (
-                      <SelectItem key={k} value={k}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="space-y-1.5 md:col-span-2">
-                <Label htmlFor="shipping_deliver_to">Entregar a</Label>
-                <Input
-                  id="shipping_deliver_to"
-                  value={data.shipping.deliver_to}
-                  onChange={(e) =>
-                    setData('shipping', { ...data.shipping, deliver_to: e.target.value })
-                  }
-                />
-              </div>
-            </div>
-          </div>
+          {/* US-CRM-078 PR2 — o bloco "Entrega / Frete" SAIU daqui pra a seção
+              de 1ª classe `sec-entrega` (acima, entre Produtos e Pagamento). */}
         </div>
       </details>
 

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -17,6 +17,26 @@ import { Search, Loader2, X, UserPlus } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import QuickAddCustomerSheet from './QuickAddCustomerSheet';
 
+/**
+ * US-CRM-078 — endereço estruturado do catálogo do cliente (`contact_addresses`).
+ * Alimenta o seletor de entrega na venda (destinatário ↔ local de entrega).
+ */
+export interface ContactAddressOption {
+  id: number;
+  label?: string | null;
+  zip_code?: string | null;
+  address_line_1?: string | null;
+  numero?: string | null;
+  address_line_2?: string | null;
+  neighborhood?: string | null;
+  city?: string | null;
+  state?: string | null;
+  /** Código IBGE do município (cMun NF-e) — gatilho MDF-e quando difere da origem. */
+  city_code?: string | null;
+  is_default?: boolean;
+  is_shipping?: boolean;
+}
+
 export interface CustomerSearchResult {
   id: number;
   text: string;
@@ -34,8 +54,10 @@ export interface CustomerSearchResult {
   pay_term_number?: number | string | null;
   /** Tipo prazo — 'days' | 'months'. */
   pay_term_type?: 'days' | 'months' | string | null;
-  /** Endereço entrega — pré-fill no campo shipping. */
+  /** Endereço entrega (legacy one-line) — pré-fill/fallback do campo shipping. */
   shipping_address?: string | null;
+  /** US-CRM-078 — catálogo de endereços estruturados do cliente (seletor de entrega). */
+  addresses?: ContactAddressOption[] | null;
 }
 
 /**

--- a/tests/Feature/Sells/SellsCreatePageTest.php
+++ b/tests/Feature/Sells/SellsCreatePageTest.php
@@ -104,7 +104,7 @@ it('Page tem os 8 campos sempre visíveis (location, contact, date, status, prod
     expect($source)->toContain('id="notes"');
 });
 
-it('Page tem <details> "Mais opções" colapsável (10 campos restantes)', function () {
+it('Page tem <details> "Mais opções" colapsável (campos avançados — frete saiu p/ seção Entrega)', function () {
     $source = readPage();
     expect($source)->toContain('Mais opções');
     expect($source)->toMatch('/<details[^>]*open=\\{advancedOpen\\}/');
@@ -123,13 +123,43 @@ it('Page renderiza price_group e commission_agent CONDICIONAL (só se aplicável
     expect($source)->toContain('hasCommissionAgent');
 });
 
-it('Page tem bloco frete colapsável dentro de "Mais opções" (5 campos juntos)', function () {
+it('Page tem seção Entrega de 1ª classe (sec-entrega) — frete saiu de "Mais opções"', function () {
     $source = readPage();
+    // US-CRM-078 PR2 — endereço de entrega promovido a seção própria + pill.
+    expect($source)->toContain('id="sec-entrega"');
+    expect($source)->toContain("label: 'Entrega'");
+    // Toggle retirada × entrega.
+    expect($source)->toContain("setDeliveryMode('retirada')");
+    expect($source)->toContain("setDeliveryMode('entrega')");
+    // Campos de logística preservados.
     expect($source)->toContain('id="shipping_details"');
-    expect($source)->toContain('id="shipping_address"');
     expect($source)->toContain('id="shipping_cost"');
     expect($source)->toContain('id="shipping_status"');
     expect($source)->toContain('id="shipping_deliver_to"');
+    // Form estruturado "Outro" endereço (espelha contact_addresses).
+    expect($source)->toContain('id="shipping_address_line_1"');
+    expect($source)->toContain('id="shipping_city"');
+    expect($source)->toContain('id="shipping_state"');
+});
+
+it('Page consome o catálogo de endereços do cliente (contact.addresses[]) no seletor de entrega', function () {
+    $source = readPage();
+    expect($source)->toContain('customerAddresses');
+    // Pré-seleciona endereço de entrega (is_shipping) > default (is_default).
+    expect($source)->toContain('is_shipping');
+    expect($source)->toContain('selectSavedAddress');
+    // Hint de MDF-e quando a entrega sai do município da loja.
+    expect($source)->toContain('mdfeHint');
+    expect($source)->toContain('MDF-e');
+});
+
+it('Page tem select de Tipo de serviço CONDICIONAL (CU-G4 — só se módulo types_of_service habilitado)', function () {
+    $source = readPage();
+    // FK único transactions.types_of_service_id. Render gated por hasTypesOfService
+    // (prop typesOfService vazia em vestuário → seção some, zero ruído ROTA LIVRE).
+    expect($source)->toContain('hasTypesOfService');
+    expect($source)->toContain('id="types_of_service_id"');
+    expect($source)->toContain('props.typesOfService');
 });
 
 it('Page importa shadcn primitives (R-DS-001 reutilização)', function () {


### PR DESCRIPTION
Fecha as 2 pendências reais da tela de venda (`/sells/create`) levantadas nos casos de uso executáveis (#2115). Núcleo da venda já era ✅; estes eram os gaps vs Blade.

## CU-11 — Frete/entrega de 1ª classe (re-do do PR2 revertido #2104 / revert #2107)
- Seção própria `sec-entrega` (entre Produtos e Pagamento) com SubNav + scroll-spy.
- Toggle **Retirada × Entrega**. Em entrega: consome o catálogo `contact.addresses[]` (eager-load em `getCustomers`), pré-seleciona `is_shipping > is_default > 1º`, "Outro" endereço estruturado, **hint de MDF-e** por divergência de município (gatilho fiscal real cMun fica pro PR3 / US-SELL-044). Frete saiu de "Mais opções".
- Persiste one-line derivado em `transactions.shipping_address` (compat UPOS/NFe).

### 🐛 Causa raiz do revert #2107 — corrigida
O PR2 fazia `->with(['addresses'])` **cego** no `getCustomers` — endpoint **compartilhado com o Blade legado**. Sem a migration `contact_addresses` em prod → **500** derrubava a busca de cliente do POS inteiro. Este re-do **guarda com `Schema::hasTable('contact_addresses')`** (degrada gracioso pro fallback one-line). A dependência PR1 (migration + model + relations, `efc31745a`) **já está em main** desde o revert.

## CU-G4 — Tipo de serviço (`types_of_service_id`)
- Select **único** (não multi — UPOS usa FK único) na `sec-dados`, gated por `hasTypesOfService`. Some em vestuário (ROTA LIVRE, prop vazia) → zero ruído. Vai no payload via spread; `TransactionUtil` converte `''` → `null`.

## Tier 0 / testes
- `business_id` global scope preservado: `ContactAddress` usa `HasBusinessScope`, o eager-load é tenant-scoped automático ([ADR 0093](../blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md)).
- Pest estrutural restaurado: sec-entrega + catálogo + MDF-e hint + select de tipo.

## ⚠️ Smoke pendente antes do merge (lição do incidente #2107)
**Não mergear a tela #1 sem smoke visual real**, mesmo com CI verde:
- [ ] CT 100 staging logado → buscar cliente real → dropdown popula **sem 500**
- [ ] Toggle Entrega → escolher endereço do catálogo + "Outro" → salvar → `shipping_address` persiste
- [ ] Console limpo + screenshot (Chrome MCP)

Refs: US-CRM-078, US-SELL-044, CASOS-USO-CREATE-VENDA · incidente [`2026-06-02-incidente-revert-pr2-sells-endereco.md`](../blob/main/memory/sessions/2026-06-02-incidente-revert-pr2-sells-endereco.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)