### PR TITLE
ci(financeiro): Batch 2 — fix guard MultiTenantComprehensive anti-poison (lane 10→11 arquivos) (US-FIN-053)

### DIFF
--- a/.github/workflows/financeiro-pest.yml
+++ b/.github/workflows/financeiro-pest.yml
@@ -180,4 +180,6 @@ jobs:
             Modules/Financeiro/Tests/Feature/PluggyIntegrationTest.php \
             Modules/Financeiro/Tests/Feature/TituloRepositoryWave18Test.php \
             Modules/Financeiro/Tests/Feature/Wave27PolishTest.php \
-            Modules/Financeiro/Tests/Feature/Wave28PolishTest.php
+            Modules/Financeiro/Tests/Feature/Wave28PolishTest.php \
+            Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php \
+            Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php

--- a/.github/workflows/financeiro-pest.yml
+++ b/.github/workflows/financeiro-pest.yml
@@ -181,5 +181,4 @@ jobs:
             Modules/Financeiro/Tests/Feature/TituloRepositoryWave18Test.php \
             Modules/Financeiro/Tests/Feature/Wave27PolishTest.php \
             Modules/Financeiro/Tests/Feature/Wave28PolishTest.php \
-            Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php \
             Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php

--- a/Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php
+++ b/Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php
@@ -3,11 +3,16 @@
 declare(strict_types=1);
 
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 
-uses(Tests\TestCase::class, RefreshDatabase::class);
+// US-FIN-053 Batch 2: era RefreshDatabase (migrate:fresh) — incompatível com o
+// schema baseline (dropa FK + limpa o biz=1 seedado, envenenando a lane). Agora
+// DatabaseTransactions (rollback por teste, sem re-migrate) + skip-guard quando o
+// schema/biz não estão presentes (lanes SQLite sem migrate).
+uses(Tests\TestCase::class, DatabaseTransactions::class);
 
 /**
  * Regressao do check caixa_movimento_freshness (FinanceiroHealthCommand Wave 25 D9 #10).
@@ -19,7 +24,12 @@ uses(Tests\TestCase::class, RefreshDatabase::class);
  *
  * @see Modules/Financeiro/Console/Commands/FinanceiroHealthCommand.php (checkCaixaMovimentoFreshness)
  */
-beforeEach(fn () => Carbon::setTestNow(Carbon::create(2026, 5, 31, 12, 0, 0)));
+beforeEach(function () {
+    if (! Schema::hasTable('fin_caixa_movimentos') || ! DB::table('business')->where('id', 1)->exists()) {
+        test()->markTestSkipped('Precisa schema MySQL + biz=1 seedado (lane Financeiro · MySQL).');
+    }
+    Carbon::setTestNow(Carbon::create(2026, 5, 31, 12, 0, 0));
+});
 afterEach(fn () => Carbon::setTestNow());
 
 function finCaixaFreshnessSeed(int $daysAgo): void

--- a/Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php
+++ b/Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php
@@ -3,16 +3,11 @@
 declare(strict_types=1);
 
 use Carbon\Carbon;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
 
-// US-FIN-053 Batch 2: era RefreshDatabase (migrate:fresh) — incompatível com o
-// schema baseline (dropa FK + limpa o biz=1 seedado, envenenando a lane). Agora
-// DatabaseTransactions (rollback por teste, sem re-migrate) + skip-guard quando o
-// schema/biz não estão presentes (lanes SQLite sem migrate).
-uses(Tests\TestCase::class, DatabaseTransactions::class);
+uses(Tests\TestCase::class, RefreshDatabase::class);
 
 /**
  * Regressao do check caixa_movimento_freshness (FinanceiroHealthCommand Wave 25 D9 #10).
@@ -24,12 +19,7 @@ uses(Tests\TestCase::class, DatabaseTransactions::class);
  *
  * @see Modules/Financeiro/Console/Commands/FinanceiroHealthCommand.php (checkCaixaMovimentoFreshness)
  */
-beforeEach(function () {
-    if (! Schema::hasTable('fin_caixa_movimentos') || ! DB::table('business')->where('id', 1)->exists()) {
-        test()->markTestSkipped('Precisa schema MySQL + biz=1 seedado (lane Financeiro · MySQL).');
-    }
-    Carbon::setTestNow(Carbon::create(2026, 5, 31, 12, 0, 0));
-});
+beforeEach(fn () => Carbon::setTestNow(Carbon::create(2026, 5, 31, 12, 0, 0)));
 afterEach(fn () => Carbon::setTestNow());
 
 function finCaixaFreshnessSeed(int $daysAgo): void

--- a/Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php
+++ b/Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php
@@ -109,6 +109,14 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    // US-FIN-053 Batch 2: SÓ dropa no SQLite in-memory. No MySQL (lane baseline)
+    // dropar fin_titulo_baixas/fin_titulos mataria o schema pra TODOS os testes
+    // (DDL = auto-commit). Guard espelha o do beforeEach.
+    $isSqliteMemory = config('database.default') === 'sqlite'
+        && str_contains((string) config('database.connections.sqlite.database'), ':memory:');
+    if (! $isSqliteMemory) {
+        return;
+    }
     Schema::dropIfExists('fin_titulo_baixas');
     Schema::dropIfExists('fin_titulos');
 });

--- a/Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php
+++ b/Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php
@@ -29,8 +29,15 @@ beforeEach(function () {
     config()->set('otel.enabled', false);
     config()->set('activitylog.enabled', false);
 
-    if (config('database.default') !== 'sqlite' && ! str_contains((string) config('database.connections.sqlite.database'), ':memory:')) {
-        $this->markTestSkipped('MultiTenantComprehensive rodado apenas em SQLite in-memory.');
+    // US-FIN-053 Batch 2: guard anterior tinha lógica AND invertida — como
+    // sqlite.database é ':memory:' por default, NUNCA skipava, e rodava
+    // Schema::dropIfExists no MySQL → SQLSTATE 3730 (drop fin_titulos com FK) +
+    // limpava o schema baseline (veneno). Este teste é SQLite-in-memory only
+    // (cria as próprias tabelas) — skipa em qualquer outra conexão.
+    $isSqliteMemory = config('database.default') === 'sqlite'
+        && str_contains((string) config('database.connections.sqlite.database'), ':memory:');
+    if (! $isSqliteMemory) {
+        $this->markTestSkipped('MultiTenantComprehensive roda apenas em SQLite in-memory.');
     }
 
     Schema::dropIfExists('fin_titulo_baixas');


### PR DESCRIPTION
## Batch 2 da catraca Financeiro — neutraliza o pior veneno (Categoria B)

Segue o [Batch 1 (#2247)](https://github.com/wagnerra23/oimpresso.com/pull/2247). O diagnóstico ([landscape](memory/sessions/2026-06-04-financeiro-suite-landscape.md)) identificou que `MultiTenantComprehensiveTest` é **SQLite-in-memory only** (cria as próprias tabelas) mas tinha **skip-guard com lógica AND invertida** → no MySQL nunca skipava e rodava `Schema::dropIfExists('fin_titulos')` no `beforeEach` **e no `afterEach`** → `SQLSTATE 3730` + **dropava o schema baseline** (DDL = auto-commit → envenenava TODOS os testes seguintes).

### O que entrega
1. **Fix do guard** (beforeEach **+ afterEach**) — `$isSqliteMemory = default==='sqlite' && db contém ':memory:'`. No MySQL agora **skipa limpo** sem tocar no schema. Continua rodando normal nas lanes SQLite in-memory.
2. **Lane: +MultiTenantComprehensive na allowlist** (10→11 arquivos). Ele skipa no MySQL — o valor é provar que **não envenena mais**: os 87 testes verdes seguem passando.

### Verde (workflow_dispatch)
`Tests: 21 skipped, 87 passed (348 assertions)` — 87 passed inalterado (zero-poison) + MultiTenant 17 skips limpos.

### Fora de escopo (documentado pra batch futuro)
- **CaixaMovimentoFreshness / CashRegisterBridge** (`RefreshDatabase`): tentei converter pra `DatabaseTransactions` mas esbarrei em **drift do baseline** — `Unknown column 'deleted_at' in fin_caixa_movimentos` (o schema dump #2240 não tem a coluna que o command SoftDelete espera). É questão de **completude do baseline**, não de teste. Vira task separada.
- Categorias C (Cowork-mock, ~47), A (CacheManager, 15), D/E (~64): próximos batches.

> Squash merge sugerido.

<!-- no-ui-smoke: PR de teste/CI, não toca UI -->