### PR TITLE
fix(whatsapp/tests): resolve makeChannel() redeclare blocking suite bootstrap

### DIFF
--- a/Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php
@@ -98,7 +98,7 @@ function cuaSetBiz(int $businessId): void
     app()->forgetInstance(ScopeByBusiness::class);
 }
 
-function makeChannel(int $businessId, string $label = 'Suporte', string $uuid = null): Channel
+function cuaMakeChannel(int $businessId, string $label = 'Suporte', ?string $uuid = null): Channel
 {
     return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => $businessId,
@@ -119,8 +119,8 @@ it('R-WA-068-001 — Schema da tabela channel_user_access existe com colunas esp
 });
 
 it('R-WA-068-002 — ChannelUserAccess respeita BusinessIdScope (biz=1 não vê biz=99)', function () {
-    $ch1 = makeChannel(1, 'Vendas biz1');
-    $ch99 = makeChannel(99, 'Vendas biz99');
+    $ch1 = cuaMakeChannel(1, 'Vendas biz1');
+    $ch99 = cuaMakeChannel(99, 'Vendas biz99');
 
     ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1,
@@ -147,7 +147,7 @@ it('R-WA-068-002 — ChannelUserAccess respeita BusinessIdScope (biz=1 não vê 
 
 it('R-WA-068-003 — Scope active() filtra revoked_at IS NULL', function () {
     cuaSetBiz(1);
-    $ch = makeChannel(1);
+    $ch = cuaMakeChannel(1);
 
     // Grant ativo
     ChannelUserAccess::create([
@@ -168,7 +168,7 @@ it('R-WA-068-003 — Scope active() filtra revoked_at IS NULL', function () {
 
 it('R-WA-068-004 — Re-grant após revoke funciona (UNIQUE inclui revoked_at)', function () {
     cuaSetBiz(1);
-    $ch = makeChannel(1);
+    $ch = cuaMakeChannel(1);
 
     // 1º grant
     $first = ChannelUserAccess::create([
@@ -194,7 +194,7 @@ it('R-WA-068-004 — Re-grant após revoke funciona (UNIQUE inclui revoked_at)',
 
 it('R-WA-068-005 — Grant duplicado ATIVO (mesma combinação channel+user+revoked=NULL) viola UNIQUE', function () {
     cuaSetBiz(1);
-    $ch = makeChannel(1);
+    $ch = cuaMakeChannel(1);
 
     ChannelUserAccess::create([
         'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
@@ -210,7 +210,7 @@ it('R-WA-068-005 — Grant duplicado ATIVO (mesma combinação channel+user+revo
 
 it('R-WA-068-006 — Múltiplos revokes podem coexistir (history preservation)', function () {
     cuaSetBiz(1);
-    $ch = makeChannel(1);
+    $ch = cuaMakeChannel(1);
 
     // 3 ciclos grant→revoke do mesmo user no mesmo canal
     foreach ([3, 2, 1] as $daysAgo) {
@@ -238,7 +238,7 @@ it('R-WA-068-006 — Múltiplos revokes podem coexistir (history preservation)',
 
 it('R-WA-068-007 — Channel relation funciona (BelongsTo channel)', function () {
     cuaSetBiz(1);
-    $ch = makeChannel(1, 'Suporte X');
+    $ch = cuaMakeChannel(1, 'Suporte X');
 
     $access = ChannelUserAccess::create([
         'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
@@ -264,7 +264,7 @@ it('R-WA-068-008 — Migration idempotente: Schema::hasTable guard previne re-cr
 
 it('R-WA-068-009 — granted_at e revoked_at são castados pra Carbon', function () {
     cuaSetBiz(1);
-    $ch = makeChannel(1);
+    $ch = cuaMakeChannel(1);
 
     $access = ChannelUserAccess::create([
         'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
@@ -280,8 +280,8 @@ it('R-WA-068-009 — granted_at e revoked_at são castados pra Carbon', function
 });
 
 it('R-WA-068-010 — withoutGlobalScopes permite query cross-tenant (superadmin scenario)', function () {
-    $ch1 = makeChannel(1);
-    $ch99 = makeChannel(99);
+    $ch1 = cuaMakeChannel(1);
+    $ch99 = cuaMakeChannel(99);
 
     ChannelUserAccess::withoutGlobalScope(ScopeByBusiness::class)->create([
         'business_id' => 1, 'channel_id' => $ch1->id, 'user_id' => 10,

--- a/Modules/Whatsapp/Tests/Feature/LidCrossContactIncidentP0Test.php
+++ b/Modules/Whatsapp/Tests/Feature/LidCrossContactIncidentP0Test.php
@@ -119,7 +119,7 @@ beforeEach(function () {
     });
 });
 
-function makeChannel(int $bizId, string $uuidSuffix = '000'): Channel
+function lidMakeChannel(int $bizId, string $uuidSuffix = '000'): Channel
 {
     return Channel::query()->create([
         'business_id' => $bizId,
@@ -150,7 +150,7 @@ it('R-WA-INCIDENT-2026-05-14-P0-1 — Linker NÃO faz cross-contact via tail4 co
         'type' => 'customer', 'contact_id' => 'CO_WAGNER',
     ]);
 
-    $channel = makeChannel(1, '101');
+    $channel = lidMakeChannel(1, '101');
     $conv = Conversation::query()->create([
         'business_id' => 1, 'channel_id' => $channel->id,
         'customer_external_id' => '+5548999872822',
@@ -171,7 +171,7 @@ it('R-WA-INCIDENT-2026-05-14-P0-1b — Linker mantém match exact E.164 sem ambi
         'mobile' => '+5548999872822',
         'type' => 'customer', 'contact_id' => 'CO_EXATO',
     ]);
-    $channel = makeChannel(1, '102');
+    $channel = lidMakeChannel(1, '102');
     $conv = Conversation::query()->create([
         'business_id' => 1, 'channel_id' => $channel->id,
         'customer_external_id' => '+5548999872822',
@@ -234,7 +234,7 @@ it('R-WA-INCIDENT-2026-05-14-P0-3 — MessagePersister history-sync resolve LID 
         LidPhoneMap::SOURCE_WEBHOOK_SENDER_PN,
     );
 
-    $channel = makeChannel(1, '301');
+    $channel = lidMakeChannel(1, '301');
 
     $persister = new MessagePersister($channel);
     $result = $persister->persist([
@@ -255,7 +255,7 @@ it('R-WA-INCIDENT-2026-05-14-P0-3 — MessagePersister history-sync resolve LID 
 });
 
 it('R-WA-INCIDENT-2026-05-14-P0-3b — history-sync sem cache REGISTRA LID com phone=NULL pra rastreio', function () {
-    $channel = makeChannel(1, '302');
+    $channel = lidMakeChannel(1, '302');
     $persister = new MessagePersister($channel);
 
     $persister->persist([

--- a/memory/requisitos/Infra/RUNBOOK-acesso-ct100-testes-time.md
+++ b/memory/requisitos/Infra/RUNBOOK-acesso-ct100-testes-time.md
@@ -1,0 +1,104 @@
+# RUNBOOK — Acesso da equipe (Maiara/Felipe) ao CT 100 pra rodar testes
+
+> **Tipo:** runbook reproduzível
+> **Origem:** 2026-06-04 — Wagner: dar acesso à Maiara e ao Felipe pro CT 100
+> rodarem a suíte Pest "sem perder segurança".
+> **Refs:** [INFRA-ACESSO-CANON](../../reference/INFRA-ACESSO-CANON.md) ·
+> [feedback-testes-no-ct100-nao-local](../../reference/feedback-testes-no-ct100-nao-local.md) ·
+> [ADR 0235 staging](../../decisions/0235-staging-ct100-clone-anonimizado.md) ·
+> [RUNBOOK-ssh-hardening-ct](RUNBOOK-ssh-hardening-ct.md) ·
+> ACL versionado: [tailscale-acl.hujson](tailscale-acl.hujson)
+
+## Objetivo
+
+Maiara[M] e Felipe[F] (L2) precisam rodar `php artisan test` no container
+`oimpresso-staging` (CT 100) — testes **não** rodam local nem no Hostinger
+(feedback Wagner 2026-06-01). Liberar **sem** os 2 vazamentos clássicos:
+
+1. **`-G docker` = root** — membro do grupo `docker` escala pra root do host
+   (`docker run -v /:/host`). ❌ NÃO usar.
+2. **ACL Tailscale catch-all `*→*`** — daria a TODO device acesso a TODA
+   máquina/porta (Proxmox, Windows dev, etc.). ❌ Substituído por least-privilege.
+
+## Modelo de segurança (defesa em profundidade)
+
+| Camada | Mecanismo | Garante |
+|---|---|---|
+| Rede | ACL Tailscale por grupo+tag | suporte só alcança `tag:ct100:22` |
+| Auth | Tailscale SSH `check` mode | re-autentica; revoga central (tira do tailnet) |
+| OS | usuário próprio, **sem docker, sem sudo geral** | não vira root |
+| Comando | 2 wrappers via sudo NOPASSWD | só roda teste/sync, não toca docker socket |
+| Dado | staging anonimizado + isolado de prod (ADR 0235) | sem PII real, sem ação no mundo |
+
+## Parte A — Lado servidor (CT 100) — ✅ FEITO 2026-06-04
+
+Usuários `maiara` (uid 1000) e `felipe` (uid 1001), **sem** grupo docker/sudo.
+
+Wrappers (root-owned `0755`, usuário não edita):
+
+```bash
+# /usr/local/bin/staging-test  — roda a suíte DENTRO do container (confinado)
+#!/usr/bin/env bash
+set -euo pipefail
+exec docker exec -e DB_CONNECTION=mysql oimpresso-staging php artisan test "$@"
+
+# /usr/local/bin/staging-sync  — atualiza o código pra origin/main (idempotente)
+#!/usr/bin/env bash
+set -euo pipefail
+cd /opt/oimpresso-staging/code
+git fetch origin
+git reset --hard origin/main
+echo "staging sincronizado em: $(git rev-parse --short HEAD)"
+```
+
+sudoers `/etc/sudoers.d/staging-testers` (`0440`):
+
+```
+Cmnd_Alias STAGING_TEST = /usr/local/bin/staging-test, /usr/local/bin/staging-sync
+maiara ALL=(root) NOPASSWD: STAGING_TEST
+felipe ALL=(root) NOPASSWD: STAGING_TEST
+```
+
+Validado: `maiara` roda o wrapper; `maiara docker ps` → `permission denied` (✅).
+
+## Parte B — Tailscale (painel `login.tailscale.com/admin`)
+
+1. **Access Controls** → colar o conteúdo de [tailscale-acl.hujson](tailscale-acl.hujson) → Save.
+2. **Machines** → `ct100-mcp` → menu `...` → **Edit ACL tags** → adicionar `tag:ct100`.
+3. **Users** → **Invite external users** → `maiara@wr2.com.br` e `felipewr2@gmail.com`.
+4. Validar (do PC do Wagner, que é admin):
+   `tailscale ssh root@ct100-mcp "echo ok"` deve continuar funcionando.
+
+## Parte C — O que Maiara/Felipe fazem (na máquina deles)
+
+1. Aceitar o convite Tailscale no e-mail → instalar Tailscale
+   (`https://tailscale.com/download`) → logar com o **mesmo e-mail** convidado.
+2. Token MCP chega via **Vaultwarden**, nunca email/WhatsApp.
+3. Rodar os testes:
+
+```bash
+ssh maiara@ct100-mcp          # (Tailscale SSH; 1ª vez abre re-auth no browser)
+sudo staging-sync             # traz o código de origin/main
+sudo staging-test --filter=NomeDoTeste
+```
+
+> Eles **não** editam código no servidor — código sempre via git (`staging-sync`).
+> Só `oimpresso-staging`, **nunca** `oimpresso-mcp` (MCP server LIVE do time).
+
+## Revogar acesso
+
+- **Imediato:** painel Tailscale → Users → remover do tailnet (ou tirar de
+  `group:suporte` no ACL). Acesso some sem mexer no servidor.
+- **No host (opcional):** `userdel -r maiara` / remover de `/etc/sudoers.d/staging-testers`.
+
+## Pendências / follow-up
+
+- [ ] **Session recording** (Tailscale SSH) — requer container `tsrecorder` no
+  CT 100 + `recorder:["tag:recorder"]` nas regras ssh. Hoje a auditoria é via
+  journald (`_SYSTEMD_USER=maiara/felipe`) + logs de conexão Tailscale.
+- [ ] **Bug pré-existente na suíte:** `Cannot redeclare function makeChannel()`
+  (colisão `Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php` ×
+  `LidCrossContactIncidentP0Test.php`) trava `php artisan test` cheio. Corrigir
+  antes deles dependerem da suíte completa.
+- [ ] **Auto-deploy da `main` no staging** (gap ADR 0235) — eliminaria o
+  `staging-sync` manual.

--- a/memory/requisitos/Infra/RUNBOOK-acesso-ct100-testes-time.md
+++ b/memory/requisitos/Infra/RUNBOOK-acesso-ct100-testes-time.md
@@ -85,6 +85,34 @@ sudo staging-test --filter=NomeDoTeste
 > Eles **não** editam código no servidor — código sempre via git (`staging-sync`).
 > Só `oimpresso-staging`, **nunca** `oimpresso-mcp` (MCP server LIVE do time).
 
+## Parte D — Session recording (tsrecorder) — ✅ FEITO 2026-06-04
+
+As sessões SSH da suporte são **gravadas** por um container `tsrecorder` no CT 100.
+
+1. ACL: `tag:session-recorder` em `tagOwners` + `"recorder": ["tag:session-recorder"]`
+   e `"enforceRecorder": false` nas regras ssh de Maiara/Felipe (`false` = um hiccup
+   do recorder **não** bloqueia o acesso; troca pra `true` se quiser gravação obrigatória).
+2. Auth key tagueada `tag:session-recorder` (painel → Settings → Keys → Generate,
+   Tags ON, single-use, não-ephemeral). **Segredo → Vaultwarden**, nunca git.
+3. Container (CT 100):
+
+```bash
+mkdir -p /opt/tsrecorder
+chown -R 65532:65532 /opt/tsrecorder   # PEGADINHA: imagem roda como uid nonroot 65532
+docker run -d --name tsrecorder --restart unless-stopped \
+  -e TS_AUTHKEY="$TS_AUTHKEY" \
+  -v /opt/tsrecorder:/data \
+  tailscale/tsrecorder:stable \
+  /tsrecorder --dst=/data/recordings --statedir=/data/state
+```
+
+- **Sem `--ui`** de propósito: `--ui` exige HTTPS habilitado no tailnet (DNS →
+  Enable HTTPS). Pra playback no browser depois, ligar HTTPS + readicionar `--ui`.
+- Gravações ficam em `/opt/tsrecorder/recordings` (arquivos `.cast`, pequenos).
+- Node aparece no tailnet como `recorder` com tag `tag:session-recorder`.
+- ⚠️ **Retenção:** tsrecorder não faz prune automático em disco local — CT 100 estava
+  83% cheio. Adicionar limpeza periódica (cron) ou mover pra S3 (follow-up).
+
 ## Revogar acesso
 
 - **Imediato:** painel Tailscale → Users → remover do tailnet (ou tirar de
@@ -93,9 +121,11 @@ sudo staging-test --filter=NomeDoTeste
 
 ## Pendências / follow-up
 
-- [ ] **Session recording** (Tailscale SSH) — requer container `tsrecorder` no
-  CT 100 + `recorder:["tag:recorder"]` nas regras ssh. Hoje a auditoria é via
-  journald (`_SYSTEMD_USER=maiara/felipe`) + logs de conexão Tailscale.
+- [x] **Session recording** (Tailscale SSH) — ✅ feito (Parte D). Container
+  `tsrecorder` gravando em `/opt/tsrecorder/recordings`.
+- [ ] **Retenção das gravações** — tsrecorder não prune sozinho; agendar limpeza
+  (cron) ou mover storage pra S3. CT 100 a 83% de disco.
+- [ ] **Playback web** — opcional: ligar HTTPS no tailnet + readicionar `--ui`.
 - [ ] **Bug pré-existente na suíte:** `Cannot redeclare function makeChannel()`
   (colisão `Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php` ×
   `LidCrossContactIncidentP0Test.php`) trava `php artisan test` cheio. Corrigir

--- a/memory/requisitos/Infra/tailscale-acl.hujson
+++ b/memory/requisitos/Infra/tailscale-acl.hujson
@@ -20,6 +20,8 @@
 	// Edit ACL tags). Sem isso as regras abaixo não casam com ele.
 	"tagOwners": {
 		"tag:ct100": ["group:admin"],
+		// Nó tsrecorder (container no CT 100) que grava as sessões SSH da suporte.
+		"tag:session-recorder": ["group:admin"],
 	},
 
 	"grants": [
@@ -47,6 +49,8 @@
 			"src":    ["wr2backup@gmail.com"],
 			"dst":    ["tag:ct100"],
 			"users":  ["maiara"],
+			"recorder": ["tag:session-recorder"],
+			"enforceRecorder": false, // false: hiccup do recorder não bloqueia o acesso
 		},
 
 		// Felipe entra no CT 100 SOMENTE como usuário `felipe` (nunca root).
@@ -55,6 +59,8 @@
 			"src":    ["felipewr2@gmail.com"],
 			"dst":    ["tag:ct100"],
 			"users":  ["felipe"],
+			"recorder": ["tag:session-recorder"],
+			"enforceRecorder": false,
 		},
 
 		// Demais máquinas (não-tagueadas): cada um no que é seu (default).

--- a/memory/requisitos/Infra/tailscale-acl.hujson
+++ b/memory/requisitos/Infra/tailscale-acl.hujson
@@ -1,0 +1,68 @@
+// Tailscale ACL — oimpresso (tailnet wagnerra@gmail.com / controlplane.tailscale.com)
+// FONTE DE VERDADE VERSIONADA. Alterações: editar aqui + aplicar no painel
+// (Access Controls) ou via API. Histórico de versões fica também no painel.
+//
+// Modelo: least-privilege por grupo + tag.
+//  - group:admin  (Wagner) = acesso total (mantém o comportamento antigo).
+//  - group:suporte (Maiara/Felipe, L2) = SOMENTE CT 100, SOMENTE SSH, como
+//    usuário próprio NÃO-root, via Tailscale SSH em modo `check` (re-autentica).
+// Substitui o antigo grant catch-all {"src":["*"],"dst":["*"],"ip":["*"]} que
+// dava a TODO device acesso a TODA máquina/porta (o vazamento real).
+// Ref: memory/requisitos/Infra/RUNBOOK-acesso-ct100-testes-time.md
+{
+	"groups": {
+		"group:admin":   ["wagnerra@gmail.com"],
+		// Maiara usa a conta wr2backup@gmail.com ("WR2 Sistema"); Felipe felipewr2@gmail.com.
+		"group:suporte": ["wr2backup@gmail.com", "felipewr2@gmail.com"],
+	},
+
+	// CT 100 precisa receber a tag tag:ct100 no painel (Machines → ct100-mcp →
+	// Edit ACL tags). Sem isso as regras abaixo não casam com ele.
+	"tagOwners": {
+		"tag:ct100": ["group:admin"],
+	},
+
+	"grants": [
+		// Admin (Wagner): acesso total — preserva tudo que já existia.
+		{"src": ["group:admin"], "dst": ["*"], "ip": ["*"]},
+
+		// Suporte: SOMENTE o CT 100, SOMENTE a porta SSH (nada de Proxmox,
+		// nada de outras máquinas, nada de outras portas).
+		{"src": ["group:suporte"], "dst": ["tag:ct100"], "ip": ["tcp:22"]},
+	],
+
+	"ssh": [
+		// Admin (dono do tailnet) entra no CT 100 como root. `accept` (não
+		// `check`) pra não quebrar automação non-interactive do Wagner/Claude.
+		{
+			"action": "accept",
+			"src":    ["group:admin"],
+			"dst":    ["tag:ct100"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
+
+		// Maiara (conta wr2backup@gmail.com / "WR2 Sistema") -> unix `maiara`, nunca root.
+		{
+			"action": "check",
+			"src":    ["wr2backup@gmail.com"],
+			"dst":    ["tag:ct100"],
+			"users":  ["maiara"],
+		},
+
+		// Felipe entra no CT 100 SOMENTE como usuário `felipe` (nunca root).
+		{
+			"action": "check",
+			"src":    ["felipewr2@gmail.com"],
+			"dst":    ["tag:ct100"],
+			"users":  ["felipe"],
+		},
+
+		// Demais máquinas (não-tagueadas): cada um no que é seu (default).
+		{
+			"action": "check",
+			"src":    ["autogroup:member"],
+			"dst":    ["autogroup:self"],
+			"users":  ["autogroup:nonroot", "root"],
+		},
+	],
+}


### PR DESCRIPTION
## Problema

`ChannelUserAccessTest` e `LidCrossContactIncidentP0Test` declaravam a **mesma função global** `makeChannel()` no escopo do arquivo. O Pest inclui todos os arquivos de teste no bootstrap, então o PHP lançava:

```
Cannot redeclare function makeChannel()
(previously declared in Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php:101)
in Modules/Whatsapp/Tests/Feature/LidCrossContactIncidentP0Test.php on line 122
```

Isso **abortava `php artisan test` no bootstrap**, travando a suíte inteira antes de rodar qualquer teste — bloqueia também o acesso de testes da equipe ao CT 100 (ver RUNBOOK-acesso-ct100-testes-time, item pendente).

## Correção

Rename dos helpers para nomes file-scoped, seguindo a convenção **já existente** no módulo (`makeChannelDrift`, `makeChannelConv`, `makeChannelE2E`, `makeChannelAndConv`, `cuaSetBiz`):

| Arquivo | Antes | Depois |
|---|---|---|
| `ChannelUserAccessTest.php` | `makeChannel(int, string $label, string $uuid = null)` | `cuaMakeChannel(int, string $label, ?string $uuid = null)` |
| `LidCrossContactIncidentP0Test.php` | `makeChannel(int, string $uuidSuffix)` | `lidMakeChannel(int, string $uuidSuffix)` |

Bônus: corrigida a deprecation PHP 8.4 de implicit-nullable (`string $uuid = null` → `?string $uuid = null`) na linha tocada.

### Por que rename e não `if (!function_exists())`

Os dois helpers têm **assinaturas e comportamento diferentes** (`withoutGlobalScope` + label/uuid vs `Channel::query()` + uuidSuffix). Um guard `function_exists` ligaria silenciosamente os callers à implementação que carregasse primeiro → bugs sutis de impl errada. Rename preserva a intenção de cada teste.

## Validação (CT 100 staging — nunca local, feedback Wagner 2026-06-01)

- Fatal reproduzido em `oimpresso-staging` antes da correção.
- Após o rename: **fatal eliminado**, a suíte do módulo Whatsapp volta a dar bootstrap e executar (318 deprecated, 1071 assertions — antes: 0, abortava no load).
- 9 testes do `ChannelUserAccessTest` passam usando `cuaMakeChannel()`.

## Fora de escopo (flagged, não corrigido aqui)

- **`invokePrivate()` redeclare** — mesmo bug de classe entre `tests/Feature/Modules/Governance/DashboardExtensionTest.php:71` × `Modules/Governance/Tests/Feature/ModuleGradeServiceV3D1HardenedTest.php:29`. Trava o `php artisan test` cheio do mesmo jeito.
- **~493 falhas pré-existentes de DB no staging** — testes fazem `Schema::create`/`dropIfExists` cru em tabelas compartilhadas, colidindo com o grafo de FK do clone anonimizado da prod (`Cannot delete parent row: contacts`) e semântica MySQL vs SQLite (UNIQUE com `NULL` distinto). Nenhuma relacionada a este rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
