### PR TITLE
fix(financeiro): remover uso do trait RendersMockCowork dos 11 controllers (main quebrada pós #2256)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/BoletoController.php
+++ b/Modules/Financeiro/Http/Controllers/BoletoController.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\BoletoRemessa;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Services\TituloService;
@@ -34,8 +33,6 @@ use Modules\Financeiro\Services\TituloService;
  */
 class BoletoController extends Controller
 {
-    use RendersMockCowork;
-
     public function __construct()
     {
         $this->middleware('auth');
@@ -44,10 +41,6 @@ class BoletoController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = (int) $request->session()->get('business.id');
         $hoje = CarbonImmutable::today();
 

--- a/Modules/Financeiro/Http/Controllers/CategoriaController.php
+++ b/Modules/Financeiro/Http/Controllers/CategoriaController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertCategoriaRequest;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\PlanoConta;
@@ -26,14 +25,8 @@ use Modules\Financeiro\Models\PlanoConta;
  */
 class CategoriaController extends Controller
 {
-    use RendersMockCowork;
-
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $categorias = Categoria::query()
             ->orderBy('ativo', 'desc')
             ->orderBy('nome')

--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertContaBancariaRequest;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Strategies\CnabDirectStrategy;
@@ -27,8 +26,6 @@ use Modules\Financeiro\Strategies\CnabDirectStrategy;
  */
 class ContaBancariaController extends Controller
 {
-    use RendersMockCowork;
-
     // Bancos gateway-only (sem CNAB tradicional). Asaas continua selecionável
     // como conta destino aqui — a credencial é cadastrada em
     // /settings/payment-gateways e referencia esta conta via FK
@@ -37,10 +34,6 @@ class ContaBancariaController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = $request->session()->get('business.id');
 
         $accounts = Account::where('accounts.business_id', $businessId)

--- a/Modules/Financeiro/Http/Controllers/ContaPagarController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaPagarController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -18,14 +17,8 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class ContaPagarController extends Controller
 {
-    use RendersMockCowork;
-
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = $request->session()->get('business.id');
 
         $titulos = Titulo::where('business_id', $businessId)

--- a/Modules/Financeiro/Http/Controllers/ContaReceberController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaReceberController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\BoletoRemessa;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Services\TituloService;
@@ -23,14 +22,8 @@ use Modules\Financeiro\Services\TituloService;
  */
 class ContaReceberController extends Controller
 {
-    use RendersMockCowork;
-
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = $request->session()->get('business.id');
 
         $titulos = Titulo::where('business_id', $businessId)

--- a/Modules/Financeiro/Http/Controllers/DashboardController.php
+++ b/Modules/Financeiro/Http/Controllers/DashboardController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -25,8 +24,6 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class DashboardController extends Controller
 {
-    use RendersMockCowork;
-
     public function __construct()
     {
         $this->middleware('auth');
@@ -35,10 +32,6 @@ class DashboardController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = (int) session('user.business_id');
         $hoje = now()->toDateString();
         $inicioMes = now()->startOfMonth()->toDateString();

--- a/Modules/Financeiro/Http/Controllers/DreController.php
+++ b/Modules/Financeiro/Http/Controllers/DreController.php
@@ -11,7 +11,6 @@ use Illuminate\Http\Response as IlluminateResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Exports\DreExport;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Services\DreService;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -43,8 +42,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class DreController extends Controller
 {
-    use RendersMockCowork;
-
     public function __construct(private DreService $service)
     {
         $this->middleware('auth');
@@ -53,10 +50,6 @@ class DreController extends Controller
 
     public function index(Request $request): Response|IlluminateResponse
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = (int) session('user.business_id');
         [$periodoTipo, $anchorMes] = $this->parseQuery($request);
         $aba = $this->resolveAba($request);

--- a/Modules/Financeiro/Http/Controllers/ExtratoController.php
+++ b/Modules/Financeiro/Http/Controllers/ExtratoController.php
@@ -11,7 +11,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\ExtratoLancamento;
 
@@ -28,8 +27,6 @@ use Modules\Financeiro\Models\ExtratoLancamento;
  */
 class ExtratoController extends Controller
 {
-    use RendersMockCowork;
-
     /**
      * Ponto de entrada SEM id: /financeiro/extrato.
      * O sidebar/topnav apontam pra /financeiro/extrato (sem contaBancariaId), mas a
@@ -59,10 +56,6 @@ class ExtratoController extends Controller
 
     public function index(Request $request, int $contaBancariaId): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         // Session key canônica UPOS `user.business_id` (B5 — padroniza com o resto do módulo).
         $businessId = (int) $request->session()->get('user.business_id');
 

--- a/Modules/Financeiro/Http/Controllers/FluxoController.php
+++ b/Modules/Financeiro/Http/Controllers/FluxoController.php
@@ -7,7 +7,6 @@ use App\Util\OtelHelper;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Services\FluxoCaixaService;
 use Modules\Financeiro\Services\FluxoRealizadoService;
 
@@ -35,8 +34,6 @@ use Modules\Financeiro\Services\FluxoRealizadoService;
  */
 class FluxoController extends Controller
 {
-    use RendersMockCowork;
-
     public function __construct(
         private FluxoCaixaService $service,
         private FluxoRealizadoService $realizadoService,
@@ -47,10 +44,6 @@ class FluxoController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = (int) session('user.business_id');
         $tab = $this->resolveTab($request);
         $dias = $this->resolveDias($request);

--- a/Modules/Financeiro/Http/Controllers/RelatoriosController.php
+++ b/Modules/Financeiro/Http/Controllers/RelatoriosController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
 
@@ -29,8 +28,6 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class RelatoriosController extends Controller
 {
-    use RendersMockCowork;
-
     public function __construct()
     {
         $this->middleware('auth');
@@ -39,10 +36,6 @@ class RelatoriosController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = (int) session('user.business_id');
         $filters = $this->parseFilters($request);
 

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Events\TituloCriado;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\StoreTituloRequest;
 use Modules\Financeiro\Http\Requests\UpdateTituloRequest;
 use Modules\Financeiro\Models\Categoria;
@@ -41,8 +40,6 @@ use Spatie\Activitylog\Models\Activity;
  */
 class UnificadoController extends Controller
 {
-    use RendersMockCowork;
-
     public function __construct()
     {
         $this->middleware('auth');
@@ -51,11 +48,6 @@ class UnificadoController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        // Wagner 2026-05-18 Mock Cowork Mode (config/financeiro.php).
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
-
         $businessId = (int) session('user.business_id');
         $hoje = now()->toDateString();
         $vencendoLimite = now()->addDays(7)->toDateString();


### PR DESCRIPTION
## 🚨 Desquebra a `main`

O **#2256** (`c4b7ca158`) deletou o trait `RendersMockCowork` + `CoworkDataMapper` + `MockCoworkModeTest`, mas **deixou 11 controllers do Financeiro ainda usando** `use RendersMockCowork;` + `$this->tryRenderMockCowork()`. Resultado: fatal **`Trait not found`** em Boleto, Categoria, ContaBancaria, ContaPagar, ContaReceber, Dashboard, Dre, Extrato, Fluxo, Relatorios, Unificado.

- Pest (Financeiro · MySQL) + PHPStan **vermelhos na main**.
- Em produção (Hostinger) derrubaria o módulo Financeiro inteiro pra todos os tenants.

## Correção

Completa o refactor que o #2256 começou: remove de cada controller o import, o `use` do trait e o bloco `if ($mock = $this->tryRenderMockCowork()) { return $mock; }` no `index()`.

O *mock cowork mode* era preview de dev (`config('financeiro.mock_cowork_mode')`, **default false** em prod) — o **comportamento de produção (Inertia normal) é preservado**. 78 deleções, 11 arquivos, zero referências pendentes ao trait/serviço deletados.

## Validação
- `grep` confirma **zero** `RendersMockCowork`/`tryRenderMockCowork` restantes no módulo.
- CI PHPStan + Pest (Financeiro · MySQL) — que estavam vermelhos na main — são o gate autoritativo deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)