### PR TITLE
fix(financeiro): HOTFIX P0 — remove trait órfão RendersMockCowork dos 11 controllers (main quebrado pós-#2256)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/BoletoController.php
+++ b/Modules/Financeiro/Http/Controllers/BoletoController.php
@@ -10,7 +10,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\BoletoRemessa;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Services\TituloService;
@@ -34,7 +33,6 @@ use Modules\Financeiro\Services\TituloService;
  */
 class BoletoController extends Controller
 {
-    use RendersMockCowork;
 
     public function __construct()
     {
@@ -44,9 +42,6 @@ class BoletoController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = (int) $request->session()->get('business.id');
         $hoje = CarbonImmutable::today();

--- a/Modules/Financeiro/Http/Controllers/CategoriaController.php
+++ b/Modules/Financeiro/Http/Controllers/CategoriaController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertCategoriaRequest;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\PlanoConta;
@@ -26,13 +25,9 @@ use Modules\Financeiro\Models\PlanoConta;
  */
 class CategoriaController extends Controller
 {
-    use RendersMockCowork;
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $categorias = Categoria::query()
             ->orderBy('ativo', 'desc')

--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertContaBancariaRequest;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Strategies\CnabDirectStrategy;
@@ -27,7 +26,6 @@ use Modules\Financeiro\Strategies\CnabDirectStrategy;
  */
 class ContaBancariaController extends Controller
 {
-    use RendersMockCowork;
 
     // Bancos gateway-only (sem CNAB tradicional). Asaas continua selecionável
     // como conta destino aqui — a credencial é cadastrada em
@@ -37,9 +35,6 @@ class ContaBancariaController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = $request->session()->get('business.id');
 

--- a/Modules/Financeiro/Http/Controllers/ContaPagarController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaPagarController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -18,13 +17,9 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class ContaPagarController extends Controller
 {
-    use RendersMockCowork;
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = $request->session()->get('business.id');
 

--- a/Modules/Financeiro/Http/Controllers/ContaReceberController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaReceberController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\BoletoRemessa;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Services\TituloService;
@@ -23,13 +22,9 @@ use Modules\Financeiro\Services\TituloService;
  */
 class ContaReceberController extends Controller
 {
-    use RendersMockCowork;
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = $request->session()->get('business.id');
 

--- a/Modules/Financeiro/Http/Controllers/DashboardController.php
+++ b/Modules/Financeiro/Http/Controllers/DashboardController.php
@@ -7,7 +7,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -25,7 +24,6 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class DashboardController extends Controller
 {
-    use RendersMockCowork;
 
     public function __construct()
     {
@@ -35,9 +33,6 @@ class DashboardController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = (int) session('user.business_id');
         $hoje = now()->toDateString();

--- a/Modules/Financeiro/Http/Controllers/DreController.php
+++ b/Modules/Financeiro/Http/Controllers/DreController.php
@@ -11,7 +11,6 @@ use Illuminate\Http\Response as IlluminateResponse;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Exports\DreExport;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Services\DreService;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -43,7 +42,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  */
 class DreController extends Controller
 {
-    use RendersMockCowork;
 
     public function __construct(private DreService $service)
     {
@@ -53,9 +51,6 @@ class DreController extends Controller
 
     public function index(Request $request): Response|IlluminateResponse
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = (int) session('user.business_id');
         [$periodoTipo, $anchorMes] = $this->parseQuery($request);

--- a/Modules/Financeiro/Http/Controllers/ExtratoController.php
+++ b/Modules/Financeiro/Http/Controllers/ExtratoController.php
@@ -11,7 +11,6 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\ExtratoLancamento;
 
@@ -28,7 +27,6 @@ use Modules\Financeiro\Models\ExtratoLancamento;
  */
 class ExtratoController extends Controller
 {
-    use RendersMockCowork;
 
     /**
      * Ponto de entrada SEM id: /financeiro/extrato.
@@ -59,9 +57,6 @@ class ExtratoController extends Controller
 
     public function index(Request $request, int $contaBancariaId): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         // Session key canônica UPOS `user.business_id` (B5 — padroniza com o resto do módulo).
         $businessId = (int) $request->session()->get('user.business_id');

--- a/Modules/Financeiro/Http/Controllers/FluxoController.php
+++ b/Modules/Financeiro/Http/Controllers/FluxoController.php
@@ -7,7 +7,6 @@ use App\Util\OtelHelper;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Services\FluxoCaixaService;
 use Modules\Financeiro\Services\FluxoRealizadoService;
 
@@ -35,7 +34,6 @@ use Modules\Financeiro\Services\FluxoRealizadoService;
  */
 class FluxoController extends Controller
 {
-    use RendersMockCowork;
 
     public function __construct(
         private FluxoCaixaService $service,
@@ -47,9 +45,6 @@ class FluxoController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = (int) session('user.business_id');
         $tab = $this->resolveTab($request);

--- a/Modules/Financeiro/Http/Controllers/RelatoriosController.php
+++ b/Modules/Financeiro/Http/Controllers/RelatoriosController.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Carbon;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Inertia\Inertia;
 use Inertia\Response;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
 
@@ -29,7 +28,6 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class RelatoriosController extends Controller
 {
-    use RendersMockCowork;
 
     public function __construct()
     {
@@ -39,9 +37,6 @@ class RelatoriosController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = (int) session('user.business_id');
         $filters = $this->parseFilters($request);

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -12,7 +12,6 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Events\TituloCriado;
-use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\StoreTituloRequest;
 use Modules\Financeiro\Http\Requests\UpdateTituloRequest;
 use Modules\Financeiro\Models\Categoria;
@@ -41,7 +40,6 @@ use Spatie\Activitylog\Models\Activity;
  */
 class UnificadoController extends Controller
 {
-    use RendersMockCowork;
 
     public function __construct()
     {
@@ -51,10 +49,6 @@ class UnificadoController extends Controller
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
-        // Wagner 2026-05-18 Mock Cowork Mode (config/financeiro.php).
-        if ($mock = $this->tryRenderMockCowork()) {
-            return $mock;
-        }
 
         $businessId = (int) session('user.business_id');
         $hoje = now()->toDateString();


### PR DESCRIPTION
## 🚨 HOTFIX P0 — main quebrado

O PR **#2256** ("docs(infra): grant ct100->recorder...") deletou 3 arquivos:
`Concerns/RendersMockCowork.php`, `Services/CoworkDataMapper.php`, `Tests/Feature/MockCoworkModeTest.php` —
**mas deixou 11 controllers do Financeiro com `use RendersMockCowork;`**. Resultado: **`Trait "...RendersMockCowork" not found` (fatal)** ao instanciar qualquer controller do Financeiro → módulo inteiro fora no `main` (e iria pra prod no próximo deploy).

### O que entrega
Completa a deprecação que o #2256 começou (Wagner decidiu "terminar a remoção", não restaurar): remove dos **11 controllers** o `use` import + o `use RendersMockCowork;` (trait) + o bloco morto:
```php
if ($mock = $this->tryRenderMockCowork()) {
    return $mock;
}
```
O preview Cowork-mock (`config('financeiro.mock_cowork_mode')`, env `FINANCEIRO_MOCK_COWORK`) era scaffolding de protótipo, **desligado em prod**, com assets já apagados no #1214 → código morto.

Controllers: Boleto, Categoria, ContaBancaria, ContaPagar, ContaReceber, Dashboard, Dre, Extrato, Fluxo, Relatorios, Unificado.

### Verificação
- `php -l` nos 11 → **No syntax errors**.
- Zero refs dangling a `RendersMockCowork`/`CoworkDataMapper` em código de produção (grep limpo).
- Lane Financeiro·MySQL roda e fica verde (controllers carregam de novo).

### Fora de escopo
- Config morta `financeiro.mock_cowork_mode`/`mock_route_map`/`sidebar_wrap_enabled` — inofensiva, fica pra limpeza posterior.
- `OndaCommentsAuditBridgeTest` (tem Tier 0 real + testes Cowork-mock stale) — só uma string `(CoworkDataMapper format)` numa descrição, sem fatal; triagem na task de auditoria.

<!-- no-ui-smoke: remoção de código morto, não toca UI -->