### PR TITLE
fix(tests): green full-suite Pest discovery — guard invokePrivate + remove redundant uses()

### DIFF
--- a/Modules/Governance/Tests/Feature/ModuleGradeServiceV3D1HardenedTest.php
+++ b/Modules/Governance/Tests/Feature/ModuleGradeServiceV3D1HardenedTest.php
@@ -25,13 +25,18 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0158-module-grade-v3-d1-heuristica-hardening.md (proposto)
  */
 
-// Helper local — invoca método privado via reflection
-function invokePrivate(ModuleGradeService $service, string $method, array $args = []): mixed
-{
-    $reflection = new \ReflectionClass($service);
-    $m = $reflection->getMethod($method);
-    $m->setAccessible(true);
-    return $m->invoke($service, ...$args);
+// Helper local — invoca método privado via reflection.
+// Guardado por function_exists: o mesmo helper genérico é declarado em
+// tests/Feature/Modules/Governance/DashboardExtensionTest.php; sem o guard,
+// a descoberta da suíte cheia (php artisan test) fatala "Cannot redeclare".
+if (! function_exists('invokePrivate')) {
+    function invokePrivate(object $obj, string $method, array $args = []): mixed
+    {
+        $ref = new ReflectionMethod($obj, $method);
+        $ref->setAccessible(true);
+
+        return $ref->invokeArgs($obj, $args);
+    }
 }
 
 // Helper local — gera fixture path temporário no storage (limpa via cleanup)

--- a/tests/Feature/Guards/UcGuardsTest.php
+++ b/tests/Feature/Guards/UcGuardsTest.php
@@ -2,10 +2,6 @@
 
 declare(strict_types=1);
 
-use Tests\TestCase;
-
-uses(TestCase::class);
-
 /**
  * GUARDs de Caso de Uso — telas canon (Vendas + Oficina).
  *

--- a/tests/Feature/Modules/Governance/DashboardExtensionTest.php
+++ b/tests/Feature/Modules/Governance/DashboardExtensionTest.php
@@ -68,12 +68,14 @@ function controllerInstance(): \Modules\Governance\Http\Controllers\DashboardCon
     return new \Modules\Governance\Http\Controllers\DashboardController;
 }
 
-function invokePrivate(object $obj, string $method, array $args = []): mixed
-{
-    $ref = new ReflectionMethod($obj, $method);
-    $ref->setAccessible(true);
+if (! function_exists('invokePrivate')) {
+    function invokePrivate(object $obj, string $method, array $args = []): mixed
+    {
+        $ref = new ReflectionMethod($obj, $method);
+        $ref->setAccessible(true);
 
-    return $ref->invokeArgs($obj, $args);
+        return $ref->invokeArgs($obj, $args);
+    }
 }
 
 test('failedJobs24h conta apenas registros recentes', function () {


### PR DESCRIPTION
## Problema

A descoberta da suíte cheia (`php artisan test` **sem PATH**) carrega TODOS os
arquivos de teste num processo só. Helpers globais em escopo de arquivo colidem
e **fatalam o bootstrap** — hoje a equipe só consegue rodar passando o PATH do
arquivo (que evita a descoberta global). Continua o sweep iniciado em `makeChannel`
([#2251](https://github.com/wagnerra23/oimpresso.com/pull/2251)). Refs **US-INFRA-033**
+ [RUNBOOK-acesso-ct100-testes-time](../blob/main/memory/requisitos/Infra/RUNBOOK-acesso-ct100-testes-time.md) ("falta `invokePrivate` et al").

## Sweep sistêmico

Grep `^function` / `uses(` / `^const` em `tests/**` + `Modules/**/Tests/**`,
nomes em **2+ arquivos reais** (descontando heredocs e guards já existentes):

### Fatais corrigidos (bloqueavam a descoberta)
1. **`invokePrivate`** — declarada sem guard em `tests/Feature/Modules/Governance/DashboardExtensionTest.php` **e** `Modules/Governance/Tests/Feature/ModuleGradeServiceV3D1HardenedTest.php` → `Cannot redeclare`. As assinaturas **divergiam** (`object` vs `ModuleGradeService`), então só guardar com `function_exists` seria load-order-dependent (TypeError se a versão tipada carregasse primeiro). **Unificadas** num helper genérico `object`-typed idêntico e guardado → ordem irrelevante. Call sites inalterados.
2. **`UcGuardsTest`** — `uses(Tests\TestCase::class)` redundante: a pasta já é ligada por `uses(TestCase::class)->in('Feature')` em `tests/Pest.php` → fatal *"folder already uses the test case"*. Removido o `uses()` + import. **Absorve [#2255](https://github.com/wagnerra23/oimpresso.com/pull/2255)** (fechar sem merge).

### Não-colisões verificadas (sem ação)
- `repo_path` (14×) e `pgEnsureSchema` (2×) — já guardados por `function_exists`. `pgEnsureSchema` tem corpos divergentes mas todo `Schema::create` é guardado por `hasTable` → na suíte **MySQL** real ambos no-op, sem efeito de load-order.
- `setBizSession` — a 2ª "ocorrência" é conteúdo de **heredoc** (fixture do `isCrossTenantTestFile`), não decl real.

## Validação (CT 100 staging — nunca local)

```
docker exec -e DB_CONNECTION=mysql oimpresso-staging php artisan test --filter='__nada_nomatch__'
```

- **Antes:** fatal em `UcGuardsTest` (folder already uses) → descoberta aborta.
- **Depois (branch aplicada):** descoberta percorre a suíte INTEIRA e termina em
  `INFO  No tests found.` — **bootstrap verde, zero fatal**. `php -l` limpo nos 3 arquivos.

## Follow-up (separado)
Restam **warnings não-fatais** `Constant ... already defined` (`BIZ_WAGNER`/`BIZ_FICTICIO` em ~13 módulos + path-consts em `tests/Feature/Sells/*`). Um subconjunto tem **valores divergentes cross-módulo** (ex `EDIT_CHARTER_PATH` Purchase≠Sells) — latente sob discovery, exige **rename** (não guard). Vai em PR próprio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)