### PR TITLE
test(financeiro): Batch 6 — BaixaDialog + EditPlanoConta cleanup-fix → allowlist 12→14 (US-FIN-053)

### DIFF
--- a/.github/workflows/financeiro-pest.yml
+++ b/.github/workflows/financeiro-pest.yml
@@ -183,4 +183,6 @@ jobs:
             Modules/Financeiro/Tests/Feature/Wave28PolishTest.php \
             Modules/Financeiro/Tests/Feature/CaixaMovimentoFreshnessTest.php \
             Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php \
-            Modules/Financeiro/Tests/Feature/UnificadoFormaPagamentoGuardTest.php
+            Modules/Financeiro/Tests/Feature/UnificadoFormaPagamentoGuardTest.php \
+            Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php \
+            Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php

--- a/Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php
@@ -4,12 +4,23 @@ declare(strict_types=1);
 
 use App\Business;
 use App\User;
+use Illuminate\Support\Facades\DB;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
 use Spatie\Permission\Models\Permission;
 
 uses(Tests\TestCase::class);
+
+/**
+ * Cleanup via DB raw: Titulo::forceDelete() é bloqueado por DomainException
+ * (fin_titulos não permite delete). US-FIN-053 Batch 6.
+ */
+function bxCleanup(Titulo $t): void
+{
+    DB::table('fin_titulo_baixas')->where('titulo_id', $t->id)->delete();
+    DB::table('fin_titulos')->where('id', $t->id)->delete();
+}
 
 /**
  * 2026-06-03 — GUARD do diálogo de baixa (escolher valor/conta/forma/plano).
@@ -87,7 +98,7 @@ it('GUARD G1: shapeTitulo expõe valor_aberto', function () {
 
     $response = $this->actingAs($user)->get('/financeiro/unificado');
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        bxCleanup($titulo);
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
 
@@ -100,7 +111,7 @@ it('GUARD G1: shapeTitulo expõe valor_aberto', function () {
         }
     });
 
-    $titulo->forceDelete();
+    bxCleanup($titulo);
 });
 
 // G2 — baixar() aceita conta + valor + meio escolhidos
@@ -119,7 +130,7 @@ it('GUARD G2: baixar persiste conta/valor/meio escolhidos e quita', function () 
         'data_baixa'        => now()->toDateString(),
     ]);
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        bxCleanup($titulo);
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
 
@@ -132,7 +143,7 @@ it('GUARD G2: baixar persiste conta/valor/meio escolhidos e quita', function () 
     expect((float) $baixa->valor_baixa)->toBe(100.0);
 
     $baixa->forceDelete();
-    $titulo->forceDelete();
+    bxCleanup($titulo);
 });
 
 // G3 — baixa parcial
@@ -150,7 +161,7 @@ it('GUARD G3: baixa parcial reduz valor_aberto e marca parcial', function () {
         'meio_pagamento'    => 'dinheiro',
     ]);
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        bxCleanup($titulo);
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
 
@@ -167,9 +178,9 @@ it('GUARD G3: baixa parcial reduz valor_aberto e marca parcial', function () {
     expect($filho->status)->toBe('quitado');
 
     TituloBaixa::where('titulo_id', $filho->id)->forceDelete();
-    $filho->forceDelete();
+    bxCleanup($filho);
     TituloBaixa::where('titulo_id', $titulo->id)->forceDelete();
-    $titulo->forceDelete();
+    bxCleanup($titulo);
 });
 
 // G4 — conta cross-tenant/inexistente rejeitada
@@ -183,7 +194,7 @@ it('GUARD G4: conta inexistente/cross-tenant é rejeitada (não cria baixa)', fu
         'meio_pagamento'    => 'pix',
     ]);
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        bxCleanup($titulo);
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
 
@@ -191,7 +202,7 @@ it('GUARD G4: conta inexistente/cross-tenant é rejeitada (não cria baixa)', fu
     expect($titulo->status)->toBe('aberto', 'Conta inválida não deveria ter quitado o título');
     expect(TituloBaixa::where('titulo_id', $titulo->id)->exists())->toBeFalse();
 
-    $titulo->forceDelete();
+    bxCleanup($titulo);
 });
 
 // G5 — body vazio = legacy preservado
@@ -205,7 +216,7 @@ it('GUARD G5: body vazio mantém baixa instantânea legacy', function () {
 
     $response = $this->actingAs($user)->post("/financeiro/unificado/{$titulo->id}/baixar", []);
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        bxCleanup($titulo);
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
 
@@ -213,5 +224,5 @@ it('GUARD G5: body vazio mantém baixa instantânea legacy', function () {
     expect($titulo->status)->toBe('quitado');
 
     TituloBaixa::where('titulo_id', $titulo->id)->forceDelete();
-    $titulo->forceDelete();
+    bxCleanup($titulo);
 });

--- a/Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoBaixaDialogGuardTest.php
@@ -142,7 +142,7 @@ it('GUARD G2: baixar persiste conta/valor/meio escolhidos e quita', function () 
     expect($baixa->meio_pagamento)->toBe('pix');
     expect((float) $baixa->valor_baixa)->toBe(100.0);
 
-    $baixa->forceDelete();
+    DB::table('fin_titulo_baixas')->where('id', $baixa->id)->delete();
     bxCleanup($titulo);
 });
 

--- a/Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php
@@ -24,6 +24,16 @@ uses(Tests\TestCase::class);
  * subscription gate bloqueia financeiro_module no env atual.
  */
 
+/**
+ * Cleanup via DB raw: Titulo::forceDelete() é bloqueado por DomainException
+ * (fin_titulos não permite delete). US-FIN-053 Batch 6.
+ */
+function epcCleanup(Titulo $t): void
+{
+    DB::table('fin_titulo_baixas')->where('titulo_id', $t->id)->delete();
+    DB::table('fin_titulos')->where('id', $t->id)->delete();
+}
+
 function planoContaBootstrap(): array
 {
     try {
@@ -110,7 +120,7 @@ it('update salva plano_conta_id quando válido', function () {
     ]);
 
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        epcCleanup($titulo);
         $plano->forceDelete();
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
@@ -119,7 +129,7 @@ it('update salva plano_conta_id quando válido', function () {
     $titulo->refresh();
     expect($titulo->plano_conta_id)->toBe($plano->id);
 
-    $titulo->forceDelete();
+    epcCleanup($titulo);
     $plano->forceDelete();
 });
 
@@ -139,7 +149,7 @@ it('update com plano_conta_id null limpa o campo', function () {
     ]);
 
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        epcCleanup($titulo);
         $plano->forceDelete();
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
@@ -148,7 +158,7 @@ it('update com plano_conta_id null limpa o campo', function () {
     $titulo->refresh();
     expect($titulo->plano_conta_id)->toBeNull();
 
-    $titulo->forceDelete();
+    epcCleanup($titulo);
     $plano->forceDelete();
 });
 
@@ -178,7 +188,7 @@ it('rejeita plano de outro business (Tier 0 ADR 0093)', function () {
     ]);
 
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        epcCleanup($titulo);
         $planoCrossTenant->forceDelete();
         DB::table('business')->where('id', $otherBizId)->delete();
         test()->markTestSkipped('Module gate bloqueia neste env.');
@@ -189,7 +199,7 @@ it('rejeita plano de outro business (Tier 0 ADR 0093)', function () {
     $titulo->refresh();
     expect($titulo->plano_conta_id)->toBeNull();
 
-    $titulo->forceDelete();
+    epcCleanup($titulo);
     $planoCrossTenant->forceDelete();
     DB::table('business')->where('id', $otherBizId)->delete();
 });
@@ -209,7 +219,7 @@ it('rejeita plano de tipo incompatível (receber + despesa)', function () {
     ]);
 
     if (in_array($response->status(), [403, 404], true)) {
-        $titulo->forceDelete();
+        epcCleanup($titulo);
         $planoDespesa->forceDelete();
         test()->markTestSkipped('Module gate bloqueia neste env.');
     }
@@ -218,6 +228,6 @@ it('rejeita plano de tipo incompatível (receber + despesa)', function () {
     $titulo->refresh();
     expect($titulo->plano_conta_id)->toBeNull();
 
-    $titulo->forceDelete();
+    epcCleanup($titulo);
     $planoDespesa->forceDelete();
 });

--- a/Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php
@@ -167,11 +167,17 @@ it('rejeita plano de outro business (Tier 0 ADR 0093)', function () {
 
     // Cria business B falso (id absurdo evita colisão com seeders).
     $otherBizId = (int) (DB::table('business')->max('id') ?? 0) + 99999;
+    // owner_id NOT NULL FK→users + colunas NOT NULL do baseline (espelha seed da lane).
     DB::table('business')->insert([
         'id'         => $otherBizId,
         'name'       => 'TEST-OTHER-BIZ',
         'currency_id' => 1,
+        'owner_id'   => $user->id,
         'start_date' => now()->toDateString(),
+        'stop_selling_before'             => 0,
+        'weighing_scale_setting'          => '',
+        'certificado'                     => '',
+        'officeimpresso_numerodemaquinas' => 0,
         'created_at' => now(),
         'updated_at' => now(),
     ]);


### PR DESCRIPTION
## Batch 6 — greena +2 guards Unificado na catraca

Segue [#2264](https://github.com/wagnerra23/oimpresso.com/pull/2264) (Batch 5a). Mesmo padrão de cleanup-fix do bug pós-#2257: agora que `/unificado` não 500a, os guards falhavam só no teardown.

### O que entrega
- **`UnificadoBaixaDialogGuardTest`** + **`UnificadoEditPlanoContaTest`** → cleanup `Titulo::forceDelete()` (e `TituloBaixa::forceDelete()` instância — **descoberto: TituloBaixa também bloqueia `delete()`**) trocado por `DB::table(...)->delete()` raw.
- **EditPlanoConta cross-tenant test:** o `DB::table('business')->insert()` não setava `owner_id` → o baseline tem FK `business.owner_id→users` NOT NULL → `SQLSTATE 1452`. Fix: `owner_id` + colunas NOT NULL (espelha o seed da lane).
- allowlist **12 → 14 arquivos**.

### Verde (workflow_dispatch)
`Tests: 21 skipped, 106 passed (431 assertions)` (era 97 → **+9**).

### Resta (Batch 7)
`UnificadoPlanoContaGuardTest` — mesmo cleanup-fix + 1 `AssertionFailedError` real a investigar (não é cleanup).

> Squash merge sugerido.

<!-- no-ui-smoke: PR de teste/CI, não toca UI -->