### PR TITLE
fix(tests): eliminate const-collision warnings (+ divergent-value bug) in full-suite Pest discovery

### DIFF
--- a/Modules/ADS/Tests/Feature/BrainBIsolationTest.php
+++ b/Modules/ADS/Tests/Feature/BrainBIsolationTest.php
@@ -27,8 +27,8 @@ beforeEach(function () {
     }
 });
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 it('Brain B trace biz=1 não contribui pra cost agregado biz=99', function () {
     DB::table('mcp_dual_brain_decisions')->insert([

--- a/Modules/ADS/Tests/Feature/MultiTenantDecisionTest.php
+++ b/Modules/ADS/Tests/Feature/MultiTenantDecisionTest.php
@@ -30,8 +30,8 @@ beforeEach(function () {
     }
 });
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 it('decisão biz=1 NÃO aparece com filtro biz=99', function () {
     $id = DB::table('mcp_dual_brain_decisions')->insertGetId([

--- a/Modules/Admin/Tests/Feature/CrossTenantAdminTest.php
+++ b/Modules/Admin/Tests/Feature/CrossTenantAdminTest.php
@@ -28,8 +28,8 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0122-admin-center-ct100.md
  */
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 // Guard SQLite: Pest local Wagner mandatory MySQL UltimatePOS — ADR 0101.
 beforeEach(function () {

--- a/Modules/AssetManagement/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/AssetManagement/Tests/Feature/MultiTenantIsolationTest.php
@@ -37,8 +37,8 @@ beforeEach(function () {
 });
 
 // IDs canônicos — biz=1 (Wagner WR2) e biz=99 (fictício)
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 // ------------------------------------------------------------------
 // Asset — isolamento via filtro manual where('business_id', ...)

--- a/Modules/Brief/Tests/Feature/BriefMultiTenantTest.php
+++ b/Modules/Brief/Tests/Feature/BriefMultiTenantTest.php
@@ -25,8 +25,8 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
  */
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 // Guard SQLite: mcp_briefs vive no schema MCP MySQL only.
 beforeEach(function () {

--- a/Modules/ComunicacaoVisual/Tests/Feature/MultiTenantTest.php
+++ b/Modules/ComunicacaoVisual/Tests/Feature/MultiTenantTest.php
@@ -35,8 +35,8 @@ beforeEach(function () {
 });
 
 // IDs usados nos testes — biz=1 (Wagner) e biz=99 (fictício isolamento)
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 // ------------------------------------------------------------------
 // Helpers internos

--- a/Modules/Connector/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Connector/Tests/Feature/MultiTenantIsolationTest.php
@@ -31,8 +31,8 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
  */
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 beforeEach(function () {
     if (DB::connection()->getDriverName() === 'sqlite') {

--- a/Modules/ConsultaOs/Tests/Feature/PublicTokenSecurityTest.php
+++ b/Modules/ConsultaOs/Tests/Feature/PublicTokenSecurityTest.php
@@ -32,8 +32,8 @@ beforeEach(function () {
 });
 
 // ID Wagner WR2 — biz canonico para tests (ADR 0101) e ID ficticio sem dados
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 it('cenario A: numero invalido/inexistente retorna 404 com found=false (sem vazar dados)', function () {
     // Tentar varios numeros aleatorios — nenhum existe no mock.

--- a/Modules/Crm/Tests/Feature/Wave27DealPipelineTest.php
+++ b/Modules/Crm/Tests/Feature/Wave27DealPipelineTest.php
@@ -31,7 +31,7 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
  */
 
-const W27_BIZ_FICTICIO = 99;
+defined('W27_BIZ_FICTICIO') || define('W27_BIZ_FICTICIO', 99);
 const W27_BIZ_FICTICIO_B = 88;
 const W27_OWNER_ID = 1;
 

--- a/Modules/Financeiro/Tests/Feature/CoworkBundleIntegralTest.php
+++ b/Modules/Financeiro/Tests/Feature/CoworkBundleIntegralTest.php
@@ -22,7 +22,7 @@ uses(Tests\TestCase::class);
  */
 
 const FIN_BUNDLE = __DIR__ . '/../../../../resources/css/cowork-financeiro-bundle.css';
-const FIN_INERTIA_CSS = __DIR__ . '/../../../../resources/css/inertia.css';
+defined('FIN_INERTIA_CSS') || define('FIN_INERTIA_CSS', __DIR__ . '/../../../../resources/css/inertia.css');
 const FIN_COWORK_JSX_DIR = __DIR__ . '/../../../../resources/js/Pages/Financeiro/_cowork-bundle';
 
 describe('Cowork Bundle Integral — arquivo + header', function () {

--- a/Modules/Financeiro/Tests/Feature/Onda5CuradoriaR1Test.php
+++ b/Modules/Financeiro/Tests/Feature/Onda5CuradoriaR1Test.php
@@ -23,7 +23,7 @@ uses(Tests\TestCase::class);
 
 const FIN_BASE = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
 const FIN_CSS_PATH = __DIR__ . '/../../../../resources/css/fin-curadoria.css';
-const FIN_INERTIA_CSS = __DIR__ . '/../../../../resources/css/inertia.css';
+defined('FIN_INERTIA_CSS') || define('FIN_INERTIA_CSS', __DIR__ . '/../../../../resources/css/inertia.css');
 
 describe('Onda 5 Financeiro R1 Curadoria — 4 components existem', function () {
     it('FinPillFrescor existe e exporta finFrescorInfo + 6 kinds', function () {

--- a/Modules/Manufacturing/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Manufacturing/Tests/Feature/MultiTenantIsolationTest.php
@@ -69,8 +69,8 @@ describe('Wave 13 — adoção HasBusinessScope (reflection-only)', function () 
  * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
  */
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 describe('Isolamento multi-tenant Manufacturing (DB-dependent — MySQL only)', function () {
     // Guard SQLite + schema. UltimatePOS Manufacturing requer schema MySQL real.

--- a/Modules/Officeimpresso/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Officeimpresso/Tests/Feature/MultiTenantIsolationTest.php
@@ -37,8 +37,8 @@ beforeEach(function () {
     }
 });
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 // ------------------------------------------------------------------
 // Licenca_Computador (computador desktop licenciado bridge Delphi)

--- a/Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php
@@ -27,8 +27,8 @@ uses(Tests\TestCase::class);
  * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-003
  */
 
-const BIZ_WAGNER_FSM = 1;
-const BIZ_FICTICIO_FSM = 99;
+defined('BIZ_WAGNER_FSM') || define('BIZ_WAGNER_FSM', 1);
+defined('BIZ_FICTICIO_FSM') || define('BIZ_FICTICIO_FSM', 99);
 
 beforeEach(function () {
     if (DB::connection()->getDriverName() === 'sqlite') {

--- a/Modules/OficinaAuto/Tests/Feature/VehicleCrudTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/VehicleCrudTest.php
@@ -20,7 +20,7 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
  */
 
-const BIZ_WAGNER = 1;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
 
 beforeEach(function () {
     // CI SQLite :memory: sem migrate UltimatePOS — testes precisam schema MySQL completo

--- a/Modules/Ponto/Tests/Feature/Wave27CrossTenantEscalaTest.php
+++ b/Modules/Ponto/Tests/Feature/Wave27CrossTenantEscalaTest.php
@@ -47,7 +47,7 @@ uses(Tests\TestCase::class);
  */
 
 const W27_BIZ_WAGNER = 1;
-const W27_BIZ_FICTICIO = 99;
+defined('W27_BIZ_FICTICIO') || define('W27_BIZ_FICTICIO', 99);
 const W27_MARCADOR_NOME = 'W27-cross-tenant-escala';
 const W27_MARCADOR_IP = 'w27-ct-marc';
 

--- a/Modules/SRS/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/SRS/Tests/Feature/MultiTenantIsolationTest.php
@@ -29,8 +29,8 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
  */
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 
 beforeEach(function () {
     if (DB::connection()->getDriverName() === 'sqlite') {

--- a/tests/Feature/Modules/OficinaAuto/CacambaFsmSeederTest.php
+++ b/tests/Feature/Modules/OficinaAuto/CacambaFsmSeederTest.php
@@ -29,8 +29,8 @@ use Modules\OficinaAuto\Database\Seeders\OficinaAutoFsmSeeder;
  * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
  */
 
-const BIZ_WAGNER_FSM = 1;
-const BIZ_FICTICIO_FSM = 99;
+defined('BIZ_WAGNER_FSM') || define('BIZ_WAGNER_FSM', 1);
+defined('BIZ_FICTICIO_FSM') || define('BIZ_FICTICIO_FSM', 99);
 
 beforeEach(function () {
     if (DB::connection()->getDriverName() === 'sqlite') {

--- a/tests/Feature/Produto/Wave2EditInertiaTest.php
+++ b/tests/Feature/Produto/Wave2EditInertiaTest.php
@@ -9,15 +9,15 @@ if (! function_exists('repo_path')) {
     }
 }
 
-const EDIT_PAGE_PATH = 'resources/js/Pages/Produto/Edit.tsx';
+const PRODUTO_EDIT_PAGE_PATH = 'resources/js/Pages/Produto/Edit.tsx';
 
 function readProdutoEdit(): string
 {
-    return file_get_contents(repo_path(EDIT_PAGE_PATH));
+    return file_get_contents(repo_path(PRODUTO_EDIT_PAGE_PATH));
 }
 
 it('Page existe em Pages/Produto/Edit.tsx', function () {
-    expect(file_exists(repo_path(EDIT_PAGE_PATH)))->toBeTrue();
+    expect(file_exists(repo_path(PRODUTO_EDIT_PAGE_PATH)))->toBeTrue();
 });
 
 it('Page importa AppShellV2', function () {

--- a/tests/Feature/Produto/Wave2IndexInertiaTest.php
+++ b/tests/Feature/Produto/Wave2IndexInertiaTest.php
@@ -20,15 +20,15 @@ if (! function_exists('repo_path')) {
     }
 }
 
-const PAGE_PATH = 'resources/js/Pages/Produto/Index.tsx';
+const PRODUTO_INDEX_PAGE_PATH = 'resources/js/Pages/Produto/Index.tsx';
 
 function readProdutoIndex(): string
 {
-    return file_get_contents(repo_path(PAGE_PATH));
+    return file_get_contents(repo_path(PRODUTO_INDEX_PAGE_PATH));
 }
 
 it('Page Inertia existe em Pages/Produto/Index.tsx', function () {
-    expect(file_exists(repo_path(PAGE_PATH)))->toBeTrue();
+    expect(file_exists(repo_path(PRODUTO_INDEX_PAGE_PATH)))->toBeTrue();
 });
 
 it('Page importa AppShellV2 (Persistent Layout)', function () {

--- a/tests/Feature/Produto/Wave2ShowInertiaTest.php
+++ b/tests/Feature/Produto/Wave2ShowInertiaTest.php
@@ -9,15 +9,15 @@ if (! function_exists('repo_path')) {
     }
 }
 
-const SHOW_PAGE_PATH = 'resources/js/Pages/Produto/Show.tsx';
+const PRODUTO_SHOW_PAGE_PATH = 'resources/js/Pages/Produto/Show.tsx';
 
 function readProdutoShow(): string
 {
-    return file_get_contents(repo_path(SHOW_PAGE_PATH));
+    return file_get_contents(repo_path(PRODUTO_SHOW_PAGE_PATH));
 }
 
 it('Page existe em Pages/Produto/Show.tsx', function () {
-    expect(file_exists(repo_path(SHOW_PAGE_PATH)))->toBeTrue();
+    expect(file_exists(repo_path(PRODUTO_SHOW_PAGE_PATH)))->toBeTrue();
 });
 
 it('Page importa AppShellV2', function () {

--- a/tests/Feature/Purchase/Wave2EditInertiaTest.php
+++ b/tests/Feature/Purchase/Wave2EditInertiaTest.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
  */
 
 const EDIT_INERTIA_PATH = 'resources/js/Pages/Purchase/Edit.tsx';
-const EDIT_CHARTER_PATH = 'resources/js/Pages/Purchase/Edit.charter.md';
-const EDIT_CONTROLLER_PATH = 'app/Http/Controllers/PurchaseController.php';
+const PURCHASE_EDIT_CHARTER_PATH = 'resources/js/Pages/Purchase/Edit.charter.md';
+const PURCHASE_EDIT_CONTROLLER_PATH = 'app/Http/Controllers/PurchaseController.php';
 const EDIT_RUNBOOK_PATH = 'memory/requisitos/Inventory/RUNBOOK-purchase-edit.md';
 const EDIT_VISUAL_PATH = 'memory/requisitos/Inventory/purchase-edit-visual-comparison.md';
 
@@ -19,7 +19,7 @@ function readEditInertia(): string
 
 function readEditControllerInertia(): string
 {
-    return file_get_contents(base_path(EDIT_CONTROLLER_PATH));
+    return file_get_contents(base_path(PURCHASE_EDIT_CONTROLLER_PATH));
 }
 
 it('Page Edit.tsx existe', function () {
@@ -27,8 +27,8 @@ it('Page Edit.tsx existe', function () {
 });
 
 it('Charter Edit.charter.md existe (ADR 0149)', function () {
-    expect(file_exists(base_path(EDIT_CHARTER_PATH)))->toBeTrue();
-    $content = file_get_contents(base_path(EDIT_CHARTER_PATH));
+    expect(file_exists(base_path(PURCHASE_EDIT_CHARTER_PATH)))->toBeTrue();
+    $content = file_get_contents(base_path(PURCHASE_EDIT_CHARTER_PATH));
     expect($content)->toContain('mwart_pattern_reuse:');
 });
 

--- a/tests/Feature/Sells/CommissionSplitEditorTest.php
+++ b/tests/Feature/Sells/CommissionSplitEditorTest.php
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Schema;
 const COMMISSION_CONTROLLER_PATH = 'app/Http/Controllers/SellCommissionSplitController.php';
 const COMMISSION_EDITOR_TSX_PATH = 'resources/js/Pages/Sells/_components/CommissionSplitEditor.tsx';
 const COMMISSION_EDIT_TSX_PATH = 'resources/js/Pages/Sells/Edit.tsx';
-const COMMISSION_SELL_CONTROLLER_PATH = 'app/Http/Controllers/SellController.php';
+defined('COMMISSION_SELL_CONTROLLER_PATH') || define('COMMISSION_SELL_CONTROLLER_PATH', 'app/Http/Controllers/SellController.php');
 const COMMISSION_ROUTES_PATH = 'routes/web.php';
 
 function commRead(string $rel): string

--- a/tests/Feature/Sells/CriarOsPorVendaTest.php
+++ b/tests/Feature/Sells/CriarOsPorVendaTest.php
@@ -30,8 +30,8 @@ use Modules\OficinaAuto\Entities\Vehicle;
  * @see Modules/OficinaAuto/Database/Migrations/2026_05_12_230001_add_transaction_sell_line_id_to_service_orders.php
  */
 
-const BIZ_WAGNER = 1;
-const BIZ_FICTICIO = 99;
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+defined('BIZ_FICTICIO') || define('BIZ_FICTICIO', 99);
 const TEST_PLATE_PREFIX = 'OSTL';
 
 beforeEach(function () {

--- a/tests/Feature/Sells/SellsCommissionColumnTest.php
+++ b/tests/Feature/Sells/SellsCommissionColumnTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
  *  - PR #1043 "NÃO INCLUI" (Onda 5 Polish — dados reais)
  */
 
-const COMMISSION_SELL_CONTROLLER_PATH = 'app/Http/Controllers/SellController.php';
+defined('COMMISSION_SELL_CONTROLLER_PATH') || define('COMMISSION_SELL_CONTROLLER_PATH', 'app/Http/Controllers/SellController.php');
 const COMMISSION_INDEX_TSX_PATH = 'resources/js/Pages/Sells/Index.tsx';
 
 function commissionReadSellController(): string

--- a/tests/Feature/Sells/SellsDraftsCoworkTest.php
+++ b/tests/Feature/Sells/SellsDraftsCoworkTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
  */
 
 const DRAFTS_TSX_PATH = 'resources/js/Pages/Sells/Drafts.tsx';
-const DRAFTS_CHARTER_PATH = 'resources/js/Pages/Sells/Drafts.charter.md';
+defined('DRAFTS_CHARTER_PATH') || define('DRAFTS_CHARTER_PATH', 'resources/js/Pages/Sells/Drafts.charter.md');
 const DRAFTS_CSS_PATH = 'resources/css/sells-cowork-drafts.css';
 const DRAFTS_INERTIA_CSS_PATH = 'resources/css/inertia.css';
 const DRAFTS_INDEX_TSX_PATH = 'resources/js/Pages/Sells/Index.tsx';

--- a/tests/Feature/Sells/SellsEditCoworkTest.php
+++ b/tests/Feature/Sells/SellsEditCoworkTest.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
  */
 
 const EDIT_TSX_PATH = 'resources/js/Pages/Sells/Edit.tsx';
-const EDIT_CHARTER_PATH = 'resources/js/Pages/Sells/Edit.charter.md';
+defined('EDIT_CHARTER_PATH') || define('EDIT_CHARTER_PATH', 'resources/js/Pages/Sells/Edit.charter.md');
 const EDIT_CSS_PATH = 'resources/css/sells-cowork-edit.css';
 const EDIT_INERTIA_CSS_PATH = 'resources/css/inertia.css';
 

--- a/tests/Feature/Sells/SellsFilterHintStaleTest.php
+++ b/tests/Feature/Sells/SellsFilterHintStaleTest.php
@@ -21,12 +21,12 @@ declare(strict_types=1);
  *   - PR #1034 (DateFilter reintegration que preservou keys legacy)
  */
 
-const SELLS_INDEX_PATH = __DIR__ . '/../../../resources/js/Pages/Sells/Index.tsx';
+const SELLS_INDEX_PATH_ABS = __DIR__ . '/../../../resources/js/Pages/Sells/Index.tsx';
 const INERTIA_CSS_PATH = __DIR__ . '/../../../resources/css/inertia.css';
 
 describe('Bug fix 2026-05-18 — hint filter stale em Sells/Index', function () {
     it('Index.tsx define helpers de detecção de filter ativo + stale', function () {
-        $src = file_get_contents(SELLS_INDEX_PATH);
+        $src = file_get_contents(SELLS_INDEX_PATH_ABS);
         // Helpers novos
         expect($src)->toContain('const clearDateFilter = useCallback');
         expect($src)->toContain('const dateFilterActive =');
@@ -42,7 +42,7 @@ describe('Bug fix 2026-05-18 — hint filter stale em Sells/Index', function () 
     });
 
     it('Index.tsx renderiza JSX hint condicional com botao Limpar filtro', function () {
-        $src = file_get_contents(SELLS_INDEX_PATH);
+        $src = file_get_contents(SELLS_INDEX_PATH_ABS);
         // Render conditional
         expect($src)->toContain('{dateFilterActive && (');
         expect($src)->toContain('vd-date-filter-hint');
@@ -55,7 +55,7 @@ describe('Bug fix 2026-05-18 — hint filter stale em Sells/Index', function () 
     });
 
     it('Index.tsx detecta dateTo < ontem como stale (proteção contra localStorage stuck)', function () {
-        $src = file_get_contents(SELLS_INDEX_PATH);
+        $src = file_get_contents(SELLS_INDEX_PATH_ABS);
         // Logica core: dateTo < yesterday
         expect($src)->toContain('86_400_000');
         expect($src)->toContain('today.getTime() - 86_400_000');

--- a/tests/Feature/Sells/SellsKb975CheatToastTest.php
+++ b/tests/Feature/Sells/SellsKb975CheatToastTest.php
@@ -19,9 +19,9 @@ declare(strict_types=1);
 const KB975_CHEAT_PATH = 'resources/js/Pages/Sells/_components/SellsCheatSheet.tsx';
 const KB975_TOAST_PATH = 'resources/js/Lib/oimpressoToast.ts';
 const KB975_CHEAT_CSS = 'resources/css/sells-kb975-cheatsheet.css';
-const KB975_INERTIA_CSS = 'resources/css/inertia.css';
-const KB975_INDEX_PAGE = 'resources/js/Pages/Sells/Index.tsx';
-const KB975_SHOW_PAGE = 'resources/js/Pages/Sells/Show.tsx';
+defined('KB975_INERTIA_CSS') || define('KB975_INERTIA_CSS', 'resources/css/inertia.css');
+defined('KB975_INDEX_PAGE') || define('KB975_INDEX_PAGE', 'resources/js/Pages/Sells/Index.tsx');
+defined('KB975_SHOW_PAGE') || define('KB975_SHOW_PAGE', 'resources/js/Pages/Sells/Show.tsx');
 
 // ──────────────────────────────────────────────────────────────
 // SellsCheatSheet.tsx (gap P3 #12)

--- a/tests/Feature/Sells/SellsKb975EmitModalsTest.php
+++ b/tests/Feature/Sells/SellsKb975EmitModalsTest.php
@@ -20,9 +20,9 @@ const KB975_NFE_MODAL_PATH = 'resources/js/Pages/Sells/_components/VdNfeEmitModa
 const KB975_NFSE_MODAL_PATH = 'resources/js/Pages/Sells/_components/VdNfseEmitModal.tsx';
 const KB975_BULK_MODAL_PATH = 'resources/js/Pages/Sells/_components/VdBulkEmitModal.tsx';
 const KB975_EMIT_CSS = 'resources/css/sells-kb975-emit-modals.css';
-const KB975_INERTIA_CSS = 'resources/css/inertia.css';
-const KB975_INDEX_PAGE = 'resources/js/Pages/Sells/Index.tsx';
-const KB975_SHOW_PAGE = 'resources/js/Pages/Sells/Show.tsx';
+defined('KB975_INERTIA_CSS') || define('KB975_INERTIA_CSS', 'resources/css/inertia.css');
+defined('KB975_INDEX_PAGE') || define('KB975_INDEX_PAGE', 'resources/js/Pages/Sells/Index.tsx');
+defined('KB975_SHOW_PAGE') || define('KB975_SHOW_PAGE', 'resources/js/Pages/Sells/Show.tsx');
 const KB975_NEXTACTION = 'resources/js/Pages/Sells/_components/VdNextActionPanel.tsx';
 
 // ─────────────────────────────────────────────────────────────

--- a/tests/Feature/Sells/SellsKb975NextActionPanelTest.php
+++ b/tests/Feature/Sells/SellsKb975NextActionPanelTest.php
@@ -18,8 +18,8 @@ declare(strict_types=1);
 const KB975_NEXTACTION_PATH = 'resources/js/Pages/Sells/_components/VdNextActionPanel.tsx';
 const KB975_VALIDATIONS_PATH = 'resources/js/Lib/validacoesFiscaisBr.ts';
 const KB975_CSS_PATH = 'resources/css/sells-kb975-next-action.css';
-const KB975_INERTIA_CSS = 'resources/css/inertia.css';
-const KB975_SHOW_PAGE = 'resources/js/Pages/Sells/Show.tsx';
+defined('KB975_INERTIA_CSS') || define('KB975_INERTIA_CSS', 'resources/css/inertia.css');
+defined('KB975_SHOW_PAGE') || define('KB975_SHOW_PAGE', 'resources/js/Pages/Sells/Show.tsx');
 
 it('VdNextActionPanel.tsx existe', function () {
     expect(file_exists(base_path(KB975_NEXTACTION_PATH)))->toBeTrue();

--- a/tests/Feature/Sells/SellsQuotationsCoworkTest.php
+++ b/tests/Feature/Sells/SellsQuotationsCoworkTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
  */
 
 const QUOTATIONS_TSX_PATH = 'resources/js/Pages/Sells/Quotations.tsx';
-const QUOTATIONS_CHARTER_PATH = 'resources/js/Pages/Sells/Quotations.charter.md';
+defined('QUOTATIONS_CHARTER_PATH') || define('QUOTATIONS_CHARTER_PATH', 'resources/js/Pages/Sells/Quotations.charter.md');
 const QUOTATIONS_CSS_PATH = 'resources/css/sells-cowork-quotations.css';
 const QUOTATIONS_INERTIA_CSS_PATH = 'resources/css/inertia.css';
 const QUOTATIONS_INDEX_TSX_PATH = 'resources/js/Pages/Sells/Index.tsx';

--- a/tests/Feature/Sells/SellsShowCoworkTest.php
+++ b/tests/Feature/Sells/SellsShowCoworkTest.php
@@ -21,7 +21,7 @@ declare(strict_types=1);
  */
 
 const SHOW_TSX_PATH = 'resources/js/Pages/Sells/Show.tsx';
-const SHOW_CHARTER_PATH = 'resources/js/Pages/Sells/Show.charter.md';
+defined('SHOW_CHARTER_PATH') || define('SHOW_CHARTER_PATH', 'resources/js/Pages/Sells/Show.charter.md');
 const SHOW_CSS_PATH = 'resources/css/sells-cowork-show.css';
 const SHOW_INERTIA_CSS_PATH = 'resources/css/inertia.css';
 

--- a/tests/Feature/Sells/SellsSubscriptionsCoworkTest.php
+++ b/tests/Feature/Sells/SellsSubscriptionsCoworkTest.php
@@ -26,7 +26,7 @@ declare(strict_types=1);
  */
 
 const SUBSCRIPTIONS_TSX_PATH = 'resources/js/Pages/Sells/Subscriptions.tsx';
-const SUBSCRIPTIONS_CHARTER_PATH = 'resources/js/Pages/Sells/Subscriptions.charter.md';
+defined('SUBSCRIPTIONS_CHARTER_PATH') || define('SUBSCRIPTIONS_CHARTER_PATH', 'resources/js/Pages/Sells/Subscriptions.charter.md');
 const SUBSCRIPTIONS_CSS_PATH = 'resources/css/sells-cowork-subscriptions.css';
 const SUBSCRIPTIONS_INERTIA_CSS_PATH = 'resources/css/inertia.css';
 const SUBSCRIPTIONS_INDEX_TSX_PATH = 'resources/js/Pages/Sells/Index.tsx';

--- a/tests/Feature/Sells/Wave1DraftsInertiaTest.php
+++ b/tests/Feature/Sells/Wave1DraftsInertiaTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
  */
 
 const DRAFTS_PAGE_PATH = 'resources/js/Pages/Sells/Drafts.tsx';
-const DRAFTS_CHARTER_PATH = 'resources/js/Pages/Sells/Drafts.charter.md';
+defined('DRAFTS_CHARTER_PATH') || define('DRAFTS_CHARTER_PATH', 'resources/js/Pages/Sells/Drafts.charter.md');
 const DRAFTS_CONTROLLER_PATH = 'app/Http/Controllers/SellController.php';
 
 function readDraftsPage(): string

--- a/tests/Feature/Sells/Wave1EditInertiaTest.php
+++ b/tests/Feature/Sells/Wave1EditInertiaTest.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 
 const EDIT_PAGE_PATH = 'resources/js/Pages/Sells/Edit.tsx';
-const EDIT_CHARTER_PATH = 'resources/js/Pages/Sells/Edit.charter.md';
+defined('EDIT_CHARTER_PATH') || define('EDIT_CHARTER_PATH', 'resources/js/Pages/Sells/Edit.charter.md');
 const EDIT_CONTROLLER_PATH = 'app/Http/Controllers/SellController.php';
 
 function readEditPage(): string

--- a/tests/Feature/Sells/Wave1QuotationsInertiaTest.php
+++ b/tests/Feature/Sells/Wave1QuotationsInertiaTest.php
@@ -17,7 +17,7 @@ declare(strict_types=1);
  */
 
 const QUOTATIONS_PAGE_PATH = 'resources/js/Pages/Sells/Quotations.tsx';
-const QUOTATIONS_CHARTER_PATH = 'resources/js/Pages/Sells/Quotations.charter.md';
+defined('QUOTATIONS_CHARTER_PATH') || define('QUOTATIONS_CHARTER_PATH', 'resources/js/Pages/Sells/Quotations.charter.md');
 const QUOTATIONS_CONTROLLER_PATH = 'app/Http/Controllers/SellController.php';
 
 function readQuotationsPage(): string

--- a/tests/Feature/Sells/Wave1ShowInertiaTest.php
+++ b/tests/Feature/Sells/Wave1ShowInertiaTest.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 
 const SHOW_PAGE_PATH = 'resources/js/Pages/Sells/Show.tsx';
-const SHOW_CHARTER_PATH = 'resources/js/Pages/Sells/Show.charter.md';
+defined('SHOW_CHARTER_PATH') || define('SHOW_CHARTER_PATH', 'resources/js/Pages/Sells/Show.charter.md');
 const SHOW_CONTROLLER_PATH = 'app/Http/Controllers/SellController.php';
 
 function readShowPage(): string

--- a/tests/Feature/Sells/Wave1SubscriptionsInertiaTest.php
+++ b/tests/Feature/Sells/Wave1SubscriptionsInertiaTest.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
  */
 
 const SUBSCRIPTIONS_PAGE_PATH = 'resources/js/Pages/Sells/Subscriptions.tsx';
-const SUBSCRIPTIONS_CHARTER_PATH = 'resources/js/Pages/Sells/Subscriptions.charter.md';
+defined('SUBSCRIPTIONS_CHARTER_PATH') || define('SUBSCRIPTIONS_CHARTER_PATH', 'resources/js/Pages/Sells/Subscriptions.charter.md');
 const SUBSCRIPTIONS_CONTROLLER_PATH = 'app/Http/Controllers/SellPosController.php';
 
 function readSubscriptionsPage(): string


### PR DESCRIPTION
Follow-up de **[#2263](https://github.com/wagnerra23/oimpresso.com/pull/2263)** (fatais). Aquele deixou a descoberta **sem fatal**; este zera os ~88 Warnings `Constant X already defined` que poluíam a saída — e corrige um **bug latente de valor divergente** escondido entre eles.

## Dois tratamentos, por natureza da colisão

### (A) Mesmo valor em N arquivos → guard `defined() || define()` — 53 decls / 39 arquivos
Order-independent, mantém o valor canônico. Cobre:
- `BIZ_WAGNER`(=1) / `BIZ_FICTICIO`(=99) — multi-tenant Tier 0 (ADR 0101) em ~13 módulos + `tests/Feature/Sells`.
- `BIZ_WAGNER_FSM`/`BIZ_FICTICIO_FSM`, `W27_BIZ_FICTICIO`, `FIN_INERTIA_CSS`, `KB975_*`, `*_CHARTER_PATH` (Sells), `COMMISSION_SELL_CONTROLLER_PATH`.

### (B) Valor DIVERGENTE cross-módulo → RENAME (guard travaria o valor errado)
⚠️ **Bug latente real:** sob descoberta global, o 1º arquivo a carregar vence e o 2º (warning, ignorado) passava a apontar pro **arquivo errado**. Guardar com `defined()` *perpetuaria* isso. Como cada const é usado só no próprio arquivo, renomeei decl + usos:
| Const (lado divergente) | Novo nome |
|---|---|
| `EDIT_CHARTER_PATH` / `EDIT_CONTROLLER_PATH` (Purchase) | `PURCHASE_*` |
| `EDIT_PAGE_PATH` (Produto) | `PRODUTO_EDIT_PAGE_PATH` |
| `PAGE_PATH` (Produto/Index) | `PRODUTO_INDEX_PAGE_PATH` |
| `SHOW_PAGE_PATH` (Produto) | `PRODUTO_SHOW_PAGE_PATH` |
| `SELLS_INDEX_PATH` (`__DIR__`-abs, FilterHintStale) | `SELLS_INDEX_PATH_ABS` |

Os lados Sells (mesmo valor) ficam: `EDIT_CHARTER_PATH` guardado; os demais viram declaração única → sem warning.

## Validação (CT 100 staging — nunca local)
Branch combinada (este + #2263), `php artisan test --filter='__nada_nomatch__'`:
- `Cannot redeclare` / `can not be used` / `Fatal`: **0**
- `Constant ... already defined`: **0** (antes: ~88)
- termina em `INFO  No tests found.`

Diff: **39 arquivos, +71/−71** (< 300 linhas, 1 intent). Refs **US-INFRA-033**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)