### PR TITLE
docs(feedback): reforça não-tocar-PR-fora-escopo (reincidência 2026-06-04)

### DIFF
--- a/memory/reference/feedback-nao-tocar-pr-fora-escopo.md
+++ b/memory/reference/feedback-nao-tocar-pr-fora-escopo.md
@@ -34,3 +34,27 @@ Padrão observado nesta sessão:
 - [ADR 0094](../decisions/0094-constituicao-v2-7-camadas-8-principios.md) §2 — Tiered cost (token não é grátis)
 - [publication-policy skill](../../.claude/skills/publication-policy/SKILL.md) — escala vs executa direto
 - Sessão de origem: 2026-05-26 pacote 11 CnabDrivers — PR #1599 Fiscal/Cockpit ignorado a pedido Wagner
+
+---
+
+## Reincidência 2026-06-04 — violei esta regra DE NOVO (mesma classe)
+
+> Wagner: *"Porque começou a pegar coisa que não era era sua?"* → *"Aprenda para não fazer novamente"*.
+
+**Escopo declarado da sessão:** corrigir 1 bug (`makeChannel` redeclare na suíte Pest). Só isso.
+
+**Como derrapei (cadeia):**
+1. Fiz o fix (#2251) — ✅ no escopo.
+2. Ao validar, achei `main` quebrada pelo #2256 (trait `RendersMockCowork` do Financeiro). **Avisar foi certo.**
+3. **Erro:** em vez de avisar e devolver pro dono, **peguei pra consertar** (#2260) → duplicou o #2261 que a sessão dona já estava fazendo.
+4. **Erro:** tratei `ci-monitor-event` de PR alheio (#2262, draft de outra sessão) como tarefa minha.
+5. **Erro:** tentei regen de baseline PHPStan (drift causado pelas mudanças de model da sessão do Financeiro) — nem reproduzível do meu ambiente.
+
+**Duas nuances NOVAS (que faltavam nesta regra):**
+
+- **"Main quebrada / risco de produção" NÃO é licença pra cruzar a raia.** A urgência justifica **avisar alto e claro** ("main quebrada, dono = sessão X"), não **consertar** trabalho de outra sessão. Flag-and-hand-off, não fix.
+- **Pedir "quer que eu assuma?" já é derrapagem.** Quando o trabalho é de outra raia, o default certo é **recomendar o hand-off** ("isso é da sessão Y, melhor eles fazerem"), não oferecer-me pra pegar. Mesmo com Wagner dizendo "sim", o resultado foi colisão + trabalho duplicado + tokens desperdiçados. A autorização não torna a ação correta.
+
+**Sinal de alerta pra mim mesmo:** se eu me pego dizendo *"achei outro problema, quer que eu conserte?"* sobre algo fora do escopo declarado → PARA. Reformula pra *"achei X, dono é Y, segue assim?"* e volto pro meu.
+
+**Agravante:** esta regra JÁ existia (origem 2026-05-26) e eu repeti mesmo assim. O fix não é mais um doc — é eu **checar o escopo declarado a cada ci-monitor/notification ANTES de agir**, como o passo "How to apply" já manda.


### PR DESCRIPTION
Reforça `memory/reference/feedback-nao-tocar-pr-fora-escopo.md` com o incidente de hoje: repeti a violação (a regra já existia desde 2026-05-26). Peguei trabalho de outra sessão (main quebrada #2256 → #2260 duplicou #2261; PR draft alheio #2262; baseline drift do Financeiro).

Adiciona 2 nuances que faltavam:
- **Urgência de produção ≠ licença pra cruzar a raia** — flag-and-hand-off, não fix.
- **"Pedir pra assumir" já é derrapagem** — o default é recomendar hand-off, não me oferecer; autorização não torna a ação correta.

> Nota: o check PHPStan deste PR pode aparecer vermelho por drift pré-existente na main (não relacionado a este doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)