### PR TITLE
fix(tests): guard FIN_* const collision dos novos Unificado*Test

### DIFF
--- a/Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php
+++ b/Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php
@@ -25,10 +25,10 @@ const FIN_BRIDGE_COMMENTS = __DIR__ . '/../../../../public/cowork-preview/_oimpr
 const FIN_BRIDGE_AUDIT = __DIR__ . '/../../../../public/cowork-preview/_oimpresso-bridge-audit.js';
 const FIN_CURATION_JSX_ONDA = __DIR__ . '/../../../../public/cowork-preview/financeiro-curation.jsx';
 const FIN_APP_JSX_ONDA = __DIR__ . '/../../../../public/cowork-preview/financeiro-app.jsx';
-const FIN_UNIFICADO_CONTROLLER = __DIR__ . '/../../Http/Controllers/UnificadoController.php';
-const FIN_ROUTES_WEB = __DIR__ . '/../../Routes/web.php';
-const FIN_TITULO_COMMENT_MODEL = __DIR__ . '/../../Models/TituloComment.php';
-const FIN_COMMENTS_MIGRATION = __DIR__ . '/../../Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php';
+defined('FIN_UNIFICADO_CONTROLLER') || define('FIN_UNIFICADO_CONTROLLER', __DIR__ . '/../../Http/Controllers/UnificadoController.php');
+defined('FIN_ROUTES_WEB') || define('FIN_ROUTES_WEB', __DIR__ . '/../../Routes/web.php');
+defined('FIN_TITULO_COMMENT_MODEL') || define('FIN_TITULO_COMMENT_MODEL', __DIR__ . '/../../Models/TituloComment.php');
+defined('FIN_COMMENTS_MIGRATION') || define('FIN_COMMENTS_MIGRATION', __DIR__ . '/../../Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php');
 
 describe('Mock Onda Comments DB — Bridge comments (estrutural)', function () {
     it('arquivo _oimpresso-bridge-comments.js existe', function () {

--- a/Modules/Financeiro/Tests/Feature/UnificadoCommentsAuditTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoCommentsAuditTest.php
@@ -29,10 +29,10 @@ uses(Tests\TestCase::class);
  * grupos — não boota app, sobrevive DB greenfield; + HTTP smoke real no fim.
  */
 
-const FIN_UNIFICADO_CONTROLLER = __DIR__ . '/../../Http/Controllers/UnificadoController.php';
-const FIN_ROUTES_WEB = __DIR__ . '/../../Routes/web.php';
-const FIN_TITULO_COMMENT_MODEL = __DIR__ . '/../../Models/TituloComment.php';
-const FIN_COMMENTS_MIGRATION = __DIR__ . '/../../Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php';
+defined('FIN_UNIFICADO_CONTROLLER') || define('FIN_UNIFICADO_CONTROLLER', __DIR__ . '/../../Http/Controllers/UnificadoController.php');
+defined('FIN_ROUTES_WEB') || define('FIN_ROUTES_WEB', __DIR__ . '/../../Routes/web.php');
+defined('FIN_TITULO_COMMENT_MODEL') || define('FIN_TITULO_COMMENT_MODEL', __DIR__ . '/../../Models/TituloComment.php');
+defined('FIN_COMMENTS_MIGRATION') || define('FIN_COMMENTS_MIGRATION', __DIR__ . '/../../Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php');
 
 describe('Comments + Audit — Backend Laravel (endpoints)', function () {
     it('UnificadoController tem 3 métodos: comments + addComment + auditTrail', function () {


### PR DESCRIPTION
Fecha o último resíduo do sweep de descoberta da suíte (#2263 + #2266).

#2262 adicionou `UnificadoCommentsAuditTest.php` que redeclara as 4 mesmas consts de `OndaCommentsAuditBridgeTest` (`FIN_UNIFICADO_CONTROLLER` / `FIN_ROUTES_WEB` / `FIN_TITULO_COMMENT_MODEL` / `FIN_COMMENTS_MIGRATION`, mesmos valores `__DIR__`) → 4 warnings `already defined`. O arquivo novo entrou **depois** do sweep #2266, por isso não foi coberto.

Fix: guard `defined() || define()` nos 2 arquivos (padrão #2266). Validado no CT 100 staging — descoberta termina em `No tests found`, **zero fatal, zero warning**. Refs US-INFRA-033.

🤖 Generated with [Claude Code](https://claude.com/claude-code)