### PR TITLE
docs(governance): anti-regressão do código — §5 rejeitados + gate pontuado (Opção B 1-2)

### DIFF
--- a/.claude/skills/module-completeness-audit/SKILL.md
+++ b/.claude/skills/module-completeness-audit/SKILL.md
@@ -4,11 +4,11 @@ mission: "Substituir auditoria humana de governança interna de módulo por chec
 description: ATIVAR antes de marcar US como `done` (`tasks-update task_id:US-XXX-NNN status:done` ou `tasks-update from:review to:done`), OU quando user pedir "auditar completude de {modulo}", "{modulo} está pronto?", "checklist de governança {modulo}", "/module-completeness-audit {modulo}", "está pronto pra fechar?", "vai poder marcar done?". Roda 8-10 verificações objetivas (multi-instance scope, permissions UI, charter, RUNBOOK, Pest cobertura, AuditLog write, business_id scope, browser MCP smoke salvo) cruzando código + memory/requisitos + Charter + browser MCP screenshots. Bloqueia transição se faltar item. Complementa skill `comparativo-do-modulo` (que detecta gaps mercado) — esta detecta gaps governança interna.
 type: process-skill
 status: active
-version: 1.0.0
+version: 1.1.0
 trust_level: L2
 owner: wagner
 created_at: 2026-05-10
-updated_at: 2026-05-10
+updated_at: 2026-06-05
 charter_adr: 0094
 parent_mission: "Toda skill substitui trabalho humano repetitivo com ROI provado, rumo ao ERP autônomo de R$ 10M em 24 meses."
 triggers_on:
@@ -49,7 +49,7 @@ related_adrs: [0089, 0093, 0095, 0101, 0104, 0110]
 
 # module-completeness-audit (v1.0)
 
-Skill que **bloqueia** a transição `review → done` de uma US se o módulo não cobrir o checklist objetivo de 8 dimensões de governança interna.
+Skill que **bloqueia** a transição `review → done` de uma US se o módulo não cobrir o checklist objetivo **pontuado** de 9 dimensões de governança interna (score estilo Bateria §9 do [`PROCESSO_MEMORIA_CC`](../../../prototipo-ui/PROCESSO_MEMORIA_CC.md): corte **≥90**, qualquer check **duro** ❌ = **INVÁLIDO**). É o gate pré-adoção (Peça 2 do anti-regressão do código, Opção B).
 
 Diferente de [`comparativo-do-modulo`](../comparativo-do-modulo/SKILL.md) (que mede gap **vs mercado**), esta mede gap **vs nossa própria Constituição v2** ([ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md)).
 
@@ -78,9 +78,9 @@ Pergunta dele: "como automatizar essas verificações? deveria ter uma maneira d
 - Comparar com mercado (use `comparativo-do-modulo`)
 - Criar módulo novo (use `criar-modulo`)
 
-## Os 8 itens do checklist
+## Os 9 itens do checklist (pontuados)
 
-Cada item é **binário** (✅/❌) com evidência citada em arquivo. Item 🟡 (parcial) conta como ❌ até evidência completa.
+Cada item é **binário** (✅/❌) com evidência citada em arquivo. Item 🟡 (parcial) conta como ❌ até evidência completa. **4 itens são DUROS** (#5, #7, #8, #9) — qualquer duro ❌ = **INVÁLIDO** (não fecha US), independente do score. Pontuação na §"Veredito" abaixo.
 
 ### 1. Multi-instance scope decidido e documentado
 
@@ -188,6 +188,33 @@ Cada item é **binário** (✅/❌) com evidência citada em arquivo. Item 🟡 
 - US done sem smoke (Wagner descobre quebrado pelo cliente)
 - Smoke só em local — não validou prod (ex: caso Whatsapp 2026-05-10 onde local mostrava inbox vazia mas prod tinha mensagens reais)
 
+### 9. Teste ancorado em CONTRATO, não no código (DURO — novo v1.1)
+
+**Pergunta:** Cada teste novo/alterado deriva de um contrato **externo** (SPEC / ADR / proibicoes / charter / casos) citado — e não da implementação?
+
+**Aprovado se:**
+- O teste cita no cabeçalho/doc-comment a fonte do contrato (ex: `@see ADR 0143` + a regra em português que ele prova)
+- A asserção corresponde à **regra do contrato**, não ao que a classe já faz
+- Invariante de negócio escrita a partir da proibição/SPEC, não copiada do comportamento atual
+
+**Reprovado se:**
+- Invariante/asserção extraída do código (tautológico) — passa ✅ mesmo se o comportamento estiver errado vs a intenção, **travando o drift** em vez de pegá-lo. Ver [§"Ideias avaliadas e DESCARTADAS"](../../../memory/proibicoes.md) entrada 2026-06-05 "Teste tautológico".
+- Teste sem nenhuma âncora de contrato citada.
+
+**Por que DURO:** teste tautológico é **pior que não ter teste** (catraca o desvio). NÚCLEO invariante 4 do método: *"Casos = contrato de não-regressão"*. Caso real: `FsmAuthorizationFlagPropertyTest` (2026-06-05) derivou invariantes da classe, não do contrato ADR 0143.
+
+## Veredito — pontuação (Bateria §9 portada)
+
+> Porta a régua do [`PROCESSO_MEMORIA_CC`](../../../prototipo-ui/PROCESSO_MEMORIA_CC.md) §9 pro mundo de código. **Não é bateria nova** — é a mesma lógica, sistema separado (Opção B).
+
+- **Peso:** cada check = 1 ponto. Os **4 duros (#5, #7, #8, #9) contam dobrado.** Total possível = **13**.
+- **Corte duro:** qualquer check DURO ❌ → **INVÁLIDO** (não fecha US), independente do score.
+- **Senão, pelo score%** (pontos ÷ 13):
+  - **≥90%** → ✅ APROVADO (pode marcar done)
+  - **75–89%** → 🟡 CONDICIONAL (corrige os ❌ e re-roda; não fecha ainda)
+  - **<75%** → ❌ INVÁLIDO
+- Score registrado no `AUDIT-LOG.md` junto do resultado (§7) — alimenta a métrica de drift (Peça 3).
+
 ## Os 7 passos do ciclo
 
 ### 1. Detectar trigger
@@ -227,11 +254,12 @@ Check 5 → Read phpunit.xml + Glob Modules/{Modulo}/Tests/ + Bash `vendor\bin\p
 Check 6 → Grep AuditLog::write em Modules/{Modulo}/Http/Controllers/
 Check 7 → Grep BelongsToBusiness + grep withoutGlobalScopes
 Check 8 → Glob memory/requisitos/{Modulo}/smoke/*.png (data > merge da US)
+Check 9 → grep doc-comment (@see/ADR/SPEC/proibicoes/charter) em cada *Test.php novo/alterado; conferir asserção vs regra do CONTRATO (não vs a classe)
 ```
 
 ### 4. Compilar resultado
 
-Tabela com 8 linhas:
+Tabela com 9 linhas + linha de **Veredito** (score/13 + duros ❌ se houver):
 
 ```markdown
 | # | Check | Status | Evidência | Próximo passo |
@@ -246,8 +274,9 @@ Tabela com 8 linhas:
 ```
 🔍 Audit completude — Modules/{Modulo} ({task_id ou "módulo inteiro"})
 
-✅ Aprovados: {N}/8
-❌ Reprovados: {M}
+✅ Aprovados: {N}/9  ·  Score: {pontos}/13 ({pct}%)
+❌ Reprovados: {M}  {duros ❌: [#5/#7/#8/#9] se houver}
+Veredito: {APROVADO ≥90 / CONDICIONAL 75-89 / INVÁLIDO <75 OU qualquer duro ❌}
 
 Reprovados:
 - #2 Permissions UI: {evidência curta}
@@ -296,7 +325,7 @@ Atualizar `metrics:` no frontmatter desta skill.
 Resultado: {APROVADO ✅ / BLOQUEADO ❌}
 
 [se aprovado]
-✅ 8/8 checks passaram. Pode marcar US-XXX-NNN como done.
+✅ 9/9 checks · score 13/13 (100%). Pode marcar US-XXX-NNN como done.
 
 [se bloqueado]
 ❌ {M} reprovados. Bloqueio transição review→done.

--- a/memory/proibicoes.md
+++ b/memory/proibicoes.md
@@ -216,6 +216,22 @@
 
 Skill pareada (cultural, Tier B auto-trigger): [`.claude/skills/smoke-prod-evidence/SKILL.md`](../.claude/skills/smoke-prod-evidence/SKILL.md).
 
+## Ideias avaliadas e DESCARTADAS — não re-propor (registro de regressões · equiv. §5 do PROCESSO_MEMORIA_CC)
+
+> **Por que existe:** o método de design ([`prototipo-ui/PROCESSO_MEMORIA_CC.md`](../prototipo-ui/PROCESSO_MEMORIA_CC.md) §5) tem um registro de "tentei, reprovou, não repete". O mundo de **código** não tinha equivalente — então uma sessão futura **re-propõe ideia morta** e regride na prática. Este é o §5 do código (Opção B: sistema separado do design, mesmo princípio). **Antes de propor abordagem técnica, conferir aqui; se bater, eu mesmo barro e cito a entrada.**
+>
+> Estrutura de cada entrada (igual ao §5): **o que foi tentado · por que caiu · o limite (a variante parecida também é proibida)**. Append-only — nada sai daqui sem ADR explícito.
+
+### 2026-06-05 — Roadmap/plano de evolução PARALELO a canon existente
+- **O que foi tentado:** criar um roadmap de evolução (design + teste) num doc novo, em paralelo ao [`AUTOMATION-ROADMAP.md`](requisitos/_DesignSystem/AUTOMATION-ROADMAP.md) (que já tem Ondas) — e um roadmap de teste órfão sem casa.
+- **Por que caiu:** viola o gate **T6 (DURO)** do método — *"evoluindo o que EXISTE, não criando paralelo; 1 tema = 1 doc"*. Dois roadmaps competindo pelo mesmo juiz = fragmentação (a dor que Wagner levantou: "não saber onde está nada").
+- **O limite (variante também proibida):** qualquer doc de plano/roadmap/SPEC novo que **duplique** roadmap/SPEC/ADR já existente. Antes de criar plano, achar o canon dono do tema e **estender** (nova Onda/seção), nunca abrir paralelo.
+
+### 2026-06-05 — Teste que deriva do CÓDIGO (tautológico) em vez do contrato
+- **O que foi tentado:** property test (`FsmAuthorizationFlagPropertyTest`) cujas invariantes foram extraídas do que a classe **faz hoje**, não de um contrato independente ([ADR 0143](decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) + §"FSM Pipeline Canônico" deste arquivo).
+- **Por que caiu:** teste derivado do código é tautológico — passa ✅ mesmo se o comportamento estiver errado vs a intenção, e **trava (catraca) o desvio** em vez de pegá-lo. Pior que não ter teste. (NÚCLEO invariante 4 do método: *"Casos = contrato de não-regressão"*.)
+- **O limite (variante também proibida):** qualquer teste cuja asserção venha da implementação (ou do palpite do agente) e não de um contrato externo (SPEC / ADR / proibicoes / charter / casos). **Teste sem âncora de contrato citada = rejeitado** no gate pré-adoção (Peça 2).
+
 ## Sempre fazer
 
 - ✅ **PT-BR em tudo** — texto, commit, comentário, label. Código em inglês ok; domínio negócio em PT (`Marcacao`, `Intercorrencia`, `BancoHoras`)


### PR DESCRIPTION
## O que é

**Opção B (Wagner, 2026-06-05)** — dar ao mundo de **código** as 2 peças anti-regressão que o método de design ([`PROCESSO_MEMORIA_CC.md`](prototipo-ui/PROCESSO_MEMORIA_CC.md)) já tinha e o código não, **sem inchar** o método de design (sistemas separados, mesmo princípio).

Origem: sessão onde o plano de evolução foi gerado **sem** pré-flight de charter/regras → quase entrou roadmap paralelo + teste tautológico. Wagner: *"sem a real documentação… sempre vai ficar brigando com a IA pra centrar ela. pode ver o que eu já construí pra não acontecer isso."*

## Peça 1 — Registro de rejeitados (equiv. §5)

Nova seção em [`memory/proibicoes.md`](memory/proibicoes.md): **"Ideias avaliadas e DESCARTADAS — não re-propor"**, estrutura idêntica ao §5 (*o que · por que caiu · o limite*). Semeada com as 2 regressões reais nascidas na própria sessão:
1. **Roadmap paralelo a canon existente** → cai por T6.
2. **Teste tautológico** (deriva do código) → cai por invariante 4.

## Peça 2 — Gate pré-adoção pontuado (equiv. Bateria §9)

Estende `module-completeness-audit` v1.0→v1.1:
- **Check 9 (DURO):** "Teste ancorado em contrato, não no código" — barra teste tautológico, linka pro §5.
- **Veredito pontuado** portado da Bateria §9: 9 checks, **4 duros** (#5/#7/#8/#9) dobrados (total 13), corte **≥90 APROVADO / 75-89 CONDICIONAL / <75 INVÁLIDO**, qualquer duro ❌ = INVÁLIDO.

## Respeitou o próprio princípio

T6 obedecido: **estendi `proibicoes.md` e a skill que já existiam**, não criei doc/sistema paralelo — o registro de regressões nasceu seguindo a regra que ele mesmo cataloga.

## Fora de escopo (PR próprio)

**Peça 3** (métrica de drift: recidiva + escapes-a-[W]) — é maior, precisa de substrato de dados (computa a partir do §5 + AUDIT-LOG desta PR). Fica pra PR separado.

<!-- no-ui-smoke: docs-only, não toca resources/js nem .css -->
