### PR TITLE
fix(contacts): incluir "other" nos whitelists $types e $inertiaTypes (ADR 0246)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -257,11 +257,13 @@ class ContactController extends Controller
 
         $type = request()->get('type');
 
-        // ADR 0188 (multi-type 2026-05-24) + Wagner 2026-05-25: whitelist canon canônica
-        // alinhada com $inertiaTypes abaixo (linha ~237). Antes era ['supplier', 'customer']
+        // ADR 0188 (multi-type 2026-05-24) + ADR 0246 (Outros 2026-06-03) + Wagner 2026-05-25:
+        // whitelist canon alinhada com $inertiaTypes abaixo. Antes era ['supplier', 'customer']
         // UPOS legacy → /contacts?type=all/employee/representative caía em redirect()->back()
         // (bug: usuário em /sells clicava em "Contatos" sidebar → voltava pra /sells).
-        $types = ['supplier', 'customer', 'employee', 'representative', 'all'];
+        // ADR 0246: adicionado 'other' — sem isso, ?type=other rejeitado e cai default 'customer'
+        // (bug Wagner reportou 2026-06-04 pós-deploy PR #2205: aba Outros mostrava Clientes).
+        $types = ['supplier', 'customer', 'employee', 'representative', 'other', 'all'];
 
         if (empty($type) || ! in_array($type, $types)) {
             return redirect()->back();
@@ -293,7 +295,8 @@ class ContactController extends Controller
         // Spatie permanecem mapeadas pra 'customer.*' (UPOS legacy) por simplicidade
         // operacional — Wagner expande pra 'supplier.*' etc em ondas futuras se time
         // pedir granularidade por papel.
-        $inertiaTypes = ['customer', 'supplier', 'employee', 'representative', 'all'];
+        // ADR 0188 + ADR 0246 — 5 papéis canônicos + 'all' agregado.
+        $inertiaTypes = ['customer', 'supplier', 'employee', 'representative', 'other', 'all'];
         if (in_array($type, $inertiaTypes, true) && $this->shouldRenderInertiaCliente('cliente_index', (int) $business_id)) {
             return Inertia::render('Cliente/Index', [
                 'activeType' => $type,


### PR DESCRIPTION
## Resumo

Hotfix do PR #2205 (ADR 0246 — tipo "Outros"). Wagner reportou em prod 2026-06-04 que clicar na aba "Outros" do `/cliente` mostrava registros de Clientes.

## Diagnóstico

`ContactController::index()` tem 2 whitelists que validam o param `?type=`:

```php
// linha 264 — validation: se type não está aqui, redirect()->back()
$types = ['supplier', 'customer', 'employee', 'representative', 'all'];

// linha 296 — gate Inertia render
$inertiaTypes = ['customer', 'supplier', 'employee', 'representative', 'all'];
```

Eu adicionei `'other' => 'is_other'` no array `$flagColumn` de `applyContactTypeFilter` (PR #2205), mas esqueci destes 2 whitelists. Resultado: `?type=other` rejeitado → cai no default `'customer'`.

## Fix

Adiciona `'other'` em ambos arrays. Comportamento esperado:
- `?type=other` → passa validation → render Inertia → `applyContactTypeFilter('other')` → `WHERE is_other=1`

Sem mudança schema. Pest `IsOtherFlagTest` (já mergeado) continua cobrindo backend correto.

## Test plan

- [ ] CI verde
- [ ] Deploy automático Hostinger
- [ ] Smoke prod Wagner: aba "Outros" mostra 0 cadastros (esperado — sem `is_other=1` ainda)
- [ ] Regression adjacent: abas Clientes/Fornec./Equipe/Repr. continuam mostrando seus tipos

Refs: PR #2205 · [ADR 0246](memory/decisions/0246-tipo-outros-default-migracoes-legacy.md) · [ADR 0188](memory/decisions/0188-contacts-multi-type-flag-aditiva.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)