### PR TITLE
feat(sells): veículo na venda direta de oficina — seletor + cadastro rápido + placa na consulta (ADR 0251)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/VehicleController.php
+++ b/Modules/OficinaAuto/Http/Controllers/VehicleController.php
@@ -163,7 +163,7 @@ class VehicleController extends Controller
         ]);
     }
 
-    public function store(StoreVehicleRequest $request): RedirectResponse
+    public function store(StoreVehicleRequest $request): RedirectResponse|\Illuminate\Http\JsonResponse
     {
         // D8 Security Wave 15: authorize() rodou no FormRequest (Spatie permission check).
         // abort_unless mantido como defense-in-depth caso FormRequest::authorize seja burlado.
@@ -175,6 +175,23 @@ class VehicleController extends Controller
 
         // business_id é setado automaticamente pelo Model::creating hook (ADR 0093)
         $vehicle = Vehicle::create($request->validated());
+
+        // ADR 0251 — quick-add da venda (QuickAddVehicleSheet) faz fetch direto (não
+        // Inertia router) pra NÃO perder o draft da venda; espera JSON com o veículo
+        // criado. Gate `wantsJson() && !X-Inertia` distingue do form Inertia normal
+        // (que manda X-Requested-With mas Accept:text/html + header X-Inertia) — sem
+        // isso o redirect do fluxo padrão quebraria.
+        if ($request->wantsJson() && ! $request->header('X-Inertia')) {
+            return response()->json([
+                'success' => true,
+                'data' => [
+                    'id'              => (int) $vehicle->id,
+                    'plate'           => $vehicle->plate,
+                    'secondary_plate' => $vehicle->secondary_plate,
+                    'vehicle_type'    => $vehicle->vehicle_type,
+                ],
+            ]);
+        }
 
         return redirect('/oficina-auto/veiculos/' . $vehicle->id)
             ->with('status', ['success' => 1, 'msg' => 'Veículo cadastrado.']);

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -2425,6 +2425,7 @@ class ContactController extends Controller
             // Schema::hasTable degrada gracioso quando OficinaAuto não está instalado
             // (sem catálogo, o seletor some) em vez de quebrar a busca de cliente.
             // Vehicle tem global scope por business_id (ADR 0093) — Tier 0 automático.
+            $vehiclesByContact = collect();
             if (\Illuminate\Support\Facades\Schema::hasTable('vehicles') && $contacts->isNotEmpty()) {
                 $contactIds = $contacts->pluck('id')->all();
                 $vehiclesByContact = \Modules\OficinaAuto\Entities\Vehicle::query()
@@ -2432,21 +2433,26 @@ class ContactController extends Controller
                     ->orderByDesc('id')
                     ->get(['id', 'contact_id', 'plate', 'secondary_plate', 'vehicle_type'])
                     ->groupBy('contact_id');
-
-                $contacts->each(function ($c) use ($vehiclesByContact) {
-                    $c->vehicles = ($vehiclesByContact[$c->id] ?? collect())
-                        ->map(fn ($v) => [
-                            'id'              => (int) $v->id,
-                            'plate'           => $v->plate,
-                            'secondary_plate' => $v->secondary_plate,
-                            'vehicle_type'    => $v->vehicle_type,
-                        ])
-                        ->values()
-                        ->all();
-                });
             }
 
-            return json_encode($contacts);
+            // Mapeia pra array (em vez de setar propriedade dinâmica no Model — Larastan
+            // acusaria App\Contact::$vehicles undefined) anexando vehicles[] por contato.
+            $payload = $contacts->map(function ($c) use ($vehiclesByContact) {
+                $arr = $c->toArray();
+                $arr['vehicles'] = collect($vehiclesByContact->get($c->id) ?? [])
+                    ->map(fn ($v) => [
+                        'id'              => (int) $v->id,
+                        'plate'           => $v->plate,
+                        'secondary_plate' => $v->secondary_plate,
+                        'vehicle_type'    => $v->vehicle_type,
+                    ])
+                    ->values()
+                    ->all();
+
+                return $arr;
+            });
+
+            return json_encode($payload);
         }
     }
 

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -2417,6 +2417,35 @@ class ContactController extends Controller
             }
             $contacts = $contacts->get();
 
+            // ADR 0251 — catálogo de veículos do cliente p/ o seletor de veículo na
+            // venda direta de oficina (Sells/Create). Query separada + map (mesmo
+            // padrão do vehiclesCountMap) porque o select() acima é custom + leftjoin.
+            //
+            // BLINDAGEM: este endpoint é COMPARTILHADO com o Blade legado. Guard
+            // Schema::hasTable degrada gracioso quando OficinaAuto não está instalado
+            // (sem catálogo, o seletor some) em vez de quebrar a busca de cliente.
+            // Vehicle tem global scope por business_id (ADR 0093) — Tier 0 automático.
+            if (\Illuminate\Support\Facades\Schema::hasTable('vehicles') && $contacts->isNotEmpty()) {
+                $contactIds = $contacts->pluck('id')->all();
+                $vehiclesByContact = \Modules\OficinaAuto\Entities\Vehicle::query()
+                    ->whereIn('contact_id', $contactIds)
+                    ->orderByDesc('id')
+                    ->get(['id', 'contact_id', 'plate', 'secondary_plate', 'vehicle_type'])
+                    ->groupBy('contact_id');
+
+                $contacts->each(function ($c) use ($vehiclesByContact) {
+                    $c->vehicles = ($vehiclesByContact[$c->id] ?? collect())
+                        ->map(fn ($v) => [
+                            'id'              => (int) $v->id,
+                            'plate'           => $v->plate,
+                            'secondary_plate' => $v->secondary_plate,
+                            'vehicle_type'    => $v->vehicle_type,
+                        ])
+                        ->values()
+                        ->all();
+                });
+            }
+
             return json_encode($contacts);
         }
     }

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -934,11 +934,14 @@ class SellController extends Controller
         // OficinaAuto DataController::modifyAdminMenu): superadmin vê se módulo instalado;
         // demais via hasThePermissionInSubscription('oficina_auto_module'). Vestuário
         // (ROTA LIVRE biz=4) NÃO habilita → seletor de veículo nem aparece (Tier 0 ADR 0093).
+        // Instância local de ModuleUtil (mesmo pattern do DataController) — evita
+        // somar acessos a $this->moduleUtil baselined no PHPStan ratchet.
+        $oficinaModuleUtil = new \App\Utils\ModuleUtil();
         $has_oficina_auto = false;
         if (auth()->user()->can('superadmin')) {
-            $has_oficina_auto = $this->moduleUtil->isModuleInstalled('OficinaAuto');
+            $has_oficina_auto = $oficinaModuleUtil->isModuleInstalled('OficinaAuto');
         } else {
-            $has_oficina_auto = (bool) $this->moduleUtil->hasThePermissionInSubscription(
+            $has_oficina_auto = (bool) $oficinaModuleUtil->hasThePermissionInSubscription(
                 $business_id,
                 'oficina_auto_module',
                 'superadmin_package'

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -1296,8 +1296,22 @@ class SellController extends Controller
                 ->map(fn($group) => $group->first());
         }
 
+        // ADR 0251 — placa do veículo por venda (consulta). Lookup separado guardado
+        // por hasColumn/hasTable (degrada gracioso pré-migration ou OficinaAuto ausente,
+        // inclusive no SQLite do Pest). Scoped por business_id (Tier 0 ADR 0093).
+        $vehiclePlateByTx = collect();
+        if (! empty($txIds)
+            && \Illuminate\Support\Facades\Schema::hasColumn('transactions', 'vehicle_id')
+            && \Illuminate\Support\Facades\Schema::hasTable('vehicles')) {
+            $vehiclePlateByTx = \DB::table('transactions')
+                ->join('vehicles', 'vehicles.id', '=', 'transactions.vehicle_id')
+                ->whereIn('transactions.id', $txIds)
+                ->where('vehicles.business_id', $business_id)
+                ->pluck('vehicles.plate', 'transactions.id');
+        }
+
         $rows = $rows
-            ->map(function ($r) use ($fiscalByTx) {
+            ->map(function ($r) use ($fiscalByTx, $vehiclePlateByTx) {
                 // Calcula overdue inline (boolean derivado, evita re-query).
                 $overdue = false;
                 $daysToDue = null;
@@ -1438,6 +1452,9 @@ class SellController extends Controller
                         default   => 'Balcão',
                     },
                     'os_ref' => $r->os_ref,
+                    // ADR 0251 — placa do veículo (venda direta de oficina). null quando
+                    // a venda não tem veículo; frontend renderiza a plaquinha Mercosul.
+                    'vehicle_plate' => $vehiclePlateByTx->get($r->id),
                 ];
             });
 
@@ -2444,6 +2461,18 @@ class SellController extends Controller
                     'id' => (int) $sell->location_id,
                     'name' => optional(\App\BusinessLocation::find($sell->location_id))->name,
                 ] : null,
+                // ADR 0251 — veículo da venda direta de oficina (placa na consulta).
+                // Vehicle tem global scope por business_id (Tier 0). Guard hasColumn/
+                // hasTable degrada gracioso (pré-migration ou OficinaAuto ausente → null).
+                'vehicle' => (\Illuminate\Support\Facades\Schema::hasColumn('transactions', 'vehicle_id')
+                    && $sell->vehicle_id
+                    && \Illuminate\Support\Facades\Schema::hasTable('vehicles'))
+                    ? optional(\Modules\OficinaAuto\Entities\Vehicle::find($sell->vehicle_id), fn ($v) => [
+                        'id' => (int) $v->id,
+                        'plate' => (string) $v->plate,
+                        'secondary_plate' => $v->secondary_plate,
+                    ])
+                    : null,
             ];
 
             // Detail payload já calculado acima — encapsular pra defer.

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -930,6 +930,24 @@ class SellController extends Controller
             $types_of_service = TypesOfService::forDropdown($business_id);
         }
 
+        // ADR 0251 — Veículo na venda (oficina). Gate per-business CANÔNICO (mesmo de
+        // OficinaAuto DataController::modifyAdminMenu): superadmin vê se módulo instalado;
+        // demais via hasThePermissionInSubscription('oficina_auto_module'). Vestuário
+        // (ROTA LIVRE biz=4) NÃO habilita → seletor de veículo nem aparece (Tier 0 ADR 0093).
+        $has_oficina_auto = false;
+        if (auth()->user()->can('superadmin')) {
+            $has_oficina_auto = $this->moduleUtil->isModuleInstalled('OficinaAuto');
+        } else {
+            $has_oficina_auto = (bool) $this->moduleUtil->hasThePermissionInSubscription(
+                $business_id,
+                'oficina_auto_module',
+                'superadmin_package'
+            );
+        }
+        $vehicle_types = ($has_oficina_auto && class_exists(\Modules\OficinaAuto\Http\Controllers\VehicleController::class))
+            ? \Modules\OficinaAuto\Http\Controllers\VehicleController::vehicleTypes()
+            : [];
+
         //Accounts
         $accounts = [];
         if ($this->moduleUtil->isModuleEnabled('account')) {
@@ -999,6 +1017,9 @@ class SellController extends Controller
                 'customerGroups'       => $customer_groups,
                 'accounts'             => $accounts,
                 'typesOfService'       => $types_of_service,
+                // ADR 0251 — veículo na venda direta de oficina (gated per-business).
+                'hasOficinaAuto'       => $has_oficina_auto,
+                'vehicleTypes'         => $vehicle_types,
                 'users'                => $users,
                 'permissions'          => [
                     'editDiscount' => true,  // SellController não tem flag separado (pos screen é só SellPosController)

--- a/app/Utils/TransactionUtil.php
+++ b/app/Utils/TransactionUtil.php
@@ -117,6 +117,9 @@ class TransactionUtil extends Util
             'rp_redeemed_amount' => ! empty($input['rp_redeemed_amount']) ? $input['rp_redeemed_amount'] : 0,
             'is_created_from_api' => ! empty($input['is_created_from_api']) ? 1 : 0,
             'types_of_service_id' => ! empty($input['types_of_service_id']) ? $input['types_of_service_id'] : null,
+            // ADR 0251 — veículo na venda direta de oficina (nullable; só vem quando
+            // OficinaAuto habilitado + vendedor selecionou/cadastrou veículo).
+            'vehicle_id' => ! empty($input['vehicle_id']) ? $input['vehicle_id'] : null,
             'packing_charge' => ! empty($input['packing_charge']) ? $input['packing_charge'] : 0,
             'packing_charge_type' => ! empty($input['packing_charge_type']) ? $input['packing_charge_type'] : null,
             'service_custom_field_1' => ! empty($input['service_custom_field_1']) ? $input['service_custom_field_1'] : null,
@@ -238,6 +241,9 @@ class TransactionUtil extends Util
             'rp_redeemed' => ! empty($input['rp_redeemed']) ? $input['rp_redeemed'] : 0,
             'rp_redeemed_amount' => ! empty($input['rp_redeemed_amount']) ? $input['rp_redeemed_amount'] : 0,
             'types_of_service_id' => ! empty($input['types_of_service_id']) ? $input['types_of_service_id'] : null,
+            // ADR 0251 — veículo na venda direta de oficina (nullable; só vem quando
+            // OficinaAuto habilitado + vendedor selecionou/cadastrou veículo).
+            'vehicle_id' => ! empty($input['vehicle_id']) ? $input['vehicle_id'] : null,
             'packing_charge' => ! empty($input['packing_charge']) ? $input['packing_charge'] : 0,
             'packing_charge_type' => ! empty($input['packing_charge_type']) ? $input['packing_charge_type'] : null,
             'service_custom_field_1' => ! empty($input['service_custom_field_1']) ? $input['service_custom_field_1'] : null,

--- a/database/migrations/2026_06_05_120000_add_vehicle_id_to_transactions.php
+++ b/database/migrations/2026_06_05_120000_add_vehicle_id_to_transactions.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0192 (extensão) — Veículo na venda direta de oficina.
+ *
+ * Schema aditivo: liga uma venda (transaction) a 1 veículo do catálogo
+ * `vehicles` (Modules/OficinaAuto). Pareia com `source`/`os_ref` (migration
+ * 2026_05_25_140000): aquela cobre a venda DERIVADA de OS (OS→Venda); esta
+ * cobre a venda DIRETA de balcão de oficina, onde o vendedor seleciona/cadastra
+ * o veículo no próprio /sells/create sem abrir OS.
+ *
+ *   vehicle_id  BIGINT UNSIGNED  NULL  AFTER os_ref
+ *   FK vehicle_id → vehicles.id  ON DELETE SET NULL  (preserva a venda se o
+ *                                                     veículo for removido)
+ *   INDEX idx_transactions_vehicle (business_id, vehicle_id)
+ *
+ * nullable + default null retroativo = zero breaking change (vendas de
+ * vestuário/balcão comum nunca têm veículo; a coluna fica NULL).
+ *
+ * Multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL: business_id PRIMEIRO no índice;
+ * todas queries continuam scoped por business global scope. O Vehicle model
+ * já tem global scope por business_id — leak cross-tenant impossível.
+ *
+ * FK guardada por Schema::hasTable('vehicles'): se OficinaAuto não estiver
+ * instalado num ambiente, a coluna é criada mesmo assim (fica sempre NULL) e
+ * a FK é pulada — degrada gracioso sem quebrar a migration.
+ *
+ * IDEMPOTENTE — Schema::hasColumn + SHOW INDEXES checks protegem re-execução.
+ * down() reverte sem perda de dados.
+ *
+ * @see memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see Modules/OficinaAuto/Entities/Vehicle.php
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (! Schema::hasColumn('transactions', 'vehicle_id')) {
+                $after = Schema::hasColumn('transactions', 'os_ref') ? 'os_ref' : 'id';
+                $table->unsignedBigInteger('vehicle_id')
+                    ->nullable()
+                    ->after($after)
+                    ->comment('Veículo do catálogo OficinaAuto na venda direta de oficina · ext ADR 0192');
+            }
+        });
+
+        // FK só quando a tabela vehicles existe (OficinaAuto instalado).
+        if (Schema::hasTable('vehicles')) {
+            $fks = collect(DB::select('SHOW CREATE TABLE transactions'))
+                ->first();
+            $createSql = $fks->{'Create Table'} ?? '';
+            if (! str_contains((string) $createSql, 'fk_transactions_vehicle')) {
+                Schema::table('transactions', function (Blueprint $table) {
+                    $table->foreign('vehicle_id', 'fk_transactions_vehicle')
+                        ->references('id')->on('vehicles')
+                        ->nullOnDelete();
+                });
+            }
+        }
+
+        // Índice composto Tier 0 multi-tenant (ADR 0093): business_id PRIMEIRO.
+        Schema::table('transactions', function (Blueprint $table) {
+            $existing = collect(DB::select('SHOW INDEXES FROM transactions'))
+                ->pluck('Key_name')
+                ->toArray();
+
+            if (! in_array('idx_transactions_vehicle', $existing, true)) {
+                $table->index(['business_id', 'vehicle_id'], 'idx_transactions_vehicle');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $createSql = (string) (collect(DB::select('SHOW CREATE TABLE transactions'))->first()->{'Create Table'} ?? '');
+            if (str_contains($createSql, 'fk_transactions_vehicle')) {
+                $table->dropForeign('fk_transactions_vehicle');
+            }
+
+            $existing = collect(DB::select('SHOW INDEXES FROM transactions'))
+                ->pluck('Key_name')
+                ->toArray();
+            if (in_array('idx_transactions_vehicle', $existing, true)) {
+                $table->dropIndex('idx_transactions_vehicle');
+            }
+
+            if (Schema::hasColumn('transactions', 'vehicle_id')) {
+                $table->dropColumn('vehicle_id');
+            }
+        });
+    }
+};

--- a/memory/decisions/0251-veiculo-na-venda-direta-oficina.md
+++ b/memory/decisions/0251-veiculo-na-venda-direta-oficina.md
@@ -1,0 +1,80 @@
+---
+slug: 0251-veiculo-na-venda-direta-oficina
+number: 251
+title: "Veículo na venda direta de oficina (transactions.vehicle_id) — extensão da Integração Vendas × Oficina"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-06-05"
+accepted_at: "2026-06-05"
+accepted_via: "Wagner pediu a feature ('vamos colocar veículo na venda') e escolheu o schema via AskUserQuestion nesta sessão: opção 'Sim, vehicle_id em transactions' (coluna nullable + FK, mesmo padrão de source/os_ref). Sequência confirmada: feature numa branch nova do fresh main."
+module: sells
+quarter: 2026-Q2
+tags: [sells, oficinaauto, vehicle, cross-module, multi-tenant, tier-0, schema, kb-9.75]
+supersedes: []
+supersedes_partially: []
+amends: []
+superseded_by: []
+related: [0192-auto-faturar-os-venda-jobsheet-observer, 0093-multi-tenant-isolation-tier-0, 0137-oficinaauto-qualificada]
+---
+
+# ADR 0251 — Veículo na venda direta de oficina (`transactions.vehicle_id`)
+
+## Contexto
+
+Numa oficina, ao vender peça/serviço, é preciso saber **qual veículo** está em
+atendimento. Hoje o veículo (`Modules/OficinaAuto`, tabela `vehicles`, multi-placa
+cavalo+reboque) só é selecionado **na OS** (`service_orders.vehicle_id` NOT NULL).
+A OS depois vira venda via `transaction_sell_line_id` ([ADR 0192](0192-auto-faturar-os-venda-jobsheet-observer.md)).
+
+Lacuna (Wagner, 2026-06-05): a **venda direta de balcão de oficina** — vender uma
+peça/serviço rápido **sem abrir a OS Kanban completa** — não tem onde registrar o
+veículo. As 8 telas de venda (`/sells/*`) não têm campo de veículo (confirmado:
+ausente em todo código e em todo o histórico do git). O protótipo Cowork
+(`prototipo-ui/vendas-page.jsx`) chegou a desenhar "Veículo (placa)" mas nunca foi
+pra produção.
+
+## Decisão
+
+1. **Coluna `transactions.vehicle_id`** (BIGINT UNSIGNED, **nullable**, FK →
+   `vehicles.id` `ON DELETE SET NULL`). Liga 1 venda a 1 veículo. Pareia com
+   `source`/`os_ref` (ADR 0192): aquela cobre a venda **derivada** de OS; esta a
+   venda **direta**. `vehicle_id` único (1 veículo por venda) — não pivot.
+   - FK guardada por `Schema::hasTable('vehicles')` (degrada gracioso se OficinaAuto
+     não instalado num ambiente); índice composto `(business_id, vehicle_id)` Tier 0.
+2. **Seletor na `/sells/create`** consome `contact.vehicles[]` (eager-load guardado
+   por `Schema::hasTable`, mesmo padrão do `vehiclesCountMap` já existente no
+   `getCustomers`), exibe a **plaquinha `MercosulPlate`** (promovida de OficinaAuto
+   pra `@/Components/shared`).
+3. **Cadastro rápido sem perder a venda** — `QuickAddVehicleSheet` (espelha
+   `QuickAddCustomerSheet`: fetch direto + CSRF, não Inertia router) POST num branch
+   JSON de `VehicleController::store` com `contact_id` pré-preenchido; o veículo novo
+   entra selecionado.
+4. **Gate multi-tenant** ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)): toda a
+   UI de veículo só aparece quando o módulo **OficinaAuto está habilitado** pro
+   business — vestuário (ROTA LIVRE biz=4) **não vê** (zero ruído), exatamente como
+   o tipo-de-serviço.
+5. **Consulta** (`Sells/Index` + `Sells/Show`) exibe a `MercosulPlate` quando a venda
+   tem `vehicle_id`.
+
+## Consequências
+
+- **Positivas:** venda direta de oficina vira completa; reusa 100% do que existe
+  (vehicles, MercosulPlate, ClienteVeiculosController, padrão QuickAdd); zero
+  breaking change retroativo (coluna NULL nas vendas legadas/vestuário).
+- **Tier 0 preservado:** `Vehicle` já tem global scope por `business_id`; o índice e
+  a FK respeitam o isolamento; eager-load guardado.
+- **Custo:** +1 coluna nullable + 1 FK + 1 índice em `transactions`; nenhuma tabela
+  nova. A emissão fiscal do veículo (se algum dia entrar em NF-e) fica fora de escopo
+  aqui (pareia com o gatilho cMun que ADR 0192/US-SELL-044 trata).
+- **Reversível:** `down()` dropa FK + índice + coluna sem perda de dados.
+
+## Alternativas descartadas
+
+- **Tabela ponte `transaction_vehicle`** (N veículos/venda): overkill — 1 venda
+  direta = 1 veículo em atendimento. Se algum dia precisar N, migra-se sem perder a
+  coluna (vira denormalização do "principal").
+- **Forçar passar pela OS sempre:** rejeitado — a dor é justamente a venda rápida de
+  balcão sem o peso da OS Kanban.

--- a/memory/requisitos/Sells/BRIEFING.md
+++ b/memory/requisitos/Sells/BRIEFING.md
@@ -12,6 +12,7 @@ Módulo de vendas — wrapper KB-9.75 sobre `Transaction(type='sell')` UltimateP
 
 - **Sells/Index** (`A+ · 9,75/10` KB-9.75 v2 · PR #1064) — lista vendas com KPI hero, saved tree, filtros, hover-reveal actions
 - **Sells/Create** (`A+ · 9,75/10`) — checkout balcão com search produto + cliente + payment
+- **Veículo na venda** ([ADR 0251](../../decisions/0251-veiculo-na-venda-direta-oficina.md) · 2026-06-05) — venda direta de oficina seleciona/cadastra o veículo do cliente sem abrir OS: seletor com plaquinha Mercosul (reusada do OficinaAuto) + `QuickAddVehicleSheet` (cadastro rápido sem perder a venda) na `Sells/Create`, placa na consulta (Index + Show). Schema `transactions.vehicle_id` nullable + FK. **Gated per-business** (vestuário/ROTA LIVRE não vê)
 - **Sells/Edit** — edição venda existente + Wave Z-2 `commission_split` editor (2 selects mecânico/balcão + 2 inputs % · validation total=100 server-side)
 - **Sells/Quotations / Drafts / Show / Subscriptions** — variações da entidade `Transaction`
 - **Integração Vendas × Oficina** ([ADR 0192](../../decisions/0192-auto-faturar-os-venda-jobsheet-observer.md) · Wave Z-2 mergeada 2026-05-25):

--- a/resources/js/Components/shared/MercosulPlate.tsx
+++ b/resources/js/Components/shared/MercosulPlate.tsx
@@ -1,0 +1,62 @@
+// Placa estilo Mercosul (visual, não literal) — espelha .ofc-plate do
+// protótipo Cowork canon (prototipo-ui/prototipos/producao-oficina/visual-source.html).
+//
+// Componente puro display — sem state, sem fetch. Reusável em qualquer card
+// que mostre placa de veículo. PROMOVIDO de OficinaAuto/ProducaoOficina pra
+// shared (ADR 0251) pra Sells (venda com veículo) usar a MESMA plaquinha.
+// O caminho antigo `OficinaAuto/.../MercosulPlate` é um re-export deste.
+//
+// Estrutura visual:
+//   ┌─────────────────┐
+//   │ BR · MERCOSUL   │ ← top: blue Mercosul
+//   ├─────────────────┤
+//   │   ABC-1D23      │ ← num: white bg, mono bold
+//   └─────────────────┘
+//
+// Tamanhos:
+//   - sm: 76px min-width (default Kanban card / linha de lista)
+//   - md: 96px (drawer header / seletor de venda)
+//   - lg: 120px (Show page hero)
+
+import { memo } from 'react';
+
+type Size = 'sm' | 'md' | 'lg';
+
+interface Props {
+  plate: string;
+  size?: Size;
+  className?: string;
+}
+
+const SIZES: Record<Size, { wrapper: string; top: string; num: string }> = {
+  sm: { wrapper: 'min-w-[76px]', top: 'text-[7px] py-0.5',  num: 'text-[13px] py-1 px-1.5' },
+  md: { wrapper: 'min-w-[96px]', top: 'text-[8px] py-1',    num: 'text-[16px] py-1.5 px-2' },
+  lg: { wrapper: 'min-w-[120px]', top: 'text-[10px] py-1.5', num: 'text-[20px] py-2 px-3' },
+};
+
+function MercosulPlateImpl({ plate, size = 'sm', className = '' }: Props) {
+  const s = SIZES[size];
+  return (
+    <span
+      className={`inline-flex flex-col rounded border-[1.5px] border-[var(--plate-frame)] overflow-hidden bg-white ${s.wrapper} ${className}`}
+      style={{ fontFamily: 'ui-monospace, "Cascadia Code", Menlo, monospace', lineHeight: 1 }}
+      role="img"
+      aria-label={`Placa ${plate}`}
+    >
+      <span
+        className={`text-white text-center font-semibold ${s.top}`}
+        style={{ background: 'oklch(0.45 0.13 250)', letterSpacing: '0.12em' }}
+      >
+        BR · MERCOSUL
+      </span>
+      <span
+        className={`text-center font-bold text-[var(--plate-ink)] ${s.num}`}
+        style={{ letterSpacing: '0.04em' }}
+      >
+        {plate}
+      </span>
+    </span>
+  );
+}
+
+export default memo(MercosulPlateImpl);

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx
@@ -1,60 +1,6 @@
-// Placa estilo Mercosul (visual, não literal) — espelha .ofc-plate do
-// protótipo Cowork canon (prototipo-ui/prototipos/producao-oficina/visual-source.html).
+// MercosulPlate — PROMOVIDO pra @/Components/shared/MercosulPlate (ADR 0251).
 //
-// Componente puro display — sem state, sem fetch. Reusável em qualquer card
-// que mostre placa de veículo.
-//
-// Estrutura visual:
-//   ┌─────────────────┐
-//   │ BR · MERCOSUL   │ ← top: blue Mercosul (#3b5fa9)
-//   ├─────────────────┤
-//   │   ABC-1D23      │ ← num: white bg, mono bold
-//   └─────────────────┘
-//
-// Tamanhos:
-//   - sm: 76px min-width (default Kanban card)
-//   - md: 96px (drawer header)
-//   - lg: 120px (Show page hero)
-
-import { memo } from 'react';
-
-type Size = 'sm' | 'md' | 'lg';
-
-interface Props {
-  plate: string;
-  size?: Size;
-  className?: string;
-}
-
-const SIZES: Record<Size, { wrapper: string; top: string; num: string }> = {
-  sm: { wrapper: 'min-w-[76px]', top: 'text-[7px] py-0.5',  num: 'text-[13px] py-1 px-1.5' },
-  md: { wrapper: 'min-w-[96px]', top: 'text-[8px] py-1',    num: 'text-[16px] py-1.5 px-2' },
-  lg: { wrapper: 'min-w-[120px]', top: 'text-[10px] py-1.5', num: 'text-[20px] py-2 px-3' },
-};
-
-function MercosulPlateImpl({ plate, size = 'sm', className = '' }: Props) {
-  const s = SIZES[size];
-  return (
-    <span
-      className={`inline-flex flex-col rounded border-[1.5px] border-[var(--plate-frame)] overflow-hidden bg-white ${s.wrapper} ${className}`}
-      style={{ fontFamily: 'ui-monospace, "Cascadia Code", Menlo, monospace', lineHeight: 1 }}
-      role="img"
-      aria-label={`Placa ${plate}`}
-    >
-      <span
-        className={`text-white text-center font-semibold ${s.top}`}
-        style={{ background: 'oklch(0.45 0.13 250)', letterSpacing: '0.12em' }}
-      >
-        BR · MERCOSUL
-      </span>
-      <span
-        className={`text-center font-bold text-[var(--plate-ink)] ${s.num}`}
-        style={{ letterSpacing: '0.04em' }}
-      >
-        {plate}
-      </span>
-    </span>
-  );
-}
-
-export default memo(MercosulPlateImpl);
+// Este arquivo agora é só um re-export pra não quebrar os imports existentes do
+// OficinaAuto (CacambaCard, ServiceOrderRichSheet, ServiceOrderKanbanCard).
+// Fonte canônica única lá — Sells (venda com veículo) usa a MESMA plaquinha.
+export { default } from '@/Components/shared/MercosulPlate';

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -17,8 +17,9 @@ import { router, useForm } from '@inertiajs/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useAuth, useBusiness } from '@/Hooks/usePageProps';
-import { AlertTriangle, CreditCard, FileText, Loader2, Package, Plus, Printer, Receipt, Search, Settings2, Trash2 } from 'lucide-react';
+import { AlertTriangle, CreditCard, FileText, Loader2, Package, Plus, Printer, Receipt, Search, Settings2, Trash2, Truck } from 'lucide-react';
 import EmptyState from '@/Components/shared/EmptyState';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 import { Button } from '@/Components/ui/button';
 import { Checkbox } from '@/Components/ui/checkbox';
 import { Input } from '@/Components/ui/input';
@@ -30,7 +31,9 @@ import ProductSearchAutocomplete, {
 } from './_components/ProductSearchAutocomplete';
 import CustomerSearchAutocomplete, {
   type CustomerSearchResult,
+  type VehicleOption,
 } from './_components/CustomerSearchAutocomplete';
+import QuickAddVehicleSheet from './_components/QuickAddVehicleSheet';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
 import NumericInputPtBR from './_components/NumericInputPtBR';
 import { dropdownEntries } from './_components/dropdownEntries';
@@ -93,6 +96,11 @@ export interface SellsCreatePageProps {
   customerGroups: OptionMap;
   accounts: OptionMap;
   typesOfService: OptionMap;
+  // ADR 0251 — veículo na venda direta de oficina. hasOficinaAuto = gate per-business
+  // (vestuário/ROTA LIVRE vem false → seção some). vehicleTypes alimenta o dropdown
+  // do cadastro rápido (QuickAddVehicleSheet).
+  hasOficinaAuto?: boolean;
+  vehicleTypes?: OptionMap;
   categories?: Record<string, unknown> | false;
   brands?: Record<string, unknown> | false;
   shortcuts?: Record<string, string> | null;
@@ -189,6 +197,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     price_group_id: props.defaultPriceGroupId,
     commission_agent_id: null as number | null,
     tax_rate_id: null as number | null,
+    // ADR 0251 — veículo na venda direta de oficina. null = sem veículo. Só
+    // relevante quando OficinaAuto habilitado; em vestuário fica sempre null.
+    vehicle_id: null as number | null,
     products: [] as Array<{
       product_id: number;
       variation_id: number | null;
@@ -264,6 +275,14 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   const hasMultiplePriceGroups = Object.keys(props.priceGroups).length > 1;
   const hasCommissionAgent = Object.keys(props.commissionAgents).length > 0;
   const hasTypesOfService = Object.keys(props.typesOfService).length > 0;
+
+  // ADR 0251 — Veículo na venda. Gate per-business: vestuário (ROTA LIVRE) vem
+  // hasOficinaAuto=false → toda a seção de veículo some. customerVehicles = catálogo
+  // do cliente selecionado (vem do payload getCustomers). quickAddVehicleOpen abre o
+  // drawer de cadastro rápido (sem perder a venda).
+  const hasOficinaAuto = props.hasOficinaAuto === true;
+  const [customerVehicles, setCustomerVehicles] = useState<VehicleOption[]>([]);
+  const [quickAddVehicleOpen, setQuickAddVehicleOpen] = useState(false);
 
   // Cálculos de produtos
   const productSearchRef = useRef<HTMLDivElement>(null);
@@ -481,6 +500,12 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     if (c.selling_price_group_id !== null && c.selling_price_group_id !== undefined) {
       void handlePriceGroupChange(c.selling_price_group_id);
     }
+    // ADR 0251 — catálogo de veículos do cliente alimenta o seletor. Auto-seleciona
+    // quando o cliente tem 1 veículo só (caso comum oficina); senão deixa o vendedor
+    // escolher. Troca de cliente reseta o veículo (não vaza veículo de outro dono).
+    const vs = c.vehicles ?? [];
+    setCustomerVehicles(vs);
+    setData('vehicle_id', vs.length === 1 ? vs[0].id : null);
   };
 
   // R8 — reset ao limpar cliente. Volta pros defaults (walk-in + props default).
@@ -488,6 +513,9 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     setData('contact_id', props.walkInCustomer.id);
     setData('pay_term_number', '');
     setData('pay_term_type', 'days');
+    // ADR 0251 — sem cliente, não há catálogo de veículos.
+    setCustomerVehicles([]);
+    setData('vehicle_id', null);
     // shipping fica como user editou — não auto-limpa (pode ser endereço manual)
     // price_group volta ao default do business
     if (props.defaultPriceGroupId !== data.price_group_id) {
@@ -1136,6 +1164,71 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             </Select>
             <FieldError message={errors.location_id as string | undefined} />
           </div>
+
+          {/* ADR 0251 — Veículo na venda direta de oficina. Só aparece quando
+              OficinaAuto habilitado pro business (vestuário/ROTA LIVRE não vê).
+              Consome contact.vehicles[]; plaquinha Mercosul reusada do OficinaAuto. */}
+          {hasOficinaAuto && (
+            <div className="space-y-2 md:col-span-2 lg:col-span-4">
+              <Label className="flex items-center gap-2">
+                <Truck className="h-4 w-4 text-muted-foreground" />
+                Veículo
+                {data.vehicle_id !== null && (
+                  <span className="rounded bg-primary/10 px-1.5 text-[10px] font-medium text-primary">
+                    selecionado
+                  </span>
+                )}
+              </Label>
+
+              {data.contact_id !== props.walkInCustomer.id ? (
+                <div className="flex flex-wrap items-center gap-2">
+                  {customerVehicles.map((v) => {
+                    const selected = data.vehicle_id === v.id;
+                    const typeLabel = (props.vehicleTypes ?? {})[v.vehicle_type ?? ''] ?? v.vehicle_type ?? '';
+                    return (
+                      <button
+                        key={v.id}
+                        type="button"
+                        onClick={() => setData('vehicle_id', selected ? null : v.id)}
+                        aria-pressed={selected}
+                        className={
+                          'flex items-center gap-2 rounded-md border p-2 text-left transition-colors ' +
+                          (selected
+                            ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                            : 'border-border hover:bg-muted/50')
+                        }
+                      >
+                        <MercosulPlate plate={v.plate} size="sm" />
+                        {v.secondary_plate && <MercosulPlate plate={v.secondary_plate} size="sm" />}
+                        {typeLabel && (
+                          <span className="text-xs text-muted-foreground pr-1">{typeLabel}</span>
+                        )}
+                      </button>
+                    );
+                  })}
+
+                  <button
+                    type="button"
+                    onClick={() => setQuickAddVehicleOpen(true)}
+                    className="flex items-center gap-1.5 rounded-md border border-dashed border-border p-2 text-sm text-muted-foreground transition-colors hover:bg-muted/50"
+                  >
+                    <Plus className="h-4 w-4" />
+                    Cadastrar veículo
+                  </button>
+                </div>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Selecione o cliente pra escolher ou cadastrar o veículo do atendimento.
+                </p>
+              )}
+
+              {data.contact_id !== props.walkInCustomer.id && customerVehicles.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Cliente sem veículo cadastrado — use <b>Cadastrar veículo</b>.
+                </p>
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
 
@@ -1880,6 +1973,20 @@ export default function SellsCreate(props: SellsCreatePageProps) {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* ADR 0251 — cadastro rápido de veículo sem perder a venda (drawer lateral) */}
+      {hasOficinaAuto && (
+        <QuickAddVehicleSheet
+          open={quickAddVehicleOpen}
+          onClose={() => setQuickAddVehicleOpen(false)}
+          contactId={data.contact_id !== props.walkInCustomer.id ? data.contact_id : null}
+          vehicleTypes={props.vehicleTypes ?? {}}
+          onCreated={(v) => {
+            setCustomerVehicles((prev) => [v, ...prev.filter((x) => x.id !== v.id)]);
+            setData('vehicle_id', v.id);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -107,6 +107,8 @@ interface SaleRow {
   source?: 'balcao' | 'oficina' | 'online' | string;
   source_label?: string;
   os_ref?: string | null;
+  /** ADR 0251 — placa do veículo (venda direta de oficina). null = sem veículo. */
+  vehicle_plate?: string | null;
 }
 
 interface SellKpis {

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -19,11 +19,13 @@ import {
   Phone,
   Printer,
   Trash2,
+  Truck,
   User as UserIcon,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import KpiCard from '@/Components/shared/KpiCard';
 import EmptyState from '@/Components/shared/EmptyState';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 import { Button } from '@/Components/ui/button';
 import {
   DropdownMenu,
@@ -66,6 +68,8 @@ interface Headline {
   current_stage_key: string | null;
   customer: Customer | null;
   location: { id: number; name: string } | null;
+  /** ADR 0251 — veículo da venda direta de oficina (placa na consulta). null = sem veículo. */
+  vehicle?: { id: number; plate: string; secondary_plate?: string | null } | null;
 }
 
 interface SaleLine {
@@ -430,6 +434,23 @@ export default function SellsShow(props: SellsShowPageProps) {
                       <Mail className="h-3 w-3" />
                       {headline.customer.email}
                     </p>
+                  )}
+                </div>
+              </section>
+            )}
+
+            {/* ADR 0251 — Veículo do atendimento (venda direta de oficina). Plaquinha
+                Mercosul reusada do OficinaAuto. Só aparece quando a venda tem veículo. */}
+            {headline.vehicle && (
+              <section className="rounded-lg border border-border bg-card p-5">
+                <div className="flex items-center gap-2 mb-3">
+                  <Truck className="h-4 w-4 text-muted-foreground" />
+                  <h2 className="font-semibold text-sm">Veículo</h2>
+                </div>
+                <div className="flex items-center gap-2">
+                  <MercosulPlate plate={headline.vehicle.plate} size="md" />
+                  {headline.vehicle.secondary_plate && (
+                    <MercosulPlate plate={headline.vehicle.secondary_plate} size="md" />
                   )}
                 </div>
               </section>

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -17,6 +17,17 @@ import { Search, Loader2, X, UserPlus } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import QuickAddCustomerSheet from './QuickAddCustomerSheet';
 
+/**
+ * ADR 0251 — veículo do catálogo do cliente (`vehicles`, Modules/OficinaAuto).
+ * Alimenta o seletor de veículo na venda direta de oficina (Sells/Create).
+ */
+export interface VehicleOption {
+  id: number;
+  plate: string;
+  secondary_plate?: string | null;
+  vehicle_type?: string | null;
+}
+
 export interface CustomerSearchResult {
   id: number;
   text: string;
@@ -36,6 +47,8 @@ export interface CustomerSearchResult {
   pay_term_type?: 'days' | 'months' | string | null;
   /** Endereço entrega — pré-fill no campo shipping. */
   shipping_address?: string | null;
+  /** ADR 0251 — veículos do cliente (catálogo OficinaAuto), pro seletor na venda. */
+  vehicles?: VehicleOption[] | null;
 }
 
 /**

--- a/resources/js/Pages/Sells/_components/QuickAddVehicleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/QuickAddVehicleSheet.tsx
@@ -1,0 +1,315 @@
+// QuickAddVehicleSheet — ADR 0251. Cadastro rápido de veículo SEM perder a venda.
+//
+// Espelha o QuickAddCustomerSheet (Onda R6): Sheet lateral in-place + fetch direto
+// (NÃO Inertia router, que faria redirect + recarregaria a página e perderia o
+// draft da venda). Após salvar, o Sheet fecha e o veículo novo entra selecionado
+// no seletor de veículo da venda via onCreated.
+//
+// Form mínimo (quick-add) — placa + tipo obrigatórios; resto opcional:
+//   - Placa (obrigatória)
+//   - Tipo de veículo (obrigatório — props.vehicleTypes)
+//   - Placa secundária (cavalo+reboque · opcional)
+//   - Ano / Cor (opcional)
+//
+// Cadastro completo (RENAVAM, chassi, hodômetro, etc.) continua em
+// /oficina-auto/veiculos/create.
+//
+// Backend: POST /oficina-auto/veiculos (VehicleController@store) — branch JSON
+// quando wantsJson() && !X-Inertia (ADR 0251). business_id + contact_id setados
+// server-side (Tier 0 ADR 0093). contact_id vem do cliente já selecionado na venda.
+
+import { useEffect, useState } from 'react';
+import { Truck, Loader2 } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/Components/ui/sheet';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+import type { VehicleOption } from './CustomerSearchAutocomplete';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  /** Cliente selecionado na venda — o veículo é cadastrado pra ele. */
+  contactId: number | null;
+  /** Tipos de veículo (props.vehicleTypes do SellController). */
+  vehicleTypes: Record<string | number, string>;
+  /** Placa pré-preenchida (vem da busca — "Cadastrar 'ABC1D23'"). */
+  prefillPlate?: string;
+  /** Callback quando o veículo é criado — o pai adiciona no seletor + seleciona. */
+  onCreated: (vehicle: VehicleOption) => void;
+}
+
+interface QuickAddErrors {
+  plate?: string;
+  vehicle_type?: string;
+  msg?: string;
+}
+
+function getCsrfToken(): string {
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]');
+  return meta?.content ?? '';
+}
+
+export default function QuickAddVehicleSheet({
+  open,
+  onClose,
+  contactId,
+  vehicleTypes,
+  prefillPlate = '',
+  onCreated,
+}: Props) {
+  const typeEntries = Object.entries(vehicleTypes);
+  const [plate, setPlate] = useState(prefillPlate);
+  const [vehicleType, setVehicleType] = useState<string>(typeEntries[0]?.[0] ?? '');
+  const [secondaryPlate, setSecondaryPlate] = useState('');
+  const [year, setYear] = useState('');
+  const [color, setColor] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [errors, setErrors] = useState<QuickAddErrors>({});
+
+  useEffect(() => {
+    if (open) {
+      setPlate(prefillPlate);
+      setVehicleType(typeEntries[0]?.[0] ?? '');
+      setSecondaryPlate('');
+      setYear('');
+      setColor('');
+      setErrors({});
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, prefillPlate]);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (saving) return;
+
+    const localErrors: QuickAddErrors = {};
+    if (!plate.trim()) localErrors.plate = 'Placa é obrigatória';
+    if (!vehicleType) localErrors.vehicle_type = 'Selecione o tipo';
+    if (Object.keys(localErrors).length > 0) {
+      setErrors(localErrors);
+      return;
+    }
+
+    setSaving(true);
+    setErrors({});
+
+    try {
+      const res = await fetch('/oficina-auto/veiculos', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          plate: plate.trim().toUpperCase(),
+          vehicle_type: vehicleType,
+          secondary_plate: secondaryPlate.trim() ? secondaryPlate.trim().toUpperCase() : null,
+          manufacture_year: year.trim() ? Number(year.trim()) : null,
+          color: color.trim() || null,
+          contact_id: contactId,
+        }),
+      });
+
+      if (res.status === 422) {
+        const data = await res.json().catch(() => ({}));
+        const ve = (data?.errors ?? {}) as Record<string, string[]>;
+        const flat: QuickAddErrors = {};
+        if (ve.plate?.[0]) flat.plate = ve.plate[0];
+        if (ve.vehicle_type?.[0]) flat.vehicle_type = ve.vehicle_type[0];
+        if (Object.keys(flat).length === 0) {
+          flat.msg = data?.message ?? 'Falha na validação. Confira os campos.';
+        }
+        setErrors(flat);
+        setSaving(false);
+        return;
+      }
+
+      if (res.status === 403) {
+        setErrors({ msg: 'Você não tem permissão pra cadastrar veículo. Peça ao admin.' });
+        setSaving(false);
+        return;
+      }
+
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        setErrors({ msg: data?.msg ?? data?.message ?? 'Não foi possível cadastrar. Tente novamente.' });
+        setSaving(false);
+        return;
+      }
+
+      const data = await res.json().catch(() => ({}));
+      const created = data?.data ?? data;
+      const newId = Number(created?.id ?? 0);
+      if (!newId) {
+        setErrors({ msg: 'Cadastro feito mas não recebemos ID. Recarregue e busque manualmente.' });
+        setSaving(false);
+        return;
+      }
+
+      onCreated({
+        id: newId,
+        plate: String(created?.plate ?? plate.trim().toUpperCase()),
+        secondary_plate: created?.secondary_plate ?? null,
+        vehicle_type: created?.vehicle_type ?? vehicleType,
+      });
+      setSaving(false);
+      onClose();
+    } catch {
+      setErrors({ msg: 'Erro de rede. Verifique sua conexão.' });
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && !saving && onClose()}>
+      <SheetContent side="right" className="w-[420px] sm:max-w-[420px] flex flex-col p-0">
+        <header className="border-b border-border px-5 py-4">
+          <SheetTitle asChild>
+            <h2 className="m-0 flex items-center gap-2 text-base font-semibold">
+              <Truck size={18} className="text-primary" />
+              Cadastrar veículo
+            </h2>
+          </SheetTitle>
+          <SheetDescription asChild>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Cadastro rápido. RENAVAM, chassi e hodômetro ficam em <i>/oficina-auto/veiculos</i>.
+            </p>
+          </SheetDescription>
+        </header>
+
+        <form onSubmit={submit} className="flex-1 overflow-y-auto p-5 space-y-4 text-[13px]">
+          {errors.msg && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-[12px] text-destructive">
+              {errors.msg}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <label htmlFor="qav-plate" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
+              Placa <span className="text-destructive">*</span>
+            </label>
+            <Input
+              id="qav-plate"
+              type="text"
+              value={plate}
+              onChange={(e) => setPlate(e.target.value.toUpperCase())}
+              placeholder="ABC1D23"
+              autoFocus
+              required
+              maxLength={10}
+              className="uppercase"
+              data-testid="quickadd-vehicle-plate"
+            />
+            {errors.plate && <p className="text-[11px] text-destructive">{errors.plate}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="qav-type" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
+              Tipo de veículo <span className="text-destructive">*</span>
+            </label>
+            <Select value={vehicleType} onValueChange={setVehicleType}>
+              <SelectTrigger id="qav-type" data-testid="quickadd-vehicle-type">
+                <SelectValue placeholder="Selecionar tipo" />
+              </SelectTrigger>
+              <SelectContent>
+                {typeEntries.map(([k, label]) => (
+                  <SelectItem key={k} value={k}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.vehicle_type && <p className="text-[11px] text-destructive">{errors.vehicle_type}</p>}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="qav-secplate" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
+              Placa secundária (cavalo+reboque)
+            </label>
+            <Input
+              id="qav-secplate"
+              type="text"
+              value={secondaryPlate}
+              onChange={(e) => setSecondaryPlate(e.target.value.toUpperCase())}
+              placeholder="(opcional)"
+              maxLength={10}
+              className="uppercase"
+              data-testid="quickadd-vehicle-secplate"
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label htmlFor="qav-year" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
+                Ano
+              </label>
+              <Input
+                id="qav-year"
+                type="number"
+                inputMode="numeric"
+                value={year}
+                onChange={(e) => setYear(e.target.value)}
+                placeholder="2020"
+                min={1900}
+                max={2100}
+                data-testid="quickadd-vehicle-year"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label htmlFor="qav-color" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
+                Cor
+              </label>
+              <Input
+                id="qav-color"
+                type="text"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                placeholder="Branco"
+                maxLength={30}
+                data-testid="quickadd-vehicle-color"
+              />
+            </div>
+          </div>
+
+          {!contactId && (
+            <p className="text-[11px] text-muted-foreground pt-2">
+              Sem cliente selecionado o veículo fica sem dono — selecione o cliente
+              antes pra vincular automaticamente.
+            </p>
+          )}
+        </form>
+
+        <footer className="border-t border-border px-5 py-3 flex items-center justify-end gap-2">
+          <Button type="button" variant="ghost" onClick={onClose} disabled={saving} data-testid="quickadd-vehicle-cancel">
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={submit}
+            disabled={saving || !plate.trim() || !vehicleType}
+            data-testid="quickadd-vehicle-submit"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Salvando…
+              </>
+            ) : (
+              'Cadastrar e usar'
+            )}
+          </Button>
+        </footer>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/resources/js/Pages/Sells/_components/QuickAddVehicleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/QuickAddVehicleSheet.tsx
@@ -18,7 +18,7 @@
 // quando wantsJson() && !X-Inertia (ADR 0251). business_id + contact_id setados
 // server-side (Tier 0 ADR 0093). contact_id vem do cliente já selecionado na venda.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { Truck, Loader2 } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
@@ -85,7 +85,7 @@ export default function QuickAddVehicleSheet({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, prefillPlate]);
 
-  const submit = async (e: React.FormEvent) => {
+  const submit = async (e: FormEvent) => {
     e.preventDefault();
     if (saving) return;
 

--- a/resources/js/Pages/Sells/_components/SellsTabelaUnificada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsTabelaUnificada.tsx
@@ -23,6 +23,7 @@ import {
 } from '../Index';
 import QuickPaymentPopover from './QuickPaymentPopover';
 import VdSource, { type VdSourceKind } from './VdSource';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 import { Checkbox } from '@/Components/ui/checkbox';
 
 // ──────────────────────────────────────────────────────────────
@@ -74,6 +75,8 @@ export interface SaleRow {
   source?: VdSourceKind | string;
   source_label?: string;
   os_ref?: string | null;
+  /** ADR 0251 — placa do veículo (venda direta de oficina). null = sem veículo. */
+  vehicle_plate?: string | null;
 }
 
 // Identificadores canônicos das colunas. Ordem desta enumeração = ordem default
@@ -335,6 +338,12 @@ function renderCell(id: ColumnId, v: SaleRow, ctx: CellCtx): ReactNode {
         <td key={id} className="vd-client">
           <div className="vd-client-name">{v.customer_name ?? '—'}</div>
           {v.items_summary && <div className="vd-notes">{v.items_summary}</div>}
+          {/* ADR 0251 — placa do veículo (venda direta de oficina) na consulta. */}
+          {v.vehicle_plate && (
+            <div className="mt-1">
+              <MercosulPlate plate={v.vehicle_plate} size="sm" />
+            </div>
+          )}
         </td>
       );
     case 'seller':

--- a/tests/Feature/Sells/SellsCreatePageTest.php
+++ b/tests/Feature/Sells/SellsCreatePageTest.php
@@ -421,3 +421,46 @@ it('ProductSearchAutocomplete tipa campos backend explícitos (anti AP-12 F3)', 
     expect($componentSource)->toContain("type?: 'variable' | 'single'");
     expect($componentSource)->toContain('variation_group_price?: number');
 });
+
+// ─── ADR 0251 — Veículo na venda direta de oficina ──────────────────────────
+
+it('Page tem seletor de veículo gated por OficinaAuto (ADR 0251)', function () {
+    $source = readPage();
+    // Gate per-business — vestuário/ROTA LIVRE (hasOficinaAuto=false) não vê.
+    expect($source)->toContain('hasOficinaAuto');
+    // Plaquinha Mercosul reusada do OficinaAuto via shared.
+    expect($source)->toContain("from '@/Components/shared/MercosulPlate'");
+    expect($source)->toContain('<MercosulPlate');
+    // Consome o catálogo de veículos do cliente + liga em vehicle_id.
+    expect($source)->toContain('customerVehicles');
+    expect($source)->toContain('vehicle_id');
+    // Cadastro rápido sem perder a venda.
+    expect($source)->toContain('Cadastrar veículo');
+    expect($source)->toContain('QuickAddVehicleSheet');
+});
+
+it('QuickAddVehicleSheet faz fetch direto (não Inertia) pra não perder a venda (ADR 0251)', function () {
+    $src = file_get_contents(
+        base_path('resources/js/Pages/Sells/_components/QuickAddVehicleSheet.tsx'),
+    );
+    // POST no endpoint canônico de veículo do OficinaAuto.
+    expect($src)->toContain("fetch('/oficina-auto/veiculos'");
+    // CSRF manual (sem Inertia router) — preserva o draft da venda.
+    expect($src)->toContain('X-CSRF-TOKEN');
+    expect($src)->toContain('csrf-token');
+    // Placa + tipo obrigatórios (espelha StoreVehicleRequest).
+    expect($src)->toContain('vehicle_type');
+    expect($src)->toContain('contact_id');
+});
+
+it('Show e Index exibem a placa do veículo na consulta (ADR 0251)', function () {
+    $show = file_get_contents(base_path('resources/js/Pages/Sells/Show.tsx'));
+    expect($show)->toContain("from '@/Components/shared/MercosulPlate'");
+    expect($show)->toContain('headline.vehicle');
+
+    $tabela = file_get_contents(
+        base_path('resources/js/Pages/Sells/_components/SellsTabelaUnificada.tsx'),
+    );
+    expect($tabela)->toContain('vehicle_plate');
+    expect($tabela)->toContain('<MercosulPlate');
+});

--- a/tests/Feature/Sells/VeiculoNaVendaSchemaTest.php
+++ b/tests/Feature/Sells/VeiculoNaVendaSchemaTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * ADR 0251 — Veículo na venda direta de oficina (transactions.vehicle_id).
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ * Multi-tenant Tier 0 (ADR 0093): Vehicle tem global scope por business_id.
+ *
+ * Schema UltimatePOS completo só existe no MySQL (CT 100 oficina-staging) — o
+ * lane SQLite do CI pula (mesmo padrão de VehicleCrudTest).
+ *
+ * @see memory/decisions/0251-veiculo-na-venda-direta-oficina.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+defined('BIZ_WAGNER') || define('BIZ_WAGNER', 1);
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema transactions/vehicles requer MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('transactions') || ! Schema::hasTable('vehicles')) {
+        $this->markTestSkipped('schema base ausente — rode as migrations UltimatePOS + OficinaAuto');
+    }
+});
+
+it('migration adicionou transactions.vehicle_id (ADR 0251)', function () {
+    expect(Schema::hasColumn('transactions', 'vehicle_id'))->toBeTrue();
+});
+
+it('transactions.vehicle_id é nullable — venda sem veículo é o caso comum (vestuário)', function () {
+    $col = collect(DB::select('SHOW COLUMNS FROM transactions WHERE Field = ?', ['vehicle_id']))->first();
+    expect($col)->not->toBeNull();
+    expect($col->Null)->toBe('YES');
+});
+
+it('existe FK fk_transactions_vehicle pra vehicles', function () {
+    $createSql = (string) (collect(DB::select('SHOW CREATE TABLE transactions'))->first()->{'Create Table'} ?? '');
+    expect($createSql)->toContain('fk_transactions_vehicle');
+});
+
+it('Vehicle do biz=1 não vaza pro escopo de outro business (Tier 0 ADR 0093)', function () {
+    session(['user.business_id' => BIZ_WAGNER]);
+
+    $meu = Vehicle::create([
+        'business_id'  => BIZ_WAGNER,
+        'plate'        => 'VND0251',
+        'vehicle_type' => 'automovel',
+    ]);
+
+    // Cria veículo de OUTRO business (99) bypassa scope só pra inserir.
+    $outro = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => 99,
+        'plate'        => 'OTR0251',
+        'vehicle_type' => 'automovel',
+    ]);
+
+    // Com a sessão biz=1, o global scope só enxerga o veículo do biz=1.
+    $visiveis = Vehicle::pluck('plate')->all();
+    expect($visiveis)->toContain('VND0251');
+    expect($visiveis)->not->toContain('OTR0251');
+})->afterEach(function () {
+    Vehicle::withoutGlobalScopes()->whereIn('plate', ['VND0251', 'OTR0251'])->forceDelete();
+});


### PR DESCRIPTION
Numa oficina, ao vender peça/serviço, é preciso registrar **qual veículo** está em atendimento. Hoje o veículo só existe na OS; a **venda direta de balcão** não tinha onde guardar. Esta feature costura o veículo na `/sells/create` **reusando 100%** do que já existe no `Modules/OficinaAuto` (confirmado: veículo era inédito em todas as 8 telas de venda e em todo o histórico do git).

## O que entrega (o que o Wagner pediu)
1. **Selecionar** o veículo do cliente na venda + **opção de cadastrar sem perder a venda** (drawer lateral).
2. **Plaquinha bonita** — a MESMA de `/oficina-auto/producao-oficina` (`MercosulPlate`, promovida pra `@/Components/shared`).
3. **Placa na consulta** da venda — Index (linha) + Show (detalhe).
4. Cadastro completo segue em `/oficina-auto/veiculos/create`.

## Schema (ADR 0251 — estende 0192)
- Migration idempotente: `transactions.vehicle_id` nullable + FK `vehicles` (`ON DELETE SET NULL`, guardada por `Schema::hasTable`) + índice `(business_id, vehicle_id)` Tier 0. `down()` reversível.
- `TransactionUtil` mapeia `vehicle_id` no create/update (null-safe).

## Backend
- `ContactController@getCustomers` eager-load `vehicles[]` do cliente, **guardado por `Schema::hasTable`** (endpoint compartilhado com Blade não quebra se OficinaAuto ausente). `Vehicle` tem global scope por `business_id` (Tier 0 automático).
- `SellController` passa `hasOficinaAuto` (**gate per-business CANÔNICO** — mesmo de `OficinaAuto::modifyAdminMenu`: `hasThePermissionInSubscription('oficina_auto_module')`) + `vehicleTypes`. **Vestuário (ROTA LIVRE biz=4) vem false → seção some** (Tier 0 ADR 0093).
- `VehicleController@store` ganha branch JSON (`wantsJson() && !X-Inertia`) pro quick-add sem quebrar o fluxo Inertia normal.
- `inertiaList` + `show` incluem a placa na consulta (lookup guardado, scoped por business).

## Frontend
- **Sells/Create**: seletor de veículo na sec-dados (gated) com cards `MercosulPlate` + auto-seleção quando o cliente tem 1 veículo. `QuickAddVehicleSheet` (espelha `QuickAddCustomerSheet`: fetch direto + CSRF, **não perde o draft da venda**).
- **Sells/Index**: plaquinha sob o nome do cliente (sem nova coluna). **Sells/Show**: seção "Veículo".

## Multi-tenant Tier 0 (ADR 0093) — preservado em todas as camadas
Global scope no `Vehicle` + gate per-business + eager-load/lookup guardados + Pest de isolamento biz=1 vs biz=99.

## Testes
- `SellsCreatePageTest` (+3 estruturais, rodam no CI SQLite).
- `VeiculoNaVendaSchemaTest` (schema + FK + multi-tenant biz=1 — skip SQLite, **roda no CT 100**).

## ⚠️ Smoke pendente antes do merge (tela #1)
- [ ] CT 100 staging: buscar cliente com veículo → seletor mostra a plaquinha
- [ ] Cadastrar veículo no drawer → entra selecionado **sem perder a venda**
- [ ] Salvar → `vehicle_id` persiste → placa aparece no Show + Index
- [ ] Vestuário (biz=4) **não** vê a seção (gate per-business)
- [ ] Console limpo + screenshot (Chrome MCP)

Refs: ADR 0251, ADR 0192, ADR 0093, US-OFICINA-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)