### PR TITLE
feat(governance): nudge hook contract-anchor — mecaniza Check 9 (anti-regressão Stage 1)

### DIFF
--- a/.claude/hooks/nudge-test-contract-anchor.ps1
+++ b/.claude/hooks/nudge-test-contract-anchor.ps1
@@ -1,0 +1,28 @@
+# nudge-test-contract-anchor.ps1 - PreToolUse (advisory - Check 9 / anti-regressao Opcao B Stage 1)
+# Lembra de ancorar teste em CONTRATO (SPEC/ADR/proibicoes/charter), nao no codigo.
+# Origem: sessao 2026-06-05 - teste tautologico FsmAuthorizationFlagPropertyTest mergeou (#2271).
+# Mecaniza: memory/proibicoes.md secao "Ideias avaliadas e DESCARTADAS" (2026-06-05)
+#           + Check 9 da skill module-completeness-audit.
+# Advisory: exit 0 SEMPRE (nunca bloqueia). Fail-open.
+
+$ErrorActionPreference = 'SilentlyContinue'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if (-not $raw) { exit 0 }
+    $payload = $raw | ConvertFrom-Json
+    $path = [string]$payload.tool_input.file_path
+    if (-not $path) { exit 0 }
+
+    # So dispara em arquivo de teste PHP
+    if ($path -notmatch '(?i)Test\.php$') { exit 0 }
+
+    Write-Host ""
+    Write-Host "[ANCORA DE CONTRATO - Check 9 / anti-regressao Opcao B]"
+    Write-Host "  Antes de escrever este teste, confirme que a assercao deriva de um CONTRATO"
+    Write-Host "  externo (SPEC / ADR / proibicoes / charter), NAO do que a classe ja faz."
+    Write-Host "  - Cite a fonte no cabecalho: @see ADR-XXXX + a regra em portugues."
+    Write-Host "  - Teste que copia o comportamento atual = tautologico = trava o drift (pior que nao ter)."
+    Write-Host "  Ref: memory/proibicoes.md secao 'Ideias avaliadas e DESCARTADAS' (2026-06-05)."
+    Write-Host ""
+    exit 0
+} catch { exit 0 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -80,6 +80,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-routes-string-legacy.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/nudge-test-contract-anchor.ps1"
           }
         ]
       },


### PR DESCRIPTION
## O que é

**Stage 1 da mecanização anti-regressão (Opção B)** — sobe o Check 9 ("teste ancorado em contrato") de "regra que se lê" pra **defesa que dispara**, no tier mais seguro (advisory, nunca bloqueia).

Justificativa pela catraca do método (PROCESSO_MEMORIA_CC §12 *"falhou 2× → sobe de tier"*): 2 falhas documentadas na sessão 2026-06-05 — o teste tautológico `FsmAuthorizationFlagPropertyTest` que **mergeou** (#2271) + o roadmap paralelo tentado. Gatilho disparou.

## O hook

`.claude/hooks/nudge-test-contract-anchor.ps1` — PreToolUse advisory (`exit 0` sempre, fail-open, espelha `nudge-diagnosis-without-evidence.ps1`). Ao editar um `*Test.php`, **lembra** de ancorar a asserção num contrato externo (SPEC/ADR/proibicoes/charter), não no código. Registrado no bloco `Write|Edit|MultiEdit` do `settings.json`.

Mecaniza:
- `memory/proibicoes.md` §"Ideias avaliadas e DESCARTADAS" (entrada 2026-06-05) — #2273
- Check 9 da skill `module-completeness-audit` — #2273

## Validação (smoke)

- ✅ Dispara em `*Test.php` (imprime o lembrete)
- ✅ Mudo em `Controller.php` (só teste)
- ✅ `settings.json` JSON válido + hook registrado

## Escopo / limites honestos

- **Advisory, não bloqueia** — é o tier mais seguro de propósito. Vira bloqueio só se reincidir (catraca: sobe de tier quando falha).
- **§5 ("não re-propor")** não é 100% mecanizável (não dá grep pra "ideia igual a uma rejeitada") — o nudge é o teto realista; quem pega re-proposta segue sendo leitura.
- **Stages 2-3** (CI gate determinístico do Check 9 default-OFF · audit pontuado em CI) ficam pra PRs próprios, quando este provar que precisa.

<!-- no-ui-smoke: backend/governança, não toca resources/js nem .css -->
