### PR TITLE
fix(sells): valor inflado ×100k — num_uf strippava ponto decimal (incidente prod ROTA LIVRE)

### DIFF
--- a/app/Utils/Util.php
+++ b/app/Utils/Util.php
@@ -74,12 +74,21 @@ class Util
             $normalized = $intPart.'.'.$decPart;
         } elseif ($hasDot) {
             // Apenas ponto: heurística inequívoca.
-            //   1 ponto + ≤2 dígitos após = decimal en-US tolerado ("80.00" = 80)
-            //   1 ponto + ≥3 dígitos após OU múltiplos pontos = milhar pt-BR ("25.000" = 25000)
+            //   1 ponto + ≤2 dígitos após  = decimal en-US tolerado ("80.00" = 80)
+            //   1 ponto + EXATAMENTE 3 após = milhar pt-BR ("25.000" = 25000)
+            //   1 ponto + ≥4 dígitos após  = decimal (separador de milhar tem SEMPRE
+            //                                 3 dígitos; ≥4 não é grupo de milhar).
+            //   múltiplos pontos           = milhar pt-BR ("1.234.567" = 1234567)
+            //
+            // INCIDENTE 2026-06-05 (Larissa @ Rota Livre biz=4): venda com desconto
+            // percentual gera total fracionado de 5 casas no React (ex 204.99605 =
+            // 227,90 − 10,05%). O `<= 2` caía no else e str_replace removia o ponto:
+            // "204.99605" → "20499605" → R$ 20.499.605 (real R$ 205). Como grupo de
+            // milhar nunca tem 4+ dígitos, `!== 3` trata esses casos como decimal.
             $dotCount = substr_count($abs, '.');
             $lastDot = strrpos($abs, '.');
             $afterLastDot = strlen($abs) - $lastDot - 1;
-            if ($dotCount === 1 && $afterLastDot <= 2) {
+            if ($dotCount === 1 && $afterLastDot !== 3) {
                 $normalized = $abs;
             } else {
                 $normalized = str_replace('.', '', $abs);

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -685,8 +685,11 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       additional_expense_value_3: d.additional_expenses[2]?.value ?? '',
       additional_expense_key_4: d.additional_expenses[3]?.key ?? '',
       additional_expense_value_4: d.additional_expenses[3]?.value ?? '',
-      // Total calculado client-side (backend re-calcula via productUtil mas evita 422)
-      final_total: totalGeral,
+      // Total calculado client-side (backend re-calcula via productUtil mas evita 422).
+      // INCIDENTE 2026-06-05: desconto percentual gera total fracionado de 5 casas
+      // (ex 204.99605). Enviar arredondado a 2 casas evita float "204.99605" que o
+      // num_uf pt-BR do backend interpretava como milhar e inflava p/ 20.499.605.
+      final_total: Math.round(totalGeral * 100) / 100,
       // Campos hidden Blade que controller espera
       default_price_group: d.price_group_id,
       // Products precisam de campos que ProductUtil acessa direto (Undefined array key

--- a/tests/Unit/Utils/NumUfHeuristicPtBRTest.php
+++ b/tests/Unit/Utils/NumUfHeuristicPtBRTest.php
@@ -65,10 +65,19 @@ class NumUfHeuristicPtBRTest extends TestCase
             '1.5 → 1.5'                   => ['1.5', 1.5],
             '0.5 → 0.5'                   => ['0.5', 0.5],
 
-            // Heurística milhar pt-BR (1 ponto + ≥3 dígitos, ou múltiplos pontos)
+            // Heurística milhar pt-BR (1 ponto + EXATAMENTE 3 dígitos, ou múltiplos pontos)
             '25.000 → 25000'              => ['25.000', 25000.0],
             '1.234 → 1234'                => ['1.234', 1234.0],
             '1.234.567 → 1234567'         => ['1.234.567', 1234567.0],
+
+            // INCIDENTE 2026-06-05 (Larissa @ Rota Livre): desconto percentual gera
+            // total fracionado de >3 casas no React (227,90 − 10,05% = 204.99605).
+            // Antes o else stripava o ponto → 20499605 (R$ 20.499.605). Grupo de
+            // milhar tem SEMPRE 3 dígitos; ≥4 casas após o ponto = decimal.
+            'INCIDENTE 204.99605 → 204.99605' => ['204.99605', 204.99605],
+            '20.5005 (4 casas) → 20.5005'     => ['20.5005', 20.5005],
+            '227.9 (1 casa) → 227.9'          => ['227.9', 227.9],
+            '1329.0567 → 1329.0567'           => ['1329.0567', 1329.0567],
 
             // Símbolo de moeda + espaços (bug secundário antes retornava 0)
             'R$ 80,00 → 80'               => ['R$ 80,00', 80.0],


### PR DESCRIPTION
## 🔴 Incidente prod (ROTA LIVRE biz=4)
Vendas com **desconto percentual** gravavam `final_total` inflado ~×100.000. Real: calça R$227,90 com 10,05% desc = **R$205,00** → gravou **R$20.499.605,00** (venda id 81939 / invoice 17702, criada hoje 13:22 back-datada p/ ontem).

## Causa raiz (confirmada via dados de prod)
1. React `Sells/Create` calcula `totalGeral = 227,90 − (227,90×10,05/100) = 204.99605` (float 5 casas) e envia como `final_total`.
2. Backend `Util::num_uf("204.99605")` — heurística pt-BR tratava **>2 casas após o ponto** como separador de **milhar** → `str_replace('.', '')` → `"20499605"` → **R$ 20.499.605**. Bate exato.

A heurística (do fix anterior "80.00→8000") só cobria ≤2 casas. **Separador de milhar tem SEMPRE 3 dígitos** → 4+ casas após o ponto é inequivocamente decimal.

## Fix (2 camadas)
- **`Util::num_uf`**: `$afterLastDot !== 3` — decimal pra ≤2 e ≥4 casas; milhar só pra exatamente 3. Conserta **todo path** (React Create/Edit, API, Delphi). "25.000"→25000 e "80.00"→80 **intactos**.
- **`Sells/Create.tsx`**: `final_total: Math.round(totalGeral*100)/100` — não envia mais float de 5 casas (defesa + valor limpo).
- **`NumUfHeuristicPtBRTest`**: +4 casos guard (204.99605, 20.5005, 227.9, 1329.0567).

## ⚠️ Dado existente (separado)
Vendas já corrompidas têm **linhas + desconto intactos** → `final_total` é recomputável. Pra achar todas:
```sql
SELECT id, invoice_no, total_before_tax, discount_amount, discount_type, final_total
FROM transactions WHERE business_id=4 AND type='sell' AND final_total > (total_before_tax+1)*2;
```
Correção de dados (backfill recomputando final_total) vai num passo separado pós-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)