### PR TITLE
ci(incident): workflow pra corrigir final_total inflado na prod (16 vendas ROTA LIVRE)

### DIFF
--- a/.github/workflows/hostinger-final-total-fix.yml
+++ b/.github/workflows/hostinger-final-total-fix.yml
@@ -1,0 +1,45 @@
+name: Hostinger — corrigir final_total inflado (incidente num_uf 2026-06-05)
+
+# Dispatch manual pra rodar `sells:final-total-audit` na PROD Hostinger via SSH
+# (secrets SSH_HOST/PORT/USER/PRIVATE_KEY já existentes). Criado durante o
+# incidente ROTA LIVRE biz=4 (valores inflados ~×100k por num_uf strippar ponto
+# decimal de total fracionado). O comando é DRY-RUN por padrão; --apply exige
+# --transaction=ID (segurança per-row do próprio comando).
+#
+# Prefixo FIXO `php artisan sells:final-total-audit` (least-privilege: este
+# workflow só roda ESSE comando, não artisan arbitrário). Remover pós-incidente.
+#
+# Ref: PR fix #2279 (Util::num_uf) · app/Console/Commands/SellsFinalTotalAuditCommand.php
+
+on:
+  workflow_dispatch:
+    inputs:
+      args:
+        description: 'Args do sells:final-total-audit (ex: "--business=4 --since=2026-05-26" ou "--business=4 --apply --transaction=81939")'
+        required: true
+        type: string
+
+concurrency:
+  group: hostinger-final-total-fix
+  cancel-in-progress: false
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: SSH Hostinger → php artisan sells:final-total-audit
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          ARTISAN_ARGS: ${{ github.event.inputs.args }}
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          port: ${{ secrets.SSH_PORT }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: ARTISAN_ARGS
+          command_timeout: 10m
+          script: |
+            set -e
+            cd domains/oimpresso.com/public_html
+            echo "== pwd: $(pwd) =="
+            php artisan sells:final-total-audit $ARTISAN_ARGS

--- a/.github/workflows/hostinger-final-total-fix.yml
+++ b/.github/workflows/hostinger-final-total-fix.yml
@@ -3,20 +3,34 @@ name: Hostinger — corrigir final_total inflado (incidente num_uf 2026-06-05)
 # Dispatch manual pra rodar `sells:final-total-audit` na PROD Hostinger via SSH
 # (secrets SSH_HOST/PORT/USER/PRIVATE_KEY já existentes). Criado durante o
 # incidente ROTA LIVRE biz=4 (valores inflados ~×100k por num_uf strippar ponto
-# decimal de total fracionado). O comando é DRY-RUN por padrão; --apply exige
-# --transaction=ID (segurança per-row do próprio comando).
+# decimal de total fracionado — fix #2279).
 #
-# Prefixo FIXO `php artisan sells:final-total-audit` (least-privilege: este
-# workflow só roda ESSE comando, não artisan arbitrário). Remover pós-incidente.
+# Least-privilege: business FIXO=4, comando FIXO `sells:final-total-audit`, sem
+# args livres de shell. mode=dry-run só lista; mode=apply corrige os IDs passados
+# (o comando faz UPDATE cirúrgico só do final_total, recomputado dos campos intactos).
+# Remover pós-incidente.
 #
-# Ref: PR fix #2279 (Util::num_uf) · app/Console/Commands/SellsFinalTotalAuditCommand.php
+# Ref: PR #2279 (Util::num_uf) · app/Console/Commands/SellsFinalTotalAuditCommand.php
 
 on:
   workflow_dispatch:
     inputs:
-      args:
-        description: 'Args do sells:final-total-audit (ex: "--business=4 --since=2026-05-26" ou "--business=4 --apply --transaction=81939")'
+      mode:
+        description: 'dry-run (lista as infladas) ou apply (corrige os IDs)'
         required: true
+        default: 'dry-run'
+        type: choice
+        options:
+          - dry-run
+          - apply
+      since:
+        description: 'dry-run: auditar desde esta data (YYYY-MM-DD)'
+        required: false
+        default: '2026-05-26'
+        type: string
+      ids:
+        description: 'apply: IDs de transaction separados por espaço'
+        required: false
         type: string
 
 concurrency:
@@ -27,19 +41,31 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - name: SSH Hostinger → php artisan sells:final-total-audit
+      - name: SSH Hostinger → sells:final-total-audit
         uses: appleboy/ssh-action@v1.0.3
         env:
-          ARTISAN_ARGS: ${{ github.event.inputs.args }}
+          MODE: ${{ github.event.inputs.mode }}
+          SINCE: ${{ github.event.inputs.since }}
+          IDS: ${{ github.event.inputs.ids }}
         with:
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          envs: ARTISAN_ARGS
-          command_timeout: 10m
+          envs: MODE,SINCE,IDS
+          command_timeout: 15m
           script: |
             set -e
             cd domains/oimpresso.com/public_html
-            echo "== pwd: $(pwd) =="
-            php artisan sells:final-total-audit $ARTISAN_ARGS
+            echo "== pwd: $(pwd) · mode=$MODE =="
+            if [ "$MODE" = "apply" ]; then
+              for id in $IDS; do
+                case "$id" in
+                  ''|*[!0-9]*) echo "SKIP id inválido: $id"; continue ;;
+                esac
+                echo "---- apply transaction=$id ----"
+                php artisan sells:final-total-audit --business=4 --apply --transaction="$id"
+              done
+            else
+              php artisan sells:final-total-audit --business=4 --since="$SINCE"
+            fi


### PR DESCRIPTION
Workflow `workflow_dispatch` que roda `sells:final-total-audit` na **prod Hostinger** via os secrets SSH já existentes (SSH_HOST/PORT/USER/PRIVATE_KEY) — sem precisar de chave SSH local.

**Por quê:** incidente ROTA LIVRE biz=4 — 16 vendas com `final_total` inflado ~×100k (bug num_uf, fix #2279 já mergeado). O comando `sells:final-total-audit` (já existente, feito pra este bug) corrige, mas roda por artisan/shell. Esta sessão não tem chave SSH local; o workflow usa o segredo do GitHub.

**Segurança:** prefixo FIXO `php artisan sells:final-total-audit` (least-privilege — não roda artisan arbitrário). DRY-RUN por padrão; --apply exige --transaction=ID. **Remover pós-incidente.**

Mergeia que eu disparo o dry-run (te mostro o antes→depois das 16), aplico, e valido no browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)