### PR TITLE
fix(jana): juiz de UI vira de fato Sonnet 4.6 + G-Eval rationale-first (G2+G3 do parecer #2270)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           php artisan key:generate
           php artisan package:discover --ansi
 
-      - name: Run Pest (Form shim + FeatureFlagService offline-safe)
+      - name: Run Pest (Form shim + FeatureFlagService offline-safe + UI Judge catraca)
         # ModuleUtil::isModuleInstalled e getModuleVersionInfo agora sao
         # graceful (try/catch) — boot da app funciona sem migrate completo.
         #
@@ -86,7 +86,12 @@ jobs:
         # NAO incluir o diretorio inteiro: GrowthBookAdminServiceTest usa
         # RefreshDatabase e esbarra na migration MySQL-only (ALTER TABLE
         # transactions MODIFY COLUMN type ENUM) — fica pra um setup MySQL em CI.
-        run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php --no-coverage
+        #
+        # PrUiJudgeAgentTest e DB-less (reflexao nos atributos + string do prompt):
+        # trava provider/model do juiz de UI (anti "mentira do Sonnet", parecer
+        # PR #2270). Modules/Jana nao esta no modules-pest.yml, entao ancoramos a
+        # catraca aqui pra ela rodar de fato em todo PR.
+        run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php --no-coverage
 
   frontend:
     name: Frontend / Vite build

--- a/.github/workflows/pr-ui-judge.yml
+++ b/.github/workflows/pr-ui-judge.yml
@@ -1,11 +1,11 @@
 name: PR UI Judge (LLM Brain B · Constituição UI v2)
 
 # Onda 4.1 do AUTOMATION-ROADMAP. Avalia PRs Inertia/React contra a
-# Constituição UI v2 usando Claude Sonnet 4.5. Posta comentário inline
+# Constituição UI v2 usando Claude Sonnet 4.6. Posta comentário inline
 # com score 0-100 + 9 dimensões + violações estruturais + sugestões.
 #
 # CUSTO REAL:
-# - ~$0.034/PR (Claude Sonnet 4.5)
+# - ~$0.034/PR (Claude Sonnet 4.6)
 # - ~$0.005/PR após primeiro do dia (prompt caching ~85% reuse)
 # - ~$3/mês a 100 PRs/mês
 #
@@ -48,7 +48,7 @@ permissions:
 
 jobs:
   judge:
-    name: PR UI Judge · Claude Sonnet 4.5
+    name: PR UI Judge · Claude Sonnet 4.6
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
+++ b/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
@@ -14,7 +14,8 @@ use Stringable;
 /**
  * PrUiJudgeAgent — Onda 4.1 do AUTOMATION-ROADMAP.
  *
- * Agente LLM (OpenAI gpt-4o-mini · consistente com BriefDiarioAgent etc) que
+ * Agente LLM (Anthropic claude-sonnet-4-6 · review de design exige juízo
+ * semântico superior ao gpt-4o-mini) que
  * avalia PRs Inertia/React contra a Constituição UI v2 (ADR UI-0013). Carrega
  * no system prompt:
  *  - Hierarquia 4 camadas (Fundações → Shell → PT → Módulo)
@@ -37,21 +38,23 @@ use Stringable;
  * "copy não-PT-BR em string template", "PT-01 violado em essência mesmo
  * importando PageHeader (uso fora do slot 1)".
  *
- * Custo estimado por PR: ~10k tokens input + ~1k tokens output = $0.002/PR
- * (gpt-4o-mini @ $0.15/M input + $0.60/M output).
+ * Custo estimado por PR: ~10k tokens input + ~1k tokens output ≈ $0.034/PR
+ * (claude-sonnet-4-6 @ $3/M input + $15/M output) · com prompt caching do
+ * system prompt fixo cai pra ~$0.005/PR.
  *
- * UPGRADE PRA ANTHROPIC: trocar `#[Provider('openai')]` por
- * `#[Provider('anthropic')]` + `#[Model('claude-sonnet-4-5-20250929')]` se
- * `ANTHROPIC_API_KEY` for configurada (config/ai.php já provider 'anthropic'
- * registrado). Sonnet 4.5 dá review de qualidade superior · custo ~15x maior
- * ($0.034/PR) mas com prompt caching cai pra ~$0.005/PR.
+ * HISTÓRICO: nasceu em OpenAI gpt-4o-mini ($0.002/PR), mas o command e o
+ * workflow já se anunciavam como "Claude Sonnet" — inconsistência ativa
+ * (a tela dizia Sonnet, rodava gpt-4o-mini). Migrado pra anthropic /
+ * claude-sonnet-4-6 (canon do projeto · BrainBAgent, EvalCommands) tanto
+ * pra resolver a inconsistência quanto pela qualidade de juízo semântico
+ * que review de design exige. `ANTHROPIC_API_KEY` já é pré-req do kill-switch.
  *
  * @see memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md (Onda 4.1)
  * @see memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md
  * @see memory/decisions/0141-agents-tool-use-pattern-claude-code.md
  */
-#[Provider('openai')]
-#[Model('gpt-4o-mini')]
+#[Provider('anthropic')]
+#[Model('claude-sonnet-4-6')]
 #[MaxSteps(3)]
 class PrUiJudgeAgent implements Agent
 {
@@ -105,28 +108,36 @@ class PrUiJudgeAgent implements Agent
 
         UI-0009 + UI-0014 — Wagner-explícito 2026-05-24. v2 externa propõe dark sempre · **NÃO aplicar**.
 
-        ## Como você avalia
+        ## Como você avalia (método G-Eval · raciocine ANTES de pontuar)
 
-        Para cada PR recebido (metadata + diff), produza output JSON estrito:
+        Avalie em ordem encadeada — **primeiro o rationale dimensão-por-dimensão, só depois o score agregado**. Nunca crave o score total antes de raciocinar cada dimensão; o score é *derivado* das 9 dimensões, não chutado de cabeça.
+
+        Passos obrigatórios, nesta ordem:
+
+        1. **Para cada uma das 9 dimensões:** escreva primeiro o `rationale` (1-2 frases citando o que viu no diff — arquivo/linha quando possível), e só então atribua o `score` 0-10 coerente com esse rationale.
+        2. **Liste as `violacoes_estruturais`** grep-invisíveis encontradas (com arquivo/linha/severidade).
+        3. **Só então** compute o `score` total 0-100 (proporcional à soma das 9 dimensões · 9×10=90 → normalize pra 100) e derive o `verdict` dele: `< 60` → `request_changes`, `60-84` → `comment`, `≥ 85` → `approve`.
+
+        Produza output JSON estrito **nesta ordem de chaves** (a ordem reflete a ordem do raciocínio):
 
         ```json
         {
-          "score": 0-100,
-          "verdict": "approve | request_changes | comment",
           "dimensoes": {
-            "hierarquia_4_camadas": { "score": 0-10, "nota": "..." },
-            "pt_01_slot_adherence": { "score": 0-10, "nota": "..." },
-            "anti_padroes_ap1_ap8": { "score": 0-10, "nota": "..." },
-            "tokens_semanticos": { "score": 0-10, "nota": "..." },
-            "componentes_shared": { "score": 0-10, "nota": "..." },
-            "atalhos_canonicos_jk_cmdk": { "score": 0-10, "nota": "..." },
-            "localStorage_prefix_oimpresso": { "score": 0-10, "nota": "..." },
-            "pt_br_voice_tone": { "score": 0-10, "nota": "..." },
-            "lucide_iconography_only": { "score": 0-10, "nota": "..." }
+            "hierarquia_4_camadas": { "rationale": "...", "score": 0-10 },
+            "pt_01_slot_adherence": { "rationale": "...", "score": 0-10 },
+            "anti_padroes_ap1_ap8": { "rationale": "...", "score": 0-10 },
+            "tokens_semanticos": { "rationale": "...", "score": 0-10 },
+            "componentes_shared": { "rationale": "...", "score": 0-10 },
+            "atalhos_canonicos_jk_cmdk": { "rationale": "...", "score": 0-10 },
+            "localStorage_prefix_oimpresso": { "rationale": "...", "score": 0-10 },
+            "pt_br_voice_tone": { "rationale": "...", "score": 0-10 },
+            "lucide_iconography_only": { "rationale": "...", "score": 0-10 }
           },
           "violacoes_estruturais": [
             { "tipo": "...", "arquivo": "...", "linha": N, "detalhe": "...", "severidade": "critical|warning|info" }
           ],
+          "score": 0-100,
+          "verdict": "approve | request_changes | comment",
           "sugestoes": [
             "..."
           ],
@@ -137,6 +148,8 @@ class PrUiJudgeAgent implements Agent
           ]
         }
         ```
+
+        > Nota de compatibilidade: o campo de texto de cada dimensão chama-se agora `rationale` (antes `nota`). Quem consome o JSON deve aceitar ambos.
 
         ## Princípios de avaliação
 

--- a/Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Ai\Attributes\Model;
+use Laravel\Ai\Attributes\Provider;
+use Modules\Jana\Ai\Agents\PrUiJudgeAgent;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-JANA-UI-JUDGE — GUARD/catraca do PrUiJudgeAgent (juiz de UI · Onda 4.1).
+ *
+ * Origem 2026-06-05 (parecer PR #2270): o juiz se anunciava "Claude Sonnet 4.5"
+ * em 3 lugares (command + workflow) mas rodava #[Provider('openai')] /
+ * #[Model('gpt-4o-mini')] — inconsistência ativa ("a mentira do Sonnet").
+ * G3 resolveu migrando pra anthropic / claude-sonnet-4-6 (canon do projeto).
+ * Estes testes TRAVAM a consistência pra ela não regredir silenciosamente.
+ *
+ *  001. provider declarado = anthropic (não openai)
+ *  002. model declarado = claude-sonnet-4-6 (canon · BrainBAgent/EvalCommands)
+ *  003. instructions() carrega contrato G-Eval (rationale ANTES do score)
+ *  004. instructions() ainda carrega a Constituição UI v2 (4 camadas + AP1-AP8)
+ *
+ * @see memory/handoffs/2026-06-05-1430-parecer-pr2270-julgamento-ia-design.md
+ * @see memory/decisions/0141-agents-tool-use-pattern-claude-code.md
+ */
+it('R-JANA-UI-JUDGE-001 — declara provider anthropic (não a mentira do openai)', function () {
+    $attrs = (new ReflectionClass(PrUiJudgeAgent::class))->getAttributes(Provider::class);
+
+    expect($attrs)->not->toBeEmpty();
+    expect($attrs[0]->getArguments()[0])->toBe('anthropic');
+});
+
+it('R-JANA-UI-JUDGE-002 — declara model claude-sonnet-4-6 (canon do projeto)', function () {
+    $attrs = (new ReflectionClass(PrUiJudgeAgent::class))->getAttributes(Model::class);
+
+    expect($attrs)->not->toBeEmpty();
+    expect($attrs[0]->getArguments()[0])->toBe('claude-sonnet-4-6');
+});
+
+it('R-JANA-UI-JUDGE-003 — instructions() exige rationale ANTES do score (G-Eval)', function () {
+    $prompt = (string) (new PrUiJudgeAgent)->instructions();
+
+    expect($prompt)
+        ->toContain('G-Eval')
+        ->toContain('rationale')
+        ->toContain('raciocine ANTES de pontuar')
+        ->toContain('dimensão-por-dimensão');
+});
+
+it('R-JANA-UI-JUDGE-004 — instructions() carrega Constituição UI v2 (4 camadas + anti-padrões)', function () {
+    $prompt = (string) (new PrUiJudgeAgent)->instructions();
+
+    expect($prompt)
+        ->toContain('Constituição UI v2')
+        ->toContain('PT-01')
+        ->toContain('AP1')
+        ->toContain('AP8');
+});

--- a/app/Console/Commands/UiJudgePrCommand.php
+++ b/app/Console/Commands/UiJudgePrCommand.php
@@ -12,12 +12,12 @@ use Modules\Jana\Ai\Agents\PrUiJudgeAgent;
  * `ui:judge-pr` — Onda 4.1 do AUTOMATION-ROADMAP (Constituição UI v2).
  *
  * Avalia um PR contra a Constituição UI v2 usando agente LLM (Anthropic Claude
- * Sonnet 4.5) e — opcionalmente — posta comentário inline no PR via `gh`.
+ * Sonnet 4.6) e — opcionalmente — posta comentário inline no PR via `gh`.
  *
  * Workflow:
  *   1. Pega metadata do PR (título · descrição · arquivos modificados) via gh CLI
  *   2. Pega diff filtrado (.tsx, .jsx, .css)
- *   3. Manda pro PrUiJudgeAgent (anthropic / claude-sonnet-4-5)
+ *   3. Manda pro PrUiJudgeAgent (anthropic / claude-sonnet-4-6)
  *   4. Parse output JSON
  *   5. Print score + violações no console
  *   6. (Opcional) `--post-comment` posta no PR via gh
@@ -28,7 +28,7 @@ use Modules\Jana\Ai\Agents\PrUiJudgeAgent;
  *   php artisan ui:judge-pr 1438 --post-comment # postar comentário no PR
  *   php artisan ui:judge-pr 1438 --strict       # exit 1 se verdict=request_changes
  *
- * Custo estimado por run: ~$0.034 (Claude Sonnet 4.5) · com prompt caching
+ * Custo estimado por run: ~$0.034 (Claude Sonnet 4.6) · com prompt caching
  * cai pra ~$0.005 após primeiro PR do dia.
  *
  * @see Modules\Jana\Ai\Agents\PrUiJudgeAgent
@@ -100,7 +100,7 @@ class UiJudgePrCommand extends Command
         $this->line('  Diff UI: '.strlen($diff).' bytes');
 
         // 4. Mandar pro agent
-        $this->info('Enviando pra PrUiJudgeAgent (Claude Sonnet 4.5)...');
+        $this->info('Enviando pra PrUiJudgeAgent (Claude Sonnet 4.6)...');
         $output = $this->runAgent($prData, $diff);
         if ($output === null) {
             return self::FAILURE;
@@ -236,17 +236,15 @@ class UiJudgePrCommand extends Command
     private function runAgent(array $prData, string $diff): ?string
     {
         // Pre-flight: validar API key do provider configurado no PrUiJudgeAgent.
-        // Default PrUiJudgeAgent = OpenAI gpt-4o-mini (consistente com BriefDiarioAgent
-        // etc). Wagner pode trocar pra Anthropic editando o @Provider/@Model do agent.
-        $openaiKey = (string) (config('ai.providers.openai.key') ?? env('OPENAI_API_KEY') ?? '');
+        // PrUiJudgeAgent = Anthropic claude-sonnet-4-6 (review de design exige
+        // juízo semântico · canon do projeto). Wagner pode trocar editando o
+        // @Provider/@Model do agent.
         $anthropicKey = (string) (config('ai.providers.anthropic.key') ?? env('ANTHROPIC_API_KEY') ?? '');
 
-        if ($openaiKey === '' && $anthropicKey === '') {
-            $this->error('Nenhuma API key configurada (OPENAI_API_KEY nem ANTHROPIC_API_KEY)');
-            $this->line('  Adicionar em .env: OPENAI_API_KEY=sk-... (default do PrUiJudgeAgent)');
-            $this->line('  OU: ANTHROPIC_API_KEY=sk-ant-... (upgrade pra Claude Sonnet 4.5)');
-            $this->line('  Pegar key em: https://platform.openai.com/api-keys (OpenAI)');
-            $this->line('                https://console.anthropic.com/settings/keys (Anthropic)');
+        if ($anthropicKey === '') {
+            $this->error('ANTHROPIC_API_KEY não configurada (provider do PrUiJudgeAgent)');
+            $this->line('  Adicionar em .env: ANTHROPIC_API_KEY=sk-ant-... (Claude Sonnet 4.6)');
+            $this->line('  Pegar key em: https://console.anthropic.com/settings/keys');
             $this->line('  Depois: php artisan config:clear');
 
             return null;
@@ -320,7 +318,7 @@ class UiJudgePrCommand extends Command
             foreach ($review['dimensoes'] as $dim => $data) {
                 if (is_array($data)) {
                     $s = (int) ($data['score'] ?? 0);
-                    $nota = (string) ($data['nota'] ?? '');
+                    $nota = (string) ($data['rationale'] ?? $data['nota'] ?? '');
                     $this->line("  {$dim}: {$s}/10 · {$nota}");
                 }
             }
@@ -388,7 +386,7 @@ class UiJudgePrCommand extends Command
             foreach ($review['dimensoes'] as $dim => $data) {
                 if (is_array($data)) {
                     $s = (int) ($data['score'] ?? 0);
-                    $nota = (string) ($data['nota'] ?? '');
+                    $nota = (string) ($data['rationale'] ?? $data['nota'] ?? '');
                     $out[] = "| `{$dim}` | {$s}/10 | {$nota} |";
                 }
             }


### PR DESCRIPTION
## Contexto

Implementa **G2+G3** do parecer do PR #2270 (handoff `2026-06-05-1430-parecer-pr2270`). Wagner escolheu "corrigir o juiz".

## G3 — a "mentira do Sonnet" (inconsistência ativa)

O `PrUiJudgeAgent` se anunciava **"Claude Sonnet 4.5"** no command + workflow, mas rodava `#[Provider('openai')]` / `#[Model('gpt-4o-mini')]`. Quem ligasse o juiz veria "Sonnet" na tela e receberia gpt-4o-mini ($0.002 vs $0.034). O command **já diagnosticava erro 401 da Anthropic** e o workflow **já passava `ANTHROPIC_API_KEY`** — sinal de que a intenção sempre foi Anthropic; só o agente estava desalinhado.

- `PrUiJudgeAgent`: `#[Provider('anthropic')]` + `#[Model('claude-sonnet-4-6')]` (canon do projeto — BrainBAgent, EvalCommands; **não** o `4-5-20250929` stale do comentário antigo)
- `UiJudgePrCommand` + workflow: textos `Sonnet 4.5`→`4.6`; pré-flight passa a exigir `ANTHROPIC_API_KEY`

## G2 — qualidade via G-Eval (rationale-first)

`instructions()` reestruturado pro padrão G-Eval: **raciocínio dimensão-por-dimensão ANTES do score agregado** (hoje o `score` vinha primeiro no schema, enviesando o modelo a cravar número antes de raciocinar). O score total passa a ser *derivado* das 9 dimensões. Campo de texto por dimensão `nota`→`rationale` (render aceita ambos · retrocompat).

## Catraca

`PrUiJudgeAgentTest` (4 testes de reflexão, sem DB) trava provider/model + presença do contrato G-Eval, pra a inconsistência não regredir silenciosamente.

## Fora de escopo

PR #2270 (docs-only) continua OPEN — decisão separada do Wagner.

Refs: CYCLE-08 (off-cycle — engenharia do juiz de UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)