### PR TITLE
feat(jana): medição do PR UI Judge — jana_ui_judge_runs + jana:ui-judge-trend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         # trava provider/model do juiz de UI (anti "mentira do Sonnet", parecer
         # PR #2270). Modules/Jana nao esta no modules-pest.yml, entao ancoramos a
         # catraca aqui pra ela rodar de fato em todo PR.
-        run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php --no-coverage
+        run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage
 
   frontend:
     name: Frontend / Vite build

--- a/Modules/Jana/Console/Commands/UiJudgeTrendCommand.php
+++ b/Modules/Jana/Console/Commands/UiJudgeTrendCommand.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Jana\Entities\UiJudgeRun;
+
+/**
+ * jana:ui-judge-trend — responde "a técnica do juiz de UI está sendo medida?".
+ *
+ * Lê jana_ui_judge_runs (gravado por ui:judge-pr) e mostra, na janela pedida:
+ *  - volume de julgamentos + custo estimado total
+ *  - score médio + distribuição de verdict (loop fechado por métrica · princípio 4)
+ *  - últimos N runs
+ *
+ *   php artisan jana:ui-judge-trend                 # últimos 30 dias
+ *   php artisan jana:ui-judge-trend --days=7        # última semana
+ *   php artisan jana:ui-judge-trend --last=20       # mostra 20 runs recentes
+ *
+ * @see app/Console/Commands/UiJudgePrCommand.php (grava as runs)
+ */
+class UiJudgeTrendCommand extends Command
+{
+    protected $signature = 'jana:ui-judge-trend
+                            {--days=30 : Janela em dias}
+                            {--last=10 : Quantos runs recentes listar}';
+
+    protected $description = 'Trend do PR UI Judge — score médio, verdict, custo estimado por janela';
+
+    public function handle(): int
+    {
+        $days = max(1, (int) $this->option('days'));
+        $last = max(1, (int) $this->option('last'));
+
+        $since = now()->subDays($days);
+        $runs = UiJudgeRun::query()->where('judged_at', '>=', $since);
+
+        $total = (clone $runs)->count();
+
+        if ($total === 0) {
+            $this->warn("Nenhum julgamento nos últimos {$days} dias.");
+            $this->line('  O juiz dispara em PR que toca UI (kill-switch PR_UI_JUDGE_ENABLED=true)');
+            $this->line('  ou via: php artisan ui:judge-pr <N> --post-comment');
+
+            return self::SUCCESS;
+        }
+
+        $avgScore = round((float) (clone $runs)->avg('score'), 1);
+        $custo = round((float) (clone $runs)->sum('custo_usd_estimado'), 3);
+
+        $verdicts = (clone $runs)
+            ->selectRaw('verdict, count(*) as n')
+            ->groupBy('verdict')
+            ->pluck('n', 'verdict');
+
+        $this->newLine();
+        $this->info("PR UI Judge · últimos {$days} dias");
+        $this->line("  Julgamentos: {$total}");
+        $this->line("  Score médio: {$avgScore}/100");
+        $this->line('  Verdict: '
+            .'approve='.($verdicts['approve'] ?? 0).' · '
+            .'comment='.($verdicts['comment'] ?? 0).' · '
+            .'request_changes='.($verdicts['request_changes'] ?? 0));
+        $this->line("  Custo estimado: ~\${$custo}");
+        $this->newLine();
+
+        $recent = (clone $runs)
+            ->orderByDesc('judged_at')
+            ->limit($last)
+            ->get(['pr_number', 'model', 'score', 'verdict', 'violacoes_count', 'judged_at']);
+
+        $this->table(
+            ['PR', 'Modelo', 'Score', 'Verdict', 'Violações', 'Quando'],
+            $recent->map(fn (UiJudgeRun $r) => [
+                "#{$r->pr_number}",
+                $r->model,
+                "{$r->score}/100",
+                $r->verdict,
+                (string) $r->violacoes_count,
+                $r->judged_at?->format('d/m H:i') ?? '—',
+            ])->all(),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Jana/Database/Migrations/2026_06_05_120000_create_jana_ui_judge_runs_table.php
+++ b/Modules/Jana/Database/Migrations/2026_06_05_120000_create_jana_ui_judge_runs_table.php
@@ -1,0 +1,57 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * jana_ui_judge_runs — medição do PR UI Judge (Onda 4.1 · ADR UI-0013).
+ *
+ * Cada julgamento do PrUiJudgeAgent vira 1 INSERT aqui (append-only audit ·
+ * mesma filosofia de mcp_automation_runs / ENFORCEMENT.md §L7: nunca UPDATE/
+ * DELETE em rows existentes). Sem isso o juiz era fire-and-forget — postava o
+ * comentário no PR e o score evaporava, impossível medir trend/custo/acerto.
+ *
+ * NÃO É DADO MULTI-TENANT (Tier 0): o juiz roda a nível de repositório/CI, não
+ * por business. Logo NÃO tem business_id nem HasBusinessScope — é artefato de
+ * tooling de engenharia, não dado de cliente. (multi-tenant-patterns: caso
+ * system/CLI tratado explicitamente.)
+ *
+ * Retenção: via jana:retention-purge se o volume crescer (~100 PRs/mês = trivial).
+ * Idempotente (Schema::hasTable guard) + down().
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('jana_ui_judge_runs')) {
+            return;
+        }
+
+        Schema::create('jana_ui_judge_runs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('pr_number');
+            $table->string('repo', 140)->nullable();
+            $table->string('provider', 40);
+            $table->string('model', 60);
+            $table->unsignedSmallInteger('score');
+            $table->enum('verdict', ['approve', 'request_changes', 'comment']);
+            $table->unsignedSmallInteger('violacoes_count')->default(0);
+            $table->json('dimensoes')->nullable()
+                ->comment('score 0-10 por dimensão (9 dimensões da Constituição UI v2)');
+            $table->decimal('custo_usd_estimado', 8, 4)->nullable()
+                ->comment('estimativa por modelo · não é billing real');
+            $table->timestamp('judged_at');
+            $table->timestamps();
+
+            $table->index('judged_at', 'idx_ui_judge_judged_at');
+            $table->index('pr_number', 'idx_ui_judge_pr');
+            $table->index('verdict', 'idx_ui_judge_verdict');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jana_ui_judge_runs');
+    }
+};

--- a/Modules/Jana/Entities/UiJudgeRun.php
+++ b/Modules/Jana/Entities/UiJudgeRun.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * UiJudgeRun — 1 linha por julgamento do PrUiJudgeAgent (medição append-only).
+ *
+ * Tabela: jana_ui_judge_runs
+ * NÃO multi-tenant: artefato de CI/repo, não dado de business (sem business_id /
+ * HasBusinessScope · ver migration). Append-only: só INSERT, nunca UPDATE/DELETE.
+ *
+ * Gravado por UiJudgePrCommand após parse do review. Lido por
+ * `jana:ui-judge-trend` pra responder "a técnica está sendo medida?" — trend de
+ * score, distribuição de verdict e custo estimado por janela.
+ *
+ * @see app/Console/Commands/UiJudgePrCommand.php (grava)
+ * @see Modules/Jana/Console/Commands/UiJudgeTrendCommand.php (lê)
+ * @see Modules/Jana/Ai/Agents/PrUiJudgeAgent.php (o juiz)
+ */
+class UiJudgeRun extends Model
+{
+    protected $table = 'jana_ui_judge_runs';
+
+    protected $fillable = [
+        'pr_number',
+        'repo',
+        'provider',
+        'model',
+        'score',
+        'verdict',
+        'violacoes_count',
+        'dimensoes',
+        'custo_usd_estimado',
+        'judged_at',
+    ];
+
+    protected $casts = [
+        'pr_number' => 'integer',
+        'score' => 'integer',
+        'violacoes_count' => 'integer',
+        'dimensoes' => 'array',
+        'custo_usd_estimado' => 'decimal:4',
+        'judged_at' => 'datetime',
+    ];
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -73,6 +73,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\IndexRegenCommand::class, // regressão 2026-05-29 — gate integridade/priorização memory/INDEX.md (Tier 0 + links + contagens)
                 \Modules\Jana\Console\Commands\MeilisearchIndexSetupCommand::class, // 2026-05-29 — config-as-code dos embedders Meilisearch (Sprint 9b se perdeu)
                 \Modules\Jana\Console\Commands\ReconcileCommand::class, // ADR 0237 — jana:reconcile loop único (orquestra Reconcilers index/settings/content/deploy/eval)
+                \Modules\Jana\Console\Commands\UiJudgeTrendCommand::class, // parecer PR #2270 — medição do PR UI Judge (trend score/verdict/custo)
             ]);
         }
     }

--- a/Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\UiJudgeRun;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-JANA-UI-JUDGE-MEASURE — medição do PR UI Judge (parecer PR #2270).
+ *
+ * Antes o juiz era fire-and-forget: postava o comentário e o score evaporava.
+ * Estes testes travam o contrato de medição (jana_ui_judge_runs + trend):
+ *
+ *  001. UiJudgeRun persiste + casts (dimensoes array · judged_at datetime · int)
+ *  002. jana:ui-judge-trend agrega score médio + distribuição de verdict
+ *  003. trend sem dados não quebra (exit 0 + aviso de como ligar)
+ *
+ * Schema montado à mão (sqlite :memory:) — espelha o job Pest Unit do ci.yml
+ * que não roda migrate (Modules/Jana fora do modules-pest.yml).
+ *
+ * @see Modules/Jana/Database/Migrations/2026_06_05_120000_create_jana_ui_judge_runs_table.php
+ */
+beforeEach(function () {
+    Schema::dropIfExists('jana_ui_judge_runs');
+    Schema::create('jana_ui_judge_runs', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('pr_number');
+        $t->string('repo', 140)->nullable();
+        $t->string('provider', 40);
+        $t->string('model', 60);
+        $t->unsignedSmallInteger('score');
+        $t->string('verdict', 20);
+        $t->unsignedSmallInteger('violacoes_count')->default(0);
+        $t->json('dimensoes')->nullable();
+        $t->decimal('custo_usd_estimado', 8, 4)->nullable();
+        $t->timestamp('judged_at');
+        $t->timestamps();
+    });
+});
+
+it('R-JANA-UI-JUDGE-MEASURE-001 — persiste run com casts corretos', function () {
+    $run = UiJudgeRun::create([
+        'pr_number' => 2284,
+        'repo' => 'wagnerra23/oimpresso.com',
+        'provider' => 'anthropic',
+        'model' => 'claude-sonnet-4-6',
+        'score' => 87,
+        'verdict' => 'approve',
+        'violacoes_count' => 2,
+        'dimensoes' => ['pt_01_slot_adherence' => ['score' => 9, 'rationale' => 'ok']],
+        'custo_usd_estimado' => 0.034,
+        'judged_at' => now(),
+    ]);
+
+    $fresh = $run->fresh();
+
+    expect($fresh->score)->toBe(87)
+        ->and($fresh->pr_number)->toBe(2284)
+        ->and($fresh->dimensoes)->toBeArray()
+        ->and($fresh->dimensoes['pt_01_slot_adherence']['score'])->toBe(9)
+        ->and($fresh->judged_at)->not->toBeNull()
+        ->and($fresh->model)->toBe('claude-sonnet-4-6');
+});
+
+it('R-JANA-UI-JUDGE-MEASURE-002 — trend agrega score médio + verdict', function () {
+    foreach ([['s' => 80, 'v' => 'approve'], ['s' => 60, 'v' => 'comment'], ['s' => 40, 'v' => 'request_changes']] as $i => $row) {
+        UiJudgeRun::create([
+            'pr_number' => 100 + $i,
+            'provider' => 'anthropic',
+            'model' => 'claude-sonnet-4-6',
+            'score' => $row['s'],
+            'verdict' => $row['v'],
+            'violacoes_count' => 0,
+            'custo_usd_estimado' => 0.034,
+            'judged_at' => now(),
+        ]);
+    }
+
+    $this->artisan('jana:ui-judge-trend', ['--days' => 30])
+        ->expectsOutputToContain('Julgamentos: 3')
+        ->expectsOutputToContain('Score médio: 60')
+        ->assertExitCode(0);
+});
+
+it('R-JANA-UI-JUDGE-MEASURE-003 — trend sem dados avisa e não quebra', function () {
+    $this->artisan('jana:ui-judge-trend')
+        ->expectsOutputToContain('Nenhum julgamento')
+        ->assertExitCode(0);
+});

--- a/app/Console/Commands/UiJudgePrCommand.php
+++ b/app/Console/Commands/UiJudgePrCommand.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
 use Modules\Jana\Ai\Agents\PrUiJudgeAgent;
+use Modules\Jana\Entities\UiJudgeRun;
 
 /**
  * `ui:judge-pr` — Onda 4.1 do AUTOMATION-ROADMAP (Constituição UI v2).
@@ -118,6 +119,11 @@ class UiJudgePrCommand extends Command
         // 6. Render no console
         $this->renderReview($review);
 
+        // 6.5. Medição (append-only · jana_ui_judge_runs). Sem isto o juiz era
+        // fire-and-forget: postava o comentário e o score evaporava. Best-effort —
+        // medição NUNCA derruba o julgamento.
+        $this->recordRun($prNumber, $repo, $review);
+
         // 7. Save to file
         if ($saveTo !== '') {
             file_put_contents(base_path($saveTo), json_encode($review, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
@@ -138,6 +144,76 @@ class UiJudgePrCommand extends Command
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Persiste 1 linha de medição (append-only) por julgamento.
+     *
+     * Provider/model são lidos por reflexão dos atributos do PrUiJudgeAgent —
+     * assim a medição reflete o modelo REAL em uso (nunca mais "anuncia X, roda
+     * Y"). Best-effort: qualquer falha aqui é avisada mas não derruba o run.
+     */
+    private function recordRun(int $prNumber, string $repo, array $review): void
+    {
+        try {
+            [$provider, $model] = $this->agentProviderModel();
+
+            $verdict = $review['verdict'] ?? 'comment';
+            if (! in_array($verdict, ['approve', 'request_changes', 'comment'], true)) {
+                $verdict = 'comment';
+            }
+
+            UiJudgeRun::create([
+                'pr_number' => $prNumber,
+                'repo' => $repo !== '' ? $repo : null,
+                'provider' => $provider,
+                'model' => $model,
+                'score' => (int) ($review['score'] ?? 0),
+                'verdict' => $verdict,
+                'violacoes_count' => is_array($review['violacoes_estruturais'] ?? null)
+                    ? count($review['violacoes_estruturais'])
+                    : 0,
+                'dimensoes' => $review['dimensoes'] ?? null,
+                'custo_usd_estimado' => $this->estimateCostUsd($model),
+                'judged_at' => now(),
+            ]);
+
+            $this->line('  Medição registrada em jana_ui_judge_runs (jana:ui-judge-trend)');
+        } catch (\Throwable $e) {
+            $this->warn('  Medição não registrada (não-bloqueante): '.$e->getMessage());
+        }
+    }
+
+    /**
+     * Provider + model declarados nos atributos do PrUiJudgeAgent (reflexão).
+     *
+     * @return array{0:string, 1:string}
+     */
+    private function agentProviderModel(): array
+    {
+        $ref = new \ReflectionClass(PrUiJudgeAgent::class);
+
+        $provider = ($ref->getAttributes(\Laravel\Ai\Attributes\Provider::class)[0] ?? null)
+            ?->getArguments()[0] ?? 'unknown';
+        $model = ($ref->getAttributes(\Laravel\Ai\Attributes\Model::class)[0] ?? null)
+            ?->getArguments()[0] ?? 'unknown';
+
+        return [(string) $provider, (string) $model];
+    }
+
+    /**
+     * Estimativa grosseira de custo por PR (~10k tokens in + ~1k out).
+     * NÃO é billing real — só pra dar ordem de grandeza no trend.
+     */
+    private function estimateCostUsd(string $model): ?float
+    {
+        return match (true) {
+            str_contains($model, 'opus') => 0.165,
+            str_contains($model, 'sonnet') => 0.034,
+            str_contains($model, 'haiku') => 0.003,
+            str_contains($model, 'gpt-4o-mini') => 0.002,
+            default => null,
+        };
     }
 
     /**


### PR DESCRIPTION
## Por quê

O parecer do #2270 + cobrança do Wagner ("vai estar sendo medida?") revelou que o juiz de UI era **fire-and-forget**: postava o comentário no PR e o score evaporava. Não dava pra responder *"a técnica está acertando? qual o trend? quanto custou?"*. Princípio duro #4 (loop fechado por métrica) não estava sendo cumprido.

## O que entra

- **Migration `jana_ui_judge_runs`** — append-only audit (idempotente + `down()`). **Sem `business_id`**: é artefato de CI/repo, não dado de tenant (documentado na migration · multi-tenant-patterns caso system tratado explícito).
- **Entity `UiJudgeRun`** — casts (`dimensoes` array, `judged_at` datetime).
- **`UiJudgePrCommand`** grava a run após o parse do review (best-effort — medição nunca derruba o julgamento). Provider/model lidos por **reflexão dos atributos do agent**, então a medição reflete o modelo real em uso — nunca mais "anuncia X, roda Y".
- **`jana:ui-judge-trend`** — score médio + distribuição de verdict + custo estimado por janela + últimos N runs.
- **Catraca `UiJudgeRunMeasurementTest`** (3 testes) ancorada no `ci.yml` Pest Unit (Jana está fora do `modules-pest.yml`).

## Como medir, na prática

```
php artisan jana:ui-judge-trend            # últimos 30 dias
php artisan jana:ui-judge-trend --days=7
```

O juiz já está **ligado** (`PR_UI_JUDGE_ENABLED=true`) — a partir de agora todo PR que toca UI alimenta a tabela.

## Sequência

Depende do #2284 (já mergeado) — esta branch saiu da main atualizada.

Refs: CYCLE-08 (off-cycle — engenharia do juiz de UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)