### PR TITLE
docs(design): protótipo da prancheta Designer · oimpresso_designer_view

### DIFF
--- a/oimpresso_designer_view/README.md
+++ b/oimpresso_designer_view/README.md
@@ -1,0 +1,15 @@
+# oimpresso_designer_view
+
+Protótipo da **prancheta de design** do Oimpresso — ferramenta estilo Figma, canon-locked, pra compor/padronizar telas do ERP em co-design humano + IA.
+
+## Como abrir
+Abra `index.html` no navegador (arquivo único, autocontido — sem build).
+
+## O que tem
+- Canvas + camadas + inspector + undo/redo
+- Modo ▶ Visualizar com ações executáveis (Trigger→Ação)
+- 6 estados (cheia/loading/vazia/sem-resultado/erro)
+- Auditor (lint contra o padrão) + export (pedido / YAML / JSON / HTML)
+
+## Status
+Protótipo (ponto de partida). ⚠️ Embute tokens do **canon antigo (azul 220)** — re-baseiar no canon vivo (roxo 295) é o próximo passo. Não está plugado em nenhum pipeline; é referência pra evoluir.

--- a/oimpresso_designer_view/index.html
+++ b/oimpresso_designer_view/index.html
@@ -1,0 +1,1400 @@
+<!doctype html>
+<html lang="pt-BR" data-ui="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Oimpresso Designer · canvas + ações + Claude Code</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+/* ============================================================
+   PARTE 1 · CHROME DO EDITOR
+   ============================================================ */
+*{box-sizing:border-box}
+:root{
+  --c-bg:#0f1115; --c-panel:#171a21; --c-panel-2:#1c2029; --c-line:#262b35;
+  --c-line-2:#313847; --c-text:#e6e9ef; --c-dim:#9aa3b2; --c-mute:#6b7484;
+  --c-accent:#4c8dff; --c-accent-soft:#1b2740; --c-canvas:#0b0d11;
+  --c-good:#3fb37f; --c-warn:#d9a441; --c-bad:#e0594b; --c-play:#27c08a;
+  --c-r:7px; --c-r-sm:5px;
+}
+html,body{margin:0;height:100%;background:var(--c-bg);color:var(--c-text);
+  font-family:"IBM Plex Sans",system-ui,sans-serif;font-size:13px;overflow:hidden}
+.mono{font-family:"IBM Plex Mono",monospace}
+button{font-family:inherit}
+.app{display:grid;grid-template-rows:46px 1fr;height:100vh}
+
+/* TOPBAR */
+.topbar{display:flex;align-items:center;gap:10px;padding:0 14px;background:var(--c-panel);
+  border-bottom:1px solid var(--c-line);z-index:30}
+.brand{display:flex;align-items:center;gap:9px;font-weight:700;letter-spacing:-.01em}
+.brand .dot{width:18px;height:18px;border-radius:5px;background:linear-gradient(135deg,#4c8dff,#8a6dff);
+  display:grid;place-items:center;color:#fff;font-size:11px;font-weight:700}
+.brand small{font-weight:500;color:var(--c-mute);font-size:11px;font-family:"IBM Plex Mono"}
+.fname{background:var(--c-panel-2);border:1px solid var(--c-line);color:var(--c-text);
+  border-radius:var(--c-r-sm);padding:6px 10px;font-size:12.5px;font-weight:600;width:150px;outline:none}
+.fname:focus{border-color:var(--c-accent)}
+.tb-sp{flex:1}
+.tb-group{display:flex;align-items:center;gap:4px;background:var(--c-panel-2);border:1px solid var(--c-line);
+  border-radius:var(--c-r-sm);padding:3px}
+.tb-group button{background:transparent;border:0;color:var(--c-dim);padding:5px 8px;border-radius:4px;
+  cursor:pointer;font-size:12px;font-weight:600;display:flex;align-items:center;gap:5px}
+.tb-group button:hover{background:var(--c-line);color:var(--c-text)}
+.tb-group button:disabled{opacity:.35;cursor:default}
+.tb-group button[aria-pressed=true]{background:var(--c-accent);color:#fff}
+.tb-group.mode button[data-v=preview][aria-pressed=true]{background:var(--c-play)}
+.tb-state{background:var(--c-panel-2);border:1px solid var(--c-line);color:var(--c-text);
+  border-radius:var(--c-r-sm);padding:6px 8px;font-size:12px;font-weight:600;outline:none}
+.tb-state:focus{border-color:var(--c-accent)}
+.btn-x{background:transparent;border:1px solid var(--c-line-2);color:var(--c-text);padding:7px 12px;
+  border-radius:var(--c-r-sm);cursor:pointer;font-weight:600;font-size:12.5px}
+.btn-x:hover{background:var(--c-panel-2)}
+.btn-pri{background:var(--c-accent);border-color:var(--c-accent);color:#fff}
+.btn-pri:hover{background:#3d7df0}
+
+/* BODY GRID */
+.body{display:grid;grid-template-columns:248px 1fr 290px;height:100%;overflow:hidden}
+.body.preview{grid-template-columns:0 1fr 0}
+.pane{background:var(--c-panel);overflow:hidden;display:flex;flex-direction:column;min-height:0}
+.pane.left{border-right:1px solid var(--c-line)}
+.pane.right{border-left:1px solid var(--c-line)}
+.body.preview .pane{display:none}
+.pane-tabs{display:flex;border-bottom:1px solid var(--c-line);flex:none}
+.pane-tabs button{flex:1;background:transparent;border:0;color:var(--c-mute);padding:10px 6px;
+  cursor:pointer;font-weight:600;font-size:11.5px;text-transform:uppercase;letter-spacing:.06em;
+  border-bottom:2px solid transparent;margin-bottom:-1px}
+.pane-tabs button[aria-pressed=true]{color:var(--c-text);border-bottom-color:var(--c-accent)}
+.pane-body{overflow-y:auto;flex:1;min-height:0}
+.pane-body::-webkit-scrollbar{width:9px}
+.pane-body::-webkit-scrollbar-thumb{background:var(--c-line-2);border-radius:9px;border:2px solid var(--c-panel)}
+
+/* PALETTE */
+.pal-group{padding:12px 12px 4px}
+.pal-group h4{margin:0 0 8px;font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--c-mute);font-weight:700}
+.pal-grid{display:grid;grid-template-columns:1fr 1fr;gap:6px}
+.pal-item{display:flex;flex-direction:column;align-items:flex-start;gap:6px;background:var(--c-panel-2);
+  border:1px solid var(--c-line);border-radius:var(--c-r-sm);padding:9px;cursor:pointer;text-align:left;color:var(--c-text)}
+.pal-item:hover{border-color:var(--c-accent);background:var(--c-accent-soft)}
+.pal-item .gi{width:22px;height:16px;border-radius:3px;display:grid;place-items:center;color:var(--c-dim)}
+.pal-item b{font-size:11.5px;font-weight:600}
+.pal-note{padding:4px 12px 14px;color:var(--c-mute);font-size:11px;line-height:1.5}
+
+/* LAYERS */
+.layers{padding:6px 6px 16px}
+.lyr{display:flex;align-items:center;gap:6px;padding:5px 6px;border-radius:5px;cursor:pointer;
+  font-size:12.5px;color:var(--c-dim);user-select:none;position:relative}
+.lyr:hover{background:var(--c-panel-2);color:var(--c-text)}
+.lyr.sel{background:var(--c-accent-soft);color:var(--c-text)}
+.lyr.sel::before{content:"";position:absolute;left:0;top:3px;bottom:3px;width:2px;background:var(--c-accent);border-radius:2px}
+.lyr .tw{width:14px;flex:none;text-align:center;color:var(--c-mute);font-size:10px}
+.lyr .ic{width:15px;flex:none;color:var(--c-mute);display:grid;place-items:center}
+.lyr .nm{flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.lyr .bolt{color:var(--c-play);font-size:10px;flex:none}
+.lyr .ty{font-size:10px;color:var(--c-mute);font-family:"IBM Plex Mono"}
+.lyr .vis{opacity:0;color:var(--c-mute);cursor:pointer;font-size:11px;padding:2px}
+.lyr:hover .vis{opacity:1}
+.lyr.hidden .nm{opacity:.4;text-decoration:line-through}
+.lyr.drop-into{background:var(--c-accent-soft);box-shadow:inset 0 0 0 1px var(--c-accent)}
+.lyr.drop-before::after,.lyr.drop-after::after{content:"";position:absolute;left:6px;right:6px;height:2px;background:var(--c-accent);border-radius:2px}
+.lyr.drop-before::after{top:-1px}
+.lyr.drop-after::after{bottom:-1px}
+
+/* CANVAS */
+.canvas-wrap{background:var(--c-canvas);position:relative;overflow:auto;min-height:0;
+  background-image:radial-gradient(var(--c-line) 1px,transparent 1px);background-size:22px 22px}
+.canvas-scroll{min-width:100%;min-height:100%;display:grid;place-items:center;padding:60px 40px}
+.stage{transform-origin:center top;transition:transform .12s ease}
+.frame-label{font-size:12px;color:var(--c-dim);font-weight:600;margin:0 0 8px 2px;display:flex;gap:8px;align-items:center}
+.frame-label .mono{color:var(--c-mute);font-size:11px}
+.frame-label .play{color:var(--c-play)}
+.frame{width:1180px;background:var(--oi-bg,#fff);border-radius:10px;overflow:hidden;position:relative;
+  box-shadow:0 20px 60px -20px rgba(0,0,0,.6),0 0 0 1px rgba(255,255,255,.04)}
+
+.zoom{position:absolute;left:50%;transform:translateX(-50%);bottom:16px;display:flex;align-items:center;gap:2px;
+  background:var(--c-panel);border:1px solid var(--c-line-2);border-radius:99px;padding:4px;z-index:12;
+  box-shadow:0 8px 24px -8px #000}
+.zoom button{background:transparent;border:0;color:var(--c-dim);width:30px;height:28px;border-radius:99px;cursor:pointer;font-size:15px}
+.zoom button:hover{background:var(--c-panel-2);color:var(--c-text)}
+.zoom .lvl{min-width:48px;text-align:center;font-size:12px;font-weight:600;font-family:"IBM Plex Mono"}
+
+[data-node-id]{position:relative}
+.oi-canvas.edit [data-node-id].node-hover{outline:1.5px solid color-mix(in srgb,var(--c-accent) 60%,transparent);outline-offset:0}
+.oi-canvas.edit [data-node-id].node-sel{outline:2px solid var(--c-accent);outline-offset:0}
+.oi-canvas.edit [data-node-id].node-sel::after{content:attr(data-tag);position:absolute;top:-19px;left:-2px;
+  background:var(--c-accent);color:#fff;font-size:10px;font-weight:700;font-family:"IBM Plex Mono";
+  padding:1px 6px;border-radius:4px 4px 0 0;white-space:nowrap;pointer-events:none;z-index:5}
+.oi-canvas [data-hidden=true]{display:none!important}
+.oi-canvas.play [data-act]{cursor:pointer}
+
+/* INSPECTOR */
+.insp{padding:0 0 24px}
+.insp-empty{padding:40px 18px;color:var(--c-mute);text-align:center;line-height:1.6;font-size:12.5px}
+.insp-head{padding:12px 14px;border-bottom:1px solid var(--c-line);display:flex;align-items:center;gap:8px;position:sticky;top:0;background:var(--c-panel);z-index:2}
+.insp-head .ic{width:18px;color:var(--c-accent)}
+.insp-head b{font-size:13px}
+.insp-head .ty{margin-left:auto;font-size:10px;color:var(--c-mute);font-family:"IBM Plex Mono"}
+.insp-sec{padding:12px 14px;border-bottom:1px solid var(--c-line)}
+.insp-sec h5{margin:0 0 10px;font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--c-mute);font-weight:700;display:flex;align-items:center;gap:6px}
+.insp-sec h5 .bolt{color:var(--c-play)}
+.row{display:flex;flex-direction:column;gap:5px;margin-bottom:11px}
+.row:last-child{margin-bottom:0}
+.row label{font-size:11.5px;color:var(--c-dim);font-weight:600}
+.row input[type=text],.row textarea,.row select{width:100%;background:var(--c-panel-2);border:1px solid var(--c-line);
+  color:var(--c-text);border-radius:var(--c-r-sm);padding:7px 9px;font-size:12.5px;outline:none;font-family:inherit}
+.row textarea{resize:vertical;min-height:54px;line-height:1.45}
+.row input:focus,.row textarea:focus,.row select:focus{border-color:var(--c-accent)}
+.seg{display:flex;border:1px solid var(--c-line);border-radius:var(--c-r-sm);overflow:hidden}
+.seg button{flex:1;background:var(--c-panel-2);border:0;color:var(--c-dim);padding:7px 4px;cursor:pointer;
+  font-size:11.5px;font-weight:600;border-left:1px solid var(--c-line)}
+.seg button:first-child{border-left:0}
+.seg button[aria-pressed=true]{background:var(--c-accent);color:#fff}
+.chk{display:flex;align-items:center;gap:8px;cursor:pointer;font-size:12.5px;color:var(--c-text)}
+.chk input{accent-color:var(--c-accent);width:15px;height:15px}
+.list-edit{display:flex;flex-direction:column;gap:6px}
+.li{display:flex;gap:5px;align-items:center}
+.li input,.li select{flex:1;min-width:0;background:var(--c-panel-2);border:1px solid var(--c-line);color:var(--c-text);border-radius:5px;padding:6px 7px;font-size:12px;outline:none}
+.li .del{background:transparent;border:1px solid var(--c-line);color:var(--c-mute);width:28px;height:30px;border-radius:5px;cursor:pointer;flex:none}
+.li .del:hover{border-color:var(--c-bad);color:var(--c-bad)}
+.act-card{background:var(--c-panel-2);border:1px solid var(--c-line);border-radius:6px;padding:8px;display:flex;flex-direction:column;gap:6px;margin-bottom:7px;position:relative}
+.act-card .act-del{position:absolute;top:6px;right:6px;background:transparent;border:0;color:var(--c-mute);cursor:pointer;font-size:13px}
+.act-card .act-del:hover{color:var(--c-bad)}
+.act-card .two{display:flex;gap:6px}
+.act-card .two select{flex:1}
+.add-row{background:var(--c-panel-2);border:1px dashed var(--c-line-2);color:var(--c-dim);
+  border-radius:var(--c-r-sm);padding:7px;cursor:pointer;font-size:12px;font-weight:600;width:100%}
+.add-row:hover{border-color:var(--c-accent);color:var(--c-text)}
+.insp-actions{display:flex;gap:6px;padding:12px 14px}
+.insp-actions button{flex:1;background:var(--c-panel-2);border:1px solid var(--c-line);color:var(--c-text);
+  padding:7px;border-radius:var(--c-r-sm);cursor:pointer;font-size:12px;font-weight:600;display:flex;align-items:center;justify-content:center;gap:5px}
+.insp-actions button:hover{border-color:var(--c-accent)}
+.insp-actions .danger:hover{border-color:var(--c-bad);color:var(--c-bad)}
+
+.swatches{display:flex;gap:6px;flex-wrap:wrap}
+.swatch{width:30px;height:30px;border-radius:6px;cursor:pointer;border:2px solid transparent;position:relative}
+.swatch[aria-pressed=true]{border-color:var(--c-text)}
+.hint-line{font-size:11px;color:var(--c-mute);line-height:1.5;margin:8px 0 0}
+.sov{font-size:11px;line-height:1.5;color:var(--c-dim);background:var(--c-accent-soft);border-left:3px solid var(--c-accent);
+  padding:9px 11px;border-radius:6px;margin-top:10px}
+.sov b{color:var(--c-text)}
+
+/* EXPORT MODAL */
+.modal-host{position:fixed;inset:0;z-index:60;display:none}
+.modal-host.on{display:block}
+.scrim{position:absolute;inset:0;background:rgba(0,0,0,.55);backdrop-filter:blur(2px)}
+.modal{position:absolute;inset:5% 8%;background:var(--c-panel);border:1px solid var(--c-line-2);border-radius:12px;
+  display:flex;flex-direction:column;overflow:hidden;box-shadow:0 30px 80px -20px #000}
+.modal-head{display:flex;align-items:center;gap:10px;padding:14px 18px;border-bottom:1px solid var(--c-line)}
+.modal-head b{font-size:15px}
+.modal-head .sp{flex:1}
+.exp-tabs{display:flex;gap:2px;padding:10px 18px 0;flex-wrap:wrap}
+.exp-tabs button{background:transparent;border:0;color:var(--c-mute);padding:9px 13px;cursor:pointer;
+  font-weight:600;font-size:12.5px;border-bottom:2px solid transparent}
+.exp-tabs button[aria-pressed=true]{color:var(--c-text);border-bottom-color:var(--c-accent)}
+.exp-body{flex:1;overflow:auto;padding:14px 18px 18px}
+.exp-lead{color:var(--c-dim);font-size:12.5px;line-height:1.55;margin:0 0 12px}
+.exp-lead b{color:var(--c-text)}
+pre.out{background:var(--c-canvas);border:1px solid var(--c-line);color:#cfe3ff;font-family:"IBM Plex Mono";
+  font-size:12px;line-height:1.55;padding:14px;border-radius:8px;white-space:pre-wrap;word-break:break-word;margin:0}
+.copy-bar{display:flex;align-items:center;gap:10px;margin-bottom:10px}
+.copy-msg{color:var(--c-good);font-size:12px;font-weight:600}
+
+/* ============================================================
+   PARTE 2 · TOKENS OIMPRESSO (Camada 1) — escopo .oi-scope
+   ============================================================ */
+.oi-scope{
+  --p-accent:oklch(.58 .09 220); --p-accent-2:oklch(.66 .09 220);
+  --p-accent-soft:oklch(.94 .025 220); --p-accent-line:oklch(.80 .045 220);
+  --accent:var(--p-accent); --accent-2:var(--p-accent-2);
+  --accent-soft:var(--p-accent-soft); --accent-line:var(--p-accent-line); --accent-fg:#fff;
+  --bg:oklch(.985 .003 90); --bg-2:oklch(.965 .004 90); --surface:#fff;
+  --border:oklch(.90 .004 90); --border-2:oklch(.93 .004 90);
+  --text:oklch(.22 .01 80); --text-dim:oklch(.50 .01 80); --text-mute:oklch(.65 .01 80);
+  --ok:oklch(.55 .14 145); --warn:oklch(.62 .13 60); --bad:oklch(.55 .18 25);
+  --info:oklch(.58 .13 240); --jana:oklch(.55 .13 295);
+  --sb-bg:oklch(.21 0 0); --sb-bg-2:oklch(.18 0 0); --sb-border:oklch(.28 0 0);
+  --sb-text:oklch(.78 0 0); --sb-text-dim:oklch(.55 0 0); --sb-text-hi:oklch(.96 0 0);
+  --sb-hover:oklch(.27 0 0); --sb-active:oklch(.32 0 0);
+  --origin-OS-bg:oklch(.93 .06 70);  --origin-OS-fg:oklch(.40 .10 60);
+  --origin-CRM-bg:oklch(.92 .06 220);--origin-CRM-fg:oklch(.40 .10 220);
+  --origin-FIN-bg:oklch(.93 .07 145);--origin-FIN-fg:oklch(.36 .10 145);
+  --origin-PNT-bg:oklch(.93 .06 295);--origin-PNT-fg:oklch(.40 .10 295);
+  --origin-MFG-bg:oklch(.93 .05 30); --origin-MFG-fg:oklch(.40 .10 30);
+  --font-sans:"IBM Plex Sans",sans-serif; --font-mono:"IBM Plex Mono",monospace;
+  --space-1:4px;--space-2:8px;--space-3:12px;--space-4:16px;--space-5:20px;--space-6:24px;--space-8:32px;
+  --radius-sm:6px;--radius:8px;--radius-lg:12px;--radius-pill:99px;
+  --row-h:40px;--fs-body:14px;--fs-h2:18px;--fs-title:22px;--fs-label:11px;
+  --shadow-soft:0 1px 2px rgba(0,0,0,.04);
+  --shadow-pop:0 6px 24px -8px rgba(0,0,0,.18),0 2px 6px -2px rgba(0,0,0,.10);
+}
+.oi-scope[data-theme=dark]{
+  --bg:oklch(.18 .006 260); --bg-2:oklch(.21 .006 260); --surface:oklch(.235 .007 260);
+  --border:oklch(.32 .008 260); --border-2:oklch(.28 .008 260);
+  --text:oklch(.96 .005 260); --text-dim:oklch(.74 .01 260); --text-mute:oklch(.60 .01 260);
+  --accent-soft:oklch(.30 .05 220); --shadow-soft:0 1px 2px rgba(0,0,0,.3);
+}
+.oi-scope[data-density=comfortable]{--row-h:48px}
+.oi-scope[data-density=compact]{--row-h:34px;--fs-body:13px}
+.oi-scope[data-radius=sharp]{--radius-sm:2px;--radius:3px;--radius-lg:4px}
+.oi-scope[data-radius=round]{--radius-sm:10px;--radius:14px;--radius-lg:18px}
+.oi-scope{font-family:var(--font-sans);color:var(--text);font-size:var(--fs-body);background:var(--bg)}
+.oi-mono{font-family:var(--font-mono)}
+
+/* ============================================================
+   PARTE 3 · COMPONENTS OIMPRESSO (Camada 3)
+   ============================================================ */
+.oi-scope .screen{padding:var(--space-6) var(--space-8);display:flex;flex-direction:column;gap:var(--space-5);min-height:200px}
+.oi-scope .cluster{display:flex;gap:var(--space-3);flex-wrap:wrap;align-items:center}
+.oi-scope .stack{display:flex;flex-direction:column;gap:var(--space-3)}
+
+.oi-scope .page-header{display:flex;align-items:flex-start;justify-content:space-between;gap:var(--space-4)}
+.oi-scope .page-header .ph-l h2{margin:0;font-size:var(--fs-title);font-weight:700;letter-spacing:-.02em}
+.oi-scope .page-header .ph-kpi{margin:4px 0 0;color:var(--text-dim);font-size:13px}
+.oi-scope .page-header .ph-r{display:flex;gap:var(--space-2);flex:none}
+
+.oi-scope .btn{font:inherit;font-weight:600;font-size:13px;padding:9px 14px;border-radius:var(--radius-sm);
+  border:1px solid transparent;cursor:pointer;display:inline-flex;align-items:center;gap:7px;line-height:1}
+.oi-scope .btn-primary{background:var(--accent);color:var(--accent-fg)}
+.oi-scope .btn-ghost{background:transparent;color:var(--accent);border-color:var(--border)}
+.oi-scope .btn-subtle{background:var(--bg-2);color:var(--text-dim);border-color:var(--border)}
+.oi-scope .btn-danger{background:transparent;color:var(--bad);border-color:color-mix(in oklch,var(--bad) 40%,var(--border))}
+.oi-scope .btn-sm{padding:6px 10px;font-size:12px} .oi-scope .btn-lg{padding:12px 18px;font-size:14px}
+.oi-scope .btn:disabled{opacity:.5}
+.oi-scope .btn-icon{padding:7px;width:32px;height:32px;justify-content:center;color:var(--text-dim);background:transparent;border-color:var(--border)}
+
+.oi-scope .field{display:flex;flex-direction:column;gap:6px}
+.oi-scope .label{font-size:12px;font-weight:600;color:var(--text-dim)}
+.oi-scope .input,.oi-scope .textarea{font:inherit;font-size:13.5px;width:100%;background:var(--surface);
+  border:1px solid var(--border);border-radius:var(--radius-sm);padding:9px 11px;color:var(--text);outline:none}
+.oi-scope .textarea{min-height:70px;resize:vertical;line-height:1.45}
+.oi-scope .input:focus,.oi-scope .textarea:focus{border-color:var(--accent);box-shadow:0 0 0 3px var(--accent-soft)}
+.oi-scope .input-group{display:flex;align-items:stretch;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden;background:var(--surface)}
+.oi-scope .input-group .addon{display:grid;place-items:center;padding:0 11px;background:var(--bg-2);color:var(--text-mute);font-size:13px;border-right:1px solid var(--border)}
+.oi-scope .input-group .input{border:0;border-radius:0} .oi-scope .input-group .input:focus{box-shadow:none}
+.oi-scope .field.is-error .input{border-color:var(--bad)}
+.oi-scope .hint{font-size:11.5px;color:var(--text-mute)} .oi-scope .field.is-error .hint{color:var(--bad)}
+.oi-scope select.input{appearance:none;background-image:linear-gradient(45deg,transparent 50%,var(--text-mute) 50%),linear-gradient(135deg,var(--text-mute) 50%,transparent 50%);background-position:calc(100% - 16px) 55%,calc(100% - 11px) 55%;background-size:5px 5px;background-repeat:no-repeat}
+
+.oi-scope .badge{display:inline-flex;align-items:center;gap:7px;font-size:12.5px;font-weight:600}
+.oi-scope .badge::before{content:"";width:7px;height:7px;border-radius:50%;background:currentColor}
+.oi-scope .badge.is-ok{color:var(--ok)} .oi-scope .badge.is-warn{color:var(--warn)}
+.oi-scope .badge.is-bad{color:var(--bad)} .oi-scope .badge.is-info{color:var(--info)}
+.oi-scope .badge.is-jana{color:var(--jana)} .oi-scope .badge.is-neutral{color:var(--text-mute)}
+
+.oi-scope .chip{font-size:11.5px;font-weight:700;padding:3px 10px;border-radius:var(--radius-pill);letter-spacing:.02em}
+.oi-scope .chip.origin-OS{background:var(--origin-OS-bg);color:var(--origin-OS-fg)}
+.oi-scope .chip.origin-CRM{background:var(--origin-CRM-bg);color:var(--origin-CRM-fg)}
+.oi-scope .chip.origin-FIN{background:var(--origin-FIN-bg);color:var(--origin-FIN-fg)}
+.oi-scope .chip.origin-PNT{background:var(--origin-PNT-bg);color:var(--origin-PNT-fg)}
+.oi-scope .chip.origin-MFG{background:var(--origin-MFG-bg);color:var(--origin-MFG-fg)}
+.oi-scope .tag{font-size:11.5px;font-weight:600;padding:3px 9px;border-radius:var(--radius-pill);background:var(--bg-2);color:var(--text-dim);border:1px solid var(--border)}
+
+.oi-scope .card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);padding:var(--space-5);box-shadow:var(--shadow-soft)}
+.oi-scope .kpi-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:var(--space-4)}
+.oi-scope .kpi{display:flex;flex-direction:column;gap:5px}
+.oi-scope .kpi-label{font-size:12px;color:var(--text-mute);font-weight:600}
+.oi-scope .kpi-value{font-family:var(--font-mono);font-size:26px;font-weight:500;letter-spacing:-.02em}
+.oi-scope .kpi-delta{font-size:12px;color:var(--text-mute)}
+.oi-scope .kpi-delta.up{color:var(--ok)} .oi-scope .kpi-delta.down{color:var(--bad)}
+
+.oi-scope .tabs{display:flex;gap:2px;border-bottom:1px solid var(--border)}
+.oi-scope .tabs a{display:flex;align-items:center;gap:7px;padding:10px 13px;text-decoration:none;color:var(--text-dim);font-weight:600;font-size:13px;border-bottom:2px solid transparent;margin-bottom:-1px}
+.oi-scope .tabs a[aria-current=true]{color:var(--accent);border-bottom-color:var(--accent)}
+.oi-scope .tabs .count{font-size:11px;font-family:var(--font-mono);background:var(--bg-2);color:var(--text-mute);padding:1px 7px;border-radius:var(--radius-pill)}
+
+.oi-scope .toolbar{display:flex;align-items:center;gap:var(--space-3)}
+.oi-scope .search{display:flex;align-items:center;gap:8px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-sm);padding:0 11px;flex:1;max-width:340px}
+.oi-scope .search svg{width:15px;height:15px;color:var(--text-mute);flex:none}
+.oi-scope .search .input{border:0;padding:9px 0;background:transparent} .oi-scope .search .input:focus{box-shadow:none}
+.oi-scope .kbd{font-family:var(--font-mono);font-size:11px;color:var(--text-mute);border:1px solid var(--border);border-radius:5px;padding:2px 6px;background:var(--bg-2)}
+.oi-scope .segmented{display:inline-flex;border:1px solid var(--border);border-radius:var(--radius-sm);overflow:hidden}
+.oi-scope .segmented button{font:inherit;font-size:12.5px;font-weight:600;padding:7px 12px;border:0;border-left:1px solid var(--border);background:var(--surface);color:var(--text-dim);cursor:pointer}
+.oi-scope .segmented button:first-child{border-left:0}
+.oi-scope .segmented button[aria-pressed=true]{background:var(--accent);color:var(--accent-fg)}
+
+.oi-scope .table{width:100%;border-collapse:collapse;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);overflow:hidden}
+.oi-scope .table th,.oi-scope .table td{text-align:left;padding:0 14px;height:var(--row-h);border-bottom:1px solid var(--border-2);font-size:13.5px;white-space:nowrap}
+.oi-scope .table th{font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--text-mute);background:var(--bg-2);font-weight:700}
+.oi-scope .table td.mono,.oi-scope .table td.num{font-family:var(--font-mono);color:var(--text-dim)}
+.oi-scope .table td.num{text-align:right}
+.oi-scope .table tr:last-child td{border-bottom:0}
+.oi-scope .table tbody tr.is-selected{background:var(--accent-soft)}
+.oi-scope.play .table tbody tr:hover{background:var(--bg-2)}
+
+.oi-scope .callout{background:var(--accent-soft);border-left:3px solid var(--accent);border-radius:var(--radius-sm);padding:11px 14px;color:var(--text-dim);font-size:13px;line-height:1.5}
+.oi-scope .callout.is-bad{background:color-mix(in oklch,var(--bad) 12%,var(--surface));border-left-color:var(--bad);color:var(--bad)}
+
+.oi-scope .empty{display:flex;flex-direction:column;align-items:center;text-align:center;gap:6px;padding:40px 20px}
+.oi-scope .empty-icon{width:36px;height:36px;color:var(--text-mute)}
+.oi-scope .empty-title{margin:6px 0 0;font-weight:700;font-size:15px}
+.oi-scope .empty-sub{margin:0;color:var(--text-dim);font-size:13px;max-width:360px;line-height:1.5}
+.oi-scope .empty-actions{display:flex;gap:var(--space-2);margin-top:10px}
+
+.oi-scope .h-text{margin:0;font-weight:700;letter-spacing:-.01em}
+.oi-scope .h1{font-size:var(--fs-title)} .oi-scope .h2{font-size:var(--fs-h2)} .oi-scope .h3{font-size:14px}
+.oi-scope .p-text{margin:0;line-height:1.55} .oi-scope .p-text.dim{color:var(--text-dim)}
+.oi-scope .divider{border:0;border-top:1px solid var(--border);margin:var(--space-2) 0}
+
+/* novos componentes */
+.oi-scope .check{display:inline-flex;align-items:center;gap:8px;font-size:13px;color:var(--text);cursor:pointer}
+.oi-scope .check input{accent-color:var(--accent);width:16px;height:16px}
+.oi-scope .switch{display:inline-flex;align-items:center;gap:9px;font-size:13px;color:var(--text);cursor:pointer}
+.oi-scope .switch input{position:absolute;opacity:0}
+.oi-scope .switch .track{width:36px;height:20px;border-radius:99px;background:var(--border);position:relative;transition:.15s}
+.oi-scope .switch .track::after{content:"";position:absolute;top:2px;left:2px;width:16px;height:16px;border-radius:50%;background:#fff;transition:.15s;box-shadow:0 1px 2px rgba(0,0,0,.3)}
+.oi-scope .switch input:checked+.track{background:var(--accent)}
+.oi-scope .switch input:checked+.track::after{left:18px}
+.oi-scope .breadcrumb{display:flex;align-items:center;gap:7px;font-size:12.5px;color:var(--text-mute)}
+.oi-scope .breadcrumb a{color:var(--text-dim);text-decoration:none} .oi-scope .breadcrumb a:last-child{color:var(--text);font-weight:600}
+.oi-scope .breadcrumb .sep{color:var(--text-mute)}
+.oi-scope .pagination{display:inline-flex;gap:4px;align-items:center}
+.oi-scope .pagination button{min-width:32px;height:32px;border:1px solid var(--border);background:var(--surface);color:var(--text-dim);border-radius:var(--radius-sm);cursor:pointer;font:inherit;font-size:12.5px;font-weight:600}
+.oi-scope .pagination button[aria-current=true]{background:var(--accent);color:var(--accent-fg);border-color:var(--accent)}
+.oi-scope .avatar{width:32px;height:32px;border-radius:50%;background:var(--accent-soft);color:var(--accent);display:inline-grid;place-items:center;font-weight:700;font-size:12px;border:1px solid var(--accent-line)}
+.oi-scope .skel{background:linear-gradient(90deg,var(--bg-2) 25%,var(--border-2) 50%,var(--bg-2) 75%);background-size:200% 100%;animation:shimmer 1.3s infinite;border-radius:var(--radius-sm)}
+@keyframes shimmer{0%{background-position:200% 0}100%{background-position:-200% 0}}
+.oi-scope .skel-row{height:14px;margin:13px 14px;border-radius:5px}
+
+/* SHELL */
+.shell{display:grid;grid-template-columns:212px 1fr}
+.shell .sb{background:var(--sb-bg);padding:16px 12px;display:flex;flex-direction:column;gap:3px}
+.shell .sb .sb-brand{display:flex;align-items:center;gap:9px;color:var(--sb-text-hi);font-weight:700;font-size:14px;padding:4px 8px 14px}
+.shell .sb .sb-brand .g{width:22px;height:22px;border-radius:6px;background:var(--accent);display:grid;place-items:center;color:#fff;font-size:12px}
+.shell .sb a{color:var(--sb-text);text-decoration:none;padding:8px 11px;border-radius:var(--radius-sm);font-size:13px;font-weight:500}
+.shell .sb a:hover{background:var(--sb-hover);color:var(--sb-text-hi)}
+.shell .sb a.on{background:var(--sb-active);color:var(--sb-text-hi)}
+.shell .sb a.dim{color:var(--sb-text-dim)}
+.shell .sb .sb-sp{flex:1}
+.shell .main-col{background:var(--bg);min-width:0}
+.shell .topbar-oi{height:54px;border-bottom:1px solid var(--border);display:flex;align-items:center;gap:10px;padding:0 var(--space-6);background:var(--surface)}
+.shell .topbar-oi .crumb{color:var(--text-mute);font-size:12.5px} .shell .topbar-oi .crumb b{color:var(--text)}
+.shell .topbar-oi .sp{flex:1}
+.shell .topbar-oi .ava2{width:30px;height:30px;border-radius:50%;background:var(--accent-soft);border:1px solid var(--accent-line)}
+
+/* OVERLAYS runtime (preview) */
+.oi-overlay{position:absolute;inset:0;z-index:40;display:none}
+.oi-overlay.on{display:block}
+.oi-overlay .o-scrim{position:absolute;inset:0;background:rgba(0,0,0,.4)}
+.oi-scope .drawer{position:absolute;top:0;right:0;bottom:0;width:min(620px,80%);background:var(--surface);
+  border-left:1px solid var(--border);box-shadow:var(--shadow-pop);display:flex;flex-direction:column;animation:slideIn .18s ease}
+@keyframes slideIn{from{transform:translateX(20px);opacity:.6}to{transform:none;opacity:1}}
+.oi-scope .drawer-head,.oi-scope .modal-oi-head{display:flex;align-items:center;justify-content:space-between;padding:var(--space-4) var(--space-5);border-bottom:1px solid var(--border)}
+.oi-scope .drawer-head h3,.oi-scope .modal-oi-head h3{margin:0;font-size:var(--fs-h2);font-weight:700}
+.oi-scope .drawer-body,.oi-scope .modal-oi-body{padding:var(--space-5);display:flex;flex-direction:column;gap:var(--space-4);overflow:auto;flex:1}
+.oi-scope .drawer-foot,.oi-scope .modal-oi-foot{display:flex;justify-content:flex-end;gap:var(--space-2);padding:var(--space-4) var(--space-5);border-top:1px solid var(--border)}
+.oi-scope .x-btn{background:transparent;border:0;color:var(--text-mute);font-size:18px;cursor:pointer;line-height:1}
+.oi-scope .modal-oi{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:min(460px,86%);background:var(--surface);border-radius:var(--radius-lg);box-shadow:var(--shadow-pop);overflow:hidden}
+.bulkbar{position:absolute;left:50%;bottom:20px;transform:translateX(-50%);z-index:42;display:none;align-items:center;gap:12px;
+  background:var(--text);color:var(--bg);border-radius:var(--radius-pill);padding:8px 10px 8px 16px;box-shadow:var(--shadow-pop)}
+.bulkbar.on{display:flex}
+.bulkbar .b-count{font-size:13px;font-weight:600}
+.bulkbar .sep{width:1px;height:18px;background:color-mix(in oklch,var(--bg) 40%,transparent)}
+.bulkbar button{background:transparent;border:0;color:var(--bg);font:inherit;font-size:12.5px;font-weight:600;cursor:pointer;padding:6px 8px;border-radius:var(--radius-sm)}
+.bulkbar button:hover{background:color-mix(in oklch,var(--bg) 20%,transparent)}
+.bulkbar button.danger{color:#ffb4ab}
+.oi-toasts{position:absolute;right:18px;bottom:18px;z-index:44;display:flex;flex-direction:column;gap:8px;align-items:flex-end}
+.oi-scope .toast{background:var(--text);color:var(--bg);padding:10px 14px;border-radius:var(--radius);font-size:13px;font-weight:600;
+  box-shadow:var(--shadow-pop);display:flex;align-items:center;gap:8px;animation:toastIn .2s ease}
+.oi-scope .toast.stub{background:var(--warn);color:#1a1200}
+.oi-scope .toast.ok::before{content:"✓"}
+@keyframes toastIn{from{transform:translateY(8px);opacity:0}to{transform:none;opacity:1}}
+
+/* AUDITORIA */
+.audit-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;align-items:start}
+.audit-col{display:flex;flex-direction:column;min-height:0}
+.audit-ta{min-height:46vh;width:100%;background:var(--c-canvas);border:1px solid var(--c-line);color:#cfe3ff;
+  font-family:"IBM Plex Mono";font-size:12px;line-height:1.5;padding:12px;border-radius:8px;resize:vertical;outline:none}
+.audit-ta:focus{border-color:var(--c-accent)}
+.audit-report{border:1px solid var(--c-line);border-radius:8px;overflow:auto;max-height:46vh}
+.rep-head{padding:11px 14px;font-weight:700;font-size:13px;display:flex;gap:8px;align-items:center}
+.rep-head.pass{background:rgba(63,179,127,.15);color:var(--c-good)}
+.rep-head.fail{background:rgba(224,89,75,.15);color:var(--c-bad)}
+.hit{padding:10px 14px;border-top:1px solid var(--c-line);font-size:12px;line-height:1.5}
+.hit .ln{font-family:"IBM Plex Mono";color:var(--c-mute);font-size:11px}
+.hit .rule{font-weight:700;color:var(--c-text)}
+.hit .sev{font-size:10px;font-weight:700;padding:1px 6px;border-radius:4px;margin-left:6px}
+.sev-P0{background:var(--c-bad);color:#fff}.sev-P1{background:var(--c-warn);color:#1a1200}.sev-P2{background:var(--c-line-2);color:var(--c-dim)}
+.hit .val{font-family:"IBM Plex Mono";color:var(--c-bad);font-weight:600}
+.hit .sug{font-family:"IBM Plex Mono";color:var(--c-good)}
+.hit .snip{display:block;margin-top:4px;color:var(--c-mute);font-family:"IBM Plex Mono";font-size:11px;white-space:pre-wrap;word-break:break-word}
+.chklist{margin-top:16px}
+.chklist h5{font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--c-mute);font-weight:700;margin:0 0 8px}
+.chk-item{display:flex;gap:9px;align-items:flex-start;padding:5px 0;font-size:12.5px;color:var(--c-dim);cursor:pointer}
+.chk-item input{margin-top:2px;accent-color:var(--c-accent);flex:none}
+</style>
+</head>
+<body>
+<div class="app">
+
+  <!-- TOPBAR -->
+  <header class="topbar">
+    <div class="brand"><span class="dot">O</span><div>Oimpresso&nbsp;Designer<br><small class="mono">canvas · ações · claude code</small></div></div>
+    <input class="fname" id="fname" value="Faturas" title="Nome da tela"/>
+
+    <div class="tb-group" title="Desfazer / Refazer">
+      <button id="undo" title="Desfazer (Ctrl+Z)">↶</button>
+      <button id="redo" title="Refazer (Ctrl+Shift+Z)">↷</button>
+    </div>
+
+    <div class="tb-group mode" id="segMode" title="Editar = compor · Visualizar = as ações executam">
+      <button data-v="edit" aria-pressed="true">✎ Editar</button>
+      <button data-v="preview">▶ Visualizar</button>
+    </div>
+
+    <select class="tb-state" id="selState" title="Estado da tela (PADRÃO B4 · 6 estados)">
+      <option value="full">Estado: cheia</option>
+      <option value="loading">Estado: loading</option>
+      <option value="empty">Estado: vazia</option>
+      <option value="noresults">Estado: sem resultado</option>
+      <option value="error">Estado: erro</option>
+    </select>
+
+    <div class="tb-sp"></div>
+
+    <div class="tb-group" id="segTheme" title="Tema (claro/escuro)">
+      <button data-v="light" aria-pressed="true">☀</button>
+      <button data-v="dark">☾</button>
+    </div>
+    <button class="btn-x" id="btnShell" aria-pressed="true" title="Shell (sidebar dark + header)">▦ Shell</button>
+    <button class="btn-x" id="btnAudit" title="Fiscalizar uma tela existente contra o PADRÃO">⌕ Auditar</button>
+    <button class="btn-x btn-pri" id="btnExport">⤓ Exportar</button>
+  </header>
+
+  <!-- BODY -->
+  <div class="body" id="bodyGrid">
+
+    <!-- LEFT -->
+    <aside class="pane left">
+      <div class="pane-tabs" id="leftTabs">
+        <button data-lt="insert" aria-pressed="true">Inserir</button>
+        <button data-lt="layers">Camadas</button>
+      </div>
+      <div class="pane-body" id="leftInsert">
+        <div class="pal-group">
+          <h4>Padrão de tela (Camada 3)</h4>
+          <div class="pal-grid" id="palTemplates"></div>
+          <p class="pal-note">Substitui a tela pelo template canônico (já com ações de exemplo).</p>
+        </div>
+        <div class="pal-group"><h4>Containers</h4><div class="pal-grid" id="palContainers"></div></div>
+        <div class="pal-group"><h4>Componentes</h4><div class="pal-grid" id="palComponents"></div></div>
+        <p class="pal-note">Lib soberana Oimpresso — você é dono do código (modelo shadcn). Tudo consome <span class="mono">var(--token)</span>; zero dependência externa.</p>
+      </div>
+      <div class="pane-body" id="leftLayers" style="display:none"><div class="layers" id="layers"></div></div>
+    </aside>
+
+    <!-- CENTER -->
+    <section class="canvas-wrap" id="canvasWrap">
+      <div class="canvas-scroll">
+        <div class="stage" id="stage">
+          <div class="frame-label">
+            <span id="flName">Faturas</span><span class="mono" id="flMeta">lista · 1180px</span>
+            <span class="play" id="flPlay" style="display:none">● ações ativas</span>
+          </div>
+          <div class="frame" id="frame">
+            <div class="oi-canvas oi-scope edit" id="oiRoot" data-theme="light"></div>
+            <div class="oi-overlay oi-scope" id="oiOverlay"></div>
+            <div class="oi-toasts oi-scope" id="oiToasts"></div>
+          </div>
+        </div>
+      </div>
+      <div class="zoom">
+        <button id="zOut" title="Diminuir">−</button>
+        <span class="lvl" id="zLvl">100%</span>
+        <button id="zIn" title="Aumentar">+</button>
+        <button id="zFit" title="100%">⤢</button>
+      </div>
+    </section>
+
+    <!-- RIGHT -->
+    <aside class="pane right">
+      <div class="pane-tabs" id="rightTabs">
+        <button data-rt="insp" aria-pressed="true">Propriedades</button>
+        <button data-rt="design">Design</button>
+      </div>
+      <div class="pane-body" id="rightInsp"><div class="insp" id="insp"></div></div>
+      <div class="pane-body" id="rightDesign" style="display:none">
+        <div class="insp-sec"><h5>Marca · accent (seed)</h5><div class="swatches" id="brandSwatches"></div>
+          <p class="hint-line">Cada vertical tem seu accent. O resto da paleta é fixo.</p></div>
+        <div class="insp-sec"><h5>Densidade</h5><div class="seg" id="segDen">
+          <button data-v="comfortable">conf.</button><button data-v="default" aria-pressed="true">padrão</button><button data-v="compact">compacto</button></div></div>
+        <div class="insp-sec"><h5>Raio</h5><div class="seg" id="segRad">
+          <button data-v="sharp">reto</button><button data-v="default" aria-pressed="true">padrão</button><button data-v="round">arred.</button></div></div>
+        <div class="insp-sec"><h5>Módulo / origem</h5>
+          <div class="row"><label>Módulo</label><input type="text" id="modName" value="Faturas"/></div>
+          <div class="row"><label>Origem dominante</label><select id="modOrigin">
+            <option value="">— nenhuma —</option><option value="OS">OS · ordem de serviço</option>
+            <option value="CRM">CRM · clientes</option><option value="FIN" selected>FIN · financeiro</option>
+            <option value="PNT">PNT · apontamento</option><option value="MFG">MFG · produção</option></select></div>
+          <div class="sov">⛔ <b>Soberano (ADR-0050):</b> sidebar dark, roxo da <b>Jana</b> (IA · 295) e os hues de <b>status</b> não mudam por marca/tema.</div>
+        </div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<!-- EXPORT MODAL -->
+<div class="modal-host" id="modalHost">
+  <div class="scrim" data-close></div>
+  <div class="modal">
+    <div class="modal-head"><b>Exportar</b><span class="mono" style="color:var(--c-mute);font-size:11px">handoff p/ Claude Code</span><span class="sp"></span><button class="btn-x" data-close>Fechar</button></div>
+    <div class="exp-tabs" id="expTabs">
+      <button data-et="prompt" aria-pressed="true">Pedido (Parte F)</button>
+      <button data-et="yaml">Spec YAML</button>
+      <button data-et="json">JSON</button>
+      <button data-et="html">HTML ref.</button>
+    </div>
+    <div class="exp-body">
+      <p class="exp-lead" id="expLead"></p>
+      <div class="copy-bar"><button class="btn-x btn-pri" id="btnCopy">Copiar</button><span class="copy-msg" id="copyMsg"></span></div>
+      <pre class="out" id="expOut"></pre>
+    </div>
+  </div>
+</div>
+
+<!-- AUDIT MODAL -->
+<div class="modal-host" id="auditHost">
+  <div class="scrim" data-aclose></div>
+  <div class="modal">
+    <div class="modal-head"><b>Auditar tela · padronizar sem ferir o core</b>
+      <span class="mono" style="color:var(--c-mute);font-size:11px">o que o Figma não faz: fiscalizar o código</span>
+      <span class="sp"></span>
+      <button class="btn-x" id="auditCur">Analisar composição atual</button>
+      <button class="btn-x" data-aclose>Fechar</button>
+    </div>
+    <div class="exp-body">
+      <p class="exp-lead">Cole o HTML/CSS de uma tela <b>existente</b>. O auditor aponta o que fere o PADRÃO — cor hardcoded (AP1), soberania (U-02), storage sem prefixo (AP3), fonte/raio/gradiente/emoji — com o <b>token/correção</b> e a <b>severidade</b>. Ele fiscaliza; não conserta sozinho.</p>
+      <div class="audit-grid">
+        <div class="audit-col"><textarea class="audit-ta" id="auditIn" spellcheck="false"></textarea></div>
+        <div class="audit-col">
+          <div class="audit-report" id="auditRep"></div>
+          <div class="chklist" id="auditChk"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ================================================================ ENGINE ================================================================ */
+const $  = s => document.querySelector(s);
+const $$ = s => [...document.querySelectorAll(s)];
+const KEY = "oimpresso.designer.v2";
+
+const TYPES = {
+  screen:{label:"Tela",icon:"▢",container:true},
+  card:{label:"Card",icon:"▭",container:true},
+  cluster:{label:"Cluster",icon:"☰",container:true},
+  stack:{label:"Stack",icon:"≡",container:true},
+  kpiGrid:{label:"KPI grid",icon:"▦",container:true},
+  pageHeader:{label:"PageHeader",icon:"⬓",actionable:true},
+  breadcrumb:{label:"Breadcrumb",icon:"›"},
+  tabs:{label:"Tabs",icon:"⊟",actionable:true},
+  toolbar:{label:"Toolbar",icon:"⛏",actionable:true},
+  kpi:{label:"KPI",icon:"#"},
+  table:{label:"Tabela",icon:"▤",actionable:true},
+  pagination:{label:"Paginação",icon:"⋯",actionable:true},
+  button:{label:"Botão",icon:"⬚",actionable:true},
+  field:{label:"Campo",icon:"⌨",actionable:true},
+  checkbox:{label:"Checkbox",icon:"☑"},
+  switch:{label:"Switch",icon:"◑"},
+  badge:{label:"Badge",icon:"●"},
+  chip:{label:"Chip origem",icon:"◆"},
+  avatar:{label:"Avatar",icon:"◯"},
+  callout:{label:"Callout",icon:"!"},
+  empty:{label:"EmptyState",icon:"○",actionable:true},
+  heading:{label:"Título",icon:"H"},
+  text:{label:"Texto",icon:"¶"},
+  tag:{label:"Tag",icon:"⬩"},
+  divider:{label:"Divisor",icon:"—"},
+};
+const ACTIONS = {
+  none:"— nada —", toast:"Toast (feedback)", drawer:"Abrir drawer", modal:"Abrir modal",
+  navigate:"Navegar / trocar aba", bulk:"Mostrar bulk bar", selectRow:"Selecionar linha", stub:"Stub 'em breve'",
+};
+const TRIGGERS = { click:"clique", hover:"hover", change:"mudança" };
+
+function defaults(type){
+  switch(type){
+    case "card": return {pad:true};
+    case "pageHeader": return {title:"Faturas",kpi:"128 faturas · R$ 84.250 a receber",primary:"Nova fatura",showExport:true};
+    case "breadcrumb": return {items:["Início","Financeiro","Faturas"]};
+    case "tabs": return {items:[{label:"Todas",count:"128"},{label:"Em aberto",count:"32"},{label:"Vencidas",count:"7"},{label:"Pagas",count:"89"}],active:0};
+    case "toolbar": return {placeholder:"Buscar…",kbd:true,segments:["Lista","Kanban","Calendário"],active:0};
+    case "kpi": return {label:"A receber",value:"R$ 84.250",delta:"▲ 12% vs. mês anterior",dir:"up"};
+    case "table": return {columns:["NF-e","Cliente","Valor","Emissão","Status"],rows:3,mono:[0,2,3],origin:""};
+    case "pagination": return {pages:4,active:1};
+    case "button": return {label:"Nova fatura",variant:"primary",size:"md"};
+    case "field": return {label:"Cliente",placeholder:"Buscar cliente…",value:"",kind:"input",state:"default",hint:"",addon:""};
+    case "checkbox": return {label:"Emitir NF-e automática",checked:true};
+    case "switch": return {label:"Notificações",checked:true};
+    case "badge": return {label:"Pago",status:"ok"};
+    case "chip": return {origin:"FIN",label:"FIN"};
+    case "avatar": return {initials:"GS"};
+    case "callout": return {text:"Tudo aqui consome var(--token). Troque tema ou marca e a tela retematiza.",variant:"info"};
+    case "empty": return {title:"Nenhuma fatura ainda",sub:"Crie a primeira fatura ou peça à Jana pra gerar a partir de uma OS concluída.",primary:"Criar primeira fatura",secondary:"Perguntar à Jana"};
+    case "heading": return {text:"Resumo",level:"h2"};
+    case "text": return {text:"Texto de corpo padrão da interface.",dim:false};
+    case "tag": return {label:"rascunho"};
+    default: return {};
+  }
+}
+
+let _id = 0;
+const uid = () => "n"+(++_id);
+function node(type, props={}, children=[], actions=[]){ return {id:uid(), type, props:Object.assign(defaults(type),props), children, actions, hidden:false}; }
+
+/* templates já com AÇÕES de exemplo (funções que executam no Visualizar) */
+const T = {
+  lista(){ return node("screen",{pattern:"lista"},[
+    node("pageHeader",{},[],[{trigger:"click",do:"drawer",arg:"Nova fatura"}]),
+    node("tabs",{},[],[{trigger:"click",do:"navigate",arg:""}]),
+    node("toolbar"),
+    node("table",{},[],[{trigger:"click",do:"drawer",arg:"Detalhe da fatura"},{trigger:"click",do:"bulk",arg:""}]),
+  ]); },
+  dashboard(){ return node("screen",{pattern:"dashboard"},[
+    node("pageHeader",{title:"Visão geral",kpi:"junho · 2026",primary:"Exportar relatório"},[],[{trigger:"click",do:"toast",arg:"Relatório exportado ✓"}]),
+    node("kpiGrid",{},[ node("kpi",{label:"A receber",value:"R$ 84.250",delta:"▲ 12%",dir:"up"}),
+      node("kpi",{label:"Vencidas",value:"R$ 12.100",delta:"▼ 3 faturas",dir:"down"}),
+      node("kpi",{label:"Ticket médio",value:"R$ 2.634",delta:"32 faturas",dir:""}) ]),
+    node("card",{},[ node("heading",{text:"Últimas faturas",level:"h3"}), node("table") ]),
+  ]); },
+  form(){ return node("screen",{pattern:"form"},[
+    node("breadcrumb"),
+    node("pageHeader",{title:"Nova fatura",kpi:"",primary:"Salvar fatura",showExport:false},[],[{trigger:"click",do:"toast",arg:"Fatura salva ✓"}]),
+    node("card",{},[ node("field",{label:"Cliente",placeholder:"Buscar cliente…"}),
+      node("cluster",{},[ node("field",{label:"Valor",placeholder:"0,00",addon:"R$"}), node("field",{label:"Vencimento",placeholder:"dd/mm/aaaa"}) ]),
+      node("field",{label:"Origem",kind:"select",placeholder:"OS · CRM · FIN · Manual"}),
+      node("field",{label:"Observação",kind:"textarea",placeholder:"Notas internas…"}),
+      node("checkbox"),
+      node("callout",{text:"A cor primária deste form é a marca selecionada. Troque no painel Design."}) ]),
+    node("cluster",{},[ node("button",{label:"Cancelar",variant:"ghost"}), node("button",{label:"Salvar fatura",variant:"primary"},[],[{trigger:"click",do:"toast",arg:"Fatura salva ✓"}]) ]),
+  ]); },
+  detalhe(){ return node("screen",{pattern:"detalhe"},[
+    node("breadcrumb",{items:["Início","Faturas","000.128"]}),
+    node("pageHeader",{title:"NF-e 000.128",kpi:"Gráfica Sol · emitida 04/06/2026",primary:"Imprimir"},[],[{trigger:"click",do:"stub",arg:""}]),
+    node("cluster",{},[ node("badge",{label:"Autorizada",status:"ok"}), node("chip",{origin:"FIN",label:"FIN"}), node("avatar",{initials:"GS"}) ]),
+    node("kpiGrid",{},[ node("kpi",{label:"Valor",value:"R$ 2.480",delta:"",dir:""}),
+      node("kpi",{label:"Impostos",value:"R$ 312",delta:"",dir:""}), node("kpi",{label:"Líquido",value:"R$ 2.168",delta:"",dir:""}) ]),
+    node("card",{},[ node("heading",{text:"Itens",level:"h3"}), node("table",{columns:["Item","Qtd","Unit.","Total"],rows:3,mono:[1,2,3]}) ]),
+  ]); },
+  config(){ return node("screen",{pattern:"config"},[
+    node("pageHeader",{title:"Configurações",kpi:"Fiscal · emissão · usuários",primary:"Salvar",showExport:false},[],[{trigger:"click",do:"toast",arg:"Configurações salvas ✓"}]),
+    node("card",{},[ node("heading",{text:"Emissão de NF-e",level:"h3"}),
+      node("field",{label:"Série padrão",placeholder:"1"}),
+      node("field",{label:"Ambiente",kind:"select",placeholder:"Produção · Homologação"}),
+      node("switch",{label:"Emitir automaticamente ao concluir OS"}),
+      node("divider"), node("text",{text:"Estas opções valem para todo o módulo Fiscal.",dim:true}) ]),
+  ]); },
+  vazia(){ return node("screen",{pattern:"lista"},[ node("pageHeader",{title:"Nova tela",kpi:"",primary:"Ação"}) ]); },
+};
+
+let state = { fname:"Faturas", module:"Faturas", origin:"FIN",
+  theme:"light", brand:220, density:"default", radius:"default", shell:true,
+  mode:"edit", screenState:"full", zoom:1, tree:null, selected:null };
+let history=[], hIdx=-1;
+const BRANDS=[{h:220,name:"Azul (default)"},{h:330,name:"Oficina"},{h:145,name:"Financeiro"},{h:70,name:"Âmbar"},{h:25,name:"Produção"}];
+
+/* persistência + history */
+function serialize(){ return JSON.stringify({fname:state.fname,module:state.module,origin:state.origin,theme:state.theme,brand:state.brand,
+  density:state.density,radius:state.radius,shell:state.shell,mode:state.mode,screenState:state.screenState,tree:state.tree,selected:state.selected}); }
+function save(){ localStorage.setItem(KEY, serialize()); }
+function pushHistory(){ const s=serialize(); history=history.slice(0,hIdx+1); history.push(s); hIdx=history.length-1;
+  if(history.length>80){history.shift();hIdx--;} updateUndoButtons(); save(); }
+function restore(s){ const o=JSON.parse(s); Object.assign(state,o); reindexIds(state.tree); syncControls(); renderAll(); }
+function undo(){ if(hIdx>0){hIdx--;restore(history[hIdx]);updateUndoButtons();save();} }
+function redo(){ if(hIdx<history.length-1){hIdx++;restore(history[hIdx]);updateUndoButtons();save();} }
+function updateUndoButtons(){ $("#undo").disabled=hIdx<=0; $("#redo").disabled=hIdx>=history.length-1; }
+function reindexIds(n){ const m=+(String(n.id).replace(/\D/g,""))||0; if(m>_id)_id=m; (n.children||[]).forEach(reindexIds); }
+
+/* tree helpers */
+function walk(n,fn,parent=null){ fn(n,parent); (n.children||[]).forEach(c=>walk(c,fn,n)); }
+function find(id,n=state.tree){ let r=null; walk(n,x=>{if(x.id===id)r=x;}); return r; }
+function findParent(id,n=state.tree){ let r=null; walk(n,(x,p)=>{if(x.id===id)r=p;}); return r; }
+function isContainer(t){ return !!TYPES[t]?.container; }
+function clone(n){ const c=JSON.parse(JSON.stringify(n)); walk(c,x=>x.id=uid()); return c; }
+
+function insert(type){
+  const n=node(type);
+  let target=state.selected?find(state.selected):state.tree; if(!target)target=state.tree;
+  let parent = isContainer(target.type)?target:(findParent(target.id)||state.tree);
+  if(state.selected){ const sel=find(state.selected); const idx=parent.children.indexOf(sel);
+    if(idx>=0)parent.children.splice(idx+1,0,n); else parent.children.push(n); }
+  else parent.children.push(n);
+  state.selected=n.id; pushHistory(); renderAll();
+}
+function del(id){ if(!id||id===state.tree.id)return; const p=findParent(id); if(!p)return;
+  p.children=p.children.filter(c=>c.id!==id); if(state.selected===id)state.selected=p.id===state.tree.id?null:p.id; pushHistory(); renderAll(); }
+function duplicate(id){ if(!id||id===state.tree.id)return; const p=findParent(id),o=find(id),c=clone(o);
+  p.children.splice(p.children.indexOf(o)+1,0,c); state.selected=c.id; pushHistory(); renderAll(); }
+function moveSibling(id,dir){ const p=findParent(id); if(!p)return; const i=p.children.findIndex(c=>c.id===id),j=i+dir;
+  if(j<0||j>=p.children.length)return; [p.children[i],p.children[j]]=[p.children[j],p.children[i]]; pushHistory(); renderAll(); }
+function moveNode(dragId,targetId,mode){ if(dragId===targetId)return; const drag=find(dragId); if(!drag)return;
+  let bad=false; walk(drag,x=>{if(x.id===targetId)bad=true;}); if(bad)return;
+  const dp=findParent(dragId); dp.children=dp.children.filter(c=>c.id!==dragId);
+  if(mode==="into"){ const t=find(targetId); t.children=t.children||[]; t.children.push(drag); }
+  else { const tp=findParent(targetId),idx=tp.children.findIndex(c=>c.id===targetId); tp.children.splice(mode==="after"?idx+1:idx,0,drag); }
+  pushHistory(); renderAll(); }
+
+/* ================================================================ RENDER · CANVAS ================================================================ */
+const el=(tag,cls,txt)=>{const e=document.createElement(tag); if(cls)e.className=cls; if(txt!=null)e.textContent=txt; return e;};
+const ST=state; // alias
+
+function renderNode(n){
+  let e; const p=n.props;
+  switch(n.type){
+    case "screen": e=el("div","screen"); n.children.forEach(c=>e.appendChild(renderNode(c))); break;
+    case "card": { e=el("div","card"); if(!p.pad)e.style.padding="0"; n.children.forEach(c=>e.appendChild(renderNode(c)));
+      if(!n.children.length){ const ph=el("div",null,"Card vazio"); ph.style.cssText="color:var(--text-mute);font-size:12px;padding:6px"; e.appendChild(ph);} break; }
+    case "cluster": e=el("div","cluster"); n.children.forEach(c=>e.appendChild(renderNode(c))); break;
+    case "stack": e=el("div","stack"); n.children.forEach(c=>e.appendChild(renderNode(c))); break;
+    case "kpiGrid": e=el("div","kpi-grid"); n.children.forEach(c=>e.appendChild(renderNode(c))); break;
+    case "pageHeader": { e=el("div","page-header"); const l=el("div","ph-l"); l.appendChild(el("h2",null,p.title||"Título"));
+      if(p.kpi)l.appendChild(el("p","ph-kpi",p.kpi)); const r=el("div","ph-r");
+      if(p.showExport)r.appendChild(el("button","btn btn-ghost","Exportar"));
+      if(p.primary){const b=el("button","btn btn-primary",p.primary); b.dataset.role="primary"; r.appendChild(b);} e.appendChild(l); e.appendChild(r); break; }
+    case "breadcrumb": { e=el("nav","breadcrumb"); (p.items||[]).forEach((it,i)=>{ if(i)e.appendChild(el("span","sep","›")); const a=el("a",null,it); a.href="#"; e.appendChild(a); }); break; }
+    case "tabs": { e=el("nav","tabs"); (p.items||[]).forEach((it,i)=>{ const a=el("a",null); a.href="#"; if(i===(p.active|0))a.setAttribute("aria-current","true");
+      a.appendChild(document.createTextNode(it.label)); if(it.count)a.appendChild(el("span","count",it.count)); e.appendChild(a); }); break; }
+    case "toolbar": { e=el("div","toolbar"); const s=el("span","search");
+      s.innerHTML='<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg>';
+      const inp=el("input","input"); inp.placeholder=p.placeholder||"Buscar…"; s.appendChild(inp); e.appendChild(s);
+      if(p.kbd)e.appendChild(el("span","kbd","⌘K")); const sp=el("span"); sp.style.flex="1"; e.appendChild(sp);
+      if((p.segments||[]).length){ const seg=el("div","segmented"); p.segments.forEach((t,i)=>{const b=el("button",null,t); if(i===(p.active|0))b.setAttribute("aria-pressed","true"); seg.appendChild(b);}); e.appendChild(seg);} break; }
+    case "kpi": { e=el("div","card kpi"); e.appendChild(el("span","kpi-label",p.label||"")); e.appendChild(el("span","kpi-value",p.value||""));
+      if(p.delta)e.appendChild(el("span","kpi-delta"+(p.dir?" "+p.dir:""),p.delta)); break; }
+    case "table": e=renderTable(n); break;
+    case "pagination": { e=el("div","pagination"); const b0=el("button",null,"‹"); e.appendChild(b0);
+      for(let i=1;i<=(p.pages|0||4);i++){const b=el("button",null,String(i)); if(i===(p.active|0))b.setAttribute("aria-current","true"); e.appendChild(b);} e.appendChild(el("button",null,"›")); break; }
+    case "button": e=el("button","btn btn-"+(p.variant||"primary")+(p.size&&p.size!=="md"?" btn-"+p.size:""),p.label||"Botão"); break;
+    case "field": { e=el("label","field"+(p.state==="error"?" is-error":"")); if(p.label)e.appendChild(el("span","label",p.label));
+      if(p.kind==="textarea"){const t=el("textarea","textarea"); t.placeholder=p.placeholder||""; t.value=p.value||""; e.appendChild(t);}
+      else if(p.kind==="select"){const s=el("select","input"); (p.placeholder||"Opção").split("·").forEach(o=>s.appendChild(el("option",null,o.trim()))); e.appendChild(s);}
+      else if(p.addon){const g=el("div","input-group"); g.appendChild(el("span","addon",p.addon)); const i=el("input","input oi-mono"); i.placeholder=p.placeholder||""; i.value=p.value||""; g.appendChild(i); e.appendChild(g);}
+      else {const i=el("input","input"); i.placeholder=p.placeholder||""; i.value=p.value||""; e.appendChild(i);}
+      if(p.hint)e.appendChild(el("span","hint",p.hint)); break; }
+    case "checkbox": { e=el("label","check"); const i=el("input"); i.type="checkbox"; i.checked=!!p.checked; e.appendChild(i); e.appendChild(el("span",null,p.label||"")); break; }
+    case "switch": { e=el("label","switch"); const i=el("input"); i.type="checkbox"; i.checked=!!p.checked; e.appendChild(i); e.appendChild(el("span","track")); if(p.label)e.appendChild(el("span",null,p.label)); break; }
+    case "badge": e=el("span","badge is-"+(p.status||"ok"),p.label||""); break;
+    case "chip": e=el("span","chip origin-"+(p.origin||"FIN"),p.label||p.origin||""); break;
+    case "avatar": e=el("span","avatar",p.initials||"·"); break;
+    case "callout": e=el("div","callout"+(p.variant==="bad"?" is-bad":""),p.text||""); break;
+    case "empty": e=renderEmpty(p); break;
+    case "heading": e=el(p.level||"h2","h-text "+(p.level||"h2"),p.text||""); break;
+    case "text": e=el("p","p-text"+(p.dim?" dim":""),p.text||""); break;
+    case "tag": e=el("span","tag",p.label||""); break;
+    case "divider": e=el("hr","divider"); break;
+    default: e=el("div",null,"["+n.type+"]");
+  }
+  e.setAttribute("data-node-id",n.id);
+  e.setAttribute("data-tag",TYPES[n.type]?.label||n.type);
+  if((n.actions||[]).some(a=>a.do&&a.do!=="none")) e.setAttribute("data-act","1");
+  if(n.hidden)e.setAttribute("data-hidden","true");
+  if(state.mode==="edit" && n.id===state.selected)e.classList.add("node-sel");
+  return e;
+}
+function renderEmpty(p){ const e=el("div","card"); e.style.padding="0"; const em=el("div","empty");
+  const svg=document.createElementNS("http://www.w3.org/2000/svg","svg"); svg.setAttribute("class","empty-icon");
+  svg.setAttribute("viewBox","0 0 24 24"); svg.setAttribute("fill","none"); svg.setAttribute("stroke","currentColor"); svg.setAttribute("stroke-width","1.5");
+  svg.innerHTML='<path d="M4 7h16M4 12h16M4 17h10"/>'; em.appendChild(svg);
+  em.appendChild(el("p","empty-title",p.title||"")); em.appendChild(el("p","empty-sub",p.sub||""));
+  const acts=el("div","empty-actions"); if(p.primary){const b=el("button","btn btn-primary",p.primary); b.dataset.role="primary"; acts.appendChild(b);}
+  if(p.secondary)acts.appendChild(el("button","btn btn-ghost",p.secondary)); em.appendChild(acts); e.appendChild(em); return e; }
+
+function renderTable(n){
+  const p=n.props; const e=el("table","table");
+  const cols=p.columns||[];
+  const thead=el("thead"); const trh=el("tr"); cols.forEach(c=>trh.appendChild(el("th",null,c))); thead.appendChild(trh); e.appendChild(thead);
+  const tb=el("tbody");
+  // estados (PADRÃO B4)
+  if(state.screenState==="loading"){ for(let r=0;r<4;r++){ const tr=el("tr"); const td=el("td"); td.colSpan=cols.length||1;
+      const sk=el("div","skel skel-row"); sk.style.width=(40+((r*23)%55))+"%"; td.appendChild(sk); tr.appendChild(td); tb.appendChild(tr);} e.appendChild(tb); return e; }
+  if(state.screenState==="noresults"){ const tr=el("tr"); const td=el("td"); td.colSpan=cols.length||1; td.style.cssText="text-align:center;color:var(--text-mute);height:120px";
+      td.textContent="Nenhum resultado para a busca."; tr.appendChild(td); tb.appendChild(tr); e.appendChild(tb); return e; }
+  const sample=[["000.128","Gráfica Sol","R$ 2.480,00","04/06/2026","Autorizada"],["000.127","Editora Lume","R$ 1.190,00","03/06/2026","Processando"],
+    ["000.126","Studio Vento","R$ 6.730,00","02/06/2026","Rejeitada"],["000.125","Papelaria Rio","R$ 980,00","01/06/2026","Autorizada"],["000.124","Mídia Norte","R$ 3.410,00","31/05/2026","Cancelada"]];
+  const smap={Autorizada:"is-ok",Processando:"is-warn",Rejeitada:"is-bad",Cancelada:"is-neutral"};
+  const nrows=Math.max(1,Math.min(p.rows|0||3,5));
+  for(let r=0;r<nrows;r++){ const tr=el("tr"); if(r===0)tr.className="is-selected";
+    cols.forEach((col,ci)=>{ let val=sample[r]?(sample[r][ci]??"—"):"—"; const td=el("td");
+      if(/status/i.test(col))td.appendChild(el("span","badge "+(smap[val]||"is-neutral"),val));
+      else { td.textContent=val; if((p.mono||[]).includes(ci))td.className=ci===2?"num":"mono"; } tr.appendChild(td); });
+    tb.appendChild(tr); }
+  e.appendChild(tb); return e;
+}
+
+function renderCanvas(){
+  const root=$("#oiRoot");
+  root.setAttribute("data-theme",state.theme); root.setAttribute("data-density",state.density); root.setAttribute("data-radius",state.radius);
+  root.classList.toggle("edit",state.mode==="edit"); root.classList.toggle("play",state.mode==="preview");
+  applyBrand();
+  root.innerHTML="";
+  let content;
+  const screenEl=renderNode(state.tree);
+  // estados que substituem o conteúdo de lista
+  if(state.screenState==="empty"){ /* mostra empty no lugar das tabelas */ stripTablesToEmpty(screenEl); }
+  if(state.shell){
+    const shell=el("div","shell"); const sb=el("aside","sb");
+    sb.innerHTML=`<div class="sb-brand"><span class="g">O</span>Oimpresso</div>`;
+    ["Faturas","Clientes","Ordens de serviço","Notas fiscais"].forEach(t=>{ const a=el("a",null,t); if(t===state.module||t===state.fname)a.className="on"; sb.appendChild(a); });
+    sb.appendChild(el("div","sb-sp")); sb.appendChild(el("a","dim","Configurações"));
+    const mc=el("div","main-col"); const top=el("div","topbar-oi");
+    top.innerHTML=`<span class="crumb">Oimpresso · <b>${escapeHtml(state.module||state.fname)}</b></span><span class="sp"></span>`;
+    top.appendChild(el("span","kbd","⌘K")); top.appendChild(el("span","ava2"));
+    mc.appendChild(top);
+    if(state.screenState==="error") mc.appendChild(errorBanner());
+    mc.appendChild(screenEl); shell.appendChild(sb); shell.appendChild(mc); content=shell;
+  } else {
+    const w=el("div"); if(state.screenState==="error")w.appendChild(errorBanner()); w.appendChild(screenEl); content=w;
+  }
+  root.appendChild(content);
+  // overlays/toasts host reset
+  $("#oiOverlay").className="oi-overlay oi-scope"; $("#oiOverlay").setAttribute("data-theme",state.theme); $("#oiOverlay").innerHTML="";
+  $("#oiToasts").setAttribute("data-theme",state.theme);
+  // bulkbar host (sempre presente, escondido)
+  ensureBulkbar();
+  // preview bindings
+  if(state.mode==="preview") bindPreview(root);
+  // labels
+  $("#flName").textContent=state.fname; $("#flMeta").textContent=(state.tree.props.pattern||"tela")+" · "+state.screenState+" · 1180px";
+  $("#flPlay").style.display=state.mode==="preview"?"":"none";
+}
+function errorBanner(){ const w=el("div"); w.style.cssText="padding:16px 32px 0";
+  const c=el("div","callout is-bad"); c.style.display="flex"; c.style.alignItems="center"; c.style.gap="12px";
+  c.appendChild(el("span",null,"Não foi possível carregar as faturas. Verifique a conexão.")); const sp=el("span"); sp.style.flex="1"; c.appendChild(sp);
+  const b=el("button","btn btn-ghost btn-sm","Tentar de novo"); b.onclick=()=>{ state.screenState="full"; syncControls(); renderCanvas(); showToast("Recarregado ✓","ok"); }; c.appendChild(b); w.appendChild(c); return w; }
+function stripTablesToEmpty(scope){ scope.querySelectorAll(".table").forEach(t=>{ const card=renderEmpty({title:"Nenhuma fatura ainda",sub:"Crie a primeira fatura ou peça à Jana pra gerar a partir de uma OS concluída.",primary:"Criar primeira fatura",secondary:"Perguntar à Jana"}); t.replaceWith(card); }); }
+
+function applyBrand(){ const root=$("#oiRoot"),h=state.brand;
+  [["--p-accent",`oklch(0.58 0.09 ${h})`],["--p-accent-2",`oklch(0.66 0.09 ${h})`],["--p-accent-soft",`oklch(0.94 0.025 ${h})`],["--p-accent-line",`oklch(0.80 0.045 ${h})`]]
+    .forEach(([k,v])=>{ root.style.setProperty(k,v); $("#oiOverlay").style.setProperty(k,v); $("#oiToasts").style.setProperty(k,v); }); }
+function escapeHtml(s){return String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));}
+
+/* ================================================================ AÇÕES (runtime · preview) ================================================================ */
+function bindPreview(root){
+  walk(state.tree, n=>{
+    const acts=(n.actions||[]).filter(a=>a.do&&a.do!=="none"); if(!acts.length)return;
+    const e=root.querySelector(`[data-node-id="${n.id}"]`); if(!e)return;
+    if(n.type==="table"){ e.querySelectorAll("tbody tr").forEach(tr=>{ tr.addEventListener("click",()=>{ tr.classList.toggle("is-selected"); runActions(n,"click"); updateBulkCount(e); }); }); return; }
+    if(n.type==="tabs"){ e.querySelectorAll("a").forEach((a,i)=>{ a.addEventListener("click",ev=>{ ev.preventDefault();
+        e.querySelectorAll("a").forEach(x=>x.removeAttribute("aria-current")); a.setAttribute("aria-current","true"); runActions(n,"click"); }); }); return; }
+    let targets=[e];
+    if(n.type==="pageHeader"||n.type==="empty"){ const b=e.querySelector('[data-role=primary]'); targets=b?[b]:[]; }
+    if(n.type==="field"){ const c=e.querySelector("input,select,textarea"); targets=c?[c]:[];
+      targets.forEach(t=>t.addEventListener("change",()=>runActions(n,"change"))); }
+    targets.forEach(t=>{
+      acts.forEach(a=>{
+        if(a.trigger==="hover") t.addEventListener("mouseenter",()=>doAction(a));
+        else if(a.trigger==="change"){ /* já tratado */ }
+        else t.addEventListener("click",ev=>{ ev.preventDefault(); ev.stopPropagation(); doAction(a); });
+      });
+    });
+  });
+}
+function runActions(n,trigger){ (n.actions||[]).filter(a=>a.do&&a.do!=="none"&&(a.trigger||"click")===trigger).forEach(doAction); }
+function doAction(a){
+  switch(a.do){
+    case "toast": showToast(a.arg||"Feito ✓","ok"); break;
+    case "stub": showToast("Em breve — função em construção","stub"); break;
+    case "drawer": openDrawer(a.arg||"Detalhe"); break;
+    case "modal": openModal(a.arg||"Confirmar ação"); break;
+    case "navigate": showToast(a.arg?("Navegando: "+a.arg):"Aba trocada","ok"); break;
+    case "bulk": toggleBulk(true); break;
+    case "selectRow": showToast("Linha selecionada","ok"); break;
+  }
+}
+let toastTimer=[];
+function showToast(msg,kind){ const host=$("#oiToasts"); const t=el("div","toast"+(kind?" "+kind:"")); t.textContent=msg; host.appendChild(t);
+  const id=setTimeout(()=>{ t.style.opacity="0"; setTimeout(()=>t.remove(),200); },2600); toastTimer.push(id); }
+function openDrawer(title){ const ov=$("#oiOverlay"); ov.innerHTML="";
+  const scrim=el("div","o-scrim"); scrim.onclick=closeOverlay; ov.appendChild(scrim);
+  const d=el("aside","drawer");
+  const head=el("div","drawer-head"); head.appendChild(el("h3",null,title)); const x=el("button","x-btn","✕"); x.onclick=closeOverlay; head.appendChild(x); d.appendChild(head);
+  const body=el("div","drawer-body");
+  body.innerHTML=`<label class="field"><span class="label">Cliente</span><input class="input" placeholder="Buscar cliente…"></label>
+    <div class="cluster"><label class="field" style="flex:1"><span class="label">Valor</span><div class="input-group"><span class="addon">R$</span><input class="input oi-mono" placeholder="0,00"></div></label>
+    <label class="field" style="flex:1"><span class="label">Vencimento</span><input class="input" placeholder="dd/mm/aaaa"></label></div>
+    <div class="callout">Drawer real, 620px, fecha por X / Esc / clique-fora — função executa (PADRÃO Parte D).</div>`;
+  d.appendChild(body);
+  const foot=el("div","drawer-foot"); const c=el("button","btn btn-ghost","Cancelar"); c.onclick=closeOverlay;
+  const s=el("button","btn btn-primary","Salvar"); s.onclick=()=>{ closeOverlay(); showToast("Salvo ✓","ok"); }; foot.appendChild(c); foot.appendChild(s); d.appendChild(foot);
+  ov.appendChild(d); ov.classList.add("on");
+}
+function openModal(title){ const ov=$("#oiOverlay"); ov.innerHTML="";
+  const scrim=el("div","o-scrim"); scrim.onclick=closeOverlay; ov.appendChild(scrim);
+  const m=el("div","modal-oi"); const head=el("div","modal-oi-head"); head.appendChild(el("h3",null,title));
+  const x=el("button","x-btn","✕"); x.onclick=closeOverlay; head.appendChild(x); m.appendChild(head);
+  const body=el("div","modal-oi-body"); body.appendChild(el("p","p-text dim","Tem certeza? Esta ação executa de verdade no preview e fecha corretamente.")); m.appendChild(body);
+  const foot=el("div","modal-oi-foot"); const c=el("button","btn btn-ghost","Cancelar"); c.onclick=closeOverlay;
+  const ok=el("button","btn btn-primary","Confirmar"); ok.onclick=()=>{ closeOverlay(); showToast("Confirmado ✓","ok"); }; foot.appendChild(c); foot.appendChild(ok); m.appendChild(foot);
+  ov.appendChild(m); ov.classList.add("on");
+}
+function closeOverlay(){ $("#oiOverlay").classList.remove("on"); $("#oiOverlay").innerHTML=""; }
+function ensureBulkbar(){ let bb=$("#frame .bulkbar"); if(bb)bb.remove();
+  bb=el("div","bulkbar oi-scope"); bb.id="oiBulk"; bb.setAttribute("data-theme",state.theme);
+  bb.innerHTML=`<span class="b-count">1 selecionada</span><span class="sep"></span>
+    <button>Marcar paga</button><button>Exportar</button><button class="danger">Excluir</button>`;
+  bb.querySelectorAll("button").forEach(b=>b.onclick=()=>{ showToast(b.textContent+" ✓",b.classList.contains("danger")?"":"ok"); toggleBulk(false); });
+  $("#frame").appendChild(bb); }
+function toggleBulk(on){ const bb=$("#oiBulk"); if(bb)bb.classList.toggle("on",on); }
+function updateBulkCount(tableEl){ const n=tableEl.querySelectorAll("tbody tr.is-selected").length; const bb=$("#oiBulk");
+  if(bb){ bb.classList.toggle("on",n>0); bb.querySelector(".b-count").textContent=n+(n===1?" selecionada":" selecionadas"); } }
+
+/* ================================================================ RENDER · LAYERS ================================================================ */
+function renderLayers(){ const host=$("#layers"); host.innerHTML="";
+  function rowFor(n,depth){ const r=el("div","lyr"+(n.id===state.selected?" sel":"")+(n.hidden?" hidden":""));
+    r.dataset.id=n.id; r.draggable=n.id!==state.tree.id; r.style.paddingLeft=(6+depth*14)+"px";
+    r.appendChild(el("span","tw",isContainer(n.type)&&n.children.length?"▾":""));
+    r.appendChild(el("span","ic",TYPES[n.type]?.icon||"•"));
+    r.appendChild(el("span","nm",n.props.title||n.props.label||n.props.text||TYPES[n.type]?.label||n.type));
+    if((n.actions||[]).some(a=>a.do&&a.do!=="none"))r.appendChild(el("span","bolt","⚡"));
+    r.appendChild(el("span","ty",n.type));
+    const vis=el("span","vis",n.hidden?"⊘":"👁"); vis.title="Mostrar/ocultar"; vis.onclick=ev=>{ev.stopPropagation();n.hidden=!n.hidden;pushHistory();renderAll();}; r.appendChild(vis);
+    r.onclick=()=>select(n.id);
+    r.addEventListener("dragstart",e=>{e.dataTransfer.setData("text/plain",n.id);e.dataTransfer.effectAllowed="move";});
+    r.addEventListener("dragend",clearDrop);
+    r.addEventListener("dragover",e=>{e.preventDefault();markDrop(r,dropMode(e,r,n));});
+    r.addEventListener("dragleave",()=>r.classList.remove("drop-into","drop-before","drop-after"));
+    r.addEventListener("drop",e=>{e.preventDefault();const id=e.dataTransfer.getData("text/plain");const m=dropMode(e,r,n);clearDrop();moveNode(id,n.id,m);});
+    host.appendChild(r); (n.children||[]).forEach(c=>rowFor(c,depth+1)); }
+  rowFor(state.tree,0);
+}
+function dropMode(e,r,n){ const rect=r.getBoundingClientRect(),y=e.clientY-rect.top,h=rect.height;
+  if(isContainer(n.type)&&y>h*0.3&&y<h*0.7)return "into"; return y<h/2?"before":"after"; }
+function markDrop(r,m){ r.classList.remove("drop-into","drop-before","drop-after"); r.classList.add("drop-"+m); }
+function clearDrop(){ $$(".lyr").forEach(x=>x.classList.remove("drop-into","drop-before","drop-after")); }
+
+/* ================================================================ RENDER · INSPECTOR ================================================================ */
+function field(label,inputEl){ const r=el("div","row"); r.appendChild(el("label",null,label)); r.appendChild(inputEl); return r; }
+function textInput(val,oninput){ const i=el("input"); i.type="text"; i.value=val||""; i.oninput=e=>oninput(e.target.value); return i; }
+function textArea(val,oninput){ const t=el("textarea"); t.value=val||""; t.oninput=e=>oninput(e.target.value); return t; }
+function selectInput(val,opts,onchange){ const s=el("select"); opts.forEach(([v,l])=>{const o=el("option",null,l);o.value=v;if(v===val)o.selected=true;s.appendChild(o);}); s.onchange=e=>onchange(e.target.value); return s; }
+function segInput(val,opts,onchange){ const w=el("div","seg"); opts.forEach(([v,l])=>{const b=el("button",null,l);if(v===val)b.setAttribute("aria-pressed","true");b.onclick=()=>onchange(v);w.appendChild(b);}); return w; }
+function checkInput(label,val,onchange){ const w=el("label","chk"); const i=el("input");i.type="checkbox";i.checked=!!val;i.onchange=e=>onchange(e.target.checked); w.appendChild(i);w.appendChild(el("span",null,label)); return w; }
+function setProp(n,k,v,h=true){ n.props[k]=v; renderCanvas(); renderLayers(); if(h)save(); }
+let propTimer=null;
+function liveProp(n,k,v){ n.props[k]=v; renderCanvas(); renderLayers(); clearTimeout(propTimer); propTimer=setTimeout(pushHistory,500); }
+
+function renderInspector(){
+  const host=$("#insp"); host.innerHTML="";
+  const n=state.selected?find(state.selected):null;
+  if(!n){ host.innerHTML='<div class="insp-empty">Nenhum elemento selecionado.<br><br>Clique num elemento no canvas ou numa camada pra editar. No modo <b>▶ Visualizar</b>, as ações executam.</div>'; return; }
+  const p=n.props;
+  const head=el("div","insp-head"); head.appendChild(el("span","ic",TYPES[n.type]?.icon||"•")); head.appendChild(el("b",null,TYPES[n.type]?.label||n.type)); head.appendChild(el("span","ty","#"+n.id)); host.appendChild(head);
+  const sec=el("div","insp-sec"); host.appendChild(sec); const add=e=>sec.appendChild(e);
+
+  switch(n.type){
+    case "screen": add(field("Padrão de tela",selectInput(p.pattern||"lista",[["lista","Lista"],["dashboard","Dashboard"],["form","Form / Drawer"],["detalhe","Detalhe"],["config","Config"]],v=>setProp(n,"pattern",v))));
+      add(el("p","hint-line","Guia a anatomia e o pedido exportado. Pra recriar os filhos, use os templates à esquerda.")); break;
+    case "pageHeader": add(field("Título",textInput(p.title,v=>liveProp(n,"title",v)))); add(field("KPI / resumo",textInput(p.kpi,v=>liveProp(n,"kpi",v))));
+      add(field("Ação primária",textInput(p.primary,v=>liveProp(n,"primary",v)))); add(field("Mostrar 'Exportar'",checkInput("botão secundário",p.showExport,v=>setProp(n,"showExport",v)))); break;
+    case "breadcrumb": add(simpleListEditor("Trilha",p.items,n)); break;
+    case "tabs": add(listEditor("Abas",p.items,["label","count"],["Rótulo","Count"])); add(field("Aba ativa",selectInput(String(p.active|0),(p.items||[]).map((it,i)=>[String(i),it.label]),v=>setProp(n,"active",+v)))); break;
+    case "toolbar": add(field("Placeholder",textInput(p.placeholder,v=>liveProp(n,"placeholder",v)))); add(field("Mostrar ⌘K",checkInput("atalho",p.kbd,v=>setProp(n,"kbd",v)))); add(simpleListEditor("Segmented (views)",p.segments,n)); break;
+    case "kpi": add(field("Rótulo",textInput(p.label,v=>liveProp(n,"label",v)))); add(field("Valor",textInput(p.value,v=>liveProp(n,"value",v)))); add(field("Delta / nota",textInput(p.delta,v=>liveProp(n,"delta",v)))); add(field("Direção",segInput(p.dir||"",[["up","▲"],["","—"],["down","▼"]],v=>setProp(n,"dir",v)))); break;
+    case "table": add(simpleListEditor("Colunas",p.columns,n)); add(field("Linhas de exemplo",selectInput(String(p.rows|0||3),[["1","1"],["2","2"],["3","3"],["4","4"],["5","5"]],v=>setProp(n,"rows",+v))));
+      add(field("Colunas mono (ex: 0,2,3)",textInput((p.mono||[]).join(","),v=>setProp(n,"mono",v.split(",").map(x=>parseInt(x.trim())).filter(x=>!isNaN(x)),false)))); add(el("p","hint-line","Coluna 'Status' vira badge sem-fill. No Visualizar, clicar numa linha seleciona + bulk bar.")); break;
+    case "pagination": add(field("Total de páginas",selectInput(String(p.pages|0||4),[["3","3"],["4","4"],["5","5"],["6","6"]],v=>setProp(n,"pages",+v)))); add(field("Página ativa",textInput(String(p.active||1),v=>setProp(n,"active",+v||1,false)))); break;
+    case "button": add(field("Rótulo",textInput(p.label,v=>liveProp(n,"label",v)))); add(field("Variante",segInput(p.variant||"primary",[["primary","prim."],["ghost","ghost"],["subtle","subtle"],["danger","danger"]],v=>setProp(n,"variant",v)))); add(field("Tamanho",segInput(p.size||"md",[["sm","P"],["md","M"],["lg","G"]],v=>setProp(n,"size",v)))); break;
+    case "field": add(field("Rótulo",textInput(p.label,v=>liveProp(n,"label",v)))); add(field("Tipo",segInput(p.kind||"input",[["input","input"],["select","select"],["textarea","área"]],v=>setProp(n,"kind",v)))); add(field("Placeholder",textInput(p.placeholder,v=>liveProp(n,"placeholder",v))));
+      if((p.kind||"input")==="input"){ add(field("Valor",textInput(p.value,v=>liveProp(n,"value",v)))); add(field("Addon (R$)",textInput(p.addon,v=>liveProp(n,"addon",v)))); }
+      add(field("Estado",segInput(p.state||"default",[["default","normal"],["error","erro"]],v=>setProp(n,"state",v)))); add(field("Dica / erro",textInput(p.hint,v=>liveProp(n,"hint",v)))); break;
+    case "checkbox": case "switch": add(field("Rótulo",textInput(p.label,v=>liveProp(n,"label",v)))); add(field("Marcado",checkInput("ligado",p.checked,v=>setProp(n,"checked",v)))); break;
+    case "badge": add(field("Texto",textInput(p.label,v=>liveProp(n,"label",v)))); add(field("Status (soberano)",selectInput(p.status||"ok",[["ok","ok · verde"],["warn","warn · âmbar"],["bad","bad · vermelho"],["info","info · azul"],["jana","jana · roxo (IA)"],["neutral","neutral"]],v=>setProp(n,"status",v)))); break;
+    case "chip": add(field("Origem",selectInput(p.origin||"FIN",[["OS","OS"],["CRM","CRM"],["FIN","FIN"],["PNT","PNT"],["MFG","MFG"]],v=>{setProp(n,"origin",v);if(["OS","CRM","FIN","PNT","MFG"].includes(p.label))setProp(n,"label",v);}))); add(field("Texto",textInput(p.label,v=>liveProp(n,"label",v)))); break;
+    case "avatar": add(field("Iniciais",textInput(p.initials,v=>liveProp(n,"initials",v)))); break;
+    case "callout": add(field("Texto",textArea(p.text,v=>liveProp(n,"text",v)))); add(field("Variante",segInput(p.variant||"info",[["info","info"],["bad","erro"]],v=>setProp(n,"variant",v)))); break;
+    case "empty": add(field("Título",textInput(p.title,v=>liveProp(n,"title",v)))); add(field("Subtítulo",textArea(p.sub,v=>liveProp(n,"sub",v)))); add(field("Ação primária",textInput(p.primary,v=>liveProp(n,"primary",v)))); add(field("Ação secundária",textInput(p.secondary,v=>liveProp(n,"secondary",v)))); break;
+    case "heading": add(field("Texto",textInput(p.text,v=>liveProp(n,"text",v)))); add(field("Nível",segInput(p.level||"h2",[["h1","H1"],["h2","H2"],["h3","H3"]],v=>setProp(n,"level",v)))); break;
+    case "text": add(field("Texto",textArea(p.text,v=>liveProp(n,"text",v)))); add(field("Esmaecido",checkInput("text-dim",p.dim,v=>setProp(n,"dim",v)))); break;
+    case "tag": add(field("Rótulo",textInput(p.label,v=>liveProp(n,"label",v)))); break;
+    case "card": add(field("Padding interno",checkInput("usar padding",p.pad!==false,v=>setProp(n,"pad",v)))); add(el("p","hint-line","Container. Insira componentes dentro.")); break;
+    case "cluster": add(el("p","hint-line","Container horizontal (flex-wrap).")); break;
+    case "stack": add(el("p","hint-line","Container vertical.")); break;
+    case "kpiGrid": add(el("p","hint-line","Grade responsiva. Insira KPIs dentro.")); break;
+    case "divider": add(el("p","hint-line","Linha divisória. Sem props.")); break;
+    default: add(el("p","hint-line","Sem propriedades editáveis."));
+  }
+
+  // AÇÕES
+  if(TYPES[n.type]?.actionable){ host.appendChild(actionsEditor(n)); }
+
+  if(n.id!==state.tree.id){ const a=el("div","insp-actions");
+    const up=el("button",null,"↑ subir"); up.onclick=()=>moveSibling(n.id,-1);
+    const dn=el("button",null,"↓ descer"); dn.onclick=()=>moveSibling(n.id,1);
+    const du=el("button",null,"⧉ duplicar"); du.onclick=()=>duplicate(n.id);
+    const rm=el("button","danger","🗑 excluir"); rm.onclick=()=>del(n.id);
+    a.appendChild(up);a.appendChild(dn);a.appendChild(du);a.appendChild(rm); host.appendChild(a); }
+}
+function actionsEditor(n){
+  const sec=el("div","insp-sec"); const h=el("h5"); h.innerHTML='<span class="bolt">⚡</span> Ações (funções)'; sec.appendChild(h);
+  n.actions=n.actions||[];
+  n.actions.forEach((a,i)=>{
+    const card=el("div","act-card");
+    const del=el("button","act-del","✕"); del.onclick=()=>{ n.actions.splice(i,1); pushHistory(); renderInspector(); renderCanvas(); }; card.appendChild(del);
+    const two=el("div","two");
+    two.appendChild(selectInput(a.trigger||"click",Object.entries(TRIGGERS).map(([k,v])=>[k,v]),v=>{a.trigger=v;pushHistory();renderCanvas();}));
+    two.appendChild(selectInput(a.do||"toast",Object.entries(ACTIONS).map(([k,v])=>[k,v]),v=>{a.do=v;pushHistory();renderInspector();renderCanvas();renderLayers();}));
+    card.appendChild(two);
+    if(["toast","drawer","modal","navigate"].includes(a.do)){
+      const ph={toast:"mensagem do toast",drawer:"título do drawer",modal:"título do modal",navigate:"destino / aba"}[a.do];
+      const inp=el("input"); inp.type="text"; inp.placeholder=ph; inp.value=a.arg||""; inp.style.cssText="width:100%;background:var(--c-panel);border:1px solid var(--c-line);color:var(--c-text);border-radius:5px;padding:6px 8px;font-size:12px;outline:none";
+      inp.oninput=e=>{a.arg=e.target.value; clearTimeout(propTimer); propTimer=setTimeout(pushHistory,500);}; card.appendChild(inp);
+    }
+    sec.appendChild(card);
+  });
+  const addb=el("button","add-row","+ adicionar ação"); addb.onclick=()=>{ n.actions.push({trigger:"click",do:"toast",arg:"Feito ✓"}); pushHistory(); renderInspector(); renderCanvas(); renderLayers(); };
+  sec.appendChild(addb);
+  const tip=el("p","hint-line","Trigger → ação. No modo ▶ Visualizar elas executam de verdade (abre drawer/modal, toast, bulk). Exportadas no pedido pro Claude Code ligar handlers reais — sem botão morto (PADRÃO D).");
+  sec.appendChild(tip); return sec;
+}
+function listEditor(title,arr,keys,labels){ const sec=el("div"); sec.appendChild(label_h5(title)); const wrap=el("div","list-edit");
+  (arr||[]).forEach((item,i)=>{ const li=el("div","li"); keys.forEach((k,ki)=>{ const inp=el("input");inp.type="text";inp.placeholder=labels[ki];inp.value=item[k]||"";
+    inp.oninput=e=>{item[k]=e.target.value;renderCanvas();renderLayers();clearTimeout(propTimer);propTimer=setTimeout(pushHistory,500);};li.appendChild(inp);});
+    const d=el("button","del","✕");d.onclick=()=>{arr.splice(i,1);pushHistory();renderInspector();renderCanvas();};li.appendChild(d);wrap.appendChild(li);});
+  const addb=el("button","add-row","+ adicionar");addb.onclick=()=>{const o={};keys.forEach(k=>o[k]="");arr.push(o);pushHistory();renderInspector();renderCanvas();};wrap.appendChild(addb);sec.appendChild(wrap);return sec; }
+function simpleListEditor(title,arr,n){ const sec=el("div");sec.appendChild(label_h5(title));const wrap=el("div","list-edit");
+  (arr||[]).forEach((v,i)=>{const li=el("div","li");const inp=el("input");inp.type="text";inp.value=v;
+    inp.oninput=e=>{arr[i]=e.target.value;renderCanvas();renderLayers();clearTimeout(propTimer);propTimer=setTimeout(pushHistory,500);};
+    const d=el("button","del","✕");d.onclick=()=>{arr.splice(i,1);pushHistory();renderInspector();renderCanvas();};li.appendChild(inp);li.appendChild(d);wrap.appendChild(li);});
+  const addb=el("button","add-row","+ adicionar");addb.onclick=()=>{arr.push("Novo");pushHistory();renderInspector();renderCanvas();};wrap.appendChild(addb);sec.appendChild(wrap);return sec; }
+function label_h5(t){ const h=el("h5",null,t); h.style.cssText="margin:0 0 9px;font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--c-mute);font-weight:700"; return h; }
+
+/* select + render all */
+function select(id){ state.selected=id; renderCanvas(); renderLayers(); renderInspector(); save(); }
+function renderAll(){ renderCanvas(); renderLayers(); renderInspector(); }
+
+/* canvas interaction */
+const oiRoot=$("#oiRoot");
+oiRoot.addEventListener("mousedown",e=>{ if(state.mode==="edit"&&e.target.closest("input,textarea,select"))e.preventDefault(); });
+oiRoot.addEventListener("click",e=>{ if(state.mode!=="edit")return; const t=e.target.closest("[data-node-id]"); if(!t)return; e.preventDefault(); e.stopPropagation(); select(t.getAttribute("data-node-id")); });
+let hoverEl=null;
+oiRoot.addEventListener("mousemove",e=>{ if(state.mode!=="edit")return; const t=e.target.closest("[data-node-id]");
+  if(hoverEl&&hoverEl!==t)hoverEl.classList.remove("node-hover"); if(t&&!t.classList.contains("node-sel")){t.classList.add("node-hover");hoverEl=t;}else hoverEl=null; });
+oiRoot.addEventListener("mouseleave",()=>{ if(hoverEl){hoverEl.classList.remove("node-hover");hoverEl=null;} });
+
+/* palettes */
+function buildPalettes(){
+  const tpl=[["lista","Lista"],["dashboard","Dashboard"],["form","Form/Drawer"],["detalhe","Detalhe"],["config","Config"],["vazia","Em branco"]];
+  const th=$("#palTemplates"); tpl.forEach(([k,l])=>{ const b=el("button","pal-item"); b.innerHTML=`<span class="gi">▢</span><b>${l}</b>`;
+    b.onclick=()=>{ if(confirm("Substituir a tela atual pelo template '"+l+"'?")){ state.tree=T[k](); state.selected=null; pushHistory(); renderAll(); } }; th.appendChild(b); });
+  const containers=["card","cluster","stack","kpiGrid"];
+  const comps=["pageHeader","breadcrumb","tabs","toolbar","kpi","table","pagination","button","field","checkbox","switch","badge","chip","avatar","callout","empty","heading","text","tag","divider"];
+  containers.forEach(t=>$("#palContainers").appendChild(palBtn(t)));
+  comps.forEach(t=>$("#palComponents").appendChild(palBtn(t)));
+}
+function palBtn(t){ const b=el("button","pal-item"); b.innerHTML=`<span class="gi">${TYPES[t].icon}</span><b>${TYPES[t].label}</b>`; b.onclick=()=>insert(t); return b; }
+
+/* controls */
+function syncControls(){
+  $("#fname").value=state.fname; $("#flName").textContent=state.fname; $("#modName").value=state.module; $("#modOrigin").value=state.origin;
+  $$("#segTheme button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.v===state.theme));
+  $("#btnShell").setAttribute("aria-pressed",state.shell);
+  $$("#segMode button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.v===state.mode));
+  $("#selState").value=state.screenState;
+  $("#bodyGrid").classList.toggle("preview",state.mode==="preview");
+  $$("#segDen button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.v===state.density));
+  $$("#segRad button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.v===state.radius));
+  $$("#brandSwatches .swatch").forEach(s=>s.setAttribute("aria-pressed",+s.dataset.h===state.brand));
+  $("#zLvl").textContent=Math.round(state.zoom*100)+"%"; $("#stage").style.transform=`scale(${state.zoom})`;
+}
+function buildBrandSwatches(){ const host=$("#brandSwatches"); host.innerHTML="";
+  BRANDS.forEach(b=>{ const s=el("button","swatch"); s.dataset.h=b.h; s.title=b.name; s.style.background=`oklch(0.58 0.09 ${b.h})`;
+    s.onclick=()=>{ state.brand=b.h; syncControls(); applyBrand(); pushHistory(); }; host.appendChild(s); }); }
+
+$("#segTheme").onclick=e=>{const v=e.target.dataset.v;if(!v)return;state.theme=v;syncControls();renderCanvas();pushHistory();};
+$("#btnShell").onclick=()=>{state.shell=!state.shell;syncControls();renderCanvas();pushHistory();};
+$("#segMode").onclick=e=>{const v=e.target.dataset.v;if(!v)return;state.mode=v;closeOverlay();syncControls();renderAll();save();};
+$("#selState").onchange=e=>{state.screenState=e.target.value;renderCanvas();save();};
+$("#segDen").onclick=e=>{const v=e.target.dataset.v;if(!v)return;state.density=v;syncControls();renderCanvas();pushHistory();};
+$("#segRad").onclick=e=>{const v=e.target.dataset.v;if(!v)return;state.radius=v;syncControls();renderCanvas();pushHistory();};
+$("#fname").oninput=e=>{state.fname=e.target.value;$("#flName").textContent=e.target.value;clearTimeout(propTimer);propTimer=setTimeout(pushHistory,500);};
+$("#modName").oninput=e=>{state.module=e.target.value;renderCanvas();clearTimeout(propTimer);propTimer=setTimeout(pushHistory,500);};
+$("#modOrigin").onchange=e=>{state.origin=e.target.value;pushHistory();};
+$("#undo").onclick=undo; $("#redo").onclick=redo;
+function setZoom(z){state.zoom=Math.max(0.3,Math.min(2,z));$("#stage").style.transform=`scale(${state.zoom})`;$("#zLvl").textContent=Math.round(state.zoom*100)+"%";}
+$("#zIn").onclick=()=>setZoom(state.zoom+0.1); $("#zOut").onclick=()=>setZoom(state.zoom-0.1); $("#zFit").onclick=()=>setZoom(1);
+$("#canvasWrap").addEventListener("wheel",e=>{if(e.ctrlKey){e.preventDefault();setZoom(state.zoom+(e.deltaY<0?0.08:-0.08));}},{passive:false});
+$("#leftTabs").onclick=e=>{const v=e.target.dataset.lt;if(!v)return;$$("#leftTabs button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.lt===v));$("#leftInsert").style.display=v==="insert"?"":"none";$("#leftLayers").style.display=v==="layers"?"":"none";};
+$("#rightTabs").onclick=e=>{const v=e.target.dataset.rt;if(!v)return;$$("#rightTabs button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.rt===v));$("#rightInsp").style.display=v==="insp"?"":"none";$("#rightDesign").style.display=v==="design"?"":"none";};
+
+document.addEventListener("keydown",e=>{
+  const typing=/input|textarea|select/i.test(document.activeElement.tagName);
+  if((e.ctrlKey||e.metaKey)&&e.key.toLowerCase()==="z"){e.preventDefault();e.shiftKey?redo():undo();return;}
+  if((e.ctrlKey||e.metaKey)&&e.key.toLowerCase()==="y"){e.preventDefault();redo();return;}
+  if(e.key==="Escape"){ if($("#oiOverlay").classList.contains("on"))closeOverlay(); else if($("#auditHost").classList.contains("on"))closeAudit(); else if($("#modalHost").classList.contains("on"))closeModal(); else if(state.mode==="edit")select(null); return; }
+  if(typing)return;
+  if((e.key==="Delete"||e.key==="Backspace")&&state.selected&&state.mode==="edit"){e.preventDefault();del(state.selected);}
+  if((e.ctrlKey||e.metaKey)&&e.key.toLowerCase()==="d"&&state.selected){e.preventDefault();duplicate(state.selected);}
+});
+
+/* ================================================================ EXPORT ================================================================ */
+function openModal(){ $("#modalHost").classList.add("on"); setExpTab(curExp); }
+function closeModal(){ $("#modalHost").classList.remove("on"); }
+$("#btnExport").onclick=openModal; $$("#modalHost [data-close]").forEach(b=>b.onclick=closeModal);
+let curExp="prompt";
+$("#expTabs").onclick=e=>{const v=e.target.dataset.et;if(!v)return;setExpTab(v);};
+function setExpTab(v){ curExp=v; $$("#expTabs button").forEach(b=>b.setAttribute("aria-pressed",b.dataset.et===v));
+  let out="",lead="";
+  if(v==="prompt"){ out=exportPrompt(); lead="Cole o <b>PADRÃO-OIMPRESSO</b> no topo do chat, depois este pedido (Parte F). Inclui as <b>ações</b> de cada elemento — o Claude liga handlers reais, sem botão morto (Parte D)."; }
+  if(v==="yaml"){ out=exportYAML(); lead="Spec estruturada (anatomia + tokens + interações), no estilo do plugin Figma <b>Specs</b> — formato enxuto que agentes de código consomem com precisão."; }
+  if(v==="json"){ out=JSON.stringify(exportSpec(),null,2); lead="Árvore completa em JSON (tipos, props, ações, ordem). Sem ambiguidade."; }
+  if(v==="html"){ out=exportHTML(); lead="HTML de referência com <b>tokens.css + components.css</b>. Zero cor literal — tudo <span class='mono'>var(--token)</span>."; }
+  $("#expOut").textContent=out; $("#expLead").innerHTML=lead; $("#copyMsg").textContent="";
+}
+$("#btnCopy").onclick=async()=>{try{await navigator.clipboard.writeText($("#expOut").textContent);$("#copyMsg").textContent="copiado ✓";setTimeout(()=>$("#copyMsg").textContent="",1600);}catch(_){$("#copyMsg").textContent="selecione e copie manual";}};
+
+function collectByType(t){ const o=[]; walk(state.tree,n=>{if(n.type===t&&!n.hidden)o.push(n);}); return o; }
+function describeAction(a){ const m={toast:`toast "${a.arg||"feedback"}"`,drawer:`abre drawer "${a.arg||"Detalhe"}"`,modal:`abre modal "${a.arg||"Confirmar"}"`,navigate:`navega (${a.arg||"aba"})`,bulk:"mostra bulk bar",selectRow:"seleciona linha",stub:'stub declarado ("em breve")'}; return m[a.do]||a.do; }
+function exportPrompt(){
+  const pat=state.tree.props.pattern||"lista"; const ph=collectByType("pageHeader")[0]; const tables=collectByType("table");
+  const tabs=collectByType("tabs")[0]; const chips=collectByType("chip"); const tb=collectByType("toolbar")[0];
+  const brandName=(BRANDS.find(b=>b.h===state.brand)||{}).name||("hue "+state.brand);
+  const patName={lista:"Lista",dashboard:"Dashboard",form:"Form / Drawer",detalhe:"Detalhe",config:"Config"}[pat]||pat;
+  const L=[];
+  L.push(`Monta a tela **${state.fname}** (módulo ${state.module}) seguindo o PADRÃO OIMPRESSO.`); L.push("");
+  L.push(`Padrão de tela (Camada 3): **${patName}**.`);
+  if(ph){ if(ph.props.title)L.push(`Título: ${ph.props.title}.`); if(ph.props.kpi)L.push(`Resumo/KPI no header: ${ph.props.kpi}.`); if(ph.props.primary)L.push(`Ação primária: ${ph.props.primary}.`); }
+  if(tabs?.props.items?.length)L.push(`Sub-tabs: ${tabs.props.items.map(i=>i.label+(i.count?` (${i.count})`:"")).join(", ")}.`);
+  if(tb){const segs=(tb.props.segments||[]).join(", ");if(segs)L.push(`Toolbar: busca ${tb.props.kbd?"(⌘K) ":""}+ segmented de views: ${segs}.`);}
+  tables.forEach((t,i)=>L.push(`Tabela${tables.length>1?" "+(i+1):""}: colunas ${t.props.columns.join(", ")}. Mono em id/valor/data. Status = badge sem-fill.`));
+  if(collectByType("kpi").length)L.push(`KPIs: ${collectByType("kpi").map(k=>k.props.label).join(", ")} (valor em mono).`);
+  if(chips.length){const os=[...new Set(chips.map(c=>c.props.origin))];L.push(`Origem(ns): ${os.join(", ")} — par --origin-<X>-bg/fg.`);} else if(state.origin)L.push(`Origem dominante: ${state.origin} — --origin-${state.origin}-*.`);
+  // AÇÕES
+  const acts=[]; walk(state.tree,n=>{ (n.actions||[]).filter(a=>a.do&&a.do!=="none").forEach(a=>{ const nm=n.props.title||n.props.label||TYPES[n.type]?.label||n.type; acts.push(`- ${nm} → ${a.trigger||"clique"}: ${describeAction(a)}`); }); });
+  if(acts.length){ L.push(""); L.push("**Ações (funções que DEVEM executar — sem botão morto, PADRÃO Parte D):**"); acts.forEach(a=>L.push(a)); L.push("Drawer/modal fecham por X, Esc e clique-fora. Toda ação dá feedback (toast/estado)."); }
+  L.push("");
+  L.push(`Tema base: ${state.theme==="dark"?"escuro":"claro"} (funciona nos dois). Marca/accent: ${brandName} (hue ${state.brand}) via --p-accent — NÃO toca em Jana/status/sidebar (soberania, ADR-0050).`);
+  L.push(`Densidade: ${state.density}. Raio: ${state.radius}. Shell: ${state.shell?"dentro do Shell (sidebar dark + header) — herda":"sem shell"}.`);
+  L.push("");
+  L.push("Regras duras:");
+  L.push("- Cor SÓ via var(--token); zero hardcoded (AP1). Reusa shared (Table, Drawer, PageHeader…); não reinventa (AP2).");
+  if(pat==="lista"||pat==="dashboard")L.push("- Cobre os 6 estados: cheia, vazia (+'Criar primeira X'/'Perguntar à Jana'), busca sem resultado, loading (skeleton), seleção/hover, erro (toast + retry).");
+  L.push(`- PT-BR, sem emoji (SVG), HTML canônico, foco AA, localStorage oimpresso.${state.module.toLowerCase().replace(/\s+/g,"")}.*`);
+  L.push("- Atalhos: J/K, Enter, N, /, ⌘K, Esc. Roda os portões C e D e me diz o resultado.");
+  return L.join("\n");
+}
+function exportSpec(){
+  function strip(n){ const o={type:n.type,props:n.props}; if((n.actions||[]).length)o.actions=n.actions; if(n.children?.length)o.children=n.children.map(strip); return o; }
+  return { tela:state.fname, modulo:state.module, origem:state.origin, padrao:state.tree.props.pattern,
+    tokens:{tema:state.theme,marca_hue:state.brand,densidade:state.density,raio:state.radius,shell:state.shell},
+    soberania:"sidebar dark + Jana(295) + status fixos — ADR-0050", estados_obrigatorios:["cheia","vazia","sem_resultado","loading","erro"],
+    arvore:state.tree.children.map(strip) };
+}
+function exportYAML(){
+  const L=[]; L.push(`tela: ${state.fname}`); L.push(`modulo: ${state.module}`); L.push(`padrao: ${state.tree.props.pattern}`); L.push(`origem: ${state.origin||"—"}`);
+  L.push("tokens:"); L.push(`  tema: ${state.theme}`); L.push(`  marca_accent_hue: ${state.brand}`); L.push(`  densidade: ${state.density}`); L.push(`  raio: ${state.radius}`); L.push(`  shell: ${state.shell}`);
+  L.push("soberania: sidebar-dark + jana-295 + status-fixos (ADR-0050)");
+  L.push("anatomia:");
+  function yk(n,d){ const ind="  ".repeat(d); const nm=n.props.title||n.props.label||n.props.text||"";
+    let line=`${ind}- ${n.type}`; if(nm)line+=`: "${String(nm).replace(/"/g,"'")}"`; L.push(line);
+    const meta=[];
+    if(n.type==="table"&&n.props.columns)meta.push(`colunas: [${n.props.columns.join(", ")}]`);
+    if(n.type==="tabs"&&n.props.items)meta.push(`abas: [${n.props.items.map(i=>i.label).join(", ")}]`);
+    if(n.type==="button"&&n.props.variant)meta.push(`variante: ${n.props.variant}`);
+    if(n.type==="badge")meta.push(`status: ${n.props.status}`);
+    if(n.type==="chip")meta.push(`origem: ${n.props.origin}`);
+    meta.forEach(m=>L.push(`${ind}    ${m}`));
+    (n.actions||[]).filter(a=>a.do&&a.do!=="none").forEach(a=>L.push(`${ind}    acao: { trigger: ${a.trigger||"click"}, faz: ${a.do}${a.arg?`, arg: "${a.arg}"`:""} }`));
+    (n.children||[]).forEach(c=>yk(c,d+1));
+  }
+  state.tree.children.forEach(c=>yk(c,1));
+  L.push("estados_obrigatorios: [cheia, vazia, sem_resultado, loading, erro]");
+  return L.join("\n");
+}
+function exportHTML(){ const body=htmlNode(state.tree,2); const inner=state.shell?shellHTML(body):body;
+  return `<!-- ${state.fname} · padrão ${state.tree.props.pattern} · Oimpresso Designer -->
+<link rel="stylesheet" href="tokens.css">
+<link rel="stylesheet" href="components.css">
+
+<div class="oi-root" data-theme="${state.theme}" data-density="${state.density}" data-radius="${state.radius}">
+${inner}
+</div>
+<!-- accent da marca: --p-accent hue ${state.brand} no :root -->`; }
+function pad(d){return "  ".repeat(d);}
+function shellHTML(c){ return `${pad(1)}<div class="shell">
+${pad(2)}<aside class="sidebar"><!-- sidebar dark herdada --></aside>
+${pad(2)}<div class="main-col">
+${pad(3)}<header class="app-header">${escapeHtml(state.module)}</header>
+${c}
+${pad(2)}</div>
+${pad(1)}</div>`; }
+function htmlNode(n,d){ const p=n.props; const open=(t,c,x="")=>`${pad(d)}<${t}${c?` class="${c}"`:""}${x}>`; const kids=()=>(n.children||[]).map(c=>htmlNode(c,d+1)).join("\n");
+  switch(n.type){
+    case "screen": return `${open("main","screen")}\n${kids()}\n${pad(d)}</main>`;
+    case "card": return `${open("div","card"+(p.pad===false?" card-pad-0":""))}\n${kids()}\n${pad(d)}</div>`;
+    case "cluster": return `${open("div","cluster")}\n${kids()}\n${pad(d)}</div>`;
+    case "stack": return `${open("div","stack")}\n${kids()}\n${pad(d)}</div>`;
+    case "kpiGrid": return `${open("div","kpi-grid")}\n${kids()}\n${pad(d)}</div>`;
+    case "pageHeader": return `${open("header","page-header")}
+${pad(d+1)}<div><h1 class="page-title">${escapeHtml(p.title||"")}</h1>${p.kpi?`<p class="page-sub">${escapeHtml(p.kpi)}</p>`:""}</div>
+${pad(d+1)}<div class="cluster">${p.showExport?'<button class="btn btn-ghost">Exportar</button>':""}${p.primary?`<button class="btn btn-primary">${escapeHtml(p.primary)}</button>`:""}</div>
+${pad(d)}</header>`;
+    case "breadcrumb": return `${open("nav","breadcrumb")}${(p.items||[]).map((it,i)=>(i?'<span class="sep">›</span>':"")+`<a href="#">${escapeHtml(it)}</a>`).join("")}</nav>`;
+    case "tabs": return `${open("nav","tabs")}\n`+(p.items||[]).map((it,i)=>`${pad(d+1)}<a href="#"${i===(p.active|0)?' aria-current="true"':""}>${escapeHtml(it.label)}${it.count?` <span class="count">${escapeHtml(it.count)}</span>`:""}</a>`).join("\n")+`\n${pad(d)}</nav>`;
+    case "toolbar": return `${open("div","toolbar")}
+${pad(d+1)}<span class="search"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m21 21-4.3-4.3"/></svg><input class="input" placeholder="${escapeHtml(p.placeholder||"")}"></span>${p.kbd?'<span class="kbd">⌘K</span>':""}
+${pad(d+1)}<span style="flex:1"></span>
+${pad(d+1)}<div class="segmented">${(p.segments||[]).map((s,i)=>`<button${i===(p.active|0)?' aria-pressed="true"':""}>${escapeHtml(s)}</button>`).join("")}</div>
+${pad(d)}</div>`;
+    case "kpi": return `${open("div","card kpi")}<span class="kpi-label">${escapeHtml(p.label||"")}</span><span class="kpi-value">${escapeHtml(p.value||"")}</span>${p.delta?`<span class="kpi-delta${p.dir?" "+p.dir:""}">${escapeHtml(p.delta)}</span>`:""}</div>`;
+    case "table": return `${open("table","table")}
+${pad(d+1)}<thead><tr>${(p.columns||[]).map(c=>`<th>${escapeHtml(c)}</th>`).join("")}</tr></thead>
+${pad(d+1)}<tbody><!-- linhas do módulo · mono em id/valor/data · status=badge --></tbody>
+${pad(d)}</table>`;
+    case "pagination": return `${pad(d)}<div class="pagination"><button>‹</button>${Array.from({length:p.pages|0||4},(_,i)=>`<button${i+1===(p.active|0)?' aria-current="true"':""}>${i+1}</button>`).join("")}<button>›</button></div>`;
+    case "button": return `${pad(d)}<button class="btn btn-${p.variant||"primary"}${p.size&&p.size!=="md"?" btn-"+p.size:""}">${escapeHtml(p.label||"")}</button>`;
+    case "field": { let ctrl; if(p.kind==="textarea")ctrl=`<textarea class="textarea" placeholder="${escapeHtml(p.placeholder||"")}"></textarea>`;
+      else if(p.kind==="select")ctrl=`<select class="input"><!-- opções --></select>`;
+      else if(p.addon)ctrl=`<div class="input-group"><span class="addon">${escapeHtml(p.addon)}</span><input class="input mono" placeholder="${escapeHtml(p.placeholder||"")}"></div>`;
+      else ctrl=`<input class="input" placeholder="${escapeHtml(p.placeholder||"")}">`;
+      return `${open("label","field"+(p.state==="error"?" is-error":""))}<span class="label">${escapeHtml(p.label||"")}</span>${ctrl}${p.hint?`<span class="hint">${escapeHtml(p.hint)}</span>`:""}</label>`; }
+    case "checkbox": return `${pad(d)}<label class="check"><input type="checkbox"${p.checked?" checked":""}><span>${escapeHtml(p.label||"")}</span></label>`;
+    case "switch": return `${pad(d)}<label class="switch"><input type="checkbox"${p.checked?" checked":""}><span class="track"></span>${p.label?`<span>${escapeHtml(p.label)}</span>`:""}</label>`;
+    case "badge": return `${pad(d)}<span class="badge is-${p.status||"ok"}">${escapeHtml(p.label||"")}</span>`;
+    case "chip": return `${pad(d)}<span class="chip origin-${p.origin||"FIN"}">${escapeHtml(p.label||p.origin||"")}</span>`;
+    case "avatar": return `${pad(d)}<span class="avatar">${escapeHtml(p.initials||"")}</span>`;
+    case "callout": return `${pad(d)}<div class="callout${p.variant==="bad"?" is-bad":""}">${escapeHtml(p.text||"")}</div>`;
+    case "empty": return `${open("div","empty")}
+${pad(d+1)}<svg class="empty-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 7h16M4 12h16M4 17h10"/></svg>
+${pad(d+1)}<p class="empty-title">${escapeHtml(p.title||"")}</p><p class="empty-sub">${escapeHtml(p.sub||"")}</p>
+${pad(d+1)}<div class="empty-actions">${p.primary?`<button class="btn btn-primary">${escapeHtml(p.primary)}</button>`:""}${p.secondary?`<button class="btn btn-ghost">${escapeHtml(p.secondary)}</button>`:""}</div>
+${pad(d)}</div>`;
+    case "heading": return `${pad(d)}<${p.level||"h2"} class="h-text">${escapeHtml(p.text||"")}</${p.level||"h2"}>`;
+    case "text": return `${pad(d)}<p class="p-text${p.dim?" dim":""}">${escapeHtml(p.text||"")}</p>`;
+    case "tag": return `${pad(d)}<span class="tag">${escapeHtml(p.label||"")}</span>`;
+    case "divider": return `${pad(d)}<hr class="divider">`;
+    default: return `${pad(d)}<!-- ${n.type} -->`;
+  }
+}
+
+/* ================================================================ AUDITORIA (fiscaliza tela contra o PADRÃO) ================================================================ */
+const AKEY = KEY+".audit";
+const AUDIT_SAMPLE = `<!-- tela legada: Clientes (cole a sua aqui) -->
+<aside class="sidebar" style="background:#ffffff">  <!-- sidebar -->
+  <a href="#">Clientes</a>
+</aside>
+
+<button class="btn" style="background:#7c3aed;color:#fff">Novo cliente</button>
+<span class="status" style="color:#e11d48">Vencido</span>
+
+<div class="card" style="border:1px solid oklch(0.90 0.004 90); border-radius:24px"></div>
+<h2 style="font-family:Arial">Clientes 😀</h2>
+
+<style>
+  :root{ --bg: oklch(0.985 0.003 90); }   /* OK: definição de token */
+  .alert{ color:#e11d48 !important; background:linear-gradient(#fff,#eee); }
+</style>
+<script>localStorage.setItem('clientes_filtro', '1')<\/script>`;
+
+const C3 = [
+  "Disposição do baseline preservada (ou há decisão/ADR registrada).",
+  "Só token de cor — nada hardcoded novo (U-01 / AP1).",
+  "Soberania intacta: sem roxo-295 primário, sem sidebar-light, magenta 330 permitido como marca (U-02).",
+  "Testado em claro e escuro com contraste (U-03).",
+  "Fundações/Shell intactos — sem token/fonte fora do contrato (U-04/05).",
+  "Smoke test das interações do baseline passou (INV-B).",
+  "Nenhum estado/caso de uso rebaixado (INV-C).",
+  "Componentes do shared reusados; nada reinventado (U-07 / AP2).",
+  "Higiene: PT-BR, sem emoji, HTML canônico, sem console error, hit target ≥44px (U-06 / A5).",
+  "Pedido era determinístico (A0).",
+];
+
+function _hex2rgb(h){ h=h.replace("#",""); if(h.length===3)h=h.split("").map(c=>c+c).join(""); const n=parseInt(h.slice(0,6),16); return [(n>>16)&255,(n>>8)&255,n&255]; }
+function _rgb2hsl(r,g,b){ r/=255;g/=255;b/=255; const mx=Math.max(r,g,b),mn=Math.min(r,g,b); let h,s,l=(mx+mn)/2;
+  if(mx===mn){h=0;s=0;} else { const d=mx-mn; s=l>0.5?d/(2-mx-mn):d/(mx+mn);
+    switch(mx){case r:h=(g-b)/d+(g<b?6:0);break;case g:h=(b-r)/d+2;break;default:h=(r-g)/d+4;} h*=60; } return [h,s,l]; }
+function classifyColor(raw){
+  let l,c,h, m=raw.match(/oklch\(\s*([\d.]+)\s+([\d.]+)\s+([\d.]+)/i);
+  if(m){ l=+m[1]; c=+m[2]; h=+m[3]; }
+  else { let rgb; const rm=raw.match(/rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/i);
+    if(rm)rgb=[+rm[1],+rm[2],+rm[3]]; else { const hm=raw.match(/#([0-9a-fA-F]{3,8})/); if(hm)rgb=_hex2rgb(hm[1]); }
+    if(!rgb)return "o token de cor mais próximo (--accent/--text/--border…)";
+    const hsl=_rgb2hsl(rgb[0],rgb[1],rgb[2]); h=hsl[0]; c=hsl[1]*0.2; l=hsl[2]; }
+  if(c<0.03){ if(l>0.92)return "var(--surface) / var(--bg)"; if(l<0.30)return "var(--text)"; if(l<0.58)return "var(--text-dim)"; return "var(--border) / var(--text-mute)"; }
+  if(h>=345||h<45)return "var(--bad)";
+  if(h>=45&&h<95)return "var(--warn)";
+  if(h>=95&&h<170)return "var(--ok)";
+  if(h>=170&&h<255)return "var(--accent) (ou --info)";
+  if(h>=255&&h<330)return "var(--jana) — ⚠ roxo é SOBERANO da IA, não use como primário (use --accent)";
+  return "o token semântico/marca mais próximo";
+}
+const EMOJI_RE=/[\u{1F000}-\u{1FAFF}\u{2600}-\u{26FF}\u{2700}-\u{27BF}]/u;
+function runAudit(code){
+  const lines=String(code).split(/\n/); const hits=[];
+  lines.forEach((ln,i)=>{
+    const line=i+1; const isDef=/--[\w-]+\s*:/.test(ln); // declaração de token → cor literal é permitida
+    // cores literais
+    const colorRe=/(#[0-9a-fA-F]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\)|oklch\([^)]*\))/g; let m;
+    while((m=colorRe.exec(ln))){ const val=m[1]; const low=val.toLowerCase().replace(/\s+/g,"");
+      if(/^#(fff|ffffff|000|000000)$/.test(low))continue;          // #fff/#000 permitidos (A3)
+      if(isDef)continue;                                            // mora no :root como token: OK
+      hits.push({line,code:ln.trim(),value:val,sev:"P1",rule:"AP1 · cor hardcoded",suggest:classifyColor(val)}); }
+    // soberania: sidebar light
+    if(/sidebar|--sb-bg/i.test(ln) && /(background[^;:]*:\s*)?(#fff|#ffffff|white|oklch\(\s*0?\.[6-9])/i.test(ln) && !/--sb-bg\s*:\s*oklch\(\s*0?\.[0-3]/.test(ln))
+      hits.push({line,code:ln.trim(),value:"sidebar claro",sev:"P0",rule:"U-02 · soberania (sidebar é sempre dark)",suggest:"use os tokens --sb-* (dark), mesmo em tema claro"});
+    // soberania: roxo ~295 como cor (fora de --jana)
+    if(/oklch\([^)]*\b29[0-9](?:\.\d+)?\s*\)/.test(ln) && !/--jana/.test(ln) && !isDef)
+      hits.push({line,code:ln.trim(),value:"hue ~295",sev:"P0",rule:"U-02 · roxo 295 é da Jana (IA)",suggest:"primário = --accent (azul 220); 295 só em --jana"});
+    // storage sem prefixo
+    if(/localStorage|sessionStorage/.test(ln) && !/oimpresso\./.test(ln))
+      hits.push({line,code:ln.trim(),value:/sessionStorage/.test(ln)?"sessionStorage":"localStorage",sev:"P1",rule:"AP3 · storage sem prefixo",suggest:"use 'oimpresso.<modulo>.*' (e localStorage, não sessionStorage)"});
+    // fonte fora do contrato
+    if(/font-family\s*:/.test(ln) && !/var\(--font/.test(ln) && !/IBM Plex/i.test(ln) && !/inherit|monospace|sans-serif\s*$/.test(ln))
+      hits.push({line,code:ln.trim(),value:"font-family",sev:"P2",rule:"U-04 · fonte fora do contrato",suggest:"var(--font-sans) / var(--font-mono) (IBM Plex)"});
+    // raio acima do teto
+    const rr=ln.match(/border-radius\s*:\s*(\d+)px/); if(rr && +rr[1]>16)
+      hits.push({line,code:ln.trim(),value:rr[0],sev:"P2",rule:"A4 · raio acima do teto (12 / 16px)",suggest:"var(--radius) / var(--radius-lg)"});
+    // gradiente decorativo
+    if(/linear-gradient|radial-gradient/.test(ln) && !isDef)
+      hits.push({line,code:ln.trim(),value:"gradient",sev:"P2",rule:"A4 · sem gradiente decorativo",suggest:"cor sólida via token + sombra em camada"});
+    // !important
+    if(/!important/.test(ln))
+      hits.push({line,code:ln.trim(),value:"!important",sev:"P2",rule:"higiene · !important",suggest:"ajuste a especificidade em vez de forçar"});
+    // emoji na UI
+    if(EMOJI_RE.test(ln))
+      hits.push({line,code:ln.trim(),value:"emoji",sev:"P2",rule:"A5 · sem emoji na UI",suggest:"use ícone SVG (lucide-like)"});
+  });
+  return hits;
+}
+function renderAuditReport(hits){
+  const rep=$("#auditRep");
+  const p0=hits.filter(h=>h.sev==="P0").length, p1=hits.filter(h=>h.sev==="P1").length, p2=hits.filter(h=>h.sev==="P2").length;
+  const pass=p0===0&&p1===0;
+  let h=`<div class="rep-head ${pass?"pass":"fail"}">${pass?"✓ Passa nos invariantes de cor/estrutura":"✕ "+(p0+p1)+" violação(ões) que bloqueiam"}<span class="mono" style="margin-left:auto;font-size:11px;color:var(--c-mute)">P0:${p0} · P1:${p1} · P2:${p2}</span></div>`;
+  if(!hits.length){ h+=`<div class="hit" style="color:var(--c-dim)">Nenhuma cor hardcoded nem violação detectada — tudo via var(--token). Pronto pro portão funcional (D).</div>`; }
+  hits.sort((a,b)=>a.sev.localeCompare(b.sev)||a.line-b.line).forEach(x=>{
+    h+=`<div class="hit"><span class="ln">linha ${x.line}</span> · <span class="rule">${escapeHtml(x.rule)}</span><span class="sev sev-${x.sev}">${x.sev}</span><br>
+      <span class="val">${escapeHtml(x.value)}</span> → use <span class="sug">${escapeHtml(x.suggest)}</span>
+      <span class="snip">${escapeHtml(x.code).slice(0,170)}</span></div>`;
+  });
+  rep.innerHTML=h;
+}
+function renderChecklist(){
+  const host=$("#auditChk"); let saved={}; try{ saved=JSON.parse(localStorage.getItem(AKEY)||"{}"); }catch(_){}
+  host.innerHTML=`<h5>Portão C3 · anti-regressão (confirme manualmente o que o lint não pega)</h5>`;
+  C3.forEach((t,i)=>{ const lab=el("label","chk-item"); const c=el("input"); c.type="checkbox"; c.checked=!!saved["c"+i];
+    c.onchange=()=>{ saved["c"+i]=c.checked; localStorage.setItem(AKEY,JSON.stringify(saved)); };
+    lab.appendChild(c); lab.appendChild(el("span",null,(i+1)+". "+t)); host.appendChild(lab); });
+}
+function doAudit(){ renderAuditReport(runAudit($("#auditIn").value)); }
+function openAudit(){ if(!$("#auditIn").value) $("#auditIn").value=AUDIT_SAMPLE; renderChecklist(); doAudit(); $("#auditHost").classList.add("on"); }
+function closeAudit(){ $("#auditHost").classList.remove("on"); }
+$("#btnAudit").onclick=openAudit;
+$("#auditIn").oninput=doAudit;
+$("#auditCur").onclick=()=>{ $("#auditIn").value=exportHTML(); doAudit(); };
+$$("#auditHost [data-aclose]").forEach(b=>b.onclick=closeAudit);
+
+/* ================================================================ INIT ================================================================ */
+function init(){
+  const saved=localStorage.getItem(KEY);
+  if(saved){ try{ Object.assign(state,JSON.parse(saved)); }catch(_){} }
+  if(!state.tree){ state.tree=T.lista(); }
+  state.mode=state.mode||"edit"; state.screenState=state.screenState||"full";
+  reindexIds(state.tree);
+  buildPalettes(); buildBrandSwatches(); syncControls(); renderAll();
+  history=[serialize()]; hIdx=0; updateUndoButtons();
+}
+init();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Pasta nova `oimpresso_designer_view/` com **só 2 arquivos**: `index.html` (protótipo da prancheta de design, autocontido) + `README.md`.

Referência/ponto de partida — não toca pipeline nem `.mcp.json`. ds-guard: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)