### PR TITLE
chore(sells): prune 3.6k linhas de CSS morto do sells-cowork.css + generaliza tooling (−47%)

### DIFF
--- a/config/stylelint-baseline.json
+++ b/config/stylelint-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-05T17:57:34.968Z",
-    "total_violations": 657,
+    "generated_at": "2026-06-05T18:14:15.483Z",
+    "total_violations": 494,
     "stylelint_version": "17.x",
     "adr": "0209",
     "note": "G5 anti-drift CSS — gêmeo do eslint-baseline. Ratchet por path+rule, falha só em delta>0."
@@ -30,9 +30,9 @@
     "resources/css/sells-cowork-quotations.css|color-no-hex": 1,
     "resources/css/sells-cowork-show.css|color-no-hex": 11,
     "resources/css/sells-cowork-show.css|declaration-no-important": 2,
-    "resources/css/sells-cowork.css|color-no-hex": 188,
-    "resources/css/sells-cowork.css|declaration-no-important": 40,
-    "resources/css/sells-cowork.css|no-duplicate-selectors": 39,
+    "resources/css/sells-cowork.css|color-no-hex": 69,
+    "resources/css/sells-cowork.css|declaration-no-important": 11,
+    "resources/css/sells-cowork.css|no-duplicate-selectors": 24,
     "resources/css/sells-kb975-cheatsheet.css|color-no-hex": 25,
     "resources/css/sells-kb975-emit-modals.css|color-no-hex": 4,
     "resources/css/sells-kb975-next-action.css|color-no-hex": 6,

--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -1,4 +1,6 @@
 /* SCOPED-OK */ - escopo .sells-cowork aplicado por scripts/scope-sells-cowork-css.py
+/* SCOPED-OK */
+.sells-cowork - escopo .sells-cowork aplicado por scripts/scope-sells-cowork-css.py
 /* ───────────────────── Oimpresso ERP — Sells Cowork ─────────────────────
  * Copiado verbatim de prototipo-ui/prototipos/sells-index/styles.css (handoff
  * Claude Design `Kf6GHQu6fkwlh0vnL30Oog`, sessão chat10 "KB-9.75 Vendas"
@@ -15,7 +17,7 @@
  * Fontes IBM Plex Sans/Mono são carregadas via <link rel="stylesheet"> no
  * resources/views/layouts/inertia.blade.php — não via @import aqui. Motivo:
  * @import de URL externa em CSS bundleado é descartado pelo Vite no build de
- * produção, fazendo a fonte cair em system-ui em todo browser que não tem
+ * produção, .sells-cowork fazendo a fonte cair em system-ui em todo browser que não tem
  * IBM Plex instalado no SO (causava prod "errada" e localhost ok).
  */
 .sells-cowork {
@@ -106,10 +108,6 @@
 /* .app.app--sb-rail { --sb-w: 56px; } */
 /* .app.app--sb-hidden { --sb-w: 0px; } */
 /* .main { ... } */
-.sells-cowork .main-body-noop {
-  min-height: 0;
-  min-width: 0;
-}
 .sells-cowork .main-body {
   min-height: 0;
   min-width: 0;
@@ -127,85 +125,15 @@
   gap: 0;
   flex-shrink: 0;
 }
-.sells-cowork .topbar-l {
-  display: flex; align-items: center; gap: 8px;
-  padding: 0 14px;
-  min-width: 160px;
-  border-right: 1px solid var(--border);
-  flex-shrink: 0;
-}
-.sells-cowork .topbar-dot {
-  width: 8px; height: 8px; border-radius: 50%;
-  flex-shrink: 0;
-}
-.sells-cowork .topbar-area-label {
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--text);
-  white-space: nowrap;
-}
-.sells-cowork .topbar-tabs {
-  flex: 1 1 auto;
-  display: flex;
-  align-items: stretch;
-  gap: 0;
-  overflow-x: auto;
-  scrollbar-width: thin;
-  scrollbar-color: var(--border) transparent;
-  padding: 0 8px;
-  min-width: 0;
-}
-.sells-cowork .topbar-tabs::-webkit-scrollbar { height: 4px; }
-.sells-cowork .topbar-tabs::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; }
-.sells-cowork .topbar-tabs-empty { flex: 1; }
-.sells-cowork .topbar-tab {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 0 10px;
-  border: 0;
-  background: transparent;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  color: var(--text-mute);
-  font-size: 12px;
-  font-family: inherit;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: color .12s, border-color .12s;
-}
-.sells-cowork .topbar-tab svg { opacity: 0.6; }
-.sells-cowork .topbar-tab:hover { color: var(--text); }
-.sells-cowork .topbar-tab:hover svg { opacity: 0.85; }
 .sells-cowork .topbar-tab.active {
   color: var(--accent);
   border-bottom-color: var(--accent);
   font-weight: 600;
 }
 .sells-cowork .topbar-tab.active svg { opacity: 1; }
-.sells-cowork .topbar-r {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 12px;
-  flex-shrink: 0;
-  border-left: 1px solid var(--border);
-}
-.sells-cowork .topbar-tenant {
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: 0.04em;
-  color: var(--text-mute);
-  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
-  padding: 0 6px;
-}
 /* legados breadcrumb — manter caso algum ponto ainda use */
 .sells-cowork .bc { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--text-dim); }
-.sells-cowork .bc-tenant { color: var(--text); font-weight: 600; }
 .sells-cowork .bc-sep { color: var(--text-mute); }
-.sells-cowork .bc-up { color: var(--text-dim); }
 .sells-cowork .bc-cur { color: var(--text); font-weight: 500; }
 /* ────────────────── Sidebar ────────────────── */
 .sells-cowork .sb {
@@ -289,30 +217,6 @@
 }
 .sells-cowork .sb-dd-foot:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
 /* Tabs Chat/Menu */
-.sells-cowork .sb-tabs {
-  display: flex;
-  gap: 2px;
-  padding: 8px;
-  border-bottom: 1px solid var(--sb-border);
-}
-.sells-cowork .sb-tab {
-  flex: 1 1 0;
-  appearance: none;
-  border: 0;
-  background: transparent;
-  color: var(--sb-text-dim);
-  padding: 6px 8px;
-  border-radius: var(--radius-sm);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  font: inherit;
-  font-size: 12px;
-  font-weight: 500;
-  cursor: default;
-}
-.sells-cowork .sb-tab:hover { color: var(--sb-text-hi); background: var(--sb-hover); }
 .sells-cowork .sb-tab.active {
   background: var(--sb-active);
   color: var(--sb-text-hi);
@@ -332,7 +236,6 @@
   background-clip: content-box;
 }
 /* ── Aba CHAT ── */
-.sells-cowork .sb-chat { padding: 8px; }
 .sells-cowork .sb-actions { display: flex; flex-direction: column; gap: 1px; margin-bottom: 8px; }
 .sells-cowork .sb-action {
   display: flex; align-items: center; gap: 10px;
@@ -378,15 +281,6 @@
   color: var(--sb-text-dim);
   padding: 14px 10px 6px;
 }
-.sells-cowork .sb-pin-empty {
-  display: flex; align-items: center; gap: 8px;
-  padding: 8px 10px;
-  font-size: 11.5px;
-  color: var(--sb-text-dim);
-  border: 1px dashed var(--sb-border);
-  border-radius: var(--radius-sm);
-  margin: 0 4px;
-}
 .sells-cowork .sb-bullet {
   width: 7px; height: 7px;
   border-radius: 50%;
@@ -410,27 +304,7 @@
   flex: 1 1 auto;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-.sells-cowork .sb-routine {
-  display: flex; align-items: center; gap: 10px;
-  padding: 0 10px;
-  height: 28px;
-  border-radius: var(--radius-sm);
-  color: var(--sb-text);
-  font-size: 12.5px;
-  cursor: default;
-}
-.sells-cowork .sb-routine:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
-.sells-cowork .sb-routine-t {
-  flex: 1 1 auto;
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-}
-.sells-cowork .sb-routine-f {
-  font-size: 10.5px;
-  color: var(--sb-text-dim);
-  flex: 0 0 auto;
-}
 /* ── Aba MENU ── */
-.sells-cowork .sb-menu { padding: 8px; }
 .sells-cowork .sb-group-h {
   font-size: 10px;
   font-weight: 600;
@@ -854,12 +728,6 @@
   font-size: 10.5px;
   color: var(--text);
 }
-.sells-cowork .tk-empty-old {
-  padding: 60px 20px;
-  text-align: center;
-  color: var(--text-mute);
-  font-size: 13px;
-}
 /* Detail */
 .sells-cowork .tk-detail {
   display: flex; flex-direction: column;
@@ -938,260 +806,28 @@
   background: var(--border); border-radius: 5px;
   border: 3px solid transparent; background-clip: content-box;
 }
-.sells-cowork .vw-grid {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-  margin-bottom: 10px;
-}
-.sells-cowork .vw-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 14px 16px;
-  margin-bottom: 10px;
-}
-.sells-cowork .vw-card.hi {
-  background: linear-gradient(135deg, var(--accent-soft), oklch(0.96 0.02 145));
-  border-color: var(--accent-soft);
-}
-.sells-cowork [data-theme="dark"] .vw-card.hi {
-  background: linear-gradient(135deg, oklch(0.26 0.06 220), oklch(0.24 0.04 145));
-}
-.sells-cowork .vw-card h3 {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .06em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-  margin: 0 0 10px;
-}
-.sells-cowork .vw-card h4 { font-size: 12px; margin: 10px 0 6px; color: var(--text); }
-.sells-cowork .vw-card .vw-sub {
-  font-size: 10.5px; font-weight: 700; letter-spacing: .06em;
-  text-transform: uppercase; color: var(--text-mute);
-  margin: 12px 0 6px;
-}
-.sells-cowork .vw-p { margin: 0; font-size: 13px; line-height: 1.5; color: var(--text-dim); }
-.sells-cowork .vw-dl { display: grid; grid-template-columns: 100px 1fr; gap: 6px 10px; margin: 0; font-size: 12.5px; }
-.sells-cowork .vw-dl dt { color: var(--text-mute); font-weight: 500; }
-.sells-cowork .vw-dl dd { margin: 0; color: var(--text); }
 .sells-cowork .vw-dl dd.mono { font-family: var(--font-mono); }
 .sells-cowork .vw-dl dd.urgent { color: var(--neg); font-weight: 600; }
-.sells-cowork .vw-stage {
-  display: inline-flex;
-  background: var(--origin-OS-bg);
-  color: var(--origin-OS-fg);
-  padding: 2px 8px;
-  border-radius: 999px;
-  font-size: 11px;
-  font-weight: 500;
-}
-.sells-cowork .vw-art {
-  display: flex; gap: 12px; align-items: center;
-  padding: 10px;
-  background: var(--bg-2);
-  border-radius: var(--radius-sm);
-}
-.sells-cowork .vw-art-thumb {
-  width: 56px; height: 56px;
-  border-radius: var(--radius-sm);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  display: grid; place-items: center;
-  color: var(--text-mute);
-  flex: 0 0 auto;
-}
-.sells-cowork .vw-art-meta { flex: 1 1 auto; min-width: 0; }
-.sells-cowork .vw-art-meta b { display: block; font-size: 13px; }
-.sells-cowork .vw-art-meta small { display: block; font-size: 11.5px; color: var(--text-dim); font-family: var(--font-mono); }
-.sells-cowork .vw-art-actions { display: flex; gap: 6px; margin-top: 6px; }
-.sells-cowork .vw-hist { list-style: none; margin: 0; padding: 0; font-size: 12.5px; }
-.sells-cowork .vw-hist li {
-  padding: 6px 0;
-  border-bottom: 1px solid var(--border-2);
-  display: flex; gap: 8px;
-}
-.sells-cowork .vw-hist li:last-child { border-bottom: 0; }
 .sells-cowork .vw-hist .t { color: var(--text-mute); font-variant-numeric: tabular-nums; }
-.sells-cowork .vw-thread-mini { display: flex; flex-direction: column; gap: 6px; }
-.sells-cowork .mini-msg { display: flex; gap: 8px; align-items: flex-end; }
 .sells-cowork .mini-msg.me { justify-content: flex-end; }
-.sells-cowork .mini-av {
-  width: 22px; height: 22px;
-  border-radius: 50%;
-  display: grid; place-items: center;
-  color: #fff; font-size: 9.5px; font-weight: 600;
-  flex: 0 0 auto;
-}
-.sells-cowork .mini-bub {
-  background: var(--bubble-them);
-  padding: 6px 10px;
-  border-radius: 12px;
-  border-top-left-radius: 3px;
-  font-size: 12.5px;
-  max-width: 70%;
-}
 .sells-cowork .mini-bub.me {
   background: var(--bubble-me);
   color: var(--bubble-me-fg);
   border-top-left-radius: 12px;
   border-top-right-radius: 3px;
 }
-.sells-cowork .mini-input {
-  margin-top: 6px;
-  appearance: none;
-  width: 100%;
-  height: 32px;
-  padding: 0 12px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: var(--surface);
-  color: var(--text);
-  font: inherit;
-  font-size: 12.5px;
-  outline: none;
-}
-.sells-cowork .mini-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 /* CRM */
-.sells-cowork .vw-contact { display: flex; gap: 12px; align-items: center; margin-bottom: 12px; }
-.sells-cowork .vw-contact-av {
-  width: 44px; height: 44px;
-  border-radius: 50%;
-  display: grid; place-items: center;
-  color: #fff; font-weight: 700;
-  flex: 0 0 auto;
-}
-.sells-cowork .vw-contact b { font-size: 14px; }
-.sells-cowork .vw-contact small { display: block; font-size: 12px; color: var(--text-dim); }
-.sells-cowork .vw-contact-row {
-  display: flex; align-items: center; gap: 10px;
-  padding: 8px 10px;
-  background: var(--bg-2);
-  border-radius: var(--radius-sm);
-  margin-bottom: 6px;
-  font-size: 13px;
-}
 .sells-cowork .vw-contact-row .ic { color: var(--text-mute); }
-.sells-cowork .vw-contact-row a { flex: 1 1 auto; color: var(--text); }
-.sells-cowork .vw-notes { margin: 0; padding-left: 18px; font-size: 12.5px; color: var(--text-dim); line-height: 1.6; }
 /* Radio/Chips/Textarea reutilizáveis */
-.sells-cowork .vw-radio-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
-.sells-cowork .vw-radio {
-  display: flex; align-items: center; gap: 8px;
-  padding: 7px 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  font-size: 12.5px;
-  cursor: default;
-}
-.sells-cowork .vw-radio:hover { background: var(--border-2); }
-.sells-cowork .vw-radio input { accent-color: var(--accent); }
-.sells-cowork .vw-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
-.sells-cowork .vw-chip {
-  appearance: none;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  color: var(--text);
-  padding: 5px 12px;
-  border-radius: 999px;
-  font: inherit;
-  font-size: 12px;
-  cursor: default;
-}
-.sells-cowork .vw-chip:hover { background: var(--border-2); }
 .sells-cowork .vw-chip.on {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
 }
-.sells-cowork .vw-textarea {
-  appearance: none;
-  width: 100%;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  color: var(--text);
-  border-radius: var(--radius-sm);
-  padding: 8px 10px;
-  font: inherit;
-  font-size: 12.5px;
-  resize: vertical;
-  outline: none;
-}
-.sells-cowork .vw-textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
-.sells-cowork .vw-check { display: flex; align-items: center; gap: 8px; font-size: 12.5px; margin-top: 8px; color: var(--text-dim); }
 /* PNT */
-.sells-cowork .vw-pnt-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 6px;
-}
-.sells-cowork .vw-pnt-cell {
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 10px;
-  text-align: center;
-}
-.sells-cowork .vw-pnt-cell small { display: block; font-size: 10px; color: var(--text-mute); text-transform: uppercase; letter-spacing: .06em; }
-.sells-cowork .vw-pnt-cell b { display: block; font-size: 16px; font-weight: 600; font-family: var(--font-mono); margin-top: 4px; }
-.sells-cowork .vw-pnt-cell.miss {
-  background: oklch(0.96 0.04 25);
-  border-color: oklch(0.85 0.08 25);
-  border-style: dashed;
-}
-.sells-cowork .vw-pnt-cell.miss b { color: var(--neg); }
-.sells-cowork [data-theme="dark"] .vw-pnt-cell.miss {
-  background: oklch(0.26 0.06 25);
-  border-color: oklch(0.45 0.10 25);
-}
 /* FIN — money */
-.sells-cowork .vw-money { text-align: center; padding: 14px 8px; }
-.sells-cowork .vw-money small {
-  display: block;
-  font-size: 10px;
-  font-weight: 700;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-}
-.sells-cowork .vw-money b {
-  display: block;
-  font-size: 32px;
-  font-weight: 600;
-  letter-spacing: -0.02em;
-  margin: 6px 0 4px;
-  font-variant-numeric: tabular-nums;
-}
-.sells-cowork .vw-due { font-size: 12px; color: var(--text-dim); }
 .sells-cowork .vw-due.urgent { color: var(--neg); font-weight: 600; }
 /* Botões viewer */
-.sells-cowork .vw-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding-top: 12px;
-  border-top: 1px solid var(--border);
-  margin-top: 8px;
-}
-.sells-cowork .vw-spacer { flex: 1 1 auto; }
-.sells-cowork .vw-btn {
-  appearance: none;
-  border: 1px solid var(--border);
-  background: var(--surface);
-  color: var(--text);
-  height: 34px;
-  padding: 0 14px;
-  border-radius: var(--radius-sm);
-  font: inherit;
-  font-size: 12.5px;
-  font-weight: 500;
-  cursor: default;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-}
-.sells-cowork .vw-btn:hover { background: var(--border-2); }
 .sells-cowork .vw-btn.primary {
   background: var(--accent);
   color: #fff;
@@ -1212,76 +848,6 @@
 .sells-cowork .vw-btn.ghost:hover { background: var(--border-2); color: var(--text); }
 .sells-cowork .vw-btn.sm { height: 26px; padding: 0 10px; font-size: 11.5px; }
 /* ────────────────── Module stub (rich migration page) ────────────────── */
-.sells-cowork .mod-stub {
-  flex: 1 1 auto;
-  display: flex; flex-direction: column;
-  min-height: 0;
-  overflow-y: auto;
-  background:
-    radial-gradient(1200px 600px at 100% 0%, var(--accent-soft) 0%, transparent 60%),
-    var(--bg);
-}
-.sells-cowork [data-theme="dark"] .mod-stub {
-  background:
-    radial-gradient(1200px 600px at 100% 0%, oklch(0.26 0.06 var(--hue, 220)) 0%, transparent 60%),
-    var(--bg);
-}
-.sells-cowork .mod-stub-hero {
-  padding: 32px 32px 28px;
-  display: flex; align-items: flex-start; gap: 24px;
-  border-bottom: 1px solid var(--border);
-}
-.sells-cowork .mod-stub-hero-l {
-  display: flex; gap: 18px;
-  flex: 1 1 auto;
-  min-width: 0;
-}
-.sells-cowork .mod-stub-hero-l > div { min-width: 0; flex: 1 1 auto; }
-.sells-cowork .mod-stub-ico {
-  width: 56px; height: 56px;
-  border-radius: 14px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  display: grid; place-items: center;
-  color: var(--accent);
-  flex: 0 0 auto;
-  box-shadow: 0 1px 2px rgba(0,0,0,.04);
-}
-.sells-cowork .mod-stub-eyebrow {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 10.5px;
-  font-weight: 700;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-  margin-bottom: 8px;
-}
-.sells-cowork .mod-stub-hero-l h1 {
-  margin: 0;
-  font-size: 30px;
-  font-weight: 600;
-  letter-spacing: -0.025em;
-  line-height: 1.1;
-  color: var(--text);
-}
-.sells-cowork .mod-stub-hero-l p {
-  margin: 8px 0 0;
-  font-size: 14px;
-  line-height: 1.55;
-  max-width: 580px;
-  color: var(--text-dim);
-}
-.sells-cowork .mod-stub-hero-r { flex: 0 0 auto; }
-.sells-cowork .mod-stub-status {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 12px;
-  font-weight: 500;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-}
 .sells-cowork .mod-stub-status .dot {
   width: 8px; height: 8px; border-radius: 50%;
   background: var(--text-mute);
@@ -1297,84 +863,15 @@
 .sells-cowork .mod-stub-status.muted { color: var(--text-mute); }
 .sells-cowork [data-theme="dark"] .mod-stub-status.ok { background: oklch(0.30 0.07 145); color: oklch(0.85 0.10 145); }
 .sells-cowork [data-theme="dark"] .mod-stub-status.partial { background: oklch(0.30 0.07 75); color: oklch(0.85 0.10 75); }
-.sells-cowork .mod-stub-grid {
-  padding: 28px 32px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  flex: 1 1 auto;
-}
-.sells-cowork .mod-stub-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 18px 20px;
-}
 .sells-cowork .mod-stub-card.span { grid-column: 1 / -1; }
-.sells-cowork .mod-stub-card h3 {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-  margin: 0 0 14px;
-}
-.sells-cowork .mod-stub-actions {
-  display: flex; flex-wrap: wrap; gap: 6px;
-}
-.sells-cowork .mod-stub-action {
-  appearance: none;
-  border: 1px solid var(--border);
-  background: var(--bg-2);
-  color: var(--text);
-  font: inherit;
-  font-size: 12.5px;
-  font-weight: 500;
-  padding: 7px 12px;
-  border-radius: var(--radius-sm);
-  cursor: default;
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.sells-cowork .mod-stub-action:hover { background: var(--border-2); }
 .sells-cowork .mod-stub-action.primary {
   background: var(--accent);
   color: #fff;
   border-color: var(--accent);
 }
 .sells-cowork .mod-stub-action.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
-.sells-cowork .mod-stub-empty { font-size: 12.5px; color: var(--text-mute); margin: 0; }
-.sells-cowork .mod-stub-dl {
-  display: grid;
-  grid-template-columns: 110px 1fr;
-  gap: 8px 12px;
-  margin: 0;
-  font-size: 12.5px;
-}
-.sells-cowork .mod-stub-dl dt { color: var(--text-mute); font-weight: 500; }
-.sells-cowork .mod-stub-dl dd { margin: 0; color: var(--text); }
 .sells-cowork .mod-stub-dl dd.mono { font-family: var(--font-mono); font-size: 12px; }
 .sells-cowork .mod-stub-dl dd.mono.small { font-size: 11px; color: var(--text-dim); word-break: break-all; }
-.sells-cowork .mod-stub-roadmap {
-  list-style: none;
-  margin: 0; padding: 0;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-  position: relative;
-}
-.sells-cowork .mod-stub-roadmap li {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 12px 14px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  position: relative;
-  opacity: .7;
-}
-.sells-cowork .mod-stub-roadmap li b { display: block; font-size: 12.5px; font-weight: 600; color: var(--text); margin-bottom: 2px; }
-.sells-cowork .mod-stub-roadmap li small { display: block; font-size: 11px; color: var(--text-dim); line-height: 1.4; }
 .sells-cowork .mod-stub-roadmap li .step {
   width: 22px; height: 22px;
   border-radius: 50%;
@@ -1392,39 +889,7 @@
 .sells-cowork .mod-stub-roadmap li.current .step { background: var(--accent); border-color: var(--accent); color: #fff; }
 .sells-cowork [data-theme="dark"] .mod-stub-roadmap li.done { background: oklch(0.28 0.05 145); border-color: oklch(0.45 0.10 145); }
 .sells-cowork [data-theme="dark"] .mod-stub-roadmap li.current { background: oklch(0.28 0.06 220); }
-.sells-cowork .mod-stub-foot {
-  padding: 16px 32px 28px;
-  display: flex; align-items: center; gap: 8px;
-  border-top: 1px solid var(--border);
-  background: var(--bg);
-}
-.sells-cowork .mod-stub-foot-spacer { flex: 1 1 auto; }
-.sells-cowork .mod-stub-tag {
-  display: inline-flex; align-items: center; gap: 6px;
-  font-size: 11.5px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  padding: 4px 10px;
-  border-radius: 999px;
-  color: var(--text);
-}
 .sells-cowork .mod-stub-tag .mono { font-family: var(--font-mono); }
-.sells-cowork .mod-stub-link {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  font: inherit;
-  font-size: 12px;
-  color: var(--text-dim);
-  cursor: default;
-  padding: 4px 8px;
-  border-radius: 4px;
-}
-.sells-cowork .mod-stub-link:hover { background: var(--border-2); color: var(--text); }
-@media (max-width: 1100px) {
-.sells-cowork .mod-stub-grid { grid-template-columns: 1fr; }
-.sells-cowork .mod-stub-roadmap { grid-template-columns: 1fr 1fr; }
-}
 /* ────────────────── Chat (thread) ────────────────── */
 .sells-cowork .thread {
   display: flex;
@@ -1608,20 +1073,6 @@
   background: var(--bg);
   padding: 12px 18px 14px;
 }
-.sells-cowork .composer-inner {
-  border: 1px solid var(--border);
-  background: var(--surface);
-  border-radius: var(--radius-lg);
-  padding: 8px 10px 6px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  transition: border-color .15s, box-shadow .15s;
-}
-.sells-cowork .composer-inner:focus-within {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px var(--accent-soft);
-}
 .sells-cowork .composer textarea {
   appearance: none;
   border: 0;
@@ -1708,29 +1159,11 @@
   color: var(--text-mute);
 }
 /* Avatar palette helpers */
-.sells-cowork .av-1 { background: linear-gradient(135deg, oklch(0.62 0.12 30),  oklch(0.50 0.15 10)); }
-.sells-cowork .av-2 { background: linear-gradient(135deg, oklch(0.62 0.12 220), oklch(0.50 0.15 260)); }
-.sells-cowork .av-3 { background: linear-gradient(135deg, oklch(0.62 0.12 145), oklch(0.50 0.15 175)); }
-.sells-cowork .av-4 { background: linear-gradient(135deg, oklch(0.62 0.12 80),  oklch(0.50 0.15 50)); }
-.sells-cowork .av-5 { background: linear-gradient(135deg, oklch(0.62 0.12 300), oklch(0.50 0.15 270)); }
-.sells-cowork .av-6 { background: linear-gradient(135deg, oklch(0.62 0.12 180), oklch(0.50 0.15 200)); }
 /* Mono helper */
 .sells-cowork .mono { font-family: var(--font-mono); }
 /* ────────────────── Chat page (3 colunas) ────────────────── */
-.sells-cowork .chat-page {
-  display: grid;
-  grid-template-columns: 1fr 320px;
-  flex: 1 1 auto;
-  min-height: 0;
-}
 .sells-cowork .chat-page:has(.linked.collapsed) {
   grid-template-columns: 1fr 44px;
-}
-.sells-cowork .chat-main {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  min-height: 0;
 }
 /* Tabsbar interna do chat (Todos/OS/Equipe/Clientes) */
 .sells-cowork .chat-tabsbar {
@@ -1808,21 +1241,6 @@
   overflow: hidden;
   transition: width .15s;
 }
-.sells-cowork .linked-h {
-  height: 44px;
-  border-bottom: 1px solid var(--border);
-  display: flex;
-  align-items: center;
-  padding: 0 12px;
-  background: var(--bg);
-}
-.sells-cowork .linked-h b {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .08em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-}
 .sells-cowork .linked-h .icon-btn {
   width: 26px; height: 26px;
   background: transparent;
@@ -1837,30 +1255,6 @@
   gap: 6px;
 }
 .sells-cowork .linked.collapsed .linked-h .spacer { display: none; }
-.sells-cowork .linked-body {
-  flex: 1 1 auto;
-  overflow-y: auto;
-  padding: 10px;
-  scrollbar-width: thin;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.sells-cowork .linked-body::-webkit-scrollbar { width: 8px; }
-.sells-cowork .linked-body::-webkit-scrollbar-thumb {
-  background: var(--border); border-radius: 4px;
-  border: 2px solid transparent; background-clip: content-box;
-}
-.sells-cowork .linked-empty {
-  flex: 1 1 auto;
-  display: grid;
-  place-content: center;
-  text-align: center;
-  color: var(--text-mute);
-  padding: 40px 16px;
-  gap: 8px;
-}
-.sells-cowork .linked-empty p { font-size: 12px; line-height: 1.45; margin: 0; }
 /* Bloco individual */
 .sells-cowork .lblock {
   background: var(--surface);
@@ -1975,23 +1369,6 @@
   align-self: stretch;
 }
 .sells-cowork .lblock-cta:hover { background: var(--accent); color: #fff; }
-.sells-cowork .lpunch {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 4px;
-  margin-top: 4px;
-}
-.sells-cowork .lpunch-row {
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 6px 8px;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-.sells-cowork .lpunch-row span { font-size: 9.5px; color: var(--text-mute); text-transform: uppercase; letter-spacing: .04em; }
-.sells-cowork .lpunch-row b { font-size: 12.5px; }
 .sells-cowork .lpunch-row.missing {
   background: oklch(0.97 0.04 25);
   border-color: oklch(0.85 0.08 25);
@@ -2061,35 +1438,6 @@
 }
 .sells-cowork .os-page-h-r { display: flex; gap: 8px; flex: 0 0 auto; }
 /* Stats */
-.sells-cowork .os-stats {
-  padding: 16px 32px;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-2);
-}
-.sells-cowork .os-stat {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 10px 14px;
-  display: flex; flex-direction: column; gap: 2px;
-}
-.sells-cowork .os-stat small {
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: .06em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-}
-.sells-cowork .os-stat b {
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  color: var(--text);
-  font-variant-numeric: tabular-nums;
-}
 .sells-cowork .os-stat.warn {
   background: oklch(0.97 0.04 25);
   border-color: oklch(0.85 0.08 25);
@@ -2102,13 +1450,6 @@
 .sells-cowork [data-theme="dark"] .os-stat.warn b { color: oklch(0.78 0.16 25); }
 .sells-cowork .os-stat.muted b { color: var(--text-dim); font-size: 18px; }
 /* Toolbar */
-.sells-cowork .os-toolbar {
-  padding: 10px 24px 8px 24px;
-  display: flex; align-items: center; gap: 12px;
-  border-bottom: 1px solid var(--border);
-  background: var(--bg);
-  flex-wrap: wrap;
-}
 .sells-cowork .os-tabs {
   display: flex; gap: 2px;
   flex-wrap: wrap;
@@ -2146,52 +1487,7 @@
 }
 .sells-cowork .os-tab.active .os-tab-n { background: var(--accent-soft); color: var(--accent); }
 .sells-cowork .os-tab.warn .os-tab-n { background: oklch(0.93 0.07 25); color: oklch(0.50 0.18 25); }
-.sells-cowork .os-toolbar-r {
-  margin-left: auto;
-  display: flex; align-items: center; gap: 8px;
-}
-.sells-cowork .os-select {
-  appearance: none;
-  font: inherit;
-  font-size: 12px;
-  height: 30px;
-  padding: 0 26px 0 10px;
-  border: 1px solid var(--border);
-  background: var(--surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2'><path d='m6 9 6 6 6-6'/></svg>") right 8px center/12px no-repeat;
-  border-radius: var(--radius-sm);
-  color: var(--text);
-  outline: none;
-  cursor: default;
-}
-.sells-cowork .os-select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
-.sells-cowork .os-search {
-  display: flex; align-items: center; gap: 6px;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 5px 10px;
-  color: var(--text-mute);
-  width: 280px;
-}
-.sells-cowork .os-search input {
-  appearance: none; border: 0; background: transparent;
-  font: inherit; font-size: 12px;
-  color: var(--text);
-  flex: 1 1 auto; min-width: 0;
-  outline: none;
-}
-.sells-cowork .os-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
 /* Bulk bar */
-.sells-cowork .os-bulk {
-  padding: 8px 24px;
-  display: flex; align-items: center; gap: 8px;
-  background: var(--accent-soft);
-  border-bottom: 1px solid var(--accent-soft);
-  font-size: 12.5px;
-  color: var(--accent);
-}
-.sells-cowork .os-bulk b { color: var(--accent); }
-.sells-cowork .os-bulk-spacer { flex: 1 1 auto; }
 /* Buttons */
 .sells-cowork .os-btn {
   appearance: none;
@@ -2257,69 +1553,13 @@
 .sells-cowork .os-row.selected { background: var(--accent-soft); }
 .sells-cowork .os-row.selected td { background: var(--accent-soft); }
 .sells-cowork .os-row.urgent { box-shadow: inset 3px 0 0 oklch(0.62 0.18 25); }
-.sells-cowork .os-cell-check { width: 32px; }
-.sells-cowork .os-cell-check input { accent-color: var(--accent); cursor: default; }
-.sells-cowork .os-cell-num {
-  white-space: nowrap;
-  display: flex; align-items: center; gap: 6px;
-}
 .sells-cowork .os-cell-num .mono {
   font-family: var(--font-mono);
   font-size: 12px;
   color: var(--text-dim);
 }
-.sells-cowork .os-urgent-dot {
-  display: inline-block;
-  width: 7px; height: 7px;
-  border-radius: 50%;
-  background: oklch(0.62 0.18 25);
-}
-.sells-cowork .os-cell-client b {
-  display: block;
-  font-size: 13px;
-  font-weight: 500;
-  color: var(--text);
-  letter-spacing: -0.005em;
-}
-.sells-cowork .os-cell-client small {
-  display: block;
-  font-size: 11.5px;
-  color: var(--text-dim);
-}
-.sells-cowork .os-cell-product {
-  color: var(--text-dim);
-  font-size: 12.5px;
-  max-width: 320px;
-}
-.sells-cowork .os-cell-resp {
-  display: flex; align-items: center; gap: 6px;
-  white-space: nowrap;
-}
-.sells-cowork .os-resp-av {
-  width: 22px; height: 22px;
-  border-radius: 50%;
-  display: grid; place-items: center;
-  color: #fff;
-  font-size: 9.5px;
-  font-weight: 600;
-  flex: 0 0 auto;
-}
 .sells-cowork .os-resp-av.lg { width: 36px; height: 36px; font-size: 12px; }
-.sells-cowork .os-resp-name { font-size: 12.5px; color: var(--text-dim); }
-.sells-cowork .os-cell-deadline {
-  font-size: 12.5px;
-  color: var(--text-dim);
-  white-space: nowrap;
-  font-variant-numeric: tabular-nums;
-}
 .sells-cowork .os-cell-deadline.urgent { color: var(--neg); font-weight: 600; }
-.sells-cowork .os-cell-value {
-  text-align: right;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-  color: var(--text);
-}
 .sells-cowork .os-table tfoot td {
   border-top: 2px solid var(--border);
   background: var(--bg-2);
@@ -2327,16 +1567,7 @@
   font-size: 12px;
   font-weight: 600;
 }
-.sells-cowork .os-foot-l { text-align: right; color: var(--text-dim); }
-.sells-cowork .os-foot-v { text-align: right; color: var(--text); font-size: 14px; }
 /* Empty in table */
-.sells-cowork .os-empty-row { padding: 50px 20px !important; text-align: center; }
-.sells-cowork .os-empty-state {
-  display: flex; flex-direction: column; align-items: center; gap: 4px;
-  color: var(--text-mute);
-}
-.sells-cowork .os-empty-state b { color: var(--text); font-size: 13px; margin-top: 8px; }
-.sells-cowork .os-empty-state small { font-size: 11.5px; color: var(--text-dim); }
 /* Stage badge */
 .sells-cowork .os-stage {
   display: inline-flex; align-items: center;
@@ -2361,131 +1592,11 @@
 .sells-cowork [data-theme="dark"] .os-stage.green {   background: oklch(0.30 0.07 145); color: oklch(0.85 0.10 145); }
 .sells-cowork [data-theme="dark"] .os-stage.red {     background: oklch(0.30 0.07 25);  color: oklch(0.85 0.16 25);  }
 /* ════════════════════════ OS DETAIL DRAWER ════════════════════════ */
-.sells-cowork .os-drawer-back {
-  position: absolute;
-  inset: 0;
-  background: rgba(0,0,0,.18);
-  z-index: 8;
-  animation: fadein .15s ease-out;
-}
-.sells-cowork [data-theme="dark"] .os-drawer-back { background: rgba(0,0,0,.45); }
 @keyframes fadein { from { opacity: 0; } to { opacity: 1; } }
-.sells-cowork .os-drawer {
-  position: absolute;
-  top: 0; right: 0; bottom: 0;
-  width: min(540px, 100%);
-  background: var(--bg);
-  border-left: 1px solid var(--border);
-  z-index: 9;
-  display: flex; flex-direction: column;
-  overflow-y: auto;
-  box-shadow: -8px 0 32px rgba(0,0,0,.08);
-  animation: slidein .2s cubic-bezier(.2,.8,.2,1);
-}
-.sells-cowork [data-theme="dark"] .os-drawer { box-shadow: -8px 0 32px rgba(0,0,0,.4); }
 @keyframes slidein { from { transform: translateX(20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
-.sells-cowork .os-drawer-h {
-  padding: 16px 20px;
-  display: flex; align-items: center; gap: 10px;
-  border-bottom: 1px solid var(--border);
-  background: var(--surface);
-}
-.sells-cowork .os-drawer-h-l { display: flex; align-items: center; gap: 8px; flex: 1 1 auto; }
-.sells-cowork .os-drawer-num {
-  font-family: var(--font-mono);
-  font-size: 13px;
-  color: var(--text-dim);
-}
-.sells-cowork .os-urgent-tag {
-  font-size: 10.5px;
-  font-weight: 600;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-  background: oklch(0.95 0.06 25);
-  color: oklch(0.50 0.18 25);
-  padding: 2px 7px;
-  border-radius: 4px;
-}
-.sells-cowork .os-drawer-title {
-  padding: 18px 20px 8px;
-}
-.sells-cowork .os-drawer-title h2 {
-  margin: 0 0 4px;
-  font-size: 19px;
-  font-weight: 600;
-  letter-spacing: -0.015em;
-  line-height: 1.3;
-}
-.sells-cowork .os-drawer-title p {
-  margin: 0;
-  font-size: 13px;
-  color: var(--text-dim);
-}
-.sells-cowork .os-drawer-title b { color: var(--text); font-weight: 500; }
-.sells-cowork .os-drawer-meta {
-  padding: 8px 20px 16px;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 10px;
-}
-.sells-cowork .os-drawer-meta > div {
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-sm);
-  padding: 8px 10px;
-}
-.sells-cowork .os-drawer-meta small {
-  display: block;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: .06em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-  margin-bottom: 2px;
-}
-.sells-cowork .os-drawer-meta b {
-  display: block;
-  font-size: 13px;
-  font-weight: 600;
-  color: var(--text);
-}
 .sells-cowork .os-drawer-meta .urgent { color: var(--neg); }
 .sells-cowork .os-drawer-meta .mono { font-family: var(--font-mono); }
-.sells-cowork .os-drawer-section {
-  padding: 16px 20px;
-  border-top: 1px solid var(--border-2);
-}
-.sells-cowork .os-drawer-section h3 {
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: .06em;
-  text-transform: uppercase;
-  color: var(--text-mute);
-  margin: 0 0 12px;
-}
-.sells-cowork .os-drawer-resp {
-  display: flex; align-items: center; gap: 12px;
-}
-.sells-cowork .os-drawer-resp b { display: block; font-size: 13px; font-weight: 500; }
-.sells-cowork .os-drawer-resp small { display: block; font-size: 11.5px; color: var(--text-dim); }
-.sells-cowork .os-drawer-resp button { margin-left: auto; }
 /* Stages flow */
-.sells-cowork .os-stages-flow {
-  display: flex; flex-wrap: wrap; gap: 8px 14px;
-  padding: 4px 0;
-}
-.sells-cowork .os-stage-step {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 11.5px;
-  color: var(--text-mute);
-  position: relative;
-}
-.sells-cowork .os-stage-step .step-dot {
-  width: 8px; height: 8px;
-  border-radius: 50%;
-  background: var(--border);
-  border: 1px solid var(--border);
-}
 .sells-cowork .os-stage-step.done .step-dot { background: oklch(0.62 0.16 145); border-color: oklch(0.62 0.16 145); }
 .sells-cowork .os-stage-step.done { color: var(--text-dim); }
 .sells-cowork .os-stage-step.current .step-dot {
@@ -2495,605 +1606,54 @@
 }
 .sells-cowork .os-stage-step.current { color: var(--accent); font-weight: 600; }
 /* Timeline */
-.sells-cowork .os-timeline {
-  list-style: none;
-  margin: 0; padding: 0;
-  position: relative;
-}
-.sells-cowork .os-timeline::before {
-  content: "";
-  position: absolute;
-  left: 6px; top: 6px; bottom: 6px;
-  width: 1px;
-  background: var(--border);
-}
-.sells-cowork .os-tl-item {
-  position: relative;
-  padding: 6px 0 12px 22px;
-}
-.sells-cowork .os-tl-dot {
-  position: absolute;
-  left: 2px; top: 12px;
-  width: 9px; height: 9px;
-  border-radius: 50%;
-  background: var(--surface);
-  border: 2px solid var(--text-mute);
-}
 .sells-cowork .os-tl-item.create .os-tl-dot { border-color: var(--text-dim); }
 .sells-cowork .os-tl-item.client .os-tl-dot { border-color: oklch(0.62 0.14 220); }
 .sells-cowork .os-tl-item.art    .os-tl-dot { border-color: oklch(0.65 0.16 75);  }
 .sells-cowork .os-tl-item.prod   .os-tl-dot { border-color: oklch(0.62 0.14 295); }
 .sells-cowork .os-tl-item.pending .os-tl-dot { border-color: var(--accent); background: var(--accent); }
-.sells-cowork .os-tl-h {
-  display: flex; align-items: baseline; gap: 6px;
-  font-size: 12px;
-}
-.sells-cowork .os-tl-h b { font-weight: 600; color: var(--text); }
-.sells-cowork .os-tl-h small { color: var(--text-mute); }
-.sells-cowork .os-tl-when {
-  margin-left: auto;
-  font-size: 11px;
-  color: var(--text-mute);
-  font-variant-numeric: tabular-nums;
-}
-.sells-cowork .os-tl-content p {
-  margin: 3px 0 0;
-  font-size: 12.5px;
-  color: var(--text-dim);
-  line-height: 1.5;
-}
-.sells-cowork .os-tl-file {
-  display: inline-flex; align-items: center; gap: 5px;
-  margin-top: 5px;
-  font-size: 11.5px;
-  font-family: var(--font-mono);
-  color: var(--accent);
-  background: var(--accent-soft);
-  padding: 3px 8px;
-  border-radius: 4px;
-}
-.sells-cowork .os-drawer-actions {
-  margin-top: auto;
-  padding: 14px 20px;
-  display: flex; gap: 8px; align-items: center;
-  border-top: 1px solid var(--border);
-  background: var(--surface);
-  position: sticky; bottom: 0;
-}
 /* ════════════════════════ NOVA OS DRAWER ════════════════════════ */
 .sells-cowork .os-drawer.wide { width: min(820px, 100%); }
-.sells-cowork .os-new-num {
-  background: oklch(from var(--accent) l c h / 0.12);
-  color: var(--accent);
-  border-radius: 4px;
-  padding: 3px 8px;
-  font-weight: 700;
-  letter-spacing: .02em;
-}
-.sells-cowork .os-new-stepper {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 0;
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-  background: var(--bg-2);
-}
-.sells-cowork .os-step {
-  all: unset;
-  display: flex; align-items: center; gap: 10px;
-  padding: 12px 14px;
-  cursor: pointer;
-  border-right: 1px solid var(--border);
-  transition: background .12s;
-  position: relative;
-}
-.sells-cowork .os-step:last-child { border-right: 0; }
-.sells-cowork .os-step:hover { background: var(--bg-1); }
 .sells-cowork .os-step.active {
   background: var(--surface);
   box-shadow: inset 0 -2px 0 var(--accent);
-}
-.sells-cowork .os-step-bullet {
-  display: inline-flex; align-items: center; justify-content: center;
-  width: 22px; height: 22px;
-  border-radius: 50%;
-  background: var(--bg-1);
-  border: 1.5px solid var(--border);
-  color: var(--text-dim);
-  flex-shrink: 0;
 }
 .sells-cowork .os-step.done .os-step-bullet {
   background: var(--accent);
   border-color: var(--accent);
   color: white;
 }
-.sells-cowork .os-step-text { display: flex; flex-direction: column; min-width: 0; }
-.sells-cowork .os-step-text b { font-size: 12px; font-weight: 600; color: var(--text); }
-.sells-cowork .os-step-text small {
-  font-size: 11px; color: var(--text-dim);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  max-width: 160px;
-}
-.sells-cowork .os-new-body {
-  padding: 22px 24px 90px;
-  flex: 1 1 auto;
-  overflow-y: auto;
-}
-.sells-cowork .os-new-sec { animation: fadein .15s ease-out; }
-.sells-cowork .os-new-sec h3 {
-  margin: 0 0 4px;
-  font-size: 16px;
-  font-weight: 600;
-  color: var(--text);
-}
-.sells-cowork .os-new-help {
-  margin: 0 0 16px;
-  font-size: 12.5px;
-  color: var(--text-dim);
-}
-.sells-cowork .os-new-search {
-  display: flex; align-items: center; gap: 8px;
-  background: var(--bg-1);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 9px 12px;
-  margin-bottom: 10px;
-}
-.sells-cowork .os-new-search input {
-  all: unset;
-  flex: 1; font-size: 13px; color: var(--text);
-}
-.sells-cowork .os-new-search input::placeholder { color: var(--text-dim); }
-.sells-cowork .os-new-results {
-  list-style: none; margin: 0; padding: 0;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
-  background: var(--surface);
-}
-.sells-cowork .os-new-results li {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 14px;
-  cursor: pointer;
-  border-bottom: 1px solid var(--border-2);
-  transition: background .12s;
-}
-.sells-cowork .os-new-results li:last-child { border-bottom: 0; }
-.sells-cowork .os-new-results li:hover { background: var(--bg-2); }
-.sells-cowork .os-new-results li b { display: block; font-size: 13px; font-weight: 500; }
-.sells-cowork .os-new-results li small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
 .sells-cowork .os-new-results li.empty { cursor: default; color: var(--text-dim); justify-content: flex-start; }
 .sells-cowork .os-new-results li.empty a { color: var(--accent); cursor: pointer; margin-left: 6px; }
-.sells-cowork .os-new-last {
-  font-size: 11px; color: var(--text-dim);
-  font-family: var(--font-mono);
-}
-.sells-cowork .os-new-price { font-size: 12px; color: var(--text); font-weight: 500; }
-.sells-cowork .os-new-client-card {
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  background: var(--bg-2);
-  padding: 14px 16px;
-}
-.sells-cowork .os-new-client-h {
-  display: flex; justify-content: space-between; align-items: center;
-  margin-bottom: 14px;
-}
-.sells-cowork .os-new-client-h b { display: block; font-size: 14px; }
-.sells-cowork .os-new-client-h small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; font-family: var(--font-mono); }
-.sells-cowork .os-new-row2 {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
-}
-.sells-cowork .os-new-row2 label { display: flex; flex-direction: column; gap: 5px; }
-.sells-cowork .os-new-row2 small { font-size: 11px; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
-.sells-cowork .os-new-row2 input {
-  all: unset;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px 11px;
-  font-size: 13px; color: var(--text);
-  font-family: inherit;
-}
 .sells-cowork .os-new-row2 input.mono { font-family: var(--font-mono); }
-.sells-cowork .os-new-row2 input:focus { border-color: var(--accent); }
-.sells-cowork .os-new-prod-pickers {
-  display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px;
-}
-.sells-cowork .os-new-cats {
-  display: flex; gap: 6px; flex-wrap: wrap;
-}
-.sells-cowork .os-cat {
-  all: unset;
-  font-size: 11.5px;
-  padding: 5px 11px;
-  border-radius: 999px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  color: var(--text-dim);
-  cursor: pointer;
-  transition: all .12s;
-}
-.sells-cowork .os-cat:hover { background: var(--bg-1); color: var(--text); }
 .sells-cowork .os-cat.active {
   background: var(--accent);
   color: white;
   border-color: var(--accent);
 }
-.sells-cowork .os-new-items {
-  margin-top: 16px;
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  overflow: hidden;
-  background: var(--surface);
-}
-.sells-cowork .os-new-itable {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 13px;
-}
-.sells-cowork .os-new-itable th {
-  font-size: 10.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: .05em;
-  color: var(--text-dim);
-  text-align: left;
-  padding: 10px 12px;
-  background: var(--bg-2);
-  border-bottom: 1px solid var(--border);
-}
 .sells-cowork .os-new-itable th.r, .sells-cowork .os-new-itable td.r { text-align: right; }
-.sells-cowork .os-new-itable td {
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--border-2);
-  vertical-align: top;
-}
-.sells-cowork .os-new-itable tbody tr:last-child td { border-bottom: 0; }
-.sells-cowork .os-new-itable td b { display: block; font-weight: 500; font-size: 13px; }
-.sells-cowork .os-new-itable tfoot td {
-  background: var(--bg-2);
-  border-top: 1px solid var(--border);
-  font-size: 13px;
-  padding: 10px 12px;
-}
-.sells-cowork .os-new-itable tfoot b { font-size: 14px; }
-.sells-cowork .os-new-itemnote {
-  all: unset;
-  display: block;
-  margin-top: 4px;
-  width: 100%;
-  font-size: 11.5px;
-  color: var(--text-dim);
-  border-bottom: 1px dashed transparent;
-}
-.sells-cowork .os-new-itemnote:focus { border-bottom-color: var(--border); color: var(--text); }
-.sells-cowork .os-new-itemnote::placeholder { color: var(--text-dim); opacity: .6; }
-.sells-cowork .os-new-qty, .sells-cowork .os-new-price-i {
-  all: unset;
-  width: 60px;
-  text-align: right;
-  background: var(--bg-1);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 4px 6px;
-  font-family: var(--font-mono);
-  font-size: 12.5px;
-}
-.sells-cowork .os-new-price-i { width: 80px; }
-.sells-cowork .os-new-qty:focus, .sells-cowork .os-new-price-i:focus { border-color: var(--accent); }
-.sells-cowork .os-new-unit {
-  display: block;
-  font-size: 10px; color: var(--text-dim);
-  margin-top: 2px;
-  text-transform: lowercase;
-}
-.sells-cowork .os-new-empty {
-  text-align: center;
-  padding: 40px 20px;
-  color: var(--text-dim);
-  border: 1.5px dashed var(--border);
-  border-radius: 10px;
-}
-.sells-cowork .os-new-empty b { display: block; margin: 8px 0 2px; font-size: 13px; color: var(--text); }
-.sells-cowork .os-new-empty small { font-size: 12px; }
-.sells-cowork .os-new-toggle {
-  display: flex !important; align-items: center; gap: 8px;
-  flex-direction: row !important;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 12px;
-  cursor: pointer;
-  align-self: end;
-}
-.sells-cowork .os-new-toggle input { width: auto !important; padding: 0 !important; }
-.sells-cowork .os-new-toggle span { font-size: 13px; color: var(--text); }
-.sells-cowork .os-new-textarea {
-  display: flex; flex-direction: column; gap: 5px;
-  margin-top: 14px;
-}
-.sells-cowork .os-new-textarea small { font-size: 11px; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
-.sells-cowork .os-new-textarea textarea {
-  all: unset;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px 12px;
-  font-size: 13px; color: var(--text);
-  font-family: inherit;
-  line-height: 1.5;
-  resize: vertical;
-  min-height: 80px;
-}
-.sells-cowork .os-new-textarea textarea:focus { border-color: var(--accent); }
-.sells-cowork .os-new-shortcuts {
-  display: flex; align-items: center; gap: 8px;
-  margin-top: 12px;
-}
-.sells-cowork .os-new-shortcuts small { font-size: 11px; color: var(--text-dim); }
-.sells-cowork .os-chip {
-  all: unset;
-  font-size: 11.5px;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  color: var(--text);
-  cursor: pointer;
-}
-.sells-cowork .os-chip:hover { background: var(--bg-1); border-color: var(--accent); }
-.sells-cowork .os-new-resps {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 8px;
-}
-.sells-cowork .os-new-resp {
-  all: unset;
-  display: flex; align-items: center; gap: 10px;
-  padding: 10px 12px;
-  border: 1.5px solid var(--border);
-  border-radius: 8px;
-  cursor: pointer;
-  background: var(--surface);
-  transition: all .12s;
-}
-.sells-cowork .os-new-resp:hover { border-color: var(--text-dim); }
 .sells-cowork .os-new-resp.active {
   border-color: var(--accent);
   background: oklch(from var(--accent) l c h / 0.08);
-}
-.sells-cowork .os-new-resp b { display: block; font-size: 13px; font-weight: 500; }
-.sells-cowork .os-new-resp small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
-.sells-cowork .os-new-attach {
-  display: flex; gap: 8px; flex-wrap: wrap;
-  padding: 14px;
-  border: 1.5px dashed var(--border);
-  border-radius: 8px;
-  background: var(--bg-2);
-}
-.sells-cowork .os-new-files {
-  list-style: none; margin: 12px 0 0; padding: 0;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
-}
-.sells-cowork .os-new-files li {
-  display: flex; align-items: center; gap: 10px;
-  padding: 8px 12px;
-  border-bottom: 1px solid var(--border-2);
-  font-size: 12.5px;
-  background: var(--surface);
-}
-.sells-cowork .os-new-files li:last-child { border-bottom: 0; }
-.sells-cowork .os-new-files li span { flex: 1; }
-.sells-cowork .os-new-fkind {
-  font-size: 10px; color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: .04em;
-  background: var(--bg-2);
-  padding: 2px 6px;
-  border-radius: 3px;
-}
-.sells-cowork .os-new-foot {
-  flex-wrap: wrap;
-  gap: 12px !important;
-}
-.sells-cowork .os-new-summary {
-  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
-  font-size: 12px; color: var(--text-dim);
-}
-.sells-cowork .os-new-total {
-  font-size: 14px; color: var(--text); font-weight: 600;
-  margin-left: 6px;
 }
 .sells-cowork .os-btn.disabled, .sells-cowork .os-btn:disabled {
   opacity: .45; cursor: not-allowed;
 }
 /* ════════════════════════ APROVAR ARTE — MODAL ════════════════════════ */
-.sells-cowork .os-modal-back {
-  position: absolute;
-  inset: 0;
-  background: rgba(0,0,0,.45);
-  z-index: 90;
-  animation: fadein .15s ease-out;
-}
-.sells-cowork [data-theme="dark"] .os-modal-back { background: rgba(0,0,0,.6); }
-.sells-cowork .os-modal {
-  position: absolute;
-  top: 50%; left: 50%;
-  transform: translate(-50%, -50%);
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 14px;
-  z-index: 91;
-  display: flex; flex-direction: column;
-  max-height: 92%;
-  width: min(1080px, 96%);
-  box-shadow: 0 24px 80px rgba(0,0,0,.18);
-  animation: modalin .2s cubic-bezier(.2,.8,.2,1);
-  overflow: hidden;
-}
-.sells-cowork [data-theme="dark"] .os-modal { box-shadow: 0 24px 80px rgba(0,0,0,.6); }
 @keyframes modalin {
   from { transform: translate(-50%, -48%); opacity: 0; }
   to   { transform: translate(-50%, -50%); opacity: 1; }
 }
-.sells-cowork .os-modal-h {
-  display: flex; align-items: flex-start; gap: 12px;
-  padding: 18px 22px 14px;
-  border-bottom: 1px solid var(--border);
-}
-.sells-cowork .os-modal-h h2 {
-  margin: 0 0 3px;
-  font-size: 17px; font-weight: 600; color: var(--text);
-}
-.sells-cowork .os-modal-h p {
-  margin: 0;
-  font-size: 12.5px; color: var(--text-dim);
-}
-.sells-cowork .os-modal-h > div { flex: 1; }
 .sells-cowork .os-modal-h .icon-btn { flex-shrink: 0; }
-.sells-cowork .os-modal-foot {
-  padding: 14px 22px;
-  display: flex; align-items: center; gap: 8px;
-  border-top: 1px solid var(--border);
-  background: var(--bg-2);
-}
 /* Body do modal de aprovação: 240px coluna versões + canvas */
-.sells-cowork .os-approve-body {
-  display: grid;
-  grid-template-columns: 260px 1fr;
-  gap: 0;
-  flex: 1 1 auto;
-  min-height: 0;
-}
-.sells-cowork .os-approve-versions {
-  border-right: 1px solid var(--border);
-  display: flex; flex-direction: column;
-  min-height: 0;
-  background: var(--bg-2);
-}
-.sells-cowork .os-approve-modes {
-  display: flex; gap: 4px;
-  padding: 12px 14px;
-  border-bottom: 1px solid var(--border-2);
-}
-.sells-cowork .os-version-list {
-  list-style: none; margin: 0; padding: 8px;
-  flex: 1 1 auto;
-  overflow-y: auto;
-}
-.sells-cowork .os-version-list li {
-  padding: 11px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  border: 1.5px solid transparent;
-  transition: background .12s, border-color .12s;
-  margin-bottom: 4px;
-}
-.sells-cowork .os-version-list li:hover { background: var(--bg-1); }
 .sells-cowork .os-version-list li.selected {
   background: var(--surface);
   border-color: var(--accent);
 }
-.sells-cowork .os-version-list li.compare {
-  border-color: oklch(from var(--accent) l c h / .5);
-  border-style: dashed;
-}
-.sells-cowork .os-version-h {
-  display: flex; align-items: center; gap: 8px;
-  margin-bottom: 2px;
-}
-.sells-cowork .os-version-h b { font-size: 13px; font-weight: 600; }
-.sells-cowork .os-version-tag {
-  font-size: 9.5px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: .05em;
-  color: oklch(0.40 0.16 145);
-  background: oklch(0.92 0.06 145);
-  padding: 2px 6px;
-  border-radius: 3px;
-}
-.sells-cowork [data-theme="dark"] .os-version-tag {
-  color: oklch(0.85 0.18 145);
-  background: oklch(0.30 0.08 145);
-}
-.sells-cowork .os-version-list small {
-  display: block;
-  font-size: 11px; color: var(--text-dim);
-  margin-bottom: 4px;
-}
-.sells-cowork .os-version-list p {
-  margin: 0;
-  font-size: 11.5px; color: var(--text);
-  line-height: 1.45;
-}
-.sells-cowork .os-approve-canvas {
-  display: flex; align-items: center; justify-content: center;
-  gap: 24px;
-  padding: 28px;
-  background: var(--bg-1);
-  min-height: 0;
-  overflow: auto;
-}
-.sells-cowork .os-approve-canvas.compare { gap: 18px; }
-.sells-cowork .os-approve-vs {
-  display: flex; align-items: center; justify-content: center;
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: .12em;
-  color: var(--text-dim);
-  font-weight: 600;
-  flex-shrink: 0;
-}
-.sells-cowork .os-approve-vs span {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 6px 14px;
-}
 /* Thumbs (placeholder gráfico colorido por versão) */
-.sells-cowork .os-art-thumb {
-  display: flex; flex-direction: column; align-items: center; gap: 10px;
-}
-.sells-cowork .os-art-thumb small {
-  font-size: 11.5px; color: var(--text-dim);
-  font-family: var(--font-mono);
-}
-.sells-cowork .os-art-frame {
-  width: 320px; height: 220px;
-  background: white;
-  border: 1px solid var(--border);
-  box-shadow: 0 6px 24px rgba(0,0,0,.08);
-  position: relative;
-  overflow: hidden;
-}
-.sells-cowork [data-theme="dark"] .os-art-frame {
-  background: oklch(0.96 0.01 240);
-  box-shadow: 0 6px 24px rgba(0,0,0,.4);
-}
-.sells-cowork .os-art-corner {
-  position: absolute;
-  width: 12px; height: 12px;
-  border: 1.5px solid oklch(0.45 0.04 240);
-  opacity: .35;
-}
 .sells-cowork .os-art-corner.tl { top: 6px; left: 6px; border-right: 0; border-bottom: 0; }
 .sells-cowork .os-art-corner.tr { top: 6px; right: 6px; border-left: 0; border-bottom: 0; }
 .sells-cowork .os-art-corner.bl { bottom: 6px; left: 6px; border-right: 0; border-top: 0; }
 .sells-cowork .os-art-corner.br { bottom: 6px; right: 6px; border-left: 0; border-top: 0; }
-.sells-cowork .os-art-content {
-  position: absolute; inset: 18px;
-  display: flex; flex-direction: column; justify-content: flex-end;
-}
-.sells-cowork .os-art-blob {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(2px);
-  opacity: .85;
-}
 .sells-cowork .os-art-thumb.art-v1 .os-art-blob.a { background: #e8c468; top: -10px; right: 30px; width: 110px; height: 110px; }
 .sells-cowork .os-art-thumb.art-v1 .os-art-blob.b { background: #d97757; top: 50px; right: -20px; width: 90px; height: 90px; }
 .sells-cowork .os-art-thumb.art-v1 .os-art-blob.c { background: #a8a29e; bottom: 60px; right: 50px; width: 60px; height: 60px; opacity: .4; }
@@ -3103,48 +1663,7 @@
 .sells-cowork .os-art-thumb.art-v3 .os-art-blob.a { background: #e8c468; top: -14px; right: 24px; width: 130px; height: 130px; }
 .sells-cowork .os-art-thumb.art-v3 .os-art-blob.b { background: #d97757; top: 46px; right: -18px; width: 100px; height: 100px; }
 .sells-cowork .os-art-thumb.art-v3 .os-art-blob.c { background: #4a6b85; bottom: 56px; right: 44px; width: 70px; height: 70px; }
-.sells-cowork .os-art-text {
-  position: relative;
-  z-index: 2;
-}
-.sells-cowork .os-art-text b {
-  display: block;
-  font-size: 16px; font-weight: 700;
-  color: oklch(0.20 0.04 240);
-  font-family: var(--font-display, var(--font-sans));
-  letter-spacing: -.01em;
-}
-.sells-cowork .os-art-text span {
-  font-size: 11px;
-  color: oklch(0.45 0.04 240);
-  letter-spacing: .04em;
-  text-transform: uppercase;
-}
 /* Decisão (aprovar/ajustar/rejeitar) */
-.sells-cowork .os-approve-decision {
-  padding: 16px 22px;
-  border-top: 1px solid var(--border);
-  background: var(--surface);
-}
-.sells-cowork .os-decision-options {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 8px;
-}
-.sells-cowork .os-decision {
-  all: unset;
-  display: flex; align-items: flex-start; gap: 10px;
-  padding: 12px 14px;
-  border: 1.5px solid var(--border);
-  border-radius: 10px;
-  cursor: pointer;
-  background: var(--surface);
-  transition: all .12s;
-}
-.sells-cowork .os-decision:hover { border-color: var(--text-dim); background: var(--bg-2); }
-.sells-cowork .os-decision b { display: block; font-size: 13px; font-weight: 600; color: var(--text); }
-.sells-cowork .os-decision small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; line-height: 1.4; }
-.sells-cowork .os-decision svg { margin-top: 2px; flex-shrink: 0; opacity: .65; }
 .sells-cowork .os-decision.approve.active {
   border-color: oklch(0.55 0.16 145);
   background: oklch(0.96 0.04 145);
@@ -3169,450 +1688,32 @@
   background: oklch(0.30 0.06 25);
 }
 .sells-cowork .os-decision.reject.active svg { color: var(--neg); opacity: 1; }
-.sells-cowork .os-decision-comment {
-  display: block;
-  width: 100%;
-  margin-top: 10px;
-  padding: 10px 12px;
-  background: var(--bg-1);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  font-size: 13px; color: var(--text);
-  font-family: inherit;
-  line-height: 1.5;
-  resize: vertical;
-  min-height: 70px;
-  box-sizing: border-box;
-}
-.sells-cowork .os-decision-comment:focus { outline: none; border-color: var(--accent); }
-.sells-cowork .os-decision-confirm {
-  display: flex; align-items: center; gap: 8px;
-  margin-top: 10px;
-  padding: 10px 12px;
-  background: oklch(0.96 0.04 145);
-  border: 1px solid oklch(0.55 0.10 145 / 0.3);
-  border-radius: 6px;
-  font-size: 12.5px;
-  color: oklch(0.30 0.10 145);
-}
-.sells-cowork [data-theme="dark"] .os-decision-confirm {
-  background: oklch(0.26 0.05 145);
-  color: oklch(0.85 0.10 145);
-  border-color: oklch(0.55 0.10 145 / 0.5);
-}
-.sells-cowork .os-decision-confirm svg { flex-shrink: 0; }
-.sells-cowork .os-decision-confirm b { font-weight: 600; }
-.sells-cowork .os-kbd {
-  display: inline-block;
-  padding: 1px 5px;
-  font: 600 10px/1 "IBM Plex Mono", monospace;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-bottom-width: 2px;
-  border-radius: 3px;
-  color: var(--text-dim);
-  margin-left: 4px;
-  vertical-align: middle;
-}
 .sells-cowork .os-decision.active .os-kbd { border-color: currentColor; color: currentColor; opacity: .8; }
 /* ════════════════════════ PRINT (OS Detail) ════════════════════════ */
 @media print {
 .sells-cowork { background: white !important; }
 .sells-cowork .app-shell, .sells-cowork .sidebar, .sells-cowork .chat-panel, .sells-cowork .os-page-h-r, .sells-cowork .os-toolbar, .sells-cowork .os-bulk, .sells-cowork .os-table-wrap, .sells-cowork .os-stats, .sells-cowork .os-drawer-actions, .sells-cowork .os-drawer-back, .sells-cowork .tweaks-panel, .sells-cowork .os-modal-back, .sells-cowork .os-modal { display: none !important; }
-.sells-cowork .os-drawer {
-    position: static !important;
-    width: 100% !important;
-    box-shadow: none !important;
-    border: none !important;
-    transform: none !important;
-  }
 .sells-cowork .os-drawer-h, .sells-cowork .os-drawer-body { padding: 0 !important; }
 @page { margin: 18mm 14mm; }
 }
 /* ════════════════════════ BULK MODAL ════════════════════════ */
-.sells-cowork .os-bulk-modal { width: min(560px, 96%); }
-.sells-cowork .os-bulk-ids {
-  font-size: 11.5px;
-  color: var(--text-dim);
-}
-.sells-cowork .os-bulk-body {
-  padding: 18px 22px;
-  flex: 1 1 auto;
-  overflow-y: auto;
-  max-height: 60vh;
-}
-.sells-cowork .os-bulk-stages {
-  display: flex; flex-direction: column; gap: 6px;
-  margin-bottom: 16px;
-}
-.sells-cowork .os-bulk-stage {
-  all: unset;
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 14px;
-  border: 1.5px solid var(--border);
-  border-radius: 8px;
-  cursor: pointer;
-  background: var(--surface);
-  transition: all .12s;
-}
-.sells-cowork .os-bulk-stage:hover { border-color: var(--text-dim); background: var(--bg-2); }
 .sells-cowork .os-bulk-stage.active {
   border-color: var(--accent);
   background: oklch(from var(--accent) l c h / 0.08);
 }
-.sells-cowork .os-bulk-stage svg { color: var(--accent); }
-.sells-cowork .os-bulk-toggle {
-  display: flex; align-items: center; gap: 8px;
-  padding: 10px 12px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  cursor: pointer;
-  margin-top: 14px;
-  font-size: 13px;
-  color: var(--text);
-}
-.sells-cowork .os-bulk-toggle input { margin: 0; }
 /* ════════════════════════ CLIENTES (Fase 3) ════════════════════════ */
-.sells-cowork .cli-name { font-weight: 600; color: var(--text); }
-.sells-cowork .cli-sub { font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
-.sells-cowork .cli-seg {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 10px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  font-size: 11px;
-  color: var(--text-dim);
-}
-.sells-cowork .cli-city { font-size: 12px; color: var(--text-dim); }
-.sells-cowork .cli-num { font-variant-numeric: tabular-nums; font-weight: 500; }
-.sells-cowork .cli-last { font-size: 11.5px; color: var(--text-dim); }
-.sells-cowork .cli-status {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 10px;
-  font-size: 11px;
-  font-weight: 600;
-  text-transform: capitalize;
-}
 .sells-cowork .cli-status.ativo { background: oklch(0.93 0.07 145); color: oklch(0.36 0.10 145); }
 .sells-cowork .cli-status.inativo { background: var(--bg-2); color: var(--text-dim); }
-.sells-cowork .cli-kpis {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-  margin-bottom: 16px;
-}
-.sells-cowork .cli-kpi {
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 10px 12px;
-  display: flex; flex-direction: column;
-}
-.sells-cowork .cli-kpi b { font-size: 16px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
 .sells-cowork .cli-kpi b.ok { color: oklch(0.50 0.14 145); }
 .sells-cowork .cli-kpi b.muted { color: var(--text-dim); }
-.sells-cowork .cli-kpi small { font-size: 11px; color: var(--text-dim); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.04em; }
-.sells-cowork .cli-tabs { margin: 8px 0 14px; }
-.sells-cowork .cli-section {
-  display: flex; flex-direction: column; gap: 8px;
-}
-.sells-cowork .cli-row {
-  display: grid;
-  grid-template-columns: 140px 1fr;
-  gap: 12px;
-  padding: 8px 0;
-  border-bottom: 1px solid var(--border);
-  font-size: 13px;
-}
-.sells-cowork .cli-row span { color: var(--text-dim); }
-.sells-cowork .cli-row b { color: var(--text); font-weight: 500; }
-.sells-cowork .cli-tags { display: flex; flex-wrap: wrap; gap: 4px; }
-.sells-cowork .cli-tag {
-  padding: 1px 7px;
-  border-radius: 8px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  font-size: 10.5px;
-  color: var(--text-dim);
-}
-.sells-cowork .cli-empty {
-  margin-top: 12px;
-  padding: 16px;
-  background: var(--bg-2);
-  border: 1px dashed var(--border);
-  border-radius: 6px;
-  text-align: center;
-  color: var(--text-dim);
-}
-.sells-cowork .cli-empty b { display: block; color: var(--text); margin: 6px 0 2px; }
-.sells-cowork .cli-empty small { font-size: 11.5px; }
-.sells-cowork .cli-empty svg { opacity: 0.4; }
-.sells-cowork .cli-contact {
-  display: flex; align-items: center; gap: 12px;
-  padding: 12px;
-  background: var(--bg-2);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-}
-.sells-cowork .cli-contact-av {
-  width: 36px; height: 36px;
-  border-radius: 50%;
-  background: oklch(0.65 0.12 240);
-  color: white;
-  display: flex; align-items: center; justify-content: center;
-  font-weight: 600;
-  font-size: 13px;
-}
-.sells-cowork .cli-contact b { display: block; font-size: 13px; }
-.sells-cowork .cli-contact small { font-size: 11.5px; color: var(--text-dim); }
 /* ════════════════════════ ORÇAMENTOS ════════════════════════ */
-.sells-cowork .orc-items {
-  font-size: 12px;
-  color: var(--text-dim);
-  max-width: 280px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.sells-cowork .orc-status {
-  display: inline-block;
-  padding: 2px 8px;
-  border-radius: 4px;
-  border: 1px solid;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: .02em;
-}
-.sells-cowork .orc-os {
-  margin-left: 6px;
-  font-size: 11px;
-  color: var(--text-dim);
-}
-.sells-cowork .orc-prob {
-  position: relative;
-  width: 56px;
-  height: 14px;
-  background: var(--bg-2);
-  border-radius: 3px;
-  overflow: hidden;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-.sells-cowork .orc-prob-fill {
-  position: absolute;
-  left: 0; top: 0; bottom: 0;
-  background: oklch(0.55 0.14 240 / .35);
-}
-.sells-cowork .orc-prob span {
-  position: relative;
-  font-size: 10px;
-  font-weight: 600;
-  color: var(--text);
-}
 /* ════════════════════════ PRODUTOS ════════════════════════ */
-.sells-cowork .prod-toggle {
-  display: inline-flex;
-  gap: 6px;
-  align-items: center;
-  font-size: 12px;
-  color: var(--text-dim);
-  cursor: pointer;
-  user-select: none;
-}
-.sells-cowork .prod-toggle input { accent-color: var(--accent); }
-.sells-cowork .prod-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-  gap: 12px;
-  padding: 12px 16px;
-}
-.sells-cowork .prod-card {
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 12px 14px;
-  cursor: pointer;
-  transition: border-color .12s, transform .12s;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  position: relative;
-}
-.sells-cowork .prod-card:hover { border-color: var(--accent); }
 .sells-cowork .prod-card.selected { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
 .sells-cowork .prod-card.inactive { opacity: .55; }
-.sells-cowork .prod-card-h {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.sells-cowork .prod-cat {
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: .04em;
-  text-transform: uppercase;
-  color: var(--text-dim);
-}
-.sells-cowork .prod-inactive-badge {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: var(--bg-2);
-  color: var(--text-dim);
-}
-.sells-cowork .prod-name {
-  font-size: 14px;
-  font-weight: 600;
-  margin: 0;
-  line-height: 1.3;
-  text-wrap: pretty;
-}
-.sells-cowork .prod-id {
-  font-size: 11px;
-  color: var(--text-dim);
-}
-.sells-cowork .prod-foot {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
-  margin-top: auto;
-}
-.sells-cowork .prod-price b {
-  font-size: 16px;
-  font-weight: 700;
-}
-.sells-cowork .prod-price small {
-  font-size: 11px;
-  color: var(--text-dim);
-  margin-left: 2px;
-}
-.sells-cowork .prod-meta {
-  font-size: 11px;
-  color: var(--text-dim);
-  display: flex;
-  gap: 8px;
-  align-items: center;
-}
-.sells-cowork .prod-meta span { display: inline-flex; gap: 3px; align-items: center; }
-.sells-cowork .prod-pop {
-  position: absolute;
-  left: 0; right: 0; bottom: 0;
-  height: 2px;
-  background: var(--bg-2);
-  border-radius: 0 0 8px 8px;
-  overflow: hidden;
-}
-.sells-cowork .prod-pop-fill {
-  height: 100%;
-  background: var(--accent);
-}
-.sells-cowork .prod-bom-h {
-  font-size: 12px;
-  font-weight: 600;
-  margin: 12px 0 6px;
-  color: var(--text-dim);
-  text-transform: uppercase;
-  letter-spacing: .04em;
-}
-.sells-cowork .prod-bom-row {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12.5px;
-  padding: 4px 0;
-  color: var(--text);
-}
-.sells-cowork .prod-bom-row svg { color: var(--accent); flex-shrink: 0; }
 /* ─── Produção: Fila / Acabamento / Expedição ─── */
-.sells-cowork .prod-page {
-  display: flex; flex-direction: column;
-  height: 100%;
-  background: var(--bg);
-  overflow: hidden;
-}
-.sells-cowork .prod-header {
-  display: flex; align-items: flex-end; justify-content: space-between;
-  padding: 18px 24px 14px;
-  border-bottom: 1px solid var(--border-2);
-  gap: 16px;
-}
-.sells-cowork .prod-header-l h1 {
-  margin: 0;
-  font-size: 22px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-}
-.sells-cowork .prod-header-l p {
-  margin: 2px 0 0;
-  font-size: 12.5px;
-  color: var(--text-mute);
-}
-.sells-cowork .prod-header-r {
-  display: flex; align-items: center; gap: 8px;
-}
-.sells-cowork .prod-view-toggle {
-  display: inline-flex;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  overflow: hidden;
-  margin-right: 4px;
-}
-.sells-cowork .prod-view-toggle button {
-  appearance: none; background: var(--bg); border: 0;
-  padding: 6px 10px;
-  font: inherit; font-size: 12px;
-  display: inline-flex; align-items: center; gap: 5px;
-  color: var(--text-mute);
-  cursor: default;
-  border-right: 1px solid var(--border);
-}
-.sells-cowork .prod-view-toggle button:last-child { border-right: 0; }
 .sells-cowork .prod-view-toggle button.active {
   background: var(--accent-soft);
   color: var(--accent);
-}
-.sells-cowork .prod-kpis {
-  display: grid; grid-template-columns: repeat(5, 1fr);
-  gap: 12px;
-  padding: 14px 24px 0;
-}
-.sells-cowork .prod-kpi {
-  background: var(--bg-2);
-  border: 1px solid var(--border-2);
-  border-radius: 8px;
-  padding: 12px 14px;
-  display: flex; flex-direction: column; gap: 2px;
-}
-.sells-cowork .prod-kpi-label {
-  font-size: 11px; color: var(--text-mute);
-  text-transform: uppercase; letter-spacing: 0.04em;
-}
-.sells-cowork .prod-kpi-value {
-  font-size: 22px; font-weight: 600;
-  letter-spacing: -0.01em;
-}
-.sells-cowork .prod-kpi-sub {
-  font-size: 11.5px; color: var(--text-mute);
-}
-.sells-cowork .prod-kpi-urgent .prod-kpi-value { color: var(--neg); }
-.sells-cowork .prod-kpi-urgent { border-color: oklch(0.85 0.10 25); background: oklch(0.97 0.04 25); }
-.sells-cowork .prod-equip-filters {
-  display: flex; gap: 6px; flex-wrap: wrap;
-  padding: 14px 24px 0;
-}
-.sells-cowork .prod-equip-tab {
-  appearance: none; background: var(--bg-2);
-  border: 1px solid var(--border-2);
-  border-radius: 6px;
-  padding: 6px 10px;
-  font: inherit; font-size: 12px;
-  display: inline-flex; align-items: center; gap: 6px;
-  color: var(--text-mute);
-  cursor: default;
 }
 .sells-cowork .prod-equip-tab .count {
   font-size: 11px;
@@ -3627,157 +1728,20 @@
   border-color: var(--text-mute);
 }
 .sells-cowork .prod-equip-tab.active .count { background: var(--accent-soft); color: var(--accent); }
-.sells-cowork .prod-equip-dot {
-  width: 6px; height: 6px; border-radius: 50%;
-  display: inline-block;
-}
 .sells-cowork .prod-equip-dot.violet { background: oklch(0.55 0.18 295); }
 .sells-cowork .prod-equip-dot.blue { background: oklch(0.55 0.16 230); }
 .sells-cowork .prod-equip-dot.cyan { background: oklch(0.60 0.13 200); }
-.sells-cowork .prod-kanban {
-  display: grid; grid-template-columns: repeat(3, 1fr);
-  gap: 14px;
-  padding: 14px 24px 24px;
-  flex: 1 1 auto;
-  overflow: auto;
-  align-items: start;
-}
-.sells-cowork .prod-col {
-  background: var(--bg-2);
-  border: 1px solid var(--border-2);
-  border-radius: 10px;
-  display: flex; flex-direction: column;
-  min-height: 240px;
-}
-.sells-cowork .prod-col-head {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 10px 12px;
-  border-bottom: 1px solid var(--border-2);
-  gap: 8px;
-}
-.sells-cowork .prod-col-head-l {
-  display: flex; align-items: center; gap: 8px;
-}
-.sells-cowork .prod-col-head h3 {
-  margin: 0; font-size: 13px; font-weight: 600;
-}
-.sells-cowork .prod-col-count {
-  font-size: 11.5px;
-  background: var(--bg);
-  padding: 1px 7px;
-  border-radius: 10px;
-  color: var(--text-mute);
-  border: 1px solid var(--border-2);
-}
-.sells-cowork .prod-col-cap {
-  font-size: 11px; color: var(--text-mute);
-  font-variant-numeric: tabular-nums;
-}
-.sells-cowork .prod-col-dot {
-  width: 8px; height: 8px; border-radius: 50%;
-}
 .sells-cowork .prod-col-dot.violet { background: oklch(0.55 0.18 295); }
 .sells-cowork .prod-col-dot.amber { background: oklch(0.70 0.14 65); }
 .sells-cowork .prod-col-dot.cyan { background: oklch(0.60 0.13 200); }
-.sells-cowork .prod-col-violet { border-top: 2px solid oklch(0.65 0.14 295); }
-.sells-cowork .prod-col-amber { border-top: 2px solid oklch(0.75 0.12 65); }
-.sells-cowork .prod-col-cyan { border-top: 2px solid oklch(0.70 0.10 200); }
-.sells-cowork .prod-col-ops {
-  display: flex; gap: 4px;
-}
-.sells-cowork .prod-col-op-tag {
-  font-size: 10px;
-  padding: 1px 5px;
-  border-radius: 3px;
-  background: var(--bg);
-  border: 1px solid var(--border-2);
-  color: var(--text-mute);
-}
-.sells-cowork .prod-col-body {
-  display: flex; flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-}
-.sells-cowork .prod-empty {
-  font-size: 12px;
-  color: var(--text-mute);
-  text-align: center;
-  padding: 24px 8px;
-  border: 1px dashed var(--border-2);
-  border-radius: 6px;
-}
 /* Cards */
-.sells-cowork .prod-card {
-  background: var(--bg);
-  border: 1px solid var(--border-2);
-  border-radius: 8px;
-  padding: 10px 11px;
-  display: flex; flex-direction: column; gap: 6px;
-  cursor: default;
-  transition: border-color .12s, box-shadow .12s;
-}
-.sells-cowork .prod-card:hover {
-  border-color: var(--text-mute);
-  box-shadow: 0 1px 3px rgba(0,0,0,.04);
-}
 .sells-cowork .prod-card.urgent {
   border-color: oklch(0.75 0.16 25);
   box-shadow: 0 0 0 2px oklch(0.95 0.06 25);
 }
-.sells-cowork .prod-card-top {
-  display: flex; align-items: center; gap: 6px;
-  font-size: 11px;
-}
-.sells-cowork .prod-seq {
-  font-weight: 600;
-  color: var(--text-mute);
-  font-variant-numeric: tabular-nums;
-}
-.sells-cowork .prod-os {
-  font-family: var(--mono, "IBM Plex Mono", monospace);
-  font-size: 11px;
-  color: var(--text);
-  font-weight: 500;
-}
-.sells-cowork .prod-urgent {
-  margin-left: auto;
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  font-weight: 600;
-  color: oklch(0.50 0.18 25);
-  background: oklch(0.95 0.06 25);
-  padding: 1px 5px;
-  border-radius: 3px;
-}
-.sells-cowork .prod-card-title {
-  font-size: 13px;
-  font-weight: 500;
-  line-height: 1.3;
-  text-wrap: pretty;
-}
-.sells-cowork .prod-card-client {
-  font-size: 11.5px;
-  color: var(--text-mute);
-}
-.sells-cowork .prod-equip-row {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: 6px;
-}
-.sells-cowork .prod-equip-pill {
-  font-size: 11px;
-  padding: 2px 7px;
-  border-radius: 10px;
-  font-weight: 500;
-}
 .sells-cowork .prod-equip-pill.violet { background: oklch(0.94 0.05 295); color: oklch(0.40 0.14 295); }
 .sells-cowork .prod-equip-pill.blue { background: oklch(0.94 0.05 230); color: oklch(0.40 0.13 230); }
 .sells-cowork .prod-equip-pill.cyan { background: oklch(0.94 0.04 200); color: oklch(0.40 0.10 200); }
-.sells-cowork .prod-eta {
-  font-size: 11px;
-  color: var(--text-mute);
-  font-variant-numeric: tabular-nums;
-}
 .sells-cowork .prod-progress {
   position: relative;
   height: 6px;
@@ -3785,256 +1749,29 @@
   border-radius: 3px;
   overflow: hidden;
 }
-.sells-cowork .prod-progress-bar {
-  height: 100%;
-  background: var(--accent);
-  border-radius: 3px;
-  transition: width .3s ease;
-}
-.sells-cowork .prod-progress-label {
-  position: absolute;
-  right: 0; top: -16px;
-  font-size: 10px;
-  color: var(--text-mute);
-  font-variant-numeric: tabular-nums;
-}
-.sells-cowork .prod-card-foot {
-  display: flex; align-items: center; justify-content: space-between;
-  gap: 6px;
-  padding-top: 4px;
-}
-.sells-cowork .prod-deadline {
-  font-size: 11px;
-  color: var(--text-mute);
-}
 .sells-cowork .prod-card.urgent .prod-deadline { color: oklch(0.50 0.18 25); font-weight: 500; }
-.sells-cowork .prod-actions {
-  display: flex; gap: 4px;
-}
-.sells-cowork .prod-act {
-  appearance: none;
-  background: var(--bg-2);
-  border: 1px solid var(--border-2);
-  border-radius: 4px;
-  padding: 3px 7px;
-  font: inherit; font-size: 11px;
-  color: var(--text-mute);
-  cursor: default;
-  display: inline-flex; align-items: center; gap: 3px;
-}
-.sells-cowork .prod-act:hover { color: var(--text); border-color: var(--text-mute); }
 .sells-cowork .prod-act.primary {
   background: var(--accent);
   color: white;
   border-color: var(--accent);
 }
 .sells-cowork .prod-act.primary:hover { background: var(--accent-2); }
-.sells-cowork .prod-op-pill {
-  font-size: 10.5px;
-  padding: 1px 6px;
-  border-radius: 3px;
-  background: oklch(0.94 0.06 65);
-  color: oklch(0.42 0.12 65);
-  font-weight: 500;
-}
-.sells-cowork .prod-route-pill {
-  font-size: 10.5px;
-  padding: 1px 6px;
-  border-radius: 3px;
-  background: oklch(0.94 0.04 200);
-  color: oklch(0.40 0.10 200);
-  font-weight: 500;
-  display: inline-flex; align-items: center; gap: 3px;
-}
-.sells-cowork .prod-pieces-row {
-  display: flex; align-items: center; justify-content: space-between;
-  font-size: 11.5px;
-}
-.sells-cowork .prod-pieces { color: var(--text); font-weight: 500; }
-.sells-cowork .prod-pct { color: var(--text-mute); font-variant-numeric: tabular-nums; }
-.sells-cowork .prod-exp-meta {
-  display: grid; grid-template-columns: auto 1fr;
-  gap: 2px 8px;
-  margin: 2px 0 0;
-  font-size: 11px;
-}
-.sells-cowork .prod-exp-meta dt { color: var(--text-mute); }
-.sells-cowork .prod-exp-meta dd { margin: 0; color: var(--text); }
 /* Lista plana */
-.sells-cowork .prod-list {
-  flex: 1 1 auto;
-  overflow: auto;
-  padding: 14px 24px 24px;
-}
 .sells-cowork .prod-list .os-table tbody tr { cursor: default; }
 .sells-cowork .prod-list .os-table tbody tr:hover td { background: var(--bg-2); }
-.sells-cowork .row-urgent td:first-child {
-  border-left: 2px solid oklch(0.65 0.18 25);
-}
-.sells-cowork .stage-pill {
-  font-size: 11px;
-  padding: 2px 7px;
-  border-radius: 10px;
-  font-weight: 500;
-}
-.sells-cowork .stage-producao { background: oklch(0.94 0.05 295); color: oklch(0.40 0.14 295); }
-.sells-cowork .stage-acabamento { background: oklch(0.94 0.06 65); color: oklch(0.42 0.12 65); }
-.sells-cowork .stage-expedicao { background: oklch(0.94 0.04 200); color: oklch(0.40 0.10 200); }
-.sells-cowork .t-truncate { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.sells-cowork .t-urgent { color: oklch(0.50 0.18 25); font-weight: 500; }
 /* Drawer */
-.sells-cowork .prod-drawer-backdrop {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,.18);
-  z-index: 70;
-  display: flex; justify-content: flex-end;
-}
-.sells-cowork .prod-drawer {
-  width: 480px; max-width: 92vw;
-  background: var(--bg);
-  border-left: 1px solid var(--border);
-  display: flex; flex-direction: column;
-  box-shadow: -8px 0 24px rgba(0,0,0,.08);
-}
-.sells-cowork .prod-drawer-head {
-  display: flex; align-items: flex-start; justify-content: space-between;
-  padding: 18px 20px 14px;
-  border-bottom: 1px solid var(--border-2);
-  gap: 12px;
-}
-.sells-cowork .prod-drawer-eyebrow {
-  font-size: 11px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-mute);
-}
-.sells-cowork .prod-drawer-head h2 {
-  margin: 4px 0 2px;
-  font-size: 17px;
-  font-weight: 600;
-}
-.sells-cowork .prod-drawer-head p {
-  margin: 0;
-  font-size: 12.5px;
-  color: var(--text-mute);
-}
-.sells-cowork .prod-drawer-body {
-  padding: 16px 20px;
-  flex: 1 1 auto;
-  overflow: auto;
-}
-.sells-cowork .prod-drawer-meta {
-  display: grid; grid-template-columns: auto 1fr;
-  gap: 6px 14px;
-  margin: 0 0 18px;
-  font-size: 12.5px;
-}
-.sells-cowork .prod-drawer-meta dt { color: var(--text-mute); }
-.sells-cowork .prod-drawer-meta dd { margin: 0; color: var(--text); }
-.sells-cowork .prod-drawer-actions {
-  display: flex; gap: 8px; flex-wrap: wrap;
-}
 /* ════════════════════════ CLIENTES PAGE ════════════════════════ */
 .sells-cowork .cli-page .os-table th, .sells-cowork .cli-page .os-table td { padding: 10px 12px; }
-.sells-cowork .cli-name { display: flex; align-items: center; gap: 10px; }
-.sells-cowork .cli-avatar {
-  width: 32px; height: 32px; border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 11px; font-weight: 600; color: #fff; flex-shrink: 0;
-  letter-spacing: 0.02em;
-}
 .sells-cowork .cli-avatar.lg { width: 48px; height: 48px; font-size: 16px; }
-.sells-cowork .cli-avatar.grad-1 { background: linear-gradient(135deg, #5b6cff 0%, #8b5cf6 100%); }
-.sells-cowork .cli-avatar.grad-2 { background: linear-gradient(135deg, #06b6d4 0%, #0ea5e9 100%); }
-.sells-cowork .cli-avatar.grad-3 { background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%); }
-.sells-cowork .cli-avatar.grad-4 { background: linear-gradient(135deg, #10b981 0%, #059669 100%); }
-.sells-cowork .cli-avatar.grad-5 { background: linear-gradient(135deg, #ec4899 0%, #be185d 100%); }
-.sells-cowork .cli-name-text { font-weight: 600; color: var(--ink-1); font-size: 13px; }
-.sells-cowork .cli-doc { font-size: 11px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 1px; }
-.sells-cowork .cli-contact-line { font-weight: 500; color: var(--ink-2); font-size: 13px; }
-.sells-cowork .cli-phone { font-size: 11px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 1px; }
 .sells-cowork .cli-table .num { text-align: right; font-variant-numeric: tabular-nums; }
 .sells-cowork .cli-table .value { font-weight: 600; color: var(--ink-1); }
-.sells-cowork .cli-status {
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 2px 8px; border-radius: 999px;
-  font-size: 11px; font-weight: 500;
-}
 .sells-cowork .cli-status.late { background: #fef2f2; color: #b91c1c; }
 .sells-cowork .cli-status.active { background: #ecfdf5; color: #047857; }
 .sells-cowork .cli-status.idle { background: var(--bg-2); color: var(--ink-3); }
 /* Drawer */
-.sells-cowork .cli-drawer { width: min(620px, 100%); }
-.sells-cowork .cli-head { display: flex; align-items: center; gap: 14px; }
-.sells-cowork .cli-head-name { font-size: 17px; font-weight: 600; color: var(--ink-1); }
-.sells-cowork .cli-head-doc { font-size: 12px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 2px; }
-.sells-cowork .cli-kpis {
-  display: grid; grid-template-columns: repeat(4, 1fr);
-  gap: 8px; padding: 16px 20px;
-  border-bottom: 1px solid var(--line);
-}
-.sells-cowork .cli-kpi {
-  background: var(--bg-1);
-  border: 1px solid var(--line);
-  border-radius: 8px;
-  padding: 10px 12px;
-}
 .sells-cowork .cli-kpi.danger { border-color: #fecaca; background: #fef2f2; }
-.sells-cowork .cli-kpi-v { font-size: 18px; font-weight: 600; color: var(--ink-1); font-variant-numeric: tabular-nums; }
 .sells-cowork .cli-kpi.danger .cli-kpi-v { color: #b91c1c; }
-.sells-cowork .cli-kpi-l { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
-.sells-cowork .cli-section { padding: 18px 20px; border-bottom: 1px solid var(--line); }
-.sells-cowork .cli-section:last-of-type { border-bottom: 0; }
-.sells-cowork .cli-section-title {
-  font-size: 11px; font-weight: 600; text-transform: uppercase;
-  letter-spacing: 0.06em; color: var(--ink-3);
-  margin-bottom: 10px;
-}
-.sells-cowork .cli-info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 20px; }
-.sells-cowork .cli-info-l { font-size: 11px; color: var(--ink-3); margin-bottom: 2px; }
-.sells-cowork .cli-info-v { font-size: 13px; color: var(--ink-1); font-weight: 500; }
-.sells-cowork .cli-history { display: flex; flex-direction: column; gap: 6px; }
-.sells-cowork .cli-os {
-  display: grid;
-  grid-template-columns: 60px 1fr 110px 90px 90px;
-  gap: 10px;
-  align-items: center;
-  padding: 8px 10px;
-  background: var(--bg-1);
-  border: 1px solid var(--line);
-  border-radius: 6px;
-  font-size: 12px;
-}
-.sells-cowork .cli-os-id { font-family: var(--font-mono); font-weight: 600; color: var(--ink-2); }
-.sells-cowork .cli-os-prod { color: var(--ink-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.sells-cowork .cli-os-stage {
-  padding: 2px 8px; border-radius: 4px;
-  font-size: 10px; font-weight: 500; text-align: center;
-  background: var(--bg-2); color: var(--ink-2);
-}
-.sells-cowork .cli-os-stage.stage-aprovacao { background: #fef3c7; color: #92400e; }
-.sells-cowork .cli-os-stage.stage-producao, .sells-cowork .cli-os-stage.stage-acabamento { background: #ede9fe; color: #5b21b6; }
-.sells-cowork .cli-os-stage.stage-expedicao { background: #cffafe; color: #155e75; }
-.sells-cowork .cli-os-stage.stage-entregue { background: #d1fae5; color: #065f46; }
-.sells-cowork .cli-os-stage.stage-orcado { background: #dbeafe; color: #1e40af; }
-.sells-cowork .cli-os-stage.stage-cancelado { background: #fee2e2; color: #991b1b; }
-.sells-cowork .cli-os-deadline { color: var(--ink-3); font-size: 11px; }
-.sells-cowork .cli-os-value { text-align: right; font-weight: 600; color: var(--ink-1); font-variant-numeric: tabular-nums; }
-.sells-cowork .cli-fin { display: flex; flex-direction: column; gap: 4px; }
-.sells-cowork .cli-fin-row {
-  display: flex; justify-content: space-between;
-  padding: 8px 10px;
-  font-size: 13px;
-  background: var(--bg-1);
-  border-radius: 6px;
-}
-.sells-cowork .cli-fin-row b { font-variant-numeric: tabular-nums; }
 .sells-cowork .cli-fin-row b.danger { color: #b91c1c; }
-.sells-cowork .cli-empty {
-  text-align: center; padding: 24px;
-  color: var(--ink-3); font-size: 13px;
-  background: var(--bg-1); border-radius: 6px;
-}
 /* ════════════ VENDAS ════════════ */
 .sells-cowork .vendas-page .vd-id { font-family:var(--font-mono); font-size:12px; color:oklch(0.40 0.04 250); font-weight:600; }
 .sells-cowork .vendas-page .vd-date { font-size:11px; }
@@ -4066,112 +1803,19 @@
 .sells-cowork .vendas-page .vd-no-os { font-size:11px; color:oklch(0.55 0.02 250); font-style:italic; }
 .sells-cowork .kbd-hint { display:inline-block; padding:1px 5px; margin-left:4px; border:1px solid oklch(0.85 0.02 250); border-radius:3px; font-family:var(--font-mono); font-size:9px; color:oklch(0.40 0.04 250); background:#fff; }
 /* Drawer venda */
-.sells-cowork .vd-section { padding:14px 20px; border-bottom:1px solid oklch(0.95 0.01 250); }
-.sells-cowork .vd-section:last-child { border-bottom:none; }
-.sells-cowork .vd-section h3 { font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.45 0.02 250); margin:0 0 12px; font-weight:600; }
-.sells-cowork .vd-meta { display:grid; grid-template-columns:140px 1fr; gap:6px 16px; margin:0; font-size:13px; }
-.sells-cowork .vd-meta dt { color:oklch(0.50 0.02 250); }
-.sells-cowork .vd-meta dd { margin:0; }
-.sells-cowork .vd-total-strong { font-weight:600; font-size:15px; }
-.sells-cowork .vd-os-list { display:flex; flex-direction:column; gap:6px; }
-.sells-cowork .vd-os-link { display:flex; align-items:center; justify-content:space-between; padding:8px 12px; background:oklch(0.97 0.01 250); border-radius:6px; font-size:12px; cursor:pointer; }
-.sells-cowork .vd-os-link:hover { background:oklch(0.94 0.01 250); }
-.sells-cowork .vd-docs { display:flex; gap:8px; flex-wrap:wrap; }
 /* Stepper */
-.sells-cowork .vd-stepper { display:flex; align-items:center; gap:6px; padding:10px 20px; background:oklch(0.98 0.01 250); border-bottom:1px solid oklch(0.92 0.01 250); overflow-x:auto; }
-.sells-cowork .vd-step { display:flex; align-items:center; gap:6px; padding:6px 10px; background:transparent; border:none; cursor:pointer; font-size:12px; color:oklch(0.50 0.02 250); border-radius:4px; }
 .sells-cowork .vd-step.active { color:oklch(0.30 0.10 240); font-weight:600; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.04); }
 .sells-cowork .vd-step.done { color:oklch(0.45 0.12 145); }
-.sells-cowork .vd-step-num { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:50%; background:oklch(0.92 0.01 250); font-size:11px; font-weight:600; }
 .sells-cowork .vd-step.active .vd-step-num { background:oklch(0.55 0.14 240); color:#fff; }
 .sells-cowork .vd-step.done .vd-step-num { background:oklch(0.55 0.14 145); color:#fff; }
-.sells-cowork .vd-step-sep { color:oklch(0.75 0.01 250); margin:0 2px; }
 /* Create body */
-.sells-cowork .vd-create-body { padding:0; }
-.sells-cowork .vd-search-wrap { display:flex; align-items:center; gap:8px; padding:8px 12px; background:#fff; border:1px solid oklch(0.88 0.01 250); border-radius:6px; }
-.sells-cowork .vd-search-wrap input { flex:1; border:none; outline:none; font-size:13px; }
-.sells-cowork .vd-search-wrap input:focus { outline:none; }
-.sells-cowork .vd-walkin { background:oklch(0.92 0.04 240); color:oklch(0.30 0.10 240); border:none; padding:4px 10px; border-radius:4px; font-size:11px; cursor:pointer; }
-.sells-cowork .vd-walkin:hover { background:oklch(0.88 0.05 240); }
-.sells-cowork .vd-client-list { display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:10px; }
-.sells-cowork .vd-client-card { text-align:left; padding:10px 12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; }
-.sells-cowork .vd-client-card:hover { border-color:oklch(0.55 0.14 240); background:oklch(0.98 0.02 240); }
-.sells-cowork .vd-client-card-name { font-weight:600; font-size:13px; }
-.sells-cowork .vd-client-card-meta { font-size:11px; color:oklch(0.50 0.02 250); margin-top:2px; }
-.sells-cowork .vd-client-selected { display:flex; flex-direction:column; gap:12px; padding:12px; background:oklch(0.97 0.01 250); border-radius:6px; }
-.sells-cowork .vd-fields { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
-.sells-cowork .vd-fields label { display:flex; flex-direction:column; gap:4px; font-size:11px; color:oklch(0.45 0.02 250); }
-.sells-cowork .vd-fields input, .sells-cowork .vd-fields select { padding:6px 8px; border:1px solid oklch(0.88 0.01 250); border-radius:4px; font-size:13px; }
 /* Itens */
-.sells-cowork .vd-prod-suggest { margin-top:6px; background:#fff; border:1px solid oklch(0.92 0.01 250); border-radius:6px; max-height:240px; overflow:auto; }
-.sells-cowork .vd-prod-row { display:flex; justify-content:space-between; align-items:center; width:100%; padding:8px 12px; border:none; background:transparent; cursor:pointer; font-size:13px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
-.sells-cowork .vd-prod-row:hover { background:oklch(0.97 0.01 250); }
-.sells-cowork .vd-prod-row:last-child { border-bottom:none; }
-.sells-cowork .vd-prod-price { color:oklch(0.45 0.12 145); font-weight:600; font-variant-numeric:tabular-nums; }
-.sells-cowork .vd-empty-mini { padding:10px 12px; font-size:12px; color:oklch(0.55 0.02 250); }
-.sells-cowork .vd-empty-state { padding:30px; text-align:center; color:oklch(0.55 0.02 250); font-size:13px; background:oklch(0.98 0.01 250); border-radius:6px; margin-top:10px; }
-.sells-cowork .vd-items-table { width:100%; margin-top:14px; border-collapse:collapse; font-size:12px; }
-.sells-cowork .vd-items-table th { text-align:left; font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); padding:6px 8px; border-bottom:1px solid oklch(0.92 0.01 250); }
-.sells-cowork .vd-items-table td { padding:6px 8px; border-bottom:1px solid oklch(0.96 0.01 250); }
-.sells-cowork .vd-items-table input { width:100%; padding:4px 6px; border:1px solid oklch(0.90 0.01 250); border-radius:3px; font-size:12px; }
-.sells-cowork .vd-strong { font-weight:600; font-variant-numeric:tabular-nums; }
-.sells-cowork .vd-toggle { display:flex; align-items:center; gap:6px; font-size:11px; }
-.sells-cowork .vd-foot-l { text-align:right; padding-top:10px !important; font-size:11px; color:oklch(0.45 0.02 250); }
-.sells-cowork .vd-foot-r { text-align:right; padding-top:10px !important; font-weight:700; font-size:14px; }
 /* Pagamento */
-.sells-cowork .vd-pay-grid { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; }
-.sells-cowork .vd-pay-card { display:flex; flex-direction:column; gap:2px; align-items:flex-start; padding:12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; text-align:left; }
 .sells-cowork .vd-pay-card.active { border-color:oklch(0.55 0.14 240); background:oklch(0.97 0.03 240); box-shadow:0 0 0 2px oklch(0.55 0.14 240 / 0.15); }
-.sells-cowork .vd-pay-icon { font-size:18px; }
-.sells-cowork .vd-pay-label { font-weight:600; font-size:13px; }
-.sells-cowork .vd-pay-clear { font-size:10px; color:oklch(0.50 0.02 250); }
-.sells-cowork .vd-totals { display:grid; grid-template-columns:1fr auto; gap:6px 16px; margin:14px 0 0; font-size:13px; }
-.sells-cowork .vd-totals dt { color:oklch(0.50 0.02 250); }
-.sells-cowork .vd-totals dd { margin:0; text-align:right; font-variant-numeric:tabular-nums; }
-.sells-cowork .vd-total-row { font-weight:700; font-size:16px; padding-top:6px; border-top:1px solid oklch(0.92 0.01 250); }
 /* Confirmar */
-.sells-cowork .vd-confirm-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
-.sells-cowork .vd-confirm-block { display:flex; flex-direction:column; gap:2px; padding:12px; background:oklch(0.97 0.01 250); border-radius:6px; }
-.sells-cowork .vd-confirm-label { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
-.sells-cowork .vd-confirm-block strong { font-size:14px; }
-.sells-cowork .vd-confirm-total { background:oklch(0.55 0.14 145 / 0.08); }
-.sells-cowork .vd-total-big { font-size:22px; color:oklch(0.40 0.14 145); font-variant-numeric:tabular-nums; }
-.sells-cowork .vd-callout { margin-top:14px; padding:12px; background:oklch(0.95 0.05 240); border-left:3px solid oklch(0.55 0.14 240); border-radius:4px; font-size:12px; color:oklch(0.30 0.08 240); }
-.sells-cowork .vd-callout-ok { background:oklch(0.95 0.05 145); border-left-color:oklch(0.55 0.14 145); color:oklch(0.30 0.10 145); }
 /* Foot */
-.sells-cowork .vd-foot { display:flex; justify-content:space-between; align-items:center; }
-.sells-cowork .vd-foot-summary { display:flex; align-items:baseline; gap:10px; font-size:12px; color:oklch(0.50 0.02 250); }
-.sells-cowork .vd-foot-total { font-size:16px; font-weight:700; color:oklch(0.20 0.02 250); font-variant-numeric:tabular-nums; }
-.sells-cowork .vd-foot-actions { display:flex; gap:8px; }
 /* ════════════ VENDAS MODULE — sub-nav + extras ════════════ */
-.sells-cowork .vendas-module { display:flex; flex-direction:column; height:100%; }
-.sells-cowork .vm-subnav {
-  display:flex; align-items:center; justify-content:space-between;
-  padding:0 20px; border-bottom:1px solid oklch(0.93 0.01 250);
-  background:#fff; flex-shrink:0;
-}
-.sells-cowork .vm-subnav-tabs { display:flex; gap:0; }
-.sells-cowork .vm-subtab {
-  display:inline-flex; align-items:center; gap:6px;
-  padding:10px 14px; border:none; background:transparent; cursor:pointer;
-  font-size:12px; color:oklch(0.50 0.02 250); font-weight:500;
-  border-bottom:2px solid transparent; transition:all .12s;
-}
-.sells-cowork .vm-subtab:hover { color:oklch(0.30 0.02 250); }
 .sells-cowork .vm-subtab.active { color:var(--accent); border-bottom-color:var(--accent); }
-.sells-cowork .vm-pdv-btn {
-  display:inline-flex; align-items:center; gap:8px;
-  padding:6px 12px; border:1px solid oklch(0.85 0.02 250);
-  border-radius:6px; background:#fff; cursor:pointer;
-  font-size:12px; color:oklch(0.30 0.02 250); font-weight:500;
-}
-.sells-cowork .vm-pdv-btn:hover { background:oklch(0.97 0.01 250); }
-.sells-cowork .vm-pdv-btn kbd {
-  display:inline-block; padding:1px 5px; border:1px solid oklch(0.85 0.02 250);
-  border-radius:3px; font-family:var(--font-mono); font-size:9px;
-  color:oklch(0.40 0.04 250); background:oklch(0.97 0.01 250);
-}
-.sells-cowork .vm-body { flex:1; overflow:auto; }
 /* ──── CAIXA DO DIA ──── */
 .sells-cowork .vc-page .vc-date {
   padding:5px 8px; border:1px solid oklch(0.85 0.02 250); border-radius:6px;
@@ -4210,44 +1854,8 @@
   font-weight:600; background:oklch(0.98 0.005 250);
   border-top:2px solid oklch(0.90 0.01 250); border-bottom:none;
 }
-.sells-cowork .vc-moves { list-style:none; margin:0; padding:0; max-height:280px; overflow:auto; }
-.sells-cowork .vc-move {
-  display:grid; grid-template-columns:50px 90px 1fr 110px;
-  align-items:center; gap:10px; padding:8px 16px;
-  border-bottom:1px solid oklch(0.96 0.01 250); font-size:12px;
-}
-.sells-cowork .vc-move-time { color:oklch(0.50 0.02 250); font-family:var(--font-mono); font-size:11px; }
-.sells-cowork .vc-move-type {
-  text-transform:uppercase; font-size:10px; font-weight:600; letter-spacing:0.04em;
-}
-.sells-cowork .vc-move-abertura .vc-move-type { color:oklch(0.45 0.10 240); }
-.sells-cowork .vc-move-suprimento .vc-move-type { color:oklch(0.45 0.14 145); }
-.sells-cowork .vc-move-sangria .vc-move-type { color:oklch(0.50 0.16 25); }
-.sells-cowork .vc-move-amount { text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
 .sells-cowork .vc-move-amount.pos { color:oklch(0.45 0.14 145); }
 .sells-cowork .vc-move-amount.neg { color:oklch(0.50 0.16 25); }
-.sells-cowork .vc-move-add {
-  display:grid; grid-template-columns:130px 110px 1fr auto;
-  gap:6px; padding:12px 16px; background:oklch(0.98 0.005 250);
-  border-top:1px solid oklch(0.93 0.01 250);
-}
-.sells-cowork .vc-move-add input, .sells-cowork .vc-move-add select {
-  padding:6px 10px; border:1px solid oklch(0.88 0.01 250);
-  border-radius:5px; font-size:12px; background:#fff;
-}
-.sells-cowork .vc-counter {
-  display:grid; grid-template-columns:1fr 1.2fr 1fr; gap:24px;
-  padding:20px 16px; align-items:start;
-}
-.sells-cowork .vc-counter label { display:flex; flex-direction:column; gap:6px; font-size:11px; color:oklch(0.50 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
-.sells-cowork .vc-counter input {
-  padding:8px 12px; border:1px solid oklch(0.88 0.01 250); border-radius:6px;
-  font-size:14px; font-variant-numeric:tabular-nums; background:#fff;
-}
-.sells-cowork .vc-counter-big { font-size:22px !important; font-weight:600; padding:12px !important; }
-.sells-cowork .vc-counter-summary { margin:0; display:grid; grid-template-columns:1fr auto; gap:6px 12px; font-size:12px; }
-.sells-cowork .vc-counter-summary dt { color:oklch(0.50 0.02 250); }
-.sells-cowork .vc-counter-summary dd { margin:0; font-variant-numeric:tabular-nums; text-align:right; }
 .sells-cowork .vc-counter-summary .strong { font-weight:600; font-size:14px; padding-top:6px; border-top:1px solid oklch(0.90 0.01 250); }
 /* ──── CAIXA · POR ORIGEM (Onda 6 · ADR 0192 A1 KB-9.75) ──── */
 .sells-cowork .vc-card-source { padding:6px 0 12px; }
@@ -4299,295 +1907,29 @@
 .sells-cowork .vc-src-refs a:hover { text-decoration:underline; }
 /* Responsive: esconde refs OS abaixo de 1100px (mesmo break Sells/Index) */
 @media (max-width: 1100px) {
-  .sells-cowork .vc-src-refs { display:none; }
+.sells-cowork .vc-src-refs { display:none; }
 }
 /* ──── DEVOLUÇÕES ──── */
-.sells-cowork .vd-dev-page .vdv-reason { font-size:13px; margin:0; }
-.sells-cowork .vdv-timeline { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; font-size:12px; }
-.sells-cowork .vdv-timeline li { display:flex; align-items:center; gap:10px; }
-.sells-cowork .vdv-tl-dot { width:10px; height:10px; border-radius:50%; background:oklch(0.88 0.01 250); border:2px solid oklch(0.95 0.01 250); flex-shrink:0; }
 .sells-cowork .vdv-tl-dot.ok { background:oklch(0.55 0.14 145); }
 .sells-cowork .vdv-tl-dot.active { background:oklch(0.60 0.14 70); box-shadow:0 0 0 3px oklch(0.60 0.14 70 / 0.2); }
-.sells-cowork .vdv-input { width:100%; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-size:13px; }
-.sells-cowork .vdv-matches { margin-top:8px; display:flex; flex-direction:column; gap:4px; }
-.sells-cowork .vdv-match { display:grid; grid-template-columns:80px 1fr 100px; gap:10px; padding:8px 12px; background:oklch(0.97 0.01 250); border:none; border-radius:6px; cursor:pointer; text-align:left; font-size:12px; align-items:center; }
-.sells-cowork .vdv-match:hover { background:oklch(0.93 0.02 250); }
-.sells-cowork .vdv-selected { display:flex; align-items:center; gap:14px; padding:12px; background:oklch(0.96 0.02 145); border-radius:6px; }
-.sells-cowork .vdv-reasons { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:10px; }
-.sells-cowork .vdv-reason-btn { padding:6px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
 .sells-cowork .vdv-reason-btn.active { background:var(--accent); border-color:var(--accent); color:#fff; }
-.sells-cowork .vdv-textarea { width:100%; min-height:60px; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-family:inherit; font-size:12px; resize:vertical; }
 /* ──── COMISSÕES ──── */
-.sells-cowork .vco-period { display:inline-flex; border:1px solid oklch(0.85 0.02 250); border-radius:6px; overflow:hidden; }
-.sells-cowork .vco-period button { padding:6px 12px; border:none; background:#fff; cursor:pointer; font-size:12px; color:oklch(0.40 0.02 250); }
 .sells-cowork .vco-period button.active { background:var(--accent); color:#fff; }
-.sells-cowork .vco-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(340px, 1fr)); gap:14px; padding:0 20px 14px; }
-.sells-cowork .vco-card { background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; padding:16px; position:relative; }
-.sells-cowork .vco-card header { display:grid; grid-template-columns:auto 1fr auto; gap:12px; align-items:center; margin-bottom:14px; }
-.sells-cowork .vco-card header h3 { margin:0 0 2px; font-size:14px; }
-.sells-cowork .vco-card header span { font-size:11px; color:oklch(0.55 0.02 250); }
-.sells-cowork .vco-avatar {
-  width:40px; height:40px; border-radius:50%;
-  background:oklch(0.94 0.04 var(--accent-h, 220));
-  color:var(--accent); display:flex; align-items:center; justify-content:center;
-  font-weight:600; font-size:14px;
-}
-.sells-cowork .vco-rank {
-  font-family:var(--font-mono); font-size:14px; color:oklch(0.55 0.02 250);
-  font-weight:600;
-}
-.sells-cowork .vco-bar { height:8px; background:oklch(0.95 0.01 250); border-radius:4px; overflow:hidden; margin-bottom:12px; }
-.sells-cowork .vco-bar-fill { height:100%; background:linear-gradient(90deg, var(--accent), var(--accent-2)); }
-.sells-cowork .vco-numbers { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:12px; }
-.sells-cowork .vco-numbers > div { display:flex; flex-direction:column; gap:2px; }
-.sells-cowork .vco-numbers span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
-.sells-cowork .vco-numbers strong { font-size:18px; font-variant-numeric:tabular-nums; }
-.sells-cowork .vco-com strong { color:oklch(0.45 0.14 145); }
-.sells-cowork .vco-mix { display:flex; flex-wrap:wrap; gap:4px; }
-.sells-cowork .vco-chip { padding:2px 8px; background:oklch(0.96 0.01 250); border-radius:10px; font-size:10px; color:oklch(0.40 0.02 250); }
-.sells-cowork .vco-chip em { font-style:normal; font-weight:600; color:var(--accent); margin-left:2px; }
-.sells-cowork .vco-table-card { margin:0 20px 20px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
-.sells-cowork .vco-table-card h3 { margin:0 0 12px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
-.sells-cowork .vco-rules { width:100%; border-collapse:collapse; font-size:13px; }
-.sells-cowork .vco-rules th, .sells-cowork .vco-rules td { padding:8px 12px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
-.sells-cowork .vco-rules th { font-size:11px; color:oklch(0.50 0.02 250); font-weight:500; }
 /* ──── RELATÓRIOS ──── */
-.sells-cowork .vrep-tabs { display:flex; gap:6px; padding:0 20px 12px; }
-.sells-cowork .vrep-tabs button { padding:6px 14px; border:1px solid oklch(0.88 0.01 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
 .sells-cowork .vrep-tabs button.active { background:var(--accent); border-color:var(--accent); color:#fff; }
-.sells-cowork .vrep-summary {
-  display:grid; grid-template-columns:repeat(4, 1fr); gap:10px;
-  padding:0 20px 14px;
-}
-.sells-cowork .vrep-summary > div {
-  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
-  padding:12px 14px; display:flex; flex-direction:column; gap:4px;
-}
-.sells-cowork .vrep-summary span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
-.sells-cowork .vrep-summary strong { font-size:18px; font-variant-numeric:tabular-nums; }
-.sells-cowork .vrep-card { margin:0 20px 14px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
-.sells-cowork .vrep-card h3 { margin:0 0 14px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
-.sells-cowork .vrep-bars {
-  display:flex; align-items:flex-end; gap:14px;
-  height:240px; padding-top:30px;
-}
-.sells-cowork .vrep-bar-col {
-  flex:1; display:flex; flex-direction:column; align-items:center;
-  height:100%; min-width:40px; position:relative;
-}
-.sells-cowork .vrep-bar {
-  width:100%; max-width:54px; min-height:2px;
-  background:linear-gradient(180deg, var(--accent), var(--accent-2));
-  border-radius:4px 4px 0 0; margin-top:auto;
-}
-.sells-cowork .vrep-bar-val {
-  font-size:10px; font-variant-numeric:tabular-nums;
-  color:oklch(0.40 0.02 250); font-weight:600; margin-bottom:6px;
-}
-.sells-cowork .vrep-bar-lbl { font-size:11px; color:oklch(0.55 0.02 250); margin-top:6px; }
-.sells-cowork .vrep-clients { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; }
-.sells-cowork .vrep-clients li {
-  display:grid; grid-template-columns:30px 1fr 80px 1fr 110px;
-  gap:12px; align-items:center; padding:8px 4px; font-size:12px;
-}
-.sells-cowork .vrep-rank { font-family:var(--font-mono); color:oklch(0.55 0.02 250); font-weight:600; }
-.sells-cowork .vrep-cli-name { font-weight:500; }
-.sells-cowork .vrep-cli-n { font-size:11px; color:oklch(0.55 0.02 250); }
-.sells-cowork .vrep-cli-bar { height:6px; background:oklch(0.95 0.01 250); border-radius:3px; overflow:hidden; }
-.sells-cowork .vrep-cli-bar > div { height:100%; background:var(--accent); }
-.sells-cowork .vrep-cli-total { text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
-.sells-cowork .vrep-origin { display:flex; gap:30px; align-items:center; padding:14px 0; }
-.sells-cowork .vrep-donut {
-  width:160px; height:160px; border-radius:50%;
-  display:flex; flex-direction:column; align-items:center; justify-content:center;
-  position:relative;
-}
-.sells-cowork .vrep-donut::after {
-  content:""; position:absolute; inset:25px; background:#fff; border-radius:50%;
-}
-.sells-cowork .vrep-donut > * { position:relative; z-index:1; }
-.sells-cowork .vrep-donut span { font-size:24px; font-weight:600; }
-.sells-cowork .vrep-donut small { font-size:11px; color:oklch(0.55 0.02 250); }
-.sells-cowork .vrep-origin-legend { margin:0; display:grid; grid-template-columns:auto 1fr; gap:8px 16px; font-size:13px; }
-.sells-cowork .vrep-origin-legend dt { display:flex; align-items:center; gap:8px; color:oklch(0.30 0.02 250); }
-.sells-cowork .vrep-dot { width:10px; height:10px; border-radius:50%; }
 /* ──── PDV BALCÃO (overlay) ──── */
-.sells-cowork .pdv-overlay {
-  position:fixed; inset:0; background:oklch(0.18 0.02 250); z-index:1000;
-  display:flex; flex-direction:column; color:oklch(0.95 0.01 250);
-}
-.sells-cowork .pdv-head {
-  display:flex; align-items:center; justify-content:space-between;
-  padding:10px 18px; background:oklch(0.14 0.02 250);
-  border-bottom:1px solid oklch(0.25 0.02 250); flex-shrink:0;
-}
-.sells-cowork .pdv-head-l { display:flex; align-items:center; gap:10px; font-size:13px; }
-.sells-cowork .pdv-brand { font-weight:700; letter-spacing:0.06em; color:var(--accent-2); }
-.sells-cowork .pdv-sep { color:oklch(0.50 0.02 250); }
-.sells-cowork .pdv-head-r { display:flex; align-items:center; gap:14px; }
-.sells-cowork .pdv-shortcut { font-size:11px; color:oklch(0.65 0.02 250); }
-.sells-cowork .pdv-shortcut kbd {
-  display:inline-block; padding:2px 6px; margin-right:4px;
-  border:1px solid oklch(0.45 0.02 250); border-radius:3px;
-  font-family:var(--font-mono); font-size:10px;
-  background:oklch(0.22 0.02 250); color:oklch(0.95 0.01 250);
-}
-.sells-cowork .pdv-close {
-  width:28px; height:28px; border-radius:50%;
-  background:oklch(0.25 0.02 250); border:none; color:#fff;
-  cursor:pointer; font-size:18px; line-height:1;
-}
-.sells-cowork .pdv-grid { display:grid; grid-template-columns:1fr 380px; flex:1; overflow:hidden; }
-.sells-cowork .pdv-left { display:flex; flex-direction:column; padding:20px; overflow:hidden; }
-.sells-cowork .pdv-scan { position:relative; flex-shrink:0; margin-bottom:16px; }
-.sells-cowork .pdv-scan-label { display:block; font-size:11px; color:oklch(0.65 0.02 250); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:6px; }
-.sells-cowork .pdv-scan-input {
-  width:100%; padding:18px 20px; font-size:24px;
-  background:oklch(0.95 0.01 250); border:3px solid var(--accent);
-  border-radius:10px; color:oklch(0.18 0.02 250); font-weight:500;
-  outline:none;
-}
-.sells-cowork .pdv-suggest {
-  position:absolute; top:100%; left:0; right:0; z-index:10;
-  margin:4px 0 0; padding:0; list-style:none;
-  background:#fff; border-radius:8px; overflow:hidden;
-  box-shadow:0 8px 24px rgba(0,0,0,0.4);
-}
-.sells-cowork .pdv-suggest li {
-  display:flex; justify-content:space-between; align-items:center;
-  padding:12px 16px; cursor:pointer; color:oklch(0.18 0.02 250);
-  border-bottom:1px solid oklch(0.95 0.01 250); font-size:14px;
-}
-.sells-cowork .pdv-suggest li:hover { background:oklch(0.94 0.02 var(--accent-h, 220)); }
-.sells-cowork .pdv-items-wrap { flex:1; overflow:auto; background:oklch(0.95 0.01 250); border-radius:8px; color:oklch(0.18 0.02 250); }
-.sells-cowork .pdv-empty { padding:80px 20px; text-align:center; color:oklch(0.50 0.02 250); }
-.sells-cowork .pdv-empty-big { font-size:18px; margin-bottom:6px; color:oklch(0.30 0.02 250); }
-.sells-cowork .pdv-items { width:100%; border-collapse:collapse; font-size:14px; }
-.sells-cowork .pdv-items th { padding:12px 14px; background:oklch(0.92 0.01 250); text-align:left; font-size:11px; color:oklch(0.40 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
-.sells-cowork .pdv-items td { padding:12px 14px; border-bottom:1px solid oklch(0.92 0.01 250); }
-.sells-cowork .pdv-qty { display:inline-flex; align-items:center; gap:6px; }
-.sells-cowork .pdv-qty button { width:24px; height:24px; border-radius:4px; border:1px solid oklch(0.85 0.02 250); background:#fff; cursor:pointer; font-weight:600; }
-.sells-cowork .pdv-qty span { min-width:24px; text-align:center; font-weight:600; }
-.sells-cowork .pdv-prod { font-weight:500; }
-.sells-cowork .pdv-num { text-align:right; font-variant-numeric:tabular-nums; }
 .sells-cowork .pdv-num.strong { font-weight:600; }
-.sells-cowork .pdv-rm { width:24px; height:24px; border-radius:4px; background:oklch(0.94 0.04 25); border:none; color:oklch(0.50 0.16 25); cursor:pointer; }
-.sells-cowork .pdv-right {
-  background:oklch(0.20 0.02 250); padding:24px 20px;
-  display:flex; flex-direction:column; gap:16px;
-  border-left:1px solid oklch(0.25 0.02 250);
-}
-.sells-cowork .pdv-r-label { display:block; font-size:11px; color:oklch(0.65 0.02 250); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:6px; }
-.sells-cowork .pdv-client input {
-  width:100%; padding:10px 12px; border-radius:6px;
-  background:oklch(0.25 0.02 250); border:1px solid oklch(0.30 0.02 250);
-  color:#fff; font-size:14px;
-}
-.sells-cowork .pdv-pay-grid { display:grid; grid-template-columns:1fr 1fr; gap:6px; }
-.sells-cowork .pdv-pay-btn {
-  padding:14px 8px; border-radius:8px;
-  background:oklch(0.25 0.02 250); border:2px solid oklch(0.30 0.02 250);
-  color:#fff; cursor:pointer; display:flex; flex-direction:column;
-  align-items:center; gap:4px; font-size:12px;
-}
 .sells-cowork .pdv-pay-btn.active { border-color:var(--accent); background:oklch(0.30 0.06 var(--accent-h, 220)); }
-.sells-cowork .pdv-pay-icon { font-size:20px; }
-.sells-cowork .pdv-total-block {
-  margin-top:auto; padding:18px; border-radius:10px;
-  background:oklch(0.14 0.02 250); border:2px solid var(--accent);
-  text-align:right;
-}
-.sells-cowork .pdv-total-label { font-size:11px; color:oklch(0.65 0.02 250); letter-spacing:0.08em; }
-.sells-cowork .pdv-total-value { display:block; font-size:42px; font-weight:700; color:var(--accent-2); font-variant-numeric:tabular-nums; line-height:1.1; }
-.sells-cowork .pdv-total-meta { font-size:11px; color:oklch(0.65 0.02 250); }
-.sells-cowork .pdv-finalize {
-  padding:18px; border-radius:8px; background:oklch(0.55 0.14 145);
-  color:#fff; border:none; cursor:pointer; font-size:16px; font-weight:600;
-  display:flex; align-items:center; justify-content:center; gap:10px;
-}
-.sells-cowork .pdv-finalize:disabled { opacity:0.4; cursor:not-allowed; }
-.sells-cowork .pdv-finalize kbd {
-  padding:2px 6px; border:1px solid oklch(0.95 0.01 145 / 0.5);
-  border-radius:3px; font-family:var(--font-mono); font-size:11px;
-  background:rgba(0,0,0,0.2);
-}
-.sells-cowork .pdv-cancel { padding:10px; border-radius:6px; background:transparent; color:oklch(0.75 0.02 250); border:1px solid oklch(0.30 0.02 250); cursor:pointer; font-size:12px; }
 /* ──── RECIBO (térmica + A4) ──── */
-.sells-cowork .pdv-recibo-overlay { background:oklch(0.30 0.02 250); }
-.sells-cowork .rec-stage { flex:1; overflow:auto; display:flex; justify-content:center; padding:30px; }
-.sells-cowork .rec-layout { display:inline-flex; border:1px solid oklch(0.40 0.02 250); border-radius:6px; overflow:hidden; }
-.sells-cowork .rec-layout button { padding:6px 12px; border:none; background:transparent; color:oklch(0.85 0.02 250); cursor:pointer; font-size:12px; }
 .sells-cowork .rec-layout button.active { background:var(--accent); color:#fff; }
-.sells-cowork .rec-paper { background:#fff; color:#222; padding:20px; }
-.sells-cowork .rec-termica {
-  width:300px; font-family:var(--font-mono);
-  font-size:12px; line-height:1.4;
-}
-.sells-cowork .rec-tx-header { text-align:center; margin-bottom:8px; }
-.sells-cowork .rec-tx-title { font-weight:700; font-size:13px; }
-.sells-cowork .rec-tx-meta { font-size:11px; }
-.sells-cowork .rec-tx-divider { text-align:center; color:#777; }
-.sells-cowork .rec-tx-items { width:100%; font-size:11px; }
-.sells-cowork .rec-tx-prod { padding-top:4px; font-weight:500; }
-.sells-cowork .rec-tx-r { text-align:right; font-weight:600; }
-.sells-cowork .rec-tx-totals { margin-top:8px; }
-.sells-cowork .rec-tx-totals > div { display:flex; justify-content:space-between; }
-.sells-cowork .rec-tx-total { font-weight:700; font-size:14px; padding-top:4px; border-top:1px dashed #999; margin-top:4px; }
-.sells-cowork .rec-tx-pay { margin-top:8px; }
-.sells-cowork .rec-tx-foot { text-align:center; font-size:10px; margin-top:12px; }
-.sells-cowork .rec-tx-barcode { margin-top:8px; font-size:14px; letter-spacing:1px; }
-.sells-cowork .rec-a4 { width:794px; min-height:1100px; padding:60px 70px; font-family:var(--font-sans, sans-serif); }
-.sells-cowork .rec-a4-h { display:flex; justify-content:space-between; align-items:flex-start; padding-bottom:20px; border-bottom:2px solid #222; }
-.sells-cowork .rec-a4-logo { font-size:28px; font-weight:700; letter-spacing:0.04em; }
-.sells-cowork .rec-a4-tag { font-size:12px; color:#666; }
-.sells-cowork .rec-a4-meta { text-align:right; font-size:11px; line-height:1.6; color:#555; }
-.sells-cowork .rec-a4-title { display:flex; justify-content:space-between; align-items:baseline; margin:30px 0 24px; }
-.sells-cowork .rec-a4-title h1 { margin:0; font-size:22px; }
-.sells-cowork .rec-a4-title span { color:#666; font-size:13px; }
-.sells-cowork .rec-a4-block { margin-bottom:24px; }
-.sells-cowork .rec-a4-block h3 { margin:0 0 8px; font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:#888; }
-.sells-cowork .rec-a4-items { width:100%; border-collapse:collapse; font-size:13px; }
-.sells-cowork .rec-a4-items th { background:#f5f5f5; padding:10px 12px; text-align:left; font-size:11px; text-transform:uppercase; letter-spacing:0.04em; color:#555; }
-.sells-cowork .rec-a4-items td { padding:10px 12px; border-bottom:1px solid #eee; }
-.sells-cowork .rec-a4-items th:nth-child(n+2), .sells-cowork .rec-a4-items td:nth-child(n+2) { text-align:right; font-variant-numeric:tabular-nums; }
-.sells-cowork .rec-a4-totals { display:flex; justify-content:flex-end; margin-top:20px; }
-.sells-cowork .rec-a4-totals dl { display:grid; grid-template-columns:auto auto; gap:8px 30px; font-size:14px; }
-.sells-cowork .rec-a4-totals dt { color:#666; }
-.sells-cowork .rec-a4-totals dd { margin:0; text-align:right; font-variant-numeric:tabular-nums; }
-.sells-cowork .rec-a4-total { font-size:20px !important; font-weight:700 !important; padding-top:10px; border-top:2px solid #222; color:#222 !important; }
-.sells-cowork .rec-a4-foot { margin-top:50px; padding-top:20px; border-top:1px dashed #ccc; display:flex; justify-content:space-between; font-size:11px; color:#666; }
 /* ──── NF-e drawer extras ──── */
-.sells-cowork .nfe-cfop { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; margin-bottom:14px; }
-.sells-cowork .nfe-cfop-btn, .sells-cowork .nfe-transp-btn {
-  padding:12px; border:1.5px solid oklch(0.88 0.01 250); border-radius:8px;
-  background:#fff; cursor:pointer; text-align:left; display:flex; flex-direction:column; gap:3px;
-}
 .sells-cowork .nfe-cfop-btn.active, .sells-cowork .nfe-transp-btn.active { border-color:var(--accent); background:oklch(0.97 0.04 var(--accent-h, 220)); }
-.sells-cowork .nfe-cfop-btn strong { font-size:13px; }
-.sells-cowork .nfe-cfop-btn span, .sells-cowork .nfe-transp-btn span { font-size:11px; color:oklch(0.50 0.02 250); }
-.sells-cowork .nfe-tax-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:10px; }
-.sells-cowork .nfe-tax-grid > div { padding:10px 12px; background:oklch(0.97 0.01 250); border-radius:6px; display:flex; flex-direction:column; gap:2px; }
-.sells-cowork .nfe-tax-grid span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
-.sells-cowork .nfe-tax-grid strong { font-size:13px; }
-.sells-cowork .nfe-transp { display:grid; grid-template-columns:repeat(2, 1fr); gap:8px; margin-bottom:14px; }
-.sells-cowork .nfe-review-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:10px; }
-.sells-cowork .nfe-review-card { padding:12px 14px; background:oklch(0.97 0.01 250); border-radius:6px; display:flex; flex-direction:column; gap:3px; }
 .sells-cowork .nfe-review-card.span { grid-column:1 / -1; }
-.sells-cowork .nfe-review-card span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
-.sells-cowork .nfe-review-card strong { font-size:14px; }
 .sells-cowork .nfe-review-card .mono { font-family:var(--font-mono); }
 .sells-cowork .nfe-review-card .small { font-size:10px; word-break:break-all; line-height:1.4; }
-.sells-cowork .nfe-callout {
-  margin-top:14px; padding:12px 14px; border-radius:6px;
-  background:oklch(0.96 0.06 70); border-left:3px solid oklch(0.65 0.14 70);
-  font-size:12px; color:oklch(0.30 0.06 70);
-}
 @media print {
 .sells-cowork body > * { display:none !important; }
-.sells-cowork .pdv-overlay { position:static; background:#fff; color:#000; }
 .sells-cowork .pdv-head, .sells-cowork .rec-layout, .sells-cowork .pdv-close, .sells-cowork .os-btn { display:none !important; }
-.sells-cowork .rec-stage { padding:0; }
-.sells-cowork .rec-paper { box-shadow:none; }
 }
 /* ════════════ OS-page chrome (used by vendas-* and others) ════════════ */
 .sells-cowork .os-head {
@@ -4609,7 +1951,6 @@
 .sells-cowork .os-kpi-label { font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:600; }
 .sells-cowork .os-kpi-value { font-size:22px; font-weight:600; font-variant-numeric:tabular-nums; line-height:1.1; color:var(--text); }
 .sells-cowork .os-kpi-sub { font-size:11px; color:var(--text-dim, oklch(0.55 0.02 250)); }
-.sells-cowork .os-kpi-alert { border-color:oklch(0.75 0.14 70); background:oklch(0.985 0.02 70); }
 .sells-cowork .os-kpi-alert .os-kpi-value { color:oklch(0.50 0.14 70); }
 .sells-cowork .os-tabs {
   display:flex; align-items:center; gap:4px; flex-wrap:wrap;
@@ -4629,13 +1970,6 @@
   color:oklch(0.40 0.02 250);
 }
 .sells-cowork .os-tab.active .count { background:oklch(0.94 0.06 var(--accent-h, 220)); color:var(--accent); }
-.sells-cowork .os-tabs-r { margin-left:auto; padding:4px 0; display:flex; gap:8px; align-items:center; }
-.sells-cowork .os-search {
-  display:inline-flex; align-items:center; gap:6px;
-  padding:5px 10px; border:1px solid var(--border, oklch(0.85 0.02 250));
-  border-radius:6px; background:#fff;
-}
-.sells-cowork .os-search input { border:none; outline:none; background:transparent; font-size:12px; min-width:200px; }
 .sells-cowork .os-table-wrap { padding:14px 24px 20px; overflow:auto; }
 .sells-cowork .os-table {
   width:100%; border-collapse:collapse;
@@ -4654,7 +1988,6 @@
 .sells-cowork .os-row { cursor:pointer; transition:background .1s; }
 .sells-cowork .os-row:hover { background:oklch(0.98 0.01 var(--accent-h, 220)); }
 .sells-cowork .os-row.urgent { box-shadow:inset 3px 0 0 oklch(0.60 0.16 25); }
-.sells-cowork .os-empty { text-align:center; padding:40px; color:var(--text-dim); font-style:italic; }
 .sells-cowork .os-stage {
   display:inline-block; padding:2px 8px; border-radius:10px;
   font-size:11px; font-weight:500;
@@ -4665,10 +1998,8 @@
   background:#fff;
 }
 .sells-cowork .os-drawer-head-l { flex:1; min-width:0; }
-.sells-cowork .os-drawer-id { font-family:var(--font-mono); font-size:11px; color:var(--text-dim); text-transform:uppercase; letter-spacing:0.06em; }
 .sells-cowork .os-drawer-head-l h2 { margin:4px 0 4px; font-size:18px; }
 .sells-cowork .os-drawer-head-l p { margin:0; font-size:12px; color:var(--text-dim); }
-.sells-cowork .os-drawer-head-r { display:flex; align-items:center; gap:8px; }
 .sells-cowork .os-drawer-body { flex:1; overflow:auto; }
 .sells-cowork .icon-btn {
   width:28px; height:28px; border-radius:6px;
@@ -4678,113 +2009,18 @@
 }
 .sells-cowork .icon-btn:hover { background:var(--border-2, oklch(0.95 0.01 250)); color:var(--text); }
 /* Stepper for create/nfe drawers */
-.sells-cowork .vd-stepper {
-  display:flex; align-items:center; gap:0; padding:14px 20px;
-  background:oklch(0.98 0.005 250); border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
-}
-.sells-cowork .vd-step {
-  display:inline-flex; align-items:center; gap:6px;
-  border:none; background:transparent; cursor:pointer;
-  font-size:12px; color:var(--text-dim);
-}
-.sells-cowork .vd-step-num {
-  width:22px; height:22px; border-radius:50%;
-  background:oklch(0.92 0.01 250); color:oklch(0.40 0.02 250);
-  display:inline-flex; align-items:center; justify-content:center;
-  font-size:11px; font-weight:600;
-}
 .sells-cowork .vd-step.active .vd-step-num { background:var(--accent); color:#fff; }
 .sells-cowork .vd-step.active { color:var(--text); font-weight:600; }
 .sells-cowork .vd-step.done .vd-step-num { background:oklch(0.55 0.14 145); color:#fff; }
-.sells-cowork .vd-step-sep { margin:0 10px; color:var(--text-dim); }
 /* ────────────────── Embed (iframe consolidator) ────────────────── */
-.sells-cowork .embed-view {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  background: var(--bg-2, #fafaf9);
-}
-.sells-cowork .embed-view.embed-fs {
-  position: fixed;
-  inset: 0;
-  z-index: 200;
-  background: var(--bg, #fff);
-}
-.sells-cowork .embed-toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  padding: 6px 12px;
-  border-bottom: 1px solid var(--border, #e5e0d3);
-  background: var(--panel, #fff);
-  font-size: 11px;
-  color: var(--text-mute, #8b8580);
-  flex-shrink: 0;
-}
-.sells-cowork .embed-toolbar-l, .sells-cowork .embed-toolbar-r {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.sells-cowork .embed-label {
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  font-weight: 600;
-  font-size: 10px;
-}
-.sells-cowork .embed-src {
-  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 11px;
-  color: var(--text, #1a1917);
-  background: var(--bg-2, #f6f4ef);
-  padding: 2px 6px;
-  border-radius: 3px;
-  border: 1px solid var(--border, #e5e0d3);
-}
-.sells-cowork .embed-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 8px;
-  border-radius: 4px;
-  border: 1px solid var(--border, #e5e0d3);
-  background: var(--panel, #fff);
-  color: var(--text, #1a1917);
-  font-size: 11px;
-  cursor: pointer;
-  text-decoration: none;
-  transition: background .12s, border-color .12s;
-}
-.sells-cowork .embed-btn:hover {
-  background: var(--bg-2, #f6f4ef);
-  border-color: var(--text-mute, #8b8580);
-}
 .sells-cowork .embed-btn.on {
   background: var(--accent-soft, #eaf0f7);
   border-color: var(--accent, #1f3a5f);
   color: var(--accent, #1f3a5f);
 }
-.sells-cowork .embed-iframe {
-  flex: 1;
-  width: 100%;
-  border: 0;
-  background: #fff;
-  display: block;
-}
 /* ────────────────── Sidebar lean ────────────────── */
 .sells-cowork .sb-menu-lean .sb-item {
   margin: 1px 0;
-}
-.sells-cowork .sb-divider {
-  height: 1px;
-  background: var(--border, #e5e0d3);
-  margin: 8px 8px 6px;
-  opacity: 0.6;
-}
-.sells-cowork .sb-group-flat {
-  font-weight: 500;
 }
 .sells-cowork .sb-item .badge.muted {
   background: transparent;
@@ -4812,52 +2048,6 @@
 }
 .sells-cowork .topnav::-webkit-scrollbar { height: 4px; }
 .sells-cowork .topnav::-webkit-scrollbar-thumb { background: var(--border, #e5e0d3); border-radius: 999px; }
-.sells-cowork .topnav-area {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-  padding-right: 12px;
-  border-right: 1px solid var(--border, #e5e0d3);
-}
-.sells-cowork .topnav-area-label {
-  font-size: 10.5px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 600;
-  color: var(--text-mute, #8b8580);
-}
-.sells-cowork .topnav-pills {
-  display: flex;
-  gap: 2px;
-  flex-wrap: nowrap;
-  flex: 1;
-  min-width: 0;
-}
-.sells-cowork .topnav-pill {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  border: 0;
-  background: transparent;
-  padding: 4px 10px;
-  border-radius: 4px;
-  color: var(--text-mute, #8b8580);
-  font-size: 12px;
-  font-family: inherit;
-  cursor: pointer;
-  white-space: nowrap;
-  transition: background .12s, color .12s;
-  position: relative;
-}
-.sells-cowork .topnav-pill svg {
-  opacity: 0.7;
-}
-.sells-cowork .topnav-pill:hover {
-  background: var(--bg-2, #f6f4ef);
-  color: var(--text, #1a1917);
-}
-.sells-cowork .topnav-pill:hover svg { opacity: 1; }
 .sells-cowork .topnav-pill.active {
   color: var(--accent, #1f3a5f);
   font-weight: 600;
@@ -4917,8 +2107,6 @@
   border-left-color: var(--accent);
 }
 /* esconde estilo lean antigo */
-.sells-cowork .sb-divider, .sells-cowork .sb-menu-lean .sb-divider { display: none; }
-.sells-cowork .sb-group-flat { display: none; }
 /* ────────────────── Sidebar collapse / rail / hidden ────────────────── */
 .sells-cowork .sb { position: relative; overflow: visible; }
 /* Alça de colapsar na borda direita */
@@ -4949,30 +2137,6 @@
   color: var(--sb-text-hi);
 }
 /* Alça flutuante para reabrir quando oculta */
-.sells-cowork .sb-reopen-handle {
-  position: fixed;
-  top: 50%;
-  left: 0;
-  transform: translateY(-50%);
-  width: 18px;
-  height: 64px;
-  border-radius: 0 6px 6px 0;
-  border: 1px solid var(--border);
-  border-left: 0;
-  background: var(--bg-elev, var(--bg, #fff));
-  color: var(--text-mute, #777);
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  z-index: 40;
-  padding: 0;
-  box-shadow: 2px 0 8px oklch(0 0 0 / .06);
-}
-.sells-cowork .sb-reopen-handle:hover {
-  width: 26px;
-  color: var(--text, #111);
-  background: var(--accent-soft, var(--sb-active));
-}
 /* ── Sidebar em modo RAIL ── */
 .sells-cowork .sb--rail {
   overflow: visible;
@@ -5043,18 +2207,6 @@
 .sells-cowork .sb-rail-btn.sb-rail-group.active .ic, .sells-cowork .sb-rail-btn.sb-rail-group.open .ic {
   filter: brightness(1.15);
 }
-.sells-cowork .sb-rail-group-pill {
-  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
-  font-size: 9.5px;
-  font-weight: 700;
-  color: #fff;
-  letter-spacing: 0.02em;
-  width: 24px;
-  height: 22px;
-  border-radius: 5px;
-  display: grid;
-  place-items: center;
-}
 .sells-cowork .sb-rail-dot-badge {
   position: absolute;
   top: 8px;
@@ -5080,13 +2232,6 @@
   border-radius: 50%;
 }
 /* Dropdown de empresa quando em rail (alinhado à direita do rail) */
-.sells-cowork .sb-dd-rail {
-  left: calc(100% + 8px);
-  top: 0;
-  right: auto;
-  width: 220px;
-  z-index: 50;
-}
 /* Tooltip via data-tip (somente no rail) */
 .sells-cowork .sb--rail [data-tip] {
   position: relative;
@@ -5560,190 +2705,35 @@
 .sells-cowork .vd-drawer-aplus .os-drawer-head {
   align-items: flex-start;
 }
-.sells-cowork .vd-drawer-aplus .os-drawer-head-r {
-  display: flex; align-items: center; gap: 10px;
-}
-.sells-cowork .vd-drawer-aplus .vd-drawer-total {
-  font-family: var(--font-mono); font-size: 18px;
-  font-weight: 700; letter-spacing: -0.01em;
-  color: var(--text);
-}
 /* drawer tabs */
-.sells-cowork .vd-drawer-aplus .vd-drawer-tabs {
-  display: flex; gap: 0;
-  border-bottom: 1px solid var(--border);
-  padding: 0 24px;
-  background: var(--surface);
-}
-.sells-cowork .vd-drawer-aplus .vd-drawer-tab {
-  border: 0; background: transparent;
-  padding: 10px 14px; margin-bottom: -1px;
-  font: inherit; cursor: pointer;
-  color: var(--text-mute); font-weight: 500; font-size: 12.5px;
-  border-bottom: 2px solid transparent;
-  display: inline-flex; align-items: center; gap: 6px;
-}
-.sells-cowork .vd-drawer-aplus .vd-drawer-tab:hover { color: var(--text); }
 .sells-cowork .vd-drawer-aplus .vd-drawer-tab.on {
   color: var(--vd-green);
   border-bottom-color: var(--vd-green);
   font-weight: 600;
 }
-.sells-cowork .vd-drawer-aplus .vd-drawer-tab-ct {
-  font-family: var(--font-mono); font-size: 10px;
-  background: var(--bg-2); color: var(--text-mute);
-  padding: 1px 6px; border-radius: 99px; font-weight: 600;
-}
 .sells-cowork .vd-drawer-aplus .vd-drawer-tab.on .vd-drawer-tab-ct {
   background: var(--vd-green-soft); color: var(--vd-green);
 }
-.sells-cowork .vd-drawer-aplus .vd-drawer-body {
-  background: var(--bg-2);
-}
-.sells-cowork .vd-drawer-aplus .vd-drawer-body .vd-section h3 {
-  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--text-dim); font-weight: 700; margin: 0 0 10px;
-}
 /* Itens cards */
-.sells-cowork .vd-drawer-aplus .vd-items-cards {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 8px; overflow: hidden;
-}
-.sells-cowork .vd-drawer-aplus .vd-item-card {
-  display: grid; grid-template-columns: 1fr 50px 90px 110px;
-  align-items: center; gap: 12px;
-  padding: 10px 14px;
-  border-bottom: 1px solid var(--border-2); font-size: 12.5px;
-}
-.sells-cowork .vd-drawer-aplus .vd-item-card:last-child { border-bottom: 0; }
-.sells-cowork .vd-drawer-aplus .vd-item-c-l b { display: block; font-weight: 600; }
-.sells-cowork .vd-drawer-aplus .vd-item-c-l small { font-size: 11px; color: var(--text-mute); }
-.sells-cowork .vd-drawer-aplus .vd-item-c-qty, .sells-cowork .vd-drawer-aplus .vd-item-c-unit, .sells-cowork .vd-drawer-aplus .vd-item-c-sub {
-  text-align: right; font-family: var(--font-mono); font-variant-numeric: tabular-nums;
-}
-.sells-cowork .vd-drawer-aplus .vd-item-c-sub { font-weight: 700; }
-.sells-cowork .vd-drawer-aplus .vd-items-foot {
-  display: flex; justify-content: flex-end; gap: 14px;
-  padding: 14px 4px 0;
-  font-family: var(--font-mono); font-size: 13px;
-}
-.sells-cowork .vd-drawer-aplus .vd-items-foot span { color: var(--text-mute); }
-.sells-cowork .vd-drawer-aplus .vd-items-foot b { font-weight: 700; font-size: 16px; letter-spacing: -0.01em; }
 /* Emit panel */
-.sells-cowork .vd-drawer-aplus .vd-emit {
-  background: var(--vd-green-soft);
-  border: 1px dashed var(--vd-green);
-  border-radius: 8px; padding: 14px 16px;
-  display: flex; align-items: center; gap: 12px;
-  margin-bottom: 12px;
-}
-.sells-cowork .vd-drawer-aplus .vd-emit > div b { display: block; font-size: 13px; color: var(--vd-green); }
-.sells-cowork .vd-drawer-aplus .vd-emit > div small { font-size: 11.5px; color: var(--text-dim); }
 .sells-cowork .vd-drawer-aplus .vd-emit .os-btn { margin-left: auto; flex-shrink: 0; }
 /* Sub-tabs fiscal */
-.sells-cowork .vd-drawer-aplus .vd-fsub {
-  display: inline-flex; gap: 2px;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 6px; padding: 2px; margin-bottom: 12px;
-}
-.sells-cowork .vd-drawer-aplus .vd-fsub button {
-  border: 0; background: transparent;
-  padding: 4px 10px; font-size: 11px; font-weight: 600;
-  border-radius: 4px; color: var(--text-mute);
-  display: inline-flex; align-items: center; gap: 5px;
-  font-family: inherit; cursor: pointer;
-}
 .sells-cowork .vd-drawer-aplus .vd-fsub button.on { background: var(--bg-2); color: var(--text); }
-.sells-cowork .vd-drawer-aplus .vd-fsub button span {
-  font-family: var(--font-mono); font-size: 9.5px;
-  background: var(--border-2); padding: 0 4px; border-radius: 99px;
-}
 /* Fiscal card grid */
-.sells-cowork .vd-drawer-aplus .vd-fcard-grid {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
-}
 .sells-cowork .vd-drawer-aplus .vd-fcard-grid.single {
   grid-template-columns: 1fr; max-width: 500px;
 }
 /* Fiscal card */
-.sells-cowork .vd-drawer-aplus .vd-fcard {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 8px; padding: 14px 16px;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-h {
-  display: flex; align-items: center; gap: 8px;
-  margin-bottom: 10px;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-h h4 {
-  margin: 0; font-size: 13px; font-weight: 700;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-date {
-  margin-left: auto;
-  font-size: 11px; color: var(--text-mute);
-  font-family: var(--font-mono);
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-date span { margin-left: 4px; }
-.sells-cowork .vd-drawer-aplus .vd-fcard-fail {
-  margin-bottom: 12px; padding: 10px 12px;
-  background: var(--vd-bad-soft); border-radius: 5px;
-  border-left: 3px solid var(--vd-bad);
-  font-size: 11.5px; color: oklch(0.32 0.12 25);
-}
 .sells-cowork .vd-drawer-aplus .vd-fcard-fail.neutral {
   background: var(--vd-neutral-soft);
   border-left-color: var(--vd-neutral);
   color: var(--text-dim);
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-fail b { display: block; margin-bottom: 2px; }
-.sells-cowork .vd-drawer-aplus .vd-fcard-meta {
-  display: grid; grid-template-columns: 80px 1fr;
-  gap: 4px 12px; font-size: 11.5px; margin: 0;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-meta dt { color: var(--text-mute); }
-.sells-cowork .vd-drawer-aplus .vd-fcard-meta dd { margin: 0; font-family: var(--font-mono); }
-.sells-cowork .vd-drawer-aplus .vd-fcard-chave {
-  display: flex; align-items: center; gap: 6px;
-  margin-top: 12px; padding: 8px 10px;
-  background: var(--bg-2); border-radius: 5px;
-  font-family: var(--font-mono); font-size: 11px;
-  color: var(--text-dim);
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-chave-num {
-  letter-spacing: 0.04em; flex: 1;
-  word-break: break-all;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-copy {
-  background: transparent; border: 1px solid var(--border);
-  padding: 3px 8px; border-radius: 4px; font-size: 10.5px;
-  color: var(--text-dim); font-family: var(--font-sans);
-  flex-shrink: 0; cursor: pointer;
 }
 .sells-cowork .vd-drawer-aplus .vd-fcard-copy.copied {
   background: var(--vd-ok-soft); color: oklch(0.36 0.10 145);
   border-color: transparent;
 }
 /* Timeline SEFAZ horizontal */
-.sells-cowork .vd-drawer-aplus .vd-fcard-tl {
-  margin-top: 12px;
-  display: flex; gap: 0; align-items: flex-start;
-  padding: 10px 0;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-step {
-  flex: 1; display: flex; flex-direction: column;
-  align-items: center; gap: 4px; position: relative;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-step::before {
-  content: ''; position: absolute; top: 9px; left: -50%; right: 50%;
-  height: 2px; background: var(--border-2); z-index: 0;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-step:first-child::before { display: none; }
-.sells-cowork .vd-drawer-aplus .vd-fcard-step-d {
-  width: 18px; height: 18px; border-radius: 50%;
-  background: var(--surface); border: 2px solid var(--border-2);
-  display: grid; place-items: center;
-  font-size: 9px; font-weight: 700; color: var(--text-mute);
-  z-index: 1;
-}
 .sells-cowork .vd-drawer-aplus .vd-fcard-step.done .vd-fcard-step-d {
   background: var(--vd-green); border-color: var(--vd-green); color: #fff;
 }
@@ -5751,102 +2741,11 @@
 .sells-cowork .vd-drawer-aplus .vd-fcard-step.failed .vd-fcard-step-d {
   background: var(--vd-bad); border-color: var(--vd-bad); color: #fff;
 }
-.sells-cowork .vd-drawer-aplus .vd-fcard-step-l {
-  font-size: 9.5px; color: var(--text-mute); text-align: center;
-  font-family: var(--font-mono);
-  text-transform: uppercase; letter-spacing: 0.02em;
-  line-height: 1.2;
-}
 .sells-cowork .vd-drawer-aplus .vd-fcard.failed .vd-fcard-step.done .vd-fcard-step-d { background: var(--vd-bad); border-color: var(--vd-bad); }
 .sells-cowork .vd-drawer-aplus .vd-fcard.failed .vd-fcard-step.done::before { background: var(--vd-bad); }
-.sells-cowork .vd-drawer-aplus .vd-fcard-cce {
-  margin-top: 10px; padding-top: 10px;
-  border-top: 1px solid var(--border-2);
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-cce summary {
-  cursor: pointer; font-size: 11px;
-  color: var(--vd-green); font-weight: 600;
-  user-select: none;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-cce summary:hover { color: var(--vd-green-2); }
-.sells-cowork .vd-drawer-aplus .vd-fcard-cce p {
-  margin: 8px 0 0; font-size: 11.5px; color: var(--text-dim);
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-ctas {
-  display: flex; gap: 6px; margin-top: 14px;
-  padding-top: 12px; border-top: 1px solid var(--border-2);
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-cta {
-  flex: 1; padding: 6px 8px; font-size: 11px;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 4px; color: var(--text-dim);
-  display: inline-flex; align-items: center; justify-content: center; gap: 4px;
-  font-family: inherit; cursor: pointer;
-}
-.sells-cowork .vd-drawer-aplus .vd-fcard-cta:hover { border-color: var(--text-mute); color: var(--text); }
 /* Breakdown box */
-.sells-cowork .vd-drawer-aplus .vd-fbreak {
-  margin-top: 16px; padding: 14px 16px;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 8px;
-}
-.sells-cowork .vd-drawer-aplus .vd-fbreak h4 {
-  margin: 0 0 8px;
-  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
-  color: var(--text-dim); font-weight: 700;
-}
-.sells-cowork .vd-drawer-aplus .vd-fbreak dl {
-  margin: 0; display: grid; grid-template-columns: 1fr auto;
-  gap: 4px 12px; font-size: 12.5px;
-}
-.sells-cowork .vd-drawer-aplus .vd-fbreak dt { color: var(--text-dim); }
-.sells-cowork .vd-drawer-aplus .vd-fbreak dd { margin: 0; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
-.sells-cowork .vd-drawer-aplus .vd-fbreak dt.tot, .sells-cowork .vd-drawer-aplus .vd-fbreak dd.tot {
-  border-top: 1px solid var(--border-2); padding-top: 8px; margin-top: 4px;
-  font-weight: 700; font-size: 13px;
-}
-.sells-cowork .vd-drawer-aplus .vd-fbreak dd.tot { color: var(--text); }
 /* Payment tab */
-.sells-cowork .vd-drawer-aplus .vd-pay-meta {
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 8px; padding: 14px 16px;
-}
-.sells-cowork .vd-drawer-aplus .vd-pay-meta dl {
-  display: grid; grid-template-columns: 100px 1fr;
-  gap: 6px 12px; margin: 0; font-size: 12.5px;
-}
-.sells-cowork .vd-drawer-aplus .vd-pay-meta dt { color: var(--text-mute); font-size: 11.5px; }
-.sells-cowork .vd-drawer-aplus .vd-pay-meta dd { margin: 0; }
-.sells-cowork .vd-drawer-aplus .vd-pay-meta .vd-comm {
-  color: var(--vd-green); font-weight: 700; font-family: var(--font-mono);
-}
-.sells-cowork .vd-drawer-aplus .vd-pay-meta .vd-comm small { color: var(--text-mute); font-weight: 500; }
 /* Timeline tab */
-.sells-cowork .vd-drawer-aplus .vd-tline {
-  position: relative; padding-left: 18px;
-  background: var(--surface); border: 1px solid var(--border);
-  border-radius: 8px; padding: 14px 14px 14px 32px;
-}
-.sells-cowork .vd-drawer-aplus .vd-tline::before {
-  content: ''; position: absolute; left: 20px; top: 22px; bottom: 22px;
-  width: 2px; background: var(--border-2);
-}
-.sells-cowork .vd-drawer-aplus .vd-tline-it {
-  position: relative; padding: 6px 0;
-}
-.sells-cowork .vd-drawer-aplus .vd-tline-it::before {
-  content: ''; position: absolute; left: -18px; top: 10px;
-  width: 8px; height: 8px; border-radius: 50%;
-  background: var(--vd-green); border: 2px solid var(--surface);
-  box-shadow: 0 0 0 1px var(--vd-green);
-}
-.sells-cowork .vd-drawer-aplus .vd-tline-it small {
-  color: var(--text-mute); font-size: 11px;
-  font-family: var(--font-mono);
-}
-.sells-cowork .vd-drawer-aplus .vd-tline-it b {
-  display: block; font-size: 12.5px; font-weight: 600;
-}
 /* responsive — KPIs em 2 cols se viewport apertado */
 @media (max-width: 1180px) {
 .sells-cowork .vendas-aplus .vd-kpis { grid-template-columns: repeat(2, 1fr); }
@@ -6137,9 +3036,6 @@
   --vd-ai-text: oklch(0.32 0.18 295);
 }
 /* ── Tab IA no drawer ── */
-.sells-cowork .vd-drawer-aplus .vd-drawer-tab.vd-tab-ai {
-  color: var(--vd-ai); font-weight: 600;
-}
 .sells-cowork .vd-drawer-aplus .vd-drawer-tab.vd-tab-ai.on {
   background: var(--vd-ai-soft);
   border-bottom-color: var(--vd-ai);
@@ -6258,57 +3154,10 @@
   font-family: var(--font-mono); font-size: 11.5px;
 }
 /* ── História: stats grid ── */
-.sells-cowork .vd-ai-history { margin-bottom: 4px; }
-.sells-cowork .vd-ai-stats {
-  display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
-  margin-bottom: 10px;
-}
-.sells-cowork .vd-ai-stat {
-  background: var(--bg-2);
-  border-radius: 6px;
-  padding: 8px 10px;
-  position: relative;
-}
 .sells-cowork .vd-ai-stat.full { grid-column: 1 / -1; }
-.sells-cowork .vd-ai-stat small {
-  display: block; font-size: 9.5px; font-weight: 700;
-  letter-spacing: 0.05em; text-transform: uppercase;
-  color: var(--text-mute); margin-bottom: 3px;
-}
-.sells-cowork .vd-ai-stat b {
-  font-family: var(--font-mono);
-  font-size: 13.5px; font-weight: 700;
-  letter-spacing: -0.01em;
-}
-.sells-cowork .vd-ai-tag {
-  position: absolute; top: 6px; right: 6px;
-  font-size: 9px; font-weight: 700; letter-spacing: 0.05em;
-  text-transform: uppercase;
-  padding: 1px 5px; border-radius: 99px;
-}
 .sells-cowork .vd-ai-tag.new {
   background: var(--vd-ai); color: white;
 }
-.sells-cowork .vd-ai-prods {
-  margin: 10px 0 12px;
-  background: white;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 8px 10px;
-}
-.sells-cowork .vd-ai-prods > small {
-  display: block; font-size: 9.5px; font-weight: 700;
-  letter-spacing: 0.05em; text-transform: uppercase;
-  color: var(--text-mute); margin-bottom: 6px;
-}
-.sells-cowork .vd-ai-prods ul { list-style: none; margin: 0; padding: 0; }
-.sells-cowork .vd-ai-prods li {
-  display: grid; grid-template-columns: 40px 1fr auto;
-  gap: 8px; padding: 4px 0; font-size: 12px;
-  border-top: 1px solid var(--border-2);
-  align-items: center;
-}
-.sells-cowork .vd-ai-prods li:first-child { border-top: none; }
 .sells-cowork .vd-ai-prods .ct {
   font-family: var(--font-mono); font-size: 11px; font-weight: 600;
   color: var(--vd-ai); background: var(--vd-ai-soft);
@@ -6343,15 +3192,6 @@
   color: var(--text-dim);
   padding-left: 40px;
 }
-.sells-cowork .vd-ai-suggest-cta {
-  align-self: flex-start;
-  margin-left: 40px; margin-top: 6px;
-  background: white; color: var(--vd-ai);
-  border: 1px solid var(--vd-ai-border);
-  padding: 5px 10px; border-radius: 5px;
-  font-size: 11.5px; font-weight: 600; cursor: pointer;
-}
-.sells-cowork .vd-ai-suggest-cta:hover { background: var(--vd-ai-soft); }
 /* ── Empty-state IA no ⌘K palette ── */
 .sells-cowork .vendas-aplus .vd-pal-ai-wrap {
   padding: 8px;
@@ -6438,26 +3278,12 @@
   padding-top: 6px;
 }
 /* ── Responsive: stats grid IA cai pra 2 cols ── */
-@media (max-width: 900px) {
-.sells-cowork .vd-ai-stats { grid-template-columns: 1fr 1fr; }
-}
 /* ═══════════════════════════════════════════════════════════════════
    VENDAS · REFINO #3 KB-9.75 · CURADORIA + GUIA (2026-05-15)
    Comentários inline · histórico edições · troubleshooter · cross-link
    ═══════════════════════════════════════════════════════════════════ */
 /* ── Header note linkificada ── */
-.sells-cowork .vd-drawer-aplus .vd-drawer-note {
-  margin: 4px 0 6px !important;
-  font-size: 12.5px; color: var(--text-dim);
-  line-height: 1.45;
-}
 /* ── Tab counter comentários ── */
-.sells-cowork .vd-drawer-aplus .vd-drawer-tab-cmt {
-  margin-left: 4px;
-  font-size: 10px; font-weight: 600;
-  background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240);
-  padding: 1px 5px; border-radius: 99px;
-}
 /* ── Item card com comentários inline ── */
 .sells-cowork .vd-drawer-aplus .vd-item-cur {
   display: flex; flex-direction: column;
@@ -6628,34 +3454,6 @@
 .sells-cowork .vd-drawer-aplus .vd-audit-diff .diff-pct.pos { color: oklch(0.50 0.13 145); }
 .sells-cowork .vd-drawer-aplus .vd-audit-diff .diff-pct.neg { color: var(--vd-bad); }
 /* ── Troubleshooter button ── */
-.sells-cowork .vd-drawer-aplus .vd-trouble-btn {
-  display: inline-flex; align-items: center; gap: 8px;
-  background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60);
-  border: 1px solid oklch(0.85 0.10 60);
-  padding: 5px 10px 5px 5px; border-radius: 6px;
-  font-family: inherit; font-size: 11.5px; font-weight: 600;
-  cursor: pointer;
-  margin-right: auto;
-  transition: all .12s;
-}
-.sells-cowork .vd-drawer-aplus .vd-trouble-btn:hover {
-  background: oklch(0.93 0.08 60);
-  border-color: oklch(0.72 0.13 60);
-}
-.sells-cowork .vd-drawer-aplus .vd-trouble-ic {
-  display: grid; place-items: center;
-  width: 22px; height: 22px;
-  background: oklch(0.62 0.13 60); color: white;
-  border-radius: 4px;
-  font-size: 14px; font-weight: 700;
-}
-.sells-cowork .vd-drawer-aplus .vd-trouble-lbl { font-size: 12px; }
-.sells-cowork .vd-drawer-aplus .vd-trouble-lbl b { font-weight: 700; }
-.sells-cowork .vd-drawer-aplus .vd-trouble-ct {
-  font-family: var(--font-mono); font-size: 9.5px;
-  background: white; color: var(--text-mute);
-  padding: 1px 6px; border-radius: 99px;
-}
 /* ── Cross-link pills (#V #OS #CLI #orc) ── */
 .sells-cowork .vd-link {
   display: inline-flex; align-items: center;
@@ -6688,318 +3486,24 @@
   color: var(--text-mute); margin-left: 4px;
 }
 /* ── Botão Apresentar no drawer footer ── */
-.sells-cowork .vd-drawer-aplus .vd-btn-present {
-  color: oklch(0.42 0.13 295); font-weight: 600;
-}
-.sells-cowork .vd-drawer-aplus .vd-btn-present:hover {
-  background: oklch(0.96 0.05 295);
-  color: oklch(0.32 0.18 295);
-}
 /* ══════════════════════════════════════════
    TRANSCRIPT PDF — overlay + print layout
    ══════════════════════════════════════════ */
-.sells-cowork .vd-trans-bd {
-  position: fixed; inset: 0; z-index: 1100;
-  background: oklch(0.3 0.005 240 / 0.6);
-  overflow: auto; padding: 0;
-}
-.sells-cowork .vd-trans-toolbar {
-  position: sticky; top: 0; z-index: 10;
-  background: var(--surface);
-  border-bottom: 1px solid var(--border);
-  padding: 10px 18px;
-  display: flex; align-items: center; gap: 14px;
-}
-.sells-cowork .vd-trans-toolbar .vd-trans-tag {
-  flex: 1; text-align: center;
-  font-size: 12px; color: var(--text-dim);
-  font-family: var(--font-mono);
-}
-.sells-cowork .vd-trans-page {
-  background: white; color: #1a1a1a;
-  width: 794px; /* A4 ~96dpi */
-  min-height: 1123px;
-  margin: 24px auto;
-  padding: 50px 60px 80px;
-  box-shadow: 0 8px 40px rgba(0,0,0,0.15);
-  font-family: var(--font-sans);
-  font-size: 12px; line-height: 1.55;
-}
-.sells-cowork .vd-trans-h {
-  display: flex; justify-content: space-between;
-  align-items: flex-start;
-  padding-bottom: 18px;
-  border-bottom: 2px solid #1a1a1a;
-  margin-bottom: 22px;
-}
-.sells-cowork .vd-trans-brand {
-  font-size: 22px; font-weight: 800; letter-spacing: -0.02em;
-}
-.sells-cowork .vd-trans-brand-sub {
-  font-size: 11px; font-weight: 500; color: #555;
-  letter-spacing: 0.04em; text-transform: uppercase;
-}
-.sells-cowork .vd-trans-meta-co { text-align: right; font-size: 10.5px; color: #555; line-height: 1.5; }
-.sells-cowork .vd-trans-title { margin-bottom: 24px; }
-.sells-cowork .vd-trans-title h1 {
-  margin: 0 0 4px; font-size: 22px; font-weight: 700;
-  letter-spacing: -0.015em;
-}
-.sells-cowork .vd-trans-title h1 small {
-  font-family: var(--font-mono);
-  font-size: 14px; color: #777;
-  margin-left: 8px;
-}
-.sells-cowork .vd-trans-title span { font-size: 10.5px; color: #777; }
-.sells-cowork .vd-trans-grid {
-  display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px;
-  margin-bottom: 24px;
-}
-.sells-cowork .vd-trans-block {
-  border: 1px solid #d8d8d8; border-radius: 4px;
-  padding: 10px 14px;
-}
-.sells-cowork .vd-trans-block small {
-  display: block;
-  font-size: 9.5px; font-weight: 700;
-  text-transform: uppercase; letter-spacing: 0.06em;
-  color: #888; margin-bottom: 4px;
-}
-.sells-cowork .vd-trans-block h3 {
-  margin: 0 0 4px; font-size: 14px; font-weight: 700;
-}
-.sells-cowork .vd-trans-block p {
-  margin: 0; font-size: 11px; color: #555;
-}
-.sells-cowork .vd-trans-block.vd-trans-total {
-  background: #f4f4f0;
-  border-color: #1a1a1a;
-}
-.sells-cowork .vd-trans-block.vd-trans-total h3 { font-family: var(--font-mono); font-size: 18px; }
-.sells-cowork .vd-trans-section {
-  margin-bottom: 24px; page-break-inside: avoid;
-}
-.sells-cowork .vd-trans-section h2 {
-  margin: 0 0 10px;
-  font-size: 13px; font-weight: 700; letter-spacing: -0.005em;
-  padding-bottom: 4px;
-  border-bottom: 1px solid #1a1a1a;
-}
-.sells-cowork .vd-trans-items, .sells-cowork .vd-trans-fiscal, .sells-cowork .vd-trans-audit {
-  width: 100%; border-collapse: collapse; font-size: 11px;
-}
-.sells-cowork .vd-trans-items th, .sells-cowork .vd-trans-items td, .sells-cowork .vd-trans-fiscal th, .sells-cowork .vd-trans-fiscal td, .sells-cowork .vd-trans-audit th, .sells-cowork .vd-trans-audit td {
-  border-bottom: 1px solid #e8e8e8;
-  padding: 6px 8px; text-align: left; vertical-align: top;
-}
-.sells-cowork .vd-trans-items thead th {
-  background: #f4f4f0;
-  font-size: 9.5px; font-weight: 700;
-  text-transform: uppercase; letter-spacing: 0.05em; color: #555;
-}
 .sells-cowork .vd-trans-items .num, .sells-cowork .vd-trans-fiscal .num { text-align: right; font-variant-numeric: tabular-nums; }
 .sells-cowork .vd-trans-items .strong, .sells-cowork .vd-trans-fiscal .strong { font-weight: 700; }
 .sells-cowork .vd-trans-items .mono, .sells-cowork .vd-trans-fiscal .mono, .sells-cowork .vd-trans-audit .mono { font-family: var(--font-mono); font-size: 10px; }
-.sells-cowork .vd-trans-items tfoot td { border-top: 2px solid #1a1a1a; padding-top: 8px; font-weight: 600; }
-.sells-cowork .vd-trans-fiscal th {
-  width: 130px;
-  background: #f4f4f0;
-  font-weight: 600;
-  border-right: 1px solid #e8e8e8;
-}
 .sells-cowork .vd-trans-fiscal .small { font-size: 9.5px; color: #888; margin-top: 2px; }
 .sells-cowork .vd-trans-fiscal .fail { color: oklch(0.45 0.18 25); margin-top: 4px; }
-.sells-cowork .vd-trans-comment-block { margin-bottom: 12px; }
-.sells-cowork .vd-trans-comment-item {
-  display: block; font-size: 11.5px; font-weight: 600; color: #1a1a1a;
-  background: #f4f4f0;
-  padding: 4px 8px; margin-bottom: 4px;
-  border-left: 3px solid #888;
-}
-.sells-cowork .vd-trans-comment {
-  padding: 6px 12px; border-bottom: 1px dashed #e0e0e0;
-}
 .sells-cowork .vd-trans-comment .mono { font-family: var(--font-mono); font-size: 9.5px; color: #888; }
-.sells-cowork .vd-trans-comment p { margin: 2px 0 0; font-size: 11px; }
-.sells-cowork .vd-trans-sign {
-  display: grid; grid-template-columns: 1fr 1fr; gap: 60px;
-  margin-top: 60px; margin-bottom: 24px;
-}
-.sells-cowork .vd-trans-sign-line {
-  border-top: 1px solid #1a1a1a;
-  margin-bottom: 6px;
-}
-.sells-cowork .vd-trans-sign small {
-  font-size: 10px; color: #555;
-}
-.sells-cowork .vd-trans-foot {
-  text-align: center;
-  border-top: 1px solid #d8d8d8;
-  padding-top: 12px; margin-top: 20px;
-  font-size: 9.5px; color: #888;
-}
 /* @media print — só mostra o transcript */
-@media print {
-.sells-cowork body.vd-print-mode > *:not(.vd-trans-bd) { display: none !important; }
-.sells-cowork body.vd-print-mode .vd-trans-bd {
-    position: static !important; background: white !important; padding: 0 !important; overflow: visible !important;
-  }
-.sells-cowork body.vd-print-mode .vd-trans-toolbar { display: none !important; }
-.sells-cowork body.vd-print-mode .vd-trans-page {
-    margin: 0 !important; box-shadow: none !important; width: 100% !important;
-    padding: 0 24px !important;
-  }
-}
 /* ══════════════════════════════════════════
    MODO APRESENTAÇÃO — fullscreen
    ══════════════════════════════════════════ */
-.sells-cowork .vd-pres-overlay {
-  position: fixed; inset: 0; z-index: 1200;
-  background: linear-gradient(135deg, oklch(0.16 0.005 240), oklch(0.20 0.01 200));
-  color: white;
-  display: flex; flex-direction: column;
-  animation: vdPresFade 0.25s ease-out;
-}
 @keyframes vdPresFade { from { opacity: 0; } to { opacity: 1; } }
-.sells-cowork .vd-pres-top {
-  display: flex; align-items: center; gap: 14px;
-  padding: 16px 28px;
-  border-bottom: 1px solid oklch(1 0 0 / 0.08);
-}
-.sells-cowork .vd-pres-brand {
-  flex: 1;
-  font-size: 11px; font-weight: 700;
-  letter-spacing: 0.15em; text-transform: uppercase;
-  color: oklch(1 0 0 / 0.5);
-}
-.sells-cowork .vd-pres-counter {
-  font-family: var(--font-mono);
-  font-size: 11.5px; color: oklch(1 0 0 / 0.5);
-}
-.sells-cowork .vd-pres-close {
-  background: transparent; border: 1px solid oklch(1 0 0 / 0.2);
-  color: white; width: 32px; height: 32px;
-  border-radius: 6px; cursor: pointer;
-  font-size: 18px; line-height: 1;
-}
-.sells-cowork .vd-pres-close:hover { background: oklch(1 0 0 / 0.08); }
-.sells-cowork .vd-pres-stage {
-  flex: 1;
-  display: grid; place-items: center;
-  padding: 40px 80px;
-}
-.sells-cowork .vd-pres-slide { max-width: 900px; width: 100%; text-align: center; }
-.sells-cowork .vd-pres-eyebrow {
-  display: block;
-  font-size: 13px; font-weight: 600;
-  letter-spacing: 0.10em; text-transform: uppercase;
-  color: oklch(0.65 0.13 145);
-  margin-bottom: 16px;
-}
-.sells-cowork .vd-pres-slide h1 {
-  font-size: 64px; font-weight: 700;
-  letter-spacing: -0.025em; line-height: 1.05;
-  margin: 0 0 18px;
-}
-.sells-cowork .vd-pres-slide > p {
-  font-size: 22px; font-weight: 400; line-height: 1.45;
-  color: oklch(1 0 0 / 0.7); max-width: 700px; margin: 0 auto;
-}
-.sells-cowork .vd-pres-chips {
-  display: flex; gap: 10px; justify-content: center; margin-top: 36px; flex-wrap: wrap;
-}
-.sells-cowork .vd-pres-chip {
-  background: oklch(1 0 0 / 0.08);
-  border: 1px solid oklch(1 0 0 / 0.12);
-  border-radius: 99px;
-  padding: 8px 18px;
-  font-size: 14px; font-weight: 500;
-}
 .sells-cowork .vd-pres-chip.primary {
   background: oklch(0.50 0.14 155);
   border-color: oklch(0.55 0.14 155);
   color: white;
-}
-.sells-cowork .vd-pres-items ul {
-  list-style: none; margin: 28px 0 0; padding: 0;
-  text-align: left;
-  display: flex; flex-direction: column; gap: 14px;
-}
-.sells-cowork .vd-pres-items li {
-  display: flex; align-items: center; gap: 20px;
-  padding: 20px 26px;
-  background: oklch(1 0 0 / 0.05);
-  border: 1px solid oklch(1 0 0 / 0.08);
-  border-radius: 12px;
-}
-.sells-cowork .vd-pres-item-l { flex: 1; }
-.sells-cowork .vd-pres-item-l b { display: block; font-size: 22px; font-weight: 600; margin-bottom: 4px; }
-.sells-cowork .vd-pres-item-l small { font-size: 14px; color: oklch(1 0 0 / 0.55); }
-.sells-cowork .vd-pres-item-r {
-  font-family: var(--font-mono);
-  font-size: 26px; font-weight: 700;
-}
-.sells-cowork .vd-pres-amount {
-  font-family: var(--font-mono);
-  font-size: 96px; font-weight: 700;
-  letter-spacing: -0.03em; line-height: 1;
-  color: oklch(0.85 0.10 145);
-  margin: 12px 0 32px;
-}
-.sells-cowork .vd-pres-payment {
-  display: flex; justify-content: space-between; align-items: center;
-  max-width: 500px; margin: 12px auto;
-  padding: 14px 24px;
-  background: oklch(1 0 0 / 0.05);
-  border-radius: 10px;
-  font-size: 18px;
-}
-.sells-cowork .vd-pres-payment span { color: oklch(1 0 0 / 0.5); }
-.sells-cowork .vd-pres-payment b { font-weight: 600; }
-.sells-cowork .vd-pres-next ol {
-  text-align: left; max-width: 600px; margin: 28px auto 0;
-  padding: 0; list-style: none; counter-reset: pres;
-}
-.sells-cowork .vd-pres-next li {
-  counter-increment: pres;
-  padding: 16px 0 16px 56px;
-  font-size: 22px;
-  border-top: 1px solid oklch(1 0 0 / 0.08);
-  position: relative;
-}
-.sells-cowork .vd-pres-next li::before {
-  content: counter(pres);
-  position: absolute; left: 0; top: 14px;
-  width: 36px; height: 36px; border-radius: 50%;
-  background: oklch(0.50 0.14 155); color: white;
-  display: grid; place-items: center;
-  font-family: var(--font-mono); font-size: 14px; font-weight: 700;
-}
-.sells-cowork .vd-pres-next li:first-child { border-top: none; }
-.sells-cowork .vd-pres-foot-note {
-  margin-top: 32px;
-  font-size: 14px; color: oklch(1 0 0 / 0.5);
-}
-.sells-cowork .vd-pres-bot {
-  display: flex; align-items: center; gap: 18px; justify-content: center;
-  padding: 20px 28px;
-  border-top: 1px solid oklch(1 0 0 / 0.08);
-}
-.sells-cowork .vd-pres-bot button {
-  background: oklch(1 0 0 / 0.08);
-  border: 1px solid oklch(1 0 0 / 0.12);
-  color: white;
-  width: 44px; height: 44px;
-  border-radius: 8px;
-  font-size: 18px; cursor: pointer;
-}
-.sells-cowork .vd-pres-bot button:hover:not(:disabled) { background: oklch(1 0 0 / 0.16); }
-.sells-cowork .vd-pres-bot button:disabled { opacity: 0.3; cursor: not-allowed; }
-.sells-cowork .vd-pres-dots { display: flex; gap: 8px; }
-.sells-cowork .vd-pres-dot {
-  width: 8px; height: 8px; border-radius: 50%;
-  background: oklch(1 0 0 / 0.2); cursor: pointer;
-  transition: all .15s;
 }
 .sells-cowork .vd-pres-dot.on { background: oklch(0.65 0.14 145); width: 24px; border-radius: 99px; }
 /* ══════════════════════════════════════════
@@ -7011,22 +3515,6 @@
   border-radius: 8px;
   padding: 14px 16px;
 }
-.sells-cowork .vd-drawer-aplus .vd-msg-h {
-  display: flex; align-items: baseline; gap: 12px;
-  margin-bottom: 12px;
-}
-.sells-cowork .vd-drawer-aplus .vd-msg-h h4 { margin: 0; font-size: 14px; font-weight: 700; }
-.sells-cowork .vd-drawer-aplus .vd-msg-tpls {
-  margin-left: auto;
-  display: flex; gap: 4px;
-}
-.sells-cowork .vd-drawer-aplus .vd-msg-tpl {
-  background: var(--bg-2); border: 1px solid transparent;
-  padding: 4px 9px; border-radius: 4px;
-  font-family: inherit; font-size: 11px; cursor: pointer;
-  color: var(--text-dim);
-}
-.sells-cowork .vd-drawer-aplus .vd-msg-tpl:hover { background: var(--border-2); }
 .sells-cowork .vd-drawer-aplus .vd-msg-tpl.on {
   background: var(--vd-green-soft); color: var(--vd-green);
   border-color: var(--vd-green); font-weight: 600;
@@ -7042,12 +3530,6 @@
   letter-spacing: 0.05em; text-transform: uppercase;
   color: var(--text-mute); margin-right: 4px;
 }
-.sells-cowork .vd-drawer-aplus .vd-msg-var {
-  display: inline-flex; align-items: center; gap: 4px;
-  background: var(--bg-2);
-  padding: 2px 7px; border-radius: 4px;
-  font-size: 10.5px; line-height: 1.4;
-}
 .sells-cowork .vd-drawer-aplus .vd-msg-var .k {
   font-family: var(--font-mono);
   color: oklch(0.36 0.13 295);
@@ -7057,11 +3539,6 @@
 .sells-cowork .vd-drawer-aplus .vd-msg-var .v {
   color: var(--text); font-weight: 500;
   max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-}
-.sells-cowork .vd-drawer-aplus .vd-msg-preview {
-  background: oklch(0.97 0.025 145);
-  padding: 14px; border-radius: 8px;
-  margin-bottom: 10px;
 }
 .sells-cowork .vd-drawer-aplus .vd-msg-bubble {
   background: oklch(0.95 0.05 145);
@@ -7078,14 +3555,6 @@
 /* ══════════════════════════════════════════
    ART-SLOT (preview da arte por item)
    ══════════════════════════════════════════ */
-.sells-cowork .vd-art {
-  width: 56px; height: 56px;
-  border-radius: 6px;
-  background: var(--bg-2);
-  position: relative;
-  overflow: hidden;
-  flex-shrink: 0;
-}
 .sells-cowork .vd-art.empty {
   border: 1.5px dashed var(--border);
 }
@@ -7095,34 +3564,6 @@
 .sells-cowork .vd-art.has {
   border: 1px solid var(--border);
 }
-.sells-cowork .vd-art img {
-  width: 100%; height: 100%; object-fit: cover;
-  display: block;
-}
-.sells-cowork .vd-art-empty {
-  display: flex; flex-direction: column;
-  align-items: center; justify-content: center;
-  width: 100%; height: 100%;
-  cursor: pointer;
-  color: var(--text-mute);
-}
-.sells-cowork .vd-art-empty:hover { background: var(--border-2); }
-.sells-cowork .vd-art-ic { font-size: 18px; opacity: 0.5; line-height: 1; }
-.sells-cowork .vd-art-empty small {
-  font-size: 8.5px; line-height: 1.1;
-  padding: 0 4px; text-align: center;
-  margin-top: 3px;
-}
-.sells-cowork .vd-art-empty input { display: none; }
-.sells-cowork .vd-art-rm {
-  position: absolute; top: 3px; right: 3px;
-  background: rgba(0,0,0,0.6); color: white;
-  border: none; width: 18px; height: 18px;
-  border-radius: 50%; font-size: 12px;
-  cursor: pointer; line-height: 1;
-  opacity: 0; transition: opacity .15s;
-}
-.sells-cowork .vd-art:hover .vd-art-rm { opacity: 1; }
 /* ── Refino #4 polish · Dropdown "Visões ▾" (substitui topnav) ── */
 .sells-cowork .vendas-aplus .vd-visoes { position: relative; }
 .sells-cowork .vendas-aplus .vd-visoes-btn {
@@ -7183,7 +3624,6 @@
   padding: 1px 6px;
 }
 /* Esconder a antiga topnav (vendas-extras) — agora vive em "Visões ▾" */
-.sells-cowork .vendas-module-no-subnav .vm-subnav { display: none; }
 /* ── Vista → "Foco" label inline ── */
 .sells-cowork .vendas-aplus .vd-vista { display: inline-flex; align-items: center; }
 .sells-cowork .vendas-aplus .vd-vista-lbl {
@@ -7399,7 +3839,6 @@
   --vd-green: oklch(0.52 0.14 60);
   --vd-green-soft: oklch(0.95 0.06 60);
 }
-
 /* ──────────────────────────────────────────────────────────────
    Integração Vendas × Oficina (Ondas 3-4 · ADR 0192)
    Refs: prototipo-ui/vendas.css L1651-1775 verbatim (escopo .sells-cowork)
@@ -7417,7 +3856,6 @@
   --vd-src-online:       var(--origin-FIN-fg);
   --vd-src-online-soft:  var(--origin-FIN-bg);
 }
-
 /* Source pill — célula Origem */
 .sells-cowork .vd-src {
   display: inline-flex;
@@ -7448,25 +3886,18 @@
   white-space: nowrap;
 }
 .sells-cowork .vd-src-os:hover { opacity: 1; }
-.sells-cowork .vd-src-balcao  { background: var(--vd-src-balcao-soft);  color: var(--vd-src-balcao); }
 .sells-cowork .vd-src-balcao  .vd-src-dot { background: var(--vd-src-balcao); }
-.sells-cowork .vd-src-oficina { background: var(--vd-src-oficina-soft); color: var(--vd-src-oficina); }
 .sells-cowork .vd-src-oficina .vd-src-dot { background: var(--vd-src-oficina); }
-.sells-cowork .vd-src-online  { background: var(--vd-src-online-soft);  color: var(--vd-src-online); }
 .sells-cowork .vd-src-online  .vd-src-dot { background: var(--vd-src-online); }
-
 /* Stripe sutil na linha vinda da Oficina — assinatura visual cross-módulo */
 .sells-cowork .vendas-aplus .vd-aplus-table .os-row.vd-row-oficina td:first-child {
   box-shadow: inset 2px 0 0 var(--vd-src-oficina);
 }
-
 /* Header da coluna Origem */
-.sells-cowork .vendas-aplus .vd-aplus-table th.vd-col-source,
-.sells-cowork .vendas-aplus .vd-aplus-table td.vd-col-source {
+.sells-cowork .vendas-aplus .vd-aplus-table th.vd-col-source, .sells-cowork .vendas-aplus .vd-aplus-table td.vd-col-source {
   padding-left: 8px;
   padding-right: 8px;
 }
-
 /* KPI Hero — breakdown por source (vista=Faturamento) */
 .sells-cowork .vd-kpi-tag {
   font-size: 10px;
@@ -7512,30 +3943,27 @@
   color: white;
   white-space: nowrap;
 }
-.sells-cowork .vd-kpi-b.balcao  { border-left-color: var(--vd-src-balcao); }
+.sells-cowork .vd-kpi-b.balcao { border-left-color: var(--vd-src-balcao); }
 .sells-cowork .vd-kpi-b.oficina { border-left-color: var(--vd-src-oficina); }
-.sells-cowork .vd-kpi-b.online  { border-left-color: var(--vd-src-online); }
-
+.sells-cowork .vd-kpi-b.online { border-left-color: var(--vd-src-online); }
 /* Tree row · l1 com source dot embutido no label (saved tree "Por origem") */
 .sells-cowork .vendas-aplus .vd-tree-row.l1 .vd-tree-lbl {
   font-size: 11.5px;
 }
 /* Onda 4 (ADR 0192) — dot standalone nos filhos do branch "Por origem ▾"
    (fora do flex container .vd-src; força size + cor herdada do token). */
-.sells-cowork .vd-tree-row .vd-src-dot.vd-src-balcao  { width: 6px; height: 6px; border-radius: 50%; background: var(--vd-src-balcao); }
+.sells-cowork .vd-tree-row .vd-src-dot.vd-src-balcao { width: 6px; height: 6px; border-radius: 50%; background: var(--vd-src-balcao); }
 .sells-cowork .vd-tree-row .vd-src-dot.vd-src-oficina { width: 6px; height: 6px; border-radius: 50%; background: var(--vd-src-oficina); }
-.sells-cowork .vd-tree-row .vd-src-dot.vd-src-online  { width: 6px; height: 6px; border-radius: 50%; background: var(--vd-src-online); }
-
+.sells-cowork .vd-tree-row .vd-src-dot.vd-src-online { width: 6px; height: 6px; border-radius: 50%; background: var(--vd-src-online); }
 /* Responsive — abaixo de 1280, esconder #osRef pra não quebrar layout */
 @media (max-width: 1280px) {
-  .sells-cowork .vd-src-os { display: none; }
+.sells-cowork .vd-src-os { display: none; }
 }
 @media (max-width: 1100px) {
-  .sells-cowork .vendas-aplus .vd-aplus-table th.vd-col-source,
-  .sells-cowork .vendas-aplus .vd-aplus-table td.vd-col-source {
+.sells-cowork .vendas-aplus .vd-aplus-table th.vd-col-source, .sells-cowork .vendas-aplus .vd-aplus-table td.vd-col-source {
     display: none;
   }
-  .sells-cowork .vendas-aplus .vd-aplus-table .os-row.vd-row-oficina td:first-child {
+.sells-cowork .vendas-aplus .vd-aplus-table .os-row.vd-row-oficina td:first-child {
     box-shadow: inset 2px 0 0 var(--vd-src-oficina);
   }
 }

--- a/scripts/fin-cowork-coverage.py
+++ b/scripts/fin-cowork-coverage.py
@@ -13,7 +13,9 @@ import re, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-BUNDLE = ROOT / "resources/css/cowork-canon-financeiro-bundle.css"
+def _arg(flag, default):
+    return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else default
+BUNDLE = ROOT / _arg("--bundle", "resources/css/cowork-canon-financeiro-bundle.css")
 JS_DIR = ROOT / "resources/js"
 
 css = BUNDLE.read_text(encoding="utf-8")

--- a/scripts/fin-cowork-prune.py
+++ b/scripts/fin-cowork-prune.py
@@ -23,7 +23,9 @@ import re, sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-BUNDLE = ROOT / "resources/css/cowork-canon-financeiro-bundle.css"
+def _arg(flag, default):
+    return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else default
+BUNDLE = ROOT / _arg("--bundle", "resources/css/cowork-canon-financeiro-bundle.css")
 JS_DIR = ROOT / "resources/js"
 VIEWS_DIR = ROOT / "resources/views"
 
@@ -105,13 +107,23 @@ def split_top_level(s):
 
 CLASS_RE = re.compile(r"\.(-?[A-Za-z_][A-Za-z0-9_-]*)")
 
+# Wrapper de escopo (ex: fin-cowork / sells-cowork): classe mais frequente nos
+# seletores. É a raiz `.wrapper ...` de quase toda regra e SEMPRE viva — precisa
+# ser ignorada no teste de "toda classe morta", senão envenena todas as regras.
+from collections import Counter
+_cnt = Counter()
+for _m in re.finditer(r"([^{}]+)\{", css):
+    _cnt.update(set(CLASS_RE.findall(_m.group(1))))
+WRAPPER = _cnt.most_common(1)[0][0] if _cnt else ""
+
 def rule_deletable(header):
     """SEGURO: removível só se TODA classe do seletor (todos os branches) for
     morta. Assim nenhuma classe viva pode perder sua última definição —
-    mesmo que apareça num seletor composto junto de uma classe morta."""
-    classes = [c for c in CLASS_RE.findall(header) if c != "fin-cowork"]
+    mesmo que apareça num seletor composto junto de uma classe morta.
+    O wrapper de escopo é ignorado (sempre vivo, presente em toda regra)."""
+    classes = [c for c in CLASS_RE.findall(header) if c != WRAPPER]
     if not classes:
-        return False  # sem classe própria => mantém (ex: .fin-cowork, [data-*])
+        return False  # sem classe própria => mantém (ex: .wrapper, [data-*])
     return all(c not in used for c in classes)
 
 def inner_body(raw, header):

--- a/scripts/fin-cowork-verify-prune.py
+++ b/scripts/fin-cowork-verify-prune.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 """Integridade do prune: nenhuma classe VIVA pode ter perdido definição."""
-import re
+import re, sys
 from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
-ORIG = ROOT / "resources/css/cowork-canon-financeiro-bundle.css"
-PRUNED = ROOT / "resources/css/cowork-canon-financeiro-bundle.css.pruned"
+def _arg(flag, default):
+    return sys.argv[sys.argv.index(flag) + 1] if flag in sys.argv else default
+_rel = _arg("--bundle", "resources/css/cowork-canon-financeiro-bundle.css")
+ORIG = ROOT / _rel
+PRUNED = ROOT / (_rel + ".pruned")
 JS = ROOT / "resources/js"; VIEWS = ROOT / "resources/views"
 
 used = set()


### PR DESCRIPTION
## O quê

Mesma cirurgia do [#2291](https://github.com/wagnerra23/oimpresso.com/pull/2291) (Financeiro) no **maior bundle**: `sells-cowork.css` **7.540 → 3.968 linhas (−47%)**. Remove rule-blocks provadamente mortos (telas do protótipo Cowork nunca portadas: `topbar-*`, `main-body-noop`...). As classes vivas `vd-`/`os-` (a tela Sells é bespoke, load-bearing) são **preservadas**.

## Como — dead-code elimination

Um block só sai se **toda** classe do seletor não aparece em produção (`.tsx`/`.ts`/`.jsx`-prod/`.blade.php`). Visualmente inerte por construção.

## Generaliza o tooling + corrige bug do wrapper

- Scripts agora aceitam `--bundle <path>` (reusável p/ qualquer bundle cowork).
- **Bug corrigido:** o teste "toda classe morta" precisa ignorar o **wrapper de escopo** (`fin-cowork`/`sells-cowork`), sempre vivo e presente em toda regra. Antes hardcoded `fin-cowork` → no sells envenenava 100% das regras (0 removidas). Agora o wrapper é **auto-detectado**. Resultado do Financeiro permanece idêntico (sem regressão).

## Travas (verdes, reprodutíveis)

| Trava | Resultado |
|---|---|
| Integridade (`verify-prune --bundle sells`) | **0 classes vivas perdidas** |
| Chaves balanceadas + scope idempotente | 1096/1096, 2ª run = no-op |
| Stylelint baseline | 657 → 494 (**delta −163**) |

## ⚠️ Gate visual

Smoke da tela Sells (Index/Create/Edit/Show) recomendado — Sells é bespoke, então o bundle é load-bearing (vs Financeiro que já era majoritariamente Tailwind). Deleção provadamente inerte, mas vale o olho.

## Nota sobre `module-grades-gate`

Vai falhar pelo mesmo drift do módulo **Jana** do #2291 (baseline congelado, sem relação com CSS). Label `module-grades-allowed-regression` aplicado.

Refs: MANUAL-CSS-JS passo 3 · ADR UI-0013 · segue #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)