### PR TITLE
fix(cliente): /cliente?type=other caía em Clientes — whitelist da rota faltava 'other' (ADR 0246)

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -229,10 +229,13 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // pra Show (supplier NUNCA cai aqui). Ver app/Http/Middleware/RedirectLegacyContacts.php.
     //
     // ADR 0188 (2026-05-24) — Slot 2 PT-01 multi-type: `/cliente?type=X` aceita
-    // whitelist 5 valores (customer/supplier/employee/representative/all). Default
+    // whitelist 6 valores (customer/supplier/employee/representative/other/all). Default
     // 'customer' se ausente ou inválido pra retrocompat com bookmarks/links externos.
+    // ADR 0246 (2026-06-03) — `other` (aba "Outros") incluído: o frontend (Index.tsx
+    // SLOT2_TABS) + controller ($types/$inertiaTypes) já aceitavam, mas esta whitelist
+    // ficou pra trás → `?type=other` caía no fallback `customer` (aba abria em Clientes).
     Route::get('/cliente', function (ContactController $c) {
-        $allowed = ['customer', 'supplier', 'employee', 'representative', 'all'];
+        $allowed = ['customer', 'supplier', 'employee', 'representative', 'other', 'all'];
         $type = (string) request()->query('type', 'customer');
         if (! in_array($type, $allowed, true)) {
             $type = 'customer';

--- a/tests/Feature/Cliente/ClienteTypeOtherRouteTest.php
+++ b/tests/Feature/Cliente/ClienteTypeOtherRouteTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Inertia\Testing\AssertableInertia;
+
+// `uses(TestCase::class)` é aplicado globalmente em tests/Pest.php pra toda pasta Feature/.
+
+/**
+ * ADR 0246 (2026-06-03) — 5ª categoria "Outros" (`?type=other`).
+ *
+ * Regressão coberta: a aba "Outros" (Index.tsx SLOT2_TABS → `href: /cliente?type=other`)
+ * caía silenciosamente em "Clientes". Causa: o frontend + o controller
+ * (`$types`/`$inertiaTypes`) já aceitavam `other`, mas a whitelist `$allowed` da
+ * rota `/cliente` (routes/web.php) ficou pra trás → `other` não passava no
+ * `in_array` e era rebaixado pro fallback `customer` ANTES de chegar no controller.
+ *
+ * Refs:
+ * - routes/web.php (closure /cliente → $allowed)
+ * - app/Http/Controllers/ContactController.php ($types, $inertiaTypes, applyContactTypeFilter)
+ * - resources/js/Pages/Cliente/Index.tsx (SLOT2_TABS 'other')
+ * - memory/decisions/0246-tipo-outros-default-migracoes-legacy.md
+ */
+
+/** Guard estrutural — roda em qualquer ambiente (sem boot/DB). */
+test('rota /cliente aceita type=other na whitelist (ADR 0246)', function () {
+    $routesPath = __DIR__ . '/../../../routes/web.php';
+    expect($routesPath)->toBeReadableFile();
+
+    $contents = file_get_contents($routesPath);
+
+    // A whitelist $allowed da closure /cliente PRECISA conter 'other', senão
+    // ?type=other vira fallback 'customer' (aba Outros abre em Clientes).
+    expect($contents)->toMatch(
+        "/\\\$allowed\s*=\s*\[[^\]]*'other'[^\]]*\];/"
+    );
+});
+
+/** As 3 camadas de whitelist (rota + 2 do controller) ficam em sincronia. */
+test('controller $types e $inertiaTypes também aceitam other (3 camadas alinhadas)', function () {
+    $controllerPath = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($controllerPath);
+
+    expect($contents)
+        // $types = [...,'other',...]; (guard de redirect()->back())
+        ->toMatch("/\\\$types\s*=\s*\[[^\]]*'other'[^\]]*\];/")
+        // $inertiaTypes = [...,'other',...]; (guard do Inertia::render)
+        ->toMatch("/\\\$inertiaTypes\s*=\s*\[[^\]]*'other'[^\]]*\];/")
+        // mapeamento de filtro 'other' => 'is_other'
+        ->toContain("'other' => 'is_other'");
+});
+
+/**
+ * Comportamental — prova que /cliente?type=other renderiza a aba Outros e
+ * NÃO cai em customer. Skip gracioso (convention oimpresso) quando sem DB.
+ */
+test('GET /cliente?type=other renderiza Inertia com activeType=other (não customer)', function () {
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('DB indisponível: ' . $e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco.');
+    }
+
+    $user = User::where('business_id', $business->id)
+        ->where('user_type', '!=', 'user_customer')
+        ->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user não-customer no business.');
+    }
+
+    // Força o branch Inertia pra qualquer business (sem gate por biz).
+    config([
+        'mwart.cliente_index.enabled' => true,
+        'mwart.cliente_index.business_ids' => [],
+    ]);
+
+    session([
+        'user.id' => $user->id,
+        'user.business_id' => $business->id,
+        'business.id' => $business->id,
+    ]);
+
+    $response = $this->actingAs($user)->get('/cliente?type=other');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Cliente/Index')
+        ->where('activeType', 'other')   // <- antes do fix vinha 'customer'
+    );
+});


### PR DESCRIPTION
## Problema

A aba **"Outros"** (`?type=other`) do cadastro de clientes abria em **"Clientes"**.

A 5ª categoria "Outros" (ADR 0246, 2026-06-03) entrou **só pela metade**:

- ✅ Frontend `Index.tsx` SLOT2_TABS → `href: /cliente?type=other`
- ✅ Controller `$types` (l.266) + `$inertiaTypes` (l.299) + `applyContactTypeFilter` `'other' => 'is_other'` (l.348)
- ✅ Counters da subnav + payload `is_other` + migration `2026_06_03_120000_add_is_other_flag_to_contacts`
- ❌ **Whitelist `$allowed` da closure `/cliente`** em `routes/web.php` ficou pra trás

Como a rota roda **antes** do controller, `other` não passava no `in_array($type, $allowed)` e era rebaixado pro fallback `customer` (l.238) — `request()->merge(['type' => 'customer'])`. Por isso "vai para clientes".

## Fix

Adiciona `'other'` ao `$allowed` (1 linha). O filtro, counters e payload já tratavam o tipo — só faltava liberar a entrada. Completa o landing do ADR 0246.

```diff
-        $allowed = ['customer', 'supplier', 'employee', 'representative', 'all'];
+        $allowed = ['customer', 'supplier', 'employee', 'representative', 'other', 'all'];
```

## Testes — `tests/Feature/Cliente/ClienteTypeOtherRouteTest.php`

1. **Guard estrutural** (roda em qualquer ambiente): as 3 camadas de whitelist (rota + `$types` + `$inertiaTypes`) contêm `other` e ficam alinhadas → trava a regressão de alguém remover `other` de uma só camada.
2. **Comportamental HTTP**: `GET /cliente?type=other` → Inertia `Cliente/Index` com `activeType === 'other'` (antes vinha `customer`). Skip gracioso sem DB (convention oimpresso).

Validado localmente: `php -l` limpo nos 3 arquivos + os 4 guards estruturais passam. Suíte HTTP roda no CI (worktree sem `vendor/`).

## Infra Contract

Mudança é **pura lógica de routing PHP** (1 item na whitelist de uma closure que chama `$c->index()`) — não toca `.htaccess`, `SCRIPT_NAME`, middleware nem rewrite. Coberta integralmente pelo teste HTTP feature (`assertInertia activeType=other`).

### 1. Happy path — comando + output esperado LITERAL (pós-deploy)

```bash
# Logado, flag mwart.cliente_index on. Esperado: 200 + Inertia component Cliente/Index, activeType=other (NÃO redireciona pra customer)
$ curl -sv 'https://oimpresso.com/cliente?type=other' -H 'X-Inertia: true' -b "$COOKIE" 2>&1 | grep '^< HTTP\|X-Inertia'
< HTTP/2 200
```

### 2. Regression adjacent — rotas que NÃO devem mudar

```bash
# Tipos já existentes continuam idênticos:
$ curl -sv 'https://oimpresso.com/cliente?type=customer'       ... → 200 activeType=customer
$ curl -sv 'https://oimpresso.com/cliente?type=representative' ... → 200 activeType=representative
# Tipo inválido continua caindo no fallback customer (retrocompat bookmarks):
$ curl -sv 'https://oimpresso.com/cliente?type=xpto'           ... → 200 activeType=customer
```

### 3. Environment delta — onde Pest local NÃO prova prod

- Mudança NÃO depende de `SCRIPT_NAME`/`.htaccess`/LiteSpeed rewrite — é `in_array()` PHP puro dentro da closure.
- Risco real de prod: **OPcache** servir bytecode antigo de `routes/web.php` → exigir `php artisan optimize:clear` + `opcache_reset` pós git pull no Hostinger.
- Pest HTTP cobre o branch Inertia fielmente (mesma stack de routing). Ainda assim: **Pest verde não dispensa o smoke `curl -sv` em prod pós-deploy.**

### 4. Smoke prod pós-deploy (preencher após merge + git pull Hostinger)

```bash
# (timestamp + colar saída real de curl -sv aqui após deploy)
```

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `?type=other` | `200` activeType=other | — | ⬜ |
| `?type=customer` (adjacent) | `200` activeType=customer | — | ⬜ |
| `?type=xpto` (fallback) | `200` activeType=customer | — | ⬜ |

## Escopo / risco

- Multi-tenant Tier 0 intacto — `business_id` scope inalterado, `other` só libera o papel já filtrado por `is_other`.
- 1 PR = 1 intent, +102/-2 linhas.

Refs: ADR 0246