### PR TITLE
chore(ci): gate de tamanho do CSS — congela o sprawl pós-prune (MANUAL-CSS-JS#1)

### DIFF
--- a/.github/workflows/css-size-gate.yml
+++ b/.github/workflows/css-size-gate.yml
@@ -1,0 +1,62 @@
+name: CSS size ratchet (congelar sprawl · MANUAL-CSS-JS#1)
+
+# Passo 1 do MANUAL-CSS-JS ("Congelar o crescimento"): trava os bundles cowork
+# (e todo resources/css/) pra só ENCOLHEREM. Bloqueia PR que faça um .css crescer
+# em linhas vs config/css-size-baseline.json OU adicione .css novo sem rebaseline.
+#
+# Trava os ~8.3k linhas de CSS morto removidas em #2291/#2293/#2295.
+# Encolher é sempre OK (baseline desce no próximo --write). Crescer exige decisão
+# consciente: npm run css:size:write + justificativa no PR.
+#
+# Script é Node puro (fs) — sem deps, sem npm ci. Comando local: npm run css:size:check
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'resources/css/**'
+      - 'config/css-size-baseline.json'
+      - 'scripts/css-size-baseline.mjs'
+      - '.github/workflows/css-size-gate.yml'
+  pull_request:
+    paths:
+      - 'resources/css/**'
+      - 'config/css-size-baseline.json'
+      - 'scripts/css-size-baseline.mjs'
+      - '.github/workflows/css-size-gate.yml'
+
+concurrency:
+  group: css-size-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  css-size:
+    name: CSS size · ratchet vs baseline
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: CSS size ratchet (falha em crescimento / arquivo novo)
+        run: node scripts/css-size-baseline.mjs
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "❌ Um .css CRESCEU (ou surgiu .css novo) vs config/css-size-baseline.json"
+          echo ""
+          echo "Isso vai contra o passo 1 do MANUAL-CSS-JS (congelar o sprawl de CSS bespoke)."
+          echo "Próximos passos:"
+          echo "  1. Local: npm run css:size:check · vê qual arquivo cresceu e quanto"
+          echo "  2. Preferível: dissolver CSS em Tailwind+componentes (o arquivo ENCOLHE)"
+          echo "  3. Se o crescimento for CONSCIENTE e justificado, rebaseline no mesmo PR:"
+          echo "       npm run css:size:write"
+          echo "     (commit + justificativa — aparece no diff do JSON)"
+          echo ""
+          echo "Refs: memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md (passo 1) · ADR UI-0013"

--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,0 +1,48 @@
+{
+  "_meta": {
+    "generated_at": "2026-06-05T18:48:24.483Z",
+    "total_lines": 20294,
+    "file_count": 34,
+    "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
+    "refs": [
+      "MANUAL-CSS-JS#1",
+      "ADR UI-0013"
+    ]
+  },
+  "files": {
+    "resources/css/app.css": 10,
+    "resources/css/base.css": 12,
+    "resources/css/cockpit.css": 2289,
+    "resources/css/components.css": 22,
+    "resources/css/cowork-canon-financeiro-bundle.css": 4747,
+    "resources/css/cowork-compras-bundle.css": 182,
+    "resources/css/cowork-fields.css": 392,
+    "resources/css/cowork-payment-gateway-bundle.css": 257,
+    "resources/css/fin-cowork.css": 653,
+    "resources/css/fin-curadoria.css": 289,
+    "resources/css/fin-ia.css": 291,
+    "resources/css/fin-mobile.css": 67,
+    "resources/css/fin-output.css": 1004,
+    "resources/css/fiscal-cockpit.css": 1381,
+    "resources/css/inertia.css": 363,
+    "resources/css/kb.css": 184,
+    "resources/css/layout.css": 14,
+    "resources/css/screen-grade.css": 16,
+    "resources/css/sells-cowork-curadoria.css": 312,
+    "resources/css/sells-cowork-distribuicao.css": 439,
+    "resources/css/sells-cowork-drafts.css": 110,
+    "resources/css/sells-cowork-edit.css": 105,
+    "resources/css/sells-cowork-ia.css": 361,
+    "resources/css/sells-cowork-insights.css": 776,
+    "resources/css/sells-cowork-quotations.css": 71,
+    "resources/css/sells-cowork-show.css": 132,
+    "resources/css/sells-cowork-subscriptions.css": 121,
+    "resources/css/sells-cowork.css": 3969,
+    "resources/css/sells-kb975-cheatsheet.css": 242,
+    "resources/css/sells-kb975-emit-modals.css": 505,
+    "resources/css/sells-kb975-next-action.css": 280,
+    "resources/css/sells-kb975-print.css": 675,
+    "resources/css/themes.css": 14,
+    "resources/css/utilities.css": 9
+  }
+}

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "stylelint": "stylelint \"resources/css/**/*.css\"",
     "stylelint:baseline:write": "node scripts/stylelint-baseline.mjs --write",
     "stylelint:baseline:check": "node scripts/stylelint-baseline.mjs",
+    "css:size:write": "node scripts/css-size-baseline.mjs --write",
+    "css:size:check": "node scripts/css-size-baseline.mjs",
     "ds:report": "node scripts/ds-report.mjs",
     "ds:report:write": "node scripts/ds-report.mjs --write",
     "design:review": "node prototipo-ui/audit/review-gen.mjs",

--- a/scripts/css-size-baseline.mjs
+++ b/scripts/css-size-baseline.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+// scripts/css-size-baseline.mjs — ratchet de TAMANHO do CSS (anti-regrowth).
+//
+// Passo 1 do MANUAL-CSS-JS ("Congelar o crescimento"): trava os bundles cowork
+// (e todo resources/css/) pra só ENCOLHEREM. Gêmeo de size do stylelint-baseline:
+// falha se (a) algum .css cresceu em linhas vs baseline, OU (b) surgiu .css novo.
+//
+// Por quê: a limpeza de CSS morto (#2291/#2293/#2295, ~8.3k linhas) só fica travada
+// se nada puder re-inflar os bundles. Encolher é sempre permitido (baseline desce no
+// próximo --write); crescer exige decisão consciente (rodar --write + justificar).
+//
+// Comandos:
+//   node scripts/css-size-baseline.mjs --write   # grava baseline do estado atual
+//   node scripts/css-size-baseline.mjs           # valida (default): falha em crescimento/arquivo novo
+//
+// Refs: memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md (passo 1 + métrica-mãe) · ADR UI-0013
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const BASELINE_PATH = resolve(ROOT, 'config/css-size-baseline.json');
+const CSS_DIR = resolve(ROOT, 'resources/css');
+const MODE_WRITE = process.argv.includes('--write');
+
+function listCss(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...listCss(full));
+    else if (name.endsWith('.css')) out.push(full);
+  }
+  return out;
+}
+
+function countLines(file) {
+  const txt = readFileSync(file, 'utf8');
+  if (txt === '') return 0;
+  // conta linhas independente de CRLF/LF; ignora newline final
+  return txt.replace(/\n$/, '').split('\n').length;
+}
+
+function buildCounts() {
+  const counts = {};
+  for (const full of listCss(CSS_DIR)) {
+    const rel = relative(ROOT, full).replace(/\\/g, '/');
+    counts[rel] = countLines(full);
+  }
+  return counts;
+}
+
+function main() {
+  console.log(`CSS size ratchet · ${MODE_WRITE ? 'WRITE' : 'VALIDATE'} mode`);
+  console.log('Scanning resources/css/**/*.css...');
+
+  const counts = buildCounts();
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+  console.log(`Total linhas CSS atual: ${total} (${Object.keys(counts).length} arquivos)`);
+
+  if (MODE_WRITE) {
+    const out = {
+      _meta: {
+        generated_at: new Date().toISOString(),
+        total_lines: total,
+        file_count: Object.keys(counts).length,
+        note: 'Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).',
+        refs: ['MANUAL-CSS-JS#1', 'ADR UI-0013'],
+      },
+      files: counts,
+    };
+    writeFileSync(BASELINE_PATH, JSON.stringify(out, null, 2) + '\n');
+    console.log(`✅ Baseline gravado em ${BASELINE_PATH} (${Object.keys(counts).length} arquivos)`);
+    return;
+  }
+
+  if (!existsSync(BASELINE_PATH)) {
+    console.error(`❌ Baseline não existe em ${BASELINE_PATH}`);
+    console.error('   Rode: node scripts/css-size-baseline.mjs --write');
+    process.exit(1);
+  }
+
+  const baseline = JSON.parse(readFileSync(BASELINE_PATH, 'utf8'));
+  const baseFiles = baseline.files || {};
+  const baseTotal = Object.values(baseFiles).reduce((a, b) => a + b, 0);
+  console.log(`Total baseline: ${baseTotal} · Delta: ${total - baseTotal > 0 ? '+' : ''}${total - baseTotal}`);
+
+  const grew = [];
+  const novos = [];
+  for (const [path, atual] of Object.entries(counts)) {
+    if (!(path in baseFiles)) {
+      novos.push({ path, atual });
+    } else if (atual > baseFiles[path]) {
+      grew.push({ path, base: baseFiles[path], atual, delta: atual - baseFiles[path] });
+    }
+  }
+
+  if (grew.length === 0 && novos.length === 0) {
+    console.log('✅ Nenhum CSS cresceu e nenhum arquivo novo — ratchet OK');
+    return;
+  }
+
+  console.error('');
+  if (grew.length) {
+    console.error(`❌ CRESCIMENTO — ${grew.length} arquivo(s) com MAIS linhas vs baseline:`);
+    for (const g of grew.sort((a, b) => b.delta - a.delta)) {
+      console.error(`   ${g.path} · ${g.base} → ${g.atual} (Δ+${g.delta})`);
+    }
+  }
+  if (novos.length) {
+    console.error(`❌ ARQUIVO .css NOVO — ${novos.length} não no baseline (exige ADR + --write):`);
+    for (const n of novos) console.error(`   ${n.path} (${n.atual} linhas)`);
+  }
+  console.error('');
+  console.error('Crescer/adicionar CSS bespoke vai contra o passo 1 do MANUAL-CSS-JS (congelar sprawl).');
+  console.error('Se for crescimento CONSCIENTE e justificado: node scripts/css-size-baseline.mjs --write + explique no PR.');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## O quê

**Passo 1 do [MANUAL-CSS-JS](memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md) ("Congelar o crescimento")** — ratchet por-arquivo que trava todo `resources/css/` pra só **encolher**. Bloqueia PR que (a) faça um `.css` crescer em linhas vs baseline, OU (b) adicione `.css` novo sem rebaseline consciente.

**Por quê:** trava os ~8.3k linhas de CSS morto removidas em #2291/#2293/#2295. Sem isso, os bundles cowork podem re-inflar e desfazer a limpeza.

## Como

- Encolher é sempre OK (baseline desce no `--write`).
- Crescer / arquivo novo → **falha**, com escape consciente: `npm run css:size:write` + justificativa no PR.
- Baseline inicial: **20.294 linhas / 34 arquivos**.
- Espelha o pattern do `stylelint-baseline` (ADR 0209). Script Node puro (sem deps, sem `npm ci`).

## Arquivos

- `scripts/css-size-baseline.mjs` (check / `--write`)
- `config/css-size-baseline.json` (baseline)
- `.github/workflows/css-size-gate.yml` (gate — roda do próximo merge em diante)
- `package.json`: `css:size:check` / `css:size:write`

## Testado

✓ check verde no baseline · ✓ +1 linha em bundle → falha · ✓ `.css` novo → falha

## module-grades-gate
Drift pré-existente do Jana (baseline 01/06). Label `module-grades-allowed-regression` aplicado.

Refs: MANUAL-CSS-JS passo 1 · ADR UI-0013

🤖 Generated with [Claude Code](https://claude.com/claude-code)