### PR TITLE
feat(sells): enviar venda pra oficina + breadcrumb "onde a venda está"

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -2529,9 +2529,38 @@ class SellController extends Controller
                 ];
             };
 
+            // Breadcrumb "onde a venda está" (Wagner 2026-06-05). Gate per-business
+            // OficinaAuto (mesmo padrão de create()) — ROTA LIVRE varejo recebe
+            // show=false e o Show.tsx não renderiza nada novo. Função pura testada
+            // em tests/Unit/Services/SaleJourneyServiceTest (CI).
+            $oficinaModuleUtil = new \App\Utils\ModuleUtil();
+            $hasOficinaAuto = auth()->user()->can('superadmin')
+                ? $oficinaModuleUtil->isModuleInstalled('OficinaAuto')
+                : (bool) $oficinaModuleUtil->hasThePermissionInSubscription(
+                    $business_id,
+                    'oficina_auto_module',
+                    'superadmin_package'
+                );
+
+            $hasLinkedOs = $hasOficinaAuto
+                && class_exists(\Modules\OficinaAuto\Entities\ServiceOrder::class)
+                && \Illuminate\Support\Facades\Schema::hasTable('service_orders')
+                && \Modules\OficinaAuto\Entities\ServiceOrder::where('transaction_id', $sell->id)->exists();
+
+            $journey = (new \App\Services\SaleJourneyService())->build([
+                'source'           => (string) ($sell->source ?? 'balcao'),
+                'status'           => (string) $sell->status,
+                'has_oficina_auto' => $hasOficinaAuto,
+                'has_vehicle'      => ! empty($sell->vehicle_id),
+                'has_os'           => $hasLinkedOs,
+                'invoiced'         => in_array(strtolower((string) $fiscalStatus), ['autorizada', 'authorized', 'emitida', 'enviada', 'aprovada'], true),
+                'delivered'        => ($sell->shipping_status ?? null) === 'delivered',
+            ]);
+
             return Inertia::render('Sells/Show', [
                 'saleId' => (int) $id,
                 'headline' => $headline,
+                'journey' => $journey,
                 'detail' => Inertia::defer($detailPayload),
                 'permissions' => [
                     'edit' => auth()->user()->can('direct_sell.update') || auth()->user()->can('so.update'),

--- a/app/Services/SaleJourneyService.php
+++ b/app/Services/SaleJourneyService.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+/**
+ * Breadcrumb "onde a venda está" — jornada de negócio da venda de oficina.
+ *
+ * Wagner 2026-06-05: a venda com veículo precisa ir pra oficina e mostrar um
+ * breadcrumb marcando o estágio atual. Há DOIS fluxos (direção pelo `source`):
+ *
+ *   balcão/orçamento-first : Orçamento → Venda → Oficina → Faturamento → Entrega
+ *   oficina-first          :            Oficina → Venda → Faturamento → Entrega
+ *
+ * ("da oficina pode virar venda também" — OS entregue auto-fatura, ADR 0192,
+ *  gerando transaction com source='oficina'.)
+ *
+ * FUNÇÃO PURA de propósito: recebe escalares já resolvidos pelo Controller e
+ * devolve os nós + o estágio atual. Zero acesso a DB/Eloquent → unit-testável
+ * no lane SQLite do CI (sem schema UltimatePOS). O Controller faz o mapeamento
+ * Transaction→estado; aqui só vive a lógica da jornada.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): nada de query aqui; o gate `show` é decidido
+ * pelo Controller via hasThePermissionInSubscription. Venda de varejo (ROTA
+ * LIVRE, sem OficinaAuto) NUNCA chega aqui com show=true.
+ *
+ * @see app/Http/Controllers/SellController.php (show)
+ * @see memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ */
+class SaleJourneyService
+{
+    public const NODE_ORCAMENTO   = 'orcamento';
+    public const NODE_OFICINA     = 'oficina';
+    public const NODE_VENDA       = 'venda';
+    public const NODE_FATURAMENTO = 'faturamento';
+    public const NODE_ENTREGA     = 'entrega';
+
+    private const LABELS = [
+        self::NODE_ORCAMENTO   => 'Orçamento',
+        self::NODE_OFICINA     => 'Oficina',
+        self::NODE_VENDA       => 'Venda',
+        self::NODE_FATURAMENTO => 'Faturamento',
+        self::NODE_ENTREGA     => 'Entrega',
+    ];
+
+    /**
+     * @param array{
+     *   source?: string|null,
+     *   status?: string|null,
+     *   has_oficina_auto?: bool,
+     *   has_vehicle?: bool,
+     *   has_os?: bool,
+     *   invoiced?: bool,
+     *   delivered?: bool
+     * } $state
+     *
+     * @return array{
+     *   show: bool,
+     *   direction: string,
+     *   current: string|null,
+     *   nodes: array<int, array{key:string,label:string,state:string}>
+     * }
+     */
+    public function build(array $state): array
+    {
+        $source         = (string) ($state['source'] ?? 'balcao');
+        $status         = (string) ($state['status'] ?? 'final');
+        $hasOficinaAuto = (bool) ($state['has_oficina_auto'] ?? false);
+        $hasVehicle     = (bool) ($state['has_vehicle'] ?? false);
+        $hasOs          = (bool) ($state['has_os'] ?? false);
+        $invoiced       = (bool) ($state['invoiced'] ?? false);
+        $delivered      = (bool) ($state['delivered'] ?? false);
+
+        $isOficinaFirst = $source === 'oficina';
+
+        // Gate: o breadcrumb de oficina só aparece em venda relacionada à oficina.
+        // Varejo puro (ROTA LIVRE) → show=false → Show.tsx não renderiza nada novo.
+        $show = $hasOficinaAuto && ($isOficinaFirst || $hasVehicle || $hasOs);
+
+        // É um orçamento (ainda não virou venda final)?
+        $isQuote = in_array($status, ['quotation', 'draft', 'proforma'], true);
+
+        // Ordem dos nós por direção.
+        $order = $isOficinaFirst
+            ? [self::NODE_OFICINA, self::NODE_VENDA, self::NODE_FATURAMENTO, self::NODE_ENTREGA]
+            : [self::NODE_ORCAMENTO, self::NODE_VENDA, self::NODE_OFICINA, self::NODE_FATURAMENTO, self::NODE_ENTREGA];
+
+        // "Alcançado" por nó (monotônico): pega o nó mais avançado satisfeito.
+        $reached = [
+            self::NODE_ORCAMENTO   => true,                  // sempre o ponto de partida balcão
+            self::NODE_OFICINA     => $isOficinaFirst || $hasOs,
+            self::NODE_VENDA       => ! $isQuote,            // status final = virou venda
+            self::NODE_FATURAMENTO => $invoiced,
+            self::NODE_ENTREGA     => $delivered,
+        ];
+
+        // Índice atual = posição do nó mais avançado alcançado na ordem da direção.
+        $currentIdx = 0;
+        foreach ($order as $i => $key) {
+            if (! empty($reached[$key])) {
+                $currentIdx = $i;
+            }
+        }
+
+        $nodes = [];
+        foreach ($order as $i => $key) {
+            $nodes[] = [
+                'key'   => $key,
+                'label' => self::LABELS[$key],
+                'state' => $i < $currentIdx ? 'done' : ($i === $currentIdx ? 'current' : 'todo'),
+            ];
+        }
+
+        return [
+            'show'      => $show,
+            'direction' => $isOficinaFirst ? 'oficina' : 'balcao',
+            'current'   => $order[$currentIdx] ?? null,
+            'nodes'     => $nodes,
+        ];
+    }
+}

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -42,6 +42,7 @@ import SaleReciboPrint80mm from './_components/SaleReciboPrint80mm';
 import SaleOrcamentoA4 from './_components/SaleOrcamentoA4';
 import SellsCheatSheet, { SELLS_SHOW_SHORTCUTS } from './_components/SellsCheatSheet';
 import SaleTimeline from './_components/SaleTimeline';
+import SaleJourneyStepper, { type SaleJourney } from './_components/SaleJourneyStepper';
 
 // Modos de impressão KB-9.75 Cowork bundle 2026-05-26 P2 gaps #8 + #9
 type CoworkPrintMode = 'recibo-80mm' | 'orcamento-a4' | null;
@@ -115,6 +116,8 @@ interface ShowDetail {
 export interface SellsShowPageProps {
   saleId: number;
   headline: Headline;
+  /** Breadcrumb "onde a venda está" (oficina). show=false em varejo/ROTA LIVRE. */
+  journey?: SaleJourney;
   detail?: ShowDetail;  // deferred
   permissions: { edit: boolean; delete: boolean; print: boolean };
   urls: { edit: string; destroy: string; print: string; sheet_data: string; back: string };
@@ -173,7 +176,7 @@ function DetailSkeleton() {
 }
 
 export default function SellsShow(props: SellsShowPageProps) {
-  const { headline, urls, permissions } = props;
+  const { headline, urls, permissions, journey } = props;
   const [isPrinting, setIsPrinting] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   // KB-9.75 P0 gaps #2/#3 — emit modals abertos via VdNextActionPanel gate.
@@ -377,6 +380,10 @@ export default function SellsShow(props: SellsShowPageProps) {
             )}
           </div>
         </div>
+
+        {/* Breadcrumb "onde a venda está" — só em venda de oficina (Wagner 2026-06-05).
+            journey.show=false em varejo/ROTA LIVRE → não renderiza. */}
+        {journey?.show && <SaleJourneyStepper journey={journey} saleId={headline.id} />}
 
         {/* KPIs grandes (4-col canon V2) */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">

--- a/resources/js/Pages/Sells/_components/SaleJourneyStepper.tsx
+++ b/resources/js/Pages/Sells/_components/SaleJourneyStepper.tsx
@@ -96,10 +96,10 @@ export default function SaleJourneyStepper({ journey, saleId }: Props) {
                 <span
                   className={[
                     'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
-                    isDone
-                      ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                      : isCurrent
-                        ? 'border-primary bg-primary/10 text-primary'
+                    isCurrent
+                      ? 'border-primary bg-primary/10 text-primary'
+                      : isDone
+                        ? 'border-border bg-card text-foreground'
                         : 'border-border bg-muted/40 text-muted-foreground',
                   ].join(' ')}
                   aria-current={isCurrent ? 'step' : undefined}
@@ -107,11 +107,9 @@ export default function SaleJourneyStepper({ journey, saleId }: Props) {
                   <span
                     className={[
                       'flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-semibold',
-                      isDone
-                        ? 'bg-emerald-600 text-white'
-                        : isCurrent
-                          ? 'bg-primary text-primary-foreground'
-                          : 'bg-muted-foreground/20 text-muted-foreground',
+                      isDone || isCurrent
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted-foreground/20 text-muted-foreground',
                     ].join(' ')}
                   >
                     {isDone ? <Check size={10} strokeWidth={3} /> : i + 1}
@@ -120,7 +118,7 @@ export default function SaleJourneyStepper({ journey, saleId }: Props) {
                 </span>
                 {i < journey.nodes.length - 1 && (
                   <span
-                    className={['h-px w-5', isDone ? 'bg-emerald-300' : 'bg-border'].join(' ')}
+                    className={['h-px w-5', isDone ? 'bg-primary' : 'bg-border'].join(' ')}
                     aria-hidden="true"
                   />
                 )}

--- a/resources/js/Pages/Sells/_components/SaleJourneyStepper.tsx
+++ b/resources/js/Pages/Sells/_components/SaleJourneyStepper.tsx
@@ -1,0 +1,145 @@
+// Breadcrumb "onde a venda está" — jornada da venda de oficina (Wagner 2026-06-05).
+//
+// Stepper horizontal direcional. Os nós + o estágio atual vêm prontos do backend
+// (prop `journey`, montada por App\Services\SaleJourneyService — função pura
+// testada no CI). Duas direções:
+//   balcão : Orçamento → Venda → Oficina → Faturamento → Entrega
+//   oficina: Oficina → Venda → Faturamento → Entrega
+//
+// CTA "Enviar para a oficina" aparece só quando há um nó Oficina pendente na
+// direção balcão (= venda pronta, ainda sem OS). Reusa POST /sells/{id}/create-os
+// (mesmo endpoint do CriarOsButton, modo 'single' = 1 OS pra venda toda, padrão
+// Martinho/caçambas).
+//
+// Gate de visibilidade é do backend (journey.show=false pra varejo/ROTA LIVRE) —
+// este componente só renderiza quando journey.show é true.
+
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+import { Check, Loader2, Wrench } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/Components/ui/button';
+
+export interface JourneyNode {
+  key: string;
+  label: string;
+  state: 'done' | 'current' | 'todo';
+}
+
+export interface SaleJourney {
+  show: boolean;
+  direction: 'balcao' | 'oficina' | string;
+  current: string | null;
+  nodes: JourneyNode[];
+}
+
+interface Props {
+  journey: SaleJourney;
+  saleId: number;
+}
+
+function getCsrfToken(): string {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+}
+
+export default function SaleJourneyStepper({ journey, saleId }: Props) {
+  const [sending, setSending] = useState(false);
+
+  if (!journey?.show || !Array.isArray(journey.nodes) || journey.nodes.length === 0) {
+    return null;
+  }
+
+  // CTA só na direção balcão, quando o nó Oficina existe e ainda está pendente
+  // (venda pronta, sem OS criada).
+  const oficinaNode = journey.nodes.find((n) => n.key === 'oficina');
+  const canSendToWorkshop =
+    journey.direction === 'balcao' && oficinaNode?.state === 'todo' && journey.current === 'venda';
+
+  const handleSend = async () => {
+    if (sending) return;
+    setSending(true);
+    try {
+      const res = await fetch(`/sells/${saleId}/create-os`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ mode: 'single' }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        toast.error(json.msg ?? json.message ?? 'Falha ao enviar para a oficina.');
+        return;
+      }
+      toast.success(json.message ?? 'Venda enviada para a oficina.');
+      router.reload({ only: ['journey'] });
+    } catch (err) {
+      toast.error(`Erro: ${(err as Error)?.message ?? err}`);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-card p-4">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <ol className="flex items-center gap-1 flex-wrap" aria-label="Progresso da venda">
+          {journey.nodes.map((node, i) => {
+            const isDone = node.state === 'done';
+            const isCurrent = node.state === 'current';
+            return (
+              <li key={node.key} className="flex items-center gap-1">
+                <span
+                  className={[
+                    'flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium transition-colors',
+                    isDone
+                      ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
+                      : isCurrent
+                        ? 'border-primary bg-primary/10 text-primary'
+                        : 'border-border bg-muted/40 text-muted-foreground',
+                  ].join(' ')}
+                  aria-current={isCurrent ? 'step' : undefined}
+                >
+                  <span
+                    className={[
+                      'flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-semibold',
+                      isDone
+                        ? 'bg-emerald-600 text-white'
+                        : isCurrent
+                          ? 'bg-primary text-primary-foreground'
+                          : 'bg-muted-foreground/20 text-muted-foreground',
+                    ].join(' ')}
+                  >
+                    {isDone ? <Check size={10} strokeWidth={3} /> : i + 1}
+                  </span>
+                  {node.label}
+                </span>
+                {i < journey.nodes.length - 1 && (
+                  <span
+                    className={['h-px w-5', isDone ? 'bg-emerald-300' : 'bg-border'].join(' ')}
+                    aria-hidden="true"
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+
+        {canSendToWorkshop && (
+          <Button type="button" size="sm" onClick={handleSend} disabled={sending}>
+            {sending ? (
+              <Loader2 size={14} className="mr-1.5 animate-spin" />
+            ) : (
+              <Wrench size={14} className="mr-1.5" />
+            )}
+            Enviar para a oficina
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tests/Feature/Sells/SaleJourneyGatingTest.php
+++ b/tests/Feature/Sells/SaleJourneyGatingTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * GUARD do breadcrumb "onde a venda está" (Wagner 2026-06-05).
+ *
+ * O stepper de jornada só pode aparecer em venda de oficina — varejo (ROTA
+ * LIVRE) recebe journey.show=false e NÃO renderiza. Estes asserts trancam o
+ * gate em 3 camadas (backend computa, Show gateia o render, o componente
+ * fail-safe retorna null) pra que nenhuma regressão exponha o breadcrumb pra
+ * quem não é oficina.
+ *
+ * Estrutural (lê source, sem DB) → roda no lane SQLite do CI. A lógica da
+ * jornada em si é coberta por tests/Unit/Services/SaleJourneyServiceTest.
+ *
+ * @see app/Services/SaleJourneyService.php
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+uses(Tests\TestCase::class);
+
+it('SellController computa o journey via SaleJourneyService e passa a prop', function () {
+    $src = (string) file_get_contents(base_path('app/Http/Controllers/SellController.php'));
+    expect($src)->toContain('App\Services\SaleJourneyService');
+    expect($src)->toContain("'journey' => \$journey");
+    // O gate per-business tem que estar na composição do estado (nunca hardcode).
+    expect($src)->toContain("'has_oficina_auto' => \$hasOficinaAuto");
+    expect($src)->toContain("'oficina_auto_module'");
+});
+
+it('Show.tsx só renderiza o stepper quando journey.show (varejo/ROTA LIVRE não vê)', function () {
+    $src = (string) file_get_contents(base_path('resources/js/Pages/Sells/Show.tsx'));
+    expect($src)->toContain('journey?.show && <SaleJourneyStepper');
+});
+
+it('SaleJourneyStepper é fail-safe: retorna null sem journey.show', function () {
+    $src = (string) file_get_contents(base_path('resources/js/Pages/Sells/_components/SaleJourneyStepper.tsx'));
+    // Guard de saída antecipada antes de qualquer render.
+    expect($src)->toContain('if (!journey?.show');
+    expect($src)->toContain('return null');
+});
+
+it('o serviço de jornada não acessa DB (função pura, testável no CI)', function () {
+    $src = (string) file_get_contents(base_path('app/Services/SaleJourneyService.php'));
+    // Sem Eloquent/DB dentro do serviço — o Controller resolve o estado.
+    expect($src)->not->toContain('DB::');
+    expect($src)->not->toContain('::where(');
+    expect($src)->not->toContain('->get()');
+});

--- a/tests/Unit/Services/SaleJourneyServiceTest.php
+++ b/tests/Unit/Services/SaleJourneyServiceTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\SaleJourneyService;
+
+/**
+ * Jornada/breadcrumb da venda de oficina (Wagner 2026-06-05). Função pura →
+ * roda no lane SQLite do CI. Cobre as duas direções + progressão dos estágios
+ * + o gate que protege a ROTA LIVRE (varejo nunca mostra o breadcrumb).
+ */
+
+function journey(array $state): array
+{
+    return (new SaleJourneyService())->build($state);
+}
+
+function keys(array $built): array
+{
+    return array_map(fn ($n) => $n['key'], $built['nodes']);
+}
+
+function stateOf(array $built, string $key): ?string
+{
+    foreach ($built['nodes'] as $n) {
+        if ($n['key'] === $key) {
+            return $n['state'];
+        }
+    }
+
+    return null;
+}
+
+// ─── Gate (ROTA LIVRE protegida) ────────────────────────────────────────────
+
+it('varejo SEM OficinaAuto nunca mostra o breadcrumb (ROTA LIVRE intocada)', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => false]);
+    expect($b['show'])->toBeFalse();
+});
+
+it('venda de oficina SEM veículo/OS e não-oficina-first não mostra (sem ruído)', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true,
+        'has_vehicle' => false, 'has_os' => false]);
+    expect($b['show'])->toBeFalse();
+});
+
+it('venda com veículo + OficinaAuto mostra o breadcrumb', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true, 'has_vehicle' => true]);
+    expect($b['show'])->toBeTrue();
+});
+
+// ─── Direção balcão (orçamento-first) ───────────────────────────────────────
+
+it('balcão segue Orçamento → Venda → Oficina → Faturamento → Entrega', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true, 'has_vehicle' => true]);
+    expect(keys($b))->toBe(['orcamento', 'venda', 'oficina', 'faturamento', 'entrega']);
+    expect($b['direction'])->toBe('balcao');
+});
+
+it('orçamento (status quotation) marca Orçamento como atual', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'quotation', 'has_oficina_auto' => true, 'has_vehicle' => true]);
+    expect($b['current'])->toBe('orcamento');
+    expect(stateOf($b, 'orcamento'))->toBe('current');
+    expect(stateOf($b, 'venda'))->toBe('todo');
+});
+
+it('venda final (sem OS ainda) marca Venda como atual e Orçamento como done', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true, 'has_vehicle' => true]);
+    expect($b['current'])->toBe('venda');
+    expect(stateOf($b, 'orcamento'))->toBe('done');
+    expect(stateOf($b, 'venda'))->toBe('current');
+    expect(stateOf($b, 'oficina'))->toBe('todo');
+});
+
+it('enviada pra oficina (OS criada) marca Oficina como atual', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true,
+        'has_vehicle' => true, 'has_os' => true]);
+    expect($b['current'])->toBe('oficina');
+    expect(stateOf($b, 'venda'))->toBe('done');
+    expect(stateOf($b, 'oficina'))->toBe('current');
+});
+
+it('faturada (NFe) marca Faturamento como atual', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true,
+        'has_vehicle' => true, 'has_os' => true, 'invoiced' => true]);
+    expect($b['current'])->toBe('faturamento');
+    expect(stateOf($b, 'oficina'))->toBe('done');
+});
+
+it('entregue marca Entrega como atual (último nó)', function () {
+    $b = journey(['source' => 'balcao', 'status' => 'final', 'has_oficina_auto' => true,
+        'has_vehicle' => true, 'has_os' => true, 'invoiced' => true, 'delivered' => true]);
+    expect($b['current'])->toBe('entrega');
+    expect(stateOf($b, 'faturamento'))->toBe('done');
+    expect(stateOf($b, 'entrega'))->toBe('current');
+});
+
+// ─── Direção oficina-first (OS → venda, ADR 0192) ───────────────────────────
+
+it('oficina-first segue Oficina → Venda → Faturamento → Entrega (sem Orçamento)', function () {
+    $b = journey(['source' => 'oficina', 'status' => 'final', 'has_oficina_auto' => true, 'has_os' => true]);
+    expect(keys($b))->toBe(['oficina', 'venda', 'faturamento', 'entrega']);
+    expect($b['direction'])->toBe('oficina');
+    expect($b['show'])->toBeTrue();
+});
+
+it('oficina-first com venda final marca Venda como atual', function () {
+    $b = journey(['source' => 'oficina', 'status' => 'final', 'has_oficina_auto' => true, 'has_os' => true]);
+    expect($b['current'])->toBe('venda');
+    expect(stateOf($b, 'oficina'))->toBe('done');
+});
+
+it('oficina-first faturada+entregue chega em Entrega', function () {
+    $b = journey(['source' => 'oficina', 'status' => 'final', 'has_oficina_auto' => true,
+        'has_os' => true, 'invoiced' => true, 'delivered' => true]);
+    expect($b['current'])->toBe('entrega');
+});
+
+// ─── Robustez ───────────────────────────────────────────────────────────────
+
+it('estado vazio não explode (defaults seguros)', function () {
+    $b = journey([]);
+    expect($b['show'])->toBeFalse();
+    expect($b['nodes'])->not->toBeEmpty();
+});


### PR DESCRIPTION
## Por quê
Wagner 2026-06-05: a venda com veículo precisa **ir pra oficina** e mostrar um **breadcrumb de onde ela está**. Dois fluxos (direção pelo `source`):

- **Balcão/orçamento-first:** Orçamento → Venda → **Oficina** → Faturamento → Entrega
- **Oficina-first** (`source='oficina'`, OS→venda ADR 0192): Oficina → Venda → Faturamento → Entrega

## O que entrega
- **"Enviar para a oficina"** — CTA no stepper que reusa `POST /sells/{id}/create-os` (cria OS ligada à venda, modo single = padrão Martinho/caçambas).
- **Breadcrumb/stepper** horizontal marcando o estágio atual, calculado do estado real (status, OS ligada, NFe, entrega).

## ROTA LIVRE protegida (muuuuuito cuidado 🛡️)
`journey.show=false` pra varejo sem OficinaAuto → **Show.tsx não renderiza nada novo**. Gate per-business (`oficina_auto_module`), nunca hardcode. Trancado em 3 camadas + testes.

## Testes (CI)
- `SaleJourneyServiceTest` (unit, 13 casos) — lógica pura das 2 direções + progressão + gate.
- `SaleJourneyGatingTest` (estrutural) — tranca o gate backend+front+componente.

## Visual
Screenshot do breadcrumb renderizado vai após deploy (biz=1) pra aprovação do Wagner (R2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)