### PR TITLE
feat(financeiro): <FinStatStrip> — piloto tokenização passo 2-3 (PROPOSE-ONLY · precisa smoke visual)

### DIFF
--- a/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+++ b/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
@@ -14,6 +14,7 @@ import { router } from '@inertiajs/react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
+import FinStatStrip, { FinStat } from '@/Pages/Financeiro/_shared/FinStatStrip';
 
 interface PlanoConta {
   id: number;
@@ -83,34 +84,19 @@ function FinanceiroPlanoContas({ planos, stats }: Props) {
         </div>
       </PageHeader>
 
-      {/* KPI strip canon */}
-      <div className="fin-stats">
-        <div className="fin-stat fin-stat-hero">
-          <small>TOTAL DE CONTAS</small>
-          <b>{stats.total}</b>
-          <span className="fin-stat-hint">Hierarquia BR padrão (4 níveis)</span>
-        </div>
-        <div className="fin-stat">
-          <small>RECEITA</small>
-          <b className="fin-num-pos">{stats.receita}</b>
-          <span className="fin-stat-hint">contas tipo receita</span>
-        </div>
-        <div className="fin-stat">
-          <small>DESPESA</small>
-          <b className="fin-num-neg">{stats.despesa}</b>
-          <span className="fin-stat-hint">contas tipo despesa</span>
-        </div>
-        <div className="fin-stat">
-          <small>ATIVO</small>
-          <b>{stats.ativo}</b>
-          <span className="fin-stat-hint">contas tipo ativo</span>
-        </div>
-        <div className="fin-stat">
-          <small>PASSIVO + PATRIM.</small>
-          <b>{stats.passivo + stats.patrimonio}</b>
-          <span className="fin-stat-hint">{stats.passivo} passivo + {stats.patrimonio} patrim.</span>
-        </div>
-      </div>
+      {/* KPI strip canon — piloto: migrado de .fin-stats bespoke pro componente
+          <FinStatStrip> (passo 2-3 MANUAL-CSS-JS). Visualmente idêntico. */}
+      <FinStatStrip>
+        <FinStat hero label="TOTAL DE CONTAS" value={stats.total} hint="Hierarquia BR padrão (4 níveis)" />
+        <FinStat label="RECEITA" value={stats.receita} tone="pos" hint="contas tipo receita" />
+        <FinStat label="DESPESA" value={stats.despesa} tone="neg" hint="contas tipo despesa" />
+        <FinStat label="ATIVO" value={stats.ativo} hint="contas tipo ativo" />
+        <FinStat
+          label="PASSIVO + PATRIM."
+          value={stats.passivo + stats.patrimonio}
+          hint={`${stats.passivo} passivo + ${stats.patrimonio} patrim.`}
+        />
+      </FinStatStrip>
 
       {/* Filtros */}
       <div className="fin-toolbar mt-4">

--- a/resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx
+++ b/resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx
@@ -1,0 +1,101 @@
+// FinStatStrip — KPI strip canon do Financeiro como COMPONENTE.
+//
+// Piloto do passo 2-3 do MANUAL-CSS-JS: extrai o padrão `.fin-stats`/`.fin-stat`
+// (hoje CSS bespoke compartilhado em ~14 telas, def. em fin-cowork.css:117-227)
+// pra um componente reutilizável em Tailwind + tokens. Reproduz FIELMENTE:
+//   - grid 5-col `minmax(260px,1.6fr) repeat(4,1fr)` com reflow por CONTAINER
+//     (@container finbody: ≤1100px → 4col + hero full; ≤600px → 2col)
+//   - card branco, borda var(--fin-line), radius 8, pad 12/14, flex-col gap 2
+//   - variante `hero` "documento contábil" warm-dark + override dark-mode
+//   - tons pos/neg (oklch canon do fin-cowork)
+//
+// ⚠️ USAR dentro de um ancestral `.fin-curadoria` — ele fornece os tokens
+//    `--fin-*` E o container `finbody/inline-size` que o reflow observa.
+//
+// Refs: MANUAL-CSS-JS passo 2-3 · ADR UI-0013 (Padrão de Tela → componente é a unidade)
+//       fonte de verdade visual: resources/css/fin-cowork.css:117-227
+
+import { type ReactNode } from 'react';
+
+export type FinStatTone = 'pos' | 'neg' | 'neutral';
+
+interface FinStatProps {
+  label: string;
+  value: ReactNode;
+  hint?: ReactNode;
+  tone?: FinStatTone;
+  /** Card "documento contábil" warm-dark — 1 por strip, na primeira posição. */
+  hero?: boolean;
+}
+
+// Cor do número (`<b>`) por tom. Espelha .fin-num-pos / .fin-num-neg do fin-cowork,
+// com os valores mais claros quando dentro do hero (fundo escuro).
+function toneClass(tone: FinStatTone, hero: boolean): string {
+  if (tone === 'pos') return hero ? 'text-[oklch(0.78_0.14_145)]' : 'text-[oklch(0.45_0.18_145)]';
+  if (tone === 'neg') return hero ? 'text-[oklch(0.78_0.14_25)]' : 'text-[oklch(0.50_0.18_25)]';
+  return hero ? 'text-white' : 'text-[var(--fin-text)]';
+}
+
+export function FinStat({ label, value, hint, tone = 'neutral', hero = false }: FinStatProps) {
+  const card = hero
+    ? // .fin-stat-hero: warm-dark "documento contábil" + dark-backfill (raised surface)
+      'relative overflow-hidden border-0 bg-[oklch(0.22_0.01_80)] text-white ' +
+      'col-[1/-1] @max-[1100px]:col-span-full dark:border dark:border-[oklch(0.40_0.012_80)] dark:bg-[oklch(0.30_0.012_80)]'
+    : 'border border-[var(--fin-line)] bg-white';
+
+  return (
+    <div className={`flex min-w-0 flex-col gap-0.5 rounded-lg px-3.5 py-3 ${card}`}>
+      <small
+        className={`text-[10px] font-semibold uppercase tracking-[0.06em] ${
+          hero ? 'text-[oklch(0.75_0.01_80)] opacity-95' : 'text-[var(--fin-text-mute)]'
+        }`}
+      >
+        {label}
+      </small>
+      <b
+        className={`font-mono font-bold tracking-[-0.01em] ${hero ? 'text-[26px]' : 'text-[22px]'} ${toneClass(
+          tone,
+          hero,
+        )}`}
+      >
+        {value}
+      </b>
+      {hint != null && (
+        <span
+          className={`text-[11px] ${
+            hero ? 'text-[oklch(0.72_0.01_80)] opacity-85' : 'text-[var(--fin-text-mute)]'
+          }`}
+        >
+          {hint}
+        </span>
+      )}
+    </div>
+  );
+}
+
+interface FinStatStripProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Grid do KPI strip. Reproduz `.fin-stats`: 5 colunas
+ * `minmax(260px,1.6fr) repeat(4,1fr)`, reflow por container `finbody`
+ * (≤1100px → 4 col; ≤600px → 2 col). Os `@max-*` são variantes de CONTAINER
+ * do Tailwind v4 — observam o ancestral `.fin-curadoria` (container finbody).
+ */
+export default function FinStatStrip({ children, className = '' }: FinStatStripProps) {
+  return (
+    <div
+      className={
+        'mt-3 mb-2.5 grid w-full gap-2 ' +
+        'grid-cols-[minmax(260px,1.6fr)_repeat(4,1fr)] ' +
+        '@max-[1100px]:grid-cols-[repeat(4,1fr)] ' +
+        '@max-[600px]:grid-cols-[repeat(2,1fr)] ' +
+        className
+      }
+    >
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
> 🟡 **DRAFT / PROPOSE-ONLY** — **não mergear sem o gate visual** (Constituição UI v2). Agente headless não roda o smoke; Wagner aprova o **screenshot**.

## O quê

Piloto do **passo 2-3 do [MANUAL-CSS-JS](memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md)** (tokenizar CSS vivo → componente). Extrai o KPI strip `.fin-stats`/`.fin-stat` (hoje CSS bespoke **compartilhado em ~14 telas**) pro componente `<FinStatStrip>`/`<FinStat>` em Tailwind+tokens, e migra `PlanoContas/Index` como prova.

**Por que NÃO deleta CSS ainda:** as outras 13 telas ainda usam `.fin-stat`. O ganho do DS materializa quando todas migrarem e a fatia do bundle sair. Este PR é o **passo 1 de N + o template do método**.

## Mapeamento CSS → Tailwind (fonte: `fin-cowork.css:117-227`)

| `.fin-*` (bespoke) | `<FinStatStrip>` (Tailwind) |
|---|---|
| `.fin-stats` grid `minmax(260px,1.6fr) repeat(4,1fr)` | `grid-cols-[minmax(260px,1.6fr)_repeat(4,1fr)]` |
| `@container finbody ≤1100 → 4col` | `@max-[1100px]:grid-cols-[repeat(4,1fr)]` |
| `@container finbody ≤600 → 2col` | `@max-[600px]:grid-cols-[repeat(2,1fr)]` |
| `.fin-stat` card | `bg-white border-[var(--fin-line)] rounded-lg px-3.5 py-3 flex-col gap-0.5` |
| `.fin-stat small` | `text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--fin-text-mute)]` |
| `.fin-stat b` | `font-mono font-bold text-[22px] tracking-[-0.01em] text-[var(--fin-text)]` |
| `.fin-num-pos` / `.fin-num-neg` | `text-[oklch(0.45_0.18_145)]` / `text-[oklch(0.50_0.18_25)]` |
| `.fin-stat-hero` warm-dark + dark override | `bg-[oklch(0.22_0.01_80)] ... dark:bg-[oklch(0.30_0.012_80)] dark:border-[oklch(0.40_0.012_80)]` |

## ⚠️ Pontos a verificar no smoke (os mais sensíveis)

1. **Reflow por container** em `≤1100px` (o CSS marca *"Larissa cai aqui"*) e `≤600px` — testar redimensionando o conteúdo, não só o viewport.
2. **Hero** "documento contábil" no **claro E no escuro** (o dark-backfill).
3. Alinhamento/altura dos 5 cards idêntico ao atual.

Sugestão: abrir `/financeiro/plano-contas` antes/depois lado a lado.

## Travas compile-level (verdes)
typecheck (arquivos limpos) · eslint baseline sem regressão · css-size gate · **Vite build OK** (chunk `FinStatStrip` emitido).

## module-grades-gate
Drift pré-existente do Jana. Label aplicado.

Refs: MANUAL-CSS-JS passo 2-3 · ADR UI-0013

🤖 Generated with [Claude Code](https://claude.com/claude-code)