### PR TITLE
fix(ads): model_used reflete OpenAI (provider ativo) em vez de claude hardcoded

### DIFF
--- a/Modules/ADS/Ai/Agents/BrainBAgent.php
+++ b/Modules/ADS/Ai/Agents/BrainBAgent.php
@@ -12,8 +12,9 @@ use Stringable;
  * Recebe um evento roteado pelo DecisionRouter com destination=brain_b
  * e gera uma instrução estruturada para o Claude Code executar.
  *
- * Modelo padrão: claude-sonnet-4-6 (configurado em config/ai.php).
- * Para eventos com criticality_score >= 0.8, usar claude-opus-4-7.
+ * Provider/modelo: resolvido por config('ai.default') (= openai pós-migração) +
+ * config('ai.providers.{provider}.models.text.*'). O Agent não fixa provider —
+ * herda o default global. Trocar de provider é via config/.env, não aqui.
  */
 class BrainBAgent implements Agent
 {

--- a/Modules/ADS/Services/BrainBService.php
+++ b/Modules/ADS/Services/BrainBService.php
@@ -72,7 +72,13 @@ class BrainBService
                 ->where('id', $decisionId)
                 ->update([
                     'brain_used'            => 'brain_b',
-                    'model_used'            => config('ai.providers.anthropic.model', 'claude-sonnet-4-6'),
+                    // Reflete o provider ATIVO (config('ai.default') = openai pós-migração),
+                    // não um modelo hardcoded — mesmo resolver que LaravelAiSdkDriver usa.
+                    'model_used'            => (static function (): string {
+                        $sistema = (string) config('ai.default', 'openai');
+
+                        return (string) config("ai.providers.{$sistema}.models.text.default", 'gpt-4o-mini');
+                    })(),
                     'instruction_generated' => $rawText,
                     'tokens_used'           => $tokensUsed,
                     'execution_ms'          => $executionMs,


### PR DESCRIPTION
## Contexto

Migração **definitiva** da stack de IA do app Laravel pra **OpenAI** (sem crédito Anthropic). Diagnóstico: o runtime **já estava em OpenAI** —  `config('ai.default')='openai'`, `ANTHROPIC_API_KEY` vazia no `.env`, `OPENAI_API_KEY` válida, e nenhum pino incondicional de Anthropic nos caminhos de execução (chat Jana/Copiloto, Brief, Agents herdam o default global; prompt-caching Anthropic é condicional → no-op gracioso).

Restava **1 leftover de observabilidade** que rotulava errado.

## O que muda

- **`Modules/ADS/Services/BrainBService.php`** — a coluna `model_used` em `mcp_dual_brain_decisions` gravava `claude-sonnet-4-6` (fallback hardcoded — `ai.providers.anthropic.model` nem existe no config), mesmo o `BrainBAgent` rodando em OpenAI. Agora resolve o modelo do **provider ativo** (`config('ai.default')` + `…models.text.default`), idêntico ao resolver do `LaravelAiSdkDriver`. → passa a refletir `gpt-4o-mini`.
- **`Modules/ADS/Ai/Agents/BrainBAgent.php`** — docstring atualizado (dizia "Modelo padrão: claude-sonnet-4-6", contradizendo o config).

## Por que é seguro

- Sem mudança de comportamento de execução — só corrige o **label** persistido (observabilidade/custo honestos).
- `BrainBIsolationTest` **não quebra**: seeda `model_used` próprio pra testar escopo `business_id`, não asserta o label que o service grava.
- `php -l` limpo nos 2 arquivos.

## Fora de escopo (follow-up se você quiser)

- Migrar os 3 comandos de **eval/CI** (`EvalAdrDiscoveryCommand`, `EvalRagasBaselineCommand`, `UiJudgePrCommand`) que ainda batem em `api.anthropic.com` — não são runtime de cliente, saem graceful sem a key.
- **ADR de superseding 0035** registrando a troca definitiva pra OpenAI no Tier 0 da stack de IA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)