### PR TITLE
chore(eval): migra comandos LLM-as-judge de Anthropic pra OpenAI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,8 +88,9 @@ jobs:
         # transactions MODIFY COLUMN type ENUM) — fica pra um setup MySQL em CI.
         #
         # PrUiJudgeAgentTest e DB-less (reflexao nos atributos + string do prompt):
-        # trava provider/model do juiz de UI (anti "mentira do Sonnet", parecer
-        # PR #2270). Modules/Jana nao esta no modules-pest.yml, entao ancoramos a
+        # trava provider/model do juiz de UI (canon openai/gpt-4o pos-migracao
+        # OpenAI; ex "mentira do Sonnet", parecer PR #2270). Modules/Jana nao
+        # esta no modules-pest.yml, entao ancoramos a
         # catraca aqui pra ela rodar de fato em todo PR.
         run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage
 

--- a/.github/workflows/pr-ui-judge.yml
+++ b/.github/workflows/pr-ui-judge.yml
@@ -1,19 +1,18 @@
 name: PR UI Judge (LLM Brain B · Constituição UI v2)
 
 # Onda 4.1 do AUTOMATION-ROADMAP. Avalia PRs Inertia/React contra a
-# Constituição UI v2 usando Claude Sonnet 4.6. Posta comentário inline
+# Constituição UI v2 usando OpenAI gpt-4o. Posta comentário inline
 # com score 0-100 + 9 dimensões + violações estruturais + sugestões.
 #
 # CUSTO REAL:
-# - ~$0.034/PR (Claude Sonnet 4.6)
-# - ~$0.005/PR após primeiro do dia (prompt caching ~85% reuse)
-# - ~$3/mês a 100 PRs/mês
+# - ~$0.05/PR (OpenAI gpt-4o, ~10k in + ~1k out)
+# - ~$5/mês a 100 PRs/mês
 #
 # DEFAULT: DESLIGADO (env var PR_UI_JUDGE_ENABLED não setada).
-# Wagner ativa quando quota Brain B aprovada:
+# Wagner ativa quando quota aprovada:
 #   GitHub Repo → Settings → Secrets and variables → Actions → Variables
 #   Adicionar variable PR_UI_JUDGE_ENABLED=true
-#   Adicionar secret ANTHROPIC_API_KEY (provavelmente já existe)
+#   Adicionar secret OPENAI_API_KEY (provavelmente já existe)
 #
 # NÃO substitui ui-lint.yml (sintático/lexical) — complementa com análise
 # semântica que grep não vê: drawer modal sobre modal, slot reinventado,
@@ -48,7 +47,7 @@ permissions:
 
 jobs:
   judge:
-    name: PR UI Judge · Claude Sonnet 4.6
+    name: PR UI Judge · OpenAI gpt-4o
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
+++ b/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
@@ -14,8 +14,7 @@ use Stringable;
 /**
  * PrUiJudgeAgent — Onda 4.1 do AUTOMATION-ROADMAP.
  *
- * Agente LLM (Anthropic claude-sonnet-4-6 · review de design exige juízo
- * semântico superior ao gpt-4o-mini) que
+ * Agente LLM (OpenAI gpt-4o · review de design exige juízo semântico) que
  * avalia PRs Inertia/React contra a Constituição UI v2 (ADR UI-0013). Carrega
  * no system prompt:
  *  - Hierarquia 4 camadas (Fundações → Shell → PT → Módulo)
@@ -38,23 +37,21 @@ use Stringable;
  * "copy não-PT-BR em string template", "PT-01 violado em essência mesmo
  * importando PageHeader (uso fora do slot 1)".
  *
- * Custo estimado por PR: ~10k tokens input + ~1k tokens output ≈ $0.034/PR
- * (claude-sonnet-4-6 @ $3/M input + $15/M output) · com prompt caching do
- * system prompt fixo cai pra ~$0.005/PR.
+ * Custo estimado por PR: ~10k tokens input + ~1k tokens output ≈ $0.05/PR
+ * (gpt-4o @ $2.5/M input + $10/M output).
  *
- * HISTÓRICO: nasceu em OpenAI gpt-4o-mini ($0.002/PR), mas o command e o
- * workflow já se anunciavam como "Claude Sonnet" — inconsistência ativa
- * (a tela dizia Sonnet, rodava gpt-4o-mini). Migrado pra anthropic /
- * claude-sonnet-4-6 (canon do projeto · BrainBAgent, EvalCommands) tanto
- * pra resolver a inconsistência quanto pela qualidade de juízo semântico
- * que review de design exige. `ANTHROPIC_API_KEY` já é pré-req do kill-switch.
+ * HISTÓRICO: nasceu em OpenAI gpt-4o-mini ($0.002/PR); migrou pra
+ * anthropic/claude-sonnet-4-6 por qualidade de juízo; agora volta pra OpenAI
+ * gpt-4o (provider canon pós-migração — config('ai.default')='openai', sem
+ * crédito Anthropic). gpt-4o (smartest do config/ai.php) preserva o juízo
+ * semântico que review de design exige, melhor que o gpt-4o-mini original.
  *
  * @see memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md (Onda 4.1)
  * @see memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md
  * @see memory/decisions/0141-agents-tool-use-pattern-claude-code.md
  */
-#[Provider('anthropic')]
-#[Model('claude-sonnet-4-6')]
+#[Provider('openai')]
+#[Model('gpt-4o')]
 #[MaxSteps(3)]
 class PrUiJudgeAgent implements Agent
 {

--- a/Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
@@ -14,29 +14,33 @@ uses(Tests\TestCase::class);
  * Origem 2026-06-05 (parecer PR #2270): o juiz se anunciava "Claude Sonnet 4.5"
  * em 3 lugares (command + workflow) mas rodava #[Provider('openai')] /
  * #[Model('gpt-4o-mini')] — inconsistência ativa ("a mentira do Sonnet").
- * G3 resolveu migrando pra anthropic / claude-sonnet-4-6 (canon do projeto).
- * Estes testes TRAVAM a consistência pra ela não regredir silenciosamente.
+ * G3 resolveu migrando pra anthropic / claude-sonnet-4-6.
  *
- *  001. provider declarado = anthropic (não openai)
- *  002. model declarado = claude-sonnet-4-6 (canon · BrainBAgent/EvalCommands)
+ * Atualizado 2026-06-05 (migração definitiva pra OpenAI · sem crédito Anthropic):
+ * o canon de provider agora é openai / gpt-4o (config('ai.default')='openai').
+ * gpt-4o (smartest do config/ai.php) preserva o juízo semântico que review de
+ * design exige. Estes testes TRAVAM a consistência pra ela não regredir.
+ *
+ *  001. provider declarado = openai (canon pós-migração)
+ *  002. model declarado = gpt-4o (smartest · review de design)
  *  003. instructions() carrega contrato G-Eval (rationale ANTES do score)
  *  004. instructions() ainda carrega a Constituição UI v2 (4 camadas + AP1-AP8)
  *
  * @see memory/handoffs/2026-06-05-1430-parecer-pr2270-julgamento-ia-design.md
  * @see memory/decisions/0141-agents-tool-use-pattern-claude-code.md
  */
-it('R-JANA-UI-JUDGE-001 — declara provider anthropic (não a mentira do openai)', function () {
+it('R-JANA-UI-JUDGE-001 — declara provider openai (canon pós-migração)', function () {
     $attrs = (new ReflectionClass(PrUiJudgeAgent::class))->getAttributes(Provider::class);
 
     expect($attrs)->not->toBeEmpty();
-    expect($attrs[0]->getArguments()[0])->toBe('anthropic');
+    expect($attrs[0]->getArguments()[0])->toBe('openai');
 });
 
-it('R-JANA-UI-JUDGE-002 — declara model claude-sonnet-4-6 (canon do projeto)', function () {
+it('R-JANA-UI-JUDGE-002 — declara model gpt-4o (smartest · review de design)', function () {
     $attrs = (new ReflectionClass(PrUiJudgeAgent::class))->getAttributes(Model::class);
 
     expect($attrs)->not->toBeEmpty();
-    expect($attrs[0]->getArguments()[0])->toBe('claude-sonnet-4-6');
+    expect($attrs[0]->getArguments()[0])->toBe('gpt-4o');
 });
 
 it('R-JANA-UI-JUDGE-003 — instructions() exige rationale ANTES do score (G-Eval)', function () {

--- a/app/Console/Commands/EvalAdrDiscoveryCommand.php
+++ b/app/Console/Commands/EvalAdrDiscoveryCommand.php
@@ -9,12 +9,14 @@ use Symfony\Component\Yaml\Yaml;
 /**
  * Camada 3 — Eval LLM-as-judge da Eval Suite (Opção C).
  *
- * Roda golden questions de tests/eval/golden-questions.yaml contra Anthropic API
+ * Roda golden questions de tests/eval/golden-questions.yaml contra o LLM
  * SEM tools (testa o pior caso — modelo sem busca canônica). Score baseado em
  * substring match contra `must_contain` / `must_not_contain`.
  *
- * Modelo padrão: claude-sonnet-4-6 (Sonnet é mais barato pra eval que Opus).
- * Custo aprox: $0.30/run com 8 perguntas.
+ * Provider auto-detect (pós-migração OpenAI): prefere OpenAI (mais barato),
+ * fallback Anthropic. Forçável via --provider. Modelo default por provider:
+ * gpt-4o-mini (openai) / claude-sonnet-4-6 (anthropic). Custo gpt-4o-mini
+ * ~$0.01/run com 8 perguntas.
  *
  * Output:
  *   - Tabela no terminal
@@ -22,7 +24,7 @@ use Symfony\Component\Yaml\Yaml;
  *
  * Exit code 1 se score médio < 0.7 (CI gate).
  *
- * Sem ANTHROPIC_API_KEY no env, sai 0 graceful (não quebra CI).
+ * Sem OPENAI_API_KEY nem ANTHROPIC_API_KEY no env, sai 0 graceful (não quebra CI).
  *
  * Ver: ADR 0064/0065/0066 (entradas canônicas testadas).
  */
@@ -30,16 +32,26 @@ class EvalAdrDiscoveryCommand extends Command
 {
     protected $signature = 'eval:adr-discovery
                             {--question= : Roda apenas 1 question por id}
-                            {--model=claude-sonnet-4-6 : Modelo Anthropic}
+                            {--provider= : Forçar provider (openai | anthropic). Auto-detect via env por default.}
+                            {--model= : Modelo do LLM (auto-detect: gpt-4o-mini se OpenAI, claude-sonnet-4-6 se Anthropic)}
                             {--threshold=0.7 : Score médio mínimo pra exit 0}';
 
     protected $description = 'Eval LLM-as-judge das golden questions sobre ADRs canônicas';
 
     public function handle(): int
     {
-        $apiKey = env('ANTHROPIC_API_KEY');
+        // Provider auto-detect: prefere OpenAI (mais barato), fallback Anthropic.
+        $provider = $this->option('provider')
+            ?: (env('OPENAI_API_KEY') ? 'openai' : (env('ANTHROPIC_API_KEY') ? 'anthropic' : null));
+
+        if ($provider === null) {
+            $this->warn('Nem OPENAI_API_KEY nem ANTHROPIC_API_KEY no .env — eval pulado (graceful exit).');
+            return 0;
+        }
+
+        $apiKey = $provider === 'openai' ? env('OPENAI_API_KEY') : env('ANTHROPIC_API_KEY');
         if (! $apiKey) {
-            $this->warn('ANTHROPIC_API_KEY ausente — eval pulado (graceful exit).');
+            $this->warn(strtoupper($provider) . '_API_KEY ausente — eval pulado (graceful exit).');
             return 0;
         }
 
@@ -64,8 +76,9 @@ class EvalAdrDiscoveryCommand extends Command
             }
         }
 
-        $model = $this->option('model');
-        $systemPrompt = "Você é Claude trabalhando no projeto oimpresso (ERP gráfico Laravel + UltimatePOS). " .
+        $model = $this->option('model')
+            ?: ($provider === 'openai' ? 'gpt-4o-mini' : 'claude-sonnet-4-6');
+        $systemPrompt = "Você é um assistente trabalhando no projeto oimpresso (ERP gráfico Laravel + UltimatePOS). " .
             "Responda usando apenas conhecimento de `memory/decisions/*.md` (ADRs canônicas do projeto). " .
             "Se não souber, diga 'não tenho info canônica'. Seja conciso (3-6 frases).";
 
@@ -74,7 +87,7 @@ class EvalAdrDiscoveryCommand extends Command
             $id = $q['id'] ?? '?';
             $this->line("→ Avaliando: <info>$id</info>");
 
-            $resposta = $this->askAnthropic($apiKey, $model, $systemPrompt, $q['question']);
+            $resposta = $this->askLlm($provider, $apiKey, $model, $systemPrompt, $q['question']);
             if ($resposta === null) {
                 $results[] = [
                     'id' => $id, 'score' => 0.0, 'erro' => 'API call falhou',
@@ -115,6 +128,7 @@ class EvalAdrDiscoveryCommand extends Command
         $jsonPath = $resultsDir . '/' . date('Y-m-d-His') . '.json';
         file_put_contents($jsonPath, json_encode([
             'timestamp' => date('c'),
+            'provider'  => $provider,
             'model'     => $model,
             'avg_score' => $media,
             'results'   => $results,
@@ -122,6 +136,40 @@ class EvalAdrDiscoveryCommand extends Command
         $this->line("JSON salvo em: $jsonPath");
 
         return $media >= (float) $this->option('threshold') ? 0 : 1;
+    }
+
+    private function askLlm(string $provider, string $apiKey, string $model, string $system, string $userMsg): ?string
+    {
+        return $provider === 'openai'
+            ? $this->askOpenAi($apiKey, $model, $system, $userMsg)
+            : $this->askAnthropic($apiKey, $model, $system, $userMsg);
+    }
+
+    private function askOpenAi(string $apiKey, string $model, string $system, string $userMsg): ?string
+    {
+        try {
+            $resp = Http::withHeaders([
+                'Authorization' => "Bearer $apiKey",
+                'Content-Type'  => 'application/json',
+            ])->timeout(60)->post('https://api.openai.com/v1/chat/completions', [
+                'model'    => $model,
+                'messages' => [
+                    ['role' => 'system', 'content' => $system],
+                    ['role' => 'user',   'content' => $userMsg],
+                ],
+                'max_tokens'  => 1024,
+                'temperature' => 0,
+            ]);
+
+            if (! $resp->successful()) {
+                $this->warn("API erro {$resp->status()}: " . substr($resp->body(), 0, 200));
+                return null;
+            }
+            return $resp->json()['choices'][0]['message']['content'] ?? null;
+        } catch (\Throwable $e) {
+            $this->warn("HTTP exception: {$e->getMessage()}");
+            return null;
+        }
     }
 
     private function askAnthropic(string $apiKey, string $model, string $system, string $userMsg): ?string

--- a/app/Console/Commands/UiJudgePrCommand.php
+++ b/app/Console/Commands/UiJudgePrCommand.php
@@ -12,13 +12,13 @@ use Modules\Jana\Entities\UiJudgeRun;
 /**
  * `ui:judge-pr` — Onda 4.1 do AUTOMATION-ROADMAP (Constituição UI v2).
  *
- * Avalia um PR contra a Constituição UI v2 usando agente LLM (Anthropic Claude
- * Sonnet 4.6) e — opcionalmente — posta comentário inline no PR via `gh`.
+ * Avalia um PR contra a Constituição UI v2 usando agente LLM (OpenAI gpt-4o)
+ * e — opcionalmente — posta comentário inline no PR via `gh`.
  *
  * Workflow:
  *   1. Pega metadata do PR (título · descrição · arquivos modificados) via gh CLI
  *   2. Pega diff filtrado (.tsx, .jsx, .css)
- *   3. Manda pro PrUiJudgeAgent (anthropic / claude-sonnet-4-6)
+ *   3. Manda pro PrUiJudgeAgent (openai / gpt-4o)
  *   4. Parse output JSON
  *   5. Print score + violações no console
  *   6. (Opcional) `--post-comment` posta no PR via gh
@@ -29,8 +29,7 @@ use Modules\Jana\Entities\UiJudgeRun;
  *   php artisan ui:judge-pr 1438 --post-comment # postar comentário no PR
  *   php artisan ui:judge-pr 1438 --strict       # exit 1 se verdict=request_changes
  *
- * Custo estimado por run: ~$0.034 (Claude Sonnet 4.6) · com prompt caching
- * cai pra ~$0.005 após primeiro PR do dia.
+ * Custo estimado por run: ~$0.05 (OpenAI gpt-4o, ~10k in + ~1k out).
  *
  * @see Modules\Jana\Ai\Agents\PrUiJudgeAgent
  * @see memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md (Onda 4)
@@ -101,7 +100,7 @@ class UiJudgePrCommand extends Command
         $this->line('  Diff UI: '.strlen($diff).' bytes');
 
         // 4. Mandar pro agent
-        $this->info('Enviando pra PrUiJudgeAgent (Claude Sonnet 4.6)...');
+        $this->info('Enviando pra PrUiJudgeAgent (OpenAI gpt-4o)...');
         $output = $this->runAgent($prData, $diff);
         if ($output === null) {
             return self::FAILURE;
@@ -212,6 +211,7 @@ class UiJudgePrCommand extends Command
             str_contains($model, 'sonnet') => 0.034,
             str_contains($model, 'haiku') => 0.003,
             str_contains($model, 'gpt-4o-mini') => 0.002,
+            str_contains($model, 'gpt-4o') => 0.050,
             default => null,
         };
     }
@@ -312,15 +312,16 @@ class UiJudgePrCommand extends Command
     private function runAgent(array $prData, string $diff): ?string
     {
         // Pre-flight: validar API key do provider configurado no PrUiJudgeAgent.
-        // PrUiJudgeAgent = Anthropic claude-sonnet-4-6 (review de design exige
-        // juízo semântico · canon do projeto). Wagner pode trocar editando o
-        // @Provider/@Model do agent.
-        $anthropicKey = (string) (config('ai.providers.anthropic.key') ?? env('ANTHROPIC_API_KEY') ?? '');
+        // PrUiJudgeAgent = OpenAI gpt-4o (provider canon pós-migração). Wagner
+        // pode trocar editando o @Provider/@Model do agent — o check abaixo lê
+        // o provider por reflexão, então segue o agent sem hardcode.
+        [$provider] = $this->agentProviderModel();
+        $envVar = strtoupper($provider) . '_API_KEY';
+        $providerKey = (string) (config("ai.providers.{$provider}.key") ?? env($envVar) ?? '');
 
-        if ($anthropicKey === '') {
-            $this->error('ANTHROPIC_API_KEY não configurada (provider do PrUiJudgeAgent)');
-            $this->line('  Adicionar em .env: ANTHROPIC_API_KEY=sk-ant-... (Claude Sonnet 4.6)');
-            $this->line('  Pegar key em: https://console.anthropic.com/settings/keys');
+        if ($providerKey === '') {
+            $this->error("{$envVar} não configurada (provider '{$provider}' do PrUiJudgeAgent)");
+            $this->line("  Adicionar em .env: {$envVar}=...");
             $this->line('  Depois: php artisan config:clear');
 
             return null;
@@ -343,14 +344,14 @@ class UiJudgePrCommand extends Command
             $msg = $e->getMessage();
 
             // Diagnóstico amigável pra erros comuns
-            if (str_contains($msg, '401') || str_contains($msg, 'x-api-key') || str_contains($msg, 'authentication')) {
-                $this->error('ANTHROPIC_API_KEY inválida ou expirada (HTTP 401)');
-                $this->line('  Verificar valor em .env · regenerar key em https://console.anthropic.com');
+            if (str_contains($msg, '401') || str_contains($msg, 'x-api-key') || str_contains($msg, 'authentication') || str_contains($msg, 'Incorrect API key')) {
+                $this->error('API key do provider inválida ou expirada (HTTP 401)');
+                $this->line('  Verificar valor em .env · regenerar key no dashboard do provider');
                 $this->line('  Depois: php artisan config:clear');
             } elseif (str_contains($msg, '429') || str_contains($msg, 'rate_limit')) {
-                $this->error('Rate limit Anthropic (HTTP 429) · aguardar 60s e tentar novamente');
+                $this->error('Rate limit do provider (HTTP 429) · aguardar 60s e tentar novamente');
             } elseif (str_contains($msg, '529') || str_contains($msg, 'overloaded')) {
-                $this->error('Anthropic overloaded (HTTP 529) · tentar novamente em alguns minutos');
+                $this->error('Provider overloaded (HTTP 529) · tentar novamente em alguns minutos');
             } else {
                 $this->error("PrUiJudgeAgent falhou: {$msg}");
             }


### PR DESCRIPTION
## Contexto

Fecha a conta da **migração definitiva pra OpenAI** nas ferramentas de **eval/CI** que ainda batiam em `api.anthropic.com`. Não são runtime de cliente (saem graceful sem key), mas eram o último resíduo de Anthropic no app.

## O que muda

### `eval:adr-discovery` (`EvalAdrDiscoveryCommand`)
- Ganha **auto-detect de provider** (prefere OpenAI, fallback Anthropic) + `askOpenAi()`, espelhando o que `eval:ragas-baseline` já fazia.
- Default `gpt-4o-mini`. Graceful exit só quando **nenhuma** das duas keys existe (antes exigia `ANTHROPIC_API_KEY`).

### `ui:judge-pr` + `PrUiJudgeAgent`
- Flip `#[Provider('anthropic')]` / `#[Model('claude-sonnet-4-6')]` → **`#[Provider('openai')]` / `#[Model('gpt-4o')]`** (smartest do `config/ai.php`, preserva o juízo semântico que review de design exige).
- Pre-flight do command vira **provider-aware** (lê o provider por reflexão do agent — sem hardcode da key Anthropic).
- Catraca `PrUiJudgeAgentTest` 001/002 atualizada pro novo canon `openai`/`gpt-4o`.
- Workflows `ci.yml` + `pr-ui-judge.yml`: strings cosméticas "Claude Sonnet 4.6" → "OpenAI gpt-4o" + secret `OPENAI_API_KEY`.

### Sem mudança
- `eval:ragas-baseline` já preferia OpenAI.
- `UiJudgeRunMeasurementTest` (persistência) segue com valores de fixture arbitrários — testa a coluna, não o agent vivo.

## Validação
- `php -l` limpo nos 4 arquivos PHP.
- Catraca `PrUiJudgeAgentTest` roda no job Pest Unit do `ci.yml` (DB-less, reflexão) e valida o novo canon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)