### PR TITLE
fix(superadmin): widen subscriptions.status enum + destrava SubscriptionLifecycleService [ADR 0208]

### DIFF
--- a/Modules/Superadmin/Database/Migrations/2026_06_05_000100_widen_subscriptions_status_enum.php
+++ b/Modules/Superadmin/Database/Migrations/2026_06_05_000100_widen_subscriptions_status_enum.php
@@ -1,0 +1,54 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Widen subscriptions.status enum (additive) — destrava SubscriptionLifecycleService.
+ *
+ * Original (2018_06_28_182803_create_subscriptions_table): enum('approved','waiting','declined').
+ * SubscriptionLifecycleService (approve/expire/cancel) escreve 'expired' e 'cancelled',
+ * que NÃO existiam no enum → em MySQL strict mode lançaria ao gravar (bug latente, serviço
+ * ainda não-wired). BusinessAuditService::subscriptionAgingSummary() e BusinessController já
+ * esperam os buckets 'expired'/'cancelled' → o enum é que estava incompleto.
+ *
+ * ADITIVA: só acrescenta valores, não remove nem renomeia. Backward-compatible — código que
+ * checa 'approved'/'waiting'/'declined' segue intacto. Tabela Tier 0 cross-tenant billing
+ * (ADR 0093 §exceções Superadmin Wagner-only) — alteração de schema sem dado de tenant.
+ *
+ * MySQL-only: enum widening usa ALTER ... MODIFY (sintaxe MySQL). SQLite (test :memory:) não
+ * exercita o CHECK aqui — os testes que persistem 'expired'/'cancelled' são MySQL-only
+ * (markTestSkipped em sqlite). No-op em outros drivers evita erro no pipeline.
+ *
+ * Refs: ADR 0208 (larastan baseline ratchet — fecha os 4 erros do serviço na origem),
+ *       ADR 0093 (multi-tenant Tier 0 §exceções).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        DB::statement(
+            "ALTER TABLE `subscriptions` MODIFY `status` "
+            ."ENUM('approved','waiting','declined','expired','cancelled') NOT NULL DEFAULT 'waiting'"
+        );
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return;
+        }
+
+        // Reverte pro enum de 3 valores. Seguro apenas se nenhuma linha estiver em
+        // 'expired'/'cancelled' (do contrário o MODIFY trunca pra '' em non-strict
+        // ou lança em strict). Serviço não-wired → sem linhas nesses estados ainda.
+        DB::statement(
+            "ALTER TABLE `subscriptions` MODIFY `status` "
+            ."ENUM('approved','waiting','declined') NOT NULL DEFAULT 'waiting'"
+        );
+    }
+};

--- a/Modules/Superadmin/Entities/Subscription.php
+++ b/Modules/Superadmin/Entities/Subscription.php
@@ -8,6 +8,15 @@ use Illuminate\Support\Facades\DB;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
+/**
+ * Coluna `subscriptions.status` é enum (migration aditiva 2026_06_05_000100 amplia
+ * de 3 → 5 valores). Larastan deriva o tipo do enum da migration de criação via
+ * Blueprint, mas não enxerga `ALTER ... MODIFY` em SQL cru — daí a anotação explícita
+ * mantém o tipo estático em sincronia com o schema real (SubscriptionLifecycleService
+ * grava 'expired'/'cancelled'). Refs ADR 0208.
+ *
+ * @property 'approved'|'waiting'|'declined'|'expired'|'cancelled' $status
+ */
 class Subscription extends Model
 {
     use LogsActivity;

--- a/Modules/Superadmin/Services/SubscriptionLifecycleService.php
+++ b/Modules/Superadmin/Services/SubscriptionLifecycleService.php
@@ -13,7 +13,7 @@ use Modules\Superadmin\Entities\Subscription;
  * SubscriptionLifecycleService — encapsula transições de status Subscription.
  *
  * Wave 18 RETRY — D4 boost. Subscription tem status linear simples
- * (waiting_approval → approved → expired) — não justifica FSM Pipeline ADR 0143
+ * (waiting → approved → expired/cancelled) — não justifica FSM Pipeline ADR 0143
  * (declarado `fsm_n_a: true` em module.json), mas merece Service dedicado pra:
  *
  *   - Centralizar regra "quando approve cria audit trail automático"
@@ -45,7 +45,7 @@ class SubscriptionLifecycleService
     public function approve(Subscription $subscription, ?Carbon $startDate = null): bool
     {
         return OtelHelper::spanBiz('superadmin.subscription.approve', function () use ($subscription, $startDate): bool {
-            if ($subscription->status !== 'waiting' && $subscription->status !== 'waiting_approval') {
+            if ($subscription->status !== 'waiting') {
                 return false;
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37632,30 +37632,6 @@ parameters:
 			path: Modules/Repair/Http/Controllers/RepairController.php
 
 		-
-			message: '#^Call to function in_array\(\) with arguments ''approved''\|''declined''\|''waiting'', array\{''cancelled'', ''expired''\} and true will always evaluate to false\.$#'
-			identifier: function.impossibleType
-			count: 1
-			path: Modules/Superadmin/Services/SubscriptionLifecycleService.php
-
-		-
-			message: '#^Property Modules\\Superadmin\\Entities\\Subscription\:\:\$status \(''approved''\|''declined''\|''waiting''\) does not accept ''cancelled''\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: Modules/Superadmin/Services/SubscriptionLifecycleService.php
-
-		-
-			message: '#^Property Modules\\Superadmin\\Entities\\Subscription\:\:\$status \(''approved''\|''declined''\|''waiting''\) does not accept ''expired''\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: Modules/Superadmin/Services/SubscriptionLifecycleService.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between ''approved''\|''declined'' and ''waiting_approval'' will always evaluate to true\.$#'
-			identifier: notIdentical.alwaysTrue
-			count: 1
-			path: Modules/Superadmin/Services/SubscriptionLifecycleService.php
-
-		-
 			message: '#^Expression on left side of \?\? is not nullable\.$#'
 			identifier: nullCoalesce.expr
 			count: 1


### PR DESCRIPTION
## O quê

Fecha o débito LATENTE que a PR #2300 baselinou e deferiu pra decisão Wagner: `SubscriptionLifecycleService` gravava `'expired'`/`'cancelled'` e comparava o valor morto `'waiting_approval'`, mas `subscriptions.status` era `enum('approved','waiting','declined')`. Em MySQL strict mode isso lançaria ao gravar (serviço ainda **não-wired** → bug latente, não crash hoje).

**Decisão Wagner: Opção A — ampliar o enum** (o ciclo de vida é capacidade de billing legítima; `BusinessAuditService::subscriptionAgingSummary()` e `BusinessController` já esperam os buckets `expired`/`cancelled`).

## Mudanças (4 arquivos)

- **Migration aditiva** `2026_06_05_000100_widen_subscriptions_status_enum.php` — amplia o enum p/ 5 valores. MySQL-guarded (no-op em sqlite; os testes que persistem esses status são MySQL-only via `markTestSkipped`). Backward-compatible — Tier 0 cross-tenant billing (ADR 0093 §exceções).
- **Service** — remove o branch morto `&& $subscription->status !== 'waiting_approval'` em `approve()` (reconcilia p/ `'waiting'`, o status legacy real). Doc atualizado.
- **Model** `Subscription` — `@property` com o union de 5 valores mantém o tipo estático do Larastan em sync com o enum real (Larastan deriva o tipo da migration de criação via Blueprint, mas **não** lê `ALTER ... MODIFY` em SQL cru).
- **phpstan-baseline.neon** — remove as **4 entradas Set2** do `SubscriptionLifecycleService` (add por 46b987f9e: `function.impossibleType`, `assign.propertyType ×2`, `notIdentical.alwaysTrue`). Agora resolvidas na origem.

## Verificação

- `composer phpstan` (full project, PHP 8.4.21) → **`[OK] No errors`**
- Pest Superadmin (4 arquivos lifecycle) → **73 passed, 41 skipped** (DB tests MySQL-only), 0 falhas

## ⚠️ Stacking / base

Base aponta pra **`fix/phpstan-baseline-drift` (#2300)** de propósito: as 4 entradas removidas só existem naquele branch. Merge order sugerido: **#2300 primeiro**, depois esta. Se preferir, rebase em `main` após #2300 mergear.

Refs: ADR 0208, ADR 0093