### PR TITLE
feat(oficina): P0-2 — baixa de estoque ao concluir OS + Tier 0 no product_id

### DIFF
--- a/Modules/OficinaAuto/Observers/ServiceOrderObserver.php
+++ b/Modules/OficinaAuto/Observers/ServiceOrderObserver.php
@@ -132,6 +132,28 @@ class ServiceOrderObserver
             $so->transaction_id = $tx->id;
             $so->saveQuietly(); // saveQuietly evita re-trigger Observer (infinite loop guard)
 
+            // P0-2 — baixa de estoque das peças da OS (análise tela-venda × oficina 2026-06-04).
+            // Ancorado no mesmo caminho once-only do faturamento (transaction_id agora linkado),
+            // então uma 2ª conclusão não re-baixa. Falha de baixa NÃO desfaz o faturamento.
+            try {
+                $baixados = app(\Modules\OficinaAuto\Services\ServiceOrderItemService::class)
+                    ->baixarEstoqueConclusao((int) $so->business_id, (int) $so->id);
+
+                if ($baixados > 0) {
+                    Log::info('ServiceOrderObserver: estoque baixado na conclusão da OS', [
+                        'service_order_id' => $so->id,
+                        'business_id' => $so->business_id,
+                        'itens_baixados' => $baixados,
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                Log::error('ServiceOrderObserver: falha ao baixar estoque na conclusão (faturamento preservado)', [
+                    'service_order_id' => $so->id,
+                    'business_id' => $so->business_id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+
             Log::info('ServiceOrderObserver: Transaction derivada criada · transaction_id linkado', [
                 'transaction_id' => $tx->id,
                 'os_ref' => $osRef,

--- a/Modules/OficinaAuto/Services/ServiceOrderItemService.php
+++ b/Modules/OficinaAuto/Services/ServiceOrderItemService.php
@@ -67,6 +67,25 @@ class ServiceOrderItemService
             throw new InvalidArgumentException('descricao obrigatória');
         }
 
+        // Tier 0 (ADR 0093): se vier product_id, o produto TEM que pertencer ao mesmo
+        // business — senão um item de OS poderia referenciar (e baixar estoque de) catálogo
+        // de outro tenant. Rejeita cross-tenant antes de persistir.
+        $productId = isset($data['product_id']) ? (int) $data['product_id'] : null;
+        if ($productId !== null && $productId > 0) {
+            $produtoNoBiz = \App\Product::withoutGlobalScopes() // SUPERADMIN: check cross-tenant
+                ->where('id', $productId)
+                ->where('business_id', $businessId)
+                ->exists();
+
+            if (! $produtoNoBiz) {
+                throw new InvalidArgumentException(
+                    "product_id #{$productId} não existe OU não pertence ao business {$businessId} (Tier 0 ADR 0093)"
+                );
+            }
+        } else {
+            $productId = null;
+        }
+
         $quantidade = (float) ($data['quantidade'] ?? 1);
         $valorUnitario = (float) ($data['valor_unitario'] ?? 0);
 
@@ -83,9 +102,85 @@ class ServiceOrderItemService
             'quantidade'       => $quantidade,
             'valor_unitario'   => $valorUnitario,
             'valor_total'      => $valorTotal,
-            'product_id'       => $data['product_id'] ?? null,
+            'product_id'       => $productId,
             'notes'            => $data['notes'] ?? null,
         ]);
+    }
+
+    /**
+     * Baixa de estoque ao CONCLUIR a OS (P0-2 · análise tela-venda × oficina 2026-06-04).
+     *
+     * Para cada item `tipo=peca` com `product_id` de produto stock-managed
+     * (`enable_stock=1`), decrementa `variation_location_details.qty_available` pela
+     * `quantidade` do item — por caminho AUDITÁVEL (modelo Eloquent `save()` dispara o
+     * LogsActivity 'inventory.stock' do VariationLocationDetails · INV-1 DOC-RAIZ §7),
+     * espelhando o fix R1 de ConsumirEstoque.
+     *
+     * Itens mão-de-obra / serviço terceiro (sem product_id) NÃO mexem estoque (INV-4).
+     * Produto sem controle de estoque (`enable_stock=0`) é ignorado (INV-5).
+     *
+     * Idempotência: o caller (ServiceOrderObserver) só chama uma vez por OS — o guard
+     * `transaction_id !== null` impede re-faturar/re-baixar numa 2ª conclusão.
+     *
+     * Cross-tenant safe: itera só itens da OS (já business-scoped); VLD resolvido por
+     * product_id que addItem garantiu pertencer ao business.
+     *
+     * @return int  quantidade de itens que efetivamente baixaram estoque
+     *
+     * @see app/Domain/Fsm/SideEffects/ConsumirEstoque.php (mesmo caminho auditável)
+     * @see memory/requisitos/Estoque/DOC-RAIZ-ESTOQUE.md §7 INV-1/4/5
+     */
+    public function baixarEstoqueConclusao(int $businessId, int $osId): int
+    {
+        if ($businessId <= 0) {
+            throw new InvalidArgumentException('business_id obrigatório (Tier 0 ADR 0093)');
+        }
+
+        $itens = ServiceOrderItem::withoutGlobalScopes()
+            ->where('service_order_id', $osId)
+            ->where('business_id', $businessId)
+            ->where('tipo', ServiceOrderItem::TIPO_PECA)
+            ->whereNotNull('product_id')
+            ->whereNull('deleted_at')
+            ->get();
+
+        $baixados = 0;
+
+        foreach ($itens as $item) {
+            $product = \App\Product::withoutGlobalScopes()
+                ->where('id', $item->product_id)
+                ->where('business_id', $businessId)
+                ->first();
+
+            // INV-5: produto inexistente ou sem controle de estoque não movimenta saldo.
+            if ($product === null || (int) $product->enable_stock !== 1) {
+                continue;
+            }
+
+            $qty = (float) $item->quantidade;
+            if ($qty <= 0) {
+                continue;
+            }
+
+            // Resolve um VLD do produto com saldo pra debitar (prefere o maior saldo).
+            $vld = \App\VariationLocationDetails::query()
+                ->where('product_id', $item->product_id)
+                ->orderByDesc('qty_available')
+                ->first();
+
+            if ($vld === null) {
+                continue;
+            }
+
+            // Caminho auditável (INV-1): save() no modelo dispara LogsActivity 'inventory.stock'.
+            // Clamp em 0 (DOC-RAIZ §5) — nunca deixa saldo negativo.
+            $vld->qty_available = max(0, (float) $vld->qty_available - $qty);
+            $vld->save();
+
+            $baixados++;
+        }
+
+        return $baixados;
     }
 
     /**

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderItemStockBaixaTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderItemStockBaixaTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use App\Product;
+use App\VariationLocationDetails;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\OficinaAuto\Services\ServiceOrderItemService;
+
+uses(Tests\TestCase::class);
+uses(DatabaseTransactions::class);
+
+/**
+ * P0-2 — Catálogo de peças + baixa de estoque no item da OS.
+ *
+ * Origem: análise tela-venda × oficina 2026-06-04
+ * (memory/sessions/2026-06-04-analise-tela-venda-vs-oficina.md §4 P0-2).
+ *
+ * Contrato implementado:
+ *   1. Ao CONCLUIR a OS (`status → concluida`), cada item `tipo=peca` com `product_id`
+ *      de produto stock-managed decrementa o estoque pela `quantidade`
+ *      (caminho auditável — VariationLocationDetails::save() dispara LogsActivity).
+ *   2. `addItem` rejeita `product_id` de produto de OUTRO business (não persiste).
+ *   3. Itens sem `product_id` (mão-de-obra / serviço terceiro) NÃO mexem estoque.
+ *   4. Concluir a mesma OS 2× não baixa estoque em dobro (idempotência via
+ *      guard transaction_id do ServiceOrderObserver + dirty-check do Eloquent).
+ *
+ * Ambiente: requer schema UltimatePOS real (MySQL). Em sqlite :memory: (CI default)
+ * faz markTestSkipped gracioso — padrão do projeto (ADR 0101). Rodar no CT 100:
+ *   php artisan test --filter=ServiceOrderItemStockBaixa
+ *
+ * @see Modules/OficinaAuto/Services/ServiceOrderItemService.php (addItem + baixarEstoqueConclusao)
+ * @see Modules/OficinaAuto/Observers/ServiceOrderObserver.php (gancho 'concluida')
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+const BIZ_STOCK_BAIXA = 1;
+const PLATE_STOCK_PREFIX = 'STKBX';
+
+/**
+ * Resolve um produto stock-managed do biz piloto que tenha VLD com saldo >= $min.
+ * Retorna [Product, variationId, locationId, totalQtyAntes] ou null se não houver
+ * dado adequado (teste então faz skip gracioso — não inventa schema do zero).
+ *
+ * @return array{0:Product,1:int,2:int,3:float}|null
+ */
+function stockBaixa_resolveProdutoComEstoque(int $biz, float $min = 5.0): ?array
+{
+    $productIds = Product::withoutGlobalScopes()
+        ->where('business_id', $biz)
+        ->where('enable_stock', 1)
+        ->pluck('id');
+
+    if ($productIds->isEmpty()) {
+        return null;
+    }
+
+    $vld = VariationLocationDetails::query()
+        ->whereIn('product_id', $productIds)
+        ->where('qty_available', '>=', $min)
+        ->first();
+
+    if ($vld === null) {
+        return null;
+    }
+
+    $product = Product::withoutGlobalScopes()->find($vld->product_id);
+    if ($product === null) {
+        return null;
+    }
+
+    $total = (float) VariationLocationDetails::query()
+        ->where('product_id', $product->id)
+        ->sum('qty_available');
+
+    return [$product, (int) $vld->variation_id, (int) $vld->location_id, $total];
+}
+
+function stockBaixa_criaOs(string $suffix, int $biz = BIZ_STOCK_BAIXA): ServiceOrder
+{
+    // contact_id vai no VEÍCULO: `ServiceOrder.$fillable` ainda não inclui contact_id
+    // (gap T9 levantamento 2026-05-26 — mass-assign dropa silenciosamente). O Observer
+    // resolve via fallback `$so->vehicle?->contact_id`, então ancoramos lá.
+    $contactId = Contact::withoutGlobalScopes()
+        ->where('business_id', $biz)
+        ->value('id') ?? 1;
+
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'contact_id'   => $contactId,
+        'plate'        => PLATE_STOCK_PREFIX . $suffix,
+        'vehicle_type' => 'caminhao',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => 'manutencao',
+        'status'      => 'aberta',
+    ]);
+}
+
+beforeEach(function () {
+    try {
+        if (\App\Business::query()->count() === 0) {
+            $this->markTestSkipped('Sem business em DB — rode com DB_CONNECTION=mysql (dev/CI integration).');
+        }
+    } catch (\Throwable $e) {
+        $this->markTestSkipped('Schema UltimatePOS ausente — sqlite :memory: não tem products/variation_location_details.');
+    }
+
+    session(['user.business_id' => BIZ_STOCK_BAIXA]);
+});
+
+// ---------------------------------------------------------------------------
+// 1. Baixa de estoque ao concluir OS (núcleo do P0-2)
+// ---------------------------------------------------------------------------
+
+it('peça da OS com product_id stock-managed → baixa estoque pela quantidade ao concluir OS', function () {
+    $resolved = stockBaixa_resolveProdutoComEstoque(BIZ_STOCK_BAIXA, 5.0);
+    if ($resolved === null) {
+        $this->markTestSkipped('Sem produto stock-managed com VLD >= 5 no biz piloto.');
+    }
+    [$product, , , $totalAntes] = $resolved;
+
+    $os = stockBaixa_criaOs('A');
+
+    app(ServiceOrderItemService::class)->addItem(BIZ_STOCK_BAIXA, (int) $os->id, [
+        'tipo'           => ServiceOrderItem::TIPO_PECA,
+        'descricao'      => $product->name ?? 'Peça catálogo',
+        'quantidade'     => 2,
+        'valor_unitario' => 100.00,
+        'product_id'     => (int) $product->id,
+    ]);
+
+    // Conclui a OS → dispara baixa de estoque.
+    $os->status = 'concluida';
+    $os->save();
+
+    $totalDepois = (float) VariationLocationDetails::query()
+        ->where('product_id', $product->id)
+        ->sum('qty_available');
+
+    expect(round($totalAntes - $totalDepois, 3))->toBe(2.0);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Mão-de-obra (sem product_id) NÃO mexe estoque — guard anti-over-decrement
+// ---------------------------------------------------------------------------
+
+it('item mão-de-obra (product_id null) NÃO altera estoque ao concluir OS', function () {
+    $resolved = stockBaixa_resolveProdutoComEstoque(BIZ_STOCK_BAIXA, 1.0);
+    if ($resolved === null) {
+        $this->markTestSkipped('Sem produto stock-managed pra medir baseline.');
+    }
+    [$product, , , $totalAntes] = $resolved;
+
+    $os = stockBaixa_criaOs('B');
+
+    app(ServiceOrderItemService::class)->addItem(BIZ_STOCK_BAIXA, (int) $os->id, [
+        'tipo'           => ServiceOrderItem::TIPO_MAO_OBRA,
+        'descricao'      => 'Troca cilindro + sangria',
+        'quantidade'     => 3,
+        'valor_unitario' => 120.00,
+    ]);
+
+    $os->status = 'concluida';
+    $os->save();
+
+    $totalDepois = (float) VariationLocationDetails::query()
+        ->where('product_id', $product->id)
+        ->sum('qty_available');
+
+    expect(round($totalAntes - $totalDepois, 3))->toBe(0.0);
+});
+
+// ---------------------------------------------------------------------------
+// 3. Tier 0 (ADR 0093) — product_id de OUTRO business é rejeitado
+// ---------------------------------------------------------------------------
+
+it('addItem rejeita product_id de produto de outro business (Tier 0)', function () {
+    $foreign = Product::withoutGlobalScopes()
+        ->where('business_id', '!=', BIZ_STOCK_BAIXA)
+        ->first();
+
+    if ($foreign === null) {
+        $this->markTestSkipped('Sem produto de outro business pra testar cross-tenant.');
+    }
+
+    $os = stockBaixa_criaOs('C');
+
+    try {
+        app(ServiceOrderItemService::class)->addItem(BIZ_STOCK_BAIXA, (int) $os->id, [
+            'tipo'           => ServiceOrderItem::TIPO_PECA,
+            'descricao'      => 'Tentativa cross-tenant',
+            'quantidade'     => 1,
+            'valor_unitario' => 10.00,
+            'product_id'     => (int) $foreign->id,
+        ]);
+    } catch (\InvalidArgumentException $e) {
+        // Aceitável: rejeição via exceção.
+    }
+
+    // Contrato: NENHUM item desta OS pode acabar referenciando o produto cross-tenant
+    // (seja por throw, seja por nullar o product_id).
+    $vazou = ServiceOrderItem::withoutGlobalScopes()
+        ->where('service_order_id', $os->id)
+        ->where('product_id', $foreign->id)
+        ->exists();
+
+    expect($vazou)->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// 4. Idempotência — concluir 2× não baixa estoque em dobro
+// ---------------------------------------------------------------------------
+
+it('concluir a OS duas vezes não baixa estoque em dobro (idempotência)', function () {
+    $resolved = stockBaixa_resolveProdutoComEstoque(BIZ_STOCK_BAIXA, 5.0);
+    if ($resolved === null) {
+        $this->markTestSkipped('Sem produto stock-managed com VLD >= 5 no biz piloto.');
+    }
+    [$product, , , $totalAntes] = $resolved;
+
+    $os = stockBaixa_criaOs('D');
+
+    app(ServiceOrderItemService::class)->addItem(BIZ_STOCK_BAIXA, (int) $os->id, [
+        'tipo'           => ServiceOrderItem::TIPO_PECA,
+        'descricao'      => $product->name ?? 'Peça catálogo',
+        'quantidade'     => 1,
+        'valor_unitario' => 100.00,
+        'product_id'     => (int) $product->id,
+    ]);
+
+    $os->status = 'concluida';
+    $os->save();
+
+    // Segunda "conclusão" — re-save terminal não deve re-disparar baixa.
+    $os->refresh();
+    $os->status = 'concluida';
+    $os->save();
+
+    $totalDepois = (float) VariationLocationDetails::query()
+        ->where('product_id', $product->id)
+        ->sum('qty_available');
+
+    expect(round($totalAntes - $totalDepois, 3))->toBe(1.0);
+});


### PR DESCRIPTION
## O quê

Fecha o gap **P0-2** da [análise tela-venda × oficina (2026-06-04)](memory/sessions/2026-06-04-analise-tela-venda-vs-oficina.md) §4: o item da OS com peça de catálogo agora **baixa estoque ao concluir a OS**, por caminho **auditável**.

## Por quê

Hoje o item da OS grava `product_id` mas (a) não valida que o produto é do mesmo business e (b) não baixa estoque nunca. Resultado: estoque não fecha numa oficina real (Martinho biz=164). É pré-requisito pra OS gerar venda com valor + estoque corretos.

## Mudanças

| Arquivo | Mudança |
|---|---|
| `ServiceOrderItemService::addItem` | **Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)): rejeita `product_id` de catálogo de outro business antes de persistir |
| `ServiceOrderItemService::baixarEstoqueConclusao` | decrementa `qty_available` pela `quantidade` de cada item `tipo=peca` stock-managed, via Eloquent `save()` → dispara `LogsActivity 'inventory.stock'` (**INV-1**, espelha o fix R1 de `ConsumirEstoque`) |
| `ServiceOrderObserver` | chama a baixa na conclusão da OS, ancorada no mesmo guard once-only do faturamento (`transaction_id`) → **idempotente**; falha de baixa não desfaz faturamento |
| `ServiceOrderItemStockBaixaTest` | 4 casos Pest: baixa, mão-de-obra no-op, Tier 0 reject, idempotência. Skip gracioso fora de MySQL ([ADR 0101](memory/decisions/0101-tests-business-id-1-nunca-cliente.md)) |

Invariantes respeitadas (DOC-RAIZ-ESTOQUE §7): INV-1 (auditável), INV-4 (reserva≠baixa: mão-de-obra não mexe), INV-5 (`enable_stock=0` ignorado), clamp em 0 (§5).

## Validação

- `php -l` ✅ · **PHPStan: 0 erros** (ratchet) ✅
- Testes de integração rodam no CT 100 (`--filter=ServiceOrderItemStockBaixa`) — skip gracioso em sqlite CI.

## Relação com R1

Pareado com **PR #2258** (R1 — consumo FSM auditável + DOC-RAIZ-ESTOQUE / SPEC Estoque). Este PR depende do DOC-RAIZ que entra via #2258; merge #2258 primeiro.

Refs: ADR 0093 · 0192 · 0194

🤖 Generated with [Claude Code](https://claude.com/claude-code)