### PR TITLE
chore(financeiro): deprecar Dashboard — /financeiro redireciona pra Visão Unificada

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -191,7 +191,7 @@ class DataController extends Controller
                             ['key' => 'fluxo',         'label' => 'Fluxo de Caixa', 'href' => '/financeiro/fluxo'],
                             ['key' => 'dre',           'label' => 'DRE',            'href' => '/financeiro/dre'],
                             ['key' => 'relatorios',    'label' => 'Relatórios',     'href' => '/financeiro/relatorios'],
-                            ['key' => 'dashboard',     'label' => 'Dashboard',      'href' => '/financeiro/dashboard'],
+                            // Dashboard deprecado 2026-06-06 (Wagner não usa) — landing = Unificada.
                             ['key' => 'plano-contas',  'label' => 'Plano de Contas','href' => '/financeiro/plano-contas'],
                             ['key' => 'categorias',    'label' => 'Categorias',     'href' => '/financeiro/categorias'],
                             ['key' => 'contador',      'label' => 'Contador',       'href' => '/financeiro/configuracoes/contador'],

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -13,7 +13,6 @@ use Modules\Financeiro\Http\Controllers\ConciliacaoController;
 use Modules\Financeiro\Http\Controllers\ContaBancariaController;
 use Modules\Financeiro\Http\Controllers\ContaPagarController;
 use Modules\Financeiro\Http\Controllers\ContaReceberController;
-use Modules\Financeiro\Http\Controllers\DashboardController;
 use Modules\Financeiro\Http\Controllers\DreController;
 use Modules\Financeiro\Http\Controllers\ExtratoController;
 use Modules\Financeiro\Http\Controllers\FluxoController;
@@ -57,8 +56,12 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
     ->prefix('financeiro')
     ->name('financeiro.')
     ->group(function () {
-        // Dashboard unificado (US-FIN-013)
-        Route::get('/', [DashboardController::class, 'index'])->name('dashboard');
+        // DEPRECADO 2026-06-06 (Wagner "não vou usar o dashboard"): a landing do
+        // Financeiro é a Visão Unificada (mesmos KPIs A receber/A pagar + lançamentos).
+        // /financeiro redireciona 301 pra /financeiro/unificado. DashboardController +
+        // Pages/Financeiro/Dashboard/Index ficam DORMENTES (não deletados = reversível).
+        // Nome 'dashboard' preservado pra não quebrar route('financeiro.dashboard').
+        Route::redirect('/', '/financeiro/unificado', 301)->name('dashboard');
 
         // Visão Unificada — Cockpit V2 (US-FIN-013/020) — protótipo Cowork 2026-05-09
         Route::get('/unificado', [UnificadoController::class, 'index'])->name('unificado.index');
@@ -184,8 +187,8 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('/relatorios', [RelatoriosController::class, 'index'])->name('relatorios.index');
         Route::get('/relatorios/export-csv', [RelatoriosController::class, 'exportCsv'])->name('relatorios.export-csv');
 
-        // Alias canonical: /financeiro/dashboard → /financeiro (URL canônica é a raiz)
-        Route::redirect('/dashboard', '/financeiro', 301)->name('dashboard.alias');
+        // Alias legacy /financeiro/dashboard → Visão Unificada (Dashboard deprecado 2026-06-06).
+        Route::redirect('/dashboard', '/financeiro/unificado', 301)->name('dashboard.alias');
 
         // Wagner 2026-05-21 Fase 6 Soft (wrapper Inertia) — caixa do turno read-only.
         // Lifecycle (abrir/fechar) continua na header POS via CashRegisterController core;


### PR DESCRIPTION
## O quê
Wagner: *"não vou usar o dashboard"*. A landing canônica do Financeiro é a **Visão Unificada** (`/financeiro/unificado`) — que já tem os **mesmos KPIs** (A receber/A pagar/Recebido/Pago) + a lista de lançamentos. O `/financeiro` Dashboard virou vestígio.

## Mudanças (cirúrgicas, reversíveis)
- `/financeiro` → **redirect 301** → `/financeiro/unificado` (nome `dashboard` preservado, não quebra `route('financeiro.dashboard')` em ~10 controllers).
- alias `/financeiro/dashboard` → redireciona direto pra unificado.
- Remove o ghost **"Dashboard"** do sidebar.
- Remove import órfão `DashboardController`.

## Reversível
`DashboardController.php` + `Pages/Financeiro/Dashboard/Index.tsx` ficam **dormentes** (não deletados). Reativar = restaurar a rota + import.

## Segurança
- **Zero funcionalidade perdida** (Unificada tem os mesmos KPIs).
- **Zero teste quebra**: nenhum bate `/financeiro` raiz esperando o componente Dashboard; `financeiro.dashboard.view` é permissão (intacta).
- ⚠️ **Client-facing**: muda a landing da Larissa em `/financeiro`. **Recomendo testar no staging antes do merge** (ou seu olho no resultado).

Refs: confirmado em sessão — migração FinStatStrip era fiel mas o Dashboard será aposentado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)