### PR TITLE
fix(deploy): remove --no-dev do dump-autoload OPcache — destrava prod (Scribe 500)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -161,10 +161,18 @@ jobs:
         # Dois truques juntos forçam re-stat imediato:
         # (1) composer dump-autoload --optimize regenera arquivos compilados, mtime muda
         # (2) find ... -exec touch força mtime de todos os PHPs (LSPHP detecta em próximo request)
+        #
+        # 2026-06-06 (fix deploy quebrado 5×): REMOVIDO --no-dev daqui. Causa raiz do
+        # `Class "Knuckles\Scribe\ScribeServiceProvider" not found` que quebrou os deploys
+        # de 2026-06-05: o `package:discover` (step acima) registra o provider do Scribe
+        # (require-dev, instalado pois o install NÃO usa --no-dev — Faker em prod), mas este
+        # dump-autoload --no-dev REMOVIA as classes dev do classmap → boot (php artisan up)
+        # tentava carregar o provider e não achava → 500. Agora alinhado com o dump-autoload
+        # principal (mantém dev + ignora platform-req ext-opentelemetry do Hostinger).
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
-            /usr/local/bin/composer dump-autoload --optimize --no-dev 2>&1 | tail -3 &&
+            /usr/local/bin/composer dump-autoload --optimize --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 &&
             find app bootstrap config routes -name '*.php' -exec touch {} + 2>&1 | tail -3
           "
 


### PR DESCRIPTION
## Root cause dos 5 deploys falhos de 2026-06-05
Todos morreram em `Class "Knuckles\Scribe\ScribeServiceProvider" not found` (no `php artisan up`).

O step **"Force OPcache invalidate"** (adicionado ontem pro problema de OPcache do LiteSpeed) rodava:
```
composer dump-autoload --optimize --no-dev
```
**depois** do `package:discover`. Sequência fatal:
1. `composer install` (sem `--no-dev`, de propósito — Faker em prod) → instala Scribe (require-dev).
2. `package:discover` → registra `ScribeServiceProvider` em `bootstrap/cache/packages.php`.
3. **`dump-autoload --no-dev`** → remove as classes dev do classmap → Scribe sai.
4. `php artisan up` → boota → tenta carregar o provider registrado → **classe não existe → 500**.

## Fix
Remove o `--no-dev` desse `dump-autoload` (fica consistente com o install + o dump principal, que mantêm dev) + adiciona `--ignore-platform-req=ext-opentelemetry` (Hostinger não tem a ext). Preserva o propósito do step (mudar mtime pro OPcache re-stat).

## Validação
- YAML válido. `--no-dev` só sobra em comentários (comando limpo).
- deploy.yml roda só em `workflow_dispatch` → não há CI automático; revisão manual.

## ⚠️ Atenção pós-merge
Este fix destrava o **boot**. Mas a prod está MUITO atrás → o deploy ainda vai rodar muitas migrations, incluindo o guard do `add_external_id_unique` (precisa backfill `financeiro:backfill-extrato-ofx`). **Recomendo 1º deploy com cuidado** (ver descrição na conversa). Não dispará-lo no automático.

Refs: deploy.yml:108 (política "NÃO usar --no-dev — Faker em prod")

🤖 Generated with [Claude Code](https://claude.com/claude-code)