### PR TITLE
feat(visreg): VisregTenantSeeder minimal — ativa smoke autenticado (US-GOV-013 Fase B)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -45,7 +45,11 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-          extensions: mbstring, dom, fileinfo, pdo_mysql, gd, opentelemetry
+          # SEM `opentelemetry`: a auto-instrumentação opentelemetry-auto-laravel
+          # (QueryWatcher) acessa contexto OTel não-inicializado DENTRO do fiber do
+          # servidor do Pest Browser → ErrorException fatal em toda query DB das telas
+          # autenticadas (Fase B). O gate visual não precisa de telemetria.
+          extensions: mbstring, dom, fileinfo, pdo_mysql, gd
           coverage: none
 
       - name: Wait for MySQL ready
@@ -78,7 +82,10 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
 
       - name: Install Composer dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts
+        # --ignore-platform-req=ext-opentelemetry: o pacote opentelemetry-auto-laravel
+        # exige a ext no platform check, mas removemos a ext de propósito (ver Setup PHP).
+        # O pacote degrada gracioso sem a ext (hooks não registram).
+        run: composer install --no-progress --no-interaction --prefer-dist --no-scripts --ignore-platform-req=ext-opentelemetry
 
       - name: Install NPM dependencies
         run: npm ci

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -133,24 +133,21 @@ jobs:
           echo "=== schema-squash check: tabelas criadas ==="
           php artisan tinker --execute="echo count(DB::select('show tables')).' tabelas';"
 
-      - name: Seed demo tenant (business + admin + permissions)
+      - name: Seed demo tenant (business + admin + role Admin#1)
         # O schema-squash é schema-only (sem dados) → as telas autenticadas (Fase B)
         # precisam de um business + admin seedados.
         #
-        # FUNDAÇÃO LANDADA, SEED PENDENTE (2026-06-06): o auth bridge (rota _visreg-login
-        # + SESSION_DRIVER=file + cross-process DB) está PROVADO. Falta SÓ um tenant válido.
-        # DatabaseSeeder roda só os seeders de PROD (Permissions/Currencies). O
-        # DummyBusinessSeeder (demo, business 1 + admin id=1) está DESATUALIZADO contra o
-        # schema atual (insere contacts.first_name, coluna removida) → falha. Tolerado
-        # (|| true) → o AuthBridgeSmokeTest skipa gracioso (Business::first() null) SEM
-        # quebrar o gate. PRÓXIMO PR: consertar o DummyBusinessSeeder OU um seeder minimal
-        # de tenant (business+location+admin+role) contra o schema atual → os 2 testes
-        # autenticados ATIVAM sozinhos (já estão wired). Vide RUNBOOK US-GOV-013.
+        # 2026-06-06: o DummyBusinessSeeder (demo UltimatePOS de 2018) estava PODRE contra
+        # o schema atual (inseria contacts.first_name, coluna removida → "Unknown column")
+        # → sem business → AuthBridgeSmokeTest skipava. Trocado pelo VisregTenantSeeder
+        # MINIMAL (business 1 + location + admin id=1 + role spatie Admin#1), idempotente e
+        # alinhado ao schema. Sem `|| echo` que mascarava: agora o seed é GATE REAL — se
+        # quebrar, o job falha. Vide database/seeders/VisregTenantSeeder.php.
         run: |
           php artisan db:seed --force
-          php artisan db:seed --class=Database\\Seeders\\DummyBusinessSeeder --force || echo "DUMMY_SEED_OUTDATED (esperado — ver comentário; teste skipa gracioso)"
+          php artisan db:seed --class=Database\\Seeders\\VisregTenantSeeder --force
           echo "=== seed check ==="
-          php artisan tinker --execute="echo 'business='.\App\Business::count().' users='.\App\User::count();"
+          php artisan tinker --execute="echo 'business='.\App\Business::count().' users='.\App\User::count().' roles='.\Spatie\Permission\Models\Role::count();"
 
       - name: Build Inertia bundles
         # Build pode falhar se Setup Laravel quebrou (sem .env válido) — tolerar

--- a/database/seeders/VisregTenantSeeder.php
+++ b/database/seeders/VisregTenantSeeder.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Seeder MINIMAL de tenant pro gate de regressão visual autenticado (US-GOV-013 Fase B).
+ *
+ * Substitui o DummyBusinessSeeder (demo UltimatePOS de 2018, 1464 linhas) que estava
+ * PODRE contra o schema atual: inseria em `contacts.first_name` (coluna removida) →
+ * "Unknown column" → sem business → AuthBridgeSmokeTest skipava → telas autenticadas
+ * (99% do app, onde mora o risco visual) ficavam fora do gate.
+ *
+ * Em vez de caçar drift coluna-a-coluna nas ~30 tabelas do demo, este seeder cria o
+ * MÍNIMO bootável pro smoke renderizar `/financeiro/unificado` e `/sells`:
+ *
+ *   - 1 currency (reusa a 1ª de CurrenciesTableSeeder, ou cria BRL fallback)
+ *   - business 1 + business_location 1 + invoice_scheme 1 + invoice_layout 1
+ *   - admin (user id=1, business_id=1) com role spatie `Admin#1`
+ *   - 1 contato default "Walk-In Customer" (POS/Sells referencia)
+ *
+ * Por que role `Admin#1` basta (sem enumerar permissões): o Gate::before em
+ * AuthServiceProvider concede TODAS as abilities a quem `hasRole('Admin#'.$business_id)`.
+ *
+ * Por que só colunas existentes + as NOT-NULL-sem-default: o gate roda MySQL com
+ * `'strict' => false` (config/database.php) → colunas omitidas ganham default implícito.
+ *
+ * IDEMPOTENTE: re-rodar é no-op (browser tests NÃO usam RefreshDatabase — Pest.php).
+ *
+ * @see tests/Browser/CoreScreens/AuthBridgeSmokeTest.php
+ * @see .github/workflows/visual-regression.yml
+ * @see app/Providers/AuthServiceProvider.php (Gate::before — Admin#N = tudo)
+ * @see app/Http/Middleware/SetSessionData.php (exige business + currency)
+ */
+class VisregTenantSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (DB::table('business')->where('id', 1)->exists()) {
+            $this->ensureAdminRole();
+
+            return;
+        }
+
+        $currencyId = DB::table('currencies')->min('id');
+        if (! $currencyId) {
+            $currencyId = DB::table('currencies')->insertGetId([
+                'country' => 'Brasil', 'currency' => 'Real', 'code' => 'BRL',
+                'symbol' => 'R$', 'thousand_separator' => '.', 'decimal_separator' => ',',
+            ]);
+        }
+
+        // FK circular: business.owner_id → users.id e users.business_id → business.id.
+        // Mesma saída do DummyBusinessSeeder legacy: desliga checagem durante o bootstrap.
+        DB::statement('SET FOREIGN_KEY_CHECKS = 0');
+
+        try {
+            DB::table('business')->insert([
+                'id' => 1,
+                'name' => 'Tenant Visual Regression',
+                'currency_id' => $currencyId,
+                'owner_id' => 1,
+                'time_zone' => 'America/Sao_Paulo',
+            ]);
+
+            DB::table('users')->insert([
+                'id' => 1,
+                'user_type' => 'user',
+                'surname' => 'Sr.',
+                'first_name' => 'Admin',
+                'last_name' => 'Visreg',
+                'username' => 'visreg_admin',
+                'email' => 'visreg-admin@example.test',
+                'password' => Hash::make('visreg-secret-not-for-prod'),
+                'language' => 'pt',
+                'business_id' => 1,
+                'status' => 'active',
+                'allow_login' => 1,
+            ]);
+
+            DB::table('invoice_schemes')->insert([
+                'id' => 1, 'business_id' => 1, 'name' => 'Default', 'scheme_type' => 'blank',
+            ]);
+
+            DB::table('invoice_layouts')->insert([
+                'id' => 1, 'business_id' => 1, 'name' => 'Default',
+            ]);
+
+            DB::table('business_locations')->insert([
+                'id' => 1,
+                'business_id' => 1,
+                'name' => 'Matriz',
+                'country' => 'Brasil',
+                'state' => 'SP',
+                'city' => 'Sao Paulo',
+                'zip_code' => '0000000',
+                'invoice_scheme_id' => 1,
+                'invoice_layout_id' => 1,
+            ]);
+
+            DB::table('contacts')->insert([
+                'business_id' => 1,
+                'type' => 'customer',
+                'name' => 'Walk-In Customer',
+                'contact_id' => 'CO0001',
+                'mobile' => '',
+                'created_by' => 1,
+                'is_default' => 1,
+            ]);
+        } finally {
+            DB::statement('SET FOREIGN_KEY_CHECKS = 1');
+        }
+
+        $this->ensureAdminRole();
+    }
+
+    /**
+     * Role spatie `Admin#1` (guard web) + vínculo com o admin (model_has_roles).
+     * Insert direto (sem o model spatie) pra controlar `roles.business_id` (NOT NULL)
+     * e o morph `model_type` = App\User (sem morphMap no projeto).
+     */
+    private function ensureAdminRole(): void
+    {
+        $roleId = DB::table('roles')->where('name', 'Admin#1')->where('guard_name', 'web')->value('id');
+        if (! $roleId) {
+            $roleId = DB::table('roles')->insertGetId([
+                'name' => 'Admin#1',
+                'guard_name' => 'web',
+                'business_id' => 1,
+            ]);
+        }
+
+        $linked = DB::table('model_has_roles')
+            ->where('role_id', $roleId)
+            ->where('model_type', \App\User::class)
+            ->where('model_id', 1)
+            ->exists();
+
+        if (! $linked) {
+            DB::table('model_has_roles')->insert([
+                'role_id' => $roleId,
+                'model_type' => \App\User::class,
+                'model_id' => 1,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Por quê

O gate de regressão visual (US-GOV-013) só cobria telas **públicas** porque o seed de tenant estava quebrado: o `DummyBusinessSeeder` (demo UltimatePOS de 2018) insere `contacts.first_name` — coluna **removida** do schema → `Unknown column` → sem business → `AuthBridgeSmokeTest` skipava → **99% do app (telas autenticadas, onde mora o risco visual) ficava fora do gate**.

Retoma o **passo 1** do handoff `2026-06-06-1312-deprecar-dashboard-deploy-manual-visreg-harness`.

## O quê

`database/seeders/VisregTenantSeeder.php` — seeder **minimal** e **idempotente** com só o necessário pra `/financeiro/unificado` e `/sells` renderizarem autenticadas:

- `business` 1 + `business_location` 1 + `invoice_scheme`/`invoice_layout` 1
- admin (`users` id=1, `business_id`=1) com role spatie **`Admin#1`**
- contato default Walk-In Customer

Por que `Admin#1` basta (sem enumerar permissões): o `Gate::before` em `AuthServiceProvider` concede **todas** as abilities a quem `hasRole('Admin#'.$business_id)`.

Por que minimal em vez de consertar o demo: 1464 linhas / ~30 tabelas no schema de 2018 → drift coluna-a-coluna seria whack-a-mole. O smoke só checa render + âncora + console limpo.

`.github/workflows/visual-regression.yml`: troca `DummyBusinessSeeder` → `VisregTenantSeeder` e remove o `|| echo` que mascarava a falha (seed vira **gate real**).

## Decisões técnicas

- `strict => false` → inserir só colunas existentes + `NOT NULL` sem default; resto ganha default implícito.
- FK circular `business.owner_id ↔ users` → `FOREIGN_KEY_CHECKS=0` no bootstrap.
- `model_has_roles.model_type` = `App\User` (sem morphMap).
- `SetSessionData` exige só business + currency válida — coberto.

## Validação

CI (MySQL 8 + Playwright). Os 2 testes do `AuthBridgeSmokeTest` (já wired) ativam sozinhos quando `Business::first()` deixa de ser null.

Refs: US-GOV-013 Fase B