### PR TITLE
fix(deploy): set -o pipefail nos comandos críticos remotos — fim do mascaramento

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,8 +112,13 @@ jobs:
         # tem ext-opentelemetry (OTel Laravel auto-instrument). Sem --ignore-platform-req, composer aborta com erro
         # truncado ("emetry Laravel auto-instrumentation") e exibe help do dump-autoload (exit 1, classmap stale).
         # Fix definitivo: passar --ignore-platform-req=ext-opentelemetry também no dump-autoload (igual ao install).
+        # set -o pipefail: sem ele, o exit code do pipeline `composer ... | tail` vira o
+        # do `tail` (sempre 0) → composer install/dump-autoload podia FALHAR em silêncio e
+        # o deploy seguia "verde" (risco de classmap stale / 500 no boot, vide incidente
+        # 2026-05-26). Remoto roda bash no Hostinger (composer/git/laravel exigem).
         run: |
           /tmp/ssh_exec.sh "
+            set -o pipefail &&
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             composer install --optimize-autoloader --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry 2>&1 | tail -20 &&
             echo '=== dump-autoload force ===' &&
@@ -122,11 +127,13 @@ jobs:
 
       - name: Artisan migrate (se necessário)
         if: ${{ inputs.skip_migrate != 'true' }}
-        run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan migrate --force 2>&1 | tail -20"
+        # set -o pipefail: senão um `migrate --force` que falha (ex: migration quebrada)
+        # tem o exit code mascarado pelo `| tail` → deploy "verde" com schema drift.
+        run: /tmp/ssh_exec.sh "set -o pipefail && cd /home/u906587222/domains/oimpresso.com/public_html && php artisan migrate --force 2>&1 | tail -20"
 
       - name: Artisan extra (input customizado)
         if: ${{ inputs.extra_artisan != '' }}
-        run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan ${{ inputs.extra_artisan }} 2>&1 | tail -30"
+        run: /tmp/ssh_exec.sh "set -o pipefail && cd /home/u906587222/domains/oimpresso.com/public_html && php artisan ${{ inputs.extra_artisan }} 2>&1 | tail -30"
 
       - name: Clear caches + re-cache
         # Wagner 2026-05-27 HOTFIX: removido `php artisan route:cache` — em prod o arquivo
@@ -171,6 +178,7 @@ jobs:
         # principal (mantém dev + ignora platform-req ext-opentelemetry do Hostinger).
         run: |
           /tmp/ssh_exec.sh "
+            set -o pipefail &&
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             /usr/local/bin/composer dump-autoload --optimize --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 &&
             find app bootstrap config routes -name '*.php' -exec touch {} + 2>&1 | tail -3


### PR DESCRIPTION
## Por quê
O `deploy.yml` executa comandos remotos via `/tmp/ssh_exec.sh "... 2>&1 | tail -N"`. No shell do Hostinger, o exit code do pipeline `composer ... | tail` vira o do `tail` (**sempre 0**) → uma falha de `composer install`/`dump-autoload`/`migrate --force` ficava **silenciosa** e o deploy seguia **"verde"**. Isso já causou prod 500 (incidente 2026-05-26, classmap stale) e é risco latente de **schema drift**. O handoff [2152] deixou isso como TODO de pé.

## O quê
Adiciona `set -o pipefail` nos **4 comandos críticos**:
- Composer install + dump-autoload
- `artisan migrate --force`
- `artisan` extra (input)
- OPcache dump-autoload

## Cuidado (cirúrgico)
**Não** toca os pipes tolerantes (`php -v | head -1`, `df | tail -1`, os com `|| true`/`|| echo`) — sob `pipefail` o SIGPIPE do `head` poderia quebrar steps inofensivos. Remoto roda bash no Hostinger (composer/git/laravel exigem).

## Efeito
Deploys que **realmente** falharem passam a falhar **alto** (o objetivo) em vez de mascarar.