### PR TITLE
feat(visreg): ativa Clientes no gate via MWART_CLIENTE_INDEX — fecha o núcleo-6 (8 telas)

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -133,6 +133,10 @@ jobs:
           BCRYPT_ROUNDS=4
           TELESCOPE_ENABLED=false
           VIEW_COMPILED_PATH=storage/framework/views
+          # MWART_CLIENTE_INDEX=true: sem o flag, /cliente cai no Blade legacy e dá 500
+          # (provado por screenshot do artifact #2320) → fica fora do gate. Com o flag,
+          # renderiza a Page Inertia canônica de Clientes — que é o que o gate deve proteger.
+          MWART_CLIENTE_INDEX=true
           EOF
           php artisan key:generate --force
           php artisan package:discover --ansi

--- a/tests/Browser/CoreScreens/AuthBridgeSmokeTest.php
+++ b/tests/Browser/CoreScreens/AuthBridgeSmokeTest.php
@@ -54,12 +54,10 @@ afterEach(fn () => \Carbon\Carbon::setTestNow());
 $screens = [
     'Financeiro/Unificado' => ['/financeiro/unificado',        'financeiro.unificado.access', 'Financeiro'],
     'Venda/Lista'          => ['/sells',                       'sell.view',                   'Vendas'],
-    // TODO(Clientes): /cliente falhou no CI (#2320) — a âncora "Cliente"/"Clientes" não
-    // apareceu mesmo com a rota renderizando $c->index() direto (sem redirect). A Index de
-    // Clientes é a Page mais pesada (~1900 linhas) e provavelmente quebra em runtime React
-    // com o tenant minimal (sem customer_groups/settings ricos). Reativar quando o
-    // VisregTenantSeeder ganhar esses dados OU a Page degradar gracioso. Não bloqueia as demais.
-    // 'Clientes'          => ['/cliente',                     'customer.view',               'Clientes'],
+    // /cliente exige MWART_CLIENTE_INDEX=true no .env do gate (vide visual-regression.yml):
+    // sem o flag cai no Blade legacy → 500 (provado por screenshot do artifact #2320). Com
+    // o flag, renderiza a Page Inertia canônica (âncora = H1 "Clientes").
+    'Clientes'             => ['/cliente',                     'customer.view',               'Clientes'],
     'Compras'              => ['/compras',                     'compras.view',                'Compras'],
     'Fiscal/Cockpit'       => ['/fiscal',                      'fiscal.cockpit.access',       'Notas Fiscais'],
     'Fiscal/NF-e'          => ['/fiscal/nfe',                  'fiscal.nfe.access',           'NF-e'],


### PR DESCRIPTION
## Fecha o loose end do #2320

**Diagnóstico (B1):** baixei o screenshot do artifact do run que falhou (#2320) → `/cliente` retornava **500 Server Error** (não crash React nem âncora errada, como eu havia hipotetizado).

**Causa raiz:** a rota `/cliente` só renderiza a Page Inertia se `config('mwart.cliente_index.enabled')` (env `MWART_CLIENTE_INDEX`). Sem o flag, cai no **Blade legacy** → 500 no tenant minimal.

**Fix:**
- `.env` do `visual-regression.yml`: `MWART_CLIENTE_INDEX=true` → renderiza a Page Inertia canônica (o que o gate deve proteger).
- `AuthBridgeSmokeTest`: Clientes reativado (âncora H1 "Clientes") → **núcleo-6 completo: 8 telas autenticadas**.

Stream B (tests/CI) — sem overlap com trabalho de produto/receita.

Refs: US-GOV-013 Fase B