### PR TITLE
fix(ci): juiz UI usa gpt-4o-mini (projeto OpenAI sem acesso ao gpt-4o)

### DIFF
--- a/.github/workflows/pr-ui-judge.yml
+++ b/.github/workflows/pr-ui-judge.yml
@@ -1,12 +1,15 @@
 name: PR UI Judge (LLM Brain B · Constituição UI v2)
 
 # Onda 4.1 do AUTOMATION-ROADMAP. Avalia PRs Inertia/React contra a
-# Constituição UI v2 usando OpenAI gpt-4o. Posta comentário inline
+# Constituição UI v2 usando OpenAI gpt-4o-mini. Posta comentário inline
 # com score 0-100 + 9 dimensões + violações estruturais + sugestões.
 #
 # CUSTO REAL:
-# - ~$0.05/PR (OpenAI gpt-4o, ~10k in + ~1k out)
-# - ~$5/mês a 100 PRs/mês
+# - ~$0.002/PR (OpenAI gpt-4o-mini, ~10k in + ~1k out)
+# - ~$0.20/mês a 100 PRs/mês
+#
+# NOTA: gpt-4o-mini porque o projeto OpenAI não tem acesso ao gpt-4o (quebrava
+# todo PR). Upgrade de qualidade (gpt-4o liberado / Sonnet c/ crédito) → PR #2270.
 #
 # DEFAULT: DESLIGADO (env var PR_UI_JUDGE_ENABLED não setada).
 # Wagner ativa quando quota aprovada:
@@ -47,7 +50,7 @@ permissions:
 
 jobs:
   judge:
-    name: PR UI Judge · OpenAI gpt-4o
+    name: PR UI Judge · OpenAI gpt-4o-mini
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -143,5 +146,5 @@ jobs:
             echo "Review não gerado · ver logs acima"
           fi
           echo ""
-          echo "Custo estimado: ~\$0.034 (primeiro PR) · ~\$0.005 (subsequentes do dia)"
+          echo "Custo estimado: ~\$0.002/PR (OpenAI gpt-4o-mini)"
           echo "Refs: ADR UI-0013 · AUTOMATION-ROADMAP Onda 4"

--- a/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
+++ b/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
@@ -14,7 +14,7 @@ use Stringable;
 /**
  * PrUiJudgeAgent — Onda 4.1 do AUTOMATION-ROADMAP.
  *
- * Agente LLM (OpenAI gpt-4o · review de design exige juízo semântico) que
+ * Agente LLM (OpenAI gpt-4o-mini · review de design exige juízo semântico) que
  * avalia PRs Inertia/React contra a Constituição UI v2 (ADR UI-0013). Carrega
  * no system prompt:
  *  - Hierarquia 4 camadas (Fundações → Shell → PT → Módulo)
@@ -37,21 +37,23 @@ use Stringable;
  * "copy não-PT-BR em string template", "PT-01 violado em essência mesmo
  * importando PageHeader (uso fora do slot 1)".
  *
- * Custo estimado por PR: ~10k tokens input + ~1k tokens output ≈ $0.05/PR
- * (gpt-4o @ $2.5/M input + $10/M output).
+ * Custo estimado por PR: ~10k tokens input + ~1k tokens output ≈ $0.002/PR
+ * (gpt-4o-mini @ $0.15/M input + $0.60/M output).
  *
  * HISTÓRICO: nasceu em OpenAI gpt-4o-mini ($0.002/PR); migrou pra
- * anthropic/claude-sonnet-4-6 por qualidade de juízo; agora volta pra OpenAI
- * gpt-4o (provider canon pós-migração — config('ai.default')='openai', sem
- * crédito Anthropic). gpt-4o (smartest do config/ai.php) preserva o juízo
- * semântico que review de design exige, melhor que o gpt-4o-mini original.
+ * anthropic/claude-sonnet-4-6 (sem crédito Anthropic, inviável) e depois pra
+ * OpenAI gpt-4o por qualidade de juízo. Mas o projeto OpenAI NÃO tem acesso ao
+ * gpt-4o ("Project does not have access to model gpt-4o") → o juiz quebrava em
+ * TODO PR de tela. Revertido pra gpt-4o-mini (modelo com acesso confirmado).
+ * Upgrade de qualidade (gpt-4o c/ acesso liberado, ou Sonnet c/ crédito) fica
+ * pra decisão do PR #2270 — aqui o objetivo é o juiz VOLTAR A FUNCIONAR.
  *
  * @see memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md (Onda 4.1)
  * @see memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md
  * @see memory/decisions/0141-agents-tool-use-pattern-claude-code.md
  */
 #[Provider('openai')]
-#[Model('gpt-4o')]
+#[Model('gpt-4o-mini')]
 #[MaxSteps(3)]
 class PrUiJudgeAgent implements Agent
 {

--- a/Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
@@ -16,13 +16,15 @@ uses(Tests\TestCase::class);
  * #[Model('gpt-4o-mini')] — inconsistência ativa ("a mentira do Sonnet").
  * G3 resolveu migrando pra anthropic / claude-sonnet-4-6.
  *
- * Atualizado 2026-06-05 (migração definitiva pra OpenAI · sem crédito Anthropic):
- * o canon de provider agora é openai / gpt-4o (config('ai.default')='openai').
- * gpt-4o (smartest do config/ai.php) preserva o juízo semântico que review de
- * design exige. Estes testes TRAVAM a consistência pra ela não regredir.
+ * Atualizado 2026-06-06 (fix CI · projeto OpenAI sem acesso ao gpt-4o):
+ * o canon de provider é openai (config('ai.default')='openai'); o model é
+ * gpt-4o-mini porque o projeto OpenAI NÃO tem acesso ao gpt-4o ("Project does
+ * not have access to model gpt-4o") — o juiz quebrava em TODO PR de tela.
+ * Upgrade de qualidade (gpt-4o liberado / Sonnet c/ crédito) → decisão do #2270.
+ * Estes testes TRAVAM a consistência model↔anúncio pra não regredir a "mentira".
  *
  *  001. provider declarado = openai (canon pós-migração)
- *  002. model declarado = gpt-4o (smartest · review de design)
+ *  002. model declarado = gpt-4o-mini (modelo com acesso confirmado)
  *  003. instructions() carrega contrato G-Eval (rationale ANTES do score)
  *  004. instructions() ainda carrega a Constituição UI v2 (4 camadas + AP1-AP8)
  *
@@ -36,11 +38,11 @@ it('R-JANA-UI-JUDGE-001 — declara provider openai (canon pós-migração)', fu
     expect($attrs[0]->getArguments()[0])->toBe('openai');
 });
 
-it('R-JANA-UI-JUDGE-002 — declara model gpt-4o (smartest · review de design)', function () {
+it('R-JANA-UI-JUDGE-002 — declara model gpt-4o-mini (modelo com acesso no projeto OpenAI)', function () {
     $attrs = (new ReflectionClass(PrUiJudgeAgent::class))->getAttributes(Model::class);
 
     expect($attrs)->not->toBeEmpty();
-    expect($attrs[0]->getArguments()[0])->toBe('gpt-4o');
+    expect($attrs[0]->getArguments()[0])->toBe('gpt-4o-mini');
 });
 
 it('R-JANA-UI-JUDGE-003 — instructions() exige rationale ANTES do score (G-Eval)', function () {

--- a/app/Console/Commands/UiJudgePrCommand.php
+++ b/app/Console/Commands/UiJudgePrCommand.php
@@ -12,13 +12,13 @@ use Modules\Jana\Entities\UiJudgeRun;
 /**
  * `ui:judge-pr` — Onda 4.1 do AUTOMATION-ROADMAP (Constituição UI v2).
  *
- * Avalia um PR contra a Constituição UI v2 usando agente LLM (OpenAI gpt-4o)
+ * Avalia um PR contra a Constituição UI v2 usando agente LLM (OpenAI gpt-4o-mini)
  * e — opcionalmente — posta comentário inline no PR via `gh`.
  *
  * Workflow:
  *   1. Pega metadata do PR (título · descrição · arquivos modificados) via gh CLI
  *   2. Pega diff filtrado (.tsx, .jsx, .css)
- *   3. Manda pro PrUiJudgeAgent (openai / gpt-4o)
+ *   3. Manda pro PrUiJudgeAgent (openai / gpt-4o-mini)
  *   4. Parse output JSON
  *   5. Print score + violações no console
  *   6. (Opcional) `--post-comment` posta no PR via gh
@@ -29,7 +29,7 @@ use Modules\Jana\Entities\UiJudgeRun;
  *   php artisan ui:judge-pr 1438 --post-comment # postar comentário no PR
  *   php artisan ui:judge-pr 1438 --strict       # exit 1 se verdict=request_changes
  *
- * Custo estimado por run: ~$0.05 (OpenAI gpt-4o, ~10k in + ~1k out).
+ * Custo estimado por run: ~$0.002 (OpenAI gpt-4o-mini, ~10k in + ~1k out).
  *
  * @see Modules\Jana\Ai\Agents\PrUiJudgeAgent
  * @see memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md (Onda 4)
@@ -99,8 +99,9 @@ class UiJudgePrCommand extends Command
 
         $this->line('  Diff UI: '.strlen($diff).' bytes');
 
-        // 4. Mandar pro agent
-        $this->info('Enviando pra PrUiJudgeAgent (OpenAI gpt-4o)...');
+        // 4. Mandar pro agent — anúncio lê o modelo REAL por reflexão (nunca "anuncia X, roda Y")
+        [$annProvider, $annModel] = $this->agentProviderModel();
+        $this->info("Enviando pra PrUiJudgeAgent ({$annProvider}/{$annModel})...");
         $output = $this->runAgent($prData, $diff);
         if ($output === null) {
             return self::FAILURE;


### PR DESCRIPTION
## Problema
O **`PR UI Judge`** falhava em **TODO PR `.tsx`**: `Project … does not have access to model gpt-4o`. O `PrUiJudgeAgent` estava em `#[Model('gpt-4o')]`, mas o projeto OpenAI não tem acesso a esse modelo. **Erro de infra, não veredito** — bloqueava o sinal de design da equipe em qualquer PR de tela (descoberto ao mergear o #2326).

## Fix (mínimo, não-preemptivo)
- **`PrUiJudgeAgent`**: `gpt-4o` → **`gpt-4o-mini`** (modelo com acesso confirmado; rodava a ~$0.002/PR antes).
- **`UiJudgePrCommand`**: o anúncio do modelo agora é por **reflexão** — nunca mais "anuncia X, roda Y" (o achado-mãe do **parecer #2270**) + docblocks/custo.
- **`pr-ui-judge.yml`**: nome do job/check + custo → gpt-4o-mini.

Custo: ~$0.05 → **~$0.002/PR**.

## O que NÃO faço aqui
Não preempto a decisão estratégica do **#2270** (upgrade pra Sonnet com crédito, ou liberar gpt-4o no projeto OpenAI). Objetivo: o juiz **voltar a funcionar**.

## Verificação
Este PR não toca os paths-gatilho do juiz (`.tsx`/`cockpit.css`), então o gate dele não roda aqui. Vou **validar após o merge** disparando o workflow manualmente (`workflow_dispatch`) contra um PR de tela e confirmando que roda verde com gpt-4o-mini.

Refs: parecer PR #2270 · ADR UI-0013 · AUTOMATION-ROADMAP Onda 4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)