### PR TITLE
fix(jana): model_suggestions default gpt-4o → gpt-4o-mini (acesso real OpenAI)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -31,7 +31,10 @@ return [
     */
     'openai' => [
         'model_chat'         => env('COPILOTO_OPENAI_CHAT_MODEL', 'gpt-4o-mini'),
-        'model_suggestions'  => env('COPILOTO_OPENAI_SUGGEST_MODEL', 'gpt-4o'),
+        // Default gpt-4o-mini: único modelo a que o projeto OpenAI atual tem acesso
+        // (gpt-4o → 403 "does not have access" — mesma razão de clarify/advisor/PrUiJudgeAgent).
+        // Subir via env COPILOTO_OPENAI_SUGGEST_MODEL quando houver acesso frontier (ou Sonnet) — #2270.
+        'model_suggestions'  => env('COPILOTO_OPENAI_SUGGEST_MODEL', 'gpt-4o-mini'),
         'max_tokens_chat'    => 2000,
         'max_tokens_suggest' => 4000,
         'temperature'        => 0.7,


### PR DESCRIPTION
## Contexto
Investigação da flag-2 (pós-#2328 do juiz): mapeei todo uso de `gpt-4o` em config/agentes. **Boa notícia:** advisor/clarify **não quebram** — já são `gpt-4o-mini` + default OFF, com o comentário do 403. O caminho runtime vivo está todo em gpt-4o-mini.

## O que sobrou
`copiloto.openai.model_suggestions` era o **último default de modelo ainda em `gpt-4o`** (usado só no `OpenAiDirectDriver` legado), fora do padrão dos vizinhos. Como o projeto OpenAI não tem acesso ao gpt-4o (403, validado E2E no staging), o default era footgun: ambiente sem override de env → 403.

## Mudança
- `model_suggestions` default `gpt-4o` → **`gpt-4o-mini`** (acessível) + comentário-padrão. `env COPILOTO_OPENAI_SUGGEST_MODEL` sobe pro frontier quando houver acesso. 1 linha, sem nova `env()` (Larastan intacto).

## Residuais que ficam pra você (NÃO toquei — decisão/quality)
- **`BoletoOcrService` usa `gpt-4o` Vision (hardcoded)** — OCR de boleto provavelmente dá 403 em prod (com fallback gracioso `logFailure`). Aqui downgrade pra mini = perda de acurácia de OCR financeiro → o certo é **conceder acesso gpt-4o ao projeto** (sua ação no OpenAI), não baixar o modelo.
- **`config/ai.php` `smartest=gpt-4o`** — sem usuário runtime (inócuo).

Refs: #2328 · #2270

🤖 Generated with [Claude Code](https://claude.com/claude-code)