### PR TITLE
feat(design): primitivos de layout (Box/Stack/Inline/Grid/Container/Text) — F3 / ADR 0253

### DIFF
--- a/resources/js/Components/layout/box.tsx
+++ b/resources/js/Components/layout/box.tsx
@@ -1,0 +1,46 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Box — primitivo de layout neutro (ADR 0253 · F3).
+ *
+ * Container sem opinião visual além de ESPAÇO, e espaço só vem de token. Os
+ * valores de `p`/`px`/`py` são enumerados via CVA → o TS recusa px/hex literal
+ * em tempo de compilação (M-AP "diferente = errado" no nível do tipo).
+ *
+ * `asChild` (Radix Slot) projeta as props no filho sem inflar a árvore DOM —
+ * mesmo contrato de `@/Components/ui/badge`.
+ */
+const boxVariants = cva("", {
+  variants: {
+    p: {
+      0: "p-0", 1: "p-1", 2: "p-2", 3: "p-3", 4: "p-4", 5: "p-5",
+      6: "p-6", 8: "p-8", 10: "p-10", 12: "p-12",
+    },
+    px: {
+      0: "px-0", 1: "px-1", 2: "px-2", 3: "px-3", 4: "px-4", 5: "px-5",
+      6: "px-6", 8: "px-8", 10: "px-10", 12: "px-12",
+    },
+    py: {
+      0: "py-0", 1: "py-1", 2: "py-2", 3: "py-3", 4: "py-4", 5: "py-5",
+      6: "py-6", 8: "py-8", 10: "py-10", 12: "py-12",
+    },
+  },
+})
+
+export type BoxProps = React.ComponentProps<"div"> &
+  VariantProps<typeof boxVariants> & { asChild?: boolean }
+
+export function Box({ className, p, px, py, asChild = false, ...props }: BoxProps) {
+  const Comp = asChild ? Slot.Root : "div"
+  return (
+    <Comp
+      data-slot="box"
+      className={cn(boxVariants({ p, px, py }), className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/Components/layout/container.tsx
+++ b/resources/js/Components/layout/container.tsx
@@ -1,0 +1,45 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Container — largura-máxima de página + padding horizontal de token (ADR 0253 · F3).
+ *
+ * O wrapper de página: centraliza e limita a medida de leitura. `size` mapeia
+ * pros breakpoints-token do Tailwind; `px` é o respiro lateral (token).
+ */
+const containerVariants = cva("mx-auto w-full", {
+  variants: {
+    size: {
+      sm: "max-w-screen-sm",
+      md: "max-w-screen-md",
+      lg: "max-w-screen-lg",
+      xl: "max-w-screen-xl",
+      "2xl": "max-w-screen-2xl",
+      full: "max-w-full",
+    },
+    px: {
+      0: "px-0", 2: "px-2", 4: "px-4", 6: "px-6", 8: "px-8",
+    },
+  },
+  defaultVariants: {
+    size: "xl",
+    px: 4,
+  },
+})
+
+export type ContainerProps = React.ComponentProps<"div"> &
+  VariantProps<typeof containerVariants> & { asChild?: boolean }
+
+export function Container({ className, size, px, asChild = false, ...props }: ContainerProps) {
+  const Comp = asChild ? Slot.Root : "div"
+  return (
+    <Comp
+      data-slot="container"
+      className={cn(containerVariants({ size, px }), className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/Components/layout/grid.tsx
+++ b/resources/js/Components/layout/grid.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Grid — grade de N colunas-token com `gap` de token (ADR 0253 · F3).
+ *
+ * Substitui `<div className="grid grid-cols-3 gap-4">` solto. `cols` enumerado
+ * (1–6, 12) cobre os arranjos reais de cadastro/dashboard; responsividade fina
+ * fica por composição (`className` extra) até surgir demanda pra prop dedicada.
+ */
+const gridVariants = cva("grid", {
+  variants: {
+    cols: {
+      1: "grid-cols-1", 2: "grid-cols-2", 3: "grid-cols-3", 4: "grid-cols-4",
+      5: "grid-cols-5", 6: "grid-cols-6", 12: "grid-cols-12",
+    },
+    gap: {
+      0: "gap-0", 1: "gap-1", 2: "gap-2", 3: "gap-3", 4: "gap-4", 5: "gap-5",
+      6: "gap-6", 8: "gap-8", 10: "gap-10", 12: "gap-12",
+    },
+  },
+  defaultVariants: {
+    cols: 1,
+    gap: 4,
+  },
+})
+
+export type GridProps = React.ComponentProps<"div"> &
+  VariantProps<typeof gridVariants> & { asChild?: boolean }
+
+export function Grid({ className, cols, gap, asChild = false, ...props }: GridProps) {
+  const Comp = asChild ? Slot.Root : "div"
+  return (
+    <Comp
+      data-slot="grid"
+      className={cn(gridVariants({ cols, gap }), className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/Components/layout/index.ts
+++ b/resources/js/Components/layout/index.ts
@@ -1,0 +1,15 @@
+/**
+ * Primitivos de layout — a camada que falta entre tokens DS v6 e telas (ADR 0253 · F3).
+ *
+ * Regra: layout é COMPOSIÇÃO destes primitivos, nunca `<div className="flex gap-4">`
+ * solto nem `.css` bespoke. Props = token, sempre (enforcement no nível do tipo via CVA).
+ *
+ * @see memory/decisions/0253-primitivos-layout.md
+ * @see memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md §2.1
+ */
+export { Box, type BoxProps } from "./box"
+export { Stack, type StackProps } from "./stack"
+export { Inline, type InlineProps } from "./inline"
+export { Grid, type GridProps } from "./grid"
+export { Container, type ContainerProps } from "./container"
+export { Text, type TextProps } from "./text"

--- a/resources/js/Components/layout/inline.tsx
+++ b/resources/js/Components/layout/inline.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Inline — alinha filhos na horizontal com `gap` de token + `wrap` (ADR 0253 · F3).
+ *
+ * Substitui o `<div className="flex items-center gap-2">` solto. `wrap` liga o
+ * flex-wrap (toolbars, chips). Espaço só por token.
+ */
+const inlineVariants = cva("flex flex-row", {
+  variants: {
+    gap: {
+      0: "gap-0", 1: "gap-1", 2: "gap-2", 3: "gap-3", 4: "gap-4", 5: "gap-5",
+      6: "gap-6", 8: "gap-8", 10: "gap-10", 12: "gap-12",
+    },
+    align: {
+      start: "items-start",
+      center: "items-center",
+      end: "items-end",
+      stretch: "items-stretch",
+      baseline: "items-baseline",
+    },
+    justify: {
+      start: "justify-start",
+      center: "justify-center",
+      end: "justify-end",
+      between: "justify-between",
+      around: "justify-around",
+      evenly: "justify-evenly",
+    },
+    wrap: {
+      true: "flex-wrap",
+      false: "flex-nowrap",
+    },
+  },
+  defaultVariants: {
+    gap: 2,
+    align: "center",
+  },
+})
+
+export type InlineProps = React.ComponentProps<"div"> &
+  VariantProps<typeof inlineVariants> & { asChild?: boolean }
+
+export function Inline({ className, gap, align, justify, wrap, asChild = false, ...props }: InlineProps) {
+  const Comp = asChild ? Slot.Root : "div"
+  return (
+    <Comp
+      data-slot="inline"
+      className={cn(inlineVariants({ gap, align, justify, wrap }), className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/Components/layout/stack.tsx
+++ b/resources/js/Components/layout/stack.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Stack — empilha filhos na vertical com `gap` de token (ADR 0253 · F3).
+ *
+ * Substitui o `<div className="flex flex-col gap-4">` solto repetido pelas telas.
+ * `gap`/`align`/`justify` são enumerados → espaço nunca vem de px literal.
+ */
+const stackVariants = cva("flex flex-col", {
+  variants: {
+    gap: {
+      0: "gap-0", 1: "gap-1", 2: "gap-2", 3: "gap-3", 4: "gap-4", 5: "gap-5",
+      6: "gap-6", 8: "gap-8", 10: "gap-10", 12: "gap-12",
+    },
+    align: {
+      start: "items-start",
+      center: "items-center",
+      end: "items-end",
+      stretch: "items-stretch",
+      baseline: "items-baseline",
+    },
+    justify: {
+      start: "justify-start",
+      center: "justify-center",
+      end: "justify-end",
+      between: "justify-between",
+      around: "justify-around",
+      evenly: "justify-evenly",
+    },
+  },
+  defaultVariants: {
+    gap: 4,
+  },
+})
+
+export type StackProps = React.ComponentProps<"div"> &
+  VariantProps<typeof stackVariants> & { asChild?: boolean }
+
+export function Stack({ className, gap, align, justify, asChild = false, ...props }: StackProps) {
+  const Comp = asChild ? Slot.Root : "div"
+  return (
+    <Comp
+      data-slot="stack"
+      className={cn(stackVariants({ gap, align, justify }), className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/Components/layout/text.tsx
+++ b/resources/js/Components/layout/text.tsx
@@ -1,0 +1,75 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Text — tipografia 100% via type-scale token (ADR 0253 · F3).
+ *
+ * Mata o `className="text-[22px]"` / cor crua: `size`/`weight`/`tone` são
+ * enumerados e mapeiam pros tokens do DS v6 (`text-foreground`,
+ * `text-muted-foreground`, `text-primary`, `text-destructive`). `as` escolhe a
+ * tag semântica (h1–h6/p/span/label) — estilo e semântica desacoplados.
+ */
+const textVariants = cva("", {
+  variants: {
+    size: {
+      xs: "text-xs",
+      sm: "text-sm",
+      base: "text-base",
+      lg: "text-lg",
+      xl: "text-xl",
+      "2xl": "text-2xl",
+      "3xl": "text-3xl",
+    },
+    weight: {
+      normal: "font-normal",
+      medium: "font-medium",
+      semibold: "font-semibold",
+      bold: "font-bold",
+    },
+    tone: {
+      default: "text-foreground",
+      muted: "text-muted-foreground",
+      primary: "text-primary",
+      destructive: "text-destructive",
+    },
+    align: {
+      left: "text-left",
+      center: "text-center",
+      right: "text-right",
+    },
+    truncate: {
+      true: "truncate",
+    },
+  },
+  defaultVariants: {
+    size: "base",
+    weight: "normal",
+    tone: "default",
+  },
+})
+
+type TextElement =
+  | "p" | "span" | "div" | "label" | "strong" | "em"
+  | "h1" | "h2" | "h3" | "h4" | "h5" | "h6"
+
+export type TextProps = React.HTMLAttributes<HTMLElement> &
+  VariantProps<typeof textVariants> & {
+    as?: TextElement
+    asChild?: boolean
+  }
+
+export function Text({
+  className, size, weight, tone, align, truncate, as = "p", asChild = false, ...props
+}: TextProps) {
+  const Comp = asChild ? Slot.Root : as
+  return (
+    <Comp
+      data-slot="text"
+      className={cn(textVariants({ size, weight, tone, align, truncate }), className)}
+      {...props}
+    />
+  )
+}

--- a/resources/js/Pages/_Showcase/Components.tsx
+++ b/resources/js/Pages/_Showcase/Components.tsx
@@ -11,6 +11,7 @@ import { Input } from '@/Components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Badge } from '@/Components/ui/badge';
 import PageHeader from '@/Components/shared/PageHeader';
+import { Box, Stack, Inline, Grid, Container, Text } from '@/Components/layout';
 import KpiCard from '@/Components/shared/KpiCard';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import StatusBadge from '@/Components/shared/StatusBadge';
@@ -389,8 +390,96 @@ export default function Showcase() {
             </ul>
           </div>
         </Section>
+
+        {/* ========================================= LAYOUT PRIMITIVES ========================================= */}
+        <Section title="11. Primitivos de Layout (ADR 0253 · F3 — props = token, zero flex solto)">
+          <div className="space-y-6">
+            {/* Text */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Text — tipografia 100% type-scale token:</h3>
+              <Stack gap={1}>
+                <Text as="h2" size="2xl" weight="semibold">Título 2xl semibold</Text>
+                <Text size="base">Corpo base · tom default</Text>
+                <Text size="sm" tone="muted">Legenda sm · tom muted</Text>
+                <Text size="sm" tone="primary" weight="medium">Destaque primary</Text>
+                <Text size="sm" tone="destructive">Erro destructive</Text>
+              </Stack>
+            </div>
+
+            {/* Stack */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Stack — empilha vertical com gap-token (gap=2 vs gap=6):</h3>
+              <Inline gap={6} align="start">
+                <Stack gap={2}>
+                  <Tile>gap=2</Tile><Tile>·</Tile><Tile>·</Tile>
+                </Stack>
+                <Stack gap={6}>
+                  <Tile>gap=6</Tile><Tile>·</Tile><Tile>·</Tile>
+                </Stack>
+              </Inline>
+            </div>
+
+            {/* Inline */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Inline — alinha horizontal + wrap (chips):</h3>
+              <Inline gap={2} wrap>
+                {['Aberta', 'Orçamento', 'Aprovada', 'Em execução', 'Concluída', 'Faturada'].map((s) => (
+                  <Badge key={s} variant="secondary">{s}</Badge>
+                ))}
+              </Inline>
+            </div>
+
+            {/* Grid */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Grid — cols=3, gap=4:</h3>
+              <Grid cols={3} gap={4}>
+                {['A', 'B', 'C', 'D', 'E', 'F'].map((c) => (
+                  <Box key={c} p={4} className="rounded-md border border-border bg-muted/40">
+                    <Text size="sm" tone="muted">Card {c}</Text>
+                  </Box>
+                ))}
+              </Grid>
+            </div>
+
+            {/* Box + Container */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Box (padding p=6) dentro de Container (size=sm, centralizado):</h3>
+              <Container size="sm" px={0}>
+                <Box p={6} className="rounded-md border border-dashed border-primary/40 bg-primary/5">
+                  <Text size="sm" tone="primary">Container size=sm · Box p=6 — toda a medida vem de token</Text>
+                </Box>
+              </Container>
+            </div>
+
+            {/* Composição — a mesma "tela-cartão" do teste, agora visível */}
+            <div>
+              <h3 className="mb-2 text-sm font-medium text-muted-foreground">Composição 100% primitivos (zero className=&quot;flex gap&quot; solto):</h3>
+              <Box p={4} className="rounded-lg border border-border bg-card">
+                <Stack gap={4}>
+                  <Text as="h3" size="xl" weight="semibold">Resumo da OS</Text>
+                  <Grid cols={2} gap={4}>
+                    <Box p={3} className="rounded-md bg-muted/40"><Text size="sm" tone="muted">Peças · R$ 480,00</Text></Box>
+                    <Box p={3} className="rounded-md bg-muted/40"><Text size="sm" tone="muted">Mão de obra · R$ 360,00</Text></Box>
+                  </Grid>
+                  <Inline gap={2} justify="end">
+                    <Button variant="outline" size="sm">Cancelar</Button>
+                    <Button size="sm">Faturar</Button>
+                  </Inline>
+                </Stack>
+              </Box>
+            </div>
+          </div>
+        </Section>
       </div>
     </>
+  );
+}
+
+function Tile({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-md border border-border bg-muted/40 px-3 py-1.5 text-xs text-muted-foreground">
+      {children}
+    </div>
   );
 }
 

--- a/tests/layout-primitives.test.tsx
+++ b/tests/layout-primitives.test.tsx
@@ -1,0 +1,114 @@
+// Primitivos de layout (ADR 0253 · F3) — prova que a camada compõe e que
+// props viram TOKEN (classe utilitária), nunca px/hex literal.
+//
+// Nota: sem @testing-library/jest-dom no setup do projeto (ver tests/js/setup.ts) —
+// uso querySelector + className/tagName direto, padrão de tests/fiscal-status-badge.test.tsx.
+
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
+
+import { Box, Stack, Inline, Grid, Container, Text } from "@/Components/layout"
+
+afterEach(cleanup)
+
+describe("primitivos — props viram classe-token", () => {
+  it("Stack: gap/align/justify mapeiam pros utilitários de token", () => {
+    const { container } = render(<Stack gap={6} align="center" justify="between" />)
+    const el = container.querySelector('[data-slot="stack"]')!
+    expect(el.className).toContain("flex")
+    expect(el.className).toContain("flex-col")
+    expect(el.className).toContain("gap-6")
+    expect(el.className).toContain("items-center")
+    expect(el.className).toContain("justify-between")
+  })
+
+  it("Stack: gap default = 4 quando não passado", () => {
+    const { container } = render(<Stack />)
+    expect(container.querySelector('[data-slot="stack"]')!.className).toContain("gap-4")
+  })
+
+  it("Inline: wrap liga flex-wrap; default é horizontal centralizado", () => {
+    const { container } = render(<Inline wrap />)
+    const el = container.querySelector('[data-slot="inline"]')!
+    expect(el.className).toContain("flex-row")
+    expect(el.className).toContain("flex-wrap")
+    expect(el.className).toContain("items-center")
+  })
+
+  it("Grid: cols + gap viram grid-cols-N / gap-N", () => {
+    const { container } = render(<Grid cols={3} gap={8} />)
+    const el = container.querySelector('[data-slot="grid"]')!
+    expect(el.className).toContain("grid")
+    expect(el.className).toContain("grid-cols-3")
+    expect(el.className).toContain("gap-8")
+  })
+
+  it("Box: p/px/py viram padding-token", () => {
+    const { container } = render(<Box p={4} px={6} />)
+    const el = container.querySelector('[data-slot="box"]')!
+    expect(el.className).toContain("p-4")
+    expect(el.className).toContain("px-6")
+  })
+
+  it("Container: size vira max-width-token e centraliza", () => {
+    const { container } = render(<Container size="lg" />)
+    const el = container.querySelector('[data-slot="container"]')!
+    expect(el.className).toContain("mx-auto")
+    expect(el.className).toContain("max-w-screen-lg")
+  })
+
+  it("Text: tone/size viram token semântico; default tag = p", () => {
+    const { container } = render(<Text tone="muted" size="sm">oi</Text>)
+    const el = container.querySelector('[data-slot="text"]')!
+    expect(el.tagName).toBe("P")
+    expect(el.className).toContain("text-muted-foreground")
+    expect(el.className).toContain("text-sm")
+    expect(el.textContent).toBe("oi")
+  })
+})
+
+describe("primitivos — polimorfismo (semântica desacoplada do estilo)", () => {
+  it("Text as=h2 renderiza H2 mantendo as classes-token", () => {
+    const { container } = render(<Text as="h2" size="2xl" weight="bold">Título</Text>)
+    const el = container.querySelector('[data-slot="text"]')!
+    expect(el.tagName).toBe("H2")
+    expect(el.className).toContain("text-2xl")
+    expect(el.className).toContain("font-bold")
+  })
+
+  it("Stack asChild projeta as classes no filho (sem div extra)", () => {
+    const { container } = render(
+      <Stack asChild gap={2}>
+        <section data-testid="secao" />
+      </Stack>,
+    )
+    const el = container.querySelector("section")!
+    expect(el.getAttribute("data-slot")).toBe("stack")
+    expect(el.className).toContain("flex-col")
+    expect(el.className).toContain("gap-2")
+  })
+})
+
+describe("primitivos — composição (prova viva: zero flex solto)", () => {
+  it("uma tela-cartão composta 100% por primitivos rende a árvore esperada", () => {
+    const { container } = render(
+      <Container size="md">
+        <Stack gap={4}>
+          <Text as="h1" size="2xl" weight="semibold">Cabeçalho</Text>
+          <Grid cols={2} gap={4}>
+            <Box p={4}><Text tone="muted">A</Text></Box>
+            <Box p={4}><Text tone="muted">B</Text></Box>
+          </Grid>
+          <Inline gap={2} justify="end">
+            <button>Cancelar</button>
+            <button>Salvar</button>
+          </Inline>
+        </Stack>
+      </Container>,
+    )
+    expect(container.querySelector('[data-slot="container"]')).toBeTruthy()
+    expect(container.querySelectorAll('[data-slot="box"]').length).toBe(2)
+    expect(container.querySelector('[data-slot="grid"]')!.className).toContain("grid-cols-2")
+    expect(container.querySelector("h1")!.textContent).toBe("Cabeçalho")
+  })
+})


### PR DESCRIPTION
## O quê
A **camada de layout que faltava** entre os tokens DS v6 e as telas — `resources/js/Components/layout/`:

| Primitivo | Faz |
|---|---|
| `Box` | container neutro; padding token (`p`/`px`/`py`) |
| `Stack` | empilha vertical; `gap`/`align`/`justify` token |
| `Inline` | alinha horizontal; `gap`/`align`/`justify`/`wrap` |
| `Grid` | grade N colunas; `cols`/`gap` token |
| `Container` | largura-máx de página + `px` |
| `Text` | tipografia type-scale token; `as` h1–h6/p/span |

Implementa o **ADR 0253** (proposto · [#2332](https://github.com/wagnerra23/oimpresso.com/pull/2332)) → fecha a pendência **F3** do handoff CSS/design.

## Por que importa (o trilho que torna o padrão inevitável)
Props são **enumeradas via CVA** → o TS **recusa px/hex literal em tempo de compilação**. Não dá pra escrever `text-[22px]` nem `gap` cru: ou é token, ou não compila. É o enforcement passivo que faltava (a diferença pros best-in-class é *materialização*, não identidade).

- ✅ Estilo da casa: `cva` + `radix-ui` Slot (`asChild`) + `cn` de `@/Lib/utils` (espelha `Components/ui/badge`).
- ✅ **Zero `.css` novo** (não dispara foundation/conformance gate).
- ✅ **10 testes vitest** verdes (composição + token-mapping + polimorfismo `asChild`/`as`).
- ✅ `tsc --noEmit`: **zero erro novo** (o TS1149 em `resizable.tsx` é pré-existente da main — casing `@/lib` vs `@/Lib`).
- ✅ ESLint: 0 erros em `Components/layout`.

## Escopo (commit-discipline)
- ❌ **NÃO** migra tela de produção (isso é **F4**, sob teu gate visual) — aqui a prova é o teste de composição.
- 🔜 Follow-ups: 1 tela-piloto 100% primitivos + lint que proíbe `flex`/`grid` solto fora de `Components/layout/`.

## Ordem de merge sugerida
1. ADR 0253 (#2332) — aceitar (`proposto → aceito`)
2. este PR (a implementação que prova o ADR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)