### PR TITLE
fix(ui): corrige casing import @/Lib/utils em resizable.tsx (TS1149)

### DIFF
--- a/resources/js/Components/ui/resizable.tsx
+++ b/resources/js/Components/ui/resizable.tsx
@@ -4,7 +4,7 @@ import { GripVertical } from "lucide-react";
 import * as ResizablePrimitive from "react-resizable-panels";
 import * as React from "react";
 
-import { cn } from "@/lib/utils";
+import { cn } from "@/Lib/utils";
 
 const ResizablePanelGroup = ({
   className,


### PR DESCRIPTION
## O quê

`resources/js/Components/ui/resizable.tsx` importava `cn` de `@/lib/utils` (minúsculo), enquanto a pasta real (`resources/js/Lib/`) e **todos** os outros imports do projeto usam `@/Lib/utils` (maiúsculo).

## Por quê

Em filesystem **case-insensitive** (Windows), o `tsc` emite **TS1149** — *"File name differs only in casing"* — um erro pré-existente que poluía o baseline do `npm run typecheck` na `main`.

## Fix

Troca de **1 caractere** (`l` → `L`) na linha 7.

## Verificação

- ✅ `npx tsc --noEmit` → contagem de **TS1149 = 0** (antes ≥1)
- ✅ `git grep -iF '@/lib/utils' resources/js` → sem nenhum import com casing errado
- ℹ️ Os erros TS2339 que sobram em `resizable.tsx` (API do pacote `react-resizable-panels`) são pré-existentes e **fora de escopo** deste PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)