### PR TITLE
docs(design): Manual de Identidade canon + torna visível no SSOT

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,16 +4,23 @@
 >
 > Pra trabalhos de código backend/CRUD não-visuais, comece em [`CLAUDE.md`](CLAUDE.md). Pra acesso/deploy de produção, em [`INFRA.md`](INFRA.md).
 
+> ⚠️ **CANON ATUALIZADO 2026-06-06 (grande inspeção).** O **ponto único** de design é o SSOT
+> [`INDEX-DESIGN-MEMORIAS.md`](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) + a voz visual
+> [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) ("Clareza Confiante").
+> Canon **vivo** = **DS v6** (roxo `oklch(0.55 0.15 295)`) + **primitivos de layout** ([ADR 0253](memory/decisions/0253-primitivos-layout.md)) + **grade medido** ([ADR 0254](memory/decisions/0254-design-identity-grade-deterministico.md)).
+> ☠️ As referências a "zip Cowork canon / UI-0010 / `ui_kits/cowork-2026-04-27`" mais abaixo estão
+> **SUPERSEDED** (por [UI-0018](memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) — a pasta virou `_BACKUP-NAO-USAR-`). Ver **§3e Lápides** do SSOT.
+
 ---
 
 ## 1. O que você quer fazer?
 
 | Cenário | Vá direto pra |
 |---|---|
-| **Comparar tela alvo com canon visual antes de codar** ⭐ | [`memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/) — UI Kit canônico (`os-page.jsx` é referência pra list+detail, [_DS UI-0010](memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md)) |
+| **Saber como toda tela deve PARECER (identidade)** ⭐ | [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) (voz "Clareza Confiante") + [`INDEX-DESIGN-MEMORIAS.md`](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) (SSOT) · layout = primitivos [ADR 0253](memory/decisions/0253-primitivos-layout.md) |
 | Codar uma tela React nova ou alterar uma existente | Seção "Padrão técnico de implementação React" abaixo nesse arquivo |
-| Mockup visual numa nova sessão Claude Design canvas | [`memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md`](memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md) — colar como 1ª mensagem + anexar arquivo |
-| Decidir se um padrão visual é canônico ou divergência | [_DS UI-0010](memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md) (canon visual) + [ADR raiz 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md) (Cockpit layout-mãe) |
+| Mockup visual numa nova sessão Claude Design canvas | Cole o [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) + SSOT como 1ª mensagem _(o antigo `BRIEFING_CLAUDE_DESIGN.md` é **histórico** — paleta morta)_ |
+| Decidir se um padrão visual é canônico ou divergência | [UI-0018](memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) (canon visual vivo) + Regra de Ouro [SSOT §0](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) + grade [ADR 0254](memory/decisions/0254-design-identity-grade-deterministico.md) |
 | Buscar/usar um componente shared existente | [`memory/requisitos/_DesignSystem/SPEC.md`](memory/requisitos/_DesignSystem/SPEC.md) |
 | Gerar/auditar runbook de tela | Skill `cockpit-runbook` (pede `runbook da tela X` ou `audita tela X contra Cockpit`) |
 | Auditar uma tela contra o sistema de design | [`memory/requisitos/_DesignSystem/audits/`](memory/requisitos/_DesignSystem/audits/) |

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -118,6 +118,21 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | DS_ADOCAO_INDICE | drift-raiz: hand-rolou `<input radio>` existindo `radio-group.tsx` — falta de guard |
 | HANDOFF/SYNC_LOG | NÃO copiar zip Cowork `{Modules,Pages,resources}` direto pra raiz (viola Tier 0, regride prod) |
 
+### 3e. Lápides — mortos com lição (grande inspeção 2026-06-06)
+
+> **Histórico negativo é first-class** (decisão Wagner 2026-06-06: *"ter o histórico negativo pra não voltar a errar é muito importante"*). Estes docs/ADRs **ficam no lugar** (append-only, status de lápide + `morreu_porque` no frontmatter) — listados aqui pra **não repetir o erro já pago**.
+
+| Morto | Estado | Lição (`morreu_porque`) |
+|---|---|---|
+| **UI-0010 / UI-0012** (zip-cowork "canon visual") | `superseded` → [UI-0018](adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) | zip datado ≠ canon. Verdade viva = DS v6 + primitivos ([0253](../../decisions/0253-primitivos-layout.md)) + [Manual de Identidade](MANUAL-IDENTIDADE.md). **NÃO copiar HTML/cor de zip.** |
+| **BRIEFING_CLAUDE_DESIGN / _PROXIMA_SESSAO** | `accepted-historical` | propunham azul 220° + sidebar dark — canon = roxo 295 + light. NÃO usar de ponto de partida |
+| **CATALOGO_ACABAMENTOS** | `accepted-historical` (parcial) | só a **COR** (azul 220) morreu; estrutura/tipo/espaço seguem válidos |
+| **sidebar-rail-mode / GUIA-SIDEBAR-V3** | `superseded`/`historical` | hue-per-grupo morto — verdade = `cockpit/shared.ts` (código>doc) |
+| **AUTOMATION-ROADMAP** | `accepted-historical` | dizia "zero ondas" — falso, ondas+6 gates entregues. NÃO ler como roadmap futuro |
+| **from-claude-design/04-conventions · decisions-README** | `superseded` | importados PontoWr2 legado (Laravel 10) → `.claude/rules/` + MCP `decisions-search` |
+| **audits/2026-04-24** | `deprecated` | duplicata byte-a-byte de `2026-04-22` |
+| **ui_kits/_BACKUP-NAO-USAR-cowork-2026-04-27** | tombstone (no nome) | snapshot abril — **NÃO usar** (mantido como histórico negativo · decisão Wagner) |
+
 ---
 
 ## 4 · CONFLITOS RECONCILIADOS (a regra de ouro aplicada)
@@ -136,6 +151,8 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | **Sidebar hue-per-grupo** | **código `cockpit/shared.ts SIDEBAR_GROUP_HUE`** (reconciliado 2026-05-25) | hues de GUIA-SIDEBAR / sidebar-rail-mode (antigos) | R3 |
 | **PageHeader (estrutura)** | **3 blocos fechados** separados, gap 12px (ADR 0189 v3.1, pageheader-matriz F1) | "layout flat 3 zonas" (ADR 0182) | R1 |
 | **Azul que SOBREVIVE** | **origin-badge CRM = blue** (sistema de badge de origem, ≠ botão primary) — continua válido | confundir com cor de marca | R2 (nuance) |
+| **Canon visual (vivo vs snapshot)** | **DS v6 + primitivos (0253) + Manual de Identidade — vivo e MEDIDO** (grade 0254) | zip-cowork UI-0010/0012 (`superseded` por UI-0018) — snapshot datado | R1+R5 |
+| **DS naming (v3/v4/v5/v6)** | **"DS v6"** é o nome único (ADR 0249) | "v3/v4/v5" = nomes antigos da MESMA coisa (UI-0017 aditiva, não morre — só o nome) | R2 |
 
 ---
 

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -1,3 +1,11 @@
+---
+owner: wagner
+last_reviewed: "2026-06-06"
+next_review: "2026-07-31"
+related_adrs: [0235, 0249, 0253, 0254]
+note: "SSOT de design. next_review obrigatório (DesignDocsFreshnessChecker ADR 0236) — é o que impede este índice de apodrecer como aconteceu com 'PT-02..05 não existem'."
+---
+
 # ÍNDICE-MESTRE — Memórias de Design que o Claude Design pode usar
 
 > **Pra que serve:** ponto único de partida do Claude Design. Lista TODAS as memórias de design do projeto — **positivas** (o que copiar/seguir) e **negativas** (o que NÃO repetir) — já reconciliadas, com a **regra de ouro** que resolve conflito. Substitui a tarefa de "montar contexto de cabeça" (origem da invenção e do erro repetido).

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -23,7 +23,8 @@ Quando duas memórias divergem, vence nesta ordem:
 
 1. **[PRE-FLIGHT-TELA.md](../../../prototipo-ui/PRE-FLIGHT-TELA.md)** — monta o pacote de pré-requisitos DAQUELA tela (identidade/não-inventar/não-repetir/validar).
 2. **[GOLDEN-REFERENCE.md](../../../prototipo-ui/GOLDEN-REFERENCE.md)** — a tela-ouro do arquétipo + 10 regras binárias. "Faça idêntico, mude só X."
-3. **[REGISTRY_DS_COMPONENTES.md](../../../prototipo-ui/REGISTRY_DS_COMPONENTES.md)** — componentes `@/Components/ui` disponíveis. Se está aqui, **não hand-rola**. ⚠️ Onda F (`Segmented`/`FormSection`/`InputGroup`/`FieldState`) **ainda NÃO existe** — não assuma que existe.
+2b. **[MANUAL-IDENTIDADE.md](MANUAL-IDENTIDADE.md)** ⭐ — a VOZ visual "Clareza Confiante": como deve PARECER + DO/DON'T + as 3 assinaturas. Define o *feel*; o golden define a *estrutura*.
+3. **[REGISTRY_DS_COMPONENTES.md](../../../prototipo-ui/REGISTRY_DS_COMPONENTES.md)** — componentes `@/Components/ui` disponíveis. Se está aqui, **não hand-rola**. ➕ **Layout: usar primitivos `@/Components/layout` ([ADR 0253](../../decisions/0253-primitivos-layout.md)) — `Stack/Inline/Grid/Box/Container/Text`.** ⚠️ Onda F (`Segmented`/`FormSection`/`InputGroup`/`FieldState`) **ainda NÃO existe** — não assuma que existe.
 4. **[LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)** — os 21 anti-padrões (exemplo errado). Leitura obrigatória antes de F3.
 5. **[SCREEN-GRADE-METODO.md](SCREEN-GRADE-METODO.md)** — como a tela será notada (16 dim, níveis Beginner→Champion).
 
@@ -36,6 +37,7 @@ Quando duas memórias divergem, vence nesta ordem:
 ### 2a. Entrada / identidade do projeto
 | Memória | Usar pra |
 |---|---|
+| **[MANUAL-IDENTIDADE.md](MANUAL-IDENTIDADE.md)** ⭐ | **A VOZ VISUAL — "Clareza Confiante" (2026-06-06).** Como toda tela deve PARECER: type-scale 8 tokens (incl `2xs`), 3 assinaturas (focus-ring roxo · barra-accent · tabular-nums), densidade 36px, motion 150ms, DO/DON'T. **Leitura obrigatória antes de craftar identidade.** Irmã do MANUAL-CSS-JS (voz de código) |
 | [memory/why-oimpresso.md](../../why-oimpresso.md) | **Posicionamento REAL: ERP modular multi-vertical** (ADR 0121). Larissa/ROTA LIVRE = **vestuário** (não gráfica). ⚠️ corrige briefings antigos |
 | [personas-por-modulo.yml](personas-por-modulo.yml) + ADR UI-0016 | Persona dona da tela (Larissa 1280px densidade · Eliana tabela densa · técnico touch ≥44px) |
 | [prototipo-ui/GLOSSARY.md](../../../prototipo-ui/GLOSSARY.md) | Siglas, fases, comparáveis externos por arquétipo |
@@ -46,6 +48,7 @@ Quando duas memórias divergem, vence nesta ordem:
 | **GOLDEN-REFERENCE.md** | tela-ouro `Sells/Create` (form) + 10 regras binárias R1-R10 |
 | **padroes-tela/PT-01-Lista.md** | golden do arquétipo **lista** (status sem bg-fill, slots) |
 | **REGISTRY_DS_COMPONENTES.md** | componentes reais `@/Components/ui` |
+| **[ADR 0253 — primitivos de layout](../../decisions/0253-primitivos-layout.md)** ⭐ | `<Stack/Inline/Grid/Box/Container/Text>` em `@/Components/layout` — **layout é COMPOSIÇÃO de primitivo, nunca `flex`/`grid` solto** (props = token). Showcase em `/showcase/components` |
 | **tokens v4** (`resources/css/inertia.css`, ADR 0235) | cor = `primary` roxo. Zero `blue-*` de marca |
 | ADR 0110 (Cockpit Pattern V2) + UI-0010 `os-page.jsx` + UI-0012 | padrão list+detail / shell |
 | ADR UI-0015 | campos de form default `variant="cowork"` |
@@ -55,12 +58,13 @@ Quando duas memórias divergem, vence nesta ordem:
 | [MANUAL-CSS-JS.md](MANUAL-CSS-JS.md) | regimento **CSS/JS** — do/don't + arquitetura-alvo (token DS v6 → primitivos **layout**+ui → padrão → página) + gap dos primitivos de layout (§2.1) + roadmap de convergência F0–F7 (sair do sprawl de 28k linhas) |
 | RUNBOOK-{replicar-prototipo-cowork,onda-cowork,design-deep,inertia-defer-pattern}.md | receitas de execução (portar protótipo, ondas, defer) |
 
-> ⚠️ **Goldens de arquétipo: só existe PT-01-Lista.** Faltam **PT-02 Form/Drawer · PT-03 Detalhe · PT-04 Dashboard · PT-05 Config/Kanban** (confirmado por 2 agentes + piloto). Até existirem, o Claude Design usa o golden de código (GOLDEN-REFERENCE = form) e, p/ outros tipos, **pergunta** em vez de inventar.
+> ✅ **Goldens de arquétipo (corrigido 2026-06-06): PT-01 Lista · [PT-02 Form/Drawer](padroes-tela/PT-02-Form-Drawer.md) · [PT-03 Detalhe](padroes-tela/PT-03-Detalhe.md) · [PT-04 Dashboard](padroes-tela/PT-04-Dashboard.md) · [PT-05 Kanban](padroes-tela/PT-05-Kanban.md) — TODOS existem** em [`padroes-tela/`](padroes-tela/). _(O INDEX dizia "faltam PT-02..05" — era stale de 2026-05-30; os 5 arquivos têm 116-135 linhas cada.)_
 
 ### 2c. Validação / definição de pronto
 | Memória | Usar pra |
 |---|---|
-| **SCREEN-GRADE-METODO.md** | nota 16-dim, níveis, score-as-code |
+| **SCREEN-GRADE-METODO.md** | nota 16-dim, níveis, score-as-code (UX amplo, por tela) |
+| **[ADR 0254 — grade de identidade DETERMINÍSTICO](../../decisions/0254-design-identity-grade-deterministico.md)** ⭐ | nota de **identidade** 0-100 **σ=0** por regex (anti-alucinação — cura o LLM-judge que dava 91→71). `node scripts/design-identity-grade.mjs` · ratchet só sobe · **hoje 66, meta 85** · lista top-5 ofensores |
 | [design-requests/LEDGER.md](../../governance/design-requests/LEDGER.md) | ledger incremental de pedidos (REQ-NNN, **file-based**) — checar "já processei?" antes de trabalhar; grava resultado/grade ao fechar · ⚠️ scaffold pré-ADR ([proposta](../../decisions/proposals/design-request-ledger-incremental.md)) |
 | [PRE-MERGE-UI.md](PRE-MERGE-UI.md) | checklist AP1-AP8 antes de merge |
 | `php artisan ui:lint` (R1-R6, CI ratchet) | cor crua, FontAwesome, emoji, PT-01, origens, blade |

--- a/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
+++ b/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
@@ -1,0 +1,113 @@
+# Manual de Identidade Visual — oimpresso · "Clareza Confiante"
+
+> **O que é:** a **voz visual** do produto — as decisões de identidade que toda tela/componente
+> deve encarnar. É a peça que faltava: o projeto tinha governança (gates) e tokens, mas não tinha
+> a **identidade decidida e escrita**. Sem ela, mecanizar (codemod/ratchet) converge pro *genérico*.
+>
+> **Irmã da [`MANUAL-CSS-JS.md`](MANUAL-CSS-JS.md)** (a voz de CÓDIGO). Esta é a voz de DESIGN.
+> **Direção escolhida por Wagner 2026-06-06.** Subordinada à Constituição UI v2 (ADR UI-0013) e ao
+> DS v6 (ADR 0235 cor / 0249 nome).
+>
+> **Status:** voz **decidida** (Clareza Confiante). Implementação dos tokens novos (type-scale `2xs`,
+> motion) **pendente de ADR** — ver §Pendências.
+
+---
+
+## 0 · O princípio (a frase)
+
+**"Clareza Confiante": cada pixel tem intenção. O roxo é pontuação, não decoração. O número manda.**
+
+Precisão do Linear + legibilidade do Stripe, tunada pra **dona de PME brasileira não-técnica**
+(Larissa, 1280px) e oficina (Martinho). Não é frio-enterprise nem startup-lúdico. **Calma, precisa, confiante.**
+
+---
+
+## 1 · As 10 dimensões DECIDIDAS
+
+A ordem é por impacto na "cara" (tipografia + espaço + detalhe definem mais que cor).
+
+### 1.1 Tipografia — **escala fechada de 8 degraus** (fim do `text-[Npx]`)
+| token | px | uso |
+|---|---|---|
+| `2xs` | 11 | metadados, sub-labels (resolve `text-[10.5/11.5px]`) |
+| `xs` | 12 | legendas, badges |
+| `sm` | 13 | **corpo denso ERP (default)** |
+| `base` | 14 | corpo confortável |
+| `lg` | 16 | subtítulo |
+| `xl` | 20 | título de seção |
+| `2xl` | 24 | título de página |
+| `3xl` | 30 | hero (raro) |
+- **Pesos:** 400 corpo · 500 ênfase · 600 títulos/ações. **Sem 700.**
+- **Tracking:** títulos `-0.01em`; uppercase de seção `+0.04em`.
+- **Números: `tabular-nums` SEMPRE** (R$/qtd/data). Fonte: Inter.
+
+### 1.2 Espaço & Densidade — confortável-densa
+Unidade 4px (escala dos primitivos: 1,2,3,4,6,8,12). Linha de lista/tabela **36px** · card pad **16px** · gutter **24px**. Fim de `gap-0.5` cru.
+
+### 1.3 Detalhe & Acabamento — **as 3 assinaturas** (onde mora a alma)
+1. **Focus-ring roxo** `ring-2 ring-primary/40` em TODO interativo.
+2. **Barra-accent roxa à esquerda** (2px) no item ativo/selecionado — o "você está aqui".
+3. **Números tabulares** alinhados na vírgula.
++ **7 estados obrigatórios:** hover · focus-visible · active · disabled · empty · loading · error.
+
+### 1.4 Forma
+`rounded-md` 8px default · `lg` 12px (cards/sheets) · `full` (pills). Borda 1px `border-border` (hairline). Sombra só em flutuante (`shadow-sm`).
+
+### 1.5 Movimento
+Hover/cor **150ms ease-out** · enter/sheet **200ms** · sem bounce · foco anima (120ms).
+
+### 1.6 Cor
+Accent = roxo `oklch(0.55 0.15 295)` (ADR 0235) como **pontuação** (ação primária/foco/ativo), nunca preenchimento. Superfícies: `background` ‹ `card` ‹ `muted`. Status = soft pills (`emerald/amber/rose/sky` — convenção semântica).
+
+### 1.7–1.10
+- **Hierarquia:** 3 níveis/tela — Título `2xl/600` · Seção `xs/600/uppercase/muted` · Corpo `sm/400`.
+- **Ícone:** lucide, 14–16px, stroke 1.5, `text-muted-foreground` (forçado por gate).
+- **Voz:** PT-BR direto, rótulo ≤2 palavras, zero jargão. "Faturar", não "Processar faturamento".
+- **Sistema:** os gates mecanizam rumo a ESTA manual (não ao genérico).
+
+---
+
+## 2 · Como o design deve AGIR (instrução)
+
+Ao criar/migrar qualquer tela ou componente:
+
+1. **Rode o PRE-FLIGHT** ([`screen-grade`](../../../.claude/skills/screen-grade/SKILL.md)) — não monte contexto de cabeça.
+2. **Layout = composição de primitivos** (`<Stack/Inline/Grid/Box/Container/Text>` — [ADR 0253](../../decisions/0253-primitivos-layout.md)), nunca `flex`/`grid` solto nem `.css` bespoke.
+3. **Cor/tipo/espaço SÓ por token** (DS v6). Zero `text-[Npx]`, zero hex/cor crua neutra/azul.
+4. **Aplique as 3 assinaturas** (§1.3) — é o que torna reconhecível "oimpresso".
+5. **Meça** com o grade determinístico ([ADR 0254](../../decisions/0254-design-identity-grade-deterministico.md)): `node scripts/design-identity-grade.mjs`. **Só sobe.**
+
+### DO / DON'T (resumo)
+| ✅ DO | ❌ DON'T |
+|---|---|
+| `<Stack gap={4}>` | `<div className="flex flex-col gap-4">` |
+| `text-sm` (token) | `text-[13px]` |
+| `bg-primary` (roxo pontuação) | `bg-blue-600` / hex / roxo decorativo |
+| `focus-visible:ring-primary` | interativo sem foco visível |
+| `tabular-nums` em valor | número proporcional desalinhado |
+| status via soft pill semântico | `bg-red-500` sólido pra ESTADO |
+
+---
+
+## 3 · O placar (definição de "melhorou")
+
+Grade de identidade DETERMINÍSTICO ([ADR 0254](../../decisions/0254-design-identity-grade-deterministico.md)) — σ=0, anti-alucinação:
+- **Hoje: 66/100 · Developing.** Meta: **85 · Leader.**
+- Gaps reais medidos: `layout 0` (migração via codemod) · `tipografia 61` (token `2xs`).
+- O grade lista os **top-5 ofensores** por dimensão (roadmap).
+
+---
+
+## 4 · Pendências (o que falta virar ADR/código)
+
+- [ ] **ADR de type-scale** — formalizar os 8 tokens (incl. `2xs`) no `@theme` / tokens DS v6.
+- [ ] **ADR de motion** — tokens de duração/easing (150/200ms).
+- [ ] **Recraftar componentes-bandeira** (`Button`/`Card`/row) encarnando esta manual (gate visual Wagner).
+- [ ] **North Star aprovado** (print 2026-06-06) → vira o golden de "componente com identidade".
+
+---
+
+## Refs
+- [Constituição UI v2 — ADR UI-0013](../../decisions/../requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md) · [DS v6 — ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md) / [0249](../../decisions/0249-ds-v6-naming-amends-0235.md)
+- [Primitivos de layout — ADR 0253](../../decisions/0253-primitivos-layout.md) · [Grade determinístico — ADR 0254](../../decisions/0254-design-identity-grade-deterministico.md)
+- [`MANUAL-CSS-JS.md`](MANUAL-CSS-JS.md) (voz de código) · [`INDEX-DESIGN-MEMORIAS.md`](INDEX-DESIGN-MEMORIAS.md) (SSOT)

--- a/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
+++ b/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
@@ -1,3 +1,12 @@
+---
+title: "Manual de Identidade Visual — Clareza Confiante"
+owner: wagner
+last_reviewed: "2026-06-06"
+next_review: "2026-07-31"
+related_adrs: [0235, 0249, 0253, 0254]
+note: "Voz visual canon. next_review obrigatório (DesignDocsFreshnessChecker ADR 0236) — sobrevive ao tempo por revisão forçada + grade medido (ADR 0254), não por boa-vontade."
+---
+
 # Manual de Identidade Visual — oimpresso · "Clareza Confiante"
 
 > **O que é:** a **voz visual** do produto — as decisões de identidade que toda tela/componente


### PR DESCRIPTION
## O quê
Salva o conhecimento de identidade que construímos e o **torna visível** no SSOT — atendendo *"importante ter um manual dos padrões aceitáveis + arrumar tudo pra ficar visível"*.

### NOVO — `MANUAL-IDENTIDADE.md` (a voz visual canon)
A peça que faltava: a **identidade decidida e escrita** ("Clareza Confiante"). Inclui type-scale de 8 tokens (incl `2xs`), as 3 assinaturas (focus-ring roxo · barra-accent · tabular-nums), densidade 36px, motion 150ms, **DO/DON'T**, e a seção **"como o design deve AGIR"** (instrui o agente). Irmã do `MANUAL-CSS-JS.md` (voz de código).

### INDEX-DESIGN-MEMORIAS (o SSOT) — visível + des-staleado
- **§1 ordem de leitura obrigatória + §2a identidade:** + Manual ⭐ (o agente lê antes de craftar)
- **§2b:** + primitivos [ADR 0253](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0253-primitivos-layout.md)
- **§2c:** + grade determinístico [ADR 0254](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0254-design-identity-grade-deterministico.md)
- **Corrige stale:** o INDEX dizia "faltam PT-02..05" (de 2026-05-30) — os 5 padrões de tela **existem** (116-135 linhas cada)

## Por que importa
O conhecimento estava **invisível** (2 menções no INDEX) e **stale**. Agora o agente, ao tocar qualquer tela, lê a voz de identidade na ordem obrigatória → mecaniza rumo à **tua cara**, não ao genérico.

## Não-fechado (pendências documentadas no Manual §4)
ADR de type-scale (tokens 2xs) · ADR de motion · recraftar componentes-bandeira · refresh completo do INDEX (outras entradas stale prováveis: Onda F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)