### PR TITLE
docs(design): Onda 2 inspeção — 9 lápides com morreu_porque (histórico negativo visível)

### DIFF
--- a/memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md
+++ b/memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md
@@ -1,7 +1,11 @@
 ---
 doc: AUTOMATION-ROADMAP
 camada: meta-protocolo
-status: planejado
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+morreu_porque: "Dizia 'zero ondas executadas' (status:planejado) — FALSO em 2026-06: ondas + 6 gates já entregues (ui-lint.yml, pr-ui-judge.yml, conformance-gate, screen-grades-gate ADR 0250, eslint-baseline ADR 0209). Meta ~90% atingida por outra via. NÃO ler como roadmap futuro — é histórico do plano original. (Onda 2 inspeção 2026-06-06)"
 created: 2026-05-24
 parent_adr: UI-0013
 related_adrs: [UI-0013, UI-0014, 0187]

--- a/memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md
@@ -1,3 +1,13 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["INDEX-DESIGN-MEMORIAS.md", "MANUAL-IDENTIDADE.md"]
+morreu_porque: "Corpo de abr/2026 propõe accent azul 220° + sidebar dark — canon hoje é roxo oklch(0.55 0.15 295) (ADR 0235) + sidebar LIGHT (UI-0009/0014). Histórico negativo: NÃO copiar paleta/sidebar daqui. (Onda 2 inspeção 2026-06-06)"
+related_adrs: [0235, 0249]
+---
+
 # Briefing pra Claude Design — Migração dos módulos Blade do Oimpresso ERP
 
 > ## ⚠️ CANON ATUAL (2026-05-30) — corrige o corpo abaixo (2026-04-27)

--- a/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
@@ -1,3 +1,13 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["INDEX-DESIGN-MEMORIAS.md"]
+morreu_porque: "Briefing de sessão datado; accent 220° / sidebar dark 260px mortos (canon = roxo 295 + light, ADR 0235/UI-0014). NÃO usar como ponto de partida. (Onda 2 inspeção 2026-06-06)"
+related_adrs: [0235, 0249]
+---
+
 # Briefing para retomar o Design System Oimpresso — Claude Design
 
 > Cole este arquivo como **primeira mensagem** numa nova sessão Claude Design.

--- a/memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md
+++ b/memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md
@@ -1,3 +1,12 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+morreu_porque: "MORTE PARCIAL — paleta accent azul 220° é snapshot do Cockpit piloto; cor canon é roxo oklch(0.55 0.15 295) (ADR 0235/0249). Estrutura/tipografia/espaçamento/acabamentos seguem VÁLIDOS — só a COR morreu. (Onda 2 inspeção 2026-06-06)"
+related_adrs: [0235, 0249]
+---
+
 # Catálogo de Acabamentos · Cockpit
 
 > **Propósito**: documentar com precisão pixel-perfect cada detalhe visual do `/copiloto/cockpit` em produção (workspace Vibe, density 50%, accent hue 220°). Serve como **referência canônica** pra qualquer mudança futura — humana ou IA — não inventar tonalidade, sombra, ou tamanho que não esteja aqui.

--- a/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
+++ b/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
@@ -1,3 +1,11 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+morreu_porque: "Já tinha errata 2026-06-04; os hues por grupo estão MORTOS (verdade = cockpit/shared.ts). Plano de 5 ondas pode ter valor histórico de processo; NÃO copiar cores. (Onda 2 inspeção 2026-06-06)"
+---
+
 # GUIA — Sidebar v3 oimpresso: do estado atual ao canon completo
 
 > **Pra quem está se perguntando "como faço pra arrumar a bagunça do sidebar?"** — este guia é seu roteiro executável. Passo a passo, com comandos prontos pra copiar, ordem de execução, e validação visual a cada onda.

--- a/memory/requisitos/_DesignSystem/audits/2026-04-24.md
+++ b/memory/requisitos/_DesignSystem/audits/2026-04-24.md
@@ -1,3 +1,12 @@
+---
+status: deprecated
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["audits/2026-04-22.md"]
+morreu_porque: "Duplicata byte-a-byte do audit 2026-04-22 (re-run sem mudança nenhuma). Redundante. (Onda 2 inspeção 2026-06-06)"
+---
+
 # Auditoria · _DesignSystem · 2026-04-24
 
 - **Score**: 63/100

--- a/memory/requisitos/_DesignSystem/from-claude-design/04-conventions.md
+++ b/memory/requisitos/_DesignSystem/from-claude-design/04-conventions.md
@@ -1,3 +1,12 @@
+---
+status: superseded
+lifecycle: substituido
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: [".claude/rules/modules.md", ".claude/rules/migrations.md", "CLAUDE.md"]
+morreu_porque: "Convenções importadas do projeto PontoWr2 legado; cita Laravel 10 (stack real = 13.6). Convenções vivas em .claude/rules/ + CLAUDE.md. (Onda 2 inspeção 2026-06-06)"
+---
+
 # 04 — Convenções do Projeto
 
 ## Idioma

--- a/memory/requisitos/_DesignSystem/from-claude-design/decisions-README.md
+++ b/memory/requisitos/_DesignSystem/from-claude-design/decisions-README.md
@@ -1,3 +1,12 @@
+---
+status: superseded
+lifecycle: substituido
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["MCP decisions-search"]
+morreu_porque: "Índice de ADRs congelado em 0001-0023 (abr/2026, do PontoWr2). Índice vivo de decisões é via tool MCP decisions-search. (Onda 2 inspeção 2026-06-06)"
+---
+
 # Architecture Decision Records (ADRs)
 
 Este diretório contém os registros formais de decisões arquiteturais importantes do projeto Ponto WR2.

--- a/memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md
+++ b/memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md
@@ -1,3 +1,12 @@
+---
+status: superseded
+lifecycle: substituido
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["cockpit/shared.ts (SIDEBAR_GROUP_HUE)", "INDEX-DESIGN-MEMORIAS.md §4"]
+morreu_porque: "Hue-map por grupo obsoleto e divergente de 2 outros docs; a VERDADE é o código shared.ts (código > doc, Regra de Ouro #3). NÃO copiar os hues daqui. (Onda 2 inspeção 2026-06-06)"
+---
+
 # Sidebar — rail mode + cores por grupo (visual-comparison)
 
 **Tela:** Layout global `AppShellV2` (sidebar global do ERP)


### PR DESCRIPTION
## Onda 2 da grande inspeção — lápides
Aplica status de lápide aos **9 docs de design mortos**, com a lente que você gravou: **lápide = lição visível, nunca esconde**. Cada um ganhou o campo **`morreu_porque`** (o histórico negativo pra não repetir o erro) + `next_review` (entra no `DesignDocsFreshnessChecker`).

| doc | → estado | morreu_porque (resumo) |
|---|---|---|
| `AUTOMATION-ROADMAP` | accepted-historical | "zero ondas executadas" era falso — ondas + 6 gates entregues |
| `BRIEFING_CLAUDE_DESIGN` | accepted-historical | azul 220° + sidebar dark mortos (canon = roxo 295 + light) |
| `BRIEFING_PROXIMA_SESSAO` | accepted-historical | idem |
| `CATALOGO_ACABAMENTOS` | accepted-historical | **morte PARCIAL** — só a cor azul 220 morreu; estrutura segue válida |
| `sidebar-rail-mode` | superseded | hue-map → verdade é `shared.ts` (código>doc) |
| `GUIA-SIDEBAR-V3` | accepted-historical | hues mortos |
| `from-claude-design/04-conventions` | superseded | PontoWr2 legado (Laravel 10!) → `.claude/rules/` |
| `from-claude-design/decisions-README` | superseded | índice congelado → MCP `decisions-search` |
| `audits/2026-04-24` | deprecated | duplicata byte-a-byte de `2026-04-22` |

## Princípios respeitados
- ✅ **Append-only** — nada deletado; só status + `morreu_porque` adicionados.
- ✅ **`_BACKUP-NAO-USAR-` intocado** (tua decisão — tombstone honesto).
- ✅ **next_review 2026-09-06** em todos → o freshness checker força revalidação (anti-apodrecimento).

## Fila restante
Onda 3 (normalização frontmatter dos docs VIVOS) · Onda 4 (update stale-B) · Onda 5 (regenerar INDEX + §3 Negativo com as novas lápides).

🤖 Generated with [Claude Code](https://claude.com/claude-code)