### PR TITLE
docs(design): REVITALIZAÇÃO coordenada — inspeção consolidada num bloco único (supersede #2337/2338/2339)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,16 +4,23 @@
 >
 > Pra trabalhos de código backend/CRUD não-visuais, comece em [`CLAUDE.md`](CLAUDE.md). Pra acesso/deploy de produção, em [`INFRA.md`](INFRA.md).
 
+> ⚠️ **CANON ATUALIZADO 2026-06-06 (grande inspeção).** O **ponto único** de design é o SSOT
+> [`INDEX-DESIGN-MEMORIAS.md`](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) + a voz visual
+> [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) ("Clareza Confiante").
+> Canon **vivo** = **DS v6** (roxo `oklch(0.55 0.15 295)`) + **primitivos de layout** ([ADR 0253](memory/decisions/0253-primitivos-layout.md)) + **grade medido** ([ADR 0254](memory/decisions/0254-design-identity-grade-deterministico.md)).
+> ☠️ As referências a "zip Cowork canon / UI-0010 / `ui_kits/cowork-2026-04-27`" mais abaixo estão
+> **SUPERSEDED** (por [UI-0018](memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) — a pasta virou `_BACKUP-NAO-USAR-`). Ver **§3e Lápides** do SSOT.
+
 ---
 
 ## 1. O que você quer fazer?
 
 | Cenário | Vá direto pra |
 |---|---|
-| **Comparar tela alvo com canon visual antes de codar** ⭐ | [`memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/) — UI Kit canônico (`os-page.jsx` é referência pra list+detail, [_DS UI-0010](memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md)) |
+| **Saber como toda tela deve PARECER (identidade)** ⭐ | [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) (voz "Clareza Confiante") + [`INDEX-DESIGN-MEMORIAS.md`](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) (SSOT) · layout = primitivos [ADR 0253](memory/decisions/0253-primitivos-layout.md) |
 | Codar uma tela React nova ou alterar uma existente | Seção "Padrão técnico de implementação React" abaixo nesse arquivo |
-| Mockup visual numa nova sessão Claude Design canvas | [`memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md`](memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md) — colar como 1ª mensagem + anexar arquivo |
-| Decidir se um padrão visual é canônico ou divergência | [_DS UI-0010](memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md) (canon visual) + [ADR raiz 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md) (Cockpit layout-mãe) |
+| Mockup visual numa nova sessão Claude Design canvas | Cole o [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) + SSOT como 1ª mensagem _(o antigo `BRIEFING_CLAUDE_DESIGN.md` é **histórico** — paleta morta)_ |
+| Decidir se um padrão visual é canônico ou divergência | [UI-0018](memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) (canon visual vivo) + Regra de Ouro [SSOT §0](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) + grade [ADR 0254](memory/decisions/0254-design-identity-grade-deterministico.md) |
 | Buscar/usar um componente shared existente | [`memory/requisitos/_DesignSystem/SPEC.md`](memory/requisitos/_DesignSystem/SPEC.md) |
 | Gerar/auditar runbook de tela | Skill `cockpit-runbook` (pede `runbook da tela X` ou `audita tela X contra Cockpit`) |
 | Auditar uma tela contra o sistema de design | [`memory/requisitos/_DesignSystem/audits/`](memory/requisitos/_DesignSystem/audits/) |

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -86,11 +86,8 @@ Wagner é o aprovador final em divergências de padrão. Cliente (WR2 Sistemas /
 
 ## 6. Antes de codificar qualquer tela
 
-1. **Abra o canon visual** em [`memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/) — UI Kit Cowork. Identifique qual `.jsx` corresponde ao tipo da sua tela:
-   - **list+detail (CRUD operacional)** → [`os-page.jsx`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/os-page.jsx) ⭐ padrão canônico
-   - **inbox unificada** → [`tasks.jsx`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/tasks.jsx) + [`viewers.jsx`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/viewers.jsx)
-   - **conversação/chat** → [`chat.jsx`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-04-27/chat.jsx)
-2. **Leia [_DS UI-0010](memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md)** — formaliza zip Cowork como canon e lista conflitos resolvidos (ex.: sidebar light de UI-0009 sobrevive).
+1. **Leia a voz visual** [`MANUAL-IDENTIDADE.md`](memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md) ("Clareza Confiante") + o SSOT [`INDEX-DESIGN-MEMORIAS.md`](memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md). Layout = composição de primitivos [`@/Components/layout`](resources/js/Components/layout/index.ts) ([ADR 0253](memory/decisions/0253-primitivos-layout.md)). _(O antigo "UI Kit `ui_kits/cowork-2026-04-27/`" virou `_BACKUP-NAO-USAR-` — NÃO usar.)_
+2. **Canon visual vivo:** [UI-0018](memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) (supersede o zip-cowork UI-0010/0012).
 3. **Leia [ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md)** — define layout-mãe "Chat Cockpit" 3-colunas, dual-tab Chat/Menu, painel direito de Apps Vinculados, atalhos J/K/E/A, Tweaks (vibe/densidade/accentHue).
 4. **Leia o session log mais recente em `memory/sessions/`** — pode ter ajuste de design não refletido no ADR ainda.
 5. **Olhe `resources/js/Layouts/AppShellV2.tsx`** — shell único do ERP em React (AppShell legado removido em 2026-05-04). Cliente final NÃO pode reaprender o sistema; mudança de menu/labels/ícones precisa ser aprovada explicitamente.
@@ -113,11 +110,11 @@ Em ordem de precedência (regra mais alta vence em conflito):
 
 1. **Stack-target do projeto** (Inertia v3 + React 19 + TS + Tailwind 4) — não muda sem ADR.
 2. **Constituição UI v2** ([UI-0013](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)) — mãe atual das 4 camadas.
-3. **Tokens canon** ([ADR 0190](memory/decisions/0190-primary-button-roxo-medio-canon.md) primary roxo 295) — `oklch(0.55 0.15 295)` bg + `oklch(0.45 0.15 295)` border, universal cross-módulo.
-4. **PageHeader canon v3** ([ADR 0180](memory/decisions/0180-pageheader-canon-href-direto-ghost-rapido.md) / [0182](memory/decisions/0182-pageheader-3-zonas-esq-centro-dir.md) / [0189](memory/decisions/0189-pageheader-modo-foco-edit-create.md)) — modo NAV (Index/Show) vs modo FOCO (Edit/Create) + 3 zonas Esq/Centro/Dir.
+3. **Tokens canon** ([ADR 0190](memory/decisions/0190-primary-button-roxo-universal-295.md) primary roxo 295) — `oklch(0.55 0.15 295)` bg + `oklch(0.45 0.15 295)` border, universal cross-módulo.
+4. **PageHeader canon v3** ([ADR 0182](memory/decisions/0182-pageheadertabs-canon-pattern-telas.md) / [0189](memory/decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md)) — modo NAV (Index/Show) vs modo FOCO (Edit/Create) + 3 zonas Esq/Centro/Dir.
 5. **PT-01 Lista** ([padrão de tela canônico](memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md)) — anatomia + DNA + slots de listagem operacional.
 6. **Cockpit Pattern V2** ([ADR 0110](memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)) — list+detail consolidado (ver §16).
-7. **Canon visual Cowork 2026-04-27** ([_DS UI-0010](memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md)) — UI Kit `os-page.jsx`/`tasks.jsx`/`viewers.jsx`/`chat.jsx`.
+7. **Canon visual vivo** ([UI-0018](memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md)) — DS v6 + primitivos + Manual (supersede o zip-cowork UI-0010/0012, agora `_BACKUP-NAO-USAR-`).
 8. **Layout-mãe "Chat Cockpit"** ([ADR 0039](memory/decisions/0039-ui-chat-cockpit-padrao.md) + [_DS UI-0008](memory/requisitos/_DesignSystem/adr/ui/0008-cockpit-layout-mae-do-erp.md)).
 9. **Sidebar light por padrão** ([_DS UI-0009](memory/requisitos/_DesignSystem/adr/ui/0009-cockpit-sidebar-light-padrao.md) + [UI-0014](memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md)) — sobrevive a UI v2 (Wagner explícito).
 10. **Padrão Jana** ([ADR 0011](memory/decisions/0011-alinhamento-padrao-jana.md)) — UltimatePOS-like estrutura modular; vale pra DataController/Install (não-visual).
@@ -252,7 +249,7 @@ Quick-check resumido:
 | `pr-ui-judge.yml` (Onda 4.1) | Claude Sonnet 4.5 avalia PR contra Constituição UI v2 — score 0-100 + 9 dimensões + sugestões cirúrgicas (~$3/mês a 100 PRs) |
 | `mwart-gate.yml` | `<tela>-visual-comparison.md` obrigatório se Page Inertia nova (ADR 0107 §F1.5) |
 | `charter-gate.yml` | `.charter.md` obrigatório ao lado de `.tsx` em paths MWART |
-| `module-grades-gate.yml` ([ADR 0155](memory/decisions/0155-rubrica-module-grade-v3.md)) | Regressão de nota módulo vs baseline |
+| `module-grades-gate.yml` ([ADR 0155](memory/decisions/0155-module-grade-v3-sub-dimensoes-gate-ci.md)) | Regressão de nota módulo vs baseline |
 
 ---
 
@@ -371,7 +368,7 @@ Antes de criar componente custom, **buscar** em `resources/js/Components/`. Patt
 
 ### 16.8. Anti-padrões V2 (testes Pest CI varre)
 
-- ❌ `<AppShell>` sem V2 ([auto-mem](memory/feedback_persistent_layouts.md))
+- ❌ `<AppShell>` sem V2 ([preferência](memory/claude/preference_persistent_layouts.md))
 - ❌ `sessionStorage` (use `localStorage` com prefixo `oimpresso.`)
 - ❌ `bg-(gray|indigo|purple|pink|yellow|red|green)-[0-9]+`
 - ❌ `font-bold/extrabold/black` em h1-h3

--- a/memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md
+++ b/memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md
@@ -1,7 +1,11 @@
 ---
 doc: AUTOMATION-ROADMAP
 camada: meta-protocolo
-status: planejado
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+morreu_porque: "Dizia 'zero ondas executadas' (status:planejado) — FALSO em 2026-06: ondas + 6 gates já entregues (ui-lint.yml, pr-ui-judge.yml, conformance-gate, screen-grades-gate ADR 0250, eslint-baseline ADR 0209). Meta ~90% atingida por outra via. NÃO ler como roadmap futuro — é histórico do plano original. (Onda 2 inspeção 2026-06-06)"
 created: 2026-05-24
 parent_adr: UI-0013
 related_adrs: [UI-0013, UI-0014, 0187]

--- a/memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_CLAUDE_DESIGN.md
@@ -1,3 +1,13 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["INDEX-DESIGN-MEMORIAS.md", "MANUAL-IDENTIDADE.md"]
+morreu_porque: "Corpo de abr/2026 propõe accent azul 220° + sidebar dark — canon hoje é roxo oklch(0.55 0.15 295) (ADR 0235) + sidebar LIGHT (UI-0009/0014). Histórico negativo: NÃO copiar paleta/sidebar daqui. (Onda 2 inspeção 2026-06-06)"
+related_adrs: [0235, 0249]
+---
+
 # Briefing pra Claude Design — Migração dos módulos Blade do Oimpresso ERP
 
 > ## ⚠️ CANON ATUAL (2026-05-30) — corrige o corpo abaixo (2026-04-27)

--- a/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
@@ -1,3 +1,13 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["INDEX-DESIGN-MEMORIAS.md"]
+morreu_porque: "Briefing de sessão datado; accent 220° / sidebar dark 260px mortos (canon = roxo 295 + light, ADR 0235/UI-0014). NÃO usar como ponto de partida. (Onda 2 inspeção 2026-06-06)"
+related_adrs: [0235, 0249]
+---
+
 # Briefing para retomar o Design System Oimpresso — Claude Design
 
 > Cole este arquivo como **primeira mensagem** numa nova sessão Claude Design.

--- a/memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md
+++ b/memory/requisitos/_DesignSystem/CATALOGO_ACABAMENTOS.md
@@ -1,3 +1,12 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+morreu_porque: "MORTE PARCIAL — paleta accent azul 220° é snapshot do Cockpit piloto; cor canon é roxo oklch(0.55 0.15 295) (ADR 0235/0249). Estrutura/tipografia/espaçamento/acabamentos seguem VÁLIDOS — só a COR morreu. (Onda 2 inspeção 2026-06-06)"
+related_adrs: [0235, 0249]
+---
+
 # Catálogo de Acabamentos · Cockpit
 
 > **Propósito**: documentar com precisão pixel-perfect cada detalhe visual do `/copiloto/cockpit` em produção (workspace Vibe, density 50%, accent hue 220°). Serve como **referência canônica** pra qualquer mudança futura — humana ou IA — não inventar tonalidade, sombra, ou tamanho que não esteja aqui.

--- a/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
+++ b/memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md
@@ -1,3 +1,11 @@
+---
+status: accepted-historical
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+morreu_porque: "Já tinha errata 2026-06-04; os hues por grupo estão MORTOS (verdade = cockpit/shared.ts). Plano de 5 ondas pode ter valor histórico de processo; NÃO copiar cores. (Onda 2 inspeção 2026-06-06)"
+---
+
 # GUIA — Sidebar v3 oimpresso: do estado atual ao canon completo
 
 > **Pra quem está se perguntando "como faço pra arrumar a bagunça do sidebar?"** — este guia é seu roteiro executável. Passo a passo, com comandos prontos pra copiar, ordem de execução, e validação visual a cada onda.

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -118,6 +118,21 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | DS_ADOCAO_INDICE | drift-raiz: hand-rolou `<input radio>` existindo `radio-group.tsx` — falta de guard |
 | HANDOFF/SYNC_LOG | NÃO copiar zip Cowork `{Modules,Pages,resources}` direto pra raiz (viola Tier 0, regride prod) |
 
+### 3e. Lápides — mortos com lição (grande inspeção 2026-06-06)
+
+> **Histórico negativo é first-class** (decisão Wagner 2026-06-06: *"ter o histórico negativo pra não voltar a errar é muito importante"*). Estes docs/ADRs **ficam no lugar** (append-only, status de lápide + `morreu_porque` no frontmatter) — listados aqui pra **não repetir o erro já pago**.
+
+| Morto | Estado | Lição (`morreu_porque`) |
+|---|---|---|
+| **UI-0010 / UI-0012** (zip-cowork "canon visual") | `superseded` → [UI-0018](adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md) | zip datado ≠ canon. Verdade viva = DS v6 + primitivos ([0253](../../decisions/0253-primitivos-layout.md)) + [Manual de Identidade](MANUAL-IDENTIDADE.md). **NÃO copiar HTML/cor de zip.** |
+| **BRIEFING_CLAUDE_DESIGN / _PROXIMA_SESSAO** | `accepted-historical` | propunham azul 220° + sidebar dark — canon = roxo 295 + light. NÃO usar de ponto de partida |
+| **CATALOGO_ACABAMENTOS** | `accepted-historical` (parcial) | só a **COR** (azul 220) morreu; estrutura/tipo/espaço seguem válidos |
+| **sidebar-rail-mode / GUIA-SIDEBAR-V3** | `superseded`/`historical` | hue-per-grupo morto — verdade = `cockpit/shared.ts` (código>doc) |
+| **AUTOMATION-ROADMAP** | `accepted-historical` | dizia "zero ondas" — falso, ondas+6 gates entregues. NÃO ler como roadmap futuro |
+| **from-claude-design/04-conventions · decisions-README** | `superseded` | importados PontoWr2 legado (Laravel 10) → `.claude/rules/` + MCP `decisions-search` |
+| **audits/2026-04-24** | `deprecated` | duplicata byte-a-byte de `2026-04-22` |
+| **ui_kits/_BACKUP-NAO-USAR-cowork-2026-04-27** | tombstone (no nome) | snapshot abril — **NÃO usar** (mantido como histórico negativo · decisão Wagner) |
+
 ---
 
 ## 4 · CONFLITOS RECONCILIADOS (a regra de ouro aplicada)
@@ -136,6 +151,8 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 | **Sidebar hue-per-grupo** | **código `cockpit/shared.ts SIDEBAR_GROUP_HUE`** (reconciliado 2026-05-25) | hues de GUIA-SIDEBAR / sidebar-rail-mode (antigos) | R3 |
 | **PageHeader (estrutura)** | **3 blocos fechados** separados, gap 12px (ADR 0189 v3.1, pageheader-matriz F1) | "layout flat 3 zonas" (ADR 0182) | R1 |
 | **Azul que SOBREVIVE** | **origin-badge CRM = blue** (sistema de badge de origem, ≠ botão primary) — continua válido | confundir com cor de marca | R2 (nuance) |
+| **Canon visual (vivo vs snapshot)** | **DS v6 + primitivos (0253) + Manual de Identidade — vivo e MEDIDO** (grade 0254) | zip-cowork UI-0010/0012 (`superseded` por UI-0018) — snapshot datado | R1+R5 |
+| **DS naming (v3/v4/v5/v6)** | **"DS v6"** é o nome único (ADR 0249) | "v3/v4/v5" = nomes antigos da MESMA coisa (UI-0017 aditiva, não morre — só o nome) | R2 |
 
 ---
 

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -1,3 +1,11 @@
+---
+owner: wagner
+last_reviewed: "2026-06-06"
+next_review: "2026-07-31"
+related_adrs: [0235, 0249, 0253, 0254]
+note: "SSOT de design. next_review obrigatório (DesignDocsFreshnessChecker ADR 0236) — é o que impede este índice de apodrecer como aconteceu com 'PT-02..05 não existem'."
+---
+
 # ÍNDICE-MESTRE — Memórias de Design que o Claude Design pode usar
 
 > **Pra que serve:** ponto único de partida do Claude Design. Lista TODAS as memórias de design do projeto — **positivas** (o que copiar/seguir) e **negativas** (o que NÃO repetir) — já reconciliadas, com a **regra de ouro** que resolve conflito. Substitui a tarefa de "montar contexto de cabeça" (origem da invenção e do erro repetido).

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -23,7 +23,8 @@ Quando duas memórias divergem, vence nesta ordem:
 
 1. **[PRE-FLIGHT-TELA.md](../../../prototipo-ui/PRE-FLIGHT-TELA.md)** — monta o pacote de pré-requisitos DAQUELA tela (identidade/não-inventar/não-repetir/validar).
 2. **[GOLDEN-REFERENCE.md](../../../prototipo-ui/GOLDEN-REFERENCE.md)** — a tela-ouro do arquétipo + 10 regras binárias. "Faça idêntico, mude só X."
-3. **[REGISTRY_DS_COMPONENTES.md](../../../prototipo-ui/REGISTRY_DS_COMPONENTES.md)** — componentes `@/Components/ui` disponíveis. Se está aqui, **não hand-rola**. ⚠️ Onda F (`Segmented`/`FormSection`/`InputGroup`/`FieldState`) **ainda NÃO existe** — não assuma que existe.
+2b. **[MANUAL-IDENTIDADE.md](MANUAL-IDENTIDADE.md)** ⭐ — a VOZ visual "Clareza Confiante": como deve PARECER + DO/DON'T + as 3 assinaturas. Define o *feel*; o golden define a *estrutura*.
+3. **[REGISTRY_DS_COMPONENTES.md](../../../prototipo-ui/REGISTRY_DS_COMPONENTES.md)** — componentes `@/Components/ui` disponíveis. Se está aqui, **não hand-rola**. ➕ **Layout: usar primitivos `@/Components/layout` ([ADR 0253](../../decisions/0253-primitivos-layout.md)) — `Stack/Inline/Grid/Box/Container/Text`.** ⚠️ Onda F (`Segmented`/`FormSection`/`InputGroup`/`FieldState`) **ainda NÃO existe** — não assuma que existe.
 4. **[LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)** — os 21 anti-padrões (exemplo errado). Leitura obrigatória antes de F3.
 5. **[SCREEN-GRADE-METODO.md](SCREEN-GRADE-METODO.md)** — como a tela será notada (16 dim, níveis Beginner→Champion).
 
@@ -36,6 +37,7 @@ Quando duas memórias divergem, vence nesta ordem:
 ### 2a. Entrada / identidade do projeto
 | Memória | Usar pra |
 |---|---|
+| **[MANUAL-IDENTIDADE.md](MANUAL-IDENTIDADE.md)** ⭐ | **A VOZ VISUAL — "Clareza Confiante" (2026-06-06).** Como toda tela deve PARECER: type-scale 8 tokens (incl `2xs`), 3 assinaturas (focus-ring roxo · barra-accent · tabular-nums), densidade 36px, motion 150ms, DO/DON'T. **Leitura obrigatória antes de craftar identidade.** Irmã do MANUAL-CSS-JS (voz de código) |
 | [memory/why-oimpresso.md](../../why-oimpresso.md) | **Posicionamento REAL: ERP modular multi-vertical** (ADR 0121). Larissa/ROTA LIVRE = **vestuário** (não gráfica). ⚠️ corrige briefings antigos |
 | [personas-por-modulo.yml](personas-por-modulo.yml) + ADR UI-0016 | Persona dona da tela (Larissa 1280px densidade · Eliana tabela densa · técnico touch ≥44px) |
 | [prototipo-ui/GLOSSARY.md](../../../prototipo-ui/GLOSSARY.md) | Siglas, fases, comparáveis externos por arquétipo |
@@ -46,6 +48,7 @@ Quando duas memórias divergem, vence nesta ordem:
 | **GOLDEN-REFERENCE.md** | tela-ouro `Sells/Create` (form) + 10 regras binárias R1-R10 |
 | **padroes-tela/PT-01-Lista.md** | golden do arquétipo **lista** (status sem bg-fill, slots) |
 | **REGISTRY_DS_COMPONENTES.md** | componentes reais `@/Components/ui` |
+| **[ADR 0253 — primitivos de layout](../../decisions/0253-primitivos-layout.md)** ⭐ | `<Stack/Inline/Grid/Box/Container/Text>` em `@/Components/layout` — **layout é COMPOSIÇÃO de primitivo, nunca `flex`/`grid` solto** (props = token). Showcase em `/showcase/components` |
 | **tokens v4** (`resources/css/inertia.css`, ADR 0235) | cor = `primary` roxo. Zero `blue-*` de marca |
 | ADR 0110 (Cockpit Pattern V2) + UI-0010 `os-page.jsx` + UI-0012 | padrão list+detail / shell |
 | ADR UI-0015 | campos de form default `variant="cowork"` |
@@ -55,12 +58,13 @@ Quando duas memórias divergem, vence nesta ordem:
 | [MANUAL-CSS-JS.md](MANUAL-CSS-JS.md) | regimento **CSS/JS** — do/don't + arquitetura-alvo (token DS v6 → primitivos **layout**+ui → padrão → página) + gap dos primitivos de layout (§2.1) + roadmap de convergência F0–F7 (sair do sprawl de 28k linhas) |
 | RUNBOOK-{replicar-prototipo-cowork,onda-cowork,design-deep,inertia-defer-pattern}.md | receitas de execução (portar protótipo, ondas, defer) |
 
-> ⚠️ **Goldens de arquétipo: só existe PT-01-Lista.** Faltam **PT-02 Form/Drawer · PT-03 Detalhe · PT-04 Dashboard · PT-05 Config/Kanban** (confirmado por 2 agentes + piloto). Até existirem, o Claude Design usa o golden de código (GOLDEN-REFERENCE = form) e, p/ outros tipos, **pergunta** em vez de inventar.
+> ✅ **Goldens de arquétipo (corrigido 2026-06-06): PT-01 Lista · [PT-02 Form/Drawer](padroes-tela/PT-02-Form-Drawer.md) · [PT-03 Detalhe](padroes-tela/PT-03-Detalhe.md) · [PT-04 Dashboard](padroes-tela/PT-04-Dashboard.md) · [PT-05 Kanban](padroes-tela/PT-05-Kanban.md) — TODOS existem** em [`padroes-tela/`](padroes-tela/). _(O INDEX dizia "faltam PT-02..05" — era stale de 2026-05-30; os 5 arquivos têm 116-135 linhas cada.)_
 
 ### 2c. Validação / definição de pronto
 | Memória | Usar pra |
 |---|---|
-| **SCREEN-GRADE-METODO.md** | nota 16-dim, níveis, score-as-code |
+| **SCREEN-GRADE-METODO.md** | nota 16-dim, níveis, score-as-code (UX amplo, por tela) |
+| **[ADR 0254 — grade de identidade DETERMINÍSTICO](../../decisions/0254-design-identity-grade-deterministico.md)** ⭐ | nota de **identidade** 0-100 **σ=0** por regex (anti-alucinação — cura o LLM-judge que dava 91→71). `node scripts/design-identity-grade.mjs` · ratchet só sobe · **hoje 66, meta 85** · lista top-5 ofensores |
 | [design-requests/LEDGER.md](../../governance/design-requests/LEDGER.md) | ledger incremental de pedidos (REQ-NNN, **file-based**) — checar "já processei?" antes de trabalhar; grava resultado/grade ao fechar · ⚠️ scaffold pré-ADR ([proposta](../../decisions/proposals/design-request-ledger-incremental.md)) |
 | [PRE-MERGE-UI.md](PRE-MERGE-UI.md) | checklist AP1-AP8 antes de merge |
 | `php artisan ui:lint` (R1-R6, CI ratchet) | cor crua, FontAwesome, emoji, PT-01, origens, blade |

--- a/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
+++ b/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
@@ -1,0 +1,113 @@
+# Manual de Identidade Visual — oimpresso · "Clareza Confiante"
+
+> **O que é:** a **voz visual** do produto — as decisões de identidade que toda tela/componente
+> deve encarnar. É a peça que faltava: o projeto tinha governança (gates) e tokens, mas não tinha
+> a **identidade decidida e escrita**. Sem ela, mecanizar (codemod/ratchet) converge pro *genérico*.
+>
+> **Irmã da [`MANUAL-CSS-JS.md`](MANUAL-CSS-JS.md)** (a voz de CÓDIGO). Esta é a voz de DESIGN.
+> **Direção escolhida por Wagner 2026-06-06.** Subordinada à Constituição UI v2 (ADR UI-0013) e ao
+> DS v6 (ADR 0235 cor / 0249 nome).
+>
+> **Status:** voz **decidida** (Clareza Confiante). Implementação dos tokens novos (type-scale `2xs`,
+> motion) **pendente de ADR** — ver §Pendências.
+
+---
+
+## 0 · O princípio (a frase)
+
+**"Clareza Confiante": cada pixel tem intenção. O roxo é pontuação, não decoração. O número manda.**
+
+Precisão do Linear + legibilidade do Stripe, tunada pra **dona de PME brasileira não-técnica**
+(Larissa, 1280px) e oficina (Martinho). Não é frio-enterprise nem startup-lúdico. **Calma, precisa, confiante.**
+
+---
+
+## 1 · As 10 dimensões DECIDIDAS
+
+A ordem é por impacto na "cara" (tipografia + espaço + detalhe definem mais que cor).
+
+### 1.1 Tipografia — **escala fechada de 8 degraus** (fim do `text-[Npx]`)
+| token | px | uso |
+|---|---|---|
+| `2xs` | 11 | metadados, sub-labels (resolve `text-[10.5/11.5px]`) |
+| `xs` | 12 | legendas, badges |
+| `sm` | 13 | **corpo denso ERP (default)** |
+| `base` | 14 | corpo confortável |
+| `lg` | 16 | subtítulo |
+| `xl` | 20 | título de seção |
+| `2xl` | 24 | título de página |
+| `3xl` | 30 | hero (raro) |
+- **Pesos:** 400 corpo · 500 ênfase · 600 títulos/ações. **Sem 700.**
+- **Tracking:** títulos `-0.01em`; uppercase de seção `+0.04em`.
+- **Números: `tabular-nums` SEMPRE** (R$/qtd/data). Fonte: Inter.
+
+### 1.2 Espaço & Densidade — confortável-densa
+Unidade 4px (escala dos primitivos: 1,2,3,4,6,8,12). Linha de lista/tabela **36px** · card pad **16px** · gutter **24px**. Fim de `gap-0.5` cru.
+
+### 1.3 Detalhe & Acabamento — **as 3 assinaturas** (onde mora a alma)
+1. **Focus-ring roxo** `ring-2 ring-primary/40` em TODO interativo.
+2. **Barra-accent roxa à esquerda** (2px) no item ativo/selecionado — o "você está aqui".
+3. **Números tabulares** alinhados na vírgula.
++ **7 estados obrigatórios:** hover · focus-visible · active · disabled · empty · loading · error.
+
+### 1.4 Forma
+`rounded-md` 8px default · `lg` 12px (cards/sheets) · `full` (pills). Borda 1px `border-border` (hairline). Sombra só em flutuante (`shadow-sm`).
+
+### 1.5 Movimento
+Hover/cor **150ms ease-out** · enter/sheet **200ms** · sem bounce · foco anima (120ms).
+
+### 1.6 Cor
+Accent = roxo `oklch(0.55 0.15 295)` (ADR 0235) como **pontuação** (ação primária/foco/ativo), nunca preenchimento. Superfícies: `background` ‹ `card` ‹ `muted`. Status = soft pills (`emerald/amber/rose/sky` — convenção semântica).
+
+### 1.7–1.10
+- **Hierarquia:** 3 níveis/tela — Título `2xl/600` · Seção `xs/600/uppercase/muted` · Corpo `sm/400`.
+- **Ícone:** lucide, 14–16px, stroke 1.5, `text-muted-foreground` (forçado por gate).
+- **Voz:** PT-BR direto, rótulo ≤2 palavras, zero jargão. "Faturar", não "Processar faturamento".
+- **Sistema:** os gates mecanizam rumo a ESTA manual (não ao genérico).
+
+---
+
+## 2 · Como o design deve AGIR (instrução)
+
+Ao criar/migrar qualquer tela ou componente:
+
+1. **Rode o PRE-FLIGHT** ([`screen-grade`](../../../.claude/skills/screen-grade/SKILL.md)) — não monte contexto de cabeça.
+2. **Layout = composição de primitivos** (`<Stack/Inline/Grid/Box/Container/Text>` — [ADR 0253](../../decisions/0253-primitivos-layout.md)), nunca `flex`/`grid` solto nem `.css` bespoke.
+3. **Cor/tipo/espaço SÓ por token** (DS v6). Zero `text-[Npx]`, zero hex/cor crua neutra/azul.
+4. **Aplique as 3 assinaturas** (§1.3) — é o que torna reconhecível "oimpresso".
+5. **Meça** com o grade determinístico ([ADR 0254](../../decisions/0254-design-identity-grade-deterministico.md)): `node scripts/design-identity-grade.mjs`. **Só sobe.**
+
+### DO / DON'T (resumo)
+| ✅ DO | ❌ DON'T |
+|---|---|
+| `<Stack gap={4}>` | `<div className="flex flex-col gap-4">` |
+| `text-sm` (token) | `text-[13px]` |
+| `bg-primary` (roxo pontuação) | `bg-blue-600` / hex / roxo decorativo |
+| `focus-visible:ring-primary` | interativo sem foco visível |
+| `tabular-nums` em valor | número proporcional desalinhado |
+| status via soft pill semântico | `bg-red-500` sólido pra ESTADO |
+
+---
+
+## 3 · O placar (definição de "melhorou")
+
+Grade de identidade DETERMINÍSTICO ([ADR 0254](../../decisions/0254-design-identity-grade-deterministico.md)) — σ=0, anti-alucinação:
+- **Hoje: 66/100 · Developing.** Meta: **85 · Leader.**
+- Gaps reais medidos: `layout 0` (migração via codemod) · `tipografia 61` (token `2xs`).
+- O grade lista os **top-5 ofensores** por dimensão (roadmap).
+
+---
+
+## 4 · Pendências (o que falta virar ADR/código)
+
+- [ ] **ADR de type-scale** — formalizar os 8 tokens (incl. `2xs`) no `@theme` / tokens DS v6.
+- [ ] **ADR de motion** — tokens de duração/easing (150/200ms).
+- [ ] **Recraftar componentes-bandeira** (`Button`/`Card`/row) encarnando esta manual (gate visual Wagner).
+- [ ] **North Star aprovado** (print 2026-06-06) → vira o golden de "componente com identidade".
+
+---
+
+## Refs
+- [Constituição UI v2 — ADR UI-0013](../../decisions/../requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md) · [DS v6 — ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md) / [0249](../../decisions/0249-ds-v6-naming-amends-0235.md)
+- [Primitivos de layout — ADR 0253](../../decisions/0253-primitivos-layout.md) · [Grade determinístico — ADR 0254](../../decisions/0254-design-identity-grade-deterministico.md)
+- [`MANUAL-CSS-JS.md`](MANUAL-CSS-JS.md) (voz de código) · [`INDEX-DESIGN-MEMORIAS.md`](INDEX-DESIGN-MEMORIAS.md) (SSOT)

--- a/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
+++ b/memory/requisitos/_DesignSystem/MANUAL-IDENTIDADE.md
@@ -1,3 +1,12 @@
+---
+title: "Manual de Identidade Visual — Clareza Confiante"
+owner: wagner
+last_reviewed: "2026-06-06"
+next_review: "2026-07-31"
+related_adrs: [0235, 0249, 0253, 0254]
+note: "Voz visual canon. next_review obrigatório (DesignDocsFreshnessChecker ADR 0236) — sobrevive ao tempo por revisão forçada + grade medido (ADR 0254), não por boa-vontade."
+---
+
 # Manual de Identidade Visual — oimpresso · "Clareza Confiante"
 
 > **O que é:** a **voz visual** do produto — as decisões de identidade que toda tela/componente

--- a/memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0010-zip-cowork-2026-04-27-canon-visual.md
@@ -1,6 +1,11 @@
+> ⚰️ **SUPERSEDED em 2026-06-06 por [UI-0018](0018-canon-visual-vivo-ds-v6-manual-identidade.md).**
+> Este zip-snapshot de 2026-04-27 **deixou de ser canon visual** — a verdade viva é DS v6 + primitivos
+> (ADR 0253) + Manual de Identidade. Preservado como **histórico** (append-only); NÃO copiar.
+
 # ADR UI-0010 · Zip Cowork 2026-04-27 é canon visual; `os-page.jsx` é padrão canônico de tela list+detail
 
-- **Status**: accepted
+- **Status**: superseded · lifecycle: substituido
+- **Substituído por**: [UI-0018 — Canon visual vivo DS v6 + Manual](0018-canon-visual-vivo-ds-v6-manual-identidade.md)
 - **Data**: 2026-05-05
 - **Decisores**: Wagner, Claude
 - **Categoria**: ui · estruturante

--- a/memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0012-zip-cowork-2026-05-09-canon-visual.md
@@ -1,6 +1,11 @@
+> ⚰️ **SUPERSEDED em 2026-06-06 por [UI-0018](0018-canon-visual-vivo-ds-v6-manual-identidade.md).**
+> Este zip-snapshot de 2026-05-09 **deixou de ser canon visual** — a verdade viva é DS v6 + primitivos
+> (ADR 0253) + Manual de Identidade. Preservado como **histórico** (append-only); NÃO copiar.
+
 # ADR UI-0012 · Zip Cowork 2026-05-09 atualiza canon visual; novas telas (vendas, clientes, financeiro, produto, produção, inventário)
 
-- **Status**: accepted
+- **Status**: superseded · lifecycle: substituido
+- **Substituído por**: [UI-0018 — Canon visual vivo DS v6 + Manual](0018-canon-visual-vivo-ds-v6-manual-identidade.md)
 - **Data**: 2026-05-09
 - **Decisores**: Wagner, Claude
 - **Categoria**: ui · estruturante

--- a/memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0018-canon-visual-vivo-ds-v6-manual-identidade.md
@@ -1,0 +1,68 @@
+---
+slug: UI-0018-canon-visual-vivo-ds-v6-manual-identidade
+adr_ui: 18
+title: "Canon visual VIVO = DS v6 + primitivos + Manual de Identidade; supersede os snapshots zip-cowork (UI-0010, UI-0012)"
+status: aceito
+lifecycle: ativo
+authority: canonical
+decided_by: [W]
+decided_at: "2026-06-06"
+supersedes:
+  - "UI-0010-zip-cowork-2026-04-27-canon-visual"
+  - "UI-0012-zip-cowork-2026-05-09-canon-visual"
+related_adrs:
+  - "UI-0013-constituicao-ui-v2-camadas"
+  - "0235-ds-v4-accent-roxo-universal"
+  - "0249-ds-v6-naming-amends-0235"
+  - "0253-primitivos-layout"
+  - "0254-design-identity-grade-deterministico"
+next_review: "2026-09-06"
+pii: false
+---
+
+# ADR UI-0018 · Canon visual VIVO = DS v6 + primitivos + Manual de Identidade (supersede os zip-cowork)
+
+> Origem: grande inspeção dos docs de design 2026-06-06 (Wagner: *"adrs conflitantes devem
+> morrer e ser trocadas por novas agora"*). Subordinada à Constituição UI v2 ([UI-0013](0013-constituicao-ui-v2-camadas.md)).
+
+## Contexto
+
+[UI-0010](0010-zip-cowork-2026-04-27-canon-visual.md) (zip 2026-04-27) e
+[UI-0012](0012-zip-cowork-2026-05-09-canon-visual.md) (zip 2026-05-09) declararam **"o zip Cowork X é
+o canon visual"**. Eram corretos no seu tempo, mas **snapshots datados envelhecem por design** — os
+próprios docs admitem isso. Hoje:
+
+- A **fonte da verdade visual** é o **DS v6** (tokens semânticos — [ADR 0235](../../../decisions/0235-ds-v4-accent-roxo-universal.md) cor roxo `oklch(0.55 0.15 295)` + [0249](../../../decisions/0249-ds-v6-naming-amends-0235.md) nome).
+- O **layout** é **composição de primitivos** (`@/Components/layout` — [ADR 0253](../../../decisions/0253-primitivos-layout.md)), não cópia de HTML do zip.
+- A **identidade** ("como deve parecer") vive no **[Manual de Identidade "Clareza Confiante"](../../MANUAL-IDENTIDADE.md)**.
+- O **canon visual é MEDIDO** (grade determinístico — [ADR 0254](../../../decisions/0254-design-identity-grade-deterministico.md)), não congelado num arquivo.
+
+Um zip de abril/maio apontado como "canon" **conflita** com essa verdade viva e induz cópia de
+padrão obsoleto (cor azul pré-roxo, HTML colado em vez de primitivo).
+
+## Decisão ([W], 2026-06-06)
+
+1. **O canon visual VIVO** = `DS v6 tokens` (cor/tipo/espaço) + `primitivos de layout` (estrutura) +
+   `Manual de Identidade` (voz) + `grade determinístico` (medida). **Não há "zip canon".**
+2. **UI-0010 e UI-0012 viram `superseded`** por esta ADR (lifecycle `substituido` + `superseded_by: UI-0018`).
+   **Permanecem no lugar como histórico** (append-only — referência do que o Cowork propôs naquele momento),
+   mas **NÃO são fonte da verdade visual** nem devem ser copiados.
+3. Os zips em `ui_kits/` ficam como **arquivo de referência histórica**, não canon.
+
+## Não-decidido aqui (Tier 0 — decisão própria do [W])
+- **Link quebrado em UI-0010** (aponta `ui_kits/cowork-2026-04-27/` que foi renomeada pra
+  `_BACKUP-NAO-USAR-cowork-2026-04-27/`). Mover/renomear pasta importada por ADR é append-only Tier 0 —
+  fica como correção à parte. Esta ADR só remove 0010 do status de "canon" (atenua o impacto do link morto).
+- **UI-0007** (topbar) e **UI-0017** (DS "v3") **NÃO morrem** — a inspeção confirmou: 0007 é scoped
+  (válida pro AppShell legado) e 0017 é aditiva (só o nome "v3" é velho → DS v6). Tratadas por pointer, não lápide.
+
+## Consequências
+- ✅ Mata a única fonte de conflito real entre os snapshots e o DS v6 vivo.
+- ✅ Quem for craftar tela não copia mais HTML/cor de zip datado — usa DS v6 + primitivos + Manual.
+- ✅ Append-only respeitado (0010/0012 ficam como histórico com ponteiro).
+- 🔜 Frontmatter dos demais docs de design normalizado + INDEX regenerado (follow-up da inspeção).
+
+## Refs
+- Inspeção 2026-06-06 (5 auditores paralelos) · [INDEX-DESIGN-MEMORIAS](../../INDEX-DESIGN-MEMORIAS.md) · [MANUAL-IDENTIDADE](../../MANUAL-IDENTIDADE.md)
+- Supersede: [UI-0010](0010-zip-cowork-2026-04-27-canon-visual.md) · [UI-0012](0012-zip-cowork-2026-05-09-canon-visual.md)
+- Canon vivo: [0235](../../../decisions/0235-ds-v4-accent-roxo-universal.md)/[0249](../../../decisions/0249-ds-v6-naming-amends-0235.md) (DS v6) · [0253](../../../decisions/0253-primitivos-layout.md) (primitivos) · [0254](../../../decisions/0254-design-identity-grade-deterministico.md) (grade)

--- a/memory/requisitos/_DesignSystem/audits/2026-04-24.md
+++ b/memory/requisitos/_DesignSystem/audits/2026-04-24.md
@@ -1,3 +1,12 @@
+---
+status: deprecated
+lifecycle: arquivado
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["audits/2026-04-22.md"]
+morreu_porque: "Duplicata byte-a-byte do audit 2026-04-22 (re-run sem mudança nenhuma). Redundante. (Onda 2 inspeção 2026-06-06)"
+---
+
 # Auditoria · _DesignSystem · 2026-04-24
 
 - **Score**: 63/100

--- a/memory/requisitos/_DesignSystem/from-claude-design/04-conventions.md
+++ b/memory/requisitos/_DesignSystem/from-claude-design/04-conventions.md
@@ -1,3 +1,12 @@
+---
+status: superseded
+lifecycle: substituido
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: [".claude/rules/modules.md", ".claude/rules/migrations.md", "CLAUDE.md"]
+morreu_porque: "Convenções importadas do projeto PontoWr2 legado; cita Laravel 10 (stack real = 13.6). Convenções vivas em .claude/rules/ + CLAUDE.md. (Onda 2 inspeção 2026-06-06)"
+---
+
 # 04 — Convenções do Projeto
 
 ## Idioma

--- a/memory/requisitos/_DesignSystem/from-claude-design/decisions-README.md
+++ b/memory/requisitos/_DesignSystem/from-claude-design/decisions-README.md
@@ -1,3 +1,12 @@
+---
+status: superseded
+lifecycle: substituido
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["MCP decisions-search"]
+morreu_porque: "Índice de ADRs congelado em 0001-0023 (abr/2026, do PontoWr2). Índice vivo de decisões é via tool MCP decisions-search. (Onda 2 inspeção 2026-06-06)"
+---
+
 # Architecture Decision Records (ADRs)
 
 Este diretório contém os registros formais de decisões arquiteturais importantes do projeto Ponto WR2.

--- a/memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md
+++ b/memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md
@@ -1,3 +1,12 @@
+---
+status: superseded
+lifecycle: substituido
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+superseded_by: ["cockpit/shared.ts (SIDEBAR_GROUP_HUE)", "INDEX-DESIGN-MEMORIAS.md §4"]
+morreu_porque: "Hue-map por grupo obsoleto e divergente de 2 outros docs; a VERDADE é o código shared.ts (código > doc, Regra de Ouro #3). NÃO copiar os hues daqui. (Onda 2 inspeção 2026-06-06)"
+---
+
 # Sidebar — rail mode + cores por grupo (visual-comparison)
 
 **Tela:** Layout global `AppShellV2` (sidebar global do ERP)

--- a/tests/Feature/Design/DesignEntryPointAndTombstonesTest.php
+++ b/tests/Feature/Design/DesignEntryPointAndTombstonesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Garante que o sistema de design REVITALIZADO (2026-06-06) fica HONESTO pra sempre.
+ *
+ * Origem: a porta da frente (`DESIGN.md`) apontava pro CEMITÉRIO — `ui_kits/cowork-2026-04-27/`
+ * (virou `_BACKUP-NAO-USAR-`) + UI-0010 (morta). Wagner pegou no olho ("isso vai estar no
+ * DESIGN.md?"). Este teste TERIA pego antes do merge. *"Garantir sempre estar funcionando."*
+ *
+ *   (a) HARD — todo link markdown LOCAL do DESIGN.md (a PORTA) resolve (arquivo existe).
+ *               Pega pointer pra arquivo movido/renomeado/inexistente (o bug do _BACKUP).
+ *   (b) HARD — toda LÁPIDE de design (frontmatter `status: superseded|deprecated`) tem
+ *               `superseded_by` — não morre sem apontar o sucessor (append-only honesto).
+ *
+ * Skip gracioso quando filesystem do repo não está acessível (CI ephemeral) — padrão do
+ * DesignIndexSingleSourceTest irmão.
+ *
+ * @see DESIGN.md · memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md (§3e Lápides)
+ * @see memory/decisions/_INDEX-LIFECYCLE.md (estados de lápide · append-only)
+ */
+
+const DESIGN_EP_ROOT = __DIR__ . '/../../..';
+const DESIGN_EP_MD = 'DESIGN.md';
+const DESIGN_EP_DS_DIR = 'memory/requisitos/_DesignSystem';
+
+beforeEach(function () {
+    if (! is_dir(DESIGN_EP_ROOT) || ! is_file(DESIGN_EP_ROOT . '/' . DESIGN_EP_MD)) {
+        $this->markTestSkipped('Filesystem do repo / DESIGN.md não acessível (CI ephemeral).');
+    }
+});
+
+it('(a) HARD: todo link LOCAL do DESIGN.md (porta da frente) resolve — não aponta pro cemitério', function () {
+    $src = file_get_contents(DESIGN_EP_ROOT . '/' . DESIGN_EP_MD);
+    preg_match_all('/\]\(([^)]+)\)/', $src, $m);
+
+    $quebrados = [];
+    foreach ($m[1] as $link) {
+        if (str_starts_with($link, 'http') || str_starts_with($link, '#') || str_starts_with($link, 'mailto:')) {
+            continue;
+        }
+        $rel = explode(' ', explode('#', $link)[0])[0];
+        if ($rel === '') {
+            continue;
+        }
+        if (! file_exists(DESIGN_EP_ROOT . '/' . $rel)) {
+            $quebrados[] = $link;
+        }
+    }
+
+    expect($quebrados)->toBe([], 'DESIGN.md aponta pra arquivo inexistente (movido/renomeado/cemitério): ' . implode(' · ', $quebrados));
+});
+
+it('(b) HARD: toda lápide de design (superseded/deprecated) aponta superseded_by — não morre órfã', function () {
+    $dir = DESIGN_EP_ROOT . '/' . DESIGN_EP_DS_DIR;
+    $iter = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+    );
+
+    $orfas = [];
+    foreach ($iter as $file) {
+        if ($file->getExtension() !== 'md') {
+            continue;
+        }
+        $src = file_get_contents($file->getPathname());
+        // só docs com frontmatter YAML (--- ... ---); ADRs UI usam prosa (convenção à parte)
+        if (! preg_match('/^---\s*\n(.*?)\n---/s', $src, $fm)) {
+            continue;
+        }
+        $front = $fm[1];
+        if (! preg_match('/^\s*status:\s*["\']?(superseded|deprecated)\b/mi', $front)) {
+            continue;
+        }
+        if (! preg_match('/^\s*superseded_by:/mi', $front)) {
+            $orfas[] = str_replace($dir . '/', '', $file->getPathname());
+        }
+    }
+
+    expect($orfas)->toBe([], 'Lápide sem superseded_by (morreu sem apontar sucessor — viola append-only honesto): ' . implode(' · ', $orfas));
+});


### PR DESCRIPTION
## Por que este PR existe (e os 3 anteriores morrem)
Wagner: *"difícil fazer por parte... muitos conflitos... preciso de revitalização do sistema."* Estava certo: os 3 PRs de doc (#2337/2338/2339) **se referenciavam mutuamente** — isolados, o INDEX linkava pro UI-0018 (que estava em outro PR) → o gate **"Design index (fonte única)"** falhava. **Por parte não fecha.**

Este PR **junta tudo num bloco coerente** onde os links resolvem.

## O que entra (6 commits, cherry-picked + verificados)
- **UI-0018** mata os snapshots zip-cowork (UI-0010/0012 → superseded, append-only)
- **9 lápides** de docs mortos, cada um com `morreu_porque` (histórico negativo visível)
- **MANUAL-IDENTIDADE** canon ("Clareza Confiante") + plugado no freshness checker (next_review)
- **SSOT INDEX** §3e Lápides + §4 reconciliações + Manual/primitivos/grade visíveis
- **DESIGN.md** (porta da frente) aponta pro SSOT + Manual (parava de mandar pro cemitério)

## Gate resolvido
✅ **Os 40 links locais do INDEX resolvem** (verificado) — o que falhava no #2337 isolado agora passa, porque UI-0018 + Manual + ADR 0253/0254 estão todos no mesmo bloco.

## Princípios
- Append-only (mortos ficam com lápide + `morreu_porque`) · `_BACKUP-NAO-USAR-` intocado (decisão Wagner) · histórico negativo first-class (§3e).

## Supersede
Fecha **#2337**, **#2338**, **#2339** (todo o conteúdo deles está aqui, coerente).

## Faxina restante (mecânica, lite — follow-up)
`next_review` nos ~20 docs VIVOS · dedup dos 2 GLOSSARYs · linkar órfãos no INDEX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)