### PR TITLE
docs(design): faxina — next_review nos docs vivos core (anti-rot)

### DIFF
--- a/memory/requisitos/_DesignSystem/ARCHITECTURE.md
+++ b/memory/requisitos/_DesignSystem/ARCHITECTURE.md
@@ -1,3 +1,10 @@
+---
+status: ativo
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+related_adrs: [0235, 0249, 0253, 0013]
+---
+
 # Arquitetura · Design System
 
 ## Stack visual

--- a/memory/requisitos/_DesignSystem/CHANGELOG.md
+++ b/memory/requisitos/_DesignSystem/CHANGELOG.md
@@ -1,3 +1,9 @@
+---
+status: ativo
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+---
+
 # Changelog · Design System
 
 ## [0.6.8] - 2026-05-24 · Smoke real OpenAI · LLM judge funciona + pegou drift real

--- a/memory/requisitos/_DesignSystem/GLOSSARY.md
+++ b/memory/requisitos/_DesignSystem/GLOSSARY.md
@@ -1,3 +1,10 @@
+---
+status: ativo
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+note: "GLOSSARY de _DesignSystem (shadcn/CVA/oklch). Há outro em prototipo-ui/GLOSSARY.md (siglas/fases) — dedup pendente (faxina)."
+---
+
 # Glossário · Design System
 
 ## cn()

--- a/memory/requisitos/_DesignSystem/README.md
+++ b/memory/requisitos/_DesignSystem/README.md
@@ -2,6 +2,8 @@
 module: _DesignSystem
 alias: design-system
 status: ativo
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
 migration_target: N/A
 migration_priority: alta
 risk: baixo

--- a/memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md
+++ b/memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md
@@ -1,3 +1,10 @@
+---
+status: ativo
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+related_adrs: [0230, 0231, 0232, 0250, 0254]
+---
+
 # SCREEN-GRADE — método de maturidade de tela (nota /100 comparativa)
 
 > **O que é:** o `module-grade` ([ADR 0155](../../decisions/0155-rubrica-module-grade-v3.md)/[0160](../../decisions/0160-governance-v4-scoped-scorecards-buckets.md)) aplicado **por tela**. Nota 0-100 comparativa vs golden do arquétipo + ≥3 best-of-class, ponderada por persona e por Peso Real.

--- a/memory/requisitos/_DesignSystem/framework-15-dimensoes.md
+++ b/memory/requisitos/_DesignSystem/framework-15-dimensoes.md
@@ -1,3 +1,10 @@
+---
+status: ativo
+last_reviewed: "2026-06-06"
+next_review: "2026-09-06"
+related_adrs: [0016, 0013, 0232]
+---
+
 # Framework 15 dimensões UX — oimpresso canon
 
 > Canon do processo `design-deep-analysis`. Score 0-100 por dimensão + ponderação 1-3× por persona = decisão objetiva por tela.


### PR DESCRIPTION
Faxina cosmética final da revitalização: 6 docs vivos mais lidos (README, CHANGELOG, GLOSSARY, SCREEN-GRADE-METODO, framework-15-dimensoes, ARCHITECTURE) ganham `next_review: 2026-09-06` → entram no ciclo do `DesignDocsFreshnessChecker` (ADR 0236), que vai cobrar revalidação quando vencer. SPEC.md pulado (schema-gated). GLOSSARY local sinaliza o dedup pendente vs prototipo-ui/GLOSSARY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)