### PR TITLE
docs(rules): reuse-check path-scoped — consultar índice antes de criar símbolo

### DIFF
--- a/.claude/rules/README.md
+++ b/.claude/rules/README.md
@@ -19,6 +19,7 @@ Ver dossier: [`memory/sessions/2026-05-15-arte-claude-rules-path-scoped.md`](../
 | `migrations.md` | `**/Database/Migrations/*.php` | Idempotência + business_id + down() |
 | `routes.md` | `routes/web.php`, `routes/*.php` | FQCN obrigatório (sem string legacy) |
 | `commands.md` | `app/Console/Commands/**/*.php`, `Modules/**/Console/**/*.php` | `--detail` em vez de `--verbose` |
+| `reuse-check.md` | `resources/js/{Components,Lib,Hooks}/**`, `Modules/**/{Services,Entities,Models}/**/*.php` | `reuse:check` antes de criar símbolo (anti-duplicação · MANUAL #5) |
 
 ## Convenções internas oimpresso
 

--- a/.claude/rules/reuse-check.md
+++ b/.claude/rules/reuse-check.md
@@ -1,0 +1,38 @@
+---
+paths:
+  - "resources/js/Components/**/*.tsx"
+  - "resources/js/Components/**/*.ts"
+  - "resources/js/Lib/**/*.ts"
+  - "resources/js/Hooks/**/*.ts"
+  - "Modules/**/Services/**/*.php"
+  - "Modules/**/Entities/**/*.php"
+  - "Modules/**/Models/**/*.php"
+---
+
+# Rule path-scoped — antes de CRIAR símbolo novo, consulte o índice
+
+> Carrega ao tocar a camada onde nascem componentes/utils/hooks/Models/Services. Fecha o problema #5 do [MANUAL-CSS-JS](../../memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md) ("colisões de símbolo / copy-paste"). O caso real: `Cobranca/_components/atoms.tsx` re-implementou `PageHeader`/`KpiCard`/`StatusBadge`/`Field` que já existem em `@/Components/shared`.
+
+## Regra (reusa > recria)
+
+**Antes de escrever um `function`/`const`/`class`/componente novo, rode:**
+
+```bash
+npm run reuse:check "<nome ou o que faz>"
+```
+
+- `✅ JÁ EXISTE — REUSA` → importe o canônico (arquivo:linha na saída), **não recrie**.
+- `❌ NÃO existe` → pode criar (confirme o kind + onde mora).
+- Ex: `reuse:check "BaixaService"` → *"não existe; reais `TituloBaixa`/`BaixaRepository`"*.
+
+## Onde mora o canônico (não hand-rolar)
+
+- Primitivos UI: `@/Components/ui` (shadcn+Radix+CVA) · compartilhados: `@/Components/shared` — ver [REGISTRY_DS_COMPONENTES](../../prototipo-ui/REGISTRY_DS_COMPONENTES.md).
+- Utils JS: `resources/js/Lib/` (`cn`, `format-br`, `numberPtBR`, `utils`).
+- Models/Services PHP: namespaced por módulo — `reuse:check` acha o real.
+
+## Enforcement
+
+O gate `reuse-gate.yml` (CI) falha o PR em **duplicata NOVA** (ratchet, baseline em `scripts/reuse-duplicates-baseline.json`). Se a duplicata for legítima: `npm run reuse:baseline:write` consciente + justificativa no PR.
+
+Refs: `scripts/reuse-index.mjs` · MANUAL-CSS-JS #5 · [ADR 0240](../../memory/decisions/0240-task-ledger-evidencia-antifragilidade.md) (derivado>escrito).


### PR DESCRIPTION
## Por quê

O `reuse-index` (#2343) só vale se for **consultado**. Esta rule path-scoped fecha o loop: carrega quando Claude toca a camada onde nascem símbolos (`Components`/`Lib`/`Hooks` + `Services`/`Entities`/`Models`) e manda rodar `npm run reuse:check "<x>"` **antes** de criar — reusa > recria.

Fecha o problema #5 do `MANUAL-CSS-JS` ("colisões de símbolo / copy-paste"). Caso real: `Cobranca/atoms.tsx` re-implementou `PageHeader`/`KpiCard`/`StatusBadge`/`Field`.

## O que entra

- `.claude/rules/reuse-check.md` (path-scoped, ≤30 linhas, PT-BR) — regra reusa>recria + onde mora o canônico + enforcement (`reuse-gate.yml`).
- Linha no índice `.claude/rules/README.md`.

Docs/config only — zero código, zero risco. Complementa o gate `reuse-gate` (que pega no CI) com o pré-flight (que evita nascer).

Refs: `reuse-index.mjs` · MANUAL-CSS-JS #5 · ADR 0240

🤖 Generated with [Claude Code](https://claude.com/claude-code)