### PR TITLE
refactor(whatsapp): dedup formatBytes → re-export de @/Lib/utils

### DIFF
--- a/resources/js/Pages/Whatsapp/_components/helpers.ts
+++ b/resources/js/Pages/Whatsapp/_components/helpers.ts
@@ -77,15 +77,12 @@ export function formatDateTime(iso: string): string {
 }
 
 /**
- * Formata bytes em string legível (B / KB / MB). Usado em MediaPreviewCard
- * (US-WA-042) + MessageBubble document (US-WA-072) + MediaContent
- * (ConversationThread, PR #707/#716). Exportado pra reuso cross-component.
+ * Formata bytes em string legível. Vive no canon `@/Lib/utils` (idêntico até MB,
+ * superset com faixa GB). Re-exportado aqui pra manter o import path `./helpers`
+ * dos consumidores (MediaPreviewCard US-WA-042, ConversationThread PR #707/#716)
+ * sem duplicar a implementação — anti-duplicação (reuse-index, MANUAL #5).
  */
-export function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-}
+export { formatBytes } from '@/Lib/utils';
 
 /**
  * Detecta se `phone` parece ser um LID (Linked ID Multi-Device) em vez de

--- a/scripts/reuse-duplicates-baseline.json
+++ b/scripts/reuse-duplicates-baseline.json
@@ -1,7 +1,7 @@
 {
-  "measured_against_sha": "08411a8df",
+  "measured_against_sha": "0e8f95411",
   "generated_by": "reuse-index.mjs --write-baseline",
-  "count": 26,
+  "count": 25,
   "keys": [
     "component:Avatar",
     "component:Chat",
@@ -26,7 +26,6 @@
     "util:MOCK_NODES",
     "util:brl",
     "util:cn",
-    "util:formatBytes",
     "util:lsGet",
     "util:lsSet"
   ]


### PR DESCRIPTION
## Por quê

`reuse-index` (#2343) achou `formatBytes` duplicado: `Whatsapp/_components/helpers.ts` re-implementava o que já existe em `@/Lib/utils` (que é **superset** — idêntico até MB, + faixa GB).

## O que entra

- `helpers.ts`: troca a função local por `export { formatBytes } from '@/Lib/utils'` — mantém o import path `./helpers` dos consumidores (ConversationThread, MediaPreviewCard), remove a duplicata.
- Baseline reuse **26→25** (ratchet ↓ — *"encolher é sempre OK"*).

## Seguro

- Saída **byte-idêntica** pra toda mídia WhatsApp (< 1GB). Verifiquei o canon eu mesmo.
- Vite build (CI) cobre o typecheck.

## Honestidade — escopo reduzido de propósito

Eu ia incluir deletar o `PageHeader` "morto" do `Cobranca/atoms.tsx`. **A verificação na árvore inteira mostrou que NÃO é morto** — `Settings/PaymentGateways/Index.tsx` importa `{ Btn, KpiCard, PageHeader }` de `Cobranca/atoms` (cross-módulo). Deletar quebraria PaymentGateways. Então `PageHeader`/`KpiCard`/`StatusBadge` ficam pra ciclo de design (gate visual [W]) — só o `formatBytes` (drop-in real) entra aqui.

Refs: `reuse-index` · MANUAL-CSS-JS #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)