### PR TITLE
fix(session): quote date no frontmatter (schema /date must be string)

### DIFF
--- a/memory/sessions/2026-06-06-plano-inventario-anti-duplicacao.md
+++ b/memory/sessions/2026-06-06-plano-inventario-anti-duplicacao.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-06-06
+date: "2026-06-06"
 topic: "Plano — inventário derivado + gates anti-duplicação (CSS/JS/componentes) pra IA não recriar nem hand-rolar errado"
 authors: [W, C]
 related_adrs:


### PR DESCRIPTION
Fix-forward do #2350 — o gate Session log falhou com `/date must be string` porque `date: 2026-06-06` é parseado como YAML date, não string. Schema exige string quoted (skill memory-schema-preflight). 1-char fix: `date: "2026-06-06"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)