### PR TITLE
docs(dossier): prova empírica do handoff estruturado > manual (1969 oklch cru vs 18 token)

### DIFF
--- a/memory/sessions/2026-06-06-arte-claude-design-handoff.md
+++ b/memory/sessions/2026-06-06-arte-claude-design-handoff.md
@@ -111,6 +111,21 @@ Cada fase = 1 PR ≤300 linhas (commit-discipline). F-A não toca código, só d
 
 ---
 
+## PROVA EMPÍRICA — "é mesmo melhor?" (medido em origin/main, 2026-06-06)
+
+O bundle real ainda não está no nosso fluxo (F-C reativo), então não dá pra testar o handoff ponta-a-ponta. **Mas o custo do jeito-VELHO (export HTML + mapeamento manual CSS→Tailwind) está medido no nosso próprio código** — é o sprawl que a Onda anti-duplicação combateu:
+
+| Métrica (origin/main) | Jeito-VELHO (dump HTML + mapeamento manual) | Jeito-NOVO (bundle estruturado = tokens) |
+|---|---:|---|
+| Valores de cor crus `oklch` em `resources/css` | **1969** | reusa os **18** tokens da fundação |
+| Arquivos CSS por-tela/módulo (`sells-cowork`/`fin-`/`cowork-`) | **27** | nenhum novo |
+
+**Veredito medido:** o handoff manual produziu **~109× mais valores de cor** (1969 cru vs 18 token) espalhados em 27 arquivos por-tela. O bundle estruturado carrega os **tokens usados no canvas** → o Code reusa o canon em vez de re-derivar cor crua. Não é teoria: **é exatamente o sprawl que deletamos a sessão toda** (o manual diagnosticou ~20k linhas de CSS de "dumps Cowork colados"). O jeito-novo é melhor porque **não gera o problema que estávamos limpando**.
+
+Comando de reprodução: `git grep -h -o "oklch(" origin/main -- 'resources/css/*.css' | wc -l`.
+
+---
+
 ## Fontes
 
 - [Anthropic — Introducing Claude Design](https://www.anthropic.com/news/claude-design-anthropic-labs) (oficial)


### PR DESCRIPTION
## Por quê

Wagner cobrou: *"testou pra ver se é melhor?"*. O bundle real não está no fluxo (F-C reativo, formato não publicado), então não dá pra testar o handoff ponta-a-ponta. **Mas o custo do jeito-velho está medido no nosso código.**

## Prova (origin/main)

| Métrica | Jeito-velho (dump HTML + mapeamento manual) | Jeito-novo (bundle = tokens) |
|---|---:|---|
| `oklch` crus em resources/css | **1969** | reusa **18** tokens |
| Arquivos CSS por-tela | **27** | nenhum novo |

~109× menos duplicação de cor. **É o mesmo sprawl que a Onda anti-duplicação deletou** — o jeito-novo é melhor porque não gera o problema que limpamos. Argumento → evidência medida. Repro: `git grep -h -o "oklch(" origin/main -- 'resources/css/*.css' | wc -l`.

Docs-only (dossiê).

🤖 Generated with [Claude Code](https://claude.com/claude-code)