### PR TITLE
docs(adr): PROPOSTA 0255 — contrato de view determinístico (charter + design-spec derivado) + PoC

### DIFF
--- a/memory/decisions/0255-contrato-view-deterministico-charter-design-spec.md
+++ b/memory/decisions/0255-contrato-view-deterministico-charter-design-spec.md
@@ -1,0 +1,76 @@
+---
+slug: 0255-contrato-view-deterministico-charter-design-spec
+number: 255
+title: "Contrato de view determinístico: charter (intenção) + design-spec.json derivado (estrutura) — consolida os 4 artefatos por-tela"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+proposed_at: "2026-06-06"
+module: _DesignSystem
+quarter: 2026-Q2
+related_adrs:
+  - 0239-governanca-design-system-git-ssot-regressao-ia
+  - 0253-primitivos-layout
+  - 0114-prototipo-ui-cowork-loop-formalizado
+tags: [design-system, view-contract, design-spec, charter, derivado, deterministico, consolidacao]
+---
+
+# ADR 0255 — Contrato de view determinístico: charter + design-spec.json derivado
+
+> **PROPOSTA — Wagner aprova pra aceitar (Tier 0: muda padrão de artefato canônico por-tela).**
+> Origem: 2026-06-06, Wagner — *"esse protocolo deve ser o padrão spec da view, junto do page charter? assim consigo fazer testes? pesquise, consolide e rebaixe os conflitos — isso é evolução determinística."* Dossiê: [2026-06-06-arte-view-contract-deterministico](../sessions/2026-06-06-arte-view-contract-deterministico.md).
+
+## Contexto
+
+Hoje existem **4 artefatos por-tela**, todos **prosa, julgados por LLM**, sobrepostos:
+
+| Artefato | Qtd | Cobre | Determinístico? |
+|---|---|---|---|
+| `.charter.md` | 146 | intenção (Mission/Goals/UX) | não (LLM-judge — ok pra intenção) |
+| `<tela>-visual-comparison.md` | 68 | visual (15 dim) | não |
+| `<Tela>.review.md` | 157 | design review | não |
+| screen-grade scorecard | 222 | nota QA (16 dim) | não (LLM-as-judge) |
+
+**O determinismo está no lado errado:** a estrutura de UI por-tela (componentes compostos, tokens usados, layout) é **pura e DERIVÁVEL** — mas é julgada por LLM, enquanto só os gates **globais** (foundation-guard, conformance, reuse-index, ui-lint) são determinísticos. Falta a **projeção por-tela** desses gates.
+
+Estado-da-arte 2026 (DTCG 2025.10, Figma Code Connect, Storybook MCP, spec-anchored testing) converge: **código = SSOT; o contrato testável é DERIVADO**, não escrito à mão (que apodrece — [ADR 0239](0239-governanca-design-system-git-ssot-regressao-ia.md)). A infra de derivação **já existe** (`reuse-index.mjs` extrai imports/símbolos; `foundation-guard.mjs` tem ratchet só-desce).
+
+## Decisão
+
+**O contrato de view = DOIS artefatos canônicos por-tela:**
+
+1. **`<Tela>.charter.md` (MANTÉM)** — contrato de **intenção** (Mission/Goals/Non-Goals/UX targets/Anti-hooks). LLM-judge é apropriado: intenção é subjetiva.
+2. **`<Tela>.design-spec.json` (NOVO, DERIVADO)** — contrato de **estrutura**: shell + componentes (ui/shared/layout/local) + violações estruturais (oklch cru, px hardcoded, select/input nativo, inline-style). Gerado por `scripts/design-spec-gen.mjs` a partir da `.tsx`, com `measured_against_sha`. **Machine-checkable → teste determinístico por-tela**, não LLM-judge.
+
+**Resolução de conflitos (rebaixar):**
+- **`visual-comparison.md`** → vira **view derivada** do design-spec (não mais escrito à mão).
+- **`review.md` (157)** → **REBAIXA a gerado-on-demand** (mata 157 `.md` que apodrecem; gera quando precisa, não persiste).
+- **scorecard** → **CONSOME** o veredito determinístico do design-spec nas dimensões estruturais; LLM só nas subjetivas.
+
+**Teste:** gate por-tela re-deriva o spec + compara com o baseline commitado (drift estrutural → falha; ratchet só-desce nas violações). Espelha `foundation-guard`/`reuse-gate`.
+
+**Relação com o bundle Claude Design** ([PROTOCOL.md §10.5](../../prototipo-ui/PROTOCOL.md)): o bundle, quando chegar (F-C reativo, formato não publicado), vira o **ALVO** que o design-spec é testado contra — não o spec agora.
+
+## Consequências
+
+- **(+)** Estrutura de UI por-tela vira **deterministicamente testável** (não LLM-judge) — drift estrutural pego no CI.
+- **(+)** Fragmentação **4 → 2** artefatos; mata 157 `review.md` que apodrecem.
+- **(+)** Reusa infra existente (reuse-index + foundation-guard) — não é fundação nova, é projeção.
+- **(+)** Derivado → não apodrece (ADR 0239).
+- **(−)** Migrar 146 telas — mas **incremental e gerado** (custo baixo: derivado, não escrito).
+- **(−)** v1 do gerador cobre composição + violações; **tokens-usados via classes Tailwind** (`bg-primary`, `gap-4`) = fase 2.
+- **Tier 0:** muda padrão de artefato canônico → Wagner aprova esta ADR antes de migrar/rebaixar.
+
+## Prova (PoC, 2026-06-06)
+
+`Sells/Create.design-spec.json` derivado: 11 componentes canon (Button/Card/Input…) + 2 shared + 5 locais + **0 oklch cru** + 6 px hardcoded + 1 input nativo. Contrato estrutural real, machine-checkable, gerado em <1s. Ver `resources/js/Pages/Sells/Create.design-spec.json` + `scripts/design-spec-gen.mjs`.
+
+## Roadmap (impacto×esforço)
+
+1. **PoC** (feito) — gerador + Sells/Create.
+2. **ADR aceita** (Wagner) → padrão canônico.
+3. **Gate por-tela** `design-spec:check` (ratchet) + freshness — espelha os existentes.
+4. **Migração incremental** — toda tela tocada ganha seu design-spec (gerado); rebaixa review.md no caminho.
+5. **Fase 2** — tokens-usados (classes Tailwind) no spec; consolidar scorecard.

--- a/memory/decisions/0255-contrato-view-deterministico-charter-design-spec.md
+++ b/memory/decisions/0255-contrato-view-deterministico-charter-design-spec.md
@@ -7,6 +7,7 @@ status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
+decided_at: "2026-06-06"
 proposed_at: "2026-06-06"
 module: _DesignSystem
 quarter: 2026-Q2

--- a/memory/decisions/0255-contrato-view-deterministico-charter-design-spec.md
+++ b/memory/decisions/0255-contrato-view-deterministico-charter-design-spec.md
@@ -3,12 +3,14 @@ slug: 0255-contrato-view-deterministico-charter-design-spec
 number: 255
 title: "Contrato de view determinístico: charter (intenção) + design-spec.json derivado (estrutura) — consolida os 4 artefatos por-tela"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
 decided_at: "2026-06-06"
 proposed_at: "2026-06-06"
+accepted_at: "2026-06-06"
+accepted_via: "Wagner 2026-06-06 — 'eu aceito, merge' (após PoC Sells/Create.design-spec.json provado + dossiê 6 refs SOTA + mapa de conflitos resolvido)"
 module: _DesignSystem
 quarter: 2026-Q2
 related_adrs:
@@ -20,7 +22,7 @@ tags: [design-system, view-contract, design-spec, charter, derivado, determinist
 
 # ADR 0255 — Contrato de view determinístico: charter + design-spec.json derivado
 
-> **PROPOSTA — Wagner aprova pra aceitar (Tier 0: muda padrão de artefato canônico por-tela).**
+> **ACEITA por Wagner 2026-06-06** ("eu aceito, merge"). Tier 0: muda padrão de artefato canônico por-tela. Enactment (gate + migração incremental + rebaixar review.md) começa após este merge.
 > Origem: 2026-06-06, Wagner — *"esse protocolo deve ser o padrão spec da view, junto do page charter? assim consigo fazer testes? pesquise, consolide e rebaixe os conflitos — isso é evolução determinística."* Dossiê: [2026-06-06-arte-view-contract-deterministico](../sessions/2026-06-06-arte-view-contract-deterministico.md).
 
 ## Contexto

--- a/memory/sessions/2026-06-06-arte-view-contract-deterministico.md
+++ b/memory/sessions/2026-06-06-arte-view-contract-deterministico.md
@@ -11,7 +11,6 @@ related_adrs:
   - 0239-governanca-design-system-git-ssot-regressao-ia
   - 0093-multi-tenant-isolation-tier-0
   - 0094-constituicao-v2-7-camadas-8-principios
-  - UI-0013-constituicao-ui-v2-camadas
 ---
 
 # Contrato de view determinístico por-tela — dossiê estado-da-arte

--- a/memory/sessions/2026-06-06-arte-view-contract-deterministico.md
+++ b/memory/sessions/2026-06-06-arte-view-contract-deterministico.md
@@ -1,0 +1,114 @@
+---
+date: '2026-06-06'
+topic: "Contrato de view determinístico por-tela — charter (intenção) + design-spec DERIVADO (estrutura, machine-checkable). Consolidação dos 4 artefatos por-tela + mapa de conflitos + rascunho ADR."
+type: session
+authors: [W, C]
+slug: arte-view-contract-deterministico
+tldr: "Maior gap: nenhum dos 4 artefatos por-tela é determinístico-por-tela — todos prosa/LLM-judge. Recomendação: gerar <Tela>.design-spec.json DERIVADO da .tsx (reusa reuse-index + foundation-guard), começar pela tela-ouro Sells/Create. Charter fica (LLM-judge ok); visual-comparison/review/scorecard rebaixam a views advisory."
+status: proposta
+owner: W
+related_adrs:
+  - 0239-governanca-design-system-git-ssot-regressao-ia
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - UI-0013-constituicao-ui-v2-camadas
+---
+
+# Contrato de view determinístico por-tela — dossiê estado-da-arte
+
+> Pedido Wagner (2026-06-06): "pesquise para referenciar tudo, pesquise a integração, consolide e rebaixe todos os conflitos — isso é evolução determinística."
+> Princípio Tier-0 que rege tudo abaixo: **derivado > escrito** (ADR 0239 git=SSOT; lição reuse-index.mjs). Artefato escrito à mão apodrece.
+
+---
+
+## Seção 1 — PESQUISA (estado-da-arte 2025-2026, fontes primárias)
+
+Pesquisa feita **antes** de abrir memory/ (limpa, sem contaminar com "como nós fazemos").
+
+| # | Referência | Mecanismo concreto | Por que é referência |
+|---|---|---|---|
+| 1 | **DTCG — Design Tokens Format Module 2025.10** (W3C Community Group) | JSON vendor-neutral (`application/design-tokens+json`, `.tokens.json`); theming, color spaces modernos, cross-tool. **Primeira versão ESTÁVEL** (28-out-2025). | Standard real, 20+ editores, 10+ ferramentas (Figma/Penpot/Sketch/zeroheight). Token = contrato interoperável, não convenção. |
+| 2 | **Figma Code Connect** (Config 2025, GA) | "Describe how design *equals* code, não gera." Mapeia componente↔código 1:1, variants determinísticos, binding de estado. "Check designs linter": casa valor cru ↔ variável; lint custom força confirmar Code Connect em arquivo modificado. | Padrão de mercado pra ligar design-system-no-design ao código real. Anti-"código autogerado genérico". |
+| 3 | **Fiberplane `drift`** (documentation linter, AST-anchored) | Frontmatter ancora spec.md a código: `path` + `#Symbol` opcional + `@<git-sha>` provenance. Hash de **AST normalizado** (node kinds + token text, sem whitespace/posição) via tree-sitter. `drift check` em CI: código mudou pós-provenance → exit≠0, força re-link. | **A peça anti-rot exata.** Símbolo-level = resto do arquivo muda livre. É o freshness-gate que o Wagner descreveu, já existindo lá fora. |
+| 4 | **Spec-Driven Development w/ AI** (arXiv 2602.00180, 2026) | 3 níveis de maturidade: **spec-anchored** (specs evoluem c/ código, *testes forçam alinhamento*) → spec-as-source (código regenerado do spec, edição manual proibida). Rot resolvido por "se divergir, teste falha". | Formaliza o trade-off. Nível prático = spec-anchored (= o que propomos). Nível rigoroso = spec-as-source (= alvo do bundle Claude Design). |
+| 5 | **Storybook v9 + Storybook MCP** (2025) | Stories como casos de teste de componente; MCP expõe metadata/props/stories machine-readable p/ agente reusar DS e auto-corrigir contra testes. | Story-como-contrato é o padrão dominante p/ contrato de componente. (No oimpresso não há Storybook — code-first; relevante como *alvo* futuro, não dependência.) |
+| 6 | **LLM-as-judge vs deterministic gate** (Braintrust/Galileo, 2025-2026) | Híbrido é best-practice: gate determinístico p/ formato/estrutura/presença (<10ms, free, auditável, brittle); LLM-judge p/ qualidade subjetiva (tom, intenção) — probabilístico, flaky em single-call; mitiga com 3-5 juízes voto-maioria. | Justifica manter os DOIS: charter→LLM-judge (intenção), design-spec→gate (estrutura). Não é "trocar um pelo outro". |
+
+**Convergência:** todos apontam pro mesmo eixo — **o código é o SSOT; o contrato testável é DERIVADO do código** (Code Connect, drift, spec-anchored, SSOT design-system). Escrever spec à mão = anti-padrão unânime. Tokens viram contrato JSON padronizado (DTCG). Híbrido determinístico+LLM é consenso, não escolha.
+
+Fontes:
+- [DTCG 2025.10 stable](https://www.w3.org/community/design-tokens/2025/10/28/design-tokens-specification-reaches-first-stable-version/) · [format module](https://www.designtokens.org/tr/2025.10/format/)
+- [Figma Code Connect](https://github.com/figma/code-connect) · [Schema 2025 recap](https://www.figma.com/blog/schema-2025-design-systems-recap/)
+- [Fiberplane drift](https://fiberplane.com/blog/drift-documentation-linter/)
+- [Spec-Driven Development arXiv 2602.00180](https://arxiv.org/html/2602.00180v1)
+- [Storybook MCP](https://storybook.js.org/blog/storybook-mcp-sneak-peek/) · [Storybook v9 InfoQ](https://www.infoq.com/news/2025/07/storybook-v9-released/)
+- [Braintrust: LLM-as-judge vs deterministic](https://www.braintrust.dev/articles/what-is-llm-as-a-judge) · [Galileo](https://galileo.ai/blog/why-llm-as-a-judge-fails)
+
+---
+
+## Seção 2 — COMPARA (estado-da-arte × oimpresso hoje)
+
+Levantado no main tree (worktrees excluídos): **143** `.charter.md` · **68** `<tela>-visual-comparison.md` · **157** `<Tela>.review.md` · **1** scorecard JSON (222 telas, screen-grade LLM-judge). Gates determinísticos já existem mas são **globais**, não por-tela: `reuse-index.mjs` (símbolos JS+PHP derivados — sabe o que uma .tsx importa), `foundation-guard.mjs` (def de token só na allowlist, ratchet só-desce), `conformance-gate.mjs`, `pageheader-gate`, `css-size-gate`, `jscpd`.
+
+| Dimensão | Estado-da-arte | oimpresso hoje | Distância |
+|---|---|---|---|
+| Token como contrato testável | DTCG JSON estável, machine-checkable por-tela | foundation-guard trava DEF de token (global, ratchet); não há "quais tokens ESTA tela usa" como contrato | **média** — extração existe, falta projeção por-tela |
+| Contrato de componente/composição por-tela | Code Connect 1:1, Storybook stories | reuse-index já extrai símbolos+imports da .tsx (derivado); não emite spec por-tela nem testa "bate o esperado" | **curta** — substrato pronto, falta o artefato+teste |
+| Spec DERIVADO do código (anti-rot) | drift: AST-fingerprint + `@git-sha` provenance | reuse-index é derivado/regenerado (impossível apodrecer) MAS os 4 artefatos por-tela são **prosa escrita à mão** → apodrecem | **longa** nos 4 artefatos; **curta** na infra |
+| Freshness gate (spec vs código) | `drift check` em CI, exit≠0 | foundation-guard tem ratchet só-desce (padrão espelhável); nenhum freshness por-tela | **média** |
+| Determinístico vs LLM-judge | híbrido: gate p/ estrutura, judge p/ intenção | **invertido pro lado errado**: estrutura por-tela é julgada por LLM (screen-grade, review, visual-comparison). Só global é determinístico | **longa** — é o gap central |
+| Intenção/qualidade subjetiva | LLM-judge calibrado, multi-juiz | charter + screen-grade fazem isso bem; Peso Real (ROI→R$) supera SOTA | oimpresso **à frente** |
+| SSOT / anti-duplicação de docs | code repo canônico, docs derivadas | **4 artefatos sobrepostos por tela**, todos prosa, fontes independentes → exatamente o anti-padrão que SSOT condena | **longa** |
+
+**Honesto:** o oimpresso **já bate o mercado** em ponderação por receita (Peso Real — nenhum dos 6 SOTA pondera ROI) e na infra de extração derivada (reuse-index/foundation-guard são genuinamente estado-da-arte, code-first sem Figma). O gap **não é conceitual nem de ferramenta** — é que os 4 contratos POR-TELA ficaram do lado prosa/LLM-judge quando metade deles é estrutura pura, derivável e determinizável. A peça que falta (design-spec derivado por-tela) é uma **projeção por-tela de máquinas que já rodam**, não algo novo.
+
+### Mapa de conflitos dos 4 artefatos por-tela
+
+| Artefato | O que cobre | Prosa ou derivável? | Overlap com | Veredito |
+|---|---|---|---|---|
+| **`.charter.md`** (143) | INTENÇÃO: Mission/Goals/Non-Goals/UX targets/Anti-hooks | Prosa — **e deve ser** (intenção não se deriva) | baixo overlap estrutural; é a única peça legitimamente subjetiva | **MANTÉM canônico.** LLM-judge ok. Vira 1 dos 2 pilares. |
+| **`<tela>-visual-comparison.md`** (68) | 15 dimensões visuais (cor/espaço/tipo/layout vs golden) | ~70% derivável (tokens, espaçamento, componentes) · ~30% prosa (percepção) | alto c/ design-spec (estrutura) + c/ review.md | **VIRA VIEW DERIVADA** do design-spec p/ a parte estrutural; 30% subjetivo rebaixa a advisory dentro do screen-grade. Supersede como artefato escrito autônomo. |
+| **`<Tela>.review.md`** (157) | design review por tela (gerador `design:review`) | ~60% derivável; é re-narração do que dá pra checar | alto c/ visual-comparison + scorecard | **REBAIXA a advisory/efêmero.** Não é fonte; é relatório gerado. Não deve ser 157 arquivos versionados que apodrecem. Regenerar on-demand. |
+| **screen-grade scorecard** (222, LLM-judge) | nota QA 16-dim por tela, Peso Real | misto: ~half determinizável, ~half subjetivo | overlap c/ todos acima | **MANTÉM como camada de QUALIDADE** (LLM-judge legítimo p/ 16-dim), MAS as dims estruturais passam a CONSUMIR o design-spec determinístico (deixa de re-julgar o que a máquina já sabe). |
+
+**Resolução de cada overlap (explícita):**
+- visual-comparison ∩ design-spec → estrutura migra pro design-spec (fonte única, determinística); visual-comparison deixa de existir como .md autônomo.
+- review.md ∩ tudo → review.md vira **saída gerada, não fonte**. Some do git como artefato permanente por-tela.
+- scorecard ∩ design-spec → scorecard **importa** o veredito determinístico nas dims estruturais (ex: "usa só tokens allowlist?" vira pass/fail, não nota-de-LLM); LLM-judge fica só nas dims de gosto/intenção.
+- charter ∩ resto → zero conflito; charter é o pilar intenção, design-spec é o pilar estrutura. Ortogonais por desenho.
+
+---
+
+## Seção 3 — AVALIA (o que falta, rankeado)
+
+| Gap | Impacto | Esforço (IA-pair, ADR 0106 10x) | Pré-req bloqueante? |
+|---|---|---|---|
+| **`<Tela>.design-spec.json` derivado da .tsx** (tokens+componentes+layout) | **alto** — fecha o gap central, dá contrato determinístico por-tela | ~3-4h (reusa extração reuse-index + foundation-guard; é projeção por-tela) | **Não.** Substrato pronto. |
+| **Teste por-tela "esta .tsx bate seu design-spec?"** | alto — torna o contrato executável (spec-anchored) | ~2h (espelha ratchet foundation-guard) | Depende do design-spec acima |
+| **Freshness gate** (provenance `@git-sha` estilo drift) | médio — anti-rot se alguém editar spec à mão | ~1-2h (drift é só-leitura git+AST; reusa walker reuse-index) | Depende do design-spec |
+| **Rebaixar review.md (157) a gerado on-demand** | médio — mata 157 arquivos que apodrecem | ~1h (deprecar gerador como fonte) | Não, mas faz depois do design-spec provar valor |
+| **scorecard consome design-spec nas dims estruturais** | médio — para de re-julgar com LLM o que a máquina sabe | ~2h | Depende do design-spec |
+| **Adotar formato DTCG p/ a parte token do spec** | baixo (futuro) — interop se um dia entrar Figma/Storybook | ~1h | Não bloqueante; nice-to-have |
+
+**Risco multi-tenant (Tier 0, ADR 0093):** o design-spec descreve ESTRUTURA de UI (tokens/componentes/layout) — não toca `business_id`, não carrega dado de tenant. **Sem superfície de vazamento.** Se algum dia o spec capturar dado de exemplo/fixture, PII real é proibida (anonimizar). Por ora: P-zero de risco de tenant.
+
+**Riscos do próprio modelo:**
+- **Rot** → mitigado por desenho: spec é DERIVADO (regenerado da .tsx), nunca escrito. Freshness gate é cinto-e-suspensório.
+- **Fragmentação** → o objetivo É des-fragmentar (4→2). Risco invertido: o perigo é parar no meio e ter 6 artefatos. Mitigação: rebaixar review/visual-comparison no MESMO PR que prova o design-spec.
+- **Custo de migrar 143 telas** → **não migra à mão.** Gerador roda em batch sobre as .tsx existentes. Migração ≈ rodar o script. Esse é o ponto do "derivado".
+
+---
+
+## Recomendação final
+
+**Comece pelo `<Tela>.design-spec.json` derivado — alto-impacto, baixo-esforço, sem pré-req bloqueante.** O substrato (reuse-index extrai símbolos+imports da .tsx; foundation-guard sabe tokens válidos) já roda em CI. O design-spec é a **projeção por-tela** dessas máquinas — não código novo de fundação.
+
+**Próxima ação hoje:** prototipar o gerador numa única tela — a **tela-ouro `Sells/Create`** (A+ 9,75, já é golden-reference). Emitir `Sells/Create.design-spec.json` com 3 chaves: `tokens` (cores/espaços que a .tsx consome, cruzados c/ foundation-guard allowlist), `components` (símbolos DS importados, via reuse-index) e `layout` (primitivos `Components/layout` ADR 0253 usados). Validar que o JSON bate a tela manualmente UMA vez. Isso prova o modelo antes de escalar pras 143.
+
+**Rascunho de ADR (PROPOSTA — Tier-0, Wagner aprova):**
+
+> **ADR XXXX — Contrato de view determinístico por-tela: charter (intenção) + design-spec derivado (estrutura)**
+> **Contexto:** 4 artefatos por-tela (charter 143, visual-comparison 68, review 157, scorecard 222) sobrepostos, todos prosa/LLM-judge. Metade do conteúdo é estrutura pura (tokens/componentes/layout) — derivável e determinizável. Estado-da-arte (DTCG, Code Connect, drift, spec-anchored) converge em: código=SSOT, contrato testável DERIVADO. Gates determinísticos do oimpresso são globais, não por-tela. Princípio interno derivado>escrito (ADR 0239).
+> **Decisão:** Adotar 2 contratos canônicos por-tela: (1) `charter.md` — INTENÇÃO, prosa, LLM-judge; (2) `<Tela>.design-spec.json` — ESTRUTURA, DERIVADO da .tsx (reusa reuse-index + foundation-guard), machine-checkable. Teste por-tela spec-anchored + freshness gate estilo drift (provenance `@git-sha`). visual-comparison e review rebaixados a views derivadas/advisory geradas on-demand; scorecard consome o veredito determinístico nas dims estruturais e mantém LLM-judge só nas subjetivas.
+> **Consequências:** (+) 4→2 artefatos; determinismo por-tela; anti-rot por construção; LLM-judge só onde é insubstituível. (−) gerador a manter; migração das 143 via batch (não manual); review.md deixa de ser fonte versionada. Tier-0 multi-tenant: design-spec é estrutura de UI, sem `business_id`, sem PII — zero superfície de vazamento.
+> **Status:** PROPOSTA. Supersede nada formalmente até Wagner aprovar; complementa UI-0013 (camadas) e 0239 (git=SSOT).

--- a/resources/js/Pages/Sells/Create.design-spec.json
+++ b/resources/js/Pages/Sells/Create.design-spec.json
@@ -1,0 +1,52 @@
+{
+  "screen": "Sells/Create",
+  "path": "resources/js/Pages/Sells/Create.tsx",
+  "measured_against_sha": "5c6c557f5",
+  "generated_by": "scripts/design-spec-gen.mjs (DERIVADO — não editar à mão)",
+  "shell": [
+    "AppShellV2"
+  ],
+  "components": {
+    "ui": [
+      "Button",
+      "Card",
+      "CardContent",
+      "CardHeader",
+      "CardTitle",
+      "Checkbox",
+      "Input",
+      "Label",
+      "Textarea"
+    ],
+    "shared": [
+      "EmptyState",
+      "MercosulPlate"
+    ],
+    "layout": [],
+    "local": [
+      "NumericInputPtBR (./_components/NumericInputPtBR)",
+      "PaymentRow (./_components/PaymentRow)",
+      "QuickAddVehicleSheet (./_components/QuickAddVehicleSheet)",
+      "dropdownEntries (./_components/dropdownEntries)",
+      "type Payment (./_components/PaymentRow)"
+    ]
+  },
+  "hooks": [
+    "useAuth",
+    "useBusiness"
+  ],
+  "violations": {
+    "raw_oklch": 0,
+    "raw_hex": 0,
+    "hardcoded_px": 6,
+    "inline_style": 0,
+    "native_select": 0,
+    "native_input": 1
+  },
+  "totals": {
+    "canon_components": 11,
+    "local_components": 5,
+    "uses_layout_primitives": false,
+    "structural_violations": 7
+  }
+}

--- a/scripts/design-spec-gen.mjs
+++ b/scripts/design-spec-gen.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// scripts/design-spec-gen.mjs — PoC: deriva o CONTRATO ESTRUTURAL por-tela de uma .tsx.
+//
+// POR QUE (dossiê 2026-06-06-arte-view-contract-deterministico): hoje a estrutura de UI
+// por-tela (componentes/tokens/layout) é julgada por LLM (review/visual-comparison/screen-grade)
+// quando é PURA e DERIVÁVEL. Este gerador projeta, por-tela, o que reuse-index + foundation-guard
+// já fazem global → um `<Tela>.design-spec.json` MACHINE-CHECKABLE ao lado do `<Tela>.charter.md`.
+// Charter = intenção (LLM-judge ok). design-spec = estrutura (teste determinístico).
+//
+// DERIVADO da .tsx a cada run (measured_against_sha) → não apodrece (princípio ADR 0239, git=SSOT).
+// NÃO substitui charter nem os gates globais — é a projeção por-tela que faltava.
+//
+// USO:  node scripts/design-spec-gen.mjs resources/js/Pages/Sells/Create.tsx [--write]
+//       --write grava <Tela>.design-spec.json ao lado da .tsx; sem flag = stdout (PoC).
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const file = process.argv.find((a) => a.endsWith('.tsx'));
+const DO_WRITE = process.argv.includes('--write');
+if (!file) { console.error('uso: node scripts/design-spec-gen.mjs <Tela>.tsx [--write]'); process.exit(2); }
+
+const txt = readFileSync(file, 'utf8');
+const lines = txt.split('\n');
+
+function sha() { try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unknown'; } }
+
+// --- 1. Composição: imports categorizados por fonte (o contrato de COMPOSIÇÃO) ------------
+const comp = { shell: [], ui: [], shared: [], layout: [], local: [], hooks: [] };
+const importRe = /import\s+(?:[\w*{}\s,]+?)\s+from\s+['"]([^'"]+)['"]/g;
+// captura nomes importados pra cada source
+const named = (line) => {
+  const m = line.match(/import\s+(?:type\s+)?(?:(\w+)\s*,?\s*)?(?:\{([^}]*)\})?\s+from/);
+  const out = [];
+  if (m) {
+    if (m[1]) out.push(m[1]);
+    if (m[2]) out.push(...m[2].split(',').map((s) => s.replace(/\s+as\s+\w+/, '').trim()).filter(Boolean));
+  }
+  return out;
+};
+lines.forEach((line) => {
+  const m = line.match(/from\s+['"]([^'"]+)['"]/);
+  if (!m || !/^\s*import/.test(line)) return;
+  const src = m[1];
+  const names = named(line).filter((n) => !/^type$/.test(n));
+  if (/@\/Layouts\//.test(src)) comp.shell.push(...names);
+  else if (/@\/Components\/ui\b/.test(src)) comp.ui.push(...names);
+  else if (/@\/Components\/layout\b/.test(src)) comp.layout.push(...names);
+  else if (/@\/Components\/shared\b/.test(src)) comp.shared.push(...names);
+  else if (/@\/Components\//.test(src)) comp.shared.push(...names);
+  else if (/@\/Hooks\//.test(src)) comp.hooks.push(...names);
+  else if (/^\.\//.test(src) || /^\.\.\//.test(src)) comp.local.push(...names.map((n) => `${n} (${src})`));
+});
+for (const k of Object.keys(comp)) comp[k] = [...new Set(comp[k])].sort();
+
+// --- 2. Violações estruturais (determinísticas — o que um teste por-tela cobraria) --------
+const count = (re) => (txt.match(re) || []).length;
+const violations = {
+  raw_oklch: count(/oklch\(/g),                                  // cor crua (foundation-guard global → aqui por-tela)
+  raw_hex: count(/#[0-9a-fA-F]{3,8}\b/g),
+  hardcoded_px: count(/\[[0-9]+px\]/g),                          // text-[22px] etc — tipografia/espaço fora do token
+  inline_style: count(/style=\{\{/g),
+  native_select: count(/<select\b/g),                           // ds/no-native-select (anti-pattern REGISTRY)
+  native_input: count(/<input\b/g),
+};
+
+const spec = {
+  screen: file.replace(/^.*resources\/js\/Pages\//, '').replace(/\.tsx$/, ''),
+  path: file.replace(/\\/g, '/'),
+  measured_against_sha: sha(),
+  generated_by: 'scripts/design-spec-gen.mjs (DERIVADO — não editar à mão)',
+  shell: comp.shell,
+  components: { ui: comp.ui, shared: comp.shared, layout: comp.layout, local: comp.local },
+  hooks: comp.hooks,
+  violations,
+  totals: {
+    canon_components: comp.ui.length + comp.shared.length + comp.layout.length,
+    local_components: comp.local.length,
+    uses_layout_primitives: comp.layout.length > 0,
+    structural_violations: Object.values(violations).reduce((a, b) => a + b, 0),
+  },
+};
+
+const json = JSON.stringify(spec, null, 2);
+if (DO_WRITE) {
+  const out = file.replace(/\.tsx$/, '.design-spec.json');
+  writeFileSync(out, json + '\n');
+  console.log(`✓ design-spec gravado: ${out}`);
+} else {
+  console.log(json);
+}


### PR DESCRIPTION
## O que é

Resposta ao pedido do Wagner: *"o protocolo deve ser o spec padrão da view, junto do charter? assim consigo testar? pesquise, consolide, rebaixe conflitos — evolução determinística."*

**PROPOSTA (não mergear sem aprovação — Tier 0):** o contrato de view = **charter.md** (intenção, LLM-judge) + **design-spec.json DERIVADO** (estrutura, machine-checkable). O determinismo estava no lado errado: estrutura de UI é pura/derivável mas era julgada por LLM.

## Pacote

- **ADR 0255** (status: proposto) — decisão + mapa de conflitos resolvido (charter MANTÉM · visual-comparison vira view derivada · review.md REBAIXA a on-demand, mata 157 .md que apodrecem · scorecard CONSOME o determinístico).
- **** — gerador DERIVADO (reusa lógica do reuse-index).
- **** — PoC provado: 11 componentes canon, **0 oklch cru**, 6 px hardcoded, 1 input nativo. Contrato estrutural real, gerado em <1s, testável (drift → falha, sem juiz LLM).
- **Dossiê** da pesquisa profunda (6 refs SOTA: DTCG 2025.10, Code Connect, Storybook MCP, spec-anchored… convergem em código=SSOT, contrato DERIVADO).

## Decisão sua

Aceitar a ADR 0255 → aí formalizo o gate por-tela + migração incremental. **Não enacto nada sem seu OK** (a migração das 146 + rebaixar review.md é o passo pós-aceite).

Refs: ADR 0239 · ADR 0253

🤖 Generated with [Claude Code](https://claude.com/claude-code)