### PR TITLE
feat(governance): gate design-spec:check — contrato estrutural por-tela (enactment ADR 0255)

### DIFF
--- a/.github/workflows/design-spec-gate.yml
+++ b/.github/workflows/design-spec-gate.yml
@@ -1,0 +1,58 @@
+name: Design-spec por-tela (contrato estrutural determinístico)
+
+# ADR 0255: o contrato de view = charter.md (intenção, LLM-judge) + <Tela>.design-spec.json
+# (estrutura, DERIVADO da .tsx → machine-checkable). Este gate garante que todo design-spec
+# commitado SEMPRE reflete a .tsx: se a estrutura da tela mudou (componente novo, oklch cru,
+# px hardcoded, input nativo…) sem regenerar o spec → STALE → falha. O diff do .design-spec.json
+# no PR mostra exatamente o que mudou — drift estrutural pego DETERMINISTICAMENTE, sem juiz LLM.
+#
+# Incremental: gateia só as telas que JÁ têm .design-spec.json (ADR 0255 — toda tela tocada ganha
+# o seu). Node puro (fs), sem deps. Local: npm run design-spec:check · regenera: design-spec:write-all
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'resources/js/Pages/**'
+      - 'scripts/design-spec-gen.mjs'
+      - '.github/workflows/design-spec-gate.yml'
+  pull_request:
+    paths:
+      - 'resources/js/Pages/**'
+      - 'scripts/design-spec-gen.mjs'
+      - '.github/workflows/design-spec-gate.yml'
+
+concurrency:
+  group: design-spec-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  design-spec:
+    name: Design-spec · contrato estrutural por-tela
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: design-spec freshness (estrutura da tela bate o contrato)
+        run: node scripts/design-spec-gen.mjs --check
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "❌ A estrutura de uma tela mudou sem atualizar seu <Tela>.design-spec.json (ADR 0255)."
+          echo ""
+          echo "O design-spec é DERIVADO da .tsx — quando a composição muda (componente novo,"
+          echo "oklch cru, px hardcoded, input/select nativo), o contrato precisa refletir isso."
+          echo ""
+          echo "  1. Local: npm run design-spec:check  · vê qual tela ficou stale"
+          echo "  2. Regenera: npm run design-spec:write-all  (ou o gerador na tela específica --write)"
+          echo "  3. Commite o .design-spec.json — o DIFF mostra a mudança estrutural, revisável no PR."
+          echo ""
+          echo "Refs: ADR 0255 (contrato de view determinístico) · charter = intenção, design-spec = estrutura."

--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "dup:check": "jscpd resources/js",
     "no-mock:check": "node scripts/no-mock-in-prod.mjs",
     "no-mock:baseline:write": "node scripts/no-mock-in-prod.mjs --write-baseline",
+    "design-spec:check": "node scripts/design-spec-gen.mjs --check",
+    "design-spec:write-all": "node scripts/design-spec-gen.mjs --write-all",
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts"
   },

--- a/scripts/design-spec-gen.mjs
+++ b/scripts/design-spec-gen.mjs
@@ -1,91 +1,139 @@
 #!/usr/bin/env node
-// scripts/design-spec-gen.mjs — PoC: deriva o CONTRATO ESTRUTURAL por-tela de uma .tsx.
+// scripts/design-spec-gen.mjs — deriva + gateia o CONTRATO ESTRUTURAL por-tela de uma .tsx.
 //
-// POR QUE (dossiê 2026-06-06-arte-view-contract-deterministico): hoje a estrutura de UI
-// por-tela (componentes/tokens/layout) é julgada por LLM (review/visual-comparison/screen-grade)
-// quando é PURA e DERIVÁVEL. Este gerador projeta, por-tela, o que reuse-index + foundation-guard
-// já fazem global → um `<Tela>.design-spec.json` MACHINE-CHECKABLE ao lado do `<Tela>.charter.md`.
-// Charter = intenção (LLM-judge ok). design-spec = estrutura (teste determinístico).
+// POR QUE (ADR 0255 · dossiê 2026-06-06-arte-view-contract-deterministico): a estrutura de UI
+// por-tela (componentes/tokens/layout) é PURA e DERIVÁVEL, mas era julgada por LLM
+// (review/visual-comparison/screen-grade). Este projeta, por-tela, o que reuse-index +
+// foundation-guard fazem global → `<Tela>.design-spec.json` MACHINE-CHECKABLE ao lado do
+// `<Tela>.charter.md`. Charter = intenção (LLM-judge ok). design-spec = estrutura (teste determinístico).
 //
-// DERIVADO da .tsx a cada run (measured_against_sha) → não apodrece (princípio ADR 0239, git=SSOT).
-// NÃO substitui charter nem os gates globais — é a projeção por-tela que faltava.
+// DERIVADO da .tsx a cada run → não apodrece (ADR 0239, git=SSOT). O gate (--check) garante que o
+// spec commitado SEMPRE reflete a .tsx: mudou a tela → regenera → o diff do spec mostra a mudança
+// estrutural (componente novo, oklch cru, px hardcoded…) → revisável no PR. Drift = spec stale = falha.
 //
-// USO:  node scripts/design-spec-gen.mjs resources/js/Pages/Sells/Create.tsx [--write]
-//       --write grava <Tela>.design-spec.json ao lado da .tsx; sem flag = stdout (PoC).
+// USO:
+//   node scripts/design-spec-gen.mjs <Tela>.tsx            # imprime o spec (stdout)
+//   node scripts/design-spec-gen.mjs <Tela>.tsx --write    # grava <Tela>.design-spec.json
+//   node scripts/design-spec-gen.mjs --check               # GATE: todo .design-spec.json commitado bate a .tsx? (CI)
+//   node scripts/design-spec-gen.mjs --write-all           # regenera todos os specs commitados
 
-import { readFileSync, writeFileSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 
-const file = process.argv.find((a) => a.endsWith('.tsx'));
-const DO_WRITE = process.argv.includes('--write');
-if (!file) { console.error('uso: node scripts/design-spec-gen.mjs <Tela>.tsx [--write]'); process.exit(2); }
+const ROOT = process.cwd();
+const PAGES = 'resources/js/Pages';
 
-const txt = readFileSync(file, 'utf8');
-const lines = txt.split('\n');
+function sha() { try { return execSync('git rev-parse --short HEAD', { cwd: ROOT }).toString().trim(); } catch { return 'unknown'; } }
 
-function sha() { try { return execSync('git rev-parse --short HEAD').toString().trim(); } catch { return 'unknown'; } }
+// --- gera o spec derivado de uma .tsx -------------------------------------------------------
+function genSpec(file) {
+  const txt = readFileSync(join(ROOT, file), 'utf8');
+  const comp = { shell: [], ui: [], shared: [], layout: [], local: [], hooks: [] };
+  const named = (line) => {
+    const m = line.match(/import\s+(?:type\s+)?(?:(\w+)\s*,?\s*)?(?:\{([^}]*)\})?\s+from/);
+    const out = [];
+    if (m) {
+      if (m[1]) out.push(m[1]);
+      if (m[2]) out.push(...m[2].split(',').map((s) => s.replace(/\s+as\s+\w+/, '').trim()).filter(Boolean));
+    }
+    return out;
+  };
+  for (const line of txt.split('\n')) {
+    const m = line.match(/from\s+['"]([^'"]+)['"]/);
+    if (!m || !/^\s*import/.test(line)) continue;
+    const src = m[1];
+    const names = named(line).filter((n) => !/^type$/.test(n));
+    if (/@\/Layouts\//.test(src)) comp.shell.push(...names);
+    else if (/@\/Components\/ui\b/.test(src)) comp.ui.push(...names);
+    else if (/@\/Components\/layout\b/.test(src)) comp.layout.push(...names);
+    else if (/@\/Components\//.test(src)) comp.shared.push(...names);
+    else if (/@\/Hooks\//.test(src)) comp.hooks.push(...names);
+    else if (/^\.\.?\//.test(src)) comp.local.push(...names.map((n) => `${n} (${src})`));
+  }
+  for (const k of Object.keys(comp)) comp[k] = [...new Set(comp[k])].sort();
 
-// --- 1. Composição: imports categorizados por fonte (o contrato de COMPOSIÇÃO) ------------
-const comp = { shell: [], ui: [], shared: [], layout: [], local: [], hooks: [] };
-const importRe = /import\s+(?:[\w*{}\s,]+?)\s+from\s+['"]([^'"]+)['"]/g;
-// captura nomes importados pra cada source
-const named = (line) => {
-  const m = line.match(/import\s+(?:type\s+)?(?:(\w+)\s*,?\s*)?(?:\{([^}]*)\})?\s+from/);
-  const out = [];
-  if (m) {
-    if (m[1]) out.push(m[1]);
-    if (m[2]) out.push(...m[2].split(',').map((s) => s.replace(/\s+as\s+\w+/, '').trim()).filter(Boolean));
+  const count = (re) => (txt.match(re) || []).length;
+  const violations = {
+    raw_oklch: count(/oklch\(/g),
+    raw_hex: count(/#[0-9a-fA-F]{3,8}\b/g),
+    hardcoded_px: count(/\[[0-9]+px\]/g),
+    inline_style: count(/style=\{\{/g),
+    native_select: count(/<select\b/g),
+    native_input: count(/<input\b/g),
+  };
+  return {
+    screen: file.replace(/^.*resources\/js\/Pages\//, '').replace(/\.tsx$/, ''),
+    path: file.replace(/\\/g, '/'),
+    measured_against_sha: sha(),
+    generated_by: 'scripts/design-spec-gen.mjs (DERIVADO — não editar à mão)',
+    shell: comp.shell,
+    components: { ui: comp.ui, shared: comp.shared, layout: comp.layout, local: comp.local },
+    hooks: comp.hooks,
+    violations,
+    totals: {
+      canon_components: comp.ui.length + comp.shared.length + comp.layout.length,
+      local_components: comp.local.length,
+      uses_layout_primitives: comp.layout.length > 0,
+      structural_violations: Object.values(violations).reduce((a, b) => a + b, 0),
+    },
+  };
+}
+
+// campos voláteis ignorados na comparação de freshness (mudam a cada commit, não são estrutura)
+const VOLATILE = new Set(['measured_against_sha', 'generated_by']);
+const stable = (spec) => JSON.stringify(spec, (k, v) => (VOLATILE.has(k) ? undefined : v), 2);
+
+// acha todos os .design-spec.json commitados sob Pages/
+function findSpecs(dir = PAGES, out = []) {
+  let entries;
+  try { entries = readdirSync(join(ROOT, dir), { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    const rel = join(dir, e.name);
+    if (e.isDirectory()) findSpecs(rel, out);
+    else if (e.name.endsWith('.design-spec.json')) out.push(rel.replace(/\\/g, '/'));
   }
   return out;
-};
-lines.forEach((line) => {
-  const m = line.match(/from\s+['"]([^'"]+)['"]/);
-  if (!m || !/^\s*import/.test(line)) return;
-  const src = m[1];
-  const names = named(line).filter((n) => !/^type$/.test(n));
-  if (/@\/Layouts\//.test(src)) comp.shell.push(...names);
-  else if (/@\/Components\/ui\b/.test(src)) comp.ui.push(...names);
-  else if (/@\/Components\/layout\b/.test(src)) comp.layout.push(...names);
-  else if (/@\/Components\/shared\b/.test(src)) comp.shared.push(...names);
-  else if (/@\/Components\//.test(src)) comp.shared.push(...names);
-  else if (/@\/Hooks\//.test(src)) comp.hooks.push(...names);
-  else if (/^\.\//.test(src) || /^\.\.\//.test(src)) comp.local.push(...names.map((n) => `${n} (${src})`));
-});
-for (const k of Object.keys(comp)) comp[k] = [...new Set(comp[k])].sort();
-
-// --- 2. Violações estruturais (determinísticas — o que um teste por-tela cobraria) --------
-const count = (re) => (txt.match(re) || []).length;
-const violations = {
-  raw_oklch: count(/oklch\(/g),                                  // cor crua (foundation-guard global → aqui por-tela)
-  raw_hex: count(/#[0-9a-fA-F]{3,8}\b/g),
-  hardcoded_px: count(/\[[0-9]+px\]/g),                          // text-[22px] etc — tipografia/espaço fora do token
-  inline_style: count(/style=\{\{/g),
-  native_select: count(/<select\b/g),                           // ds/no-native-select (anti-pattern REGISTRY)
-  native_input: count(/<input\b/g),
-};
-
-const spec = {
-  screen: file.replace(/^.*resources\/js\/Pages\//, '').replace(/\.tsx$/, ''),
-  path: file.replace(/\\/g, '/'),
-  measured_against_sha: sha(),
-  generated_by: 'scripts/design-spec-gen.mjs (DERIVADO — não editar à mão)',
-  shell: comp.shell,
-  components: { ui: comp.ui, shared: comp.shared, layout: comp.layout, local: comp.local },
-  hooks: comp.hooks,
-  violations,
-  totals: {
-    canon_components: comp.ui.length + comp.shared.length + comp.layout.length,
-    local_components: comp.local.length,
-    uses_layout_primitives: comp.layout.length > 0,
-    structural_violations: Object.values(violations).reduce((a, b) => a + b, 0),
-  },
-};
-
-const json = JSON.stringify(spec, null, 2);
-if (DO_WRITE) {
-  const out = file.replace(/\.tsx$/, '.design-spec.json');
-  writeFileSync(out, json + '\n');
-  console.log(`✓ design-spec gravado: ${out}`);
-} else {
-  console.log(json);
 }
+
+const write = (file, spec) => writeFileSync(join(ROOT, file.replace(/\.tsx$/, '.design-spec.json')), JSON.stringify(spec, null, 2) + '\n');
+
+// --- dispatcher -----------------------------------------------------------------------------
+const args = process.argv.slice(2);
+
+if (args.includes('--check')) {
+  const specs = findSpecs();
+  const stale = [];
+  for (const specPath of specs) {
+    const tsx = specPath.replace(/\.design-spec\.json$/, '.tsx');
+    let committed;
+    try { committed = JSON.parse(readFileSync(join(ROOT, specPath), 'utf8')); } catch { stale.push([specPath, 'spec ilegível']); continue; }
+    const fresh = genSpec(tsx);
+    if (stable(committed) !== stable(fresh)) stale.push([specPath, 'estrutura mudou — regenere']);
+  }
+  if (stale.length === 0) {
+    console.log(`✓ design-spec:check OK — ${specs.length} spec(s) por-tela em sincronia com a .tsx.`);
+    process.exit(0);
+  }
+  console.error(`✗ design-spec:check FALHOU — ${stale.length} spec(s) STALE (não batem a .tsx):\n`);
+  for (const [p, why] of stale) console.error(`  ${p} — ${why}`);
+  console.error(`\nA estrutura da tela mudou sem atualizar o contrato. Rode: npm run design-spec:write-all`);
+  console.error(`(o diff do .design-spec.json mostra o que mudou — componente novo / oklch cru / px hardcoded — revisável no PR).`);
+  process.exit(1);
+}
+
+if (args.includes('--write-all')) {
+  const specs = findSpecs();
+  for (const specPath of specs) {
+    const tsx = specPath.replace(/\.design-spec\.json$/, '.tsx');
+    write(tsx, genSpec(tsx));
+  }
+  console.log(`✓ ${specs.length} design-spec(s) regenerado(s).`);
+  process.exit(0);
+}
+
+const file = args.find((a) => a.endsWith('.tsx'));
+if (!file) { console.error('uso: design-spec-gen.mjs <Tela>.tsx [--write] | --check | --write-all'); process.exit(2); }
+const spec = genSpec(file);
+if (args.includes('--write')) { write(file, spec); console.log(`✓ design-spec gravado: ${file.replace(/\.tsx$/, '.design-spec.json')}`); }
+else console.log(JSON.stringify(spec, null, 2));


### PR DESCRIPTION
## Enactment ADR 0255 (passo 1: o gate)

A ADR 0255 (aceita) define o contrato de view = charter (intenção) + design-spec.json (estrutura, derivado). Este PR liga o **gate** que torna o design-spec **enforçado** — sem ele, é só um arquivo.

## O que entra

- `design-spec-gen.mjs` ganha **`--check`** (gate freshness: re-deriva cada spec commitado da .tsx, falha se estrutura mudou sem atualizar) + **`--write-all`**.
- Workflow `design-spec-gate.yml` (pull_request) + npm scripts.

## Provado

- `--check` exit **0** em sincronia (Sells/Create).
- Injetando `oklch` cru na .tsx → exit **1** (drift estrutural pego, sem juiz LLM).
- Restaurado → exit 0.

**Incremental** (ADR 0255): gateia só telas que já têm `.design-spec.json` (hoje 1: Sells/Create). Toda tela tocada ganha o seu → vira gateada. Node puro, zero deps.

Refs: ADR 0255 · ADR 0239

🤖 Generated with [Claude Code](https://claude.com/claude-code)