### PR TITLE
feat(governance): a11y ratchet — acessibilidade como categoria protegida (determinístico)

### DIFF
--- a/.github/workflows/a11y-gate.yml
+++ b/.github/workflows/a11y-gate.yml
@@ -1,0 +1,59 @@
+name: A11y ratchet (acessibilidade = categoria protegida)
+
+# Auditoria 2026-06-06 (LLM-judge→determinístico) + benchmark vs SOTA: a11y era o ponto-baixo
+# (nota ~62). As 294 violações jsx-a11y viviam ENTERRADAS no baseline geral de eslint (1073) —
+# gateadas contra novas, mas absorvíveis via lint:baseline:write (porta de escape).
+# Este gate trata a11y como categoria PROTEGIDA: a contagem jsx-a11y/* só DESCE, nunca sobe —
+# nem via baseline:write. axe-core RUNTIME (contraste/ARIA/foco) = Fase 2 (vitest-axe).
+#
+# Node puro (lê config/eslint-baseline.json commitado), sem deps, sem npm ci.
+# Local: npm run a11y:check · visibilidade: npm run a11y:report
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'config/eslint-baseline.json'
+      - 'config/a11y-baseline.json'
+      - 'scripts/a11y-ratchet.mjs'
+      - '.github/workflows/a11y-gate.yml'
+  pull_request:
+    paths:
+      - 'config/eslint-baseline.json'
+      - 'config/a11y-baseline.json'
+      - 'scripts/a11y-ratchet.mjs'
+      - '.github/workflows/a11y-gate.yml'
+
+concurrency:
+  group: a11y-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a11y:
+    name: A11y · ratchet jsx-a11y (só desce)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: A11y ratchet (falha se jsx-a11y aumentou)
+        run: node scripts/a11y-ratchet.mjs
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "❌ Aumentou violação de acessibilidade (jsx-a11y) vs config/a11y-baseline.json."
+          echo ""
+          echo "Acessibilidade é categoria PROTEGIDA — não absorve débito novo, NEM via lint:baseline:write."
+          echo ""
+          echo "  1. Local: npm run a11y:report  · vê a violação nova (label/key-events/role/aria)"
+          echo "  2. CORRIJA (não suprima): <label htmlFor>, onKeyDown junto de onClick, role correto, aria-*"
+          echo "  3. Encolher é sempre OK — ao corrigir, rode: npm run a11y:baseline:write"
+          echo ""
+          echo "Refs: ADR 0209 (ratchet) · auditoria LLM-judge→determinístico 2026-06-06 · eslint-plugin-jsx-a11y"

--- a/config/a11y-baseline.json
+++ b/config/a11y-baseline.json
@@ -1,0 +1,16 @@
+{
+  "generated_by": "scripts/a11y-ratchet.mjs --write",
+  "total": 294,
+  "by_rule": {
+    "jsx-a11y/click-events-have-key-events": 94,
+    "jsx-a11y/no-static-element-interactions": 61,
+    "jsx-a11y/no-noninteractive-element-interactions": 37,
+    "jsx-a11y/no-redundant-roles": 3,
+    "jsx-a11y/label-has-associated-control": 71,
+    "jsx-a11y/no-noninteractive-element-to-interactive-role": 8,
+    "jsx-a11y/no-interactive-element-to-noninteractive-role": 2,
+    "jsx-a11y/media-has-caption": 4,
+    "jsx-a11y/role-supports-aria-props": 6,
+    "jsx-a11y/anchor-is-valid": 8
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "no-mock:baseline:write": "node scripts/no-mock-in-prod.mjs --write-baseline",
     "design-spec:check": "node scripts/design-spec-gen.mjs --check",
     "design-spec:write-all": "node scripts/design-spec-gen.mjs --write-all",
+    "a11y:check": "node scripts/a11y-ratchet.mjs",
+    "a11y:report": "node scripts/a11y-ratchet.mjs --report",
+    "a11y:baseline:write": "node scripts/a11y-ratchet.mjs --write",
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts"
   },

--- a/scripts/a11y-ratchet.mjs
+++ b/scripts/a11y-ratchet.mjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+// scripts/a11y-ratchet.mjs — acessibilidade como categoria DETERMINÍSTICA PROTEGIDA.
+//
+// POR QUE (auditoria 2026-06-06-arte-llm-judge-para-deterministico + benchmark vs SOTA):
+// a11y é o ponto-baixo do ecossistema. As 159 violações `jsx-a11y/*` viviam ENTERRADAS no
+// baseline geral de eslint (1073) — gateadas contra novas, mas SEM visibilidade, SEM redução-alvo,
+// e ABSORVÍVEIS via `lint:baseline:write` (a porta de escape do baseline geral).
+//
+// Este ratchet trata a11y como categoria PROTEGIDA: a contagem `jsx-a11y/*` só DESCE, nunca sobe —
+// nem mesmo via baseline:write. axe-core RUNTIME (contraste/ARIA/foco que o estático não vê) = Fase 2
+// (vitest-axe). Este é o Fase 1: determinístico, infra existente (eslint-plugin-jsx-a11y já ligado),
+// Node puro (lê o config/eslint-baseline.json commitado), custo zero.
+//
+// Espelha o padrão dos ratchets do projeto (ADR 0209 · reuse/no-mock/css-size).
+//
+// USO:
+//   node scripts/a11y-ratchet.mjs            # gate: falha se jsx-a11y AUMENTOU vs baseline
+//   node scripts/a11y-ratchet.mjs --report   # breakdown por regra (visibilidade)
+//   node scripts/a11y-ratchet.mjs --write     # (re)grava config/a11y-baseline.json (só pra DESCER)
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const ESLINT_BASELINE = 'config/eslint-baseline.json';
+const A11Y_BASELINE = 'config/a11y-baseline.json';
+
+// extrai a contagem jsx-a11y/* do baseline geral do eslint (fonte da verdade, commitada)
+function currentA11y() {
+  const bl = JSON.parse(readFileSync(join(ROOT, ESLINT_BASELINE), 'utf8'));
+  const byRule = {};
+  let total = 0;
+  for (const [key, n] of Object.entries(bl.counts || {})) {
+    const m = key.match(/\|(jsx-a11y\/[a-z-]+)$/);
+    if (m) { byRule[m[1]] = (byRule[m[1]] || 0) + n; total += n; }
+  }
+  return { total, byRule };
+}
+
+const args = process.argv.slice(2);
+const cur = currentA11y();
+
+if (args.includes('--report')) {
+  console.log(`# a11y (jsx-a11y) — ${cur.total} violações no baseline\n`);
+  for (const [rule, n] of Object.entries(cur.byRule).sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${String(n).padStart(3)}  ${rule}`);
+  }
+  console.log(`\n(axe-core runtime = Fase 2. Este conta só o estático jsx-a11y.)`);
+  process.exit(0);
+}
+
+if (args.includes('--write')) {
+  const payload = { generated_by: 'scripts/a11y-ratchet.mjs --write', total: cur.total, by_rule: cur.byRule };
+  writeFileSync(join(ROOT, A11Y_BASELINE), JSON.stringify(payload, null, 2) + '\n');
+  console.log(`✓ a11y-baseline gravado: ${cur.total} violações jsx-a11y conhecidas (só pode descer daqui).`);
+  process.exit(0);
+}
+
+// gate (default)
+let baseline;
+try { baseline = JSON.parse(readFileSync(join(ROOT, A11Y_BASELINE), 'utf8')); }
+catch { console.error(`✗ a11y-baseline ausente. Rode: node scripts/a11y-ratchet.mjs --write`); process.exit(2); }
+
+if (cur.total <= baseline.total) {
+  const delta = baseline.total - cur.total;
+  console.log(`✓ a11y ratchet OK — ${cur.total} violações jsx-a11y (baseline ${baseline.total}${delta > 0 ? `, ↓${delta} — rode --write pra travar o ganho` : ''}).`);
+  process.exit(0);
+}
+console.error(`✗ a11y ratchet FALHOU — jsx-a11y SUBIU: ${baseline.total} → ${cur.total} (+${cur.total - baseline.total}).`);
+console.error(`\nAcessibilidade é categoria PROTEGIDA (não absorve débito novo, nem via baseline:write).`);
+console.error(`Corrija a violação a11y (não suprima): label, key-events, role, aria. Veja --report.`);
+process.exit(1);


### PR DESCRIPTION
## Por quê

Benchmark vs SOTA marcou a11y como o **ponto-baixo** (~62/100). As **294 violações jsx-a11y** viviam **enterradas** no baseline geral de eslint (1073) — gateadas contra novas, mas **absorvíveis** via `lint:baseline:write` (a porta de escape).

## O que entra (Fase 1 — determinístico, infra existente, Node puro)

- `a11y-ratchet.mjs` — extrai jsx-a11y/* do `config/eslint-baseline.json` → trata a11y como **categoria PROTEGIDA**: só desce, nunca sobe, **nem via baseline:write**.
- `config/a11y-baseline.json` (294, breakdown por regra) + workflow + npm scripts (`a11y:check`/`:report`/`:baseline:write`).

## Provado

- `a11y:check` exit **0** (294 vs 294).
- baseline 294→293 → exit **1** (bite provado).
- `a11y:report`: 94 click-events · 71 label-control · 61 static-element · 37 noninteractive…

**Fase 2** (não neste PR): **axe-core RUNTIME** (vitest-axe) — pega contraste/ARIA/foco que o estático não vê. É o que mais sobe a nota; medium-effort (dep nova + render).

Refs: ADR 0209 · auditoria LLM-judge→determinístico

🤖 Generated with [Claude Code](https://claude.com/claude-code)