### PR TITLE
feat(a11y): Fase 2 — axe-core runtime (jsdom) nos componentes canon

### DIFF
--- a/.github/workflows/a11y-axe-gate.yml
+++ b/.github/workflows/a11y-axe-gate.yml
@@ -1,0 +1,62 @@
+name: A11y axe runtime (jsdom · componentes canon)
+
+# Fase 2 da determinização de a11y (Fase 1 = ratchet jsx-a11y estático #2359 · Fase 3 = axe
+# browser real #2360). Renderiza os componentes canon @/Components/ui no jsdom (Vitest +
+# testing-library) e roda axe-core: pega ARIA/role/nome-acessível/associação-label que o
+# estático não vê. Determinístico (axe é regra, não juiz LLM). 0 violações serious/critical.
+#
+# NOTA: nenhum workflow rodava vitest — este é o 1º gate que exercita a suíte de componente no CI.
+# jsdom NÃO vê contraste/foco (isso é a Fase 3, browser real). Local: npm run a11y:axe
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'resources/js/Components/ui/**'
+      - 'tests/a11y-primitives.test.tsx'
+      - 'tests/js/setup.ts'
+      - 'package-lock.json'
+      - '.github/workflows/a11y-axe-gate.yml'
+  pull_request:
+    paths:
+      - 'resources/js/Components/ui/**'
+      - 'tests/a11y-primitives.test.tsx'
+      - 'tests/js/setup.ts'
+      - 'package-lock.json'
+      - '.github/workflows/a11y-axe-gate.yml'
+
+concurrency:
+  group: a11y-axe-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  a11y-axe:
+    name: A11y axe · runtime nos componentes canon
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Install deps (npm ci — instala axe-core do lock)
+        run: npm ci
+
+      - name: axe runtime nos componentes canon (jsdom)
+        run: npm run a11y:axe
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "❌ Componente canon @/Components/ui tem violação axe serious/critical (jsdom)."
+          echo ""
+          echo "  1. Local: npm run a11y:axe  · vê a violação (id + help)"
+          echo "  2. CORRIJA o componente (aria-*, role, nome acessível, associação label↔control)"
+          echo "  3. NÃO mascare — a11y é categoria protegida."
+          echo ""
+          echo "Escopo jsdom: ARIA/estrutura. Contraste/foco = Fase 3 (browser real, #2360)."
+          echo "Refs: auditoria 2026-06-06-arte-llm-judge-para-deterministico · ADR 0209"

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "@typescript-eslint/eslint-plugin": "^8.60.0",
         "@typescript-eslint/parser": "^8.60.0",
         "@vitejs/plugin-react": "^4.3.0",
+        "axe-core": "^4.12.0",
         "eslint": "^9.39.4",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -5213,6 +5214,70 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
@@ -6552,9 +6617,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "a11y:check": "node scripts/a11y-ratchet.mjs",
     "a11y:report": "node scripts/a11y-ratchet.mjs --report",
     "a11y:baseline:write": "node scripts/a11y-ratchet.mjs --write",
+    "a11y:axe": "vitest run tests/a11y-primitives.test.tsx",
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts"
   },
@@ -61,6 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^8.60.0",
     "@typescript-eslint/parser": "^8.60.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "axe-core": "^4.12.0",
     "eslint": "^9.39.4",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/tests/a11y-primitives.test.tsx
+++ b/tests/a11y-primitives.test.tsx
@@ -1,0 +1,69 @@
+// a11y RUNTIME (axe-core em jsdom) nos componentes canon — Fase 2 da determinização de a11y.
+//
+// POR QUE (auditoria 2026-06-06-arte-llm-judge-para-deterministico + benchmark vs SOTA):
+// o jsx-a11y ESTÁTICO (Fase 1, ratchet #2359) pega ~40% — nome de import, role óbvio.
+// O axe RUNTIME renderiza o componente e inspeciona o DOM real: aria-* coerente, role
+// computado, nome acessível, associação label↔control. Determinístico (axe é regra, não LLM).
+//
+// ESCOPO: jsdom NÃO calcula layout → NÃO vê CONTRASTE de cor nem ordem de FOCO visual.
+// Isso é a Fase 3 (axe em browser real, Pest 4 Browser — já mergeada #2360). Aqui: estrutura/ARIA.
+//
+// Asserta 0 violações de impacto `serious`+`critical` (as que importam; minor/moderate = degrau
+// futuro do ratchet, como a Fase 3 começou em critical-only). Uso VÁLIDO dos componentes
+// (Input com Label associado) — testamos o componente canon, não uso-errado.
+
+import { describe, it, expect, afterEach } from "vitest"
+import { render, cleanup } from "@testing-library/react"
+import axe from "axe-core"
+
+import { Button } from "@/Components/ui/button"
+import { Input } from "@/Components/ui/input"
+import { Label } from "@/Components/ui/label"
+import { Checkbox } from "@/Components/ui/checkbox"
+import { Textarea } from "@/Components/ui/textarea"
+import { Badge } from "@/Components/ui/badge"
+import { Card, CardHeader, CardTitle, CardContent } from "@/Components/ui/card"
+
+afterEach(cleanup)
+
+const IMPACTFUL = new Set(["serious", "critical"])
+
+async function impactfulViolations(container: HTMLElement) {
+  const { violations } = await axe.run(container, { resultTypes: ["violations"] })
+  return violations
+    .filter((v) => IMPACTFUL.has(v.impact ?? ""))
+    .map((v) => `${v.impact}: ${v.id} — ${v.help}`)
+}
+
+describe("a11y axe (jsdom) — componentes canon, uso válido, 0 violações serious/critical", () => {
+  it("form canon: Label+Input, Label+Textarea, Checkbox+Label, Button", async () => {
+    const { container } = render(
+      <form aria-label="formulário de teste">
+        <Label htmlFor="nome">Nome</Label>
+        <Input id="nome" />
+        <Label htmlFor="obs">Observações</Label>
+        <Textarea id="obs" />
+        <div>
+          <Checkbox id="aceito" />
+          <Label htmlFor="aceito">Aceito os termos</Label>
+        </div>
+        <Button>Salvar</Button>
+      </form>,
+    )
+    expect(await impactfulViolations(container)).toEqual([])
+  })
+
+  it("conteúdo canon: Card + Badge", async () => {
+    const { container } = render(
+      <Card>
+        <CardHeader>
+          <CardTitle>Título</CardTitle>
+        </CardHeader>
+        <CardContent>
+          Conteúdo do cartão <Badge>novo</Badge>
+        </CardContent>
+      </Card>,
+    )
+    expect(await impactfulViolations(container)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Fase 2 da determinização de a11y

Fase 1 (ratchet jsx-a11y estático, #2359) pega ~40%. Esta Fase 2 renderiza os componentes canon `@/Components/ui` no **jsdom** e roda **axe-core runtime** → pega ARIA/role/nome-acessível/associação label↔control que o estático não vê. 0 violações `serious`/`critical`. Determinístico.

## O que entra

- `tests/a11y-primitives.test.tsx` — form canon (Label+Input/Textarea/Checkbox+Button) + Card+Badge, uso VÁLIDO.
- `axe-core@^4` (devDep, via `--package-lock-only`).
- **`a11y-axe-gate.yml`** — 1º workflow que roda **vitest no CI** (npm ci + a11y test). Nenhum rodava antes.

## Honesto

- **Não rodei local** (worktree sem node_modules — foi o que travou a thread anterior; resolvi com `--package-lock-only`). O **CI verifica** (npm ci + vitest).
- jsdom **não vê contraste/foco** — isso é a Fase 3 (browser real, já mergeada #2360). Escopo aqui: ARIA/estrutura.
- Se um componente canon tiver violação serious/critical → CI vermelho = achado real (corrijo, não mascaro).

Refs: auditoria LLM-judge→determinístico · ADR 0209

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)