### PR TITLE
feat(jana): Onda 1 — PR UI Judge 6/9 dims LLM→determinístico

### DIFF
--- a/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
+++ b/Modules/Jana/Ai/Agents/PrUiJudgeAgent.php
@@ -26,11 +26,17 @@ use Stringable;
  *  - Metadata do PR (título, descrição, arquivos modificados)
  *  - Diff resumido (`git diff` filtrado pra .tsx/.jsx/.css)
  *
- * Retorna:
- *  - Score 0-100
- *  - Análise por 9 dimensões
+ * Retorna (Onda 1 LLM-judge → determinístico · dossiê 2026-06-06 · ADR 0255):
+ *  - Análise das 3 dimensões SEMÂNTICAS (hierarquia_4_camadas · pt_01_slot_adherence ·
+ *    pt_br_voice_tone) — as únicas que exigem juízo que regex não captura
  *  - Lista de violações estruturais não-capturadas pelo `ui:lint` (grep-invisíveis)
  *  - Sugestões concretas de refactor
+ *
+ * As OUTRAS 6 dimensões (tokens_semanticos · componentes_shared · atalhos_canonicos_jk_cmdk ·
+ * localStorage_prefix_oimpresso · lucide_iconography_only · anti_padroes_ap1_ap8) são
+ * DETERMINÍSTICAS — computadas por regex em UiDeterministicScorer (porte de
+ * score-mechanized.mjs). O UiJudgePrCommand MESCLA as 6 determinísticas + estas 3
+ * num único review de 9 dimensões. O LLM não pontua mais as 6 (sem custo/viés/flakiness).
  *
  * NÃO substitui `ui:lint` (sintático/lexical) — complementa com análise
  * semântica: "drawer modal sobre modal", "slot 4 BulkBar inventado custom",
@@ -107,15 +113,25 @@ class PrUiJudgeAgent implements Agent
 
         UI-0009 + UI-0014 — Wagner-explícito 2026-05-24. v2 externa propõe dark sempre · **NÃO aplicar**.
 
+        ## Divisão de trabalho (Onda 1 · LLM-judge → determinístico · ADR 0255)
+
+        Das 9 dimensões da Constituição UI v2, **6 são determinísticas** (cor crua, componente nativo, atalho, localStorage-prefix, ícone-lucide, anti-padrões grep-áveis AP1/2/3/4/6/7) e são computadas FORA de você, por regex reproduzível (UiDeterministicScorer, porte de score-mechanized.mjs). **Você NÃO pontua essas 6** — elas chegam prontas e o comando mescla.
+
+        **Você julga SOMENTE as 3 dimensões SEMÂNTICAS** que regex não captura:
+
+        - `hierarquia_4_camadas` — a camada superior herda e nunca contradiz a inferior? Conflito de camada? (Fundações > Shell > PT > Módulo)
+        - `pt_01_slot_adherence` — os 6 slots da PT-01 estão na ordem/papel certos? Slot reinventado custom? PageHeader usado fora do slot 1? Drawer modal sobre modal?
+        - `pt_br_voice_tone` — copy/label/erro/empty em PT-BR natural e no tom do produto? (AP8 — string em inglês visível ao usuário, voz robótica/traduzida)
+
         ## Como você avalia (método G-Eval · raciocine ANTES de pontuar)
 
-        Avalie em ordem encadeada — **primeiro o rationale dimensão-por-dimensão, só depois o score agregado**. Nunca crave o score total antes de raciocinar cada dimensão; o score é *derivado* das 9 dimensões, não chutado de cabeça.
+        Avalie em ordem encadeada — **primeiro o rationale dimensão-por-dimensão, só depois o score**. Nunca crave o score antes de raciocinar cada dimensão; o score é *derivado* do rationale, não chutado de cabeça.
 
         Passos obrigatórios, nesta ordem:
 
-        1. **Para cada uma das 9 dimensões:** escreva primeiro o `rationale` (1-2 frases citando o que viu no diff — arquivo/linha quando possível), e só então atribua o `score` 0-10 coerente com esse rationale.
+        1. **Para cada uma das 3 dimensões semânticas:** escreva primeiro o `rationale` (1-2 frases citando o que viu no diff — arquivo/linha quando possível), e só então atribua o `score` 0-10 coerente com esse rationale.
         2. **Liste as `violacoes_estruturais`** grep-invisíveis encontradas (com arquivo/linha/severidade).
-        3. **Só então** compute o `score` total 0-100 (proporcional à soma das 9 dimensões · 9×10=90 → normalize pra 100) e derive o `verdict` dele: `< 60` → `request_changes`, `60-84` → `comment`, `≥ 85` → `approve`.
+        3. **Não calcule o score total** — o comando soma suas 3 dims às 6 determinísticas e normaliza pra 0-100. O `verdict` também é derivado lá. Você só raciocina as 3.
 
         Produza output JSON estrito **nesta ordem de chaves** (a ordem reflete a ordem do raciocínio):
 
@@ -124,31 +140,23 @@ class PrUiJudgeAgent implements Agent
           "dimensoes": {
             "hierarquia_4_camadas": { "rationale": "...", "score": 0-10 },
             "pt_01_slot_adherence": { "rationale": "...", "score": 0-10 },
-            "anti_padroes_ap1_ap8": { "rationale": "...", "score": 0-10 },
-            "tokens_semanticos": { "rationale": "...", "score": 0-10 },
-            "componentes_shared": { "rationale": "...", "score": 0-10 },
-            "atalhos_canonicos_jk_cmdk": { "rationale": "...", "score": 0-10 },
-            "localStorage_prefix_oimpresso": { "rationale": "...", "score": 0-10 },
-            "pt_br_voice_tone": { "rationale": "...", "score": 0-10 },
-            "lucide_iconography_only": { "rationale": "...", "score": 0-10 }
+            "pt_br_voice_tone": { "rationale": "...", "score": 0-10 }
           },
           "violacoes_estruturais": [
             { "tipo": "...", "arquivo": "...", "linha": N, "detalhe": "...", "severidade": "critical|warning|info" }
           ],
-          "score": 0-100,
-          "verdict": "approve | request_changes | comment",
           "sugestoes": [
             "..."
           ],
           "lembretes": [
-            "AP1 — cor hardcoded vs token semântico",
+            "AP1 — cor hardcoded vs token semântico (esta já é checada por regex)",
             "Sidebar permanece light (UI-0014)",
             "..."
           ]
         }
         ```
 
-        > Nota de compatibilidade: o campo de texto de cada dimensão chama-se agora `rationale` (antes `nota`). Quem consome o JSON deve aceitar ambos.
+        > Nota de compatibilidade: o campo de texto de cada dimensão chama-se agora `rationale` (antes `nota`). Quem consome o JSON deve aceitar ambos. Se por engano você incluir uma das 6 dims determinísticas, o comando ignora — a fonte da verdade delas é o regex.
 
         ## Princípios de avaliação
 

--- a/Modules/Jana/Ai/UiDeterministicScorer.php
+++ b/Modules/Jana/Ai/UiDeterministicScorer.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Ai;
+
+/**
+ * UiDeterministicScorer — porte PHP do regex de `prototipo-ui/audit/score-mechanized.mjs`.
+ *
+ * Onda 1 da auditoria LLM-judge → determinístico (dossiê
+ * memory/sessions/2026-06-06-arte-llm-judge-para-deterministico.md · ADR 0255).
+ *
+ * 6 das 9 dimensões do PrUiJudgeAgent são DETERMINÍSTICAS — o próprio
+ * score-mechanized.mjs já as computa por regex (R1-R9). Este scorer porta esses
+ * regex pra PHP (mesma fonte de verdade, zero LLM, reproduzível, sem custo/viés/
+ * flakiness) pra que o juiz LLM rode SÓ nas 3 dims genuinamente semânticas
+ * (hierarquia_4_camadas · pt_01_slot_adherence · pt_br_voice_tone).
+ *
+ * Por que regex e não chamar `node score-mechanized.mjs`:
+ *  - O job CI do PR UI Judge (pr-ui-judge.yml) só monta PHP, não Node → portar é
+ *    menor risco que adicionar toolchain Node no workflow.
+ *  - score-mechanized.mjs lê o ARQUIVO inteiro + ds-map do baseline; o PR Judge
+ *    avalia só o DIFF do PR (linhas adicionadas). Aplicar o mesmo regex às linhas
+ *    `+` do diff é o escopo honesto: julga o que o PR introduz.
+ *
+ * Mapeamento dim (PrUiJudgeAgent) ↔ regra (GOLDEN-REFERENCE):
+ *   tokens_semanticos              ← R1 (cor crua: #hex · oklch/rgb/hsl)
+ *   componentes_shared             ← R2 (elementos nativos <select>/<input>/<table>/<textarea>)
+ *   localStorage_prefix_oimpresso  ← R3 (localStorage sem prefixo oimpresso.<modulo>.*)
+ *   lucide_iconography_only        ← R4 (<svg> inline · import de icon-lib fora lucide)
+ *   anti_padroes_ap1_ap8           ← composto (R1+R2+R3+R4+R6+R7) — a metade grep-ável dos AP
+ *   atalhos_canonicos_jk_cmdk      ← presença de palette/hotkey canônico (cmdk · onKeyDown j/k)
+ *
+ * As 3 que NÃO entram aqui (ficam LLM): hierarquia_4_camadas, pt_01_slot_adherence,
+ * pt_br_voice_tone — exigem juízo semântico que regex não captura.
+ *
+ * Os regex abaixo são CÓPIA FIEL de RX em score-mechanized.mjs (linhas 58-70).
+ * Qualquer drift entre os dois é regressão — manter sincronizado.
+ *
+ * @see prototipo-ui/audit/score-mechanized.mjs (fonte canônica dos regex)
+ * @see prototipo-ui/audit/GOLDEN-REFERENCE.md (as 10 regras R1-R10)
+ * @see memory/sessions/2026-06-06-arte-llm-judge-para-deterministico.md (Onda 1)
+ */
+final class UiDeterministicScorer
+{
+    /**
+     * As 6 dimensões determinísticas computadas aqui (na ordem do schema do agent).
+     *
+     * @var list<string>
+     */
+    public const DETERMINISTIC_DIMENSIONS = [
+        'tokens_semanticos',
+        'componentes_shared',
+        'atalhos_canonicos_jk_cmdk',
+        'localStorage_prefix_oimpresso',
+        'lucide_iconography_only',
+        'anti_padroes_ap1_ap8',
+    ];
+
+    /**
+     * As 3 dimensões semânticas que continuam sob o juiz LLM.
+     *
+     * @var list<string>
+     */
+    public const SEMANTIC_DIMENSIONS = [
+        'hierarquia_4_camadas',
+        'pt_01_slot_adherence',
+        'pt_br_voice_tone',
+    ];
+
+    /**
+     * Pontua as 6 dimensões determinísticas a partir do diff do PR.
+     *
+     * Aplica os regex de score-mechanized.mjs SOMENTE às linhas adicionadas
+     * (`+`) do diff — o escopo honesto: julga o que o PR introduz, não o
+     * arquivo inteiro pré-existente.
+     *
+     * @return array<string, array{score:int, rationale:string}> dim => {score 0-10, rationale}
+     */
+    public function score(string $diff): array
+    {
+        $added = $this->addedLines($diff);
+
+        $hits = $this->detect($added);
+
+        return [
+            'tokens_semanticos' => $this->dim(
+                $hits['R1'],
+                'Cor crua (R1): #hex · oklch/rgb/hsl literal',
+                'Tokens semânticos OK — nenhuma cor crua nas linhas adicionadas (R1).',
+            ),
+            'componentes_shared' => $this->dim(
+                $hits['R2'],
+                'Elemento nativo (R2): use componente shared (Select/Input/Table/Textarea @/ui)',
+                'Sem elemento nativo reinventado nas linhas adicionadas (R2).',
+            ),
+            'atalhos_canonicos_jk_cmdk' => $this->dimAtalhos($hits['shortcut'], $added),
+            'localStorage_prefix_oimpresso' => $this->dim(
+                $hits['R3'],
+                'localStorage sem prefixo oimpresso.<modulo>.* (R3 · multi-tenant Tier 0)',
+                'localStorage prefixado corretamente ou ausente (R3).',
+            ),
+            'lucide_iconography_only' => $this->dim(
+                $hits['R4'],
+                'Ícone fora lucide-react (R4): <svg> inline ou icon-lib externa',
+                'Iconografia lucide-only respeitada nas linhas adicionadas (R4).',
+            ),
+            'anti_padroes_ap1_ap8' => $this->dimAntiPadroes($hits),
+        ];
+    }
+
+    /**
+     * Extrai as linhas adicionadas (`+`) de um diff unificado, sem o `+` inicial
+     * e ignorando o header `+++ b/...`.
+     */
+    private function addedLines(string $diff): string
+    {
+        $out = [];
+        foreach (preg_split('/\r\n|\r|\n/', $diff) ?: [] as $line) {
+            if ($line === '' || $line[0] !== '+') {
+                continue;
+            }
+            if (str_starts_with($line, '+++')) {
+                continue;
+            }
+            $out[] = substr($line, 1);
+        }
+
+        return implode("\n", $out);
+    }
+
+    /**
+     * Roda os regex de score-mechanized.mjs (RX, linhas 58-70). Cópia fiel.
+     *
+     * @return array{R1:list<string>, R2:list<string>, R3:list<string>, R4:list<string>, R6:list<string>, R7:list<string>, shortcut:list<string>}
+     */
+    private function detect(string $src): array
+    {
+        // R1 — cor crua. hex (exceto #fff/#000) + colorFn (oklch/rgb/hsl).
+        $hex = $this->matchAll('/#[0-9a-fA-F]{3,8}\b/', $src);
+        $hex = array_values(array_filter(
+            $hex,
+            fn (string $x): bool => preg_match('/^#(?:fff|ffffff|000|000000)$/i', $x) !== 1,
+        ));
+        $colorFn = $this->matchAll('/\b(?:oklch|rgba?|hsla?)\s*\(/', $src);
+
+        // R2 — elementos nativos.
+        $native = $this->matchAll('/<(?:select|input|textarea|table)[\s\/>]/', $src);
+
+        // R3 — localStorage sem prefixo oimpresso.*.
+        $r3 = [];
+        if (preg_match_all('/localStorage\.(?:get|set|remove)Item\s*\(\s*[`\'"]([^`\'"]+)/', $src, $m)) {
+            foreach ($m[1] as $key) {
+                if (str_starts_with($key, 'oimpresso.')) {
+                    continue;
+                }
+                // ${VAR}... — se a const resolve pra 'oimpresso.*' está OK.
+                if (preg_match('/^\$\{(\w+)\}/', $key, $tv)) {
+                    if (preg_match('/(?:const|let|var)\s+'.preg_quote($tv[1], '/').'\s*=\s*[\'"`]([^\'"`]+)/', $src, $d)
+                        && str_starts_with($d[1], 'oimpresso.')) {
+                        continue;
+                    }
+                }
+                $r3[] = $key;
+            }
+        }
+
+        // R4 — ícones fora lucide. <svg> inline + import de icon-lib externa.
+        $svg = $this->matchAll('/<svg[\s\/>]/', $src);
+        $iconLib = $this->matchAll('/from\s+[\'"](?:react-icons|@heroicons|@tabler\/icons|feather)/', $src);
+
+        // R6 — emoji real (range astral). NÃO dingbats BMP (glyphs de UI).
+        $emoji = $this->matchAll('/[\x{1F000}-\x{1FAFF}]/u', $src);
+
+        // R7 — status com bg-fill (heurística ampla, baixa precisão — sinal).
+        $statusFill = $this->matchAll('/\bbg-(?:red|rose|green|emerald|amber|yellow|orange|sky|blue|indigo|violet)-(?:50|100|200)\b/', $src);
+
+        // atalhos — presença de palette/hotkey canônico (cmdk · onKeyDown j/k).
+        $shortcut = array_merge(
+            $this->matchAll('/\bcmdk\b/i', $src),
+            $this->matchAll('/CommandPalette/', $src),
+            $this->matchAll('/onKeyDown|useHotkeys|useKeyboard/', $src),
+        );
+
+        return [
+            'R1' => array_merge($hex, $colorFn),
+            'R2' => $native,
+            'R3' => $r3,
+            'R4' => array_merge($svg, $iconLib),
+            'R6' => $emoji,
+            'R7' => $statusFill,
+            'shortcut' => $shortcut,
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function matchAll(string $pattern, string $src): array
+    {
+        if (preg_match_all($pattern, $src, $m)) {
+            return $m[0];
+        }
+
+        return [];
+    }
+
+    /**
+     * Dim binária: 10 se zero hits, 4 se houver (espelha o dedutor mecanizado
+     * `peso×4` de score-mechanized — aqui normalizado pra 0-10 por dim).
+     *
+     * @param  list<string>  $hits
+     * @return array{score:int, rationale:string}
+     */
+    private function dim(array $hits, string $failMsg, string $passMsg): array
+    {
+        if ($hits === []) {
+            return ['score' => 10, 'rationale' => $passMsg];
+        }
+
+        $ev = $this->evidence($hits);
+
+        return ['score' => 4, 'rationale' => "{$failMsg}. {$ev}"];
+    }
+
+    /**
+     * Atalhos: dim informativa. Sem hotkey nas linhas adicionadas → neutro
+     * (10, a maioria das telas não introduz atalho). Com hotkey → confirma
+     * presença (10) — a detecção é de presença, não de violação. Mantida
+     * determinística e conservadora: nunca penaliza, só registra evidência.
+     *
+     * @param  list<string>  $hits
+     * @return array{score:int, rationale:string}
+     */
+    private function dimAtalhos(array $hits, string $added): array
+    {
+        if ($hits === []) {
+            return ['score' => 10, 'rationale' => 'Nenhum atalho introduzido nas linhas adicionadas — neutro (atalho é opcional na PT-01).'];
+        }
+
+        return ['score' => 10, 'rationale' => 'Atalho/command-palette presente nas linhas adicionadas: '.$this->evidence($hits)];
+    }
+
+    /**
+     * anti_padroes_ap1_ap8 — composto da metade grep-ável dos anti-padrões:
+     * R1 (AP1 cor) · R2 (AP2 nativo) · R3 (AP3 localStorage) · R4 (AP4 ícone) ·
+     * R6 (AP6 emoji) · R7 (AP7 status-fill). AP5 (gradient) e AP8 (PT-BR) são
+     * julgados — não entram aqui.
+     *
+     * @param  array{R1:list<string>, R2:list<string>, R3:list<string>, R4:list<string>, R6:list<string>, R7:list<string>, shortcut:list<string>}  $hits
+     * @return array{score:int, rationale:string}
+     */
+    private function dimAntiPadroes(array $hits): array
+    {
+        $failed = [];
+        if ($hits['R1'] !== []) {
+            $failed[] = 'AP1(cor)';
+        }
+        if ($hits['R2'] !== []) {
+            $failed[] = 'AP2(nativo)';
+        }
+        if ($hits['R3'] !== []) {
+            $failed[] = 'AP3(localStorage)';
+        }
+        if ($hits['R4'] !== []) {
+            $failed[] = 'AP4(ícone)';
+        }
+        if ($hits['R6'] !== []) {
+            $failed[] = 'AP6(emoji)';
+        }
+        if ($hits['R7'] !== []) {
+            $failed[] = 'AP7(status-fill)';
+        }
+
+        if ($failed === []) {
+            return ['score' => 10, 'rationale' => 'Nenhum anti-padrão grep-ável (AP1/2/3/4/6/7) nas linhas adicionadas.'];
+        }
+
+        // Quanto mais AP violados, menor a nota (10 → cai 2 por AP, piso 0).
+        $score = max(0, 10 - count($failed) * 2);
+
+        return ['score' => $score, 'rationale' => 'Anti-padrões grep-áveis detectados: '.implode(' · ', $failed).' (AP5 gradient + AP8 PT-BR ficam no juiz LLM).'];
+    }
+
+    /**
+     * Resumo de evidência (espelha evidenceOf de score-mechanized): N× + amostra.
+     *
+     * @param  list<string>  $hits
+     */
+    private function evidence(array $hits): string
+    {
+        $uniq = array_slice(array_values(array_unique(array_map('strval', $hits))), 0, 4);
+
+        return count($hits).'× — '.implode(' · ', $uniq);
+    }
+}

--- a/Modules/Jana/Tests/Feature/Ai/UiDeterministicScorerTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/UiDeterministicScorerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Ai\UiDeterministicScorer;
+
+/**
+ * Onda 1 (LLM-judge → determinístico · ADR 0255): prova que o porte PHP dos regex de
+ * score-mechanized.mjs computa as 6 dimensões determinísticas a partir do diff — sem LLM,
+ * reproduzível. As 3 dims semânticas (hierarquia/slot/voz) seguem no juiz LLM.
+ *
+ * IDs:
+ *  001. diff limpo → 10 em todas as 6 dims
+ *  002. cor crua (R1) → tokens_semanticos cai pra 4
+ *  003. elemento nativo (R2) → componentes_shared cai pra 4
+ *  004. múltiplos anti-padrões → anti_padroes_ap1_ap8 cai proporcional
+ *  005. #fff/#000 não conta como cor crua (exceção do R1)
+ */
+it('R-JANA-DETSCORE-001 — diff limpo pontua 10 nas 6 dims determinísticas', function () {
+    $diff = "+++ b/x.tsx\n+<Button variant=\"cowork-primary\">Salvar</Button>\n+<Badge>novo</Badge>\n";
+
+    $r = (new UiDeterministicScorer)->score($diff);
+
+    expect($r['tokens_semanticos']['score'])->toBe(10)
+        ->and($r['componentes_shared']['score'])->toBe(10)
+        ->and($r['localStorage_prefix_oimpresso']['score'])->toBe(10)
+        ->and($r['lucide_iconography_only']['score'])->toBe(10)
+        ->and($r['anti_padroes_ap1_ap8']['score'])->toBe(10);
+});
+
+it('R-JANA-DETSCORE-002 — cor crua (R1) derruba tokens_semanticos pra 4', function () {
+    $diff = "+++ b/x.tsx\n+const cor = 'oklch(0.5 0.1 200)';\n+const outra = '#1572E8';\n";
+
+    $r = (new UiDeterministicScorer)->score($diff);
+
+    expect($r['tokens_semanticos']['score'])->toBe(4)
+        ->and($r['tokens_semanticos']['rationale'])->toContain('Cor crua');
+});
+
+it('R-JANA-DETSCORE-003 — elemento nativo (R2) derruba componentes_shared pra 4', function () {
+    $diff = "+++ b/x.tsx\n+<select className=\"h-9\"><option>a</option></select>\n";
+
+    $r = (new UiDeterministicScorer)->score($diff);
+
+    expect($r['componentes_shared']['score'])->toBe(4);
+});
+
+it('R-JANA-DETSCORE-004 — múltiplos anti-padrões grep-áveis baixam anti_padroes_ap1_ap8', function () {
+    // R1 (cor crua) + R2 (nativo) = 2 AP → 10 - 2*2 = 6
+    $diff = "+++ b/x.tsx\n+const c = '#abc123';\n+<input type=\"text\" />\n";
+
+    $r = (new UiDeterministicScorer)->score($diff);
+
+    expect($r['anti_padroes_ap1_ap8']['score'])->toBe(6);
+});
+
+it('R-JANA-DETSCORE-005 — #fff/#000 NÃO conta como cor crua (exceção R1)', function () {
+    $diff = "+++ b/x.tsx\n+<div className=\"bg-[#fff] text-[#000]\" />\n";
+
+    $r = (new UiDeterministicScorer)->score($diff);
+
+    expect($r['tokens_semanticos']['score'])->toBe(10);
+});

--- a/app/Console/Commands/UiJudgePrCommand.php
+++ b/app/Console/Commands/UiJudgePrCommand.php
@@ -7,6 +7,7 @@ namespace App\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Process;
 use Modules\Jana\Ai\Agents\PrUiJudgeAgent;
+use Modules\Jana\Ai\UiDeterministicScorer;
 use Modules\Jana\Entities\UiJudgeRun;
 
 /**
@@ -107,7 +108,7 @@ class UiJudgePrCommand extends Command
             return self::FAILURE;
         }
 
-        // 5. Parse JSON
+        // 5. Parse JSON (agora o LLM retorna só as 3 dims semânticas — sem score)
         $review = $this->parseReview($output);
         if ($review === null) {
             $this->warn('Output do LLM não é JSON válido · imprimindo raw:');
@@ -115,6 +116,12 @@ class UiJudgePrCommand extends Command
 
             return $strict ? self::FAILURE : self::SUCCESS;
         }
+
+        // 5.5. Onda 1 (LLM-judge → determinístico · ADR 0255): mescla as 6 dimensões
+        // DETERMINÍSTICAS (regex · UiDeterministicScorer) com as 3 SEMÂNTICAS do LLM → 9 dims,
+        // computa o score total (0-100) + verdict AQUI (não mais no LLM). O juiz não pontua
+        // mais as 6 → sem custo/viés/flakiness nelas.
+        $review = $this->mergeDeterministic($review, $diff);
 
         // 6. Render no console
         $this->renderReview($review);
@@ -374,11 +381,46 @@ class UiJudgePrCommand extends Command
         $clean = preg_replace('/\n```\s*$/', '', $clean) ?? $clean;
 
         $data = json_decode($clean, true);
-        if (! is_array($data) || ! isset($data['score'])) {
+        // Onda 1: o LLM agora retorna `dimensoes` (3 semânticas) — sem `score` (calculado
+        // no command após mesclar as 6 determinísticas). Exigimos `dimensoes`, não `score`.
+        if (! is_array($data) || ! isset($data['dimensoes'])) {
             return null;
         }
 
         return $data;
+    }
+
+    /**
+     * Onda 1 (LLM-judge → determinístico · ADR 0255): mescla as 6 dimensões determinísticas
+     * (regex · UiDeterministicScorer) com as 3 semânticas julgadas pelo LLM, computa o score
+     * total 0-100 (soma das 9 dims · cada 0-10) e deriva o verdict.
+     *
+     * @param  array<string, mixed>  $review
+     * @return array<string, mixed>
+     */
+    private function mergeDeterministic(array $review, string $diff): array
+    {
+        $deterministic = (new UiDeterministicScorer)->score($diff); // 6 dims
+
+        $llm = is_array($review['dimensoes'] ?? null) ? $review['dimensoes'] : [];
+        // só as 3 dimensões semânticas do LLM entram (ignora qualquer dim que o LLM
+        // tenha pontuado fora do contrato).
+        $semantic = array_intersect_key($llm, array_flip(UiDeterministicScorer::SEMANTIC_DIMENSIONS));
+
+        $dimensoes = array_merge($deterministic, $semantic); // 6 + 3 = 9
+        $review['dimensoes'] = $dimensoes;
+
+        $sum = 0;
+        foreach ($dimensoes as $d) {
+            $sum += is_array($d) ? (int) ($d['score'] ?? 0) : 0;
+        }
+        $maxPts = max(count($dimensoes), 1) * 10;
+        $score = (int) round($sum / $maxPts * 100);
+
+        $review['score'] = $score;
+        $review['verdict'] = $score < 60 ? 'request_changes' : ($score < 85 ? 'comment' : 'approve');
+
+        return $review;
     }
 
     private function renderReview(array $review): void


### PR DESCRIPTION
## Onda 1 da determinização (a maior da auditoria)

O gate **PR UI Judge** (gpt-4o-mini) julgava **9 dims de UI por LLM** — mas **6 são determinísticas** e o `score-mechanized.mjs` já as computa por regex. Esta PR porta esses regex pra PHP (`UiDeterministicScorer`) e deixa o LLM julgar **só as 3 semânticas**.

## O split

| 6 DETERMINÍSTICAS (regex · UiDeterministicScorer) | 3 SEMÂNTICAS (LLM) |
|---|---|
| tokens_semanticos (R1 cor crua) · componentes_shared (R2 nativo) · localStorage_prefix (R3) · lucide_iconography (R4) · atalhos (presença) · anti_padroes_ap1_ap8 (R1/2/3/4/6/7) | hierarquia_4_camadas · pt_01_slot_adherence · pt_br_voice_tone |

## O que entra

- `UiDeterministicScorer.php` — porte fiel dos regex de `score-mechanized.mjs` (R1-R7).
- `PrUiJudgeAgent` — prompt reduzido a 3 dims semânticas (mantém G-Eval/rationale/keywords dos testes).
- `UiJudgePrCommand` — **mescla** 6 determinísticas + 3 LLM → 9 dims, computa score+verdict (não mais o LLM).
- 5 testes do scorer.

## Ganho

Corta **custo/viés/flakiness** das 6 dims (regex reproduzível). O LLM gasta token só onde regex não vê.

## Honesto

- O scorer + prompt foram trabalho de **agente em thread que travou** no Pest local; **assumi e finalizei** a fiação do command + testes.
- **php não roda local** (container) → CI (Pest/PHPStan) verifica. O `pr-ui-judge` gate **skipa** nesta PR (toca PHP, não UI).

Refs: auditoria LLM-judge→determinístico · ADR 0255 · score-mechanized.mjs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)