### PR TITLE
chore(governance): fecha 2 pontas soltas da onda de determinização (ref 0240→0239 + guard de sync)

### DIFF
--- a/.github/workflows/scorer-sync-gate.yml
+++ b/.github/workflows/scorer-sync-gate.yml
@@ -1,0 +1,56 @@
+name: Scorer sync (regex score-mechanized.mjs ↔ UiDeterministicScorer.php)
+
+# O UiDeterministicScorer.php (juiz de PR · Onda 1 LLM-judge→determinístico) é cópia fiel dos
+# regex de score-mechanized.mjs. Duplicação consciente (PHP ≠ Node no workflow do PR Judge), mas
+# duplicação É risco: se um regex mudar num e não no outro, o juiz-de-PR e o scorer mecanizado
+# divergem em silêncio. Este gate verifica que as assinaturas R1-R4 estão nos dois fontes.
+#
+# Node puro (lê os 2 fontes), sem deps. Local: npm run scorer:sync
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'prototipo-ui/audit/score-mechanized.mjs'
+      - 'Modules/Jana/Ai/UiDeterministicScorer.php'
+      - 'scripts/scorer-sync-check.mjs'
+      - '.github/workflows/scorer-sync-gate.yml'
+  pull_request:
+    paths:
+      - 'prototipo-ui/audit/score-mechanized.mjs'
+      - 'Modules/Jana/Ai/UiDeterministicScorer.php'
+      - 'scripts/scorer-sync-check.mjs'
+      - '.github/workflows/scorer-sync-gate.yml'
+
+concurrency:
+  group: scorer-sync-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scorer-sync:
+    name: Scorer sync · regex .mjs ↔ .php
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: Sync check (regex R1-R4 nos dois fontes)
+        run: node scripts/scorer-sync-check.mjs
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "❌ Os regex de score-mechanized.mjs e UiDeterministicScorer.php divergiram."
+          echo ""
+          echo "O scorer PHP do PR Judge é CÓPIA FIEL dos regex do .mjs. Se você mudou um,"
+          echo "mude o outro também (ou ajuste a assinatura em scripts/scorer-sync-check.mjs"
+          echo "se a mudança foi intencional E sincronizada nos dois)."
+          echo ""
+          echo "Local: npm run scorer:sync"
+          echo "Refs: Onda 1 (ADR 0255) · score-mechanized.mjs é a fonte canônica dos regex"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "a11y:report": "node scripts/a11y-ratchet.mjs --report",
     "a11y:baseline:write": "node scripts/a11y-ratchet.mjs --write",
     "a11y:axe": "vitest run tests/a11y-primitives.test.tsx",
+    "scorer:sync": "node scripts/scorer-sync-check.mjs",
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts"
   },

--- a/scripts/reuse-index.mjs
+++ b/scripts/reuse-index.mjs
@@ -3,7 +3,7 @@
 //
 // POR QUE EXISTE (plano 2026-06-06 · memory/sessions/2026-06-06-plano-inventario-anti-duplicacao.md):
 // a IA recria função/componente/Model que JÁ existe porque não tem onde perguntar "isso já existe?".
-// Documento-índice escrito à mão APODRECE (ADR 0240). Este índice é REGENERADO do código a cada
+// Documento-índice escrito à mão APODRECE (ADR 0239: git=SSOT, derivado>escrito). Este índice é REGENERADO do código a cada
 // chamada — impossível apodrecer. Responde "reusa ou cria, e em qual arquivo".
 //
 // Mata os erros reais T-AP-1 / T-AP-7 (inventar Model/Service que não existe — LICOES_F3_FINANCEIRO_REJEITADO).
@@ -23,8 +23,8 @@
 // DERIVADO, consultável e abrangente (JS+PHP). Não substitui css-size/pageheader/conformance gates —
 // é a camada de "reusa ou cria, em qual arquivo" que faltava.
 //
-// Refs: memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md (problema #5) · ADR 0240 (derivado>escrito)
-//       · ADR 0239 (git=SSOT) · prototipo-ui/REGISTRY_DS_COMPONENTES.md.
+// Refs: memory/requisitos/_DesignSystem/MANUAL-CSS-JS.md (problema #5)
+//       · ADR 0239 (git=SSOT · derivado>escrito) · prototipo-ui/REGISTRY_DS_COMPONENTES.md.
 
 import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join, relative, sep, basename } from 'node:path';

--- a/scripts/scorer-sync-check.mjs
+++ b/scripts/scorer-sync-check.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// scripts/scorer-sync-check.mjs — guarda a SINCRONIA dos regex entre as duas implementações.
+//
+// POR QUE: o `UiDeterministicScorer.php` (juiz de PR · Onda 1) é CÓPIA FIEL dos regex de
+// `score-mechanized.mjs` (scorer mecanizado das 222 telas). É uma duplicação CONSCIENTE
+// (PHP não roda Node no workflow do PR Judge), mas duplicação É risco: se um regex mudar
+// num arquivo e não no outro, o juiz-de-PR e o scorer mecanizado DIVERGEM silenciosamente.
+//
+// Este gate fecha esse risco (ironia honesta: nasceu numa onda anti-duplicação): verifica que
+// as ASSINATURAS-NÚCLEO de cada regra (R1-R4) aparecem nos DOIS arquivos. Se uma existir só num
+// → DRIFT → falha. Força quem editar um a editar o outro. Node puro (lê os 2 fontes), sem deps.
+//
+// NÃO é compare AST-perfeito — é o piso pragmático que pega o drift que importa (o literal do regex).
+// Local: node scripts/scorer-sync-check.mjs
+
+import { readFileSync } from 'node:fs';
+
+const MJS_PATH = 'prototipo-ui/audit/score-mechanized.mjs';
+const PHP_PATH = 'Modules/Jana/Ai/UiDeterministicScorer.php';
+
+// Assinaturas que DEVEM existir verbatim nos dois fontes (substrings dos regex, escolhidas
+// sem ambiguidade de escaping de slash). Drift = presente num, ausente no outro.
+const SIGNATURES = {
+  'R1 hex': '#[0-9a-fA-F]{3,8}',
+  'R1 exceção fff/000': '#(?:fff|ffffff|000|000000)',
+  'R1 color-fn': '(?:oklch|rgba?|hsla?)',
+  'R2 elemento nativo': '(?:select|input|textarea|table)',
+  'R3 localStorage': '(?:get|set|remove)Item',
+  'R4 svg': '<svg',
+  'R4 icon-lib externa': '(?:react-icons|@heroicons|@tabler',
+};
+
+let mjs, php;
+try { mjs = readFileSync(MJS_PATH, 'utf8'); } catch { console.error(`✗ não achei ${MJS_PATH}`); process.exit(2); }
+try { php = readFileSync(PHP_PATH, 'utf8'); } catch { console.error(`✗ não achei ${PHP_PATH}`); process.exit(2); }
+
+const drift = [];
+for (const [rule, sig] of Object.entries(SIGNATURES)) {
+  const inMjs = mjs.includes(sig);
+  const inPhp = php.includes(sig);
+  if (inMjs !== inPhp) drift.push({ rule, sig, inMjs, inPhp });
+}
+
+if (drift.length === 0) {
+  console.log(`✓ scorer sync OK — ${Object.keys(SIGNATURES).length} assinaturas R1-R4 presentes nos dois (${MJS_PATH} ↔ ${PHP_PATH}).`);
+  process.exit(0);
+}
+
+console.error(`✗ DRIFT entre ${MJS_PATH} e ${PHP_PATH} — os regex divergiram:\n`);
+for (const d of drift) {
+  console.error(`  ${d.rule} ("${d.sig}"): score-mechanized.mjs=${d.inMjs ? 'SIM' : 'NÃO'} · UiDeterministicScorer.php=${d.inPhp ? 'SIM' : 'NÃO'}`);
+}
+console.error(`\nO scorer PHP do PR Judge é cópia fiel dos regex do .mjs. Se mudou um, mude o outro`);
+console.error(`(ou ajuste a assinatura aqui se a mudança for intencional + sincronizada nos dois).`);
+process.exit(1);


### PR DESCRIPTION
## 2 dívidas que EU gerei nesta sessão (Wagner: 'o que faltou/aperfeiçoar')

**(1) Ref errado no reuse-index** — citava `ADR 0240` pro princípio "derivado>escrito", mas o lar real é o **0239** (git=SSOT). A pesquisa pegou, eu disse "vou consertar" e não consertei. Consolidado no 0239.

**(2) Duplicação que eu introduzi sem guard** — o `UiDeterministicScorer.php` (juiz de PR · Onda 1) é **cópia fiel** dos regex do `score-mechanized.mjs`. Duplicação consciente (PHP ≠ Node no workflow), mas **sem gate driftava em silêncio** → o juiz-de-PR e o scorer mecanizado divergiriam. Ironia: nasceu numa onda anti-duplicação.

## O que entra

- `scorer-sync-check.mjs` + `scorer-sync-gate.yml` — verifica que as **assinaturas R1-R4** dos regex estão nos **dois** fontes. **Provado:** quebrei `oklch|rgba?|hsla?` no .php → exit 1 identificando o drift; restaurei → exit 0. Node puro.
- reuse-index ref `0240→0239`.

Fecha as 2 pontas soltas. O resto (cobertura design-spec 1→146, a11y 294→0) é incremental/reativo por design.

Refs: ADR 0239 · ADR 0255

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)