### PR TITLE
feat(governance): loop de aprendizado two-strikes pra erros de código

### DIFF
--- a/.claude/hooks/licoes-code-two-strikes.ps1
+++ b/.claude/hooks/licoes-code-two-strikes.ps1
@@ -1,0 +1,78 @@
+# licoes-code-two-strikes.ps1 - Gatilho mecanizado do loop de aprendizado de codigo.
+# Disparado em SessionStart (apos brief-fetch) pelo .claude/settings.json.
+# Origem: sessao 2026-06-06 (Wagner: "meu sistema esta preparado a evoluir quando
+#   esses erros aparecem? quando deve ser acionado o aprendizado?").
+# Le memory/LICOES_CODE.md e ALARMA quando uma classe de erro repetiu
+#   (Ocorrencias >= 2) e ainda NAO virou defesa mecanica (Gate: none).
+# E so um nudge: NUNCA bloqueia, sempre exit 0. ASCII puro (PS 5.1 compat).
+# Override de path pra teste: $env:OIMPRESSO_LICOES_CODE_PATH
+# Limiar configuravel: $env:OIMPRESSO_LICOES_THRESHOLD (default 2)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+try {
+    if ($env:OIMPRESSO_LICOES_CODE_PATH) {
+        $path = $env:OIMPRESSO_LICOES_CODE_PATH
+    } else {
+        $repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+        $path = Join-Path $repo 'memory\LICOES_CODE.md'
+    }
+    if (-not (Test-Path $path)) { exit 0 }
+
+    $threshold = 2
+    if ($env:OIMPRESSO_LICOES_THRESHOLD) {
+        $parsed = 0
+        if ([int]::TryParse($env:OIMPRESSO_LICOES_THRESHOLD, [ref]$parsed)) { $threshold = $parsed }
+    }
+
+    $lines = Get-Content $path -Encoding UTF8
+
+    $licoes = @()
+    $cur = $null
+    foreach ($ln in $lines) {
+        if ($ln -match '^##\s+(LC-\S+)\s*[-—]?\s*(.*)$') {
+            if ($cur) { $licoes += $cur }
+            $cur = [pscustomobject]@{ id = $Matches[1]; titulo = $Matches[2].Trim(); ocorr = 0; gate = '' }
+            continue
+        }
+        if (-not $cur) { continue }
+        if ($ln -match '\*\*Ocorr.*?(\d+)') { $cur.ocorr = [int]$Matches[1] }
+        elseif ($ln -match '\*\*Gate.*?:\s*(.+?)\s*$') { $cur.gate = ($Matches[1] -replace '\*\*','').Trim() }
+    }
+    if ($cur) { $licoes += $cur }
+
+    # Sem gate = gate vazio, 'none', 'nenhum' ou '-'
+    function Test-SemGate([string]$g) {
+        if (-not $g) { return $true }
+        return ($g -match '^(none|nenhum|nenhuma|-|n/a|na)$')
+    }
+
+    $alarme = @($licoes | Where-Object { $_.ocorr -ge $threshold -and (Test-SemGate $_.gate) })
+    $watch  = @($licoes | Where-Object { $_.ocorr -lt $threshold -and (Test-SemGate $_.gate) })
+
+    if ($alarme.Count -eq 0 -and $watch.Count -eq 0) { exit 0 }
+
+    function ConvertTo-Ascii([string]$s) { return ($s -replace '[^\x20-\x7E]', '.') }
+
+    Write-Host ""
+    Write-Host "=== LICOES [CODE] - gatilho two-strikes (audit loop de aprendizado) ==="
+
+    if ($alarme.Count -gt 0) {
+        Write-Host ("  [!] {0} classe(s) repetiram (>= {1}x) e NAO tem gate. PROMOVER A DEFESA MECANICA:" -f $alarme.Count, $threshold)
+        foreach ($a in $alarme) {
+            Write-Host ("      {0} - {1}  ({2}x, sem gate)" -f $a.id, (ConvertTo-Ascii $a.titulo), $a.ocorr)
+        }
+        Write-Host "  ACAO: avise o Wagner e proponha o gate/hook/baseline que mata essa classe."
+        Write-Host "  (Quando criar o gate, troque 'Gate: none' pelo nome dele em LICOES_CODE.md - o alarme some.)"
+    }
+
+    if ($watch.Count -gt 0) {
+        Write-Host ("  [.] {0} classe(s) em WATCH (sem gate, < {1}x). Se reincidirem, viram alarme." -f $watch.Count, $threshold)
+    }
+
+    Write-Host ""
+} catch {
+    # Falha silenciosa: nudge nunca quebra inicio de sessao.
+    exit 0
+}
+exit 0

--- a/.claude/hooks/licoes-code-two-strikes.test.ps1
+++ b/.claude/hooks/licoes-code-two-strikes.test.ps1
@@ -1,0 +1,95 @@
+# Smoke test -- licoes-code-two-strikes.ps1
+# Roda: powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/licoes-code-two-strikes.test.ps1
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path $MyInvocation.MyCommand.Path -Parent
+$hook = Join-Path $here 'licoes-code-two-strikes.ps1'
+
+$failures = 0
+$total = 0
+
+function Invoke-Hook {
+    param([string]$Content, [string]$Threshold = $null)
+
+    $tmp = [System.IO.Path]::GetTempFileName()
+    [System.IO.File]::WriteAllText($tmp, $Content, (New-Object System.Text.UTF8Encoding $false))
+
+    $env:OIMPRESSO_LICOES_CODE_PATH = $tmp
+    if ($Threshold) { $env:OIMPRESSO_LICOES_THRESHOLD = $Threshold } else { $env:OIMPRESSO_LICOES_THRESHOLD = $null }
+
+    $out = & powershell -NoProfile -ExecutionPolicy Bypass -File $hook 2>$null
+    Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    $env:OIMPRESSO_LICOES_CODE_PATH = $null
+    $env:OIMPRESSO_LICOES_THRESHOLD = $null
+
+    return ($out -join "`n")
+}
+
+function Assert-Contains {
+    param([string]$Name, [string]$Haystack, [string]$Needle, [bool]$ShouldContain = $true)
+    $script:total++
+    $has = $Haystack.Contains($Needle)
+    if ($has -eq $ShouldContain) {
+        Write-Host "  OK  $Name"
+    } else {
+        $verb = if ($ShouldContain) { 'esperava conter' } else { 'NAO devia conter' }
+        Write-Host "  FAIL $Name -- $verb '$Needle'" -ForegroundColor Red
+        Write-Host "       saida: $Haystack" -ForegroundColor DarkGray
+        $script:failures++
+    }
+}
+
+Write-Host "=== licoes-code-two-strikes smoke ==="
+
+# T1: Ocorr 2 + Gate none -> ALARME (cita LC-90 + PROMOVER)
+$c1 = @"
+# header
+## LC-90 - teste sem gate repetido
+- **Ocorrencias:** 2
+- **Gate:** none
+"@
+$o1 = Invoke-Hook -Content $c1
+Assert-Contains 'T1 alarme cita LC-90' $o1 'LC-90' $true
+Assert-Contains 'T1 mostra PROMOVER' $o1 'PROMOVER' $true
+
+# T2: Ocorr 2 + Gate preenchido -> NAO alarma (id nao aparece)
+$c2 = @"
+## LC-91 - teste com gate existente
+- **Ocorrencias:** 2
+- **Gate:** multi-tenant-gate
+"@
+$o2 = Invoke-Hook -Content $c2
+Assert-Contains 'T2 com gate nao alarma' $o2 'LC-91' $false
+
+# T3: Ocorr 1 + Gate none -> WATCH, nao alarme
+$c3 = @"
+## LC-92 - novo sem reincidencia
+- **Ocorrencias:** 1
+- **Gate:** none
+"@
+$o3 = Invoke-Hook -Content $c3
+Assert-Contains 'T3 watch mostra WATCH' $o3 'WATCH' $true
+Assert-Contains 'T3 watch sem PROMOVER' $o3 'PROMOVER' $false
+
+# T4: threshold=3 -> Ocorr 2 sem gate NAO alarma (vira watch)
+$c4 = @"
+## LC-93 - duas ocorrencias com limiar 3
+- **Ocorrencias:** 2
+- **Gate:** none
+"@
+$o4 = Invoke-Hook -Content $c4 -Threshold '3'
+Assert-Contains 'T4 limiar 3 nao alarma LC-93 promover' $o4 'PROMOVER' $false
+Assert-Contains 'T4 limiar 3 vira watch' $o4 'WATCH' $true
+
+# T5: arquivo so com gates resolvidos -> sem saida
+$c5 = @"
+## LC-94 - tudo resolvido
+- **Ocorrencias:** 5
+- **Gate:** algum-gate
+"@
+$o5 = Invoke-Hook -Content $c5
+Assert-Contains 'T5 tudo resolvido sem saida' $o5 'LICOES [CODE]' $false
+
+Write-Host ""
+Write-Host "Total: $total | Failures: $failures"
+if ($failures -gt 0) { exit 1 } else { exit 0 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,10 @@
           },
           {
             "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/licoes-code-two-strikes.ps1"
+          },
+          {
+            "type": "command",
             "command": "node .claude/hooks/git-base-freshness-guard.mjs"
           }
         ]

--- a/memory/LICOES_CODE.md
+++ b/memory/LICOES_CODE.md
@@ -1,0 +1,87 @@
+# LIÇÕES [CODE] — erros de código a não repetir
+
+> Escopo: **código backend/infra** (PHP, Eloquent, jobs, migrations, controllers, services, CI).
+> Equivalente de `LICOES_CC.md` (que cobre design/[CC]) pro lado de engenharia.
+> Subordinado a `memory/proibicoes.md` (canônico). **Append-only.**
+> Lido no início de toda sessão pelo hook `licoes-code-two-strikes.ps1`.
+>
+> **Por que existe:** fechar o elo manual do loop de aprendizado — quando uma classe de
+> erro de IA-code repete, ela precisa virar **defesa mecânica** (gate/hook/baseline), não
+> ficar só na memória de quem lembrou. Origem: sessão 2026-06-06 (Wagner: "meu sistema está
+> preparado a evoluir quando esses erros aparecem? quando deve ser acionado o aprendizado?").
+>
+> ## Regra "two-strikes" (gatilho do aprendizado)
+> - **1ª ocorrência** de um erro → conserta o bug. NÃO codifica gate ainda.
+> - **2ª ocorrência da mesma `Classe`** → PARA. Vira defesa mecânica (gate/hook/baseline).
+> - **Chegou em PROD / cliente pagante** → codifica SEMPRE (mesmo na 1ª). Espelha ADR 0105.
+> - **Override de gate usado** → revisa se o gate está errado (aprendizado reverso).
+>
+> O hook alarma quando uma lição tem `Ocorrências >= 2` **e** `Gate: none`.
+>
+> ## Formato por entrada (campos lidos pela máquina — não renomear)
+> ```
+> ## LC-NN — <título curto>
+> - **Erro:** o que aconteceu
+> - **Sintoma:** como apareceu
+> - **Regra:** o que fazer pra não repetir
+> - **Classe:** <slug-estável>   (agrupa ocorrências da mesma família)
+> - **Ocorrências:** <int>       (incrementar a cada vez que a classe reaparece)
+> - **Gate:** none | <nome-do-gate/hook/baseline que já impede>
+> - **Ref:** <ADR/PR/sessão>
+> ```
+> Ao consertar um erro de código: ache a `Classe` aqui. Existe? Incrementa `Ocorrências`.
+> Não existe? Cria `LC-NN` novo com `Ocorrências: 1`. Quando virar gate, troca `Gate: none`
+> pelo nome do gate e o alarme some sozinho (catraca — só sobe).
+
+---
+
+## LC-01 — Query sem global scope vazando entre tenants
+- **Erro:** Eloquent/Service consultando entidade com `business_id` sem o global scope (ou em job na fila que perdeu o tenant).
+- **Sintoma:** dado de um business aparecendo pra outro. Pior bug possível do projeto.
+- **Regra:** todo model de negócio usa global scope; jobs re-resolvem o tenant; CLI/superadmin trata cross-business explicitamente (skill `multi-tenant-patterns`).
+- **Classe:** multi-tenant-scope-missing
+- **Ocorrências:** 2
+- **Gate:** multi-tenant-gate (.github/workflows/multi-tenant-gate.yml) + skill Tier A
+- **Ref:** ADR 0093
+
+## LC-02 — Mock/stub deixado em código de produção
+- **Erro:** scaffolding com dados mockados (cowork/demo) sobrevivendo no caminho de produção.
+- **Sintoma:** tela "funciona" com dado falso; quebra com dado real.
+- **Regra:** mock só em teste/seed. Caminho de prod nunca importa fixture.
+- **Classe:** mock-in-prod
+- **Ocorrências:** 2
+- **Gate:** scripts/no-mock-in-prod.mjs (+ no-mock-baseline.json)
+- **Ref:** PR #2262
+
+---
+
+> Abaixo: classes **identificadas no audit 2026-06-06 como sem catraca** (`Gate: none`).
+> Ainda em `Ocorrências: 0` — registradas proativamente, viram alarme se reincidirem.
+> (Honestidade: 0 = nenhuma reincidência *observada* ainda, não "nunca aconteceu".)
+
+## LC-03 — Teste só de caminho feliz (sem prova de que pega bug)
+- **Erro:** suíte Pest verde que não exercita borda/erro; IA tende a gerar exatamente isso.
+- **Sintoma:** cobertura "verde" enquanto bug passa. Teste vira teatro.
+- **Regra:** teste tem que falhar quando o código quebra. Mutation testing (infection `--min-msi`) prova isso.
+- **Classe:** happy-path-only-test
+- **Ocorrências:** 0
+- **Gate:** none
+- **Ref:** audit 2026-06-06 (gap nº1)
+
+## LC-04 — N+1 / query dentro de loop
+- **Erro:** loop com query por iteração (IA adora gerar); sem eager-load.
+- **Sintoma:** tela lenta sob dado real; explode com volume.
+- **Regra:** eager-load + `Inertia::defer` em props pesadas (skill `inertia-defer-default`). Falta gate de contagem de queries.
+- **Classe:** n-plus-one-query
+- **Ocorrências:** 0
+- **Gate:** none
+- **Ref:** audit 2026-06-06 (gap nº5)
+
+## LC-05 — Injeção genérica (SQLi/XSS/path-traversal) fora da regra custom
+- **Erro:** input não-sanitizado em caminho sem gate específico (multi-tenant é gateado; injeção genérica não).
+- **Sintoma:** vulnerabilidade que phpstan (type-level) não pega.
+- **Regra:** prepared statements; escape na borda. Falta SAST/taint (semgrep/psalm-taint).
+- **Classe:** injection-generic
+- **Ocorrências:** 0
+- **Gate:** none
+- **Ref:** audit 2026-06-06 (gap nº2)


### PR DESCRIPTION
## O que é (em 1 frase)

Quando um **tipo de erro de código repete** e ainda não tem alarme automático (gate/hook), o sistema **te cobra** o alarme no início da sessão — em vez de depender de alguém lembrar. Fecha o elo manual do loop de aprendizado.

## Por que

Auditoria 2026-06-06: o projeto já é antifrágil pra **design** (`LICOES_CC.md`) e tem catraca em gates/baselines. Mas o lado **código** dependia de alguém *lembrar* de transformar um erro recorrente em defesa mecânica. Risco: uma classe nova de erro repetir 3-4× antes de virar gate.

## A regra "two-strikes"

- **1ª ocorrência** → conserta o bug (não codifica gate ainda)
- **2ª ocorrência da mesma classe** → vira defesa mecânica (gate/hook/baseline)
- **Chegou em prod/cliente** → codifica sempre (espelha ADR 0105 cliente-como-sinal)

## O que entra

| Arquivo | Papel |
|---|---|
| `memory/LICOES_CODE.md` | Captura append-only de lições de código (machine-readable: Classe/Ocorrências/Gate). Semeado com 5 lições reais |
| `.claude/hooks/licoes-code-two-strikes.ps1` | Nudge SessionStart. Alarma `Ocorrências>=2 + Gate:none`. **Nunca bloqueia** (exit 0), ASCII/PS 5.1 |
| `.claude/hooks/licoes-code-two-strikes.test.ps1` | 8 smoke tests |
| `.claude/settings.json` | Wiring SessionStart após `loop-fechar-check` |

## Comprovação

- Teste: **8/8 verde**
- Contra o arquivo real: mostra 3 classes em WATCH (gaps do audit: testes happy-path, N+1, injeção genérica), **zero alarme falso** (LC-01/02 já têm gate)

## Características de segurança

- Só **nudge** — nunca bloqueia trabalho, `exit 0` sempre, silent-fail
- Catraca: alarme some sozinho quando o gate é criado (`Gate: none` → nome do gate)
- Não toca Brain B / autonomia ADS

## Notas pro reviewer

- É um hook **always-on team-wide** (Tier B nudge, não-bloqueante). Se preferir formalizar via ADR Nygard, posso draftar — sinaliza.
- Próximo passo natural (separado): implementar o gate de **mutation testing (infection)** que mata o LC-03 (testes de caminho feliz — o pior hábito da IA-code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)