### PR TITLE
feat(ds): refino v2 dos primitivos de layout (ADR 0253) — cobertura ERP real

### DIFF
--- a/resources/js/Components/layout/box.tsx
+++ b/resources/js/Components/layout/box.tsx
@@ -5,14 +5,15 @@ import { Slot } from "radix-ui"
 import { cn } from "@/Lib/utils"
 
 /**
- * Box — primitivo de layout neutro (ADR 0253 · F3).
+ * Box — primitivo de layout neutro (ADR 0253 · F3 · refino v2 2026-06-07).
  *
- * Container sem opinião visual além de ESPAÇO, e espaço só vem de token. Os
- * valores de `p`/`px`/`py` são enumerados via CVA → o TS recusa px/hex literal
- * em tempo de compilação (M-AP "diferente = errado" no nível do tipo).
+ * Container sem opinião visual além de ESPAÇO e SUPERFÍCIE, e tudo só vem de
+ * token. `p`/`px`/`py` são enumerados via CVA → o TS recusa px/hex literal em
+ * tempo de compilação. O refino v2 entrega a parte de "cor" que a ADR 0253
+ * nomeou e a v1 não tinha: `bg`/`rounded`/`border` mapeiam pros tokens do
+ * `@theme` (inertia.css) — fecha o caso "card" sem nascer um `.css` bespoke.
  *
- * `asChild` (Radix Slot) projeta as props no filho sem inflar a árvore DOM —
- * mesmo contrato de `@/Components/ui/badge`.
+ * `asChild` (Radix Slot) projeta as props no filho sem inflar a árvore DOM.
  */
 const boxVariants = cva("", {
   variants: {
@@ -28,18 +29,35 @@ const boxVariants = cva("", {
       0: "py-0", 1: "py-1", 2: "py-2", 3: "py-3", 4: "py-4", 5: "py-5",
       6: "py-6", 8: "py-8", 10: "py-10", 12: "py-12",
     },
+    /* superfície — só tokens semânticos do @theme (geram utilities Tailwind v4) */
+    bg: {
+      none: "",
+      card: "bg-card text-card-foreground",
+      muted: "bg-muted",
+      background: "bg-background",
+      secondary: "bg-secondary text-secondary-foreground",
+      accent: "bg-accent text-accent-foreground",
+      primary: "bg-primary text-primary-foreground",
+    },
+    rounded: {
+      none: "rounded-none", sm: "rounded-sm", md: "rounded-md", lg: "rounded-lg",
+    },
+    border: {
+      true: "border border-border",
+      false: "",
+    },
   },
 })
 
 export type BoxProps = React.ComponentProps<"div"> &
   VariantProps<typeof boxVariants> & { asChild?: boolean }
 
-export function Box({ className, p, px, py, asChild = false, ...props }: BoxProps) {
+export function Box({ className, p, px, py, bg, rounded, border, asChild = false, ...props }: BoxProps) {
   const Comp = asChild ? Slot.Root : "div"
   return (
     <Comp
       data-slot="box"
-      className={cn(boxVariants({ p, px, py }), className)}
+      className={cn(boxVariants({ p, px, py, bg, rounded, border }), className)}
       {...props}
     />
   )

--- a/resources/js/Components/layout/container.tsx
+++ b/resources/js/Components/layout/container.tsx
@@ -5,19 +5,24 @@ import { Slot } from "radix-ui"
 import { cn } from "@/Lib/utils"
 
 /**
- * Container — largura-máxima de página + padding horizontal de token (ADR 0253 · F3).
+ * Container — largura-máxima de página + padding horizontal de token (ADR 0253 · F3 · refino v2).
  *
- * O wrapper de página: centraliza e limita a medida de leitura. `size` mapeia
- * pros breakpoints-token do Tailwind; `px` é o respiro lateral (token).
+ * O wrapper de página: centraliza e limita a medida de leitura. `px` é o respiro
+ * lateral (token).
+ *
+ * ⚠️ Correção do refino v2: a v1 usava `max-w-screen-*`, utilities REMOVIDAS no
+ * Tailwind v4 — o limite de largura virava silenciosamente nulo. Agora mapeia
+ * pra escala `max-w-*` que existe de fato no v4 (valores controlados no enum,
+ * nunca px literal no call-site).
  */
 const containerVariants = cva("mx-auto w-full", {
   variants: {
     size: {
-      sm: "max-w-screen-sm",
-      md: "max-w-screen-md",
-      lg: "max-w-screen-lg",
-      xl: "max-w-screen-xl",
-      "2xl": "max-w-screen-2xl",
+      sm: "max-w-3xl",      /* ~768px  */
+      md: "max-w-5xl",      /* ~1024px */
+      lg: "max-w-6xl",      /* ~1152px */
+      xl: "max-w-7xl",      /* ~1280px — alvo Larissa/Wagner */
+      "2xl": "max-w-[96rem]", /* ~1536px */
       full: "max-w-full",
     },
     px: {

--- a/resources/js/Components/layout/grid.tsx
+++ b/resources/js/Components/layout/grid.tsx
@@ -5,11 +5,16 @@ import { Slot } from "radix-ui"
 import { cn } from "@/Lib/utils"
 
 /**
- * Grid — grade de N colunas-token com `gap` de token (ADR 0253 · F3).
+ * Grid — grade de N colunas-token com `gap` de token (ADR 0253 · F3 · refino v2).
  *
- * Substitui `<div className="grid grid-cols-3 gap-4">` solto. `cols` enumerado
- * (1–6, 12) cobre os arranjos reais de cadastro/dashboard; responsividade fina
- * fica por composição (`className` extra) até surgir demanda pra prop dedicada.
+ * Dois modos, escolha um:
+ *  • `cols` (1–6,12) → grade FIXA de cadastro/formulário.
+ *  • `min` (sm/md/lg) → grade RESPONSIVA auto-fit: as colunas se reflowam pela
+ *    largura disponível (`repeat(auto-fill, minmax(<token>, 1fr))`). É o que
+ *    cura a quebra entre 1280 (Larissa) e 1440 (Wagner) sem media-query na tela,
+ *    e expressa o `repeat(auto-fill,minmax(…))` que a grade de cards do DS usa.
+ *
+ * Largura mínima vem de token (enum), não de px solto no call-site.
  */
 const gridVariants = cva("grid", {
   variants: {
@@ -17,13 +22,18 @@ const gridVariants = cva("grid", {
       1: "grid-cols-1", 2: "grid-cols-2", 3: "grid-cols-3", 4: "grid-cols-4",
       5: "grid-cols-5", 6: "grid-cols-6", 12: "grid-cols-12",
     },
+    /* auto-fit responsivo — largura mínima da coluna por token de escala */
+    min: {
+      sm: "grid-cols-[repeat(auto-fill,minmax(14rem,1fr))]",
+      md: "grid-cols-[repeat(auto-fill,minmax(18rem,1fr))]",
+      lg: "grid-cols-[repeat(auto-fill,minmax(22rem,1fr))]",
+    },
     gap: {
       0: "gap-0", 1: "gap-1", 2: "gap-2", 3: "gap-3", 4: "gap-4", 5: "gap-5",
       6: "gap-6", 8: "gap-8", 10: "gap-10", 12: "gap-12",
     },
   },
   defaultVariants: {
-    cols: 1,
     gap: 4,
   },
 })
@@ -31,12 +41,14 @@ const gridVariants = cva("grid", {
 export type GridProps = React.ComponentProps<"div"> &
   VariantProps<typeof gridVariants> & { asChild?: boolean }
 
-export function Grid({ className, cols, gap, asChild = false, ...props }: GridProps) {
+export function Grid({ className, cols, min, gap, asChild = false, ...props }: GridProps) {
   const Comp = asChild ? Slot.Root : "div"
+  // `min` (auto-fit) vence `cols` se ambos vierem; default = 1 coluna quando nenhum.
+  const resolvedCols = min ? undefined : (cols ?? 1)
   return (
     <Comp
       data-slot="grid"
-      className={cn(gridVariants({ cols, gap }), className)}
+      className={cn(gridVariants({ cols: resolvedCols, min, gap }), className)}
       {...props}
     />
   )

--- a/resources/js/Components/layout/index.ts
+++ b/resources/js/Components/layout/index.ts
@@ -1,5 +1,7 @@
 /**
  * Primitivos de layout — a camada que falta entre tokens DS v6 e telas (ADR 0253 · F3).
+ * Refino v2 (2026-06-07): Box+superfície · Stack/Inline+divider · Grid+auto-fit ·
+ * Container max-w TW v4-safe · Text+mono/tabular/tons/4xl-5xl. Sem mudança de exports.
  *
  * Regra: layout é COMPOSIÇÃO destes primitivos, nunca `<div className="flex gap-4">`
  * solto nem `.css` bespoke. Props = token, sempre (enforcement no nível do tipo via CVA).

--- a/resources/js/Components/layout/inline.tsx
+++ b/resources/js/Components/layout/inline.tsx
@@ -5,10 +5,12 @@ import { Slot } from "radix-ui"
 import { cn } from "@/Lib/utils"
 
 /**
- * Inline — alinha filhos na horizontal com `gap` de token + `wrap` (ADR 0253 · F3).
+ * Inline — alinha filhos na horizontal com `gap` de token + `wrap` (ADR 0253 · F3 · refino v2).
  *
  * Substitui o `<div className="flex items-center gap-2">` solto. `wrap` liga o
- * flex-wrap (toolbars, chips). Espaço só por token.
+ * flex-wrap (toolbars, chips). Espaço só por token. O refino v2 adiciona
+ * `divider` (separador vertical via `divide-x divide-border`) — o "·" entre
+ * meta-itens (ex.: "Cliente PJ · Frota · desde mar/2019").
  */
 const inlineVariants = cva("flex flex-row", {
   variants: {
@@ -35,6 +37,10 @@ const inlineVariants = cva("flex flex-row", {
       true: "flex-wrap",
       false: "flex-nowrap",
     },
+    divider: {
+      true: "divide-x divide-border",
+      false: "",
+    },
   },
   defaultVariants: {
     gap: 2,
@@ -45,12 +51,12 @@ const inlineVariants = cva("flex flex-row", {
 export type InlineProps = React.ComponentProps<"div"> &
   VariantProps<typeof inlineVariants> & { asChild?: boolean }
 
-export function Inline({ className, gap, align, justify, wrap, asChild = false, ...props }: InlineProps) {
+export function Inline({ className, gap, align, justify, wrap, divider, asChild = false, ...props }: InlineProps) {
   const Comp = asChild ? Slot.Root : "div"
   return (
     <Comp
       data-slot="inline"
-      className={cn(inlineVariants({ gap, align, justify, wrap }), className)}
+      className={cn(inlineVariants({ gap, align, justify, wrap, divider }), className)}
       {...props}
     />
   )

--- a/resources/js/Components/layout/stack.tsx
+++ b/resources/js/Components/layout/stack.tsx
@@ -5,10 +5,12 @@ import { Slot } from "radix-ui"
 import { cn } from "@/Lib/utils"
 
 /**
- * Stack — empilha filhos na vertical com `gap` de token (ADR 0253 · F3).
+ * Stack — empilha filhos na vertical com `gap` de token (ADR 0253 · F3 · refino v2).
  *
  * Substitui o `<div className="flex flex-col gap-4">` solto repetido pelas telas.
- * `gap`/`align`/`justify` são enumerados → espaço nunca vem de px literal.
+ * `gap`/`align`/`justify` enumerados → espaço nunca vem de px literal. O refino v2
+ * adiciona `divider` (hairline entre itens via `divide-y divide-border`) — o
+ * separador onipresente no DS, antes feito à mão.
  */
 const stackVariants = cva("flex flex-col", {
   variants: {
@@ -31,6 +33,10 @@ const stackVariants = cva("flex flex-col", {
       around: "justify-around",
       evenly: "justify-evenly",
     },
+    divider: {
+      true: "divide-y divide-border",
+      false: "",
+    },
   },
   defaultVariants: {
     gap: 4,
@@ -40,12 +46,12 @@ const stackVariants = cva("flex flex-col", {
 export type StackProps = React.ComponentProps<"div"> &
   VariantProps<typeof stackVariants> & { asChild?: boolean }
 
-export function Stack({ className, gap, align, justify, asChild = false, ...props }: StackProps) {
+export function Stack({ className, gap, align, justify, divider, asChild = false, ...props }: StackProps) {
   const Comp = asChild ? Slot.Root : "div"
   return (
     <Comp
       data-slot="stack"
-      className={cn(stackVariants({ gap, align, justify }), className)}
+      className={cn(stackVariants({ gap, align, justify, divider }), className)}
       {...props}
     />
   )

--- a/resources/js/Components/layout/text.tsx
+++ b/resources/js/Components/layout/text.tsx
@@ -5,12 +5,19 @@ import { Slot } from "radix-ui"
 import { cn } from "@/Lib/utils"
 
 /**
- * Text — tipografia 100% via type-scale token (ADR 0253 · F3).
+ * Text — tipografia 100% via type-scale token (ADR 0253 · F3 · refino v2 2026-06-07).
  *
- * Mata o `className="text-[22px]"` / cor crua: `size`/`weight`/`tone` são
- * enumerados e mapeiam pros tokens do DS v6 (`text-foreground`,
- * `text-muted-foreground`, `text-primary`, `text-destructive`). `as` escolhe a
- * tag semântica (h1–h6/p/span/label) — estilo e semântica desacoplados.
+ * Mata o `className="text-[22px]"` / cor crua. `as` escolhe a tag semântica
+ * (h1–h6/p/span/label) — estilo e semântica desacoplados.
+ *
+ * Refino v2 — fecha os gaps que travavam telas de NÚMERO (vendas/financeiro/OS/NF-e):
+ *  • `family="mono"` + `numeric="tabular"` → money, placa, km, NF-e alinham.
+ *    (NB: o utility `font-mono` cai no mono do sistema até o token `--font-mono`
+ *     ("IBM Plex Mono") existir no @theme — decisão Tier 0 de [W], flag no handoff.)
+ *  • `tone` ganha `success`/`warning`/`destructive` (KPI +/−) — tokens REAIS do
+ *    @theme (inertia.css), não os nomes da régua CSS (`--pos/--neg`).
+ *  • `size` sobe até `5xl` — o KPI canônico é `4xl/36px` (DESIGN.md §16.3),
+ *    que a v1 (teto `3xl`) não expressava.
  */
 const textVariants = cva("", {
   variants: {
@@ -22,6 +29,8 @@ const textVariants = cva("", {
       xl: "text-xl",
       "2xl": "text-2xl",
       "3xl": "text-3xl",
+      "4xl": "text-4xl",
+      "5xl": "text-5xl",
     },
     weight: {
       normal: "font-normal",
@@ -29,11 +38,29 @@ const textVariants = cva("", {
       semibold: "font-semibold",
       bold: "font-bold",
     },
+    /* tons = tokens semânticos do @theme (geram utilities Tailwind v4) */
     tone: {
       default: "text-foreground",
       muted: "text-muted-foreground",
       primary: "text-primary",
+      success: "text-success",
+      warning: "text-warning",
       destructive: "text-destructive",
+    },
+    family: {
+      sans: "font-sans",
+      mono: "font-mono",
+    },
+    numeric: {
+      tabular: "tabular-nums",
+      normal: "",
+    },
+    leading: {
+      none: "leading-none",
+      tight: "leading-tight",
+      snug: "leading-snug",
+      normal: "leading-normal",
+      relaxed: "leading-relaxed",
     },
     align: {
       left: "text-left",
@@ -62,13 +89,17 @@ export type TextProps = React.HTMLAttributes<HTMLElement> &
   }
 
 export function Text({
-  className, size, weight, tone, align, truncate, as = "p", asChild = false, ...props
+  className, size, weight, tone, family, numeric, leading, align, truncate,
+  as = "p", asChild = false, ...props
 }: TextProps) {
   const Comp = asChild ? Slot.Root : as
   return (
     <Comp
       data-slot="text"
-      className={cn(textVariants({ size, weight, tone, align, truncate }), className)}
+      className={cn(
+        textVariants({ size, weight, tone, family, numeric, leading, align, truncate }),
+        className,
+      )}
       {...props}
     />
   )

--- a/tests/layout-primitives.test.tsx
+++ b/tests/layout-primitives.test.tsx
@@ -50,11 +50,14 @@ describe("primitivos — props viram classe-token", () => {
     expect(el.className).toContain("px-6")
   })
 
-  it("Container: size vira max-width-token e centraliza", () => {
+  it("Container: size vira max-width-token (escala TW v4-safe) e centraliza", () => {
+    // refino v2 (ADR 0253): `max-w-screen-*` foi removido no Tailwind v4 — virava
+    // no-op silencioso. Agora `lg` mapeia pra `max-w-6xl`, que existe de fato no v4.
     const { container } = render(<Container size="lg" />)
     const el = container.querySelector('[data-slot="container"]')!
     expect(el.className).toContain("mx-auto")
-    expect(el.className).toContain("max-w-screen-lg")
+    expect(el.className).toContain("max-w-6xl")
+    expect(el.className).not.toContain("max-w-screen-")
   })
 
   it("Text: tone/size viram token semântico; default tag = p", () => {
@@ -86,6 +89,50 @@ describe("primitivos — polimorfismo (semântica desacoplada do estilo)", () =>
     expect(el.getAttribute("data-slot")).toBe("stack")
     expect(el.className).toContain("flex-col")
     expect(el.className).toContain("gap-2")
+  })
+})
+
+describe("primitivos — refino v2 (ADR 0253): cobertura ERP real, ainda só-token", () => {
+  it("Box: bg/rounded/border viram superfície-token (fecha a promessa 'espaço E cor')", () => {
+    const { container } = render(<Box p={4} bg="card" rounded="lg" border />)
+    const el = container.querySelector('[data-slot="box"]')!
+    expect(el.className).toContain("bg-card")
+    expect(el.className).toContain("text-card-foreground")
+    expect(el.className).toContain("rounded-lg")
+    expect(el.className).toContain("border-border")
+  })
+
+  it("Stack/Inline: divider liga divide-y / divide-x divide-border", () => {
+    const { container } = render(
+      <>
+        <Stack divider />
+        <Inline divider />
+      </>,
+    )
+    expect(container.querySelector('[data-slot="stack"]')!.className).toContain("divide-y")
+    expect(container.querySelector('[data-slot="inline"]')!.className).toContain("divide-x")
+  })
+
+  it("Grid: min vira auto-fit responsivo (e vence cols quando ambos vierem)", () => {
+    const { container } = render(<Grid min="md" cols={3} gap={4} />)
+    const el = container.querySelector('[data-slot="grid"]')!
+    expect(el.className).toContain("auto-fill")
+    expect(el.className).toContain("minmax")
+    expect(el.className).not.toContain("grid-cols-3")
+  })
+
+  it("Text: family=mono + numeric=tabular alinham números (money/placa/km/NF-e)", () => {
+    const { container } = render(<Text family="mono" numeric="tabular">R$ 1.234,56</Text>)
+    const el = container.querySelector('[data-slot="text"]')!
+    expect(el.className).toContain("font-mono")
+    expect(el.className).toContain("tabular-nums")
+  })
+
+  it("Text: tons success/warning/destructive viram token-KPI; size sobe até 5xl", () => {
+    const { container } = render(<Text tone="success" size="4xl">+12,5%</Text>)
+    const el = container.querySelector('[data-slot="text"]')!
+    expect(el.className).toContain("text-success")
+    expect(el.className).toContain("text-4xl")
   })
 })
 


### PR DESCRIPTION
## Contexto

Implementa o **refino v2** do handoff Claude Design *"Avaliação — Primitivos de Layout (ADR 0253)"* (claude.ai/design). A avaliação leu `@main 1f53d49`, notou os 6 primitivos em **7.6/10** e entregou o código que fecha os gaps P0/P1/P2 (projeção **9.2/10**).

Aditivo, **sem breaking change**, só tokens reais do `@theme` (`inertia.css`). Nenhum `.css` novo, nenhum token novo.

## Mudanças

| Primitivo | O que entrou | Gap |
|---|---|---|
| **Text** | `family=mono` + `numeric=tabular` (money/placa/km/NF-e) · tons `success/warning/destructive` (KPI +/−) · `size` até `5xl` (cabe KPI 4xl/36px) · `leading` | P0 |
| **Container** | `max-w-screen-*` (**removido no Tailwind v4** → no-op silencioso) trocado por escala `max-w-*` real | P0 |
| **Grid** | `min` (sm/md/lg) → `repeat(auto-fill,minmax(…,1fr))` auto-fit que reflowa 1280↔1440 sem media-query; `cols` segue pro fixo | P1 |
| **Box** | `bg`/`rounded`/`border` via token — fecha a promessa "espaço **e** cor" da ADR | P1 |
| **Stack/Inline** | `divider` (`divide-y` / `divide-x divide-border`) | P2 |

## Verificação

- `tsc --noEmit`: **0 erro** em `Components/layout/` (erros remanescentes são pré-existentes e fora do escopo).
- `vitest tests/layout-primitives.test.tsx`: **15/15** — corrige o assert do Container pro mapping TW v4-safe + 5 casos novos cobrindo as variantes.
- `foundation:check` ✅ · `conformance:check` ✅.
- `build:inertia` ✅ — CSS emitido conferido: `max-w-7xl/6xl` presentes, **`max-w-screen-*` = 0** (resolve o único risco que a avaliação não pôde testar), e `bg-card`/`text-success`/`tabular-nums`/`auto-fill`/`divide-*`/`text-4xl-5xl` geram CSS real.

## Follow-ups (fora do escopo, registrados)

- `--font-mono` ("IBM Plex Mono") no `@theme`: decisão **Tier 0, só [W]**. Até lá `family="mono"` cai no mono do sistema.
- Critério de pronto da ADR 0253: tela piloto 100% primitivos + entrada no REGISTRY.

Refs: ADR-0253

🤖 Generated with [Claude Code](https://claude.com/claude-code)