### PR TITLE
fix(reference): corrige 3 fatos stale (MCP no CT100, Baileys OUT, Reverb→Centrifugo)

### DIFF
--- a/memory/reference/infra-proxmox-ct100.md
+++ b/memory/reference/infra-proxmox-ct100.md
@@ -1,6 +1,6 @@
 ---
 name: Proxmox + CT 100 — acesso, hardening, runtime
-description: Servidor Proxmox empresa (192.168.0.2) + CT 100 docker-host (192.168.0.50) — credenciais (no Vaultwarden), SSH key-only + fail2ban systemd backend, Tailscale 100.99.207.66, stack Docker (Traefik/Portainer/Vaultwarden/Reverb/Meilisearch), bootstrap services, Traefik labels pattern, autossh tunnel pra Hostinger MySQL
+description: Servidor Proxmox empresa (192.168.0.2) + CT 100 docker-host (192.168.0.50) — credenciais (no Vaultwarden), SSH key-only + fail2ban systemd backend, Tailscale 100.99.207.66, stack Docker (Traefik/Portainer/Vaultwarden/Centrifugo/Meilisearch), bootstrap services, Traefik labels pattern, autossh tunnel pra Hostinger MySQL
 type: reference
 ---
 
@@ -195,7 +195,7 @@ Quando todos os caminhos SSH falham (Tailscale down, LAN inacessível):
   - Wagner criou conta: `wagnerra@gmail.com` / senha master (não documentar)
   - ADMIN_TOKEN: ver vaultwarden-credenciais.md
   - SIGNUPS: **false** (desabilitado após criação da conta)
-- **Reverb (Laravel 8.4)** em `https://reverb.oimpresso.com/` (creds Vaultwarden)
+- ~~**Reverb (Laravel 8.4)** em `https://reverb.oimpresso.com/`~~ **(legado — substituído por Centrifugo, [ADR 0058](../decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md))**
 - **Meilisearch v1.10.3** em `https://meilisearch.oimpresso.com/` (master key Vaultwarden)
 
 ---

--- a/memory/reference/infra-rede-empresa.md
+++ b/memory/reference/infra-rede-empresa.md
@@ -19,7 +19,7 @@ type: reference
 - **192.168.0.2** = Proxmox host (servidor `sistema`, Xeon 14C / 125 GB RAM) — ver infra-proxmox-ct100.md
 - **192.168.0.4** = Windows Server 2022 (Sistema WR2 / Delphi WR Comercial — RDS, Cpanel, FireBird, FTP, Horse/THorse/socket_horce)
 - **192.168.0.21** = Central VoIP Issabel/Asterisk
-- **192.168.0.50** = CT 100 docker-host (Reverb, Traefik, Portainer, Meilisearch, Vaultwarden)
+- **192.168.0.50** = CT 100 docker-host (Centrifugo, Traefik, Portainer, Meilisearch, Vaultwarden)
 - **192.168.0.55** = SVN dedicado (porta 8777)
 
 **`192.168.0.3` e `192.168.0.4` = MESMA máquina** (Windows Server 2022 com 2 NICs). Wagner esclareceu 2026-04-28: a "máquina servidor Delphi" tem **2 placas de rede**, e responde nos dois IPs. **NÃO usar `192.168.0.3` pra novas VMs/CTs** — é interface secundária do mesmo Windows Server.
@@ -67,7 +67,7 @@ Specs do Windows Server 2022 (.4):
 ## Recomendação pra novas VMs/CTs
 
 Reservar (permanente) por MAC. Sugestão de range fora do DHCP rotativo:
-- **192.168.0.50** → docker-host (já em uso — Reverb, Traefik, Portainer, Meilisearch, Vaultwarden)
+- **192.168.0.50** → docker-host (já em uso — Centrifugo, Traefik, Portainer, Meilisearch, Vaultwarden)
 - 192.168.0.51-59 → outras VMs (staging, workers, etc.)
 
 Adicionar reserva DHCP pelo MAC do CT/VM antes de subir, pra IP não trocar em reboot.

--- a/memory/reference/sandbox-hostnames.md
+++ b/memory/reference/sandbox-hostnames.md
@@ -14,8 +14,8 @@ type: reference
 |---|---|---|---|
 | **Produção** | `https://oimpresso.com/` | Hostinger shared hosting | Workflow GHA `quick-sync.yml` (push to main → SSH rsync) |
 | **Dev local** | `https://localhost:5173/` (Vite) + `http://localhost:8000/` (artisan serve) | Máquina do dev | `npm run dev` + `php artisan serve` |
-| **CT 100 Proxmox** | endpoints internos (Centrifugo/FrankenPHP/Reverb) | Container Docker | compose-managed, ver [INFRA.md](../../INFRA.md) §6 + [proxmox-docker-host skill](../../.claude/skills/proxmox-docker-host) |
-| **MCP server** | `mcp.oimpresso.com` | Hostinger subdomain | webhook GitHub→MCP sync |
+| **CT 100 Proxmox** | endpoints internos (Centrifugo/FrankenPHP) | Container Docker | compose-managed, ver [INFRA.md](../../INFRA.md) §6 + [proxmox-docker-host skill](../../.claude/skills/proxmox-docker-host) |
+| **MCP server** | `mcp.oimpresso.com` | CT 100 Proxmox (container `oimpresso-mcp` / FrankenPHP) — NÃO Hostinger ([ADR 0062](../decisions/0062-separacao-runtime-hostinger-ct100.md) PROÍBE MCP/daemon no Hostinger) | webhook GitHub→MCP sync |
 
 ## Ambientes DESCONTINUADOS (não usar)
 

--- a/memory/reference/whatsapp-daemon-ct100.md
+++ b/memory/reference/whatsapp-daemon-ct100.md
@@ -3,6 +3,9 @@ name: Whatsapp Daemon Baileys CT 100 — source/deploy/endpoints/anti-QR-fest/pu
 description: Daemon Baileys CT 100 (Baileys 6.7.18 + Fastify + TypeScript) — onde mora, endpoints canônicos, deploy padrão, purge sem restart, anti-QR-fest PRs #685+#686, Multi-Device unified inbox PR #688, states semântica, erros comuns
 type: reference
 ---
+
+> ⚠️ **STALE (histórico).** Baileys foi desativado em 2026-05-27 — ADR 0202 (BaileysDriver OUT, Meta Cloud default universal). Este doc descreve a era Baileys; não usar como estado atual.
+
 # Whatsapp Daemon CT 100 (Baileys 6.7.18 + Fastify + TypeScript)
 
 ## Canais em prod biz=1 (estado 2026-05-12)


### PR DESCRIPTION
## Contexto

P2 da faxina de memória (auditoria 2026-06-07). Corrige fatos STALE em `memory/reference/` que podem levar a config/deploy errado. Escopo cirúrgico: só edições de fato, sem reescrita nem scope-creep.

## Mudanças (4 arquivos)

1. **`sandbox-hostnames.md`** — MCP server estava como "Hostinger subdomain" (ERRADO). Corrigido para CT 100 Proxmox (container `oimpresso-mcp` / FrankenPHP), citando [ADR 0062](memory/decisions/0062-separacao-runtime-hostinger-ct100.md) que PROÍBE MCP/daemon no Hostinger. Também removido "Reverb" da lista de endpoints ativos do CT100 (ADR 0058 — substituído por Centrifugo).

2. **`infra-proxmox-ct100.md`** — frontmatter `description` trocava Reverb→Centrifugo na stack Docker; linha do serviço Reverb ativo marcada como "(legado — substituído por Centrifugo, [ADR 0058](memory/decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md))". Corpo já dizia Centrifugo corretamente.

3. **`infra-rede-empresa.md`** — listagens de serviços do CT100 (.50) trocadas de "Reverb" para "Centrifugo" (ADR 0058).

4. **`whatsapp-daemon-ct100.md`** — adicionado BANNER de STALE no topo (após frontmatter). Doc preservado como registro histórico: Baileys foi DESATIVADO em 2026-05-27 ([ADR 0202](memory/decisions/0202) — BaileysDriver OUT, Meta Cloud default universal).

## Notas

- PT-BR, conventional commit, 1 intent.
- Nenhum arquivo `memory/claude/*` tocado (aguardam rotação de segredo).
- NÃO fazer merge — aguarda revisão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)