### PR TITLE
fix(governance): registra colisões ADR 0236/0246 + conserta links-fantasma 0180 + ref screen-qa

### DIFF
--- a/.claude/agents/screen-qa-specialist.md
+++ b/.claude/agents/screen-qa-specialist.md
@@ -29,7 +29,7 @@ Leia o charter (Mission/Goals/Non-Goals/Anti-hooks) e o Controller real (`Inerti
 Escreva/atualize `tests/Browser/<Mod>/<Tela>Test.php`:
 - viewports **1280** (Larissa/ROTA LIVRE) **e 1440**;
 - asserções vindas do charter, não de chute;
-- **smoke biz=1** ([ADR 0101](../../memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md)) — NUNCA biz=4;
+- **smoke biz=1** ([ADR 0101](../../memory/decisions/0101-tests-business-id-1-nunca-cliente.md)) — NUNCA biz=4;
 - baseline visual via `toHaveScreenshot`/snapshot (a atualização de baseline exige aprovação humana — anti-drift);
 - injete **axe** (`@axe-core` / accessibility) e asserte zero violação crítica WCAG.
 - ⛔ **Você NÃO roda o teste local** (Pest/PHPStan são CT 100 only — `memory/proibicoes.md`). Você gera o arquivo; a catraca/CI roda no CT 100. Se precisar de execução, instrua o comando `tailscale ssh root@ct100-mcp "docker exec ... pest tests/Browser/<...>"`.

--- a/memory/decisions/_INDEX-LIFECYCLE.md
+++ b/memory/decisions/_INDEX-LIFECYCLE.md
@@ -1,6 +1,6 @@
 ---
 title: Index de Lifecycle das ADRs — pós-triagem 2026-05-06 (refresh 2026-05-09)
-description: Single source of truth pra status de lifecycle das ADRs canon (11 colisões de número — ver numbering_collisions + Bloco 11). Aprovado por Wagner em 2026-05-06; Bloco 8 apendado em 2026-05-09; entrada colisão 0195 apendada em 2026-05-27; colisão 0235 + auditoria de 6 colisões históricas apendadas em 2026-05-30. Tool MCP `decisions-search` filtra por este index.
+description: Single source of truth pra status de lifecycle das ADRs canon (13 colisões de número — ver numbering_collisions + Bloco 12). Aprovado por Wagner em 2026-05-06; Bloco 8 apendado em 2026-05-09; entrada colisão 0195 apendada em 2026-05-27; colisão 0235 + auditoria de 6 colisões históricas apendadas em 2026-05-30. Tool MCP `decisions-search` filtra por este index.
 type: index
 status: aceito
 authority: [Wagner]
@@ -8,7 +8,7 @@ last_reviewed: 2026-05-09
 next_review: 2026-08-09  # trimestral
 total_adrs: 119
 unique_numbers: 116
-numbering_collisions: [0101, 0102, 0119, 0126, 0141, 0170, 0178, 0180, 0195, 0216, 0235]  # ADR 0028 não cumprido em 11 casos — pendente housekeeping (ADR 0120). 0195 add 2026-05-27 (PR #1714+#1736). 0235 add 2026-05-30 (PR #1963 roxo + PR #1973 staging; renumber PR #1995 bloqueado pelo gate append-only). 6 colisões históricas (0126/0141/0170×3/0178/0180/0216) surfaçadas + registradas 2026-05-30 pelo novo AdrNumberCollisionTest — ver Bloco 11.
+numbering_collisions: [0101, 0102, 0119, 0126, 0141, 0170, 0178, 0180, 0195, 0216, 0235, 0236, 0246]  # ADR 0028 não cumprido em 13 casos — pendente housekeeping (ADR 0120). 0195 add 2026-05-27 (PR #1714+#1736). 0235 add 2026-05-30 (PR #1963 roxo + PR #1973 staging; renumber PR #1995 bloqueado pelo gate append-only). 6 colisões históricas (0126/0141/0170×3/0178/0180/0216) surfaçadas + registradas 2026-05-30 pelo novo AdrNumberCollisionTest — ver Bloco 11. 0236 (×3) + 0246 (×2) add 2026-06-07 — surfaçadas pelo AdrNumberCollisionTest no housekeeping P3, ver Bloco 12.
 governance_principle: append-only — ADRs nunca deletadas; lifecycle reflete uso, não validade histórica
 ---
 
@@ -338,3 +338,24 @@ Ao escrever o gate Pest [`AdrNumberCollisionTest`](../../tests/Feature/Memory/Ad
 **Achado-chave:** `0180-drift-numero-adr-0178-conflito-paralelo` é uma ADR *sobre* a colisão do 0178 — o time **documentou em prosa** mas **nunca atualizou o registro**, e o próprio 0180 colidiu depois. Prova de que doc-em-prosa não basta: precisa de **registro estruturado + teste**. Os 11 estão agora em `numbering_collisions` e o teste impede a 12ª.
 
 **Política (consolidada):** colisão de número = tech-debt aceito (Constituição append-only proíbe rename retroativo — gate provado em PR #1995). Descoberta: **referencie ADR por slug**, não pelo número cru; `decisions-search` retorna todos os slugs ao filtrar por number. Housekeeping eventual = ADR 0120.
+
+## Bloco 12 — Apendado 2026-06-07 — colisões 0236 (×3) + 0246 (×2) (housekeeping P3)
+
+Housekeeping P3 de memória: o [`AdrNumberCollisionTest`](../../tests/Feature/Memory/AdrNumberCollisionTest.php) surfaçou **2 colisões novas** no disco que ainda não constavam em `numbering_collisions` — drift acumulado desde o Bloco 11.
+
+### Colisão 0236 (×3 arquivos)
+
+| Numero | Lifecycle | Notas |
+|---|---|---|
+| 0236a | A | **Extrato/conciliação — modelo unificado** · slug `0236-extrato-conciliacao-modelo-unificado` · ⚠️ colisão com 0236b/0236c |
+| 0236b | A | **Governança da evolução de doc de design** · slug `0236-governanca-evolucao-doc-design` · ⚠️ colisão com 0236a/0236c |
+| 0236c | A | **Scorecard universal — entidade arbitrária** · slug `0236-scorecard-universal-entidade-arbitraria` · ⚠️ colisão com 0236a/0236b |
+
+### Colisão 0246 (×2 arquivos)
+
+| Numero | Lifecycle | Notas |
+|---|---|---|
+| 0246a | A | **Sessão 2026-05-30 — DS harmonização** · slug `0246-sessao-2026-05-30-ds-harmonizacao` · ⚠️ colisão com 0246b |
+| 0246b | A | **Tipo "Outros" default — migrações legacy** · slug `0246-tipo-outros-default-migracoes-legacy` · ⚠️ colisão com 0246a |
+
+**Causa:** PRs paralelos numeraram igual sem coordenação cross-branch (mesmo padrão de 0195/0235). **Renumber PROIBIDO** — append-only Tier 0 (Constituição Art. 3 + ADR 0094/0095/0180), gate `Append-only canon` bloqueia rename de ADR ratificada. **Resolução:** documentar, não mutar — coexistência tech-debt. Descoberta: referencie por slug; `decisions-search` retorna todos ao filtrar por number. Housekeeping eventual = ADR 0120.

--- a/memory/governance/scorecards/PLANO-DESIGN-TELAS-2026-05-31.md
+++ b/memory/governance/scorecards/PLANO-DESIGN-TELAS-2026-05-31.md
@@ -97,7 +97,7 @@
 
 ## Parte 3 — Onda 4: alinhamento estrutural do sidebar (4 fixes, não-tela)
 
-Cruzando o board (agrupado por **módulo**) com o `SIDEBAR_GROUPS` canon ([ADR 0180](../../decisions/0180-sidebar-v3-href-direto-ghosts-pageheader.md), 8 grupos):
+Cruzando o board (agrupado por **módulo**) com o `SIDEBAR_GROUPS` canon ([ADR 0180](../../decisions/0180-sidebar-v3-5-grupos-ghosts-header.md), 8 grupos):
 
 1. **SISTEMA está inchado (15 das 44 telas fracas).** Maioria é **ferramenta interna** (`ads/*`, `governance/*`, `MemCofre`, `Usuario360`, `RagQuality`) — não tela de cliente. **Fix:** separar "interno/superadmin" do SISTEMA do tenant (cliente não deve ver governança no menu dele). Várias já deviam viver só no footer Superadmin cascade.
 2. **Módulos órfãos caindo em MAIS:** `ads`, `MemCofre`, `kb`, `ProjectMgmt` **não declaram `group`** no DataController → caem no fallback MAIS (fim, fechado). **Fix:** dar group canon OU marcar explicitamente como interno.
@@ -154,7 +154,7 @@ Todas as 44 telas <70 implementadas + push na `feat/staging-ct100`. Fechamento p
 
 **Plano (tasks):** US-TR-309 (O0) · US-TR-310 (O1) · US-TR-311 (Público) · US-TR-312 (O2) · US-TR-313 (O3) · US-TR-314 (O4 parcial).
 
-### Onda 4 — 3 fixes que FALTAM (decisão de produto Wagner, [ADR 0180](../../decisions/0180-sidebar-v3-href-direto-ghosts-pageheader.md))
+### Onda 4 — 3 fixes que FALTAM (decisão de produto Wagner, [ADR 0180](../../decisions/0180-sidebar-v3-5-grupos-ghosts-header.md))
 Não alterados sem aprovação — mudam o que cliente vê no menu (governado, Wagner-explícito):
 1. **Desinchar SISTEMA** — 15 telas internas (`ads/*`, `governance/*`, `MemCofre`, `Usuario360`, `RagQuality`) ≠ tela de cliente. Separar interno do SISTEMA do tenant.
 2. **Grupos órfãos** — `ads`/`MemCofre`/`kb`/`ProjectMgmt` sem `group` caem em MAIS. Decidir: dar group canon OU marcar interno (talvez MAIS já seja o certo p/ ferramenta interna).

--- a/memory/requisitos/Sells/RUNBOOK-index.md
+++ b/memory/requisitos/Sells/RUNBOOK-index.md
@@ -24,7 +24,7 @@ related_adrs:
   - 0104-processo-mwart-canonico-unico-caminho
   - 0107-emendation-0104-visual-comparison-gate-f3
   - 0143-fsm-pipeline-live-prod-marco-2026-05-12
-  - 0180-pageheader-canon-v3-href-direto-sem-dropdown
+  - 0189-pageheader-canon-v3-1-cadastro-roxo
   - 0190-primary-button-roxo-universal-295
   - 0192-auto-faturar-os-venda-jobsheet-observer
 ---
@@ -230,7 +230,7 @@ curl -sv 'https://oimpresso.com/sells' -H 'X-Inertia: true' -H 'X-Inertia-Partia
 - [ADR 0104 — Processo MWART canônico](../../decisions/0104-processo-mwart-canonico-unico-caminho.md)
 - [ADR 0107 — Visual gate F1.5](../../decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
 - [ADR 0143 — FSM canon LIVE prod](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
-- [ADR 0180 — PageHeader v3 canon](../../decisions/0180-pageheader-canon-v3-href-direto-sem-dropdown.md)
+- [ADR 0189 — PageHeader v3.1 canon](../../decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md)
 - [ADR 0190 — Primary roxo 295 universal](../../decisions/0190-primary-button-roxo-universal-295.md)
 - [ADR 0192 — Auto-faturar OS→Venda Observer](../../decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)
 - PRs recentes: #1638 KB-9.75 bundle · #1641 VdNextActionPanel + validações fiscais BR · #1644 Emit modais + Bulk + saved view · #1647 charters Edit · #1648 fix BulkActionBar wire-up + z-index

--- a/memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md
+++ b/memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md
@@ -2,7 +2,7 @@
 
 > **Status:** proposto · pending Larissa biz=4 validação 7d
 > **Origem:** [ADR 0189](../../../decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md) + [ADR 0190](../../../decisions/0190-primary-button-roxo-universal-295.md) (primary universal)
-> **Supersedes parcialmente:** [ADR 0180](../../../decisions/0180-pageheader-canon-3-zonas.md), [ADR 0182](../../../decisions/0182-pageheader-canon-hue-per-grupo.md)
+> **Supersedes parcialmente:** [ADR 0189](../../../decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md) (PageHeader canon 3 zonas → v3.1), [ADR 0182](../../../decisions/0182-pageheadertabs-canon-pattern-telas.md)
 > **Protótipo visual:** [prototipo-ui/prototipos/pageheader-canon-v3/](../../../../prototipo-ui/prototipos/pageheader-canon-v3/)
 > **Diário evolutivo:** [PageHeader-LEARNINGS.md](./PageHeader-LEARNINGS.md)
 > **Última atualização:** 2026-05-25 (ADR 0190 primary universal)
@@ -799,8 +799,8 @@ interface PageHeaderProps {
 
 | Versão | Data | Mudança | ADR |
 |---|---|---|---|
-| v1 | 2026-04-XX | PageHeader canon 3 zonas inicial | [0180](../../../decisions/0180-pageheader-canon-3-zonas.md) |
-| v2 | 2026-05-21 | Hue per grupo (cadastro=202, financas=145, etc) | [0182](../../../decisions/0182-pageheader-canon-hue-per-grupo.md) |
+| v1 | 2026-04-XX | PageHeader canon 3 zonas inicial | [0189](../../../decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md) |
+| v2 | 2026-05-21 | Hue per grupo (cadastro=202, financas=145, etc) | [0182](../../../decisions/0182-pageheadertabs-canon-pattern-telas.md) |
 | **v3.1** | **2026-05-24** | **Modern SaaS + roxo médio 295 + KPI separado + ⋮ overflow + bloco fechado + tabs abreviadas** | **[0189](../../../decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md)** |
 | **v3.2** | **2026-05-25** | **BLOCO 1 final · h1 22px/700 peso Vendas + padding `pt-6 px-6 pb-3.5` + `rounded-t-lg` (bottom reta) · primary universal 295 (sem hue per grupo)** | **[0190](../../../decisions/0190-primary-button-roxo-universal-295.md)** + LEARNINGS Decisões #1 (primary universal) + #3 (h1 peso) + #4 (BLOCO 1 pattern final) |
 | **v3.3** | **2026-05-25** | **BLOCO 2 KPI strip Stripe-style flutuante · 5 cards autossuficientes · `mx-6` (24px respiro) · sem wrapper externo · toolbar move pra header BLOCO 3 · AP21 catalogado** | LEARNINGS Decisão #5 + PRs [#1481](https://github.com/wagnerra23/oimpresso.com/pull/1481), [#1482](https://github.com/wagnerra23/oimpresso.com/pull/1482), [#1483](https://github.com/wagnerra23/oimpresso.com/pull/1483) |


### PR DESCRIPTION
## P3 — Housekeeping de memória (ADRs)

Faxina de memória P3. **Sem renumerar ADR** (append-only Tier 0 — ADR 0094/0095/0180): só registro de colisões + conserto de links quebrados.

### 1. Colisões ADR 0236 e 0246 registradas
`memory/decisions/_INDEX-LIFECYCLE.md` — adicionadas ao frontmatter `numbering_collisions` (mesmo formato de 0195/0235) + novo **Bloco 12** documentando:
- **0236** (×3): `0236-extrato-conciliacao-modelo-unificado` + `0236-governanca-evolucao-doc-design` + `0236-scorecard-universal-entidade-arbitraria`
- **0246** (×2): `0246-sessao-2026-05-30-ds-harmonizacao` + `0246-tipo-outros-default-migracoes-legacy`

Objetivo: `AdrNumberCollisionTest` (`tests/Feature/Memory/AdrNumberCollisionTest.php`) parar de falhar. As duas assertions são satisfeitas (todo número de colisão do disco registrado; nenhuma entrada órfã — ambos colidem de fato no disco).

### 2. Links-fantasma do ADR 0180 (e 0182) consertados
- `memory/requisitos/Sells/RUNBOOK-index.md`: `0180-pageheader-canon-v3-*` (inexistente) → `0189-pageheader-canon-v3-1-cadastro-roxo` (frontmatter + corpo).
- `memory/governance/scorecards/PLANO-DESIGN-TELAS-2026-05-31.md`: `0180-sidebar-v3-href-direto-ghosts-pageheader` → `0180-sidebar-v3-5-grupos-ghosts-header` (2 ocorrências).
- `memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md`: `0180-pageheader-canon-3-zonas` → `0189-...` e `0182-pageheader-canon-hue-per-grupo` → `0182-pageheadertabs-canon-pattern-telas` (linha 5 + tabela de versões).

### 3. Referência errada em agente
- `.claude/agents/screen-qa-specialist.md`: smoke biz=1 apontava pra `0101-sistema-charter-capterra-governanca-escopo`; corrigido pra `0101-tests-business-id-1-nunca-cliente` (a regra real de biz=1).

### Append-only gate
Nenhum arquivo ADR (`memory/decisions/NNNN-slug.md`) foi editado — o gate `Append-only canon` (`governance-gate.yml`) só bloqueia o padrão `^M memory/decisions/[0-9]{4}-*.md`. `_INDEX-LIFECYCLE.md` (prefixo `_`) não casa. **Nada pulado por append-only.**

### Não verificado localmente
`AdrNumberCollisionTest` não rodou no ambiente (sem `vendor/` instalado na checkout). Validado por leitura do teste + estado do disco. CI confirma.

🤖 Generated with [Claude Code](https://claude.com/claude-code)