### PR TITLE
docs(memory): deprecação dos 4 fósseis raiz que contradizem o canon (P1b)

### DIFF
--- a/memory/00-user-profile.md
+++ b/memory/00-user-profile.md
@@ -1,5 +1,7 @@
 # 00 — Perfil do Usuário / Cliente
 
+> ⚠️ **FÓSSIL (pré-Constituição v2) — NÃO usar como verdade.** Descreve "Eliana/WR2 Sistemas" como usuário — ERRADO hoje: o usuário é **Wagner** (`wagnerra@gmail.com`); o cliente-piloto é **Larissa/ROTA LIVRE** (biz=4); Eliana/WR2 é relação legada/externa. Perfil atual do usuário: `~/.claude/oimpresso-local/` (ADR 0131). Mantido só por link do INDEX. Ver auditoria `memory/governance/AUDITORIA-CONFLITOS-MEMORIA-2026-06-07.md`.
+
 ## Identificação
 
 - **Empresa:** WR2 Sistemas

--- a/memory/02-technical-stack.md
+++ b/memory/02-technical-stack.md
@@ -1,5 +1,7 @@
 # 02 — Stack Técnica
 
+> ⚠️ **FÓSSIL parcial — NÃO usar a seção de stack de IA.** O cabeçalho PHP 8.4/Laravel 13.6 está correto, mas a stack de IA aqui (Vizra ADK / OpenAI como futuro) foi **DESCARTADA** — canon atual é `laravel/ai` (ADR 0035/0048). Stack canônica atual: `memory/what-oimpresso.md` (@import). Ver `memory/governance/AUDITORIA-CONFLITOS-MEMORIA-2026-06-07.md`.
+
 ## Linguagem e framework
 
 | Item | Versão real na instância | Razão |

--- a/memory/04-conventions.md
+++ b/memory/04-conventions.md
@@ -1,5 +1,7 @@
 # 04 — Convenções do Projeto
 
+> ⚠️ **FÓSSIL (pré-Constituição v2) — verificar contra canon.** Regras válidas misturadas com stale: "Laravel 10" em migrations (hoje **13.6**) e branch `develop` (hoje **`main`-protected**). Convenções canônicas atuais: `memory/how-trabalhar.md` + skills Tier A + ADRs. Ver `memory/governance/AUDITORIA-CONFLITOS-MEMORIA-2026-06-07.md`.
+
 ## Idioma
 
 - **Mensagens para o usuário / UI:** PT-BR

--- a/memory/05-preferences.md
+++ b/memory/05-preferences.md
@@ -1,5 +1,7 @@
 # 05 — Preferências do Usuário
 
+> ⚠️ **FÓSSIL (pré-Constituição v2) — NÃO usar como verdade.** Capturado com "Eliana/WR2" (cliente legado, não o usuário atual Wagner). Contém "Decida, não pergunte" que **CONTRADIZ** a regra-mestre atual da Constituição UI v2 (`wagner-request-refiner`: perguntar antes em pedido vago). Preferências canônicas: `memory/proibicoes.md` + `how-trabalhar.md` + `~/.claude/oimpresso-local/`. Ver `memory/governance/AUDITORIA-CONFLITOS-MEMORIA-2026-06-07.md`.
+
 Capturado ao longo das conversas com a Eliana (WR2 Sistemas). Estas preferências têm precedência sobre escolhas padrão a menos que conflitem com requisitos legais.
 
 ## Comunicação


### PR DESCRIPTION
## Origem
P1b da auditoria de conflitos de memória (2026-06-07). 4 arquivos `memory/NN-*.md` pré-Constituição v2 contradizem ativamente o canon e podem desorientar uma sessão nova.

## Mudança
Banner de deprecação no topo (NÃO apagados — INDEX.md ainda linka; deletar quebraria links):
- `00-user-profile.md` — descreve usuário "Eliana/WR2" (hoje: Wagner + cliente Larissa/biz=4)
- `02-technical-stack.md` — stack IA "Vizra/OpenAI" descartada (canon: laravel/ai, ADR 0035/0048)
- `04-conventions.md` — "Laravel 10" + branch `develop` (hoje 13.6 + main-protected)
- `05-preferences.md` — "Decida, não pergunte" contradiz `wagner-request-refiner` (regra-mestre UI v2)

Os fósseis puramente históricos (OPUS-MISSION-BRIEF, COMPARATIVO_TELAS_*, REQUISITOS_FUNCIONAIS_PONTO, COMO_PEDIR_*) podem receber o mesmo tratamento num follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)