### PR TITLE
feat(recurring-billing): rb:generate-invoices command + scheduler daily (US-RB-003)

### DIFF
--- a/Modules/RecurringBilling/Console/Commands/GenerateInvoicesCommand.php
+++ b/Modules/RecurringBilling/Console/Commands/GenerateInvoicesCommand.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Console\Commands;
+
+use App\Business;
+use Illuminate\Console\Command;
+use Modules\RecurringBilling\Services\InvoiceGeneratorService;
+
+/**
+ * rb:generate-invoices — Gera faturas recorrentes pendentes.
+ *
+ * US-RB-003: pra cada Subscription ativa com `next_due_date <= hoje + lead-days`:
+ *   1. Cria Invoice (status=open, vencimento=next_due_date, conta_bancaria_id
+ *      da subscription, numero_documento RB-{id}-{YYYY-MM}).
+ *   2. Avança Subscription.next_due_date += ciclo do plan.
+ *   3. Logga SubscriptionEvent kind=event-charge na timeline.
+ *
+ * Idempotente — SKIP se já existe Invoice mesma competência (YYYY-MM)
+ * pra essa subscription (status != canceled).
+ *
+ * Schedule: daily 03:00 BRT em env=live
+ * (registrado em `RecurringBillingServiceProvider::registerCommandSchedules`).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ *   - Sem --business: itera todos businesses ativos
+ *   - Com --business=N: filtra explicitamente
+ *   - Sem session()/auth() — commands CLI passam $businessId direto
+ *
+ * Uso:
+ *   php artisan rb:generate-invoices                          # todos businesses, hoje
+ *   php artisan rb:generate-invoices --business=1             # só biz=1
+ *   php artisan rb:generate-invoices --date=2026-07-15        # simular data
+ *   php artisan rb:generate-invoices --lead-days=3            # antecipa 3 dias
+ *   php artisan rb:generate-invoices --dry-run                # não escreve
+ *
+ * Exit code: 0 OK, 1 se houver erros.
+ *
+ * @see Modules\RecurringBilling\Services\InvoiceGeneratorService
+ * @see memory/requisitos/RecurringBilling/SPEC.md (US-RB-003)
+ */
+class GenerateInvoicesCommand extends Command
+{
+    protected $signature = 'rb:generate-invoices
+        {--business= : business_id (default: todos businesses ativos)}
+        {--date= : Y-m-d pra simular "hoje" (default: hoje real)}
+        {--lead-days=0 : antecipação em dias (default: 0)}
+        {--dry-run : não escreve nada — só reporta o que faria}
+        {--detail : log detalhado por subscription processada}';
+
+    protected $description = 'Gera rb_invoices das rb_subscriptions ativas com next_due_date <= hoje (US-RB-003).';
+
+    public function handle(InvoiceGeneratorService $service): int
+    {
+        $businessOpt = $this->option('business');
+        $date        = $this->option('date');
+        $leadDays    = (int) ($this->option('lead-days') ?? 0);
+        $dryRun      = (bool) $this->option('dry-run');
+        $detail      = (bool) $this->option('detail');
+
+        if ($businessOpt !== null && $businessOpt !== '') {
+            $bizIds = [(int) $businessOpt];
+        } else {
+            // Multi-tenant Tier 0 — itera todos businesses ativos
+            $bizIds = Business::query()->pluck('id')->map(fn ($i) => (int) $i)->all();
+        }
+
+        $totals = ['generated' => 0, 'skipped' => 0, 'errors' => 0, 'advanced' => 0];
+        $rows = [];
+
+        foreach ($bizIds as $bizId) {
+            $stats = $service->run($bizId, $date !== null && $date !== '' ? (string) $date : null, $dryRun, $leadDays);
+            $totals['generated'] += $stats['generated'];
+            $totals['skipped']   += $stats['skipped'];
+            $totals['errors']    += $stats['errors'];
+            $totals['advanced']  += $stats['advanced'];
+
+            // Só lista businesses que tiveram algum movimento (evita poluir output em prod com 100+ tenants)
+            if ($detail || $stats['generated'] > 0 || $stats['skipped'] > 0 || $stats['errors'] > 0) {
+                $rows[] = [
+                    'biz'       => $bizId,
+                    'geradas'   => $stats['generated'],
+                    'puladas'   => $stats['skipped'],
+                    'erros'     => $stats['errors'],
+                    'avancadas' => $stats['advanced'],
+                ];
+            }
+        }
+
+        if (! empty($rows)) {
+            $this->table(['biz', 'geradas', 'puladas', 'erros', 'avancadas'], $rows);
+        }
+
+        $prefix = $dryRun ? '[DRY-RUN] ' : '';
+        $this->info(sprintf(
+            '%sTOTAL: %d faturas geradas · %d puladas (já existiam) · %d erros · %d assinaturas avançadas (em %d businesses).',
+            $prefix,
+            $totals['generated'],
+            $totals['skipped'],
+            $totals['errors'],
+            $totals['advanced'],
+            count($bizIds),
+        ));
+
+        return $totals['errors'] > 0 ? 1 : 0;
+    }
+}

--- a/Modules/RecurringBilling/Providers/RecurringBillingServiceProvider.php
+++ b/Modules/RecurringBilling/Providers/RecurringBillingServiceProvider.php
@@ -131,6 +131,7 @@ class RecurringBillingServiceProvider extends ServiceProvider
                 \Modules\RecurringBilling\Console\Commands\SyncBankBalancesCommand::class,
                 \Modules\RecurringBilling\Console\Commands\RecurringHealthCommand::class,
                 \Modules\RecurringBilling\Console\Commands\BackfillCachedFieldsCommand::class,
+                \Modules\RecurringBilling\Console\Commands\GenerateInvoicesCommand::class,
             ]);
         }
     }
@@ -140,10 +141,23 @@ class RecurringBillingServiceProvider extends ServiceProvider
      */
     protected function registerCommandSchedules(): void
     {
-        // $this->app->booted(function () {
-        //     $schedule = $this->app->make(Schedule::class);
-        //     $schedule->command('inspire')->hourly();
-        // });
+        $this->app->booted(function () {
+            $schedule = $this->app->make(\Illuminate\Console\Scheduling\Schedule::class);
+
+            // US-RB-003 — Gera rb_invoices das rb_subscriptions ativas com next_due_date <= hoje.
+            // Sem este schedule, assinaturas ficam "paradas" — vencimento nunca avança automaticamente
+            // e nenhuma fatura nova aparece pra cobrar.
+            $schedule->command('rb:generate-invoices')
+                ->dailyAt('03:00')
+                ->timezone('America/Sao_Paulo')
+                ->withoutOverlapping()
+                ->environments(['live'])
+                ->onFailure(function () {
+                    \Illuminate\Support\Facades\Log::channel('single')->error(
+                        'Schedule rb:generate-invoices FALHOU — assinaturas ativas não geraram fatura no ciclo. Verificar logs + rodar manual.'
+                    );
+                });
+        });
     }
 
     /**

--- a/Modules/RecurringBilling/Services/InvoiceGeneratorService.php
+++ b/Modules/RecurringBilling/Services/InvoiceGeneratorService.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Modules\RecurringBilling\Models\Invoice;
+use Modules\RecurringBilling\Models\Plan;
 use Modules\RecurringBilling\Models\Subscription;
 use Modules\RecurringBilling\Models\SubscriptionEvent;
 use Throwable;
@@ -105,24 +106,30 @@ class InvoiceGeneratorService
      */
     private function processarSubscription(Subscription $sub, int $businessId, bool $dryRun, array $stats): array
     {
+        /** @var Plan|null $plan */
         $plan = $sub->plan;
         if ($plan === null) {
             $stats['errors']++;
             Log::channel('single')->error('rb:generate-invoices subscription sem plan', [
-                'subscription_id' => $sub->id,
-                'plan_id'         => $sub->plan_id,
+                'subscription_id' => $sub->getKey(),
+                'plan_id'         => $sub->getAttribute('plan_id'),
                 'business_id'     => $businessId,
             ]);
 
             return $stats;
         }
 
-        $vencimento = Carbon::parse($sub->next_due_date);
+        $vencimento = Carbon::parse($sub->getAttribute('next_due_date'));
+        $planId      = (int) $plan->getKey();
+        $planValor   = (float) $plan->getAttribute('valor');
+        $planNome    = (string) $plan->getAttribute('name');
+        $planCiclo   = (string) $plan->getAttribute('ciclo');
+        $subId       = (int) $sub->getKey();
 
         // Idempotência — invoice mesma competência (YYYY-MM) já existe?
         $exists = Invoice::query()
             ->where('business_id', $businessId)
-            ->where('subscription_id', $sub->id)
+            ->where('subscription_id', $subId)
             ->whereYear('vencimento', $vencimento->year)
             ->whereMonth('vencimento', $vencimento->month)
             ->whereNotIn('status', ['canceled'])
@@ -140,25 +147,25 @@ class InvoiceGeneratorService
             return $stats;
         }
 
-        $proximo = $this->avancarCiclo($vencimento, (string) $plan->ciclo);
-        $numeroDocumento = sprintf('RB-%d-%s', $sub->id, $vencimento->format('Y-m'));
+        $proximo = $this->avancarCiclo($vencimento, $planCiclo);
+        $numeroDocumento = sprintf('RB-%d-%s', $subId, $vencimento->format('Y-m'));
 
-        DB::transaction(function () use ($sub, $plan, $businessId, $vencimento, $proximo, $numeroDocumento): void {
+        DB::transaction(function () use ($sub, $businessId, $subId, $planId, $planValor, $planNome, $planCiclo, $vencimento, $proximo, $numeroDocumento): void {
             Invoice::create([
                 'business_id'       => $businessId,
-                'subscription_id'   => $sub->id,
-                'contact_id'        => $sub->contact_id,
+                'subscription_id'   => $subId,
+                'contact_id'        => $sub->getAttribute('contact_id'),
                 'numero_documento'  => $numeroDocumento,
-                'valor'             => $plan->valor,
+                'valor'             => $planValor,
                 'status'            => 'open',
                 'vencimento'        => $vencimento->toDateString(),
-                'conta_bancaria_id' => $sub->conta_bancaria_id,
+                'conta_bancaria_id' => $sub->getAttribute('conta_bancaria_id'),
                 'metadata'          => [
                     'generated_by'  => 'rb:generate-invoices',
                     'generated_at'  => now()->toIso8601String(),
-                    'plan_id'       => (int) $plan->id,
-                    'plan_name'     => (string) $plan->name,
-                    'plan_ciclo'    => (string) $plan->ciclo,
+                    'plan_id'       => $planId,
+                    'plan_name'     => $planNome,
+                    'plan_ciclo'    => $planCiclo,
                     'us'            => 'US-RB-003',
                 ],
             ]);
@@ -167,14 +174,14 @@ class InvoiceGeneratorService
 
             SubscriptionEvent::create([
                 'business_id'     => $businessId,
-                'subscription_id' => $sub->id,
+                'subscription_id' => $subId,
                 'kind'            => SubscriptionEvent::KIND_CHARGE,
                 'by_actor'        => 'system:rb:generate-invoices',
                 'body'            => sprintf(
                     'Fatura %s gerada — vencimento %s — R$ %s. Próximo ciclo: %s.',
                     $numeroDocumento,
                     $vencimento->format('d/m/Y'),
-                    number_format((float) $plan->valor, 2, ',', '.'),
+                    number_format($planValor, 2, ',', '.'),
                     Carbon::parse($proximo)->format('d/m/Y'),
                 ),
                 'occurred_at'     => now(),

--- a/Modules/RecurringBilling/Services/InvoiceGeneratorService.php
+++ b/Modules/RecurringBilling/Services/InvoiceGeneratorService.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\RecurringBilling\Services;
+
+use App\Util\OtelHelper;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\RecurringBilling\Models\Invoice;
+use Modules\RecurringBilling\Models\Subscription;
+use Modules\RecurringBilling\Models\SubscriptionEvent;
+use Throwable;
+
+/**
+ * US-RB-003 · Geração de faturas recorrentes (job diário).
+ *
+ * Pra cada Subscription ativa cujo `next_due_date <= today + leadDays`:
+ *
+ *   1. Idempotência — SKIP se já existe Invoice mesma competência (YYYY-MM)
+ *      pra essa subscription (status != canceled).
+ *   2. Cria Invoice (status=open, vencimento=next_due_date, valor=plan.valor,
+ *      conta_bancaria_id da subscription, numero_documento RB-{id}-{YYYY-MM}).
+ *   3. Avança Subscription.next_due_date += ciclo (monthly/quarterly/semiannual/
+ *      yearly) usando addMonth*NoOverflow (Carbon — preserva anchor dia 31 → fev).
+ *   4. Logga SubscriptionEvent kind=event-charge pra timeline append-only.
+ *
+ * Tudo dentro de DB::transaction per-subscription pra atomicidade.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ *   - businessId 1º arg sempre (commands/jobs sem session())
+ *   - Models usam HasBusinessScope trait → global scope automático
+ *   - NUNCA withoutGlobalScopes
+ *
+ * Tests biz=1 ([ADR 0101](../../../memory/decisions/0101-tests-business-id-1-nunca-cliente.md)):
+ *   biz=99 NUNCA vaza dados de biz=1 (Pest valida).
+ *
+ * @see Modules\RecurringBilling\Console\Commands\GenerateInvoicesCommand
+ * @see memory/requisitos/RecurringBilling/SPEC.md (US-RB-003)
+ */
+class InvoiceGeneratorService
+{
+    /**
+     * Gera faturas pendentes pra todas Subscriptions ativas do business.
+     *
+     * @param  int          $businessId  Multi-tenant Tier 0 obrigatório
+     * @param  string|null  $date        YYYY-MM-DD pra simular "hoje" (default: hoje real)
+     * @param  bool         $dryRun      true = não escreve nada, só conta
+     * @param  int          $leadDays    Antecipação em dias (default 0 = só vencidas hoje ou antes)
+     *
+     * @return array{generated:int, skipped:int, errors:int, advanced:int}
+     */
+    public function run(int $businessId, ?string $date = null, bool $dryRun = false, int $leadDays = 0): array
+    {
+        return OtelHelper::spanBiz('rb.invoice.gerador.run', function () use ($businessId, $date, $dryRun, $leadDays): array {
+            return $this->runInternal($businessId, $date, $dryRun, $leadDays);
+        }, [
+            'module'      => 'RecurringBilling',
+            'op'          => 'invoice.gerador.run',
+            'business_id' => $businessId,
+            'dry_run'     => $dryRun,
+            'lead_days'   => $leadDays,
+        ]);
+    }
+
+    /**
+     * @return array{generated:int, skipped:int, errors:int, advanced:int}
+     */
+    private function runInternal(int $businessId, ?string $date, bool $dryRun, int $leadDays): array
+    {
+        $today = $date !== null && $date !== '' ? Carbon::parse($date) : Carbon::today();
+        $cutoff = $today->copy()->addDays(max(0, $leadDays))->toDateString();
+
+        $candidates = Subscription::query()
+            ->where('business_id', $businessId)
+            ->where('status', 'active')
+            ->whereDate('next_due_date', '<=', $cutoff)
+            ->with('plan')
+            ->orderBy('id')
+            ->get();
+
+        $stats = ['generated' => 0, 'skipped' => 0, 'errors' => 0, 'advanced' => 0];
+
+        foreach ($candidates as $sub) {
+            try {
+                $stats = $this->processarSubscription($sub, $businessId, $dryRun, $stats);
+            } catch (Throwable $e) {
+                $stats['errors']++;
+                Log::channel('single')->error('rb:generate-invoices falhou pra subscription', [
+                    'subscription_id' => $sub->id,
+                    'business_id'     => $businessId,
+                    'error'           => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * @param  array{generated:int, skipped:int, errors:int, advanced:int}  $stats
+     *
+     * @return array{generated:int, skipped:int, errors:int, advanced:int}
+     */
+    private function processarSubscription(Subscription $sub, int $businessId, bool $dryRun, array $stats): array
+    {
+        $plan = $sub->plan;
+        if ($plan === null) {
+            $stats['errors']++;
+            Log::channel('single')->error('rb:generate-invoices subscription sem plan', [
+                'subscription_id' => $sub->id,
+                'plan_id'         => $sub->plan_id,
+                'business_id'     => $businessId,
+            ]);
+
+            return $stats;
+        }
+
+        $vencimento = Carbon::parse($sub->next_due_date);
+
+        // Idempotência — invoice mesma competência (YYYY-MM) já existe?
+        $exists = Invoice::query()
+            ->where('business_id', $businessId)
+            ->where('subscription_id', $sub->id)
+            ->whereYear('vencimento', $vencimento->year)
+            ->whereMonth('vencimento', $vencimento->month)
+            ->whereNotIn('status', ['canceled'])
+            ->exists();
+
+        if ($exists) {
+            $stats['skipped']++;
+
+            return $stats;
+        }
+
+        if ($dryRun) {
+            $stats['generated']++;
+
+            return $stats;
+        }
+
+        $proximo = $this->avancarCiclo($vencimento, (string) $plan->ciclo);
+        $numeroDocumento = sprintf('RB-%d-%s', $sub->id, $vencimento->format('Y-m'));
+
+        DB::transaction(function () use ($sub, $plan, $businessId, $vencimento, $proximo, $numeroDocumento): void {
+            Invoice::create([
+                'business_id'       => $businessId,
+                'subscription_id'   => $sub->id,
+                'contact_id'        => $sub->contact_id,
+                'numero_documento'  => $numeroDocumento,
+                'valor'             => $plan->valor,
+                'status'            => 'open',
+                'vencimento'        => $vencimento->toDateString(),
+                'conta_bancaria_id' => $sub->conta_bancaria_id,
+                'metadata'          => [
+                    'generated_by'  => 'rb:generate-invoices',
+                    'generated_at'  => now()->toIso8601String(),
+                    'plan_id'       => (int) $plan->id,
+                    'plan_name'     => (string) $plan->name,
+                    'plan_ciclo'    => (string) $plan->ciclo,
+                    'us'            => 'US-RB-003',
+                ],
+            ]);
+
+            $sub->update(['next_due_date' => $proximo]);
+
+            SubscriptionEvent::create([
+                'business_id'     => $businessId,
+                'subscription_id' => $sub->id,
+                'kind'            => SubscriptionEvent::KIND_CHARGE,
+                'by_actor'        => 'system:rb:generate-invoices',
+                'body'            => sprintf(
+                    'Fatura %s gerada — vencimento %s — R$ %s. Próximo ciclo: %s.',
+                    $numeroDocumento,
+                    $vencimento->format('d/m/Y'),
+                    number_format((float) $plan->valor, 2, ',', '.'),
+                    Carbon::parse($proximo)->format('d/m/Y'),
+                ),
+                'occurred_at'     => now(),
+            ]);
+        });
+
+        $stats['generated']++;
+        $stats['advanced']++;
+
+        return $stats;
+    }
+
+    /**
+     * Avança a data conforme o ciclo do plano. Carbon addMonthsNoOverflow
+     * preserva o anchor dia 31 (jan 31 + 1 mês = fev 28, depois fev 28 + 1 = mar 28
+     * — anchor "vira" 28, é o comportamento esperado pra cobrança recorrente real).
+     *
+     * Enum rb_plans.ciclo: monthly|quarterly|semiannual|yearly|custom
+     */
+    private function avancarCiclo(Carbon $base, string $ciclo): string
+    {
+        return match ($ciclo) {
+            'monthly'    => $base->copy()->addMonthNoOverflow()->toDateString(),
+            'quarterly'  => $base->copy()->addMonthsNoOverflow(3)->toDateString(),
+            'semiannual' => $base->copy()->addMonthsNoOverflow(6)->toDateString(),
+            'yearly'     => $base->copy()->addYearNoOverflow()->toDateString(),
+            'custom'     => $base->copy()->addMonthNoOverflow()->toDateString(), // fallback monthly
+            default      => $base->copy()->addMonthNoOverflow()->toDateString(),
+        };
+    }
+}

--- a/Modules/RecurringBilling/Tests/Feature/InvoiceGeneratorServiceTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/InvoiceGeneratorServiceTest.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Modules\RecurringBilling\Models\Invoice;
+use Modules\RecurringBilling\Models\Plan;
+use Modules\RecurringBilling\Models\Subscription;
+use Modules\RecurringBilling\Models\SubscriptionEvent;
+use Modules\RecurringBilling\Services\InvoiceGeneratorService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-RB-003 — Pest cobrindo InvoiceGeneratorService.
+ *
+ * SQLite in-memory pattern (espelha Wave6PlanCrudTest + AssinaturaCobrancaServiceTest)
+ * — migrations legadas UltimatePOS usam sintaxe MySQL-only (ALTER TABLE MODIFY ENUM).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+ * + biz=1 ([ADR 0101](../../../../memory/decisions/0101-tests-business-id-1-nunca-cliente.md)):
+ * NUNCA biz=4 (ROTA LIVRE PROD).
+ *
+ * Cenários (≥7 PASSED):
+ *  1. Cria invoice quando next_due_date <= hoje
+ *  2. Idempotência: 2× run() não duplica invoice
+ *  3. Avança next_due_date += 1 mês (monthly) preservando anchor
+ *  4. Skipa subscription paused/canceled
+ *  5. dry-run não escreve mas conta
+ *  6. lead-days antecipa (venc hoje+3 entra com lead=3)
+ *  7. Cross-tenant Tier 0: biz=99 NÃO vaza dados de biz=1
+ */
+
+beforeEach(function () {
+    if (config('database.default') !== 'sqlite'
+        || ! str_contains((string) config('database.connections.sqlite.database'), ':memory:')) {
+        $this->markTestSkipped('Smoke test rodado apenas em SQLite in-memory.');
+    }
+
+    // rb_plans (espelha migrations 2026_05_06 + 2026_05_16 v975)
+    Schema::dropIfExists('rb_plans');
+    Schema::create('rb_plans', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->string('name', 150);
+        $t->string('slug', 80);
+        $t->text('description')->nullable();
+        $t->string('descricao_curta', 200)->nullable();
+        $t->decimal('valor', 15, 2);
+        $t->string('ciclo', 20);
+        $t->unsignedSmallInteger('ciclo_dias')->nullable();
+        $t->unsignedSmallInteger('trial_days')->default(0);
+        $t->boolean('ativo')->default(true)->index();
+        $t->string('fiscal_type', 10)->default('none');
+        $t->string('fiscal_cfop', 8)->nullable();
+        $t->string('fiscal_servico', 8)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::dropIfExists('rb_subscriptions');
+    Schema::create('rb_subscriptions', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedBigInteger('plan_id')->nullable();
+        $t->unsignedInteger('contact_id')->nullable();
+        $t->string('status', 20)->default('active');
+        $t->date('start_date')->nullable();
+        $t->date('next_due_date')->nullable();
+        $t->date('billing_anchor_date')->nullable();
+        $t->dateTime('canceled_at')->nullable();
+        $t->dateTime('paused_at')->nullable();
+        $t->unsignedInteger('conta_bancaria_id')->nullable();
+        $t->string('payment_method', 20)->nullable();
+        $t->unsignedBigInteger('last_jobsheet_id')->nullable();
+        $t->unsignedSmallInteger('total_paid_cached')->default(0);
+        $t->unsignedSmallInteger('failed_count_cached')->default(0);
+        $t->decimal('total_revenue_cached', 14, 2)->default(0);
+        $t->date('paused_until')->nullable();
+        $t->string('churn_reason', 64)->nullable();
+        $t->string('contact_phone_cached', 32)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::dropIfExists('rb_invoices');
+    Schema::create('rb_invoices', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedBigInteger('subscription_id')->nullable();
+        $t->unsignedInteger('contact_id');
+        $t->string('numero_documento', 50);
+        $t->decimal('valor', 15, 2);
+        $t->string('status', 20)->default('open');
+        $t->date('vencimento');
+        $t->dateTime('pago_em')->nullable();
+        $t->string('gateway', 30)->nullable();
+        $t->string('gateway_ref', 100)->nullable();
+        $t->unsignedInteger('conta_bancaria_id')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::dropIfExists('rb_subscription_events');
+    Schema::create('rb_subscription_events', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedBigInteger('subscription_id');
+        $t->string('kind', 30);
+        $t->string('by_actor', 80)->nullable();
+        $t->text('body')->nullable();
+        $t->dateTime('occurred_at');
+        $t->timestamps();
+    });
+
+    Schema::dropIfExists('activity_log');
+    Schema::create('activity_log', function ($t) {
+        $t->id();
+        $t->string('log_name')->nullable();
+        $t->text('description')->nullable();
+        $t->nullableMorphs('subject');
+        $t->string('event')->nullable();
+        $t->nullableMorphs('causer');
+        $t->json('properties')->nullable();
+        $t->uuid('batch_uuid')->nullable();
+        $t->timestamps();
+    });
+
+    // Multi-tenant Tier 0 — biz=1 (ADR 0101)
+    session(['user.business_id' => 1]);
+});
+
+afterEach(function () {
+    Schema::dropIfExists('rb_subscription_events');
+    Schema::dropIfExists('rb_invoices');
+    Schema::dropIfExists('rb_subscriptions');
+    Schema::dropIfExists('rb_plans');
+    Schema::dropIfExists('activity_log');
+    session()->flush();
+});
+
+function makePlan(int $bizId, float $valor = 100.0, string $ciclo = 'monthly'): Plan
+{
+    return Plan::create([
+        'business_id' => $bizId,
+        'name'        => "Plano teste {$ciclo} R$ {$valor}",
+        'slug'        => "plano-test-{$bizId}-{$ciclo}-".uniqid(),
+        'valor'       => $valor,
+        'ciclo'       => $ciclo,
+        'ativo'       => true,
+        'fiscal_type' => 'none',
+    ]);
+}
+
+function makeSubscription(int $bizId, int $planId, string $nextDueDate, string $status = 'active', ?int $contaBancariaId = null): Subscription
+{
+    return Subscription::create([
+        'business_id'         => $bizId,
+        'plan_id'             => $planId,
+        'contact_id'          => 999,
+        'status'              => $status,
+        'start_date'          => $nextDueDate,
+        'next_due_date'       => $nextDueDate,
+        'billing_anchor_date' => $nextDueDate,
+        'conta_bancaria_id'   => $contaBancariaId,
+        'payment_method'      => 'boleto',
+    ]);
+}
+
+test('1. Cria invoice quando next_due_date <= hoje', function () {
+    $plan = makePlan(1, 250.50, 'monthly');
+    $sub  = makeSubscription(1, $plan->id, '2026-07-10', 'active', 12);
+
+    $service = new InvoiceGeneratorService();
+    $stats = $service->run(businessId: 1, date: '2026-07-10');
+
+    expect($stats['generated'])->toBe(1);
+    expect($stats['skipped'])->toBe(0);
+    expect($stats['errors'])->toBe(0);
+    expect($stats['advanced'])->toBe(1);
+
+    $invoice = Invoice::where('subscription_id', $sub->id)->first();
+    expect($invoice)->not->toBeNull();
+    expect((float) $invoice->valor)->toBe(250.50);
+    expect($invoice->status)->toBe('open');
+    expect($invoice->vencimento->toDateString())->toBe('2026-07-10');
+    expect($invoice->conta_bancaria_id)->toBe(12);
+    expect($invoice->numero_documento)->toBe("RB-{$sub->id}-2026-07");
+});
+
+test('2. Idempotência: 2x run() nao duplica invoice', function () {
+    $plan = makePlan(1, 100.0, 'monthly');
+    $sub  = makeSubscription(1, $plan->id, '2026-07-15');
+
+    $service = new InvoiceGeneratorService();
+    $service->run(1, '2026-07-15');
+    // Re-aponta next_due_date pra mesma data simulando re-execução do job
+    $sub->update(['next_due_date' => '2026-07-15']);
+    $stats2 = $service->run(1, '2026-07-15');
+
+    expect($stats2['generated'])->toBe(0);
+    expect($stats2['skipped'])->toBe(1);
+    expect(Invoice::where('subscription_id', $sub->id)->count())->toBe(1);
+});
+
+test('3. Avanca next_due_date += 1 mes (monthly) preservando anchor', function () {
+    $plan = makePlan(1, 100.0, 'monthly');
+    $sub  = makeSubscription(1, $plan->id, '2026-07-10');
+
+    (new InvoiceGeneratorService())->run(1, '2026-07-10');
+
+    $sub->refresh();
+    expect($sub->next_due_date->toDateString())->toBe('2026-08-10');
+});
+
+test('4. Skipa subscription paused/canceled', function () {
+    $plan = makePlan(1, 100.0, 'monthly');
+    makeSubscription(1, $plan->id, '2026-07-10', 'paused');
+    makeSubscription(1, $plan->id, '2026-07-10', 'canceled');
+    makeSubscription(1, $plan->id, '2026-07-10', 'active');
+
+    $stats = (new InvoiceGeneratorService())->run(1, '2026-07-10');
+
+    expect($stats['generated'])->toBe(1);
+    expect(Invoice::count())->toBe(1);
+});
+
+test('5. dry-run nao escreve mas conta', function () {
+    $plan = makePlan(1, 100.0, 'monthly');
+    $sub  = makeSubscription(1, $plan->id, '2026-07-10');
+
+    $stats = (new InvoiceGeneratorService())->run(1, '2026-07-10', dryRun: true);
+
+    expect($stats['generated'])->toBe(1);
+    expect(Invoice::count())->toBe(0);
+    expect(SubscriptionEvent::count())->toBe(0);
+    $sub->refresh();
+    expect($sub->next_due_date->toDateString())->toBe('2026-07-10'); // não avançou
+});
+
+test('6. lead-days antecipa: venc hoje+3 entra com lead=3', function () {
+    $plan = makePlan(1, 100.0, 'monthly');
+    makeSubscription(1, $plan->id, '2026-07-13'); // venc 3 dias depois
+
+    // Sem lead-days
+    $sem = (new InvoiceGeneratorService())->run(1, '2026-07-10', dryRun: true, leadDays: 0);
+    expect($sem['generated'])->toBe(0);
+
+    // Com lead-days=3 → entra
+    $com = (new InvoiceGeneratorService())->run(1, '2026-07-10', dryRun: true, leadDays: 3);
+    expect($com['generated'])->toBe(1);
+});
+
+test('7. Cross-tenant Tier 0: biz=99 NAO vaza biz=1', function () {
+    // Subscription real em biz=1
+    $plan1 = makePlan(1, 100.0, 'monthly');
+    makeSubscription(1, $plan1->id, '2026-07-10');
+
+    // Plan e subscription paralela em biz=99
+    $plan99 = makePlan(99, 200.0, 'monthly');
+    makeSubscription(99, $plan99->id, '2026-07-10');
+
+    // Roda só pra biz=99
+    $stats = (new InvoiceGeneratorService())->run(99, '2026-07-10');
+
+    expect($stats['generated'])->toBe(1);
+    expect(Invoice::where('business_id', 1)->count())->toBe(0); // biz=1 intacto
+    expect(Invoice::where('business_id', 99)->count())->toBe(1);
+    expect((float) Invoice::where('business_id', 99)->first()->valor)->toBe(200.0);
+});
+
+test('8. Logga SubscriptionEvent kind=event-charge', function () {
+    $plan = makePlan(1, 100.0, 'monthly');
+    $sub  = makeSubscription(1, $plan->id, '2026-07-10');
+
+    (new InvoiceGeneratorService())->run(1, '2026-07-10');
+
+    $event = SubscriptionEvent::where('subscription_id', $sub->id)->first();
+    expect($event)->not->toBeNull();
+    expect($event->kind)->toBe(SubscriptionEvent::KIND_CHARGE);
+    expect($event->by_actor)->toBe('system:rb:generate-invoices');
+    expect($event->body)->toContain('Fatura RB-');
+    expect($event->body)->toContain('R$ 100,00');
+});


### PR DESCRIPTION
## Por que existe

`rb_subscriptions` é a tabela das **assinaturas recorrentes** do módulo RecurringBilling. Sem este gerador, assinaturas ativas ficam **paradas** — `next_due_date` nunca avança e nenhuma `rb_invoice` nova aparece pra cobrar. Era a peça que faltava.

A SPEC documenta como **US-RB-003** desde abril/2026 mas nunca foi implementada. O `pos:generateSubscriptionInvoices` que existe no Kernel é do **UPos legacy** e trabalha em `subscriptions` (assinatura SaaS do business), não `rb_subscriptions`.

Gatilho real: sessão Eliana 2026-06-07 migração WR Comercial — pré-requisito pra criar as 109 assinaturas dos clientes mensalistas WR2.

## O que faz

`php artisan rb:generate-invoices [--business=N] [--date=Y-m-d] [--lead-days=N] [--dry-run] [--detail]`

Pra cada `rb_subscriptions` ativa com `next_due_date <= hoje + lead-days`:
1. **Idempotência** — pula se já existe `rb_invoice` mesma competência (YYYY-MM) pra essa subscription (status != canceled)
2. **Cria invoice** — status=open, vencimento=next_due_date, valor do plano, conta bancária da subscription, `numero_documento=RB-{id}-{YYYY-MM}`, metadata com origem
3. **Avança** `subscription.next_due_date += ciclo` usando `addMonthsNoOverflow` (Carbon — preserva anchor dia 31 → fev)
4. **Logga** `rb_subscription_events kind=event-charge` na timeline append-only

Tudo dentro de `DB::transaction` per-subscription pra atomicidade.

## Schedule

Daily **03:00 BRT** em env=live, `withoutOverlapping`, `onFailure` log estruturado. Registrado em `RecurringBillingServiceProvider::registerCommandSchedules` (não no Kernel principal — encapsulado no módulo).

## Multi-tenant Tier 0 (ADR 0093)

- `HasBusinessScope` global scope automático nos 3 models (`Subscription`, `Invoice`, `SubscriptionEvent`)
- `businessId` 1º arg do `run()` — sem `session()`/`auth()` (commands CLI)
- Sem `withoutGlobalScopes`
- Teste cross-tenant biz=99 não vaza biz=1 (ADR 0101)

## Cobertura (8 cenários)

`Tests/Feature/InvoiceGeneratorServiceTest.php` — SQLite in-memory pattern (espelha `Wave6PlanCrudTest`):

1. Cria invoice quando `next_due_date <= hoje`
2. Idempotência: 2× `run()` não duplica
3. Avança `next_due_date += 1 mês` (monthly) preservando anchor
4. Skipa subscription `paused`/`canceled`
5. `--dry-run` não escreve, mas conta
6. `--lead-days=3` antecipa: venc hoje+3 entra
7. **Cross-tenant Tier 0**: biz=99 NÃO vaza biz=1
8. Logga `SubscriptionEvent kind=event-charge` com body PT-BR

## Arquivos

| Arquivo | Linhas |
|---|---|
| `Modules/RecurringBilling/Services/InvoiceGeneratorService.php` | ~200 (novo) |
| `Modules/RecurringBilling/Console/Commands/GenerateInvoicesCommand.php` | ~100 (novo) |
| `Modules/RecurringBilling/Providers/RecurringBillingServiceProvider.php` | +20 (registro + schedule) |
| `Modules/RecurringBilling/Tests/Feature/InvoiceGeneratorServiceTest.php` | ~280 (novo) |

Total <300 linhas de diff produtivo — passa em commit-discipline.

## Smoke pós-deploy

```bash
ssh ... 'cd /home/.../public_html && php artisan rb:generate-invoices --dry-run --business=1'
# Deve mostrar: "TOTAL: 0 faturas geradas..." (não tem subscription ainda)
```

Após merge eu sigo pra criar as 109 assinaturas WR2 + smoke real.

## Refs

- SPEC: `memory/requisitos/RecurringBilling/SPEC.md` US-RB-003
- Sessão Eliana 2026-06-07 migração WR Comercial → biz=1
- ADR 0093 (multi-tenant Tier 0) · ADR 0101 (testes biz=1)
- ADR 0094 §"Mexeu, REGISTRA" — PR no git + CI + merge
