### PR TITLE
feat(governance): sentinela memory-health — batimento cardíaco da memória (ADR 0256 Onda 1)

### DIFF
--- a/.github/workflows/memory-health.yml
+++ b/.github/workflows/memory-health.yml
@@ -1,0 +1,30 @@
+name: Memory Health — ADR 0256
+
+# Sentinela de saúde da base de conhecimento (ADR 0256 Onda 1).
+# v1 = ADVISORY (--warn-only): surface no log do PR + heartbeat diário, NÃO bloqueia.
+# Onda 2 flipará pra enforce (remove --warn-only + adiciona baseline ratchet).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'memory/**'
+      - 'scripts/governance/memory-health.mjs'
+  schedule:
+    # Daily 06h30 BRT (09h30 UTC) — batimento cardíaco da memória (após health-check dados).
+    - cron: '30 9 * * *'
+  workflow_dispatch:
+
+jobs:
+  health:
+    name: memory-health (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # precisa do histórico p/ git log -1 (scorecard fantasma)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run memory-health sentinel
+        run: node scripts/governance/memory-health.mjs --warn-only

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * memory-health.mjs — sentinela de saúde da base de conhecimento (ADR 0256, Onda 1).
+ *
+ * O "batimento cardíaco" da memória: roda as checagens MECÂNICAS que a auditoria
+ * 2026-06-07 fez à mão, agora automáticas. Espelha `jana:health-check` (dados) e
+ * `screen-grades-ratchet` (telas), apontado pra a própria base de conhecimento.
+ * Determinístico, sem LLM, sem dependência — roda em CI (PR toca memory/**) e local.
+ *
+ * Checagens:
+ *   A · COLISÃO ADR não-registrada — número de ADR duplicado que NÃO aparece em
+ *       _INDEX-LIFECYCLE.md. (🔴 fail — espelha AdrNumberCollisionTest sem vendor.)
+ *   B · SCORECARD FANTASMA — scorecard cuja tela (.tsx) foi commitada DEPOIS do
+ *       graded_at → nota provavelmente stale. (🟡 warn — é sinal, não bloqueio.)
+ *   C · SEGREDO EM memory/ — secret pattern em memory/** sem entry no _INDEX-SECRETS.
+ *       (🔴 fail — defense-in-depth do secrets:scan PHP; este pega senha PT-BR/UUID.)
+ *   D · DOC STALE — doc canon com "última atualização"/reviewed_at > LIMIAR meses
+ *       que se diz canon/estado-atual. (🟡 warn.)
+ *
+ * Uso:
+ *   node scripts/governance/memory-health.mjs            (CI: exit 1 se algum 🔴)
+ *   node scripts/governance/memory-health.mjs --json     (saída JSON pra Daily Brief)
+ *   node scripts/governance/memory-health.mjs --warn-only (nunca exit 1; só relata)
+ *
+ * Refs: ADR 0256 (Knowledge Survival) · ADR 0215 (secrets) · ADR 0180 (colisão ADR)
+ *       · ADR 0250 (screen-qa) · AUDITORIA-CONFLITOS-MEMORIA-2026-06-07.md
+ */
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const JSON_OUT = process.argv.includes('--json');
+const WARN_ONLY = process.argv.includes('--warn-only');
+const STALE_MONTHS = 6; // doc canon parado > 6 meses = candidato a revisão
+
+const fails = []; // 🔴 bloqueia CI
+const warns = []; // 🟡 só sinaliza
+
+// ── helpers ────────────────────────────────────────────────────────────────
+const read = (p) => readFileSync(join(ROOT, p), 'utf8');
+const exists = (p) => existsSync(join(ROOT, p));
+function gitLastDate(relPath) {
+  try {
+    return execSync(`git log -1 --format=%cs -- "${relPath}"`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch { return ''; }
+}
+function listFiles(dir, filterFn) {
+  const out = [];
+  const walk = (d) => {
+    let entries;
+    try { entries = readdirSync(join(ROOT, d), { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const rel = `${d}/${e.name}`;
+      if (e.isDirectory()) walk(rel);
+      else if (filterFn(rel)) out.push(rel);
+    }
+  };
+  walk(dir);
+  return out;
+}
+
+// ── Check A: colisão de número de ADR não-registrada ────────────────────────
+function checkAdrCollisions() {
+  const dir = 'memory/decisions';
+  if (!exists(dir)) return;
+  const byNum = {};
+  for (const f of readdirSync(join(ROOT, dir))) {
+    const m = f.match(/^(\d{4})-.+\.md$/);
+    if (m) (byNum[m[1]] ??= []).push(f);
+  }
+  const dups = Object.entries(byNum).filter(([, fs]) => fs.length > 1);
+  // Registro de colisões conhecidas: _INDEX-LIFECYCLE.md (loose — número aparece no doc).
+  const idxPath = 'memory/decisions/_INDEX-LIFECYCLE.md';
+  const registry = exists(idxPath) ? read(idxPath) : '';
+  for (const [num, files] of dups) {
+    if (!registry.includes(num)) {
+      fails.push({ check: 'A', kind: 'colisao-adr-nao-registrada', num, files,
+        msg: `ADR ${num} colidiu (${files.length} arquivos) e NÃO está registrado em _INDEX-LIFECYCLE.md — registre a colisão (ADR 0180) ou referencie por slug.` });
+    }
+  }
+}
+
+// ── Check B: scorecard fantasma (tela mudou depois da nota) ─────────────────
+function checkScorecardFantasma() {
+  const dir = 'memory/governance/scorecards/screens';
+  if (!exists(dir)) return;
+  let stale = 0; const worst = [];
+  for (const f of readdirSync(join(ROOT, dir))) {
+    if (!f.endsWith('.yaml')) continue;
+    const txt = read(`${dir}/${f}`);
+    const graded = (txt.match(/^graded_at:\s*["']?([\d-]+)/m) || [])[1];
+    const path = (txt.match(/^path:\s*(.+)$/m) || [])[1]?.trim();
+    if (!graded || !path) continue;
+    const tsxDate = gitLastDate(path);
+    if (tsxDate && tsxDate > graded) { stale++; worst.push({ screen: f.replace('.yaml', ''), graded, tsxDate }); }
+  }
+  if (stale > 0) {
+    warns.push({ check: 'B', kind: 'scorecard-fantasma', count: stale,
+      sample: worst.slice(0, 8),
+      msg: `${stale} scorecard(s) com nota possivelmente STALE (a tela mudou depois do graded_at). Re-gradear pra a nota refletir o código atual.` });
+  }
+}
+
+// ── Check C: segredo em memory/ sem entry no índice ─────────────────────────
+// Só padrões ANCORADOS EM CONTEXTO (prefixo de segredo). Padrões genéricos de
+// alta-entropia (base64/uuid soltos) foram REMOVIDOS — davam 3000+ falso-positivos
+// (todo hash/ID em doc casava). Como Check C é GATE (🔴), precisa ser preciso.
+const SECRET_PATTERNS = {
+  bearer: /Authorization:\s*Bearer\s+([A-Za-z0-9_.\-]{20,})/i,
+  aws: /AKIA[0-9A-Z]{16}/,
+  assign_token: /\b(?:API_KEY|API_TOKEN|SECRET|SECRET_KEY|ADMIN_TOKEN|ACCESS_KEY|MASTER_KEY|CLIENT_SECRET|PRIVATE_KEY)\s*[:=]\s*["']?([A-Za-z0-9!@#$%^&*_.\-]{16,})["']?/i,
+  password_assign: /\b(?:PASSWORD|PASSWD|senha)\s*[:=]\s*["']?([^\s"'<>]{6,})["']?/i,
+};
+// valores que NÃO são segredo (reduz falso-positivo dos padrões ancorados).
+const SECRET_FALSE_POSITIVE = /placeholder|example|exemplo|REDACTED|\bxxx|\.\.\.|<[a-z_.]+>|\$\{|\$[A-Z_]+|env\(|getenv|valor no Vault|no Vaultwarden|\*{4,}/i;
+
+function checkSecretsInMemory() {
+  const idxPath = 'memory/_INDEX-SECRETS.md';
+  const index = exists(idxPath) ? read(idxPath) : '';
+  const files = listFiles('memory', (rel) => rel.endsWith('.md') && rel !== idxPath);
+  const hits = [];
+  for (const rel of files) {
+    const lines = read(rel).split('\n');
+    lines.forEach((line, i) => {
+      if (SECRET_FALSE_POSITIVE.test(line)) return;
+      for (const [name, re] of Object.entries(SECRET_PATTERNS)) {
+        const m = line.match(re);
+        if (!m) continue;
+        const value = m[1] || m[0];
+        // "coberto pelo índice" = valor OU caminho do arquivo citado no _INDEX-SECRETS.
+        const coveredByValue = index.includes(value);
+        const coveredByPath = index.includes(rel);
+        if (!coveredByValue && !coveredByPath) {
+          hits.push({ file: rel, line: i + 1, pattern: name });
+        }
+        break; // 1 hit por linha basta
+      }
+    });
+  }
+  if (hits.length) {
+    fails.push({ check: 'C', kind: 'segredo-em-memory', count: hits.length, sample: hits.slice(0, 15),
+      msg: `${hits.length} possível(is) segredo(s) em memory/** SEM entry no _INDEX-SECRETS. Mova pra CT100/Vault e cite só o ponteiro (ADR 0061/0215). Falso-positivo? Refine o padrão ou adicione ponteiro no índice.` });
+  }
+}
+
+// ── Check D: doc canon stale por idade ──────────────────────────────────────
+function checkStaleCanon() {
+  const today = new Date(gitLastDate('.') || '2026-06-07'); // evita Date.now (determinismo CI)
+  const cutoff = new Date(today); cutoff.setMonth(cutoff.getMonth() - STALE_MONTHS);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const files = listFiles('memory/reference', (rel) => rel.endsWith('.md'));
+  let staleN = 0; const sample = [];
+  for (const rel of files) {
+    const txt = read(rel);
+    const m = txt.match(/(?:reviewed_at|última atualização|ultima atualizacao)["':\s]*([\d]{4}-[\d]{2}-[\d]{2})/i);
+    if (m && m[1] < cutoffStr) { staleN++; if (sample.length < 8) sample.push({ file: rel, date: m[1] }); }
+  }
+  if (staleN > 0) {
+    warns.push({ check: 'D', kind: 'doc-stale', count: staleN, sample,
+      msg: `${staleN} doc(s) reference/ sem revisão há > ${STALE_MONTHS} meses — revisar ou marcar lifecycle.` });
+  }
+}
+
+// ── run ─────────────────────────────────────────────────────────────────────
+checkAdrCollisions();
+checkScorecardFantasma();
+checkSecretsInMemory();
+checkStaleCanon();
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ fails, warns, ok: fails.length === 0 }, null, 2));
+  process.exit(fails.length && !WARN_ONLY ? 1 : 0);
+}
+
+console.log(`\n🩺 memory-health — ${fails.length} 🔴 fail · ${warns.length} 🟡 warn\n`);
+for (const f of fails) {
+  console.error(`🔴 [${f.check}] ${f.msg}`);
+  if (f.files) f.files.forEach((x) => console.error(`     - ${x}`));
+  if (f.sample) f.sample.forEach((x) => console.error(`     - ${JSON.stringify(x)}`));
+}
+for (const w of warns) {
+  console.log(`🟡 [${w.check}] ${w.msg}`);
+  if (w.sample) w.sample.forEach((x) => console.log(`     - ${JSON.stringify(x)}`));
+}
+if (!fails.length && !warns.length) console.log('✓ base de conhecimento saudável (0 fail, 0 warn).');
+
+if (fails.length && !WARN_ONLY) {
+  console.error(`\n✗ memory-health: ${fails.length} problema(s) 🔴 — corrija ou justifique. (--warn-only pra não bloquear)`);
+  process.exit(1);
+}
+process.exit(0);

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -17,6 +17,9 @@
  *       (🔴 fail — defense-in-depth do secrets:scan PHP; este pega senha PT-BR/UUID.)
  *   D · DOC STALE — doc canon com "última atualização"/reviewed_at > LIMIAR meses
  *       que se diz canon/estado-atual. (🟡 warn.)
+ *   E · ADR ENUM-DRIFT — status/lifecycle de ADR fora do enum canônico
+ *       (accepted vs aceito, active vs ativo, canon/feature_wish inválidos).
+ *       É o que impede a contagem limpa de "ADRs ativos". (🟡 warn.)
  *
  * Uso:
  *   node scripts/governance/memory-health.mjs            (CI: exit 1 se algum 🔴)
@@ -163,11 +166,38 @@ function checkStaleCanon() {
   }
 }
 
+// ── Check E: drift de enum status/lifecycle em ADR ──────────────────────────
+// Enums canônicos do scripts/memory-schemas/adr.schema.json. Append-only bloqueia
+// editar ADR ratificada in-place — então normalizar é no leitor OU override
+// consciente; este check só IMPEDE PIORAR (flagga grafia/enum novo).
+const STATUS_OK = new Set(['rascunho', 'proposto', 'aceito', 'deprecated', 'superseded']);
+const LIFECYCLE_OK = new Set(['ativo', 'arquivado', 'substituido', 'historical']);
+function checkAdrEnumDrift() {
+  const dir = 'memory/decisions';
+  if (!exists(dir)) return;
+  const badStatus = {}, badLifecycle = {};
+  let n = 0;
+  for (const f of readdirSync(join(ROOT, dir))) {
+    if (!/^\d{4}-.+\.md$/.test(f)) continue;
+    const txt = read(`${dir}/${f}`);
+    const st = (txt.match(/^status:\s*["']?([^\s"'#]+)/m) || [])[1]?.toLowerCase();
+    const lc = (txt.match(/^lifecycle:\s*["']?([^\s"'#]+)/m) || [])[1]?.toLowerCase();
+    if (st && !STATUS_OK.has(st)) { badStatus[st] = (badStatus[st] || 0) + 1; n++; }
+    if (lc && !LIFECYCLE_OK.has(lc)) { badLifecycle[lc] = (badLifecycle[lc] || 0) + 1; n++; }
+  }
+  if (n > 0) {
+    warns.push({ check: 'E', kind: 'adr-enum-drift', count: n,
+      sample: [{ status_invalido: badStatus }, { lifecycle_invalido: badLifecycle }],
+      msg: `${n} ADR(s) com status/lifecycle fora do enum canônico (adr.schema.json). Normalizar (accepted→aceito, active→ativo; canon/feature_wish não são lifecycle válidos). Append-only bloqueia editar in-place: normalizar no leitor (decisions-search) ou override consciente.` });
+  }
+}
+
 // ── run ─────────────────────────────────────────────────────────────────────
 checkAdrCollisions();
 checkScorecardFantasma();
 checkSecretsInMemory();
 checkStaleCanon();
+checkAdrEnumDrift();
 
 if (JSON_OUT) {
   console.log(JSON.stringify({ fails, warns, ok: fails.length === 0 }, null, 2));


### PR DESCRIPTION
## O que é
Implementa a **Onda 1** da ADR 0256 (Knowledge Survival): a sentinela `memory-health` — equivalente, pra base de conhecimento, do `jana:health-check` (dados) e `screen-grades-ratchet` (telas). Determinística, Node, sem LLM, **rodável local** (sem CT100).

## Checagens
| | Check | Severidade |
|---|---|---|
| A | colisão de nº de ADR não-registrada em _INDEX-LIFECYCLE | 🔴 (espelha AdrNumberCollisionTest sem vendor) |
| B | scorecard fantasma (`.tsx` mudou depois do `graded_at`) | 🟡 |
| C | segredo em `memory/**` sem entry no _INDEX-SECRETS | 🔴 |
| D | doc `reference/` sem revisão > 6 meses | 🟡 |

## Validado localmente
Pegou a colisão **0246** (A), **85 scorecards fantasma** (B) e um **segredo real** — senha VoIP em `reference_central_voip_issabel` (C). Check C começou com 3020 falso-positivos (alta-entropia genérica) → removidos; ficou só o ancorado em contexto → 18 candidatos.

## v1 = ADVISORY
CI roda `--warn-only`: surface + heartbeat diário, **não bloqueia** (vários 🔴 zeram quando #2381/#2383 mergearem). Onda 2 = enforce + baseline + linha no Daily Brief.

Implementa ADR 0256 (#2385).

🤖 Generated with [Claude Code](https://claude.com/claude-code)