### PR TITLE
feat(governance): ADR 0257 — modelo status/lifecycle/kind de ADR + exceção de normalização

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -90,8 +90,37 @@ jobs:
           echo "--- Constituição modificada (exige cascade) ---"
           cat /tmp/const_mod.txt
 
+      - name: Exceção — normalização cirúrgica de metadados (ADR 0257)
+        id: norm
+        if: steps.detect.outputs.adr_mod_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Exceção append-only: só metadados (status/lifecycle/kind/authority), sob label.
+          # Protege a DECISÃO (corpo imutável); libera corrigir a ETIQUETA. ADR 0257.
+          labels=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" --jq '.[].name' 2>/dev/null || echo "")
+          if ! echo "$labels" | grep -qFx "adr-metadata-normalization"; then
+            echo "norm_ok=0" >> "$GITHUB_OUTPUT"
+            echo "Label 'adr-metadata-normalization' ausente — append-only normal."
+            exit 0
+          fi
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          ok=1
+          while IFS= read -r line; do
+            file=$(echo "$line" | sed -E 's/^M[[:space:]]+//')
+            [ -z "$file" ] && continue
+            bad=$(git diff "$base_sha"...HEAD -- "$file" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-](status|lifecycle|kind|authority):' || true)
+            if [ -n "$bad" ]; then
+              echo "::warning::$file muda fora de status/lifecycle/kind/authority — exceção NÃO aplica a esta PR."
+              ok=0
+            fi
+          done < /tmp/adr_mod.txt
+          echo "norm_ok=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" = "1" ]; then echo "✓ Normalização cirúrgica validada (ADR 0257) — exceção aplicada."; fi
+
       - name: Block ADR canon edits (append-only)
-        if: steps.detect.outputs.adr_mod_count != '0' || steps.detect.outputs.adr_renamed_count != '0'
+        if: steps.detect.outputs.adr_renamed_count != '0' || (steps.detect.outputs.adr_mod_count != '0' && steps.norm.outputs.norm_ok != '1')
         run: |
           set -euo pipefail
           echo "::error::ADR CANON é append-only (Constituição Art. 3 + ADR 0095)."

--- a/memory/decisions/0257-adr-status-lifecycle-kind-modelo-canonico.md
+++ b/memory/decisions/0257-adr-status-lifecycle-kind-modelo-canonico.md
@@ -1,0 +1,82 @@
+---
+slug: 0257-adr-status-lifecycle-kind-modelo-canonico
+number: 257
+title: "Modelo canônico de status/lifecycle/kind de ADR + exceção de normalização no append-only"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-06-07"
+module: governance
+related:
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0095-skills-tiers-convencao-interna
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0256-knowledge-survival-meia-vida-catraca-sentinela
+---
+
+# ADR 0257 — Modelo canônico status/lifecycle/kind de ADR
+
+## Contexto
+
+A sentinela `memory-health` (ADR 0256, Check E) achou **56 ADRs com `status`/`lifecycle` fora do enum**: `accepted`(28)/`aceita`(1)/`proposed`(10) misturados com `aceito`/`proposto`; `active`(6)/`canon`(8)/`feature_wish`(3) misturados com `ativo`. Por isso "quantos ADRs ativos?" não tinha resposta limpa.
+
+**Causa-raiz estrutural (não é só grafia):** havia **2 campos com semântica sobreposta e mal definida** (`status` vs `lifecycle` — superseded≈substituido, deprecated≈arquivado) e **nenhum eixo pra categoria** da ADR. Sem um lugar pra dizer "isto é um feature-wish / uma errata", as pessoas enfiaram isso no `lifecycle` (`feature_wish`) ou inventaram `canon`. Drift é sintoma de modelo ambíguo.
+
+Agravante: o gate append-only (`block-adr-edits`) **não tem exceção** — bloqueia QUALQUER ADR modificada, inclusive correção de schema de metadados. Append-only deve proteger a **decisão**, não impedir consertar a **etiqueta**.
+
+## Decisão
+
+### 1. Três eixos ortogonais (cada um responde 1 pergunta)
+
+| Campo | Pergunta | Enum |
+|---|---|---|
+| **`status`** | Em que ponto está a DECISÃO? | `rascunho` · `proposto` · `aceito` · `superseded` · `deprecated` |
+| **`lifecycle`** | O DOCUMENTO é fonte viva? | `ativo` · `substituido` · `arquivado` · `historical` |
+| **`kind`** (novo, opcional; default `decision`) | Que TIPO de ADR é? | `decision` · `feature-wish` · `errata` · `meta` |
+
+**Pareamentos canônicos** (status × lifecycle):
+- `aceito` + `ativo` → vigente (a maioria)
+- `superseded` + `substituido` → substituída (exige `superseded_by`)
+- `deprecated` + `arquivado` → abandonada
+- `proposto` + `ativo` → em discussão
+- qualquer + `historical` → registro que nunca foi "lei" (ex: ADR HISTORICAL, feature-wish parqueado)
+
+**"ADRs ativos"** = `lifecycle: ativo` (definição única, sem ambiguidade).
+
+### 2. Mapa de normalização (drift → canônico)
+
+| De | Para |
+|---|---|
+| status `accepted` / `aceita` | `aceito` |
+| status `proposed` | `proposto` |
+| lifecycle `active` / `canon` | `ativo` |
+| lifecycle `feature_wish` | `historical` + `kind: feature-wish` + `status: proposto` (hipótese parqueada, ADR 0105) |
+
+ADRs antigos em formato tabela (sem YAML frontmatter, ex 0126-vault/0128-smoke) = migração à parte (converter tabela→frontmatter), fora do escopo deste passo.
+
+### 3. Exceção de normalização no append-only
+
+O gate `block-adr-edits` passa a **permitir** modificação de ADR ratificada **se e somente se**:
+- a PR tem o label **`adr-metadata-normalization`**, E
+- o diff de cada ADR toca **APENAS** linhas de frontmatter dos campos `status`/`lifecycle`/`kind`/`authority` (nenhuma linha de corpo/decisão muda).
+
+Append-only do **conteúdo da decisão** continua intacto (corpo, contexto, decisão = imutáveis). Só a etiqueta de metadados pode ser normalizada, sob label + diff cirúrgico verificável.
+
+## Consequências
+
+- ✅ "ADRs ativos" vira contável (`lifecycle: ativo`).
+- ✅ `kind` dá casa pra categorias ortogonais → some o incentivo a inventar valor de lifecycle.
+- ✅ Append-only fica mais inteligente: protege decisão, libera correção de schema sob controle.
+- ✅ `memory-health` Check E + `adr.schema.json` viram a catraca que impede novo drift.
+- ⚠️ Custo: 1 migração (PR 2, ~35 arquivos) + manter o `kind` enum. Aceitável.
+
+## Implementação (2 PRs)
+- **PR 1 (este):** ADR + patch `block-adr-edits` (exceção label) + schema `adr.schema.json` (+`kind`, lifecycle `historical`) + script `scripts/governance/normalize-adr-frontmatter.mjs`.
+- **PR 2:** roda o script (normaliza ~35 ADRs frontmatter), mergeia com label `adr-metadata-normalization`. Atualiza `memory-health` Check E pro enum final.
+
+## Refs
+- Sentinela: `scripts/governance/memory-health.mjs` Check E (ADR 0256)
+- Schema: `scripts/memory-schemas/adr.schema.json`
+- Origem: pergunta Wagner "quantos ADRs ativos? isso está errado, quero estrutura melhor" (2026-06-07)

--- a/scripts/governance/normalize-adr-frontmatter.mjs
+++ b/scripts/governance/normalize-adr-frontmatter.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * normalize-adr-frontmatter.mjs — normaliza status/lifecycle de ADR pro enum canônico.
+ *
+ * Implementa o mapa de normalização da ADR 0257. SÓ toca frontmatter (status/lifecycle
+ * + adiciona kind quando aplicável) — corpo da decisão é IMUTÁVEL (append-only).
+ * O PR que rodar isto com --write precisa do label `adr-metadata-normalization`
+ * (a exceção cirúrgica do gate block-adr-edits, ADR 0257).
+ *
+ * Uso:
+ *   node scripts/governance/normalize-adr-frontmatter.mjs          (dry-run — só relata)
+ *   node scripts/governance/normalize-adr-frontmatter.mjs --write  (aplica)
+ *
+ * Refs: ADR 0257 (modelo status/lifecycle/kind) · ADR 0105 (feature-wish) · 0256 (sentinela)
+ */
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const WRITE = process.argv.includes('--write');
+const DIR = 'memory/decisions';
+
+const STATUS_MAP = { accepted: 'aceito', aceita: 'aceito', proposed: 'proposto' };
+const LIFECYCLE_MAP = { active: 'ativo', canon: 'ativo', feature_wish: 'historical' };
+
+let changed = 0;
+const report = [];
+
+for (const f of readdirSync(join(ROOT, DIR))) {
+  if (!/^\d{4}-.+\.md$/.test(f)) continue;
+  const path = join(ROOT, DIR, f);
+  const txt = readFileSync(path, 'utf8');
+  if (!txt.startsWith('---')) continue; // só ADR com YAML frontmatter (tabela = migração à parte)
+  const end = txt.indexOf('\n---', 3);
+  if (end === -1) continue;
+  const fm = txt.slice(0, end);
+  const body = txt.slice(end);
+  let lines = fm.split('\n');
+  const diffs = [];
+  let wasFeatureWish = false;
+  let hasKind = lines.some((l) => /^kind:/.test(l));
+
+  lines = lines.map((line) => {
+    let m;
+    if ((m = line.match(/^status:\s*["']?([A-Za-z_-]+)["']?\s*$/))) {
+      const v = m[1].toLowerCase();
+      if (STATUS_MAP[v]) { diffs.push(`status: ${m[1]} → ${STATUS_MAP[v]}`); return `status: ${STATUS_MAP[v]}`; }
+    }
+    if ((m = line.match(/^lifecycle:\s*["']?([A-Za-z_-]+)["']?\s*$/))) {
+      const v = m[1].toLowerCase();
+      if (v === 'feature_wish') wasFeatureWish = true;
+      if (LIFECYCLE_MAP[v]) { diffs.push(`lifecycle: ${m[1]} → ${LIFECYCLE_MAP[v]}`); return `lifecycle: ${LIFECYCLE_MAP[v]}`; }
+    }
+    return line;
+  });
+
+  // feature_wish → adiciona o eixo kind (categoria ortogonal, ADR 0257/0105) se faltar
+  if (wasFeatureWish && !hasKind) {
+    const li = lines.findIndex((l) => /^lifecycle:/.test(l));
+    if (li !== -1) { lines.splice(li + 1, 0, 'kind: feature-wish'); diffs.push('+ kind: feature-wish'); }
+  }
+
+  if (diffs.length) {
+    changed++;
+    report.push({ file: f, diffs });
+    if (WRITE) writeFileSync(path, lines.join('\n') + body);
+  }
+}
+
+console.log(`\n📐 normalize-adr-frontmatter — ${changed} ADR(s) ${WRITE ? 'NORMALIZADAS' : 'a normalizar (dry-run)'}\n`);
+for (const r of report) {
+  console.log(`  ${r.file}`);
+  r.diffs.forEach((d) => console.log(`     ${d}`));
+}
+if (!WRITE && changed) console.log(`\nDry-run. Rode com --write (PR com label adr-metadata-normalization) pra aplicar.`);
+if (!changed) console.log('✓ nenhuma ADR com drift de enum — frontmatter limpo.');

--- a/scripts/memory-schemas/adr.schema.json
+++ b/scripts/memory-schemas/adr.schema.json
@@ -48,6 +48,11 @@
       "type": "string",
       "enum": ["ativo", "arquivado", "substituido", "historical"]
     },
+    "kind": {
+      "type": "string",
+      "description": "Eixo ortogonal de categoria da ADR (ADR 0257). Default decision. feature-wish = hipótese parqueada (ADR 0105); errata = corrige outra ADR; meta = sobre o processo de ADR.",
+      "enum": ["decision", "feature-wish", "errata", "meta"]
+    },
     "decided_by": {
       "type": "array",
       "items": {


### PR DESCRIPTION
## Origem
Wagner: "quantos ADRs ativos? isso está errado, quero uma estrutura melhor, sinto necessidade."

A sentinela (ADR 0256 Check E) achou **56 ADRs com status/lifecycle fora do enum**. Raiz: **2 campos com semântica sobreposta + nenhum eixo de categoria** → gente inventava `canon`, `feature_wish`, `active`.

## A estrutura melhor (3 eixos ortogonais)
| Campo | Pergunta | Enum |
|---|---|---|
| `status` | onde está a DECISÃO? | rascunho·proposto·aceito·superseded·deprecated |
| `lifecycle` | o DOC é fonte viva? | ativo·substituido·arquivado·historical |
| `kind` (novo) | que TIPO de ADR? | decision·feature-wish·errata·meta |

**"ADRs ativos" = `lifecycle: ativo`** (definição única). O eixo `kind` dá casa pra feature-wish (ADR 0105) → some o incentivo a poluir o lifecycle.

## Exceção no append-only (a parte Tier-0)
O gate `block-adr-edits` não tinha exceção — proibia até corrigir schema. Agora libera ADR modificada **só com label `adr-metadata-normalization` E diff tocando apenas status/lifecycle/kind/authority**. **Append-only do conteúdo da decisão segue intacto**; rename segue bloqueado.

## Conteúdo do PR 1
ADR 0257 · patch do gate · `adr.schema.json` (+kind) · `normalize-adr-frontmatter.mjs` (dry-run validado: **39 ADRs, 56 campos**).

## Próximo (PR 2, após merge)
Rodar `normalize-adr-frontmatter.mjs --write` + mergear com o label → os 39 ficam canônicos. Aí "ADRs ativos" vira contável e a sentinela Check E zera.

⚠️ `status: proposto` — mexe em gate Tier-0 append-only, **requer sua ratificação**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)