### PR TITLE
fix(memory): resolve conflito de merge em Admin/UI-CATALOG.md

### DIFF
--- a/memory/requisitos/Admin/UI-CATALOG.md
+++ b/memory/requisitos/Admin/UI-CATALOG.md
@@ -1,62 +1,3 @@
-<<<<<<< HEAD
-# Admin — UI Catalog (auto-gerado bulk W31-10)
-
-> **Ultima atualizacao:** 2026-05-17 (W31-10)
-> **Auto-regeneravel.** Manter versao; reescrever via gerador (nao editar manual em campos de auto-status).
-> Pages dir: `resources/js/Pages/Admin/`
-
-## Resumo
-
-- Telas Inertia tsx: **6**
-- Charters `.charter.md`: **3** (cobertura: 50%)
-- Blade legacy do modulo (Modules/<X>/Resources/views): **0**
-
-## Telas Inertia tsx
-
-| Tela | Charter | review.md | Status | Round | Smoke pendente |
-|---|:---:|:---:|---|---:|:---:|
-| `FeatureFlags/Index.tsx` | - | - | legacy | 0 | sim |
-| `FeatureFlags/Show.tsx` | - | - | legacy | 0 | sim |
-| `GovernanceV4.tsx` | OK | - | awaiting-smoke-browser | 1 | sim |
-| `GovernanceV4Dashboard.tsx` | OK | - | awaiting-smoke-browser | 1 | sim |
-| `Index.tsx` | OK | - | awaiting-smoke-browser | 1 | sim |
-| `RagQualityDashboard.tsx` | - | - | legacy | 0 | sim |
-
-
-## Blade legacy restantes
-
-sem Blade legacy direto neste modulo
-
-## Migracao planejada (MWART — [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md))
-
-- Estimativa de telas Blade alvo MWART: **0**
-- Prioridade: **N/A — Inertia/React majoritario**
-- Skill canon: `migracao-blade-react` (Tier B auto-trigger)
-- Cross-ref: `memory/sessions/2026-05-17-blade-migration-plan.md` (plano executivo cross-projeto)
-
-## Convencoes
-
-- **Charter obrigatorio** antes de `Write` em `.tsx` ([ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md))
-- **review.md** = avaliacao Wagner pos-smoke browser (criar quando aprovar visualmente em prod)
-- **Status pipeline:**
-  - `legacy` — sem charter, sem review (precisa charter + MWART F1 design)
-  - `charter-WIP` — charter aberto sem status valido
-  - `awaiting-smoke-browser` — charter `draft` aceito, falta smoke biz=1 ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
-  - `review-pending` — tela em revisao por Wagner
-  - `reviewed-no-charter` — review.md existe mas charter ausente (regularizar)
-  - `live` — charter status `live` + smoke validado biz=1
-
-## Como regenerar
-
-```bash
-bash /tmp/generate_catalogs.sh
-```
-
-(Em S4+ vira `php artisan ui:catalog-generate` — issue futura)
-
----
-Gerado por W31-10 (bulk-screen-review-r1, areas isoladas, sem git ops).
-=======
 # Admin — UI Catalog
 
 > Gerado por `php artisan admin:ui-catalog-generate Admin` — daily 09:30 BRT.
@@ -110,4 +51,3 @@ Gerado por W31-10 (bulk-screen-review-r1, areas isoladas, sem git ops).
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-17 | W30 Agent D | UI-CATALOG.md seed criado pra Admin (4 telas: GovernanceV4 / GovernanceV4Dashboard / Index / ScreenReview). Próximas gerações automáticas via `php artisan admin:ui-catalog-generate Admin` daily 09:30 BRT. |
->>>>>>> origin/main


### PR DESCRIPTION
## O quê
`memory/requisitos/Admin/UI-CATALOG.md` tinha marcadores de conflito de merge `<<<<<<< HEAD ... ======= ... >>>>>>> origin/main` **commitados no main** (arquivo quebrado).

Causa: **dois geradores** brigando pelo mesmo arquivo auto-gerado — bulk W31-10 (HEAD) vs cron diário `admin:ui-catalog-generate` (origin/main). Mantive o lado do **gerador ativo** (cron diário 09:30 BRT); ele regenera no próximo run.

## Padrão de fundo
É o mesmo que o Wagner apontou: **arquivo auto-gerado + commitado no git + regenerado por cron = "volta" e conflita**. Outros nessa categoria: `memory/feedback/INDEX.md` (cron `feedback:reindex`), `memory/modulos/INDEX.md` (`module:specs`). Fix estrutural (gitignore auto-gen / single-owner) proposto à parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)