### PR TITLE
docs(governance): aposenta 3 índices de ADR manuais → ponteiro pro gerado (ADR 0258)

### DIFF
--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -1,5 +1,7 @@
 # memory/ — Índice navegável (~2.300 docs)
 
+> ℹ️ Contagens aqui são aproximadas (navegação). A lista canônica de ADRs é **GERADA**: [`decisions/_INDEX-GENERATED.md`](decisions/_INDEX-GENERATED.md) (ADR 0258).
+
 > Mapa pra navegar `memory/`. Para **estado VIVO** (cycle ativo, tasks, brief), use tools MCP: `brief-fetch`, `my-work`, `cycles-active`, `decisions-search`.
 > Documento canônico — atualizar quando criar nova categoria. Reorg: ver [AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13](requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md) §5 (G2).
 

--- a/memory/INDEX_TEMATICO.md
+++ b/memory/INDEX_TEMATICO.md
@@ -1,5 +1,7 @@
 # INDEX_TEMATICO.md — Índice Temático da Memória (Cowork + Git)
 
+> ⚠️ Para a lista **COMPLETA e atual de ADRs** (status/lifecycle/colisões), use o índice **GERADO** [`decisions/_INDEX-GENERATED.md`](decisions/_INDEX-GENERATED.md) (ADR 0258). Este índice temático é navegação por tema e pode estar atrás do disco.
+
 > **Busca por tema, não por número.** Une as duas memórias: a **grande memória do git**
 > (`wagnerra23/oimpresso.com` · `memory/decisions/` · ~239 ADRs Nygard, numeração monotônica
 > ADR 0028) e a **memória do Cowork** (projeto de design). Para "o que decidimos sobre X?", venha aqui.

--- a/memory/decisions/README.md
+++ b/memory/decisions/README.md
@@ -1,5 +1,7 @@
 # Architecture Decision Records (ADRs)
 
+> ⚠️ **Este README NÃO é a lista de ADRs** — está obsoleto (parou no ADR 0023, era "Ponto WR2"). A lista canônica e atual é **GERADA**: [`_INDEX-GENERATED.md`](_INDEX-GENERATED.md) (modelo Log4brains, ADR 0258 / PR #2391 · `node scripts/governance/adr-index-generate.mjs`). Este arquivo serve só como doc de "o que é / como criar uma ADR".
+
 Este diretório contém os registros formais de decisões arquiteturais importantes do projeto Ponto WR2.
 
 ## O que é uma ADR


### PR DESCRIPTION
## Peça #3 do ADR 0258
Os índices manuais que mentiam ganham banner apontando pra a **fonte única gerada** `_INDEX-GENERATED.md` (PR #2391):
- `decisions/README.md` — obsoleto (parou no ADR 0023, era "Ponto WR2")
- `INDEX_TEMATICO.md` — navegação por tema; atrás do disco
- `INDEX.md` — contagens aproximadas

**`_INDEX-LIFECYCLE.md` fica intocado de propósito** — o `decisions-search` (MCP) consome o frontmatter dele; migrá-lo é à parte e com cuidado (ADR 0258). O gerado é a lista completa; o lifecycle-index segue como companion curado de colisões/notas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)