### PR TITLE
fix(governance): gate libera superseded_by/supersedes + conserta parser do índice

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -110,9 +110,9 @@ jobs:
           while IFS= read -r line; do
             file=$(echo "$line" | sed -E 's/^M[[:space:]]+//')
             [ -z "$file" ] && continue
-            bad=$(git diff "$base_sha"...HEAD -- "$file" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-](status|lifecycle|kind|authority):' || true)
+            bad=$(git diff "$base_sha"...HEAD -- "$file" | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-](status|lifecycle|kind|authority|superseded_by|supersedes):' | grep -vE "^[+-][[:space:]]*-[[:space:]]*['\"]?[0-9]{3,4}" || true)
             if [ -n "$bad" ]; then
-              echo "::warning::$file muda fora de status/lifecycle/kind/authority — exceção NÃO aplica a esta PR."
+              echo "::warning::$file muda fora de status/lifecycle/kind/authority/superseded_by/supersedes — exceção NÃO aplica a esta PR."
               ok=0
             fi
           done < /tmp/adr_mod.txt

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -26,21 +26,17 @@
 - **0236** ×3: 0236-extrato-conciliacao-modelo-unificado · 0236-governanca-evolucao-doc-design · 0236-scorecard-universal-entidade-arbitraria
 - **0246** ×2: 0246-sessao-2026-05-30-ds-harmonizacao · 0246-tipo-outros-default-migracoes-legacy
 
-## Integridade de supersessão (14 alertas)
+## Integridade de supersessão (10 alertas)
 - ⚠️ 0011 supersedes 0002 → 0002 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0011 supersedes 0001 → 0001 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0048 supersedes 0035 → 0035 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0048 supersedes 0035 → 0035 NÃO está marcada substituido/superseded ⚠️
-- ⚠️ 0048 supersedes 2026 → ADR 2026 NÃO existe
 - ⚠️ 0053 supersedes 0036 → 0036 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0053 supersedes 0036 → 0036 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0055 supersedes 0054 → 0054 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0060 supersedes 0044 → 0044 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0092 supersedes 0088 → 0088 NÃO está marcada substituido/superseded ⚠️
-- ⚠️ 0172 supersedes 0005 → 0005 NÃO está marcada substituido/superseded ⚠️
-- ⚠️ 0172 supersedes 0001 → 0001 NÃO está marcada substituido/superseded ⚠️
 - ⚠️ 0178 supersedes 0136 → 0136 NÃO está marcada substituido/superseded ⚠️
-- ⚠️ 0235 supersedes 295 → ADR 295 NÃO existe
 
 ## Todas as ADRs (263)
 | Nº | Status | Lifecycle | Kind | Título |

--- a/scripts/governance/adr-index-generate.mjs
+++ b/scripts/governance/adr-index-generate.mjs
@@ -35,11 +35,13 @@ function field(fm, key) {
   return m ? m[1].trim().replace(/^["']|["']$/g, '') : '';
 }
 function numbersFrom(fm, key) {
-  // captura [0028] inline OU lista multilinha "- '0028'"
+  // captura [0028] inline OU lista multilinha "- '0028'".
+  // Pega só o nº do ITEM (após [ ou após -), ignorando comentários (#) e anos/hues
+  // em trailing text (ex: "- 0190 # oklch 295" → 0190, não 295; "2026-..." em comentário → nada).
   const inline = fm.match(new RegExp(`^${key}:\\s*\\[([^\\]]*)\\]`, 'mi'));
-  if (inline) return (inline[1].match(/\d{3,4}/g) || []);
+  if (inline) return inline[1].split(',').map((s) => (s.match(/(\d{3,4})/) || [])[1]).filter(Boolean);
   const block = fm.match(new RegExp(`^${key}:\\s*\\n((?:\\s*-\\s*.+\\n?)+)`, 'mi'));
-  if (block) return (block[1].match(/\d{3,4}/g) || []);
+  if (block) return block[1].split('\n').map((l) => (l.split('#')[0].match(/-\s*['"]?(\d{3,4})/) || [])[1]).filter(Boolean);
   return [];
 }
 


### PR DESCRIPTION
Habilita o conserto dos conflitos de ADR. (A) exceção do gate (ADR 0257) agora aceita superseded_by/supersedes — sem isso o adr-supersede não passava. (B) parser do gerador ignora comentário/ano/hue (somem os falsos 'supersedes 2026'/'295'). Alertas de supersessão 14→10. 🤖 Generated with [Claude Code](https://claude.com/claude-code)