### PR TITLE
fix(deps): remove ajv/ajv-formats acidentais (quebrava npm ci / Vite build no main)

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,8 +110,6 @@
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-query-devtools": "^5.0.0",
     "@tanstack/react-table": "^8.21.3",
-    "ajv": "^8.20.0",
-    "ajv-formats": "^3.0.1",
     "centrifuge": "^5.5.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## Regressão que EU introduzi (pega no 'olhe o CI')
O Vite build no main falhava no `npm ci`: package.json tinha `ajv@8`/`ajv-formats` mas o lock não → fora de sync.

**Causa:** no #2397 (teste físico), pra validar ADRs eu rodei `npm i ajv` local — sujou o package.json com essas deps, e ao commitar o package.json (pela linha do script de teste) levei as deps junto **sem o lock**.

**Fix:** removo ajv/ajv-formats do package.json (não são deps do projeto — a schema-gate instala efêmero). `npm ci --dry-run` volta a passar.

Pest já estava ✅; isto reverde o Vite build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)