### PR TITLE
docs(adr): errata 0259/0260 — resolve contradições de corpo (GAP 5)

### DIFF
--- a/memory/decisions/0259-errata-0091-brief-modelo-gpt4o-mini.md
+++ b/memory/decisions/0259-errata-0091-brief-modelo-gpt4o-mini.md
@@ -1,0 +1,33 @@
+---
+slug: 0259-errata-0091-brief-modelo-gpt4o-mini
+number: 259
+title: "Errata 0091 — modelo do Brief é gpt-4o-mini (não Sonnet); §Geração superseded por 0097/0226"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+kind: errata
+decided_by: [W]
+decided_at: "2026-06-07"
+module: governance
+related: ['0091-daily-brief', '0097-brief-model-gpt4o-mini-supersede-parcial-0091', '0226-brief-v2-1m-aware-rico']
+---
+
+# ADR 0259 — Errata 0091 (modelo do Brief)
+
+## Contexto
+
+A auditoria de conflitos 2026-06-07 (PR #2390) achou contradição entre ADRs ATIVAS: o **corpo da ADR 0091** (`daily-brief`) ainda diz que o Brain B do Brief usa `claude-sonnet-4-6`, mas a decisão vigente é **`gpt-4o-mini`** (ADR 0097, 20–25× mais barato) com limite de token 8k (ADR 0226).
+
+É supersessão **parcial** (só a §Geração de 0091 mudou; o resto do contrato do Brief vale). Como o append-only proíbe editar o corpo de uma ADR ratificada, esta **errata** é o ponteiro canônico da correção.
+
+## Decisão
+
+Quem lê a ADR 0091 deve ler junto esta errata: **o modelo do Brief é `gpt-4o-mini` (ADR 0097) + token limit ~8k (ADR 0226)**, NÃO `claude-sonnet-4-6`. A linha de modelo no corpo de 0091 é histórica.
+
+## Consequências
+- ✅ Resolve a "mentira do Sonnet" (PR #2270) sem violar append-only.
+- ✅ Padrão de erratas (`kind: errata`) pra contradições de corpo onde supersede total não cabe (GAP 5, ADR 0258).
+
+## Refs
+ADR 0091 · 0097 · 0226 · auditoria `memory/governance/AUDITORIA-CONFLITOS-ADR-2026-06-07.md`

--- a/memory/decisions/0260-errata-0182-pageheader-cor-roxo-universal.md
+++ b/memory/decisions/0260-errata-0182-pageheader-cor-roxo-universal.md
@@ -1,0 +1,33 @@
+---
+slug: 0260-errata-0182-pageheader-cor-roxo-universal
+number: 260
+title: "Errata 0182 — cor primária do PageHeader é roxo universal 295 (não hue-per-grupo); §cor superseded por 0235"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+kind: errata
+decided_by: [W]
+decided_at: "2026-06-07"
+module: governance
+related: ['0182-pageheadertabs-canon-pattern-telas', '0235-ds-v4-accent-roxo-universal']
+---
+
+# ADR 0260 — Errata 0182 (cor do PageHeader)
+
+## Contexto
+
+A auditoria de conflitos 2026-06-07 (PR #2390) achou contradição entre ADRs ATIVAS: o **corpo da ADR 0182** (`pageheadertabs-canon-pattern-telas`) ainda manda usar `oklch(0.6 0.15 {hue})` **hue-por-grupo** no botão primário (Zona R), mas a decisão vigente é **roxo universal `oklch(0.55 0.15 295)`** (ADR 0235 DS v4 — "hue-per-grupo deixa de valer").
+
+É supersessão **parcial** (só a regra de cor de 0182 mudou; o pattern de PageHeaderTabs vale). Append-only proíbe editar o corpo → esta **errata** é o ponteiro canônico.
+
+## Decisão
+
+Quem implementa tela lendo a ADR 0182 deve ler junto esta errata: **a cor primária é roxo universal `oklch(0.55 0.15 295)` (ADR 0235)**, NÃO hue-por-grupo. A instrução de hue no corpo de 0182 é histórica.
+
+## Consequências
+- ✅ Acaba o risco de tela nova nascer com cor errada (hue) por ler só 0182.
+- ✅ Padrão de erratas (GAP 5, ADR 0258) pra contradição de corpo sem supersede total.
+
+## Refs
+ADR 0182 · 0235 · auditoria `memory/governance/AUDITORIA-CONFLITOS-ADR-2026-06-07.md`

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **263** arquivos · **248** números únicos · máx **0258**
-- **ADRs ATIVOS (lifecycle ativo): 223** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 203 · proposto 34 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 223 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **265** arquivos · **250** números únicos · máx **0260**
+- **ADRs ATIVOS (lifecycle ativo): 225** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 205 · proposto 34 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 225 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (263)
+## Todas as ADRs (265)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -295,3 +295,5 @@ _(íntegra)_
 | 0256 | proposto | ativo | decision | Knowledge Survival — conhecimento tem meia-vida; sobrevive por catraca + sentine |
 | 0257 | proposto | ativo | decision | Modelo canônico de status/lifecycle/kind de ADR + exceção de normalização no app |
 | 0258 | proposto | ativo | decision | Processo de ADR estado-da-arte — índice gerado + supersede atômico + status-mutá |
+| 0259 | aceito | ativo | errata | Errata 0091 — modelo do Brief é gpt-4o-mini (não Sonnet); §Geração superseded po |
+| 0260 | aceito | ativo | errata | Errata 0182 — cor primária do PageHeader é roxo universal 295 (não hue-per-grupo |


### PR DESCRIPTION
Fecha o GAP 5 da revisão. As contradições de CORPO (0091 diz Sonnet vs 0097 gpt-4o-mini; 0182 diz hue vs 0235 roxo) são supersessão PARCIAL — append-only proíbe editar o corpo. Solução canônica: **ADRs-errata curtas** (`kind: errata`) que registram a correção. 0259→0091, 0260→0182. Índice regenerado. 🤖 Generated with [Claude Code](https://claude.com/claude-code)