### PR TITLE
feat(governance): GAP 2 — memory-health ENFORCE + baseline ratchet

### DIFF
--- a/.github/workflows/memory-health.yml
+++ b/.github/workflows/memory-health.yml
@@ -1,8 +1,10 @@
 name: Memory Health — ADR 0256
 
-# Sentinela de saúde da base de conhecimento (ADR 0256 Onda 1).
-# v1 = ADVISORY (--warn-only): surface no log do PR + heartbeat diário, NÃO bloqueia.
-# Onda 2 flipará pra enforce (remove --warn-only + adiciona baseline ratchet).
+# Sentinela de saúde da base de conhecimento (ADR 0256 + 0258 GAP 2).
+# ENFORCE: PR falha em FAIL-class (segredo NOVO acima do baseline · colisão ADR
+# não-registrada · auto-mem ressuscitada/cron reativado). Warns (scorecard stale,
+# enum drift) só sinalizam. Baseline ratchet em scripts/governance/.memory-health-baseline.json
+# (aceitos atuais; segredo novo bloqueia — `--update-baseline` se legítimo).
 
 on:
   pull_request:
@@ -10,6 +12,7 @@ on:
     paths:
       - 'memory/**'
       - 'scripts/governance/memory-health.mjs'
+      - 'scripts/governance/.memory-health-baseline.json'
   schedule:
     # Daily 06h30 BRT (09h30 UTC) — batimento cardíaco da memória (após health-check dados).
     - cron: '30 9 * * *'
@@ -17,7 +20,7 @@ on:
 
 jobs:
   health:
-    name: memory-health (advisory)
+    name: memory-health (enforce — fail-class bloqueia)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -26,5 +29,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Run memory-health sentinel
-        run: node scripts/governance/memory-health.mjs --warn-only
+      - name: Run memory-health sentinel (enforce)
+        run: node scripts/governance/memory-health.mjs

--- a/scripts/governance/.memory-health-baseline.json
+++ b/scripts/governance/.memory-health-baseline.json
@@ -1,0 +1,19 @@
+{
+  "checkC": {
+    "memory/decisions/0021-officeimpresso-contrato-api-delphi.md": 1,
+    "memory/dominios/wr-comercial/ARQUITETURA.md": 1,
+    "memory/legacy-delphi/PEGADINHAS.md": 1,
+    "memory/legacy-delphi/SCHEMA-FIREBIRD.md": 1,
+    "memory/legacy-delphi/_INDEX.md": 1,
+    "memory/reference/contrato-delphi-inviolavel.md": 1,
+    "memory/reference/legacy-delphi-firebird.md": 1,
+    "memory/reference/whatsapp-daemon-ct100.md": 1,
+    "memory/requisitos/Cms/login-spec-2026-04-26.md": 1,
+    "memory/requisitos/NfeBrasil/adr/ui/0003-configuracao-fiscal-3-niveis.md": 1,
+    "memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md": 1,
+    "memory/requisitos/Officeimpresso/RUNBOOK-financial-snapshot-cliente.md": 2,
+    "memory/requisitos/RecurringBilling/RUNBOOK-inter-pj.md": 1,
+    "memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md": 1,
+    "memory/research/clientes-legacy-officeimpresso/_COMO-ANALISAR.md": 1
+  }
+}

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -29,7 +29,7 @@
  * Refs: ADR 0256 (Knowledge Survival) · ADR 0215 (secrets) · ADR 0180 (colisão ADR)
  *       · ADR 0250 (screen-qa) · AUDITORIA-CONFLITOS-MEMORIA-2026-06-07.md
  */
-import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
 
@@ -37,6 +37,13 @@ const ROOT = process.cwd();
 const JSON_OUT = process.argv.includes('--json');
 const WARN_ONLY = process.argv.includes('--warn-only');
 const STALE_MONTHS = 6; // doc canon parado > 6 meses = candidato a revisão
+
+// GAP 2 (ADR 0258) — baseline ratchet do Check C (segredos): só falha em segredo NOVO
+// acima do teto por arquivo. Aceitos (ex: default Firebird "masterkey") ficam no baseline.
+const BASELINE_FILE = 'scripts/governance/.memory-health-baseline.json';
+const UPDATE_BASELINE = process.argv.includes('--update-baseline');
+const baseline = existsSync(join(ROOT, BASELINE_FILE)) ? JSON.parse(readFileSync(join(ROOT, BASELINE_FILE), 'utf8')) : { checkC: {} };
+let checkCByFile = {};
 
 const fails = []; // 🔴 bloqueia CI
 const warns = []; // 🟡 só sinaliza
@@ -142,9 +149,17 @@ function checkSecretsInMemory() {
       }
     });
   }
-  if (hits.length) {
-    fails.push({ check: 'C', kind: 'segredo-em-memory', count: hits.length, sample: hits.slice(0, 15),
-      msg: `${hits.length} possível(is) segredo(s) em memory/** SEM entry no _INDEX-SECRETS. Mova pra CT100/Vault e cite só o ponteiro (ADR 0061/0215). Falso-positivo? Refine o padrão ou adicione ponteiro no índice.` });
+  // Ratchet por arquivo (GAP 2): só segredo NOVO acima do baseline falha. Remover é livre.
+  for (const h of hits) checkCByFile[h.file] = (checkCByFile[h.file] || 0) + 1;
+  if (UPDATE_BASELINE) return; // no modo update só capturamos; nada de fail
+  const novos = [];
+  for (const [f, n] of Object.entries(checkCByFile)) {
+    const teto = (baseline.checkC || {})[f] || 0;
+    if (n > teto) novos.push(`${f} (${n - teto} novo acima do teto ${teto})`);
+  }
+  if (novos.length) {
+    fails.push({ check: 'C', kind: 'segredo-novo-em-memory', count: novos.length, sample: novos.slice(0, 15),
+      msg: `segredo(s) NOVO(s) em memory/** acima do baseline. Mova pra CT100/Vault + ponteiro (ADR 0061/0215). Se legítimo (ex: default doc), rode --update-baseline.` });
   }
 }
 
@@ -219,6 +234,12 @@ checkSecretsInMemory();
 checkStaleCanon();
 checkAdrEnumDrift();
 checkAntiResurrection();
+
+if (UPDATE_BASELINE) {
+  writeFileSync(join(ROOT, BASELINE_FILE), JSON.stringify({ checkC: checkCByFile }, null, 2) + '\n');
+  console.log(`✓ baseline atualizado: ${BASELINE_FILE} (${Object.keys(checkCByFile).length} arquivos com Check C aceitos)`);
+  process.exit(0);
+}
 
 if (JSON_OUT) {
   console.log(JSON.stringify({ fails, warns, ok: fails.length === 0 }, null, 2));

--- a/tests/governanceAdrScripts.spec.ts
+++ b/tests/governanceAdrScripts.spec.ts
@@ -108,3 +108,21 @@ describe('GAP 3 — invariante anti-ressurreição (memory-health Check F, ADR 0
     expect(out).not.toMatch(/\[F\]/); // Check F sem fail
   });
 });
+
+describe('GAP 2 — memory-health ENFORCE + baseline ratchet (Check C, ADR 0258)', () => {
+  it('FALHA (enforce) em segredo NOVO fora do baseline', () => {
+    writeFileSync(join(tmp, 'memory/vazou.md'), '# doc\n\nPASSWORD: hunter2secretLeak123\n');
+    let threw = false; let msg = '';
+    try { run(`node "${MH}"`); } // sem --warn-only = enforce; sem baseline no tmp = tudo novo
+    catch (e: any) { threw = true; msg = (e.stdout || '') + (e.stderr || ''); }
+    expect(threw).toBe(true);
+    expect(msg).toMatch(/segredo|memory/i);
+  });
+  it('--update-baseline aceita o atual e a próxima rodada passa (ratchet)', () => {
+    mkdirSync(join(tmp, 'scripts/governance'), { recursive: true }); // destino do baseline
+    writeFileSync(join(tmp, 'memory/legado.md'), '# doc\n\nPASSWORD: defaultDocValue123\n');
+    run(`node "${MH}" --update-baseline`); // aceita o estado atual
+    const out = run(`node "${MH}"`); // agora passa (nada NOVO acima do baseline)
+    expect(out).toMatch(/0 .*fail|saudável|🩺/i);
+  });
+});


### PR DESCRIPTION
Fecha o GAP 4... digo, GAP 2 da revisão. memory-health era **advisory** (--warn-only) → agora **enforce**: fail-class bloqueia o PR. Check C (segredo em memory/) vira **ratchet por arquivo** — baseline aceita os 15 atuais (defaults Firebird/legacy); **só segredo NOVO bloqueia** (--update-baseline se legítimo). Isso torna Check F (anti-ressurreição, GAP 3) + Check C **gates duros de verdade**. Meta-testes: **9/9** (enforce falha em segredo novo; ratchet aceita baseline). 🤖 Generated with [Claude Code](https://claude.com/claude-code)