### PR TITLE
ci(governance): Governance Gate umbrella — a rede (ADR 0256/0258)

### DIFF
--- a/.github/workflows/governance-gate-umbrella.yml
+++ b/.github/workflows/governance-gate-umbrella.yml
@@ -1,0 +1,39 @@
+name: Governance Gate (umbrella)
+
+# A REDE (ADR 0256/0258) — UM check que agrega os gates determinísticos de governança.
+# Roda em TODO PR pro main (SEM path-filter) → sempre reporta → pode ser marcado
+# `required` no ruleset sem travar PR não-relacionado (resolve o deadlock de path-filter).
+#
+# FASE: nasce ADVISORY (roda + mostra verde/vermelho, NÃO bloqueia até ser adicionado
+# aos required-checks do ruleset). Flip pra enforce = passo deliberado após ~2 semanas
+# limpo (ver memory: decisao-pendente-enforcement-gates). Break-glass = ruleset bypass-actor
+# com audit log (mantém escape de emergência, mas registrado) — não enforce_admins binário.
+#
+# Agrega: índice de ADR (--check + supersede-integrity) · memory-health (enforce) ·
+# meta-teste vitest (controle-negativo dos próprios gates). Append-only canon segue no
+# governance-gate.yml (lógica de label/gh-api própria).
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  governance:
+    name: Governance Gate (índice + memory-health + meta-teste)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # memory-health Check B usa git log -1 (scorecard fantasma)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install deps (pro vitest)
+        run: npm ci
+      - name: Índice de ADR em dia + supersede íntegra
+        run: node scripts/governance/adr-index-generate.mjs --check
+      - name: memory-health (enforce — segredo novo / colisão / ressurreição bloqueiam)
+        run: node scripts/governance/memory-health.mjs
+      - name: Meta-teste dos scripts de governança (controle-negativo)
+        run: npm run test:adr-governance


### PR DESCRIPTION
## Pendura a rede
**1 check umbrella** que agrega os gates determinísticos de governança num workflow só:
- `adr-index-generate --check` (catraca do índice + supersede-integrity)
- `memory-health` (enforce — segredo novo / colisão ADR / auto-mem ressuscitada bloqueiam)
- `npm run test:adr-governance` (meta-teste / controle-negativo dos próprios gates)

## Por que assim (deep-research)
Roda em **TODO PR pro main, SEM path-filter** → sempre reporta → pode ser marcado `required` **sem travar PR não-relacionado** (resolve a pegadinha do path-filter).

## Fase
Nasce **ADVISORY** (roda + mostra verde/vermelho, não bloqueia). O flip pra **required** é o passo seguinte: via **ruleset** + **break-glass** (bypass-actor com audit log — mantém escape de emergência, mas registrado; não o `enforce_admins` binário). Recomendado após ~2 semanas rodando limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)