### PR TITLE
chore(gitignore): ignora saída gerada (Wayfinder) + scratch local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,12 @@ tests/eval/results/*.json
 
 # jscpd — relatório local (anti-duplicação copy-paste); .jscpd.json é VERSIONADO
 /report
+
+# Saída gerada do Laravel Wayfinder (regenerável — vite plugin / php artisan wayfinder:generate)
+/resources/js/actions/
+/resources/js/routes/
+/resources/js/wayfinder/
+
+# Cache/scratch local — NÃO versionar (design fetch + prancheta de design-grading)
+/_design_fetch/
+/_preview/


### PR DESCRIPTION
## O que

Adiciona ao `.gitignore`:

```
/resources/js/actions/      # saída Wayfinder (969 arquivos, regenerável)
/resources/js/routes/
/resources/js/wayfinder/
/_design_fetch/             # cache de fetch (2572 arquivos)
/_preview/                  # scratch de design-grading (11 arquivos)
```

## Por que

No checkout principal esses dirs apareciam como **~3500 arquivos untracked**, mascarando o trabalho real e inflando `git status`. Nunca foram versionados e são regeneráveis (Wayfinder roda no build via vite plugin). Ignorar é o padrão.

Se algum dia o time decidir versionar a saída Wayfinder pra CI, é só reverter as 3 linhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)