### PR TITLE
docs(governance): ADR 0261 enforcement faseado + audit Fase 0 do IA-os

### DIFF
--- a/memory/decisions/0261-enforcement-faseado-gates-ci.md
+++ b/memory/decisions/0261-enforcement-faseado-gates-ci.md
@@ -1,0 +1,66 @@
+---
+slug: 0261-enforcement-faseado-gates-ci
+number: 261
+title: "Enforcement faseado dos gates de CI: required-checks por níveis + skip-as-pass + enforce_admins"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-06-07"
+accepted_at: "2026-06-07"
+accepted_via: "Wagner autorizou na sessão (reavaliação do IA-os, Fase 0 + deep-dive A). Alavanca 1 aplicada na mesma sessão via gh api."
+module: governance
+quarter: 2026-Q2
+tags: [governance, ci, enforcement, branch-protection, ratchet, gates, tier-0]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: ["0256-knowledge-survival-meia-vida-catraca-sentinela", "0155-module-grade-v3-sub-dimensoes-gate-ci", "0160-governance-v4-scoped-scorecards-buckets", "0093-multi-tenant-isolation-tier-0"]
+pii: false
+---
+
+# ADR 0261 — Enforcement faseado dos gates de CI
+
+## Contexto
+
+A reavaliação do IA-os (sessão 2026-06-07, ver [Fase 0 + deep-dive A](../sessions/2026-06-07-reavaliacao-iaos-fase0-enforcement.md)) achou a **falha-mãe** do aparato de governança: dos **40 workflows de CI**, apenas **1** era *required status check* no branch protection do `main` — e o único era `ADR frontmatter` (o mais trivial). Além disso `enforce_admins: false` (admin fura até esse). Na prática: dava pra mergear no `main` com **Pest quebrado, build quebrado, multi-tenant violado, segredo vazado** — só não com frontmatter de ADR malformado.
+
+**Causa-raiz (não é desleixo):** 25 dos 28 gates de PR são **path-scoped** (correto, por velocidade/custo). No GitHub, um required-check que **não roda** (path não bateu) nunca reporta status e **trava o PR eternamente** em "Expected — waiting". Exigir os path-scoped congelaria PRs não-relacionados. A saída do time foi exigir quase nada — jogando fora o enforcement junto com o deadlock.
+
+Isso colide com o **princípio duro #4 (loop fechado por métrica)** e enfraquece toda a maquinaria de catraca (ADR 0256 Knowledge Survival, ADR 0155/0160 module grades): a catraca existe, mas a **tranca da catraca** estava solta. O sistema "evolui sempre" por **disciplina**, não por **mecanismo** — frágil quando o time MCP (Felipe/Maiara/Eliana/Luiz) entrar sem o mesmo reflexo.
+
+## Decisão
+
+Enforcement em **3 alavancas faseadas**, por esforço×risco crescente:
+
+**Alavanca 1 — promover os gates always-run (risco zero, aplicada 2026-06-07).**
+Workflows sem path-filter sempre reportam status → seguros como required sem deadlock. Promovidos a required no `main`:
+`PHP / Pest (Unit)` · `Frontend / Vite build` · `module-grades-gate` (somados ao `ADR frontmatter` pré-existente → **1 → 4**).
+
+**Alavanca 2 — converter os Tier-0 path-scoped pra "always-run + skip-as-pass", aí exigir.**
+Padrão: trocar o `paths:` de nível-workflow por always-run + 1º step que detecta "nenhum arquivo relevante mudou → exit 0 verde" (o filtro de path vira filtro in-job). Assim o check **sempre reporta** → seguro pra required. Ordem por raio-de-dano:
+1. Multi-tenant gate (Tier 0 — isolamento de dados)
+2. Secrets Governance (LGPD — vazamento de credencial)
+3. Memory schema gate (determinístico, barato)
+4. PHPStan/Larastan (determinístico pós-#2294/#2300)
+5. Governance Gate + Modules Pest / Financeiro Pest
+
+**Alavanca 3 — `enforce_admins: true` (por último).**
+Só depois das Alavancas 1-2 estáveis (~1 semana sem flaky), pra não trancar o L0 fora por gate piscando. Até lá, admin-bypass é a válvula de emergência. Break-glass documentado: toggle admin temporário via `gh api`.
+
+**Nunca exigir (não-determinístico por design):** `PR UI Judge` (LLM Brain B), `Jana RAGAS Eval/Gate` (LLM eval), `Charter Gate (soft)`, `MWART Gate (soft)`. Virariam falso-vermelho bloqueando merge legítimo — ficam advisory.
+
+## Consequências
+
+**Positivas.** A catraca de qualidade (`module-grades-gate`) e os testes viram **lei mecânica**, não disciplina — "evolui sempre" deixa de depender de boa-vontade. Time MCP entra num trilho que **proíbe** regressão Tier-0, não só recomenda. Fecha a decisão-pendente de enforcement.
+
+**Negativas / riscos.** (a) Gate flaky promovido a required trava **todos** os merges → só promover gates com histórico estável; LLM-eval nunca. (b) Bug no skip-as-pass → falso-verde → o step de skip reusa exatamente o filtro de path existente. (c) `enforce_admins` trancando hotfix → por último + break-glass. (d) `strict: true` (já ligado) + mais required = mais rebase — aceitável.
+
+**Autoridade.** Branch protection é admin-only (L0 soberano). Esta decisão é Tier 0 e só Wagner aprova/reverte. Reversível em 1 comando (`gh api -X PATCH .../required_status_checks`).
+
+## Alternativas consideradas
+
+- **Agregador único (`CI` job com `needs:` todos os gates) → exigir só "CI".** Elegante, mas `ci.yml` hoje tem 2 jobs soltos sem `needs:`; reescrever pra agregador é refactor maior e cria ponto único de falha. Preterido em favor do faseamento incremental (cada gate promovido isoladamente, reversível um a um).
+- **Exigir tudo de uma vez.** Rejeitado: deadlock dos path-scoped + risco de flaky travar o time inteiro sem rodagem.
+- **Manter como estava (status quo).** Rejeitado: é a falha-mãe; sem tranca, a catraca é decorativa.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **265** arquivos · **250** números únicos · máx **0260**
-- **ADRs ATIVOS (lifecycle ativo): 225** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 205 · proposto 34 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 225 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **266** arquivos · **251** números únicos · máx **0261**
+- **ADRs ATIVOS (lifecycle ativo): 226** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 206 · proposto 34 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 226 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (265)
+## Todas as ADRs (266)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -297,3 +297,4 @@ _(íntegra)_
 | 0258 | proposto | ativo | decision | Processo de ADR estado-da-arte — índice gerado + supersede atômico + status-mutá |
 | 0259 | aceito | ativo | errata | Errata 0091 — modelo do Brief é gpt-4o-mini (não Sonnet); §Geração superseded po |
 | 0260 | aceito | ativo | errata | Errata 0182 — cor primária do PageHeader é roxo universal 295 (não hue-per-grupo |
+| 0261 | aceito | ativo | decision | Enforcement faseado dos gates de CI: required-checks por níveis + skip-as-pass + |

--- a/memory/sessions/2026-06-07-reavaliacao-iaos-fase0-enforcement.md
+++ b/memory/sessions/2026-06-07-reavaliacao-iaos-fase0-enforcement.md
@@ -1,0 +1,53 @@
+---
+date: "2026-06-07"
+topic: "Reavaliação do IA-os (aparato de IA/governança) — Fase 0 triagem das 8 partes + deep-dive A (enforcement dos gates)"
+authors: [W, C]
+---
+
+# Reavaliação do IA-os — Fase 0 + deep-dive A (enforcement)
+
+## TL;DR
+
+Wagner pediu reavaliar "todo o sistema" — o **IA-os** (gates, skills, agentes, ADRs, memória, MCP/brief, hooks), por partes, achando falhas, e perguntou "isso evolui sempre?". Fase 0 (triagem barata, evidência real) achou a **falha-mãe**: dos 40 gates de CI, só 1 era *required* (`ADR frontmatter`) + `enforce_admins:false` → dava pra mergear com Pest/build/multi-tenant/segredo quebrados. **Resposta a "evolui sempre?":** sim, dá pra provar (eslint-baseline só desce 1455→1365; ~96 commits/30d na maquinaria), MAS por **disciplina**, não por **mecanismo** — a tranca da catraca (enforcement) estava solta. **Ação tomada:** Alavanca 1 aplicada (required 1→4: + Pest + build + module-grades). Formalizado em ADR 0261.
+
+## "Isso evolui sempre?" — resposta com evidência
+
+- ✅ **Evolui (provado):** `eslint-baseline` monotônico decrescente `1455→1432→1373→1365` (catraca não deixa subir); screen-grades 37 telas <70→≥70 travadas; cadência ~96 commits/30d na governança (ADRs 44 · workflows 25 · skills/hooks 14 · scripts 13); sentinelas novas (memory-health #2386→#2401, adr-index #2391).
+- ❌ **Mas não garantido:** catraca existe, tranca solta. 40 gates, 1 required (o mais trivial), admin fura. Evolui *porque W+C constroem catracas e respeitam CI vermelho* — não porque o sistema **proíbe** regredir.
+- **Insight:** enforcement (Parte A) **É** a garantia de evolução. Conserta A → "evolui sempre" vira lei física, não comportamento.
+
+## Placar Fase 0 — IA-os em 8 partes
+
+| Parte | Severidade | Evolui? | Achado real |
+|---|---|---|---|
+| A · Enforcement | 🔴 crítico | ❌ não trava | 1/40 required + `enforce_admins:false` — **falha-mãe** |
+| B · MCP/brief/cycle | 🔴 alto | ⚠️ detecta não corrige | Cycle drift 0% (217/217 commits/7d off-cycle) — princípio #4 quebrado |
+| E · Memória/segredos | 🔴 alto | ✅ estrutura / ❌ segredo | memory-health ENFORCE+ratchet forte; mas 10 arquivos credencial em claro, rotação pendente |
+| D · ADRs (258→265) | 🟡 médio | ✅ mais forte | adr-index auto-gerado + supersede-gate-duro + anti-ressurreição; 13 colisões sendo limpas |
+| C · Skills (69) | 🟡 médio | ⚠️ parcial | só brief-first com telemetria; risco de skills mortas/sobrepostas |
+| F · Agentes (22) | 🟡 médio | ⚠️ parcial | validador local divergiu do CI (stub python3) — tooling com furo |
+| G · Hooks (45) | 🟢 bom | ✅ testado | 45 hooks, muitos `.test`. Ressalva: PowerShell locais — time MCP pode não tê-los |
+| H · Health-check | ⚪ desconhecido | ? | `jana:health-check` (5 SQL) existe mas precisa runtime — não rodado |
+
+## Deep-dive A — enforcement (detalhe)
+
+**Causa-raiz:** 25/28 gates de PR são path-scoped (correto p/ custo). GitHub: required-check que não roda → trava PR em "waiting". Exigir path-scoped congelaria PRs não-relacionados → time exigiu quase nada. Ironia: o próprio Multi-tenant gate já foi "Tier 0 dormente" antes (comentário no `.yml`); agora roda mas não é required.
+
+**3 alavancas** (ver ADR 0261 pra detalhe):
+- **A1 (feita):** promover always-run → `PHP / Pest (Unit)`, `Frontend / Vite build`, `module-grades-gate`. Required 1→4. Comando: `gh api -X PATCH .../required_status_checks`.
+- **A2 (próxima):** converter Tier-0 path-scoped → always-run + skip-as-pass, aí exigir. Ordem: Multi-tenant → Secrets → Memory schema → PHPStan → Governance Gate/Pest.
+- **A3 (por último):** `enforce_admins:true` após ~1 semana estável.
+- **Nunca exigir:** PR UI Judge, RAGAS (LLM, não-determinístico), Charter/MWART soft.
+
+## Estado pós-sessão
+
+- ✅ Alavanca 1 aplicada: `required_status_checks` = [ADR frontmatter, PHP / Pest (Unit), Frontend / Vite build, module-grades-gate], `strict:true`, `enforce_admins:false`, reviews:1.
+- ✅ ADR 0261 criado (formaliza o faseamento, fecha decisão-pendente-enforcement).
+- 🔜 Alavanca 2 PR-amostra (Multi-tenant skip-as-pass) — PR separado.
+- 🔜 Partes B/E (cycle drift, rotação de segredos) ficam pro próximo deep-dive.
+
+## Pointers
+
+- Decisão: [ADR 0261](../decisions/0261-enforcement-faseado-gates-ci.md)
+- Gates: `.github/workflows/*.yml` (40) · branch protection `main`
+- Maquinaria de evolução: `scripts/governance/memory-health.mjs` + `adr-index-generate.mjs` (ADR 0256)


### PR DESCRIPTION
## O que

Reavaliação do **IA-os** (aparato de IA/governança) pedida pelo Wagner. Fase 0 (triagem) achou a **falha-mãe**: dos 40 gates de CI, só **1 era required** (`ADR frontmatter`) + `enforce_admins:false` → dava pra mergear com Pest/build/multi-tenant/segredo quebrados.

## Conteúdo

- **ADR 0261** — enforcement faseado em 3 alavancas (always-run → skip-as-pass → enforce_admins), nunca-exigir LLM/soft, fecha a decisão-pendente de enforcement.
- **Session doc** — placar Fase 0 das 8 partes + deep-dive A + resposta a *"isso evolui sempre?"* (sim, mas por disciplina, não mecanismo — até agora).

## Já aplicado (Alavanca 1, autorizado por Wagner na sessão)

`required_status_checks` no `main`: **1 → 4** — `+PHP / Pest (Unit)` `+Frontend / Vite build` `+module-grades-gate`. Zero deadlock (todos always-run). Reversível em 1 comando.

## Próximo

Alavanca 2 (PR-amostra Multi-tenant skip-as-pass) vem em PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)