### PR TITLE
ci(governance): Multi-tenant gate → skip-as-pass (ADR 0261 Alavanca 2, amostra)

### DIFF
--- a/.github/workflows/multi-tenant-gate.yml
+++ b/.github/workflows/multi-tenant-gate.yml
@@ -9,23 +9,19 @@ name: Multi-tenant gate
 # Regra: visibilidade per-business = subscription package (Modules/Superadmin),
 # NUNCA `if ($business_id === N)`. Ver memory/proibicoes.md + ADR 0093.
 # Teste: tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
+#
+# ── SKIP-AS-PASS (ADR 0261, Alavanca 2) ──────────────────────────────────────
+# Convertido de path-scoped (workflow-level `paths:`) → ALWAYS-RUN + detecção
+# in-job. Motivo: required-check path-scoped trava PR não-relacionado em "waiting"
+# (footgun do GitHub). Agora o check SEMPRE reporta status: roda o teste quando
+# arquivo Tier 0 muda, passa instantâneo (verde) quando não. Assim pode virar
+# `required` no branch protection sem deadlock. O filtro de path vira filtro
+# in-job (step `detect`) — mesma cobertura, reportando sempre.
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'Modules/**/Http/Controllers/**'
-      - 'app/Http/Middleware/AdminSidebarMenu.php'
-      - 'app/Http/Middleware/HandleInertiaRequests.php'
-      - 'tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php'
-      - '.github/workflows/multi-tenant-gate.yml'
   pull_request:
-    paths:
-      - 'Modules/**/Http/Controllers/**'
-      - 'app/Http/Middleware/AdminSidebarMenu.php'
-      - 'app/Http/Middleware/HandleInertiaRequests.php'
-      - 'tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php'
-      - '.github/workflows/multi-tenant-gate.yml'
 
 concurrency:
   group: multi-tenant-gate-${{ github.ref }}
@@ -38,8 +34,36 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # precisa do histórico pro diff de detecção
+
+      - name: Detecta arquivos relevantes (skip-as-pass)
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+          else
+            base="${{ github.event.before }}"
+          fi
+          # Fallback se base vazio/inválido (primeiro push, force-push, etc.)
+          if [ -z "${base}" ] || [ "${base}" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "${base}" 2>/dev/null; then
+            base="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          echo "Base do diff: ${base}"
+          changed="$(git diff --name-only "${base}" HEAD || true)"
+          echo "Arquivos mudados:"; echo "${changed:-<nenhum>}"
+          if echo "${changed}" | grep -Eq '^(Modules/.*/Http/Controllers/|app/Http/Middleware/AdminSidebarMenu\.php|app/Http/Middleware/HandleInertiaRequests\.php|tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest\.php|\.github/workflows/multi-tenant-gate\.yml)'; then
+            echo "relevant=true" >> "${GITHUB_OUTPUT}"
+            echo "→ arquivo Tier 0 mudou: RODA o teste."
+          else
+            echo "relevant=false" >> "${GITHUB_OUTPUT}"
+            echo "→ nada Tier 0 mudou: SKIP-AS-PASS (gate verde sem rodar)."
+          fi
 
       - name: Setup PHP 8.4
+        if: steps.detect.outputs.relevant == 'true'
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
@@ -48,6 +72,7 @@ jobs:
           tools: composer:v2
 
       - name: Cache composer
+        if: steps.detect.outputs.relevant == 'true'
         uses: actions/cache@v4
         with:
           path: ~/.composer/cache
@@ -55,9 +80,11 @@ jobs:
           restore-keys: composer-mtgate-${{ runner.os }}-
 
       - name: Install PHP deps
+        if: steps.detect.outputs.relevant == 'true'
         run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
 
       - name: Prepare storage dirs + .env mínimo
+        if: steps.detect.outputs.relevant == 'true'
         run: |
           mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
           cat > .env <<'EOF'
@@ -76,4 +103,5 @@ jobs:
           php artisan key:generate
 
       - name: Pest — anti-hardcode business_id
+        if: steps.detect.outputs.relevant == 'true'
         run: vendor/bin/pest tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php --no-coverage


### PR DESCRIPTION
## O que

PR-**amostra** da Alavanca 2 do [ADR 0261](https://github.com/wagnerra23/oimpresso.com/pull/2408): converte o **Multi-tenant gate** (Tier 0) de *path-scoped* → **always-run + skip-as-pass**.

## Por quê

Required-check path-scoped trava PR não-relacionado em "Expected — waiting" (footgun do GitHub) → é por isso que esse gate Tier 0 **não podia** ser `required`. Agora o check **sempre reporta status**:
- arquivo Tier 0 mudou (controllers/middleware/teste/este .yml) → **roda o Pest** de verdade
- nada relevante mudou → **verde instantâneo** (skip-as-pass), sem instalar PHP/composer

Assim pode virar `required` no branch protection **sem deadlock**.

## Como

- remove `paths:` do `pull_request` (always-run)
- step `detect` faz `git diff` contra a base e seta `relevant` (mesmo conjunto de paths de antes — cobertura idêntica)
- steps pesados gateados em `if: steps.detect.outputs.relevant == 'true'`
- **job name preservado** (`No hardcode business_id (Tier 0)`) pra casar o context quando promovido

## Auto-validação

Este PR mexe no próprio `.yml` (path relevante) → `detect` dá `relevant=true` → **roda o Pest Tier 0 nesta própria PR**. Se passar, o padrão está provado.

## Escopo

Só a conversão. **Promover a `required` é passo separado** (após ~estável), conforme faseamento do ADR 0261. Se aprovado, replico o padrão nos outros Tier-0 (Secrets, Memory schema, PHPStan, Governance Gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)