### PR TITLE
fix(brief): detector de cycle drift distingue 3 causas (honesto, não cala)

### DIFF
--- a/Modules/Brief/Mcp/Tools/BriefFetchTool.php
+++ b/Modules/Brief/Mcp/Tools/BriefFetchTool.php
@@ -125,40 +125,86 @@ class BriefFetchTool extends Tool
                 return '';
             }
 
+            // 3 categorias mutuamente exclusivas (partição exata de `total`):
+            //  on_cycle    — commit em task DESTE cycle (alinhado)
+            //  other_cycle — commit em task de OUTRO cycle (pivot real)
+            //  unlinked    — commit sem task de cycle (sem `Refs: US-XXX`) → rastreio
+            //                faltando, NÃO é pivot. Antes era lumpado em "off-cycle"
+            //                e inflava o alarme (causa do falso "0% → pivot?").
             $stats = DB::selectOne(<<<'SQL'
                 SELECT
-                  SUM(CASE WHEN t.cycle_id = ? THEN 1 ELSE 0 END) AS in_cycle,
+                  SUM(CASE WHEN t.cycle_id = ? THEN 1 ELSE 0 END) AS on_cycle,
+                  SUM(CASE WHEN t.cycle_id IS NOT NULL AND t.cycle_id <> ? THEN 1 ELSE 0 END) AS other_cycle,
+                  SUM(CASE WHEN t.cycle_id IS NULL THEN 1 ELSE 0 END) AS unlinked,
                   COUNT(*) AS total
                 FROM mcp_git_links gl
                 LEFT JOIN mcp_tasks t ON t.task_id = gl.task_id
                 WHERE gl.occurred_at >= DATE_SUB(NOW(), INTERVAL 7 DAY)
-            SQL, [$row->cycle_id]);
+            SQL, [$row->cycle_id, $row->cycle_id]);
 
             $total = (int) ($stats->total ?? 0);
             if ($total === 0) {
                 return '';
             }
 
-            $inCycle = (int) ($stats->in_cycle ?? 0);
-            $aligned = $total > 0 ? (int) round($inCycle / $total * 100) : 0;
-            $offCycle = $total - $inCycle;
+            $onCycle = (int) ($stats->on_cycle ?? 0);
+            $aligned = (int) round($onCycle / $total * 100);
 
-            if ($offCycle === 0 || $aligned >= 50) {
+            if ($aligned >= 50) {
                 return '';
             }
 
-            return sprintf(
-                "\n\n⚠️ **Cycle drift detectado:** %d/%d commits/PRs (7d) NÃO tocam tasks do cycle ativo `%s` (%d%% alinhados). ".
-                "Pivot estratégico em curso? Considere `cycles-close --rollover` + `cycles-create` novo. ".
-                "_Aprendizado retro CYCLE-01 (sessão 2026-05-07)._",
-                $offCycle,
+            return self::formatCycleDriftAlert(
+                $onCycle,
+                (int) ($stats->other_cycle ?? 0),
+                (int) ($stats->unlinked ?? 0),
                 $total,
-                $row->cycle_key,
                 $aligned,
+                (string) $row->cycle_key,
             );
         } catch (Throwable) {
             return '';
         }
+    }
+
+    /**
+     * Formata o alerta de drift distinguindo as 3 causas (pura — testável sem DB).
+     *
+     * A sugestão se adapta à causa DOMINANTE: se a maior parte é trabalho em outro
+     * cycle → pivot real (rollover); se é commit sem task → rastreio faltando
+     * (linkar `Refs: US-XXX`), não pivot. Antes o alarme assumia sempre pivot,
+     * mesmo quando o problema era só falta de linkagem.
+     */
+    public static function formatCycleDriftAlert(
+        int $onCycle,
+        int $otherCycle,
+        int $unlinked,
+        int $total,
+        int $aligned,
+        string $cycleKey,
+    ): string {
+        $lines = [];
+        if ($unlinked > 0) {
+            $lines[] = sprintf('  ↳ %d sem task de cycle linkada (commits sem `Refs: US-XXX`) — rastreio faltando, não pivot', $unlinked);
+        }
+        if ($otherCycle > 0) {
+            $lines[] = sprintf('  ↳ %d em tasks de OUTRO cycle — pivot real?', $otherCycle);
+        }
+
+        $suggestion = $otherCycle > $unlinked
+            ? 'Trabalho migrou pra outro cycle — considere `cycles-close --rollover` + `cycles-create`.'
+            : 'A maior parte é commit sem task — linke com `Refs: US-XXX` ou registre a task antes de assumir pivot.';
+
+        return sprintf(
+            "\n\n⚠️ **Cycle drift detectado:** só %d/%d commits/PRs (7d) tocam o cycle ativo `%s` (%d%% alinhados).\n%s\n%s ".
+            "_Aprendizado retro CYCLE-01 (sessão 2026-05-07)._",
+            $onCycle,
+            $total,
+            $cycleKey,
+            $aligned,
+            implode("\n", $lines),
+            $suggestion,
+        );
     }
 
     private function fetchCurrent(): ?array

--- a/Modules/Brief/Tests/Feature/CycleDriftAlertTest.php
+++ b/Modules/Brief/Tests/Feature/CycleDriftAlertTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Brief\Mcp\Tools\BriefFetchTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * CycleDriftAlertTest — detector de drift 3-vias (fix/cycle-drift-3way).
+ *
+ * O alerta antigo lumpava "commit sem task" com "commit em outro cycle" → gritava
+ * "pivot!" mesmo quando o problema era só falta de `Refs: US-XXX`. Estes testes
+ * cobrem o helper PURO `formatCycleDriftAlert` (sem DB): a mensagem deve nomear a
+ * causa dominante e adaptar a sugestão.
+ *
+ * Multi-tenant Tier 0: brief é repo-wide, sem business_id — formatação pura.
+ */
+
+it('quando a causa dominante é rastreio (sem task), sugere linkar — não pivot', function () {
+    // 0 on-cycle, 2 em outro cycle, 200 sem task linkada de 202 total.
+    $msg = BriefFetchTool::formatCycleDriftAlert(0, 2, 200, 202, 0, 'CYCLE-08');
+
+    expect($msg)
+        ->toContain('só 0/202 commits/PRs')
+        ->toContain('0% alinhados')
+        ->toContain('200 sem task de cycle linkada')
+        ->toContain('linke com `Refs: US-XXX`')          // sugestão de rastreio
+        ->not->toContain('cycles-close --rollover');     // NÃO sugere pivot
+});
+
+it('quando a causa dominante é outro cycle, sugere rollover (pivot real)', function () {
+    // 5 on-cycle, 80 em outro cycle, 15 sem task de 100 total.
+    $msg = BriefFetchTool::formatCycleDriftAlert(5, 80, 15, 100, 5, 'CYCLE-08');
+
+    expect($msg)
+        ->toContain('80 em tasks de OUTRO cycle')
+        ->toContain('cycles-close --rollover')           // sugere pivot
+        ->toContain('5% alinhados');
+});
+
+it('omite a linha de uma categoria quando ela é zero', function () {
+    // Sem nada em outro cycle: a linha "OUTRO cycle" não deve aparecer.
+    $msg = BriefFetchTool::formatCycleDriftAlert(1, 0, 99, 100, 1, 'CYCLE-08');
+
+    expect($msg)
+        ->toContain('99 sem task de cycle linkada')
+        ->not->toContain('OUTRO cycle');
+});


### PR DESCRIPTION
## O que

Da reavaliação do IA-os (Parte B): o detector de cycle drift gritava **`0% → pivot estratégico?`** no CYCLE-08. Lendo o código (`BriefFetchTool::renderCycleDriftAlert`), o SQL lumpava **commit sem task linkada** (`gl.task_id NULL`) junto com **commit em outro cycle** como "off-cycle" → o alarme assumia pivot quando o real era só falta de `Refs: US-XXX`.

## Decisão: tornar honesto, NÃO calar

O detector **não está quebrado** — foi feito pra pegar pivots (retro CYCLE-01, ficou órfão 5d). Calá-lo apagaria sinal verdadeiro. Então ele fica **mais preciso**, não silencioso.

Agora particiona em 3 categorias exatas (somam `total`):
| categoria | significado |
|---|---|
| `on_cycle` | commit em task DESTE cycle (alinhado) |
| `other_cycle` | commit em task de OUTRO cycle → **pivot real** |
| `unlinked` | commit sem task de cycle (`Refs: US-XXX` faltando) → **rastreio**, não pivot |

A mensagem nomeia a causa **dominante** e adapta a sugestão (rollover vs linkar task).

## Risco

Mudança em tool de caminho crítico (brief-fetch), mas o método já tem `catch (Throwable) { return ''; }` — pior caso, a linha de drift some, brief segue. Formatação extraída pra helper puro `formatCycleDriftAlert` + **3 testes Pest sem DB**.

## Efeito no CYCLE-08

Em vez de "0% → pivot?", vai dizer algo como _"a maior parte é commit sem task — linke com Refs: US-XXX antes de assumir pivot"_ — que é o diagnóstico real. A decisão estratégica (rollover/split do cycle) continua **tua** — isto só te dá o número honesto pra decidir.

Refs: ADR 0261 (reavaliação IA-os, Parte B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)