### PR TITLE
feat(oficina): Fase 2 do kanban reparo — D-04 SLA · D-05 KPI filtra · D-06 persiste · D-07 teclado

### DIFF
--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
@@ -26,16 +26,17 @@
 // Visual comparison: memory/requisitos/OficinaAuto/producao-oficina-cacamba-visual-comparison.md
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { Head, Link, router } from '@inertiajs/react';
+import { Head, Link, router, usePage } from '@inertiajs/react';
 import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
 import { toast } from 'sonner';
-import { Plus, Printer, Search, LayoutGrid, List as ListIcon } from 'lucide-react';
+import { Plus, Printer, Search, LayoutGrid, List as ListIcon, X } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
 import { Box, Stack, Inline, Grid, Text } from '@/Components/layout';
@@ -91,6 +92,31 @@ const COLUMNS: Array<{ key: keyof KanbanGroups; status: CacambaStatus; label: st
   { key: 'manutencao',  status: 'manutencao',  label: 'Em execução' },
   { key: 'pronta',      status: 'pronta',      label: 'Pronto p/ retirar' },
 ];
+
+// D-05 — chave de filtro por KPI. As 5 etapas mapeiam pra coluna FSM; `urgentes`
+// filtra os atrasados (is_overdue) em todas as colunas. `valor` não filtra.
+type KpiFilterKey = 'recepcao' | 'diagnostico' | 'pecas' | 'execucao' | 'urgentes';
+
+const KPI_FILTER_TO_STATUS: Record<
+  Exclude<KpiFilterKey, 'urgentes'>,
+  CacambaStatus
+> = {
+  recepcao: 'disponivel',
+  diagnostico: 'locada',
+  pecas: 'aguardando',
+  execucao: 'manutencao',
+};
+
+const KPI_FILTER_KEYS: readonly KpiFilterKey[] = [
+  'recepcao',
+  'diagnostico',
+  'pecas',
+  'execucao',
+  'urgentes',
+];
+
+const isKpiFilterKey = (v: string): v is KpiFilterKey =>
+  (KPI_FILTER_KEYS as readonly string[]).includes(v);
 
 const formatBRLCompact = (value: number) =>
   new Intl.NumberFormat('pt-BR', {
@@ -248,6 +274,45 @@ const NEXT_COLUMN_FOR: Record<CacambaStatus, CacambaStatus | null> = {
 
 export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
   const [searchInput, setSearchInput] = useState(filters.q ?? '');
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  // D-06 — preferência por-usuário Tier-0-scoped (multi-tenant, ADR 0093): a chave
+  // do localStorage carrega o business_id (sessão, via shared props) pra NÃO vazar
+  // o filtro entre tenants num mesmo browser.
+  const page = usePage();
+  const bizId =
+    (page.props as { auth?: { user?: { business_id?: number } } })?.auth?.user
+      ?.business_id ?? 0;
+  const kpiFilterStorageKey = `oimpresso.b${bizId}.oficina.kpiFilter`;
+
+  // D-05 — filtro por KPI (toggle). D-07 — card em foco por teclado.
+  const [kpiFilter, setKpiFilter] = useState<KpiFilterKey | null>(null);
+  const [focusedId, setFocusedId] = useState<number | null>(null);
+
+  // D-06 — hidrata o último filtro escolhido (client-only; SSR não tem localStorage).
+  useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(kpiFilterStorageKey);
+      if (saved && isKpiFilterKey(saved)) setKpiFilter(saved);
+    } catch {
+      /* localStorage indisponível (modo privado) — ignora */
+    }
+  }, [kpiFilterStorageKey]);
+
+  // D-06 — persiste a escolha entre sessões.
+  useEffect(() => {
+    try {
+      if (kpiFilter) window.localStorage.setItem(kpiFilterStorageKey, kpiFilter);
+      else window.localStorage.removeItem(kpiFilterStorageKey);
+    } catch {
+      /* ignora */
+    }
+  }, [kpiFilter, kpiFilterStorageKey]);
+
+  const toggleKpiFilter = useCallback((key: KpiFilterKey) => {
+    setKpiFilter((cur) => (cur === key ? null : key));
+    setFocusedId(null);
+  }, []);
 
   // Debounce 300ms — evita visit por keystroke
   useEffect(() => {
@@ -508,6 +573,83 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
     return parts;
   }, [kpis]);
 
+  // D-05 — aplica o filtro de KPI ao quadro (client-side, alimenta o kanban).
+  // Etapa → mantém só a coluna correspondente; `urgentes` → só os atrasados.
+  const filteredColumnsData = useMemo(() => {
+    if (!kpiFilter) return columnsData;
+    if (kpiFilter === 'urgentes') {
+      return columnsData.map((col) => ({
+        ...col,
+        cards: col.cards.filter((c) => c.is_overdue),
+      }));
+    }
+    const targetStatus = KPI_FILTER_TO_STATUS[kpiFilter];
+    return columnsData.map((col) => ({
+      ...col,
+      cards: col.status === targetStatus ? col.cards : [],
+    }));
+  }, [columnsData, kpiFilter]);
+
+  // D-07 — lista linear dos cards visíveis pra navegação por setas.
+  const flatCards = useMemo(
+    () => filteredColumnsData.flatMap((col) => col.cards),
+    [filteredColumnsData],
+  );
+
+  // D-07 — atalhos de teclado (Larissa é teclado-first): N nova OS · / busca ·
+  // setas navegam o card em foco · Enter abre o drawer · Esc fecha.
+  // Ignora quando o foco está num input/textarea/select (não sequestra digitação).
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const tag = (target?.tagName ?? '').toLowerCase();
+      const typing =
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        Boolean(target?.isContentEditable);
+
+      if (e.key === 'Escape') {
+        setOpenOsId(null);
+        return;
+      }
+      if (typing) return;
+
+      if (e.key === '/') {
+        e.preventDefault();
+        searchInputRef.current?.focus();
+        return;
+      }
+      if (e.key === 'n' || e.key === 'N') {
+        e.preventDefault();
+        router.visit('/oficina-auto/ordens-servico/create');
+        return;
+      }
+      if (flatCards.length === 0) return;
+
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        setFocusedId((id) => {
+          const i = flatCards.findIndex((c) => c.id === id);
+          const next = flatCards[Math.min(flatCards.length - 1, i + 1)];
+          return next ? next.id : id;
+        });
+      } else if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        setFocusedId((id) => {
+          const i = flatCards.findIndex((c) => c.id === id);
+          const prev = flatCards[i <= 0 ? 0 : i - 1];
+          return prev ? prev.id : id;
+        });
+      } else if (e.key === 'Enter' && focusedId != null) {
+        const c = flatCards.find((x) => x.id === focusedId);
+        if (c) handleCardClick(c);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [flatCards, focusedId, handleCardClick]);
+
   return (
     <>
       <Head title="Oficina Auto" />
@@ -562,12 +704,26 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
           </header>
         </Box>
 
-        {/* ─── 6 KPI cards — Grid auto-fit reflowa 1280↔1440 sem media-query (ADR 0253) ─── */}
+        {/* ─── 6 KPI cards — Grid auto-fit reflowa 1280↔1440 sem media-query (ADR 0253).
+             D-05: as 5 etapas são clicáveis (toggle) e filtram o quadro; ativo ganha
+             anel, os outros esmaecem. "Valor em curso" não filtra. ─── */}
         <Box bg="card" px={6} py={4} className="border-b border-border">
           <Grid min="sm" gap={3}>
-            {kpiCards.map(({ id, ...kpi }) => (
-              <KpiCard key={id} {...kpi} />
-            ))}
+            {kpiCards.map(({ id, ...kpi }) => {
+              const filterKey = isKpiFilterKey(id) ? id : undefined;
+              const isActive = filterKey != null && kpiFilter === filterKey;
+              const isDimmed =
+                kpiFilter != null && filterKey != null && !isActive;
+              return (
+                <KpiCard
+                  key={id}
+                  {...kpi}
+                  active={isActive}
+                  dimmed={isDimmed}
+                  onToggle={filterKey ? () => toggleKpiFilter(filterKey) : undefined}
+                />
+              );
+            })}
           </Grid>
         </Box>
 
@@ -577,14 +733,27 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
             <Inline gap={2} className="flex-1 min-w-[240px] max-w-md">
               <Search size={14} className="text-muted-foreground/60 flex-shrink-0" />
               <Input
+                ref={searchInputRef}
                 type="search"
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
-                placeholder="Buscar OS, veículo ou cliente…"
+                placeholder="Buscar OS, veículo ou cliente… (/ foca)"
                 className="h-8 border-border"
                 aria-label="Buscar OS, veículo ou cliente"
               />
             </Inline>
+
+            {/* D-05 — chip pra limpar o filtro de KPI ativo */}
+            {kpiFilter && (
+              <button
+                type="button"
+                onClick={() => setKpiFilter(null)}
+                className="inline-flex items-center gap-1 h-8 px-2.5 rounded text-xs font-medium text-muted-foreground border border-border hover:bg-muted transition-colors flex-shrink-0"
+              >
+                <X size={12} />
+                Limpar filtro
+              </button>
+            )}
 
             {/* KPI inline (à direita) */}
             <Inline gap={0} className="ml-auto" aria-live="polite">
@@ -615,7 +784,7 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
         <Box p={6}>
           <KanbanDndProvider onMove={handleDragMove} evaluateDrop={evaluateDrop}>
             <Grid cols={5} gap={4}>
-              {columnsData.map((col) => (
+              {filteredColumnsData.map((col) => (
                 <CacambaKanbanColumn
                   key={col.key}
                   status={col.status}
@@ -623,6 +792,7 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
                   cards={col.cards}
                   onCardClick={handleCardClick}
                   onCardAdvance={handleCardAdvance}
+                  focusedId={focusedId}
                 />
               ))}
             </Grid>
@@ -659,30 +829,62 @@ interface KpiCardProps {
   value: string;
   sub: string;
   tone: 'default' | 'warning' | 'destructive' | 'success';
+  /** D-05 — quando presente, o card é clicável (filtra o quadro) e vira `<button>`. */
+  onToggle?: () => void;
+  active?: boolean;
+  dimmed?: boolean;
 }
 
 // KpiCard — composto nos primitivos (ADR 0253). Superfície neutra (card branco);
 // o destaque vem do `tone` semântico no valor, não de fundo tingido feito à mão.
-function KpiCard({ label, value, sub, tone }: KpiCardProps) {
+// D-05: quando `onToggle` existe, é um `<button>` real (a11y: teclado nativo +
+// aria-pressed), NUNCA um `div role="button"`.
+function KpiCard({ label, value, sub, tone, onToggle, active = false, dimmed = false }: KpiCardProps) {
+  const body = (
+    <Stack gap={0}>
+      <Text
+        as="span"
+        size="xs"
+        weight="semibold"
+        tone="muted"
+        className="uppercase tracking-wider"
+      >
+        {label}
+      </Text>
+      <Text as="span" size="4xl" weight="bold" numeric="tabular" tone={tone}>
+        {value}
+      </Text>
+      <Text as="span" size="xs" tone="muted">
+        {sub}
+      </Text>
+    </Stack>
+  );
+
+  if (!onToggle) {
+    return (
+      <Box bg="card" border rounded="lg" p={3}>
+        {body}
+      </Box>
+    );
+  }
+
   return (
-    <Box bg="card" border rounded="lg" p={3}>
-      <Stack gap={0}>
-        <Text
-          as="span"
-          size="xs"
-          weight="semibold"
-          tone="muted"
-          className="uppercase tracking-wider"
-        >
-          {label}
-        </Text>
-        <Text as="span" size="4xl" weight="bold" numeric="tabular" tone={tone}>
-          {value}
-        </Text>
-        <Text as="span" size="xs" tone="muted">
-          {sub}
-        </Text>
-      </Stack>
+    <Box
+      asChild
+      bg="card"
+      border
+      rounded="lg"
+      p={3}
+      className={
+        'w-full text-left cursor-pointer transition-colors hover:border-primary/40 ' +
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary ' +
+        (active ? 'ring-1 ring-primary border-primary/50 ' : '') +
+        (dimmed ? 'opacity-50 ' : '')
+      }
+    >
+      <button type="button" onClick={onToggle} aria-pressed={active}>
+        {body}
+      </button>
     </Box>
   );
 }

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
@@ -66,7 +66,40 @@ interface Props {
    * "Acompanhar" (locada) segue abrindo o drawer (é ver, não avançar).
    */
   onAdvance?: (cacamba: CacambaCardData) => void;
+  /**
+   * D-07 — card em foco via teclado (setas no Index). Pinta o anel pra o usuário
+   * ver onde está; Enter abre o drawer (tratado no Index).
+   */
+  isFocused?: boolean;
 }
+
+/**
+ * D-04 — tom de SLA por prazo (função pura, sem efeito colateral).
+ * `destructive` = atrasada · `warning` = vence hoje/amanhã · `null` = calmo (sem borda).
+ * Só para estados ativos (locada/aguardando) — pátio/pronta não têm prazo em curso.
+ */
+function slaTone(
+  card: CacambaCardData,
+  variant: CacambaStatus,
+): 'destructive' | 'warning' | null {
+  if (variant !== 'locada' && variant !== 'aguardando') return null;
+  if (card.is_overdue) return 'destructive';
+  if (card.expected_return) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const due = new Date(card.expected_return + 'T00:00:00');
+    if (!Number.isNaN(due.getTime())) {
+      const diffDays = Math.round((due.getTime() - today.getTime()) / 86_400_000);
+      if (diffDays <= 1) return 'warning';
+    }
+  }
+  return null;
+}
+
+const SLA_LEFT_BORDER: Record<'destructive' | 'warning', string> = {
+  destructive: 'border-l-2 border-l-destructive',
+  warning: 'border-l-2 border-l-warning',
+};
 
 const formatBRL = (value: number | null | undefined) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(Number(value ?? 0));
@@ -152,7 +185,7 @@ function actionLabelFor(variant: CacambaStatus): string | null {
   }
 }
 
-function CacambaCardImpl({ cacamba, variant, onClick, onAdvance }: Props) {
+function CacambaCardImpl({ cacamba, variant, onClick, onAdvance, isFocused = false }: Props) {
   // D-02 — estados de avanço usam a porta gate-guardada (onAdvance); "Acompanhar"
   // (locada) é ver, não avançar → segue abrindo o drawer (onClick).
   const canAdvance = onAdvance != null && variant !== 'locada';
@@ -198,6 +231,11 @@ function CacambaCardImpl({ cacamba, variant, onClick, onAdvance }: Props) {
 
   const opacityClass = isPronta ? 'opacity-95' : '';
 
+  // D-04 — borda-esquerda por SLA (token semântico). D-07 — anel de foco por teclado.
+  const sla = slaTone(cacamba, variant);
+  const slaBorder = sla ? SLA_LEFT_BORDER[sla] : '';
+  const focusRing = isFocused && !isDragging ? 'ring-2 ring-primary ring-offset-1' : '';
+
   const osLabel = cacamba.os_number ? `OS #${cacamba.os_number}` : null;
   const venceLabel = formatVence(cacamba.expected_return);
   const progressPct = computeProgressPct(cacamba.entered_at, cacamba.expected_return);
@@ -219,7 +257,7 @@ function CacambaCardImpl({ cacamba, variant, onClick, onAdvance }: Props) {
       style={dragStyle}
       {...attributes}
       {...listeners}
-      className={`${cardBg} ${opacityClass} relative rounded border border-t-2 ${cardBaseBorder} ${TOP_BORDER_COLOR[variant]} p-3 transition-colors ${
+      className={`${cardBg} ${opacityClass} ${slaBorder} ${focusRing} relative rounded border border-t-2 ${cardBaseBorder} ${TOP_BORDER_COLOR[variant]} p-3 transition-colors ${
         isDragging
           ? 'opacity-50 cursor-grabbing ring-2 ring-primary/60 ring-offset-1'
           : 'cursor-grab active:cursor-grabbing hover:shadow-sm'

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaKanbanColumn.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaKanbanColumn.tsx
@@ -26,6 +26,8 @@ interface Props {
   onCardClick: (cacamba: CacambaCardData) => void;
   /** D-02 — avançar etapa direto pelo botão do card (mesma porta do arrasto). */
   onCardAdvance?: (cacamba: CacambaCardData, from: CacambaStatus) => void;
+  /** D-07 — id do card em foco por teclado (anel visível). */
+  focusedId?: number | null;
 }
 
 const dotColorMap: Record<CacambaStatus, string> = {
@@ -45,7 +47,7 @@ const topBorderMap: Record<CacambaStatus, string> = {
   pronta:     'border-t-[var(--stage-emerald)]',
 };
 
-function CacambaKanbanColumnImpl({ status, label, cards, onCardClick, onCardAdvance }: Props) {
+function CacambaKanbanColumnImpl({ status, label, cards, onCardClick, onCardAdvance, focusedId = null }: Props) {
   // Handler estável — Card memo recebe sempre mesma referência
   const handleClick = useCallback(
     (c: CacambaCardData) => onCardClick(c),
@@ -156,6 +158,7 @@ function CacambaKanbanColumnImpl({ status, label, cards, onCardClick, onCardAdva
               variant={status}
               onClick={handleClick}
               onAdvance={onCardAdvance ? handleAdvance : undefined}
+              isFocused={focusedId === c.id}
             />
           ))
         )}


### PR DESCRIPTION
Comportamentos **graduados no charter** (✅ 2026-06-08) sobre o modelo reparo já convergido ([#2417](https://github.com/wagnerra23/oimpresso.com/pull/2417)). Tudo nos primitivos/componentes existentes; **zero `.css`**; **keys FSM + drawer travado intactos**; **zero backend**.

## Comportamentos
- **D-04 · borda-esquerda por SLA** no card (token semântico): `destructive` (atrasada), `warning` (vence hoje/amanhã), nada no calmo. Helper puro `slaTone()` em `_components/`.
- **D-05 · KPI clicável filtra o quadro** (toggle): as 5 etapas viram **`<button>`** (a11y: teclado nativo + `aria-pressed`, **nunca** `div role="button"`); ativo ganha anel, os outros esmaecem; chip **"Limpar filtro"**. `urgentes` filtra os atrasados. Filtro client-side alimenta o kanban; "Valor em curso" não filtra.
- **D-06 · persiste o filtro** entre sessões — preferência por-usuário **Tier-0-scoped**: chave `oimpresso.b<bizId>.oficina.kpiFilter` (bizId da sessão via shared props, ADR 0093) → **não vaza entre tenants**. Hidrata client-only (SSR-safe).
- **D-07 · atalhos de teclado** (Larissa teclado-first): `N` nova OS · `/` foca a busca · setas navegam o card em foco (anel) · `Enter` abre o drawer · `Esc` fecha. Ignora quando o foco está em input/textarea/select; `useEffect` com cleanup.

## Gates (locais)
- `typecheck`: **sem erro novo** (4 pré-existentes de baseline intactos: `formatVence` `parts[]` + 2× `preserveScroll` em `router.reload`).
- **ESLint ratchet: delta −1** · **a11y ratchet: 294 = 294** · **layout-primitives: sem `flex`/`grid` solto novo** · `foundation` ✅ · `conformance` ✅.

## Fora de escopo (de propósito)
Não toca controller/DB/seeder nem o drawer travado. O **filtro funcional por box/elevador** (item #3) segue na ADR proposta [#2419](https://github.com/wagnerra23/oimpresso.com/pull/2419) — D-05 aqui filtra por **etapa**, não por recurso.

Refs: charter `Index.charter.md` (D-04..D-07) · ADR 0253 · ADR 0093 · #2417.

🤖 Generated with [Claude Code](https://claude.com/claude-code)