### PR TITLE
feat(cliente): excluir contato pelo menu ⋮ da listagem (soft delete + confirmação)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -311,6 +311,10 @@ class ContactController extends Controller
                     'create' => auth()->user()->can('customer.create'),
                     'view' => auth()->user()->can('customer.view') || auth()->user()->can('customer.view_own'),
                     'import' => auth()->user()->can('customer.create'),
+                    // Exclusão (soft delete) — destroy() já valida o mesmo can()
+                    // + bloqueia se houver transação + escopo business_id (Tier 0).
+                    // OR supplier.delete cobre a aba Fornecedores. Wagner 2026-06-08.
+                    'delete' => auth()->user()->can('customer.delete') || auth()->user()->can('supplier.delete'),
                 ],
                 // Tabela de preço REAL pro drawer Comercial (ADR 0093 scope).
                 // [{id,name}] das customer_groups do business — substitui o
@@ -484,6 +488,10 @@ class ContactController extends Controller
             // Drawer ComercialTab lê pra popular o dropdown de tabela de preço.
             'contacts.customer_group_id',
             'contacts.contact_status',
+            // is_default = consumidor final / fornecedor padrão (walk-in). Canon
+            // UPOS sempre presente. Front esconde "Excluir" pra ele (destroy()
+            // protege server-side, mas evita o no-op confuso). Wagner 2026-06-08.
+            'contacts.is_default',
             'contacts.created_at',
             // Endereço completo — sem isso, router.reload({only:['rows']}) pós lookup
             // CNPJ/CEP zera campos no EnderecoTab (undefined → setState('')) e a UI
@@ -721,6 +729,8 @@ class ContactController extends Controller
                 'valor_aberto' => $valorAberto,
                 'status' => $status,
                 'last_os_at' => $lastOsAt,
+                // Consumidor/fornecedor padrão (walk-in) — front esconde "Excluir".
+                'is_default' => (bool) $contact->is_default,
                 // Wave G novos campos cadastrais.
                 // avatar_hash_seed = name (HSL hash determinístico Components/clientes/Avatar.tsx).
                 // Frontend usa name por default mas seed explícito permite estabilidade

--- a/resources/js/Pages/Cliente/Index.charter.md
+++ b/resources/js/Pages/Cliente/Index.charter.md
@@ -3,8 +3,8 @@ page: /cliente (canon) · /contacts (legacy dual-render via config('mwart.client
 component: resources/js/Pages/Cliente/Index.tsx
 owner: wagner
 status: live
-last_validated: '2026-06-03'
-charter_version: 8
+last_validated: '2026-06-08'
+charter_version: 9
 parent_module: Cliente / Crm
 related_adrs:
   - '0093-multi-tenant-isolation-tier-0'
@@ -246,3 +246,40 @@ Sem backfill (nenhum cadastro existente é "Outros"). Migration Wave 30 (importe
 - [Migration `2026_06_03_120000_add_is_other_flag_to_contacts.php`](../../../database/migrations/2026_06_03_120000_add_is_other_flag_to_contacts.php)
 - [memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md](../../../memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md) — profile WR2 motivador
 - Conversa Wagner 2026-06-03: insight "aba Classificação já tem isso pronto, só falta o chip Outros"
+
+---
+
+## v9 · 2026-06-08 · Excluir contato pela tela (menu ⋮) + consolidação no drawer (append-only)
+
+**Trigger:** Wagner 2026-06-08. Primeiro pediu "arrumar os botões da contacts" — o menu ⋮ da linha tinha 5 itens, 3 apontando pra Blade legacy (`/contacts/{id}`, `/contacts/{id}/edit`, `/contacts/ledger`), ícone `Eye` duplicado e um "Excluir" `disabled` permanente (botão morto). Consolidado no drawer 760 (PR #2420): **Ver detalhes · Editar · Extrato** abrem o drawer na aba certa. Depois Wagner: "exclusão de contato pela tela, precisa" → "Excluir" volta **funcional**.
+
+### Goals novos (append-only · v8 preservados)
+
+- **Menu ⋮ da linha consolidado no drawer** (ADR 0179): "Editar" → drawer aba Identificação · "Extrato" → drawer aba Operações › Extrato (sub-aba `ledger`). Removidos os links Blade legacy "Página completa" e o "Excluir" morto.
+- **Excluir contato (soft delete)** via `DELETE /contacts/{id}` (`ContactController::destroy`, AJAX JSON `{success,msg}`):
+  - Gated por `permissions.delete` (`customer.delete || supplier.delete`) — backend revalida o mesmo `can()`.
+  - **Escondido pro `is_default`** (consumidor/fornecedor walk-in) no front; `destroy()` também protege server-side.
+  - **AlertDialog de confirmação** (ação destrutiva nunca em 1 clique) + toast sonner de sucesso/erro.
+  - Pós-sucesso: fecha o drawer do excluído (se aberto) + `router.reload(['customers','kpis','tab_counts'])`.
+
+### Invariantes (Tier 0 IRREVOGÁVEL)
+
+1. Exclusão é **soft delete** (Contact `use SoftDeletes`) — reversível, LGPD-friendly.
+2. `destroy()` **bloqueia** se houver qualquer `Transaction` do contato (venda/compra/OS) — devolve `success:false` + msg; nada é apagado.
+3. Escopo `business_id` em todas as queries de exclusão — multi-tenant Tier 0 ([ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)).
+4. `is_default` (walk-in) **nunca** é excluído.
+5. Toda exclusão grava `ActivityLog` `contact_deleted` (LGPD Art. 18) + desabilita login de usuários associados (`allow_login=0`).
+
+### Non-Goals v9
+
+- ❌ **Merge/mesclar contatos duplicados** pela tela — segue na rota legacy `/contacts/duplicates` (Non-Goal v7 mantido; esforço maior, futuro).
+- ❌ **Exclusão em batch** (mantém Non-Goal "1 por vez").
+- ❌ **Hard delete / forceDelete** pela UI — soft delete only.
+- ❌ **Restaurar excluído** pela tela (Onda futura se demanda aparecer).
+
+### Refs v9
+
+- PR #2420 (consolidação do menu ⋮ no drawer · mergeado 2026-06-08)
+- `ContactController::destroy($id)` (trava transação + `is_default` + ActivityLog + business_id scope)
+- `Route::resource('contacts')` → `DELETE /contacts/{id}` (`contacts.destroy`)
+- Conversa Wagner 2026-06-08: "arrumar os botões" → "exclusão de contato pela tela, precisa"

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -40,12 +40,14 @@ import {
   Search,
   Sparkles,
   Star,
+  Trash2,
   Truck,
   Upload,
   UserCheck,
   Users,
   X,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
@@ -64,6 +66,16 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@/Components/ui/sheet';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/Components/ui/alert-dialog';
 // Wave C-FE — 5 tabs cadastrais com autosave on blur (ADR 0179).
 import IdentificacaoTab from './_drawer/IdentificacaoTab';
 import ContatoTab from './_drawer/ContatoTab';
@@ -160,6 +172,9 @@ interface ClienteRow {
   // ADR 0195 Bucket A — flag `bloqueado` (separada de `status` enum derivado).
   // Sells/Financeiro consultam pra impedir checkout/cobrança mesmo quando ativo.
   bloqueado?: boolean | null;
+  // Consumidor/fornecedor padrão (walk-in). destroy() protege server-side;
+  // front esconde "Excluir" pra ele. Wagner 2026-06-08.
+  is_default?: boolean | null;
   // Wagner 2026-05-27 iteracao 2 — contador veiculos pro botao header drawer.
   // Lazy: count so existe se modulo OficinaAuto instalado (gate hasTable).
   vehicles_count?: number | null;
@@ -237,6 +252,8 @@ export interface ClienteIndexPageProps {
     create: boolean;
     view: boolean;
     import: boolean;
+    /** customer.delete || supplier.delete — gate do "Excluir" no menu ⋮. */
+    delete: boolean;
   };
   /**
    * Tabelas de preço REAIS do business (customer_groups id+name). Server-side
@@ -425,6 +442,45 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
     setOpenTab(tab);
     setOpenContactId(id);
   }, []);
+
+  // 2026-06-08 (Wagner "exclusão de contato pela tela") — soft delete via
+  // DELETE /contacts/{id} (ContactController::destroy). O backend é a fonte de
+  // verdade das travas: escopo business_id (Tier 0 ADR 0093), bloqueia se há
+  // qualquer transação/venda/OS, protege is_default e grava ActivityLog
+  // (LGPD). Aqui só confirmamos e tratamos o JSON {success,msg}.
+  const [deleteTarget, setDeleteTarget] = useState<ClienteRow | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTarget || deleting) return;
+    setDeleting(true);
+    try {
+      const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+      const r = await fetch(`/contacts/${deleteTarget.id}`, {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+      const json = await r.json().catch(() => ({ success: false }));
+      if (r.ok && json?.success) {
+        toast.success(json.msg || 'Contato excluído.');
+        // Se o drawer do excluído estiver aberto, fecha. Recarrega a lista.
+        if (openContactId === deleteTarget.id) setOpenContactId(null);
+        setDeleteTarget(null);
+        router.reload({ only: ['customers', 'kpis', 'tab_counts'], preserveScroll: true });
+      } else {
+        // Caso típico: contato com vendas/OS — backend devolve success:false +
+        // msg "você não pode excluir este contato". Mantém o dialog aberto.
+        toast.error(json?.msg || 'Não foi possível excluir este contato.');
+      }
+    } catch {
+      toast.error('Falha de rede ao excluir. Verifique a conexão e tente de novo.');
+    } finally {
+      setDeleting(false);
+    }
+  }, [deleteTarget, deleting, openContactId]);
 
   // ADR 0179 evolução 2026-05-25 — "Novo cliente" via drawer 760 modo 'novo'.
   // State declarado aqui; callback (que depende de activeType) está DEPOIS
@@ -1292,9 +1348,11 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                           <td className="px-2 py-2.5 text-right pr-4" onClick={(e) => e.stopPropagation()}>
                             <ActionsMenu
                               row={row}
+                              canDelete={props.permissions.delete}
                               onView={() => openDrawer(row.id)}
                               onEdit={() => openDrawer(row.id, 'identificacao')}
                               onExtrato={() => openDrawer(row.id, 'operacoes')}
+                              onDelete={() => setDeleteTarget(row)}
                             />
                           </td>
                         </tr>
@@ -1363,6 +1421,38 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
         <Keyboard size={14} />
         <Kbd>?</Kbd>
       </button>
+
+      {/* 2026-06-08 — confirmação de exclusão (ação destrutiva → AlertDialog,
+          nunca delete num clique só). Soft delete server-side; reversível. */}
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(o) => { if (!o && !deleting) setDeleteTarget(null); }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Excluir contato?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {deleteTarget ? (
+                <>
+                  <strong>{deleteTarget.name || 'Este contato'}</strong> será excluído.
+                  Contatos com venda, compra ou OS lançada não podem ser excluídos —
+                  nesse caso o sistema avisa e nada é apagado.
+                </>
+              ) : null}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => { e.preventDefault(); confirmDelete(); }}
+              disabled={deleting}
+              className="bg-rose-600 text-white hover:bg-rose-700 focus-visible:ring-rose-600"
+            >
+              {deleting ? 'Excluindo…' : 'Excluir'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
      </div>
     </div>
   );
@@ -1668,23 +1758,29 @@ function StatusBadge({ status }: { status: ClienteRow['status'] }) {
   );
 }
 
-// 2026-06-08 (Wagner "arrumar botões da contacts") — menu ⋮ consolidado no
-// drawer 760 (ADR 0179: drawer substitui página/edit full-page Blade legacy).
-// REMOVIDOS: "Página completa" (/contacts/{id} — ícone duplicado + Non-Goal
-// Charter "Show.tsx full-page DELETADO") e "Excluir" (estava disabled permanente
-// = botão morto). "Editar" e "Extrato" não mandam mais pra Blade legacy
-// (/contacts/{id}/edit, /contacts/ledger) — abrem o drawer na aba certa.
+// 2026-06-08 (Wagner "arrumar botões da contacts" + "exclusão de contato") —
+// menu ⋮ consolidado no drawer 760 (ADR 0179: drawer substitui página/edit
+// full-page Blade legacy). "Editar"/"Extrato" abrem o drawer na aba certa (não
+// vão mais pra /contacts/{id}/edit · /contacts/ledger). "Excluir" voltou
+// funcional (soft delete via DELETE /contacts/{id}) — gated por canDelete
+// (customer/supplier.delete) e escondido pro is_default (walk-in). A trava de
+// "tem venda/OS → não exclui" é server-side (destroy()).
 function ActionsMenu({
   row,
+  canDelete,
   onView,
   onEdit,
   onExtrato,
+  onDelete,
 }: {
   row: ClienteRow;
+  canDelete: boolean;
   onView: () => void;
   onEdit: () => void;
   onExtrato: () => void;
+  onDelete: () => void;
 }) {
+  const showDelete = canDelete && !row.is_default;
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -1710,6 +1806,18 @@ function ActionsMenu({
           <CreditCard size={14} className="mr-2" />
           Extrato
         </DropdownMenuItem>
+        {showDelete && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={onDelete}
+              className="text-rose-600 focus:bg-rose-50 focus:text-rose-700 dark:text-rose-400 dark:focus:bg-rose-950/40"
+            >
+              <Trash2 size={14} className="mr-2" />
+              Excluir
+            </DropdownMenuItem>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/tests/Feature/Cliente/ClienteExcluirContatoTest.php
+++ b/tests/Feature/Cliente/ClienteExcluirContatoTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Wagner 2026-06-08 — "exclusão de contato pela tela, precisa".
+ *
+ * Excluir contato pelo menu ⋮ da listagem (/cliente) via soft delete
+ * DELETE /contacts/{id} (ContactController::destroy). O backend é a fonte de
+ * verdade das travas; o front só confirma (AlertDialog) e trata {success,msg}.
+ *
+ * Estratégia structural file_get_contents (alinhado ClienteDrawerRowsCanonBrPayloadTest).
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0), ADR 0179 (drawer 760), charter v9.
+ */
+
+// ─── GUARD 1: backend expõe is_default no select + payload ──────────────────
+// Sem is_default no payload, o front não consegue esconder "Excluir" do
+// consumidor/fornecedor padrão (walk-in) → no-op confuso (destroy protege mas
+// o usuário clica e "some" sem feedback claro).
+
+test('GUARD 1 — buildClienteIndexCustomers select + payload incluem is_default', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain("'contacts.is_default'")
+        ->toMatch("/'is_default'\\s*=>\\s*\\(bool\\)\\s*\\\$contact->is_default/");
+});
+
+// ─── GUARD 2: permissions prop do Inertia inclui `delete` ───────────────────
+// Gate do "Excluir": customer.delete || supplier.delete (cobre aba Fornecedores).
+
+test('GUARD 2 — permissions prop inclui delete (customer.delete || supplier.delete)', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toMatch("/'delete'\\s*=>\\s*auth\\(\\)->user\\(\\)->can\\('customer\\.delete'\\)\\s*\\|\\|\\s*auth\\(\\)->user\\(\\)->can\\('supplier\\.delete'\\)/");
+});
+
+// ─── GUARD 3: destroy() mantém as travas Tier 0 — sem regressão ─────────────
+// (1) escopo business_id · (2) bloqueia se houver transação · (3) protege
+// is_default · (4) ActivityLog LGPD · (5) desabilita login associado.
+
+test('GUARD 3 — destroy() preserva travas (business_id + transação + is_default + ActivityLog)', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // permissão exigida
+        ->toContain("'supplier.delete'")
+        ->toContain("'customer.delete'")
+        // bloqueio por transação (venda/compra/OS)
+        ->toContain("Transaction::where('business_id', \$business_id)")
+        ->toContain("->where('contact_id', \$id)")
+        ->toContain('if ($count == 0)')
+        // escopo Tier 0 + proteção walk-in
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        ->toContain('if (! $contact->is_default)')
+        // auditoria LGPD + corte de login
+        ->toContain("'contact_deleted'")
+        ->toContain("->update(['allow_login' => 0])")
+        ->toContain('$contact->delete()');
+});
+
+// ─── GUARD 4: Index.tsx — ClienteRow declara is_default ─────────────────────
+
+test('GUARD 4 — Cliente/Index.tsx ClienteRow declara is_default', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('is_default?: boolean | null')
+        // permissions prop tipada com delete
+        ->toContain('delete: boolean');
+});
+
+// ─── GUARD 5: ActionsMenu — "Excluir" gated por canDelete && !is_default ────
+
+test('GUARD 5 — ActionsMenu Excluir gated por canDelete e esconde is_default', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('canDelete: boolean')
+        ->toContain('const showDelete = canDelete && !row.is_default')
+        ->toContain('canDelete={props.permissions.delete}')
+        ->toContain('onDelete={() => setDeleteTarget(row)}')
+        // o item só renderiza quando showDelete
+        ->toContain('{showDelete && (')
+        ->toContain('Excluir');
+});
+
+// ─── GUARD 6: fluxo de exclusão — DELETE + CSRF + AJAX + confirmação + toast ─
+
+test('GUARD 6 — confirmDelete usa DELETE /contacts/{id} com CSRF + AlertDialog + toast', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // endpoint canon + método + headers AJAX (destroy() só responde isLegacyAjax)
+        ->toContain('/contacts/${deleteTarget.id}')
+        ->toContain("method: 'DELETE'")
+        ->toContain("'X-CSRF-TOKEN'")
+        ->toContain("'X-Requested-With': 'XMLHttpRequest'")
+        // confirmação destrutiva nunca em 1 clique
+        ->toContain('<AlertDialog')
+        ->toContain('Excluir contato?')
+        // feedback + reload da lista pós-sucesso
+        ->toContain('toast.success')
+        ->toContain('toast.error')
+        ->toContain("router.reload({ only: ['customers', 'kpis', 'tab_counts']");
+});


### PR DESCRIPTION
## Contexto

Wagner pediu **exclusão de contato direto pela tela** `/cliente` — antes só existia na rota legacy `/contacts/duplicates`. Liga o menu ⋮ da linha ao endpoint `ContactController::destroy()` que **já existe e já é seguro** (não altero a lógica destrutiva).

## Frontend (`Cliente/Index.tsx`)

- **"Excluir"** volta ao menu ⋮ — gated por `permissions.delete` **e** escondido pro `is_default` (consumidor/fornecedor walk-in).
- **AlertDialog de confirmação** — ação destrutiva nunca em 1 clique — + **toast** (sonner) de sucesso/erro.
- `DELETE /contacts/{id}` (AJAX + CSRF) → trata `{success,msg}`:
  - **Sucesso:** fecha o drawer do excluído (se aberto) + `router.reload(['customers','kpis','tab_counts'])`.
  - **Falha** (contato com venda/compra/OS): mostra a msg do backend e **não apaga nada**.

## Backend (`ContactController`)

- `permissions` prop ganha `delete` (`customer.delete || supplier.delete`).
- payload das rows ganha `is_default` (pro front esconder "Excluir" do walk-in).
- **`destroy()` INTOCADO** — a parte destrutiva é pré-existente e battle-tested:
  - **soft delete** (`Contact use SoftDeletes`) — reversível, LGPD-friendly
  - **bloqueia** se houver qualquer `Transaction` do contato → `success:false` + msg
  - protege `is_default` · escopo `business_id` (Tier 0 ADR 0093)
  - `ActivityLog` `contact_deleted` (LGPD Art. 18) + corta login associado (`allow_login=0`)

## Cobertura

`tests/Feature/Cliente/ClienteExcluirContatoTest.php` — 6 guards estáticos: select/payload `is_default`, permission `delete`, travas do `destroy()` (regressão Tier 0), gate do front (`canDelete && !is_default`), fluxo `DELETE`+CSRF+AlertDialog+toast. Charter **v9** (append-only).

## Validação local

- **tsc:** 0 erro novo de classe própria (o `preserveScroll` é falso-positivo de type-def já usado 3× neste arquivo; runtime-válido; tsc não é gate)
- **eslint ratchet:** sem regressão (delta −1)
- **vite build:** OK (chunk `alert-dialog` gerado, 4407 módulos)
- **php -l:** OK nos 2 arquivos PHP
- Pest não rodou local (vendor não instalado neste checkout) → roda no CI

## Non-Goals (charter v9)

- ❌ Merge/mesclar duplicados pela tela (segue legacy `/contacts/duplicates`)
- ❌ Exclusão em batch · ❌ hard delete pela UI · ❌ restaurar excluído pela tela

🤖 Generated with [Claude Code](https://claude.com/claude-code)