### PR TITLE
feat(oficina): filtro funcional por box + mecânico no kanban (eixo de recurso reparo)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ProducaoOficinaController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ProducaoOficinaController.php
@@ -75,10 +75,17 @@ class ProducaoOficinaController extends Controller
         // current_status, mostramos tela com kanban vazio em vez de quebrar.
         $hasFsmSchema = Schema::hasColumn('vehicles', 'current_status');
 
-        $capacidade = $this->normalizeCapacidade($request->string('capacidade')->toString());
-        $search     = trim((string) $request->string('q'));
+        // Eixo de recurso (modelo reparo): box (texto livre, Wave 2.1 US-OFICINA-027)
+        // + mecânico. Filtro funcional SEM schema novo — colunas já existem
+        // (ADR 0105: box é texto livre, sem tabela até sinal qualificado). Substitui
+        // o filtro de capacidade (m³), que era vocabulário de caçamba.
+        $hasResourceSchema = Schema::hasColumn('service_orders', 'box_label');
 
-        $vehicles = $this->loadVehicles($hasFsmSchema, $capacidade, $search);
+        $box      = trim((string) $request->string('box'));
+        $mecanico = $request->integer('mecanico') ?: null;
+        $search   = trim((string) $request->string('q'));
+
+        $vehicles = $this->loadVehicles($hasFsmSchema, $hasResourceSchema, $box, $mecanico, $search);
 
         // V3 fallback: vehicles ativos sem current_rental_id buscam most-recent
         // ServiceOrder não-terminal pra suprir dados (LOR-3F88 caso real demo).
@@ -92,48 +99,58 @@ class ProducaoOficinaController extends Controller
         $kanban = $this->groupIntoKanban($vehicles, $rentalFallbacks, $atendenteFallback);
         $kpis   = $this->buildKpis($kanban);
 
+        // Opções de filtro (box + mecânico) entre as OS ativas do business.
+        [$boxes, $mecanicos] = $hasResourceSchema
+            ? $this->buildFilterOptions()
+            : [[], []];
+
         return Inertia::render('OficinaAuto/ProducaoOficina/Index', [
-            'kanban'  => $kanban,
-            'kpis'    => $kpis,
-            'filters' => [
-                'capacidade' => $capacidade,
-                'q'          => $search,
+            'kanban'    => $kanban,
+            'kpis'      => $kpis,
+            'filters'   => [
+                'box'      => $box,
+                'mecanico' => $mecanico,
+                'q'        => $search,
             ],
+            'recursos'  => $boxes,
+            'mecanicos' => $mecanicos,
         ]);
     }
 
     /**
-     * Normaliza filtro de capacidade. Aceita 'all', '3', '5', '7'. Default 'all'.
-     */
-    protected function normalizeCapacidade(string $raw): string
-    {
-        $allowed = ['all', '3', '5', '7'];
-        return in_array($raw, $allowed, true) ? $raw : 'all';
-    }
-
-    /**
-     * Carrega vehicles aplicando filters (capacidade + q) — global scope
+     * Carrega vehicles aplicando filters (box + mecânico + q) — global scope
      * já filtra business_id automaticamente.
      *
      * @return Collection<int, Vehicle>
      */
-    protected function loadVehicles(bool $hasFsmSchema, string $capacidade, string $search): Collection
-    {
+    protected function loadVehicles(
+        bool $hasFsmSchema,
+        bool $hasResourceSchema,
+        string $box,
+        ?int $mecanico,
+        string $search
+    ): Collection {
         $query = Vehicle::query();
 
         if ($hasFsmSchema) {
             // Eager-load currentRental + contact + transaction.createdBy pra atendente
             // (transaction pode ser null em rentals draft — fallback: auth user no projector).
+            // + box_label/assigned_user_id/assignedUser pro eixo de recurso (modelo reparo).
             $query->with([
-                'currentRental:id,vehicle_id,contact_id,transaction_id,entered_at,delivery_address,expected_return_date,daily_rate,status,notes,created_at,order_type',
+                'currentRental:id,vehicle_id,contact_id,transaction_id,entered_at,delivery_address,expected_return_date,daily_rate,status,notes,created_at,order_type,box_label,assigned_user_id',
                 'currentRental.contact:id,name,mobile',
                 'currentRental.transaction:id,created_by',
                 'currentRental.transaction.createdBy:id,first_name,last_name,username',
+                'currentRental.assignedUser:id,first_name,last_name,surname,username',
             ]);
         }
 
-        if ($capacidade !== 'all') {
-            $query->where('capacity_m3', (int) $capacidade);
+        // Filtro por box (texto livre) e/ou mecânico — só OS ativa casa (whereHas).
+        if ($hasResourceSchema && $box !== '') {
+            $query->whereHas('currentRental', fn ($q) => $q->where('box_label', $box));
+        }
+        if ($hasResourceSchema && $mecanico !== null) {
+            $query->whereHas('currentRental', fn ($q) => $q->where('assigned_user_id', $mecanico));
         }
 
         if ($search !== '') {
@@ -194,6 +211,7 @@ class ProducaoOficinaController extends Controller
                 'contact:id,name,mobile',
                 'transaction:id,created_by',
                 'transaction.createdBy:id,first_name,last_name,username',
+                'assignedUser:id,first_name,last_name,surname,username',
             ])
             ->orderByDesc('id')
             ->get();
@@ -345,6 +363,21 @@ class ProducaoOficinaController extends Controller
             $atendenteIniciais = $atendenteFallback['iniciais'];
         }
 
+        // Eixo de recurso (modelo reparo): box (texto livre) + mecânico (assignedUser).
+        $mecanicoNome = null;
+        $mecanicoIniciais = null;
+        if ($rental && $rental->assignedUser) {
+            $m = $rental->assignedUser;
+            $nome = trim(
+                (string) ($m->first_name ?? '') . ' ' . (string) ($m->last_name ?? '')
+            );
+            if ($nome === '') {
+                $nome = (string) ($m->surname ?? $m->username ?? '');
+            }
+            $mecanicoNome = $nome !== '' ? $nome : null;
+            $mecanicoIniciais = $mecanicoNome !== null ? $this->makeIniciais($mecanicoNome) : null;
+        }
+
         return [
             'id'                  => $v->id,
             'plate'               => $v->plate,
@@ -365,7 +398,59 @@ class ProducaoOficinaController extends Controller
             'valor_receber'       => $rental ? (float) $rental->valor_receber : null,
             'atendente_nome'      => $atendenteNome,
             'atendente_iniciais'  => $atendenteIniciais,
+            'box_label'           => $rental?->box_label,
+            'mecanico_nome'       => $mecanicoNome,
+            'mecanico_iniciais'   => $mecanicoIniciais,
         ];
+    }
+
+    /**
+     * Opções de filtro do quadro — boxes (texto livre) + mecânicos distintos entre
+     * as OS ativas (não-terminais) do business. Global scope já filtra business_id;
+     * mecânicos resolvidos com scope explícito por business (User não tem global scope).
+     *
+     * @return array{0: list<string>, 1: list<array{id:int, nome:string}>}
+     */
+    protected function buildFilterOptions(): array
+    {
+        $terminal = ['concluida', 'cancelada', 'recolhida'];
+
+        $boxes = ServiceOrder::query()
+            ->whereNotIn('status', $terminal)
+            ->whereNotNull('box_label')
+            ->where('box_label', '!=', '')
+            ->distinct()
+            ->orderBy('box_label')
+            ->pluck('box_label')
+            ->values()
+            ->all();
+
+        $mechanicIds = ServiceOrder::query()
+            ->whereNotIn('status', $terminal)
+            ->whereNotNull('assigned_user_id')
+            ->distinct()
+            ->pluck('assigned_user_id')
+            ->all();
+
+        $mecanicos = [];
+        if (! empty($mechanicIds)) {
+            $bizId = (int) (session('user.business_id') ?? auth()->user()?->business_id ?? 0);
+            $users = User::query()
+                ->whereIn('id', $mechanicIds)
+                ->when($bizId > 0, fn ($q) => $q->where('business_id', $bizId))
+                ->orderBy('first_name')
+                ->get(['id', 'first_name', 'last_name', 'surname', 'username']);
+
+            foreach ($users as $u) {
+                $nome = trim((string) ($u->first_name ?? '') . ' ' . (string) ($u->last_name ?? ''));
+                if ($nome === '') {
+                    $nome = (string) ($u->surname ?? $u->username ?? '');
+                }
+                $mecanicos[] = ['id' => (int) $u->id, 'nome' => $nome !== '' ? $nome : '—'];
+            }
+        }
+
+        return [$boxes, $mecanicos];
     }
 
     /**

--- a/Modules/OficinaAuto/Tests/Feature/ProducaoBoxFilterTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ProducaoBoxFilterTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Filtro por box/mecânico no kanban Produção · Oficina (modelo reparo).
+ *
+ * Eixo de recurso construído SOBRE campos existentes (Wave 2.1 US-OFICINA-027):
+ * `service_orders.box_label` (texto livre) + `assigned_user_id`. Sem schema novo
+ * (ADR 0105: box texto livre até sinal qualificado). Espelha a query do
+ * `ProducaoOficinaController::loadVehicles` (whereHas currentRental box_label) +
+ * `buildFilterOptions` (distinct box_label das OS ativas).
+ *
+ * Cobre:
+ *   1. Filtro box='Box 1' retorna só os veículos cuja OS ativa está nesse box
+ *   2. Multi-tenant Tier 0 — box 'Box 1' do biz=99 NÃO vaza pro biz=1
+ *   3. buildFilterOptions: boxes distintos só das OS ativas (terminal não entra)
+ *
+ * Pattern: skip SQLite (ADR 0101 — schema MySQL UltimatePOS). Validação na query.
+ *
+ * @see Modules/OficinaAuto/Http/Controllers/ProducaoOficinaController.php
+ */
+
+const BIZ_BOX_TEST = 1;
+const BIZ_BOX_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('service_orders') || ! Schema::hasColumn('service_orders', 'box_label')) {
+        $this->markTestSkipped('service_orders.box_label ausente — rode migrate primeiro');
+    }
+});
+
+/**
+ * Cria veículo com OS ativa apontada por current_rental_id, com box_label dado.
+ */
+function boxCreateVehicleWithOs(int $bizId, ?string $box, string $status = 'locada'): Vehicle
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $bizId,
+        'plate'        => 'BOX' . substr((string) random_int(1000, 9999), 0, 4),
+        'vehicle_type' => 'caminhao',
+        'current_status' => $status,
+    ]);
+
+    $order = ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $bizId,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => 'locacao',
+        'status'      => 'aberta',
+        'entered_at'  => now(),
+        'box_label'   => $box,
+    ]);
+
+    $vehicle->forceFill(['current_rental_id' => $order->id])->save();
+
+    return $vehicle;
+}
+
+function boxCleanup(int $bizId): void
+{
+    Vehicle::withoutGlobalScopes()->where('business_id', $bizId)->where('plate', 'like', 'BOX%')->forceDelete();
+    ServiceOrder::withoutGlobalScopes()->where('business_id', $bizId)->where('order_type', 'locacao')->forceDelete();
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. filtro box="Box 1" retorna só veículos cuja OS ativa está nesse box', function () {
+    session(['user.business_id' => BIZ_BOX_TEST]);
+
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 1');
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 1');
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 2');
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, null);
+
+    // Mesma query do controller (loadVehicles → whereHas currentRental box_label)
+    $filtered = Vehicle::query()
+        ->whereHas('currentRental', fn ($q) => $q->where('box_label', 'Box 1'))
+        ->count();
+
+    expect($filtered)->toBe(2);
+})->afterEach(fn () => boxCleanup(BIZ_BOX_TEST));
+
+it('2. multi-tenant Tier 0 — box "Box 1" do biz=99 NÃO vaza pro biz=1', function () {
+    session(['user.business_id' => BIZ_BOX_TEST]);
+
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 1');
+    boxCreateVehicleWithOs(BIZ_BOX_FICTICIO, 'Box 1');
+
+    // Global scope do Vehicle filtra biz=1 automaticamente
+    $filtered = Vehicle::query()
+        ->whereHas('currentRental', fn ($q) => $q->where('box_label', 'Box 1'))
+        ->count();
+
+    expect($filtered)->toBe(1);
+})->afterEach(function () {
+    boxCleanup(BIZ_BOX_TEST);
+    boxCleanup(BIZ_BOX_FICTICIO);
+});
+
+it('3. buildFilterOptions retorna boxes distintos só das OS ativas', function () {
+    session(['user.business_id' => BIZ_BOX_TEST]);
+
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 1');
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 1'); // duplicado → distinct colapsa
+    boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Elevador 2');
+
+    // OS terminal NÃO deve aparecer nas opções
+    $terminalVeh = boxCreateVehicleWithOs(BIZ_BOX_TEST, 'Box 9');
+    $terminalVeh->currentRental->forceFill(['status' => 'concluida'])->save();
+
+    $boxes = ServiceOrder::query()
+        ->whereNotIn('status', ['concluida', 'cancelada', 'recolhida'])
+        ->whereNotNull('box_label')
+        ->where('box_label', '!=', '')
+        ->distinct()
+        ->orderBy('box_label')
+        ->pluck('box_label')
+        ->values()
+        ->all();
+
+    expect($boxes)->toBe(['Box 1', 'Elevador 2']);
+})->afterEach(fn () => boxCleanup(BIZ_BOX_TEST));

--- a/memory/decisions/proposals/oficina-filtro-recurso-box-elevador.md
+++ b/memory/decisions/proposals/oficina-filtro-recurso-box-elevador.md
@@ -13,9 +13,19 @@ relates_to:
 
 # PROPOSAL — Eixo de recurso (box/elevador + mecânico) no kanban da Oficina
 
-> **Status:** `proposal` — Wagner promove pra ADR aceita (próximo número canônico, ~0263) após validar o desenho de domínio. **Tier 0** porque toca schema com cliente LIVE (Martinho biz=164).
+> **Status:** `proposal` — Wagner promove pra ADR aceita (próximo número canônico, ~0263). **Tier 0** rebaixado a baixo-risco pela revisão abaixo (sem schema novo).
 
-## Contexto
+## ⚠️ REVISÃO 2026-06-08 — o dado JÁ EXISTE (premissa original corrigida)
+
+> A premissa do "Contexto" abaixo (escrita antes de auditar o schema) está **errada**: `service_orders` **já tem** `box_label` (texto livre) + `assigned_user_id` (mecânico) desde a **Wave 2.1 US-OFICINA-027** (migration `2026_05_26_120001_add_box_and_assigned_user_to_service_orders.php`), com relação `assignedUser()` no model e exibição no drawer. **A decisão de domínio já foi tomada lá:** box é **texto livre, sem tabela**, "até sinal qualificado" ([ADR 0105](../0105-cliente-como-sinal-guiar-sem-mandar.md)).
+>
+> **Consequência:** a proposta da **tabela `oficina_recursos`** (seção 1 abaixo) é **descartada por ora** — contradiz a decisão Wave 2.1 + ADR 0105 (nenhum cliente de reparo LIVE ainda; Martinho é mecânica pesada sem boxes). O **filtro funcional** foi implementado **sobre os campos existentes** (zero migration, zero Tier 0 de DB): `ProducaoOficinaController` projeta `box_label`/mecânico no card, filtra por `box`/`mecanico`, e expõe as opções distintas; a UI ganhou pills de box/mecânico (só aparecem quando há dado). Entregue no **PR do filtro box/mecânico** (2026-06-08).
+>
+> **A tabela `oficina_recursos` volta à mesa SE** aparecer cliente de reparo pagante que precise de agenda/capacidade por box (aí o texto-livre não basta). Até lá, **texto livre vence** (ADR 0105). O resto desta proposta fica como **registro do trade-off** e do desenho de tabela pra quando o sinal chegar.
+>
+> **Foco=Box/Mecânico (re-pivot do quadro)** segue como onda seguinte (muda a estrutura de colunas + semântica do drag) — não entrou no PR do filtro.
+
+## Contexto (premissa original — ver revisão acima)
 
 A convergência F3 da camada visível caçamba→reparo landou ([PR #2417](https://github.com/wagnerra23/oimpresso.com/pull/2417)): colunas, KPIs e vocabulário da tela `OficinaAuto/ProducaoOficina/Index` já são **reparo**. Mas o **filtro** ficou pela metade.
 

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
@@ -68,15 +68,23 @@ interface Kpis {
   valor_em_curso: number;
 }
 
-type CapacidadeFilter = 'all' | '3' | '5' | '7';
+interface Mecanico {
+  id: number;
+  nome: string;
+}
 
 interface Props {
   kanban: KanbanGroups;
   kpis: Kpis;
   filters: {
-    capacidade: CapacidadeFilter;
+    box: string;
+    mecanico: number | null;
     q: string;
   };
+  /** Boxes (texto livre) presentes nas OS ativas — eixo de recurso do modelo reparo. */
+  recursos: string[];
+  /** Mecânicos atribuídos nas OS ativas. */
+  mecanicos: Mecanico[];
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -272,7 +280,7 @@ const NEXT_COLUMN_FOR: Record<CacambaStatus, CacambaStatus | null> = {
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
+export default function ProducaoOficinaIndex({ kanban, kpis, filters, recursos, mecanicos }: Props) {
   const [searchInput, setSearchInput] = useState(filters.q ?? '');
   const searchInputRef = useRef<HTMLInputElement>(null);
 
@@ -314,19 +322,40 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
     setFocusedId(null);
   }, []);
 
-  // Debounce 300ms — evita visit por keystroke
+  // Debounce 300ms — evita visit por keystroke. Preserva box/mecânico ativos.
   useEffect(() => {
     if (searchInput === (filters.q ?? '')) return;
     const t = setTimeout(() => {
       router.get(
         '/oficina-auto/producao-oficina',
-        { q: searchInput || undefined },
+        {
+          q: searchInput || undefined,
+          box: filters.box || undefined,
+          mecanico: filters.mecanico || undefined,
+        },
         { preserveState: true, preserveScroll: true, replace: true },
       );
     }, 300);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchInput]);
+
+  // Filtro server-side por box/mecânico (eixo de recurso do modelo reparo).
+  // `null` no campo = limpar aquele eixo; preserva busca + o outro eixo.
+  const goFilter = useCallback(
+    (next: { box: string; mecanico: number | null }) => {
+      router.get(
+        '/oficina-auto/producao-oficina',
+        {
+          q: searchInput || undefined,
+          box: next.box || undefined,
+          mecanico: next.mecanico || undefined,
+        },
+        { preserveState: true, preserveScroll: true, replace: true },
+      );
+    },
+    [searchInput],
+  );
 
   // Drawer caçamba — abre OS atual (rental ativa) ao clicar card
   const [openOsId, setOpenOsId] = useState<number | null>(null);
@@ -727,6 +756,60 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
           </Grid>
         </Box>
 
+        {/* ─── Eixo de recurso (modelo reparo): filtro por box + mecânico.
+             Só aparece quando há boxes/mecânicos atribuídos (server-side). Cliente
+             sem esse eixo (ex.: Martinho mecânica pesada) não vê controle vazio. ─── */}
+        {(recursos.length > 0 || mecanicos.length > 0) && (
+          <Box bg="card" px={6} py={2} className="border-b border-border">
+            <Inline gap={4} wrap>
+              {recursos.length > 0 && (
+                <Inline gap={2} wrap align="center">
+                  <Text as="span" size="xs" weight="semibold" tone="muted" className="uppercase tracking-wide">
+                    Box
+                  </Text>
+                  <FilterPill
+                    active={filters.box === ''}
+                    onClick={() => goFilter({ box: '', mecanico: filters.mecanico })}
+                  >
+                    Todos
+                  </FilterPill>
+                  {recursos.map((b) => (
+                    <FilterPill
+                      key={b}
+                      active={filters.box === b}
+                      onClick={() => goFilter({ box: b, mecanico: filters.mecanico })}
+                    >
+                      {b}
+                    </FilterPill>
+                  ))}
+                </Inline>
+              )}
+              {mecanicos.length > 0 && (
+                <Inline gap={2} wrap align="center">
+                  <Text as="span" size="xs" weight="semibold" tone="muted" className="uppercase tracking-wide">
+                    Mecânico
+                  </Text>
+                  <FilterPill
+                    active={filters.mecanico === null}
+                    onClick={() => goFilter({ box: filters.box, mecanico: null })}
+                  >
+                    Todos
+                  </FilterPill>
+                  {mecanicos.map((m) => (
+                    <FilterPill
+                      key={m.id}
+                      active={filters.mecanico === m.id}
+                      onClick={() => goFilter({ box: filters.box, mecanico: m.id })}
+                    >
+                      {m.nome}
+                    </FilterPill>
+                  ))}
+                </Inline>
+              )}
+            </Inline>
+          </Box>
+        )}
+
         {/* ─── Filter bar sticky — busca + KPI inline ─── */}
         <Box bg="card" px={6} py={3} className="border-b border-border sticky top-0 z-10">
           <Inline gap={6} wrap className="w-full">
@@ -823,6 +906,33 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
 ProducaoOficinaIndex.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;
 
 // ─── Subcomponents ───────────────────────────────────────────────────────────
+
+// Pílula de filtro (box/mecânico) — `<button>` real (a11y: teclado + aria-pressed).
+function FilterPill({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={
+        'px-2.5 py-1 text-xs rounded font-medium transition-colors ' +
+        (active
+          ? 'bg-foreground text-background'
+          : 'bg-muted text-foreground hover:bg-muted/80')
+      }
+    >
+      {children}
+    </button>
+  );
+}
 
 interface KpiCardProps {
   label: string;

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
@@ -53,6 +53,10 @@ export interface CacambaCardData {
   valor_receber: number | null;
   atendente_nome: string | null;
   atendente_iniciais: string | null;
+  // Eixo de recurso (modelo reparo) — box (texto livre) + mecânico atribuído.
+  box_label?: string | null;
+  mecanico_nome?: string | null;
+  mecanico_iniciais?: string | null;
 }
 
 interface Props {
@@ -291,6 +295,16 @@ function CacambaCardImpl({ cacamba, variant, onClick, onAdvance, isFocused = fal
           {osLabel ?? <span className="text-muted-foreground/60 italic">sem OS</span>}
         </span>
         <div className="flex items-center gap-1.5 flex-shrink-0">
+          {/* Eixo de recurso (modelo reparo): box atribuído à OS. */}
+          {cacamba.box_label ? (
+            <span
+              className="inline-flex items-center gap-1 text-[10.5px] px-1.5 py-0.5 rounded font-medium border bg-primary/5 text-primary border-primary/20 whitespace-nowrap"
+              title={`Box: ${cacamba.box_label}`}
+            >
+              <Wrench size={9} />
+              {cacamba.box_label}
+            </span>
+          ) : null}
           {showValorTop && (
             <span
               className={


### PR DESCRIPTION
Fecha o **item #3** do handoff de design (filtro do eixo reparo) — **sobre os campos que já existem**: `service_orders.box_label` (texto livre) + `assigned_user_id` (Wave 2.1 US-OFICINA-027). **Zero migration, zero schema novo, zero Tier 0 de DB.**

## Correção de premissa
A auditoria de hoje mostrou que a ADR proposta [#2419](https://github.com/wagnerra23/oimpresso.com/pull/2419) partia de premissa errada ("o dado não existe"). Ele **existe** desde a Wave 2.1. A tabela `oficina_recursos` fica **descartada por ora** (contradiz a decisão Wave 2.1 + **ADR 0105** — box é texto livre até sinal qualificado; nenhum cliente de reparo LIVE). O proposal foi atualizado com a revisão.

## Backend (`ProducaoOficinaController`)
- `projectVehicleCard` expõe `box_label` + mecânico (`assignedUser`).
- `index` aceita `box` + `mecanico`; filtra via `whereHas('currentRental')`. **Remove o ramo morto `capacidade`/`capacity_m3`** (vocab caçamba).
- `buildFilterOptions`: boxes + mecânicos distintos das OS ativas (scope `business_id`).

## Frontend (`Index.tsx`)
- Pills de filtro por **box** + **mecânico** — **só aparecem quando há dado** (Martinho mecânica pesada, sem boxes, **não vê controle vazio** → tela do cliente LIVE inalterada). `<button>` real (a11y), server-side.
- Debounce da busca preserva box/mecânico.
- `CacambaCard`: chip de box no topo (token `primary`).

## Teste
`ProducaoBoxFilterTest` — filtro por box + **multi-tenant Tier 0** + `buildFilterOptions`; espelha o harness do `ServiceOrderIndexStageFilterTest` (query-level, skip SQLite).

## Fora de escopo (de propósito)
- **Migração de domínio** das keys FSM/`cacamba_locacao` → reparo: Tier 0 perigoso em dado LIVE, precisa **staging** primeiro.
- **Foco=Box/Mecânico re-pivot**: onda seguinte (muda a estrutura de colunas + semântica do drag).

## Gates
`typecheck` sem erro novo (4 pré-existentes de baseline) · **ESLint ratchet −2** · **a11y 294=294** · layout sem flex solto novo · `php -l` limpo. Pest roda no CI.

Refs: ADR 0105 · ADR 0093 · ADR 0194 · proposal `oficina-filtro-recurso-box-elevador` · handoff item #3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)