### PR TITLE
design(sells): residual chrome azul 220 → roxo 295 — finaliza Trilho A (modelo único de identidade)

### DIFF
--- a/resources/css/sells-cowork-edit.css
+++ b/resources/css/sells-cowork-edit.css
@@ -40,7 +40,7 @@
   --accent-fg:    #ffffff;
 
   /* Form states (focus/error — semantic via oklch) */
-  --focus-ring:   oklch(0.72 0.10 220);
+  --focus-ring:   oklch(0.72 0.10 295);
   --error:        oklch(0.55 0.16 25);
   --error-bg:     oklch(0.96 0.04 25);
   --error-border: oklch(0.65 0.14 25);
@@ -77,7 +77,7 @@
   --text-dim:  oklch(0.68 0.005 90);
   --text-mute: oklch(0.55 0.005 90);
   --accent-soft:  oklch(0.32 0.06 295);
-  --focus-ring:   oklch(0.55 0.10 220);
+  --focus-ring:   oklch(0.55 0.10 295);
   --error-bg:     oklch(0.28 0.08 25);
   --disabled-bg:  oklch(0.18 0.003 240);
   --disabled-fg:  oklch(0.50 0.005 90);

--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -888,7 +888,7 @@
 .sells-cowork .mod-stub-roadmap li.current { opacity: 1; background: var(--accent-soft); border-color: var(--accent); }
 .sells-cowork .mod-stub-roadmap li.current .step { background: var(--accent); border-color: var(--accent); color: #fff; }
 .sells-cowork [data-theme="dark"] .mod-stub-roadmap li.done { background: oklch(0.28 0.05 145); border-color: oklch(0.45 0.10 145); }
-.sells-cowork [data-theme="dark"] .mod-stub-roadmap li.current { background: oklch(0.28 0.06 220); }
+.sells-cowork [data-theme="dark"] .mod-stub-roadmap li.current { background: oklch(0.28 0.06 295); }
 .sells-cowork .mod-stub-tag .mono { font-family: var(--font-mono); }
 /* ────────────────── Chat (thread) ────────────────── */
 .sells-cowork .thread {
@@ -1919,11 +1919,11 @@
 .sells-cowork .vrep-tabs button.active { background:var(--accent); border-color:var(--accent); color:#fff; }
 /* ──── PDV BALCÃO (overlay) ──── */
 .sells-cowork .pdv-num.strong { font-weight:600; }
-.sells-cowork .pdv-pay-btn.active { border-color:var(--accent); background:oklch(0.30 0.06 var(--accent-h, 220)); }
+.sells-cowork .pdv-pay-btn.active { border-color:var(--accent); background:oklch(0.30 0.06 var(--accent-h, 295)); }
 /* ──── RECIBO (térmica + A4) ──── */
 .sells-cowork .rec-layout button.active { background:var(--accent); color:#fff; }
 /* ──── NF-e drawer extras ──── */
-.sells-cowork .nfe-cfop-btn.active, .sells-cowork .nfe-transp-btn.active { border-color:var(--accent); background:oklch(0.97 0.04 var(--accent-h, 220)); }
+.sells-cowork .nfe-cfop-btn.active, .sells-cowork .nfe-transp-btn.active { border-color:var(--accent); background:oklch(0.97 0.04 var(--accent-h, 295)); }
 .sells-cowork .nfe-review-card.span { grid-column:1 / -1; }
 .sells-cowork .nfe-review-card .mono { font-family:var(--font-mono); }
 .sells-cowork .nfe-review-card .small { font-size:10px; word-break:break-all; line-height:1.4; }
@@ -1969,7 +1969,7 @@
   background:oklch(0.95 0.01 250); font-size:10px; font-weight:600;
   color:oklch(0.40 0.02 250);
 }
-.sells-cowork .os-tab.active .count { background:oklch(0.94 0.06 var(--accent-h, 220)); color:var(--accent); }
+.sells-cowork .os-tab.active .count { background:oklch(0.94 0.06 var(--accent-h, 295)); color:var(--accent); }
 .sells-cowork .os-table-wrap { padding:14px 24px 20px; overflow:auto; }
 .sells-cowork .os-table {
   width:100%; border-collapse:collapse;
@@ -1986,7 +1986,7 @@
 .sells-cowork .os-table td { padding:6px 12px; border-bottom:1px solid oklch(0.96 0.01 250); font-size:13px; vertical-align:middle; }
 .sells-cowork .os-table tbody tr:last-child td { border-bottom:none; }
 .sells-cowork .os-row { cursor:pointer; transition:background .1s; }
-.sells-cowork .os-row:hover { background:oklch(0.98 0.01 var(--accent-h, 220)); }
+.sells-cowork .os-row:hover { background:oklch(0.98 0.01 var(--accent-h, 295)); }
 .sells-cowork .os-row.urgent { box-shadow:inset 3px 0 0 oklch(0.60 0.16 25); }
 .sells-cowork .os-stage {
   display:inline-block; padding:2px 8px; border-radius:10px;


### PR DESCRIPTION
## Contexto

Implementa o aspecto executável do artefato de design **\`Mapa de Identidade ERP — CC\`** (Claude Design handoff): **Trilho A / Fase 2 — Sells chrome azul → roxo canon**.

A decisão-raiz (Fase 0) foi ratificada por [W] em 2026-06-08: existe **um** modelo — chrome = roxo único \`oklch(0.55 0.15 295)\`; hue-por-módulo vive só na camada semântica.

## O que mudou

O bloco de token \`--accent\` do Sells **já era roxo 295**. A migração anterior deixou **leaks de chrome azul** em fallbacks/literais que não leem \`var(--accent)\`. Este PR cirúrgico fecha esses 7 pontos:

| Arquivo | Site | De → Para |
|---|---|---|
| sells-cowork.css | \`.pdv-pay-btn.active\` | \`var(--accent-h, 220)\` → \`295\` |
| sells-cowork.css | \`.nfe-cfop/transp-btn.active\` | \`var(--accent-h, 220)\` → \`295\` |
| sells-cowork.css | \`.os-tab.active .count\` | \`var(--accent-h, 220)\` → \`295\` |
| sells-cowork.css | \`.os-row:hover\` | \`var(--accent-h, 220)\` → \`295\` |
| sells-cowork.css | \`.mod-stub-roadmap li.current\` (dark) | \`oklch(0.28 0.06 220)\` → \`295\` |
| sells-cowork-edit.css | \`--focus-ring\` (claro) | \`220\` → \`295\` |
| sells-cowork-edit.css | \`--focus-ring\` (dark) | \`220\` → \`295\` |

> ⚠️ \`--accent-h\` é **undefined** no repo → os fallbacks \`220\` firavam **azul ao vivo** nos estados ativo/hover. Não é dead code: corrige render real.

## Camada semântica PRESERVADA (modelo de 2 camadas)

Continuam \`220\` **de propósito** (wayfinding, não chrome): \`--origin-CRM\`, avatar \`.av-2\`, \`.os-tl-item.client\` dot, \`--gh\` (group hue), \`--status-partial\`, \`.vd-link-cli\`.

## Gates

- ✅ \`stylelint:baseline:check\` — 487 = 487 (Δ0)
- ✅ \`css:size:check\` — Δ0 (só troca de dígitos de hue)
- ✅ PR cirúrgico — só Sells; Financeiro/Compras são fases próprias

Refs: \`memory/decisions/_PROPOSTA-modelo-unico-identidade-2-camadas.md\` · Mapa de Identidade ERP Fase 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)