### PR TITLE
design(compras): hex cru → tokens canon (modelo único de identidade)

### DIFF
--- a/config/stylelint-baseline.json
+++ b/config/stylelint-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-06T22:57:15.089Z",
-    "total_violations": 487,
+    "generated_at": "2026-06-08T17:37:09.548Z",
+    "total_violations": 436,
     "stylelint_version": "17.x",
     "adr": "0209",
     "note": "G5 anti-drift CSS — gêmeo do eslint-baseline. Ratchet por path+rule, falha só em delta>0."
@@ -13,7 +13,6 @@
     "resources/css/cowork-canon-financeiro-bundle.css|color-no-hex": 69,
     "resources/css/cowork-canon-financeiro-bundle.css|declaration-no-important": 15,
     "resources/css/cowork-canon-financeiro-bundle.css|no-duplicate-selectors": 29,
-    "resources/css/cowork-compras-bundle.css|color-no-hex": 51,
     "resources/css/cowork-fields.css|color-no-hex": 4,
     "resources/css/cowork-payment-gateway-bundle.css|color-no-hex": 2,
     "resources/css/fin-cowork.css|color-no-hex": 3,

--- a/resources/css/cowork-compras-bundle.css
+++ b/resources/css/cowork-compras-bundle.css
@@ -1,19 +1,30 @@
 /* compras-page.css — estilos do módulo Compras, todos escopados em .compras-root
-   para não vazar pro shell unificado. Migrado de Compras.html. */
+   para não vazar pro shell unificado. Migrado de Compras.html.
+   2026-06-08: hex cru → tokens canônicos (cockpit.css). Modelo único de identidade
+   (F0 ratificada): chrome roxo via --accent; surface/semântica = canon; sem paleta
+   paralela. O namespace --cmp-* agora é só alias 1:1 → dark mode passa a funcionar. */
 
 .compras-root{
-  --cmp-bg:#f6f4ef;--cmp-paper:#fff;--cmp-ink:#1a1917;--cmp-ink-2:#5b574f;--cmp-ink-3:#8b8580;
-  --cmp-line:#e5e0d3;--cmp-line-2:#efeae0;
-  --cmp-accent:#1f3a5f;--cmp-accent-soft:#eaf0f7;--cmp-accent-2:#173049;
-  --cmp-ok:#1f6d3a;--cmp-ok-soft:#e6f1e8;
-  --cmp-warn:#a35a00;--cmp-warn-soft:#fbf0dc;
-  --cmp-err:#9a2d2d;--cmp-err-soft:#fbe9e9;
-  --cmp-info:#1f5a8a;--cmp-info-soft:#e3edf6;
-  --cmp-mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  /* Namespace local = alias 1:1 nos tokens canon (cockpit.css) — zero hex, zero paleta paralela */
+  --cmp-bg:        var(--bg);
+  --cmp-paper:     var(--surface);
+  --cmp-ink:       var(--text);
+  --cmp-ink-2:     var(--text-dim);
+  --cmp-ink-3:     var(--text-mute);
+  --cmp-line:      var(--border);
+  --cmp-line-2:    var(--border-2);
+  --cmp-accent:      var(--accent);        /* navy legado → roxo canon 295 (chrome único) */
+  --cmp-accent-soft: var(--accent-soft);
+  --cmp-accent-2:    var(--accent-2);
+  --cmp-ok:        var(--pos);    --cmp-ok-soft:   var(--pos-soft);
+  --cmp-warn:      var(--warn);   --cmp-warn-soft: var(--warn-soft);
+  --cmp-err:       var(--neg);    --cmp-err-soft:  var(--neg-soft);
+  --cmp-info:      var(--accent); --cmp-info-soft: var(--accent-soft);  /* sem token --info canon → info = accent */
+  --cmp-mono:      var(--font-mono);
 
   display:flex;flex-direction:column;height:100%;
   background:var(--cmp-bg);color:var(--cmp-ink);
-  font:13px/1.45 ui-sans-serif,system-ui,-apple-system,sans-serif;
+  font:13px/1.45 var(--font-sans);
   overflow:hidden;
 }
 .compras-root button,
@@ -25,17 +36,17 @@
 .compras-root .cmp-main{display:grid;grid-template-rows:auto auto 1fr auto;overflow:hidden;flex:1}
 
 /* HEAD sticky */
-.compras-root .hd{background:#fff;border-bottom:1px solid var(--cmp-line);padding:11px 20px;display:flex;align-items:center;gap:14px}
+.compras-root .hd{background:var(--surface);border-bottom:1px solid var(--cmp-line);padding:11px 20px;display:flex;align-items:center;gap:14px}
 .compras-root .hd .crumbs{font-size:10.5px;color:var(--cmp-ink-3);text-transform:uppercase;letter-spacing:.04em;font-family:var(--cmp-mono)}
 .compras-root .hd h1{margin:0;font-size:16px;font-weight:600;letter-spacing:-.01em}
 .compras-root .hd .count{font-size:11px;font-family:var(--cmp-mono);color:var(--cmp-ink-3);background:var(--cmp-line-2);padding:2px 8px;border-radius:99px}
 .compras-root .hd .sp{flex:1}
-.compras-root .hd .search{display:flex;align-items:center;gap:6px;background:#fbf9f3;border:1px solid var(--cmp-line);border-radius:5px;padding:5px 10px;min-width:260px}
+.compras-root .hd .search{display:flex;align-items:center;gap:6px;background:var(--bg-2);border:1px solid var(--cmp-line);border-radius:5px;padding:5px 10px;min-width:260px}
 .compras-root .hd .search input{border:none;outline:none;background:transparent;font-size:12.5px;flex:1}
 .compras-root .hd .search span{color:var(--cmp-ink-3);font-size:13px}
 
 /* TABS (sub-rotas dentro de Compras) */
-.compras-root .tbs{background:#fff;border-bottom:1px solid var(--cmp-line);padding:0 20px;display:flex;align-items:center;gap:2px;overflow-x:auto}
+.compras-root .tbs{background:var(--surface);border-bottom:1px solid var(--cmp-line);padding:0 20px;display:flex;align-items:center;gap:2px;overflow-x:auto}
 .compras-root .tbs a{padding:9px 14px;font-size:12.5px;color:var(--cmp-ink-2);border-bottom:2px solid transparent;text-decoration:none;cursor:pointer;display:flex;align-items:center;gap:7px;white-space:nowrap}
 .compras-root .tbs a:hover{color:var(--cmp-ink)}
 .compras-root .tbs a.active{color:var(--cmp-accent);border-bottom-color:var(--cmp-accent);font-weight:600}
@@ -43,9 +54,9 @@
 .compras-root .tbs a.active .ct{background:var(--cmp-accent-soft);color:var(--cmp-accent)}
 .compras-root .tbs .sp{flex:1}
 .compras-root .tbs .filters{display:flex;gap:6px;font-size:11.5px;color:var(--cmp-ink-3);align-items:center}
-.compras-root .tbs .filter-pill{padding:3px 9px;border:1px solid var(--cmp-line);background:#fbf9f3;border-radius:99px;color:var(--cmp-ink-2);cursor:pointer;font-size:11px}
+.compras-root .tbs .filter-pill{padding:3px 9px;border:1px solid var(--cmp-line);background:var(--bg-2);border-radius:99px;color:var(--cmp-ink-2);cursor:pointer;font-size:11px}
 .compras-root .tbs .filter-pill:hover{border-color:var(--cmp-accent);color:var(--cmp-accent)}
-.compras-root .tbs .filter-pill.on{background:var(--cmp-accent-soft);border-color:#c9d6e8;color:var(--cmp-accent);font-weight:600}
+.compras-root .tbs .filter-pill.on{background:var(--cmp-accent-soft);border-color:color-mix(in oklch, var(--accent) 25%, var(--border));color:var(--cmp-accent);font-weight:600}
 
 /* BODY: lista + drawer */
 .compras-root .bd{display:grid;overflow:hidden;transition:grid-template-columns .2s ease;min-width:0}
@@ -55,25 +66,25 @@
   .compras-root .bd.with-drawer{grid-template-columns:minmax(680px,1fr) 540px}
 }
 .compras-root .list{min-width:0;overflow:auto;padding:14px 20px;background:var(--cmp-bg)}
-.compras-root .drawer{min-width:0;background:#fff;border-left:1px solid var(--cmp-line);display:flex;flex-direction:column;overflow:hidden}
+.compras-root .drawer{min-width:0;background:var(--surface);border-left:1px solid var(--cmp-line);display:flex;flex-direction:column;overflow:hidden}
 
 /* KPIs */
 .compras-root .kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:10px;margin-bottom:14px}
-.compras-root .kpi{background:#fff;border:1px solid var(--cmp-line);border-radius:5px;padding:10px 12px}
+.compras-root .kpi{background:var(--surface);border:1px solid var(--cmp-line);border-radius:5px;padding:10px 12px}
 .compras-root .kpi small{font-size:10px;color:var(--cmp-ink-3);text-transform:uppercase;letter-spacing:.05em;font-weight:600;display:block;margin-bottom:3px}
 .compras-root .kpi b{font-size:18px;font-weight:700;letter-spacing:-.01em;font-family:var(--cmp-mono);font-variant-numeric:tabular-nums;display:block}
 .compras-root .kpi .ln{font-size:10.5px;color:var(--cmp-ink-2);margin-top:3px}
-.compras-root .kpi.warn b{color:var(--cmp-warn)} .compras-root .kpi.warn{background:var(--cmp-warn-soft);border-color:#f1d499}
-.compras-root .kpi.ok b{color:var(--cmp-ok)}     .compras-root .kpi.ok{background:var(--cmp-ok-soft);border-color:#b8d9c0}
+.compras-root .kpi.warn b{color:var(--cmp-warn)} .compras-root .kpi.warn{background:var(--cmp-warn-soft);border-color:color-mix(in oklch, var(--warn) 30%, var(--border))}
+.compras-root .kpi.ok b{color:var(--cmp-ok)}     .compras-root .kpi.ok{background:var(--cmp-ok-soft);border-color:color-mix(in oklch, var(--pos) 30%, var(--border))}
 
 /* TABELA */
-.compras-root .tbl{background:#fff;border:1px solid var(--cmp-line);border-radius:5px;overflow:hidden}
+.compras-root .tbl{background:var(--surface);border:1px solid var(--cmp-line);border-radius:5px;overflow:hidden}
 .compras-root table.purchases{width:100%;border-collapse:collapse;font-size:12.5px}
-.compras-root table.purchases th{text-align:left;padding:8px 10px;background:#fbf9f3;border-bottom:1px solid var(--cmp-line);font-weight:600;color:var(--cmp-ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em;position:sticky;top:0;z-index:1}
+.compras-root table.purchases th{text-align:left;padding:8px 10px;background:var(--bg-2);border-bottom:1px solid var(--cmp-line);font-weight:600;color:var(--cmp-ink-2);font-size:10px;text-transform:uppercase;letter-spacing:.04em;position:sticky;top:0;z-index:1}
 .compras-root table.purchases td{padding:9px 10px;border-bottom:1px solid var(--cmp-line-2);cursor:pointer;vertical-align:middle}
 .compras-root table.purchases tr:last-child td{border-bottom:none}
-.compras-root table.purchases tr:hover td{background:#fbf9f3}
-.compras-root table.purchases tr.sel td{background:var(--cmp-accent-soft);border-bottom-color:#c9d6e8}
+.compras-root table.purchases tr:hover td{background:var(--bg-2)}
+.compras-root table.purchases tr.sel td{background:var(--cmp-accent-soft);border-bottom-color:color-mix(in oklch, var(--accent) 25%, var(--border))}
 .compras-root table.purchases td.mono{font-family:var(--cmp-mono);font-size:12px}
 .compras-root table.purchases td.num{font-family:var(--cmp-mono);text-align:right;font-variant-numeric:tabular-nums}
 .compras-root table.purchases td b{font-weight:600;font-size:12.5px}
@@ -86,7 +97,7 @@
 .compras-root .pill.pedido{background:var(--cmp-info-soft);color:var(--cmp-info)}
 .compras-root .pill.transito{background:var(--cmp-warn-soft);color:var(--cmp-warn)}
 .compras-root .pill.recebido{background:var(--cmp-ok-soft);color:var(--cmp-ok)}
-.compras-root .pill.pago{background:#dcecdf;color:#0f5a2a}
+.compras-root .pill.pago{background:var(--pos-soft);color:var(--pos)}
 .compras-root .pill.cancelada{background:var(--cmp-err-soft);color:var(--cmp-err)}
 
 /* DRAWER */
@@ -97,13 +108,13 @@
 .compras-root .drw-head .x:hover{background:var(--cmp-line-2);color:var(--cmp-ink)}
 
 /* FSM stepper inline no drawer */
-.compras-root .fsm{padding:12px 18px;border-bottom:1px solid var(--cmp-line-2);background:#fbf9f3}
+.compras-root .fsm{padding:12px 18px;border-bottom:1px solid var(--cmp-line-2);background:var(--bg-2)}
 .compras-root .fsm-track{display:flex;gap:0;align-items:stretch;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.03em}
-.compras-root .fsm-step{flex:1;padding:6px 4px;text-align:center;background:#fff;border:1px solid var(--cmp-line);border-right:none;color:var(--cmp-ink-3);position:relative}
+.compras-root .fsm-step{flex:1;padding:6px 4px;text-align:center;background:var(--surface);border:1px solid var(--cmp-line);border-right:none;color:var(--cmp-ink-3);position:relative}
 .compras-root .fsm-step:first-child{border-radius:4px 0 0 4px}
 .compras-root .fsm-step:last-child{border-radius:0 4px 4px 0;border-right:1px solid var(--cmp-line)}
-.compras-root .fsm-step.done{background:var(--cmp-ok-soft);color:var(--cmp-ok);border-color:#b8d9c0}
-.compras-root .fsm-step.now{background:var(--cmp-accent);color:#fff;border-color:var(--cmp-accent-2);font-weight:700;z-index:1}
+.compras-root .fsm-step.done{background:var(--cmp-ok-soft);color:var(--cmp-ok);border-color:color-mix(in oklch, var(--pos) 30%, var(--border))}
+.compras-root .fsm-step.now{background:var(--cmp-accent);color:var(--accent-fg);border-color:var(--cmp-accent-2);font-weight:700;z-index:1}
 .compras-root .fsm-step .ic{display:block;font-size:13px;margin-bottom:1px}
 
 .compras-root .drw-tabs{display:flex;padding:0 18px;border-bottom:1px solid var(--cmp-line-2);gap:0}
@@ -113,7 +124,7 @@
 .compras-root .drw-tabs button .ct{font-size:10px;font-family:var(--cmp-mono);color:var(--cmp-ink-3);background:var(--cmp-line-2);padding:0 5px;border-radius:99px}
 
 .compras-root .drw-body{flex:1;overflow:auto;padding:14px 18px}
-.compras-root .drw-foot{padding:11px 18px;border-top:1px solid var(--cmp-line);background:#fbf9f3;display:flex;align-items:center;gap:8px}
+.compras-root .drw-foot{padding:11px 18px;border-top:1px solid var(--cmp-line);background:var(--bg-2);display:flex;align-items:center;gap:8px}
 .compras-root .drw-foot .total{flex:1;font-size:11.5px;color:var(--cmp-ink-3)}
 .compras-root .drw-foot .total b{display:block;font-size:17px;font-weight:700;font-family:var(--cmp-mono);color:var(--cmp-ink);font-variant-numeric:tabular-nums;margin-top:1px}
 
@@ -121,7 +132,7 @@
 .compras-root .sec{margin-bottom:14px}
 .compras-root .sec h4{margin:0 0 7px;font-size:10.5px;color:var(--cmp-ink-3);text-transform:uppercase;letter-spacing:.06em;font-weight:700;display:flex;align-items:center;gap:6px}
 .compras-root .sec h4 .badge{background:var(--cmp-line-2);color:var(--cmp-ink-2);font-size:9.5px;padding:1px 6px;border-radius:99px;font-family:var(--cmp-mono)}
-.compras-root .sec .card{background:#fbf9f3;border:1px solid var(--cmp-line);border-radius:5px;padding:11px 13px}
+.compras-root .sec .card{background:var(--bg-2);border:1px solid var(--cmp-line);border-radius:5px;padding:11px 13px}
 .compras-root .field-grid{display:grid;grid-template-columns:1fr 1fr;gap:8px 16px;font-size:12px}
 .compras-root .field-grid .f label{font-size:9.5px;color:var(--cmp-ink-3);text-transform:uppercase;letter-spacing:.04em;font-weight:600;display:block;margin-bottom:1px}
 .compras-root .field-grid .f span{color:var(--cmp-ink);font-weight:500}
@@ -129,8 +140,8 @@
 .compras-root .field-grid .f.full{grid-column:span 2}
 
 /* ITEMS table */
-.compras-root .items-tbl{width:100%;border-collapse:collapse;font-size:11.5px;background:#fff;border:1px solid var(--cmp-line);border-radius:5px;overflow:hidden}
-.compras-root .items-tbl th{background:#fbf9f3;padding:6px 7px;text-align:left;font-size:9.5px;text-transform:uppercase;letter-spacing:.04em;color:var(--cmp-ink-3);font-weight:700;border-bottom:1px solid var(--cmp-line)}
+.compras-root .items-tbl{width:100%;border-collapse:collapse;font-size:11.5px;background:var(--surface);border:1px solid var(--cmp-line);border-radius:5px;overflow:hidden}
+.compras-root .items-tbl th{background:var(--bg-2);padding:6px 7px;text-align:left;font-size:9.5px;text-transform:uppercase;letter-spacing:.04em;color:var(--cmp-ink-3);font-weight:700;border-bottom:1px solid var(--cmp-line)}
 .compras-root .items-tbl td{padding:7px 7px;border-bottom:1px solid var(--cmp-line-2);vertical-align:top}
 .compras-root .items-tbl tr:last-child td{border-bottom:none}
 .compras-root .items-tbl b{font-size:11.5px;font-weight:600}
@@ -151,7 +162,7 @@
 .compras-root .tl{position:relative;padding-left:18px}
 .compras-root .tl::before{content:"";position:absolute;left:5px;top:5px;bottom:5px;width:1px;background:var(--cmp-line)}
 .compras-root .tl-item{position:relative;padding-bottom:10px;font-size:11.5px}
-.compras-root .tl-item::before{content:"";position:absolute;left:-16px;top:4px;width:9px;height:9px;border-radius:50%;background:#fff;border:2px solid var(--cmp-ink-3)}
+.compras-root .tl-item::before{content:"";position:absolute;left:-16px;top:4px;width:9px;height:9px;border-radius:50%;background:var(--surface);border:2px solid var(--cmp-ink-3)}
 .compras-root .tl-item.ok::before{border-color:var(--cmp-ok);background:var(--cmp-ok)}
 .compras-root .tl-item.warn::before{border-color:var(--cmp-warn);background:var(--cmp-warn)}
 .compras-root .tl-item.now::before{border-color:var(--cmp-accent);background:var(--cmp-accent);box-shadow:0 0 0 3px var(--cmp-accent-soft)}
@@ -160,23 +171,23 @@
 .compras-root .tl-item p{margin:3px 0 0;color:var(--cmp-ink-2);font-size:11px}
 
 /* FOOTER sticky */
-.compras-root .ft{background:#fff;border-top:1px solid var(--cmp-line);padding:8px 20px;display:flex;align-items:center;gap:14px;font-size:11.5px;color:var(--cmp-ink-3)}
+.compras-root .ft{background:var(--surface);border-top:1px solid var(--cmp-line);padding:8px 20px;display:flex;align-items:center;gap:14px;font-size:11.5px;color:var(--cmp-ink-3)}
 .compras-root .ft b{color:var(--cmp-ink);font-weight:600}
 .compras-root .ft .sp{flex:1}
 .compras-root .ft kbd{font-family:var(--cmp-mono);font-size:10px;background:var(--cmp-line-2);border:1px solid var(--cmp-line);border-radius:3px;padding:1px 5px;color:var(--cmp-ink-2)}
 
 /* BTN */
-.compras-root .btn{border:1px solid var(--cmp-line);background:#fff;padding:5px 11px;border-radius:4px;font-size:11.5px;color:var(--cmp-ink);cursor:pointer}
-.compras-root .btn:hover{border-color:#c5beae;background:#fbf9f3}
-.compras-root .btn.primary{background:var(--cmp-accent);border-color:var(--cmp-accent);color:#fff;font-weight:600}
+.compras-root .btn{border:1px solid var(--cmp-line);background:var(--surface);padding:5px 11px;border-radius:4px;font-size:11.5px;color:var(--cmp-ink);cursor:pointer}
+.compras-root .btn:hover{border-color:var(--text-mute);background:var(--bg-2)}
+.compras-root .btn.primary{background:var(--cmp-accent);border-color:var(--cmp-accent);color:var(--accent-fg);font-weight:600}
 .compras-root .btn.primary:hover{background:var(--cmp-accent-2)}
 .compras-root .btn.ghost{background:transparent;border-color:transparent;color:var(--cmp-ink-2)}
 .compras-root .btn.ghost:hover{background:var(--cmp-line-2)}
 .compras-root .btn.sm{padding:3px 8px;font-size:11px}
-.compras-root .btn.warn{background:var(--cmp-warn);border-color:var(--cmp-warn);color:#fff;font-weight:600}
-.compras-root .btn.warn:hover{background:#8c4d00}
+.compras-root .btn.warn{background:var(--cmp-warn);border-color:var(--cmp-warn);color:var(--accent-fg);font-weight:600}
+.compras-root .btn.warn:hover{background:color-mix(in oklch, var(--warn) 82%, black)}
 
 /* XML drop badge */
-.compras-root .xml-badge{background:var(--cmp-info-soft);border:1px dashed #a8c7df;color:var(--cmp-info);padding:8px 12px;border-radius:5px;font-size:11.5px;display:flex;align-items:center;gap:8px;margin-bottom:10px}
+.compras-root .xml-badge{background:var(--cmp-info-soft);border:1px dashed color-mix(in oklch, var(--accent) 30%, var(--border));color:var(--cmp-info);padding:8px 12px;border-radius:5px;font-size:11.5px;display:flex;align-items:center;gap:8px;margin-bottom:10px}
 .compras-root .xml-badge b{color:var(--cmp-info);font-weight:700}
-.compras-root .xml-badge .key{font-family:var(--cmp-mono);font-size:10.5px;background:#fff;padding:2px 6px;border-radius:3px;border:1px solid var(--cmp-line)}
+.compras-root .xml-badge .key{font-family:var(--cmp-mono);font-size:10.5px;background:var(--surface);padding:2px 6px;border-radius:3px;border:1px solid var(--cmp-line)}


### PR DESCRIPTION
## O quê

Fecha a **única ilha de identidade em hex cru confirmada no git** — o `cowork-compras-bundle.css`. Implementa a peça acionável do **Mapa de Identidade ERP - CC** (handoff Cowork): modelo único de identidade — chrome roxo `oklch(0.55 0.15 295)` via `--accent`; surface/semântica = canon; zero paleta paralela.

> Re-baseline 2026-06-08 (lido `@main`): Sells e Financeiro já estavam roxos; Compras era a última ilha.

## Como

`.compras-root` deixa de definir um bloco de tokens em hex e passa a ser **alias 1:1 dos tokens canônicos** (`cockpit.css`):

| --cmp-* | era (hex) | vira (canon) |
|---|---|---|
| accent / accent-2 / soft | navy `#1f3a5f` … | `--accent` / `--accent-2` / `--accent-soft` |
| bg / paper | papel-quente `#f6f4ef` / `#fff` | `--bg` / `--surface` |
| ink 1-3 | `#1a1917` … | `--text` / `--text-dim` / `--text-mute` |
| line 1-2 | `#e5e0d3` … | `--border` / `--border-2` |
| ok / warn / err (+soft) | `#1f6d3a` … | `--pos` / `--warn` / `--neg` (+ `-soft`) |
| info (+soft) | `#1f5a8a` (sem token --info) | `--accent` (+ soft) |
| white-on-accent | `#fff` | `--accent-fg` |
| bordas tint, hovers | `#c9d6e8`, `#8c4d00` … | `color-mix(in oklch, …)` |

**Nota:** os nomes de token de status no handoff original (`--ok-fg`/`--warn-bg`) **não existem** no repo — usei os canônicos reais (`--pos`/`--warn`/`--neg`) verificados em `cockpit.css`.

### Ganho colateral
Compras agora **herda o tema** → **dark mode funciona pela 1ª vez** (antes era imune por usar hex cravado).

## Verificação
- `grep '#[0-9a-f]'` no bundle → **0 hex** ✅
- `stylelint` no arquivo → limpo ✅
- baseline stylelint: **487 → 436 (−51)**, ratchet travado, delta 0 ✅
- só 2 arquivos (CSS + baseline); só Compras tocado ✅

## Gate pendente (humano)
Mudança visual → requer aprovação do **screenshot** (ADR 0107/0114). Screenshots light+dark anexados na conversa. Não mergear sem o ok visual do [W].

Refs: Mapa de Identidade ERP - CC (Cowork handoff) · ADR 0190 / 0235

🤖 Generated with [Claude Code](https://claude.com/claude-code)