### PR TITLE
fix(financeiro): wr2:backfill etapa4 sem shell_exec (Hostinger) [E]

### DIFF
--- a/app/Console/Commands/Wr2BackfillRecurring2026Command.php
+++ b/app/Console/Commands/Wr2BackfillRecurring2026Command.php
@@ -396,9 +396,13 @@ class Wr2BackfillRecurring2026Command extends Command
         $tam = filesize($sqlPath);
         $this->line("  SQL pré-gerado: {$sqlPath} ({$tam} bytes)");
 
-        // Conta linhas INSERT
-        $cmd = sprintf('grep -c "^INSERT" %s', escapeshellarg($sqlPath));
-        $linhas = (int) trim(shell_exec($cmd) ?: '0');
+        // Conta linhas INSERT (sem shell_exec — Hostinger bloqueia)
+        $linhas = 0;
+        $fh = fopen($sqlPath, 'r');
+        while (($line = fgets($fh)) !== false) {
+            if (str_starts_with($line, 'INSERT')) $linhas++;
+        }
+        fclose($fh);
         $this->line("  INSERTs no SQL: {$linhas}");
 
         if (!$execute) {


### PR DESCRIPTION
Hotfix do #2416 — shell_exec é disabled no Hostinger shared. Trocado por fopen/fgets nativo PHP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)