### PR TITLE
fix(financeiro): wr2:backfill etapa2 created_by FK fin_titulos [E]

### DIFF
--- a/app/Console/Commands/Wr2BackfillRecurring2026Command.php
+++ b/app/Console/Commands/Wr2BackfillRecurring2026Command.php
@@ -243,6 +243,8 @@ class Wr2BackfillRecurring2026Command extends Command
                         'subscription_id' => $sub->id,
                         'cycle_month' => $mes,
                     ], JSON_UNESCAPED_UNICODE),
+                    'created_by'     => 1, // Wagner (user system)
+                    'updated_by'     => 1,
                     'created_at'     => now(),
                     'updated_at'     => now(),
                 ]);


### PR DESCRIPTION
Hotfix etapa 2 — FK fin_titulos.created_by precisa user_id válido. Setado 1 (Wagner WR23).

Refs PR #2416, #2430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)