### PR TITLE
fix(financeiro): wr2:backfill cobrancas.origem_type ENUM válido [E]

### DIFF
--- a/app/Console/Commands/Wr2BackfillRecurring2026Command.php
+++ b/app/Console/Commands/Wr2BackfillRecurring2026Command.php
@@ -355,7 +355,7 @@ class Wr2BackfillRecurring2026Command extends Command
                 'payer_email'    => $inv->payer_email,
                 'descricao'      => sprintf('Mensalidade %s - %s', date('m/Y', strtotime($inv->vencimento)), $inv->numero_documento),
                 'idempotency_key' => $idemKey,
-                'origem_type'    => 'rb_invoice',
+                'origem_type'    => 'invoice', // ENUM válido: (sale,invoice,subscription_license,avulsa)
                 'origem_id'      => $inv->invoice_id,
                 'forma_pagamento' => 'boleto',
                 'payload_gateway' => json_encode([

--- a/scripts/legacy-migration/sql-wr2-pessoas/gerar-sql-cobrancas-boletos-firebird.py
+++ b/scripts/legacy-migration/sql-wr2-pessoas/gerar-sql-cobrancas-boletos-firebird.py
@@ -116,7 +116,7 @@ SELECT 1, 'boleto', {esc(status)}, {valor_cents}, {esc(venc_str)}, t.cliente_id,
        c.name, c.tax_number,
        CONCAT('Boleto legacy WR2 #', {esc(legacy_id)}),
        {esc(idem_key)},
-       'fin_titulo', t.id, 'boleto', {esc(payload_json)},
+       'avulsa', t.id, 'boleto', {esc(payload_json)},
        NOW(), NOW()
 FROM fin_titulos t
 LEFT JOIN contacts c ON c.id=t.cliente_id


### PR DESCRIPTION
Hotfix #4 da família PR #2416. cobrancas.origem_type é ENUM — 'rb_invoice'/'fin_titulo' viraram empty. Trocado por 'invoice'/'avulsa'. Prod biz=1 corrigido via UPDATE.