### PR TITLE
fix(crm): vendas do cliente aparecem no drawer (SalesTab self-fetch)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -144,6 +144,40 @@ class ContactController extends Controller
     }
 
     /**
+     * Fix 2026-06-08 — Endpoint JSON das vendas do contato pro SalesTab self-fetch.
+     *
+     * Bug: no paradigma drawer 760px (ADR 0179, MWART_CLIENTE_INDEX) o SalesTab
+     * dentro de OssTab recebia `sales=undefined` e NÃO tinha carga inicial — só
+     * buscava ao filtrar/paginar. Resultado: skeleton infinito, "as vendas não
+     * aparecem no cadastro de cliente". No Show.tsx full-page funcionava porque o
+     * `<Deferred data="sales">` dispara o Inertia::defer; o drawer não tem esse
+     * wrapper. Este endpoint dá ao SalesTab uma fonte AJAX (espelha o padrão
+     * self-fetch de PaymentsTab `/contacts/payments/{id}` e anexos).
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): contato resolvido DENTRO do
+     * business (404 cross-tenant) + buildClienteSalesPaginator já força
+     * business_id em todo query.
+     *
+     * GET /cliente/{id}/sales-json  (?customer_sales_start/_end/_status/_q/_page)
+     */
+    public function salesJson($id)
+    {
+        if (! auth()->user()->can('customer.view') && ! auth()->user()->can('customer.view_own')
+            && ! auth()->user()->can('supplier.view') && ! auth()->user()->can('supplier.view_own')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+
+        // 404 cross-tenant: o contato precisa existir DENTRO do business.
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        return response()->json(
+            $this->buildClienteSalesPaginator((int) $id, (int) $business_id, request())
+        );
+    }
+
+    /**
      * Wave Onda 1 PR D 2026-05-26 — Paginador de veículos do contato (frota Martinho).
      *
      * Multi-tenant Tier 0 (ADR 0093): business_id scope obrigatório.

--- a/resources/js/Pages/Cliente/_drawer/OssTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/OssTab.tsx
@@ -161,10 +161,12 @@ export default function OssTab({
           />
         )}
         {active === 'sales' && (
+          // Fix 2026-06-08: no drawer, SalesTab busca os dados sozinho via
+          // `jsonEndpoint` (self-fetch). Sem isso recebia sales=undefined e
+          // ficava preso no skeleton — "as vendas não aparecem no cadastro".
           <SalesTab
             contactId={contact.id}
-            sales={undefined}
-            endpoint={`/cliente/${contact.id}`}
+            jsonEndpoint={`/cliente/${contact.id}/sales-json`}
           />
         )}
         {active === 'payments' && (

--- a/resources/js/Pages/Cliente/_show/SalesTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SalesTab.tsx
@@ -4,12 +4,18 @@
 // Wave C entrega component que aceita paginator Inertia preferencialmente — fallback fetch quando standalone.
 //
 // Pattern reuse: Components/shared/DataTable.tsx (TanStack + server-side) — adaptado pra contexto inline da tab.
-// Como SalesTab é nested em Show.tsx (não rota standalone), Inertia router.visit faz partial reload
-// com `only: ['sales']` no parent. Wave C entrega lifting via callback `onFilterChange`.
+//
+// DOIS MODOS DE DADOS:
+//  - Modo Inertia (Show.tsx full-page): recebe `sales` via Inertia::defer (envolto
+//    em <Deferred data="sales">). Filtros/paginação fazem `router.visit(only:['sales'])`.
+//  - Modo self-fetch (drawer Cliente/Index → OssTab): recebe `jsonEndpoint`
+//    (`/cliente/{id}/sales-json`) e busca os dados sozinho via fetch() no mount +
+//    filtros/paginação. Sem isso, o drawer passava `sales=undefined` e o componente
+//    ficava preso no skeleton — as vendas nunca apareciam (fix 2026-06-08).
 
-import { useState, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { router } from '@inertiajs/react';
-import { ChevronLeft, ChevronRight, ExternalLink, Filter, Search, ShoppingCart, X } from 'lucide-react';
+import { AlertTriangle, ChevronLeft, ChevronRight, ExternalLink, Filter, Search, ShoppingCart, X } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Input } from '@/Components/ui/input';
@@ -39,7 +45,7 @@ export interface SalesPaginator {
 
 export interface SalesTabProps {
   contactId: number;
-  /** Paginador vindo via Inertia::defer no parent */
+  /** Paginador vindo via Inertia::defer no parent (modo Show.tsx full-page) */
   sales?: SalesPaginator;
   /** Filtros iniciais persistidos via URL ?customer_sales_*= */
   initialFilters?: {
@@ -48,8 +54,14 @@ export interface SalesTabProps {
     payment_status?: string | null;
     q?: string | null;
   };
-  /** Endpoint pro router.visit (parent decide: rota legacy ou /cliente/{id}?tab=sales) */
+  /** Endpoint pro router.visit (modo Inertia: rota legacy ou /cliente/{id}?tab=sales) */
   endpoint?: string;
+  /**
+   * Endpoint JSON pro modo self-fetch (drawer). Quando presente, o componente
+   * busca os dados sozinho via fetch() em vez de depender do Inertia::defer do
+   * parent. Ex: `/cliente/{id}/sales-json`.
+   */
+  jsonEndpoint?: string;
 }
 
 const formatBRL = (value: number) =>
@@ -85,28 +97,71 @@ export default function SalesTab({
   sales,
   initialFilters = {},
   endpoint,
+  jsonEndpoint,
 }: SalesTabProps) {
   const [startDate, setStartDate] = useState(initialFilters.start_date ?? '');
   const [endDate, setEndDate] = useState(initialFilters.end_date ?? '');
   const [paymentStatus, setPaymentStatus] = useState(initialFilters.payment_status ?? '');
   const [query, setQuery] = useState(initialFilters.q ?? '');
 
+  // Modo self-fetch (drawer): busca própria via fetch() quando jsonEndpoint existe.
+  const selfFetch = jsonEndpoint != null;
+  const [fetched, setFetched] = useState<SalesPaginator | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
   const baseEndpoint = endpoint ?? `/contacts/${contactId}`;
 
+  // Dados efetivos: no modo self-fetch vêm do estado interno; senão da prop Inertia.
+  const salesData = selfFetch ? fetched : sales;
+
+  const buildParams = useCallback(
+    (overrides: Record<string, string | number | undefined> = {}): Record<string, string> => {
+      const params: Record<string, string> = {};
+      const merged: Record<string, string | number | undefined> = {
+        customer_sales_start: startDate || undefined,
+        customer_sales_end: endDate || undefined,
+        customer_sales_status: paymentStatus || undefined,
+        customer_sales_q: query || undefined,
+        ...overrides,
+      };
+      Object.entries(merged).forEach(([k, v]) => {
+        if (v !== undefined && v !== '') params[k] = String(v);
+      });
+      return params;
+    },
+    [startDate, endDate, paymentStatus, query],
+  );
+
+  // ----- Modo self-fetch (fetch direto) -----
+  const loadJson = useCallback(async (url: string) => {
+    setFetchError(null);
+    try {
+      const res = await fetch(url, {
+        headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+        credentials: 'same-origin',
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const json = (await res.json()) as SalesPaginator;
+      setFetched(json);
+    } catch (err) {
+      console.error('[SalesTab] self-fetch falhou', err);
+      setFetchError('Não foi possível carregar as vendas.');
+    }
+  }, []);
+
+  // Carga inicial (mount) + recarrega quando o drawer troca de contato (jsonEndpoint muda).
+  useEffect(() => {
+    if (!selfFetch || !jsonEndpoint) return;
+    setFetched(null);
+    const qs = new URLSearchParams(buildParams()).toString();
+    loadJson(qs ? `${jsonEndpoint}?${qs}` : jsonEndpoint);
+    // Deliberado: só refaz no mount/troca de contato, não a cada tecla.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [jsonEndpoint, selfFetch]);
+
+  // ----- Modo Inertia (router.visit partial reload) -----
   const visitWith = (overrides: Record<string, string | number | undefined>) => {
-    const params: Record<string, string | number> = {
-      tab: 'sales',
-    };
-    const merged = {
-      customer_sales_start: startDate || undefined,
-      customer_sales_end: endDate || undefined,
-      customer_sales_status: paymentStatus || undefined,
-      customer_sales_q: query || undefined,
-      ...overrides,
-    };
-    Object.entries(merged).forEach(([k, v]) => {
-      if (v !== undefined && v !== '') params[k] = v;
-    });
+    const params: Record<string, string> = { tab: 'sales', ...buildParams(overrides) };
     router.visit(baseEndpoint, {
       data: params,
       preserveScroll: true,
@@ -115,12 +170,25 @@ export default function SalesTab({
     });
   };
 
-  const applyFilters = () => visitWith({});
+  const applyFilters = () => {
+    if (selfFetch && jsonEndpoint) {
+      const qs = new URLSearchParams(buildParams()).toString();
+      loadJson(qs ? `${jsonEndpoint}?${qs}` : jsonEndpoint);
+      return;
+    }
+    visitWith({});
+  };
+
   const clearFilters = () => {
     setStartDate('');
     setEndDate('');
     setPaymentStatus('');
     setQuery('');
+    if (selfFetch && jsonEndpoint) {
+      setFetched(null);
+      loadJson(jsonEndpoint);
+      return;
+    }
     router.visit(baseEndpoint, {
       data: { tab: 'sales' },
       preserveScroll: true,
@@ -129,9 +197,17 @@ export default function SalesTab({
     });
   };
 
+  const goToLink = (url: string) => {
+    if (selfFetch) {
+      loadJson(url);
+      return;
+    }
+    router.visit(url, { preserveScroll: true, preserveState: true, only: ['sales'] });
+  };
+
   const totals = useMemo(() => {
-    if (!sales?.data) return null;
-    return sales.data.reduce(
+    if (!salesData?.data) return null;
+    return salesData.data.reduce(
       (acc, s) => ({
         final_total: acc.final_total + s.final_total,
         total_paid: acc.total_paid + s.total_paid,
@@ -139,7 +215,7 @@ export default function SalesTab({
       }),
       { final_total: 0, total_paid: 0, total_due: 0 },
     );
-  }, [sales]);
+  }, [salesData]);
 
   return (
     <div className="space-y-4" data-testid="sales-tab-root">
@@ -176,6 +252,7 @@ export default function SalesTab({
               <Input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
                 placeholder="Nº fatura, ref…"
                 className="pl-9"
                 data-testid="sales-search"
@@ -197,9 +274,19 @@ export default function SalesTab({
       </div>
 
       {/* Tabela */}
-      {!sales ? (
-        <SalesSkeleton />
-      ) : sales.data.length === 0 ? (
+      {!salesData ? (
+        selfFetch && fetchError ? (
+          <div className="rounded-lg border border-border bg-background p-8 text-center" data-testid="sales-error">
+            <AlertTriangle className="mx-auto h-9 w-9 text-muted-foreground/50 mb-2" strokeWidth={1.5} aria-hidden />
+            <p className="text-sm text-foreground">{fetchError}</p>
+            <Button variant="outline" size="sm" className="mt-3" onClick={applyFilters} data-testid="sales-retry-btn">
+              Tentar de novo
+            </Button>
+          </div>
+        ) : (
+          <SalesSkeleton />
+        )
+      ) : salesData.data.length === 0 ? (
         <div className="rounded-lg border border-border bg-background p-12 text-center" data-testid="sales-empty">
           <ShoppingCart className="mx-auto h-10 w-10 text-muted-foreground/40 mb-2" strokeWidth={1.5} aria-hidden />
           <p className="text-sm text-muted-foreground">Nenhuma venda encontrada.</p>
@@ -222,7 +309,7 @@ export default function SalesTab({
                   </tr>
                 </thead>
                 <tbody>
-                  {sales.data.map((s) => (
+                  {salesData.data.map((s) => (
                     <tr key={s.id} className="border-b border-border hover:bg-muted/40" data-testid={`sales-row-${s.id}`}>
                       <td className="px-4 py-2.5 text-xs text-muted-foreground tabular-nums">{formatDate(s.transaction_date)}</td>
                       <td className="px-4 py-2.5">
@@ -258,7 +345,7 @@ export default function SalesTab({
                   <tfoot className="bg-muted/30 border-t border-border">
                     <tr>
                       <td colSpan={2} className="px-4 py-2.5 text-xs text-muted-foreground">
-                        Totais ({sales.from ?? 0}–{sales.to ?? 0} de {sales.total})
+                        Totais ({salesData.from ?? 0}–{salesData.to ?? 0} de {salesData.total})
                       </td>
                       <td className="px-4 py-2.5 text-right tabular-nums font-semibold text-foreground">
                         {formatBRL(totals.final_total)}
@@ -278,13 +365,13 @@ export default function SalesTab({
           </div>
 
           {/* Paginação */}
-          {sales.last_page > 1 && (
+          {salesData.last_page > 1 && (
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>
-                Página {sales.current_page} de {sales.last_page} · {sales.total} venda(s)
+                Página {salesData.current_page} de {salesData.last_page} · {salesData.total} venda(s)
               </span>
               <div className="flex gap-1">
-                {sales.links.map((link, i) => {
+                {salesData.links.map((link, i) => {
                   const isPrev = link.label.includes('Previous') || link.label.includes('&laquo;');
                   const isNext = link.label.includes('Next') || link.label.includes('&raquo;');
                   return (
@@ -294,14 +381,7 @@ export default function SalesTab({
                       size="sm"
                       className="h-7 min-w-8 px-2 text-xs"
                       disabled={!link.url}
-                      onClick={() =>
-                        link.url &&
-                        router.visit(link.url, {
-                          preserveScroll: true,
-                          preserveState: true,
-                          only: ['sales'],
-                        })
-                      }
+                      onClick={() => link.url && goToLink(link.url)}
                       aria-label={isPrev ? 'Anterior' : isNext ? 'Próxima' : `Página ${link.label}`}
                     >
                       {isPrev ? <ChevronLeft size={12} /> : isNext ? <ChevronRight size={12} /> : <span dangerouslySetInnerHTML={{ __html: link.label }} />}

--- a/routes/web.php
+++ b/routes/web.php
@@ -299,6 +299,13 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::delete('/cliente/{id}/anexos/{mediaId}', [ContactController::class, 'destroyAnexo'])
         ->name('cliente.anexos.destroy')->whereNumber('id')->whereNumber('mediaId');
 
+    // Fix 2026-06-08 — vendas do cliente (drawer Operações → Vendas). JSON.
+    // Bug: SalesTab no drawer recebia sales=undefined e nunca buscava → skeleton
+    // infinito ("as vendas não aparecem no cadastro de cliente"). Endpoint dá o
+    // self-fetch que faltava. Tier 0 multi-tenant: scope no ContactController::salesJson.
+    Route::get('/cliente/{id}/sales-json', [ContactController::class, 'salesJson'])
+        ->name('cliente.sales.json')->whereNumber('id');
+
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);
     Route::resource('taxonomies', TaxonomyController::class);
 

--- a/tests/Feature/Cliente/ClienteSalesJsonEndpointTest.php
+++ b/tests/Feature/Cliente/ClienteSalesJsonEndpointTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fix 2026-06-08 — endpoint JSON das vendas do cliente (drawer Operacoes -> Vendas).
+ *
+ * Bug: no paradigma drawer 760px (ADR 0179, MWART_CLIENTE_INDEX) o SalesTab dentro
+ * de OssTab recebia `sales=undefined` e NAO tinha carga inicial — so buscava ao
+ * filtrar/paginar. Resultado: skeleton infinito, "as vendas nao aparecem no
+ * cadastro de cliente". No Show.tsx full-page funcionava via <Deferred data="sales">
+ * (Inertia::defer); o drawer nao tem esse wrapper. GET /cliente/{id}/sales-json da
+ * ao SalesTab a fonte AJAX que faltava (espelha o self-fetch de PaymentsTab/anexos).
+ *
+ * GUARDs estruturais (file_get_contents) + 1 integracao (auth gate graceful-skip),
+ * mesmo bar do ClienteAnexosEndpointTest.
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0) · ADR 0179 (drawer 760).
+ */
+
+// ─── GUARD 1: rota registrada ─────────────────────────────────────────────
+
+test('GUARD 1 — routes/web.php registra GET /cliente/{id}/sales-json', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../routes/web.php');
+
+    expect($contents)
+        ->toContain("Route::get('/cliente/{id}/sales-json', [ContactController::class, 'salesJson'])")
+        ->toContain("->name('cliente.sales.json')");
+});
+
+// ─── GUARD 2: ContactController::salesJson — tenant scope + permissao ──────
+
+test('GUARD 2 — ContactController::salesJson com business_id scope + permissao + delega ao paginador', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../app/Http/Controllers/ContactController.php');
+
+    expect($contents)
+        ->toContain('public function salesJson($id)')
+        // Permissao: precisa poder ver cliente/fornecedor (espelha show()).
+        ->toContain("auth()->user()->can('customer.view')")
+        ->toContain("abort(403, 'Unauthorized action.')")
+        // Tier 0 (ADR 0093 IRREVOGAVEL): 404 cross-tenant antes de qualquer dado.
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        // Reusa o paginador canon (ja forca business_id + type=sell + !draft).
+        ->toContain('$this->buildClienteSalesPaginator((int) $id, (int) $business_id, request())')
+        ->toContain('response()->json(');
+});
+
+// ─── GUARD 3: drawer (OssTab) faz self-fetch via jsonEndpoint ─────────────
+
+test('GUARD 3 — OssTab passa jsonEndpoint pro SalesTab (nao mais sales=undefined)', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx');
+
+    expect($contents)
+        // Fonte de dados do drawer = endpoint JSON dedicado.
+        ->toContain('jsonEndpoint={`/cliente/${contact.id}/sales-json`}')
+        // O bug antigo (sales=undefined fixo) nao volta.
+        ->not->toContain('sales={undefined}');
+});
+
+// ─── GUARD 4: SalesTab self-fetch (mount) sem quebrar modo Inertia ────────
+
+test('GUARD 4 — SalesTab busca sozinho quando jsonEndpoint presente, preserva modo Inertia', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_show/SalesTab.tsx');
+
+    expect($contents)
+        // Modo self-fetch.
+        ->toContain('jsonEndpoint?: string')
+        ->toContain('const selfFetch = jsonEndpoint != null')
+        ->toContain('useEffect(')
+        ->toContain('loadJson')
+        ->toContain('await fetch(url')
+        // Modo Inertia legado intacto (Show.tsx full-page).
+        ->toContain("only: ['sales']")
+        ->toContain('router.visit')
+        // Estado de erro com retry (nao fica preso em skeleton em falha de rede).
+        ->toContain('data-testid="sales-error"')
+        ->toContain('data-testid="sales-retry-btn"');
+});
+
+// ─── GUARD 5: endpoint exige sessao (integracao, nao vaza sem auth) ───────
+
+test('GUARD 5 — GET /cliente/{id}/sales-json nao vaza vendas sem auth', function () {
+    // Cross-tenant real precisa de DB+seed que sqlite memory CI nao tem;
+    // skip-graceful pattern canon (igual GUARD 4 de ClienteAnexosEndpointTest).
+    if (! \Illuminate\Support\Facades\Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql.');
+    }
+
+    $response = $this->get('/cliente/1/sales-json');
+    // Sem auth: redirect login (302) ou 401/403/404. O importante e NAO 200
+    // (vazaria vendas sem sessao) nem 500 (erro de codigo).
+    expect(in_array($response->status(), [302, 401, 403, 404], true))->toBeTrue();
+});


### PR DESCRIPTION
## Sintoma (Wagner)
> as vendas não aparecem lá no cadastro de cliente

## Causa raiz
No paradigma **drawer 760px** (ADR 0179, `MWART_CLIENTE_INDEX=true` — ativo no biz=1/WR2), a sub-aba **OS → Vendas** renderiza o `SalesTab`. Em `OssTab.tsx` ele recebia **`sales={undefined}` fixo** e o `SalesTab` **não tem carga no mount** — só busca ao filtrar/paginar (`router.visit(only:['sales'])`). Com `sales` undefined e sem carga inicial → **skeleton infinito**, as vendas nunca aparecem.

No `Show.tsx` full-page funcionava porque lá há `<Deferred data="sales">` disparando o `Inertia::defer`. O drawer não tem esse wrapper. As outras sub-abas (Pagamentos/Extrato/Documentos) já fazem *self-fetch* via AJAX — o `SalesTab` era a única exceção.

## Fix
- **Backend:** `GET /cliente/{id}/sales-json` (`ContactController::salesJson`) reusando `buildClienteSalesPaginator`. Tier 0 (ADR 0093): 404 cross-tenant (`Contact::where('business_id', …)->findOrFail`) + permissão `customer/supplier.view` antes de qualquer dado.
- **Frontend:** `SalesTab` ganha modo *self-fetch* via prop `jsonEndpoint` (espelha `PaymentsTab`). Modo Inertia do `Show.tsx` full-page **intacto**. `OssTab` passa `jsonEndpoint` em vez de `sales=undefined`. Estado de erro com retry (não trava em skeleton).
- **Teste:** `ClienteSalesJsonEndpointTest` (5 guards estruturais + auth gate graceful-skip).

## Infra Contract

Mudança de runtime: **1 rota nova** `GET /cliente/{id}/sales-json` dentro do grupo middleware `['setData','auth','SetSessionData','language','timezone',…]` (mesmo grupo das demais `/cliente/*`). Sem mudança em `.htaccess`, Kernel, middleware ou ServiceProviders.

Contrato esperado (validar pós-deploy no biz=1):

```
# autenticado, contato do próprio business → 200 + JSON paginator
curl -sv -b "$COOKIE" https://app.oimpresso.com/cliente/123/sales-json
< HTTP/2 200
< content-type: application/json
{"data":[…],"total":N,"current_page":1,"last_page":…,"links":[…]}

# sem sessão → NÃO 200 (não vaza vendas): redirect login
curl -sv https://app.oimpresso.com/cliente/123/sales-json
< HTTP/2 302   # Location: /login

# contato de OUTRO business (cross-tenant) → 404 (findOrFail scoped)
< HTTP/2 404
```

Invariantes Tier 0 (ADR 0093): `business_id` forçado em `findOrFail` + dentro de `buildClienteSalesPaginator` (`type=sell`, `status!=draft`). Permissão exigida antes de qualquer query. Nenhum dado financeiro sem sessão.

## Validação local
- `php -l` controller + routes: OK
- `tsc --noEmit`: zero erros novos nos arquivos tocados
- `eslint`: SalesTab volta a **4 errors + 4 warnings = idêntico ao baseline `main`** (ratchet); OssTab sem mudança de contagem
- Pest roda no CI (CT 100)

## Não testado automaticamente
Smoke visual no drawer real (abrir cliente → aba OS → Vendas) + os 3 curls acima — recomendo antes/depois do deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)