### PR TITLE
docs(crm): silenciar módulo CRM/Cliente na memória canônica

### DIFF
--- a/Modules/Crm/BRIEFING.md
+++ b/Modules/Crm/BRIEFING.md
@@ -1,5 +1,7 @@
 # Crm — BRIEFING (estado consolidado)
 
+> 🔇 **SILENCIADO NA MEMÓRIA — Wagner 2026-06-08.** Este BRIEFING descreve o **pipeline-legacy do UltimatePOS** (Leads/Proposals/Campaigns/Schedules/CallLogs) — exatamente a parte que o Wagner considera defasada e que não deve mais ser comentada, evoluída nem virar task sem decisão explícita dele. **O cadastro de Cliente (drawer 760px) NÃO está aqui** — vive em `memory/requisitos/Crm/` e segue ativo no app (`module.json active: 1` intacto). Reversível (remover banner).
+
 > **Última atualização:** 2026-05-16 (Wave 18 RETRY)
 > **Wave 18 RETRY score (target 97):** D1=30/30 · D4=20/20 · D8=8/8 (saturado)
 

--- a/memory/reference/crm-e-o-modulo-de-cliente.md
+++ b/memory/reference/crm-e-o-modulo-de-cliente.md
@@ -1,5 +1,7 @@
 # `Modules/Crm` **É** o módulo de Cliente (contatos do cliente)
 
+> 🔇 **SILENCIADO NA MEMÓRIA — Wagner 2026-06-08.** Não comentar, não evoluir, não criar task pra este módulo sem decisão explícita do Wagner. Motivo: o "CRM" (pipeline herdado do UltimatePOS — Leads/Proposals/Campaigns/Schedules/CallLogs) não faz sentido pro negócio (gráfica/vestuário) e estava confundindo/irritando recorrentemente. **O app NÃO foi tocado:** `Modules/Crm/module.json` segue `active: 1` — o cadastro de Cliente (drawer 760px) continua funcionando pra biz=4 (Larissa) e demais tenants. **Reversível:** basta remover este banner. **Decisão permanente pendente (Wagner aprova):** (a) renomear `Modules/Crm` → `Modules/Cliente` pra matar a confusão de nome, e/ou (b) separar/deprecar o pipeline-legacy mantendo só o cadastro de Cliente.
+
 > **Origem:** Wagner 2026-06-01 — *"por no crm? era para ser no contatos do cliente. o crm está me incomodando e sempre confundindo."* Desambiguação canônica pra parar a confusão recorrente (humano **e** agente).
 
 ## A regra (decore isto)

--- a/memory/requisitos/Crm/BRIEFING.md
+++ b/memory/requisitos/Crm/BRIEFING.md
@@ -1,5 +1,7 @@
 # BRIEFING — Modules/Crm
 
+> 🔇 **SILENCIADO NA MEMÓRIA — Wagner 2026-06-08.** Não comentar, não evoluir, não criar task pra este módulo sem decisão explícita do Wagner. O "CRM" (pipeline herdado UltimatePOS) não faz sentido pro negócio e confundia. **App intacto** (`module.json active: 1` — cadastro de Cliente segue funcionando pra Larissa/biz=4). Reversível (remover banner). Ver [`memory/reference/crm-e-o-modulo-de-cliente.md`](../../reference/crm-e-o-modulo-de-cliente.md).
+
 > **Última atualização:** 2026-05-21 (Wave A-G+Z — drawer 760px paradigma cadastral)
 > **Owner:** Wagner | **Status produção:** ✅ usado por biz=4 (ROTA LIVRE — Larissa)
 > **Nota Module Grade v1:** 42/100 (Médio) → meta pós-wave 60+/100


### PR DESCRIPTION
## O quê

Adiciona banner de **silenciamento** no topo dos 3 docs canônicos de entrada do módulo `Crm` (= módulo de Cliente):
- `memory/reference/crm-e-o-modulo-de-cliente.md`
- `memory/requisitos/Crm/BRIEFING.md`
- `Modules/Crm/BRIEFING.md`

O banner marca o módulo como **não comentar / não evoluir / não criar task** sem decisão explícita do Wagner.

## Por quê

Wagner 2026-06-08: o "CRM" (pipeline herdado do UltimatePOS — Leads/Proposals/Campaigns/Schedules/CallLogs) não faz sentido pro negócio (gráfica/vestuário) e estava confundindo/irritando recorrentemente. Já tinha sido desativado no app, mas a memória canônica continuava narrando como vivo → voltava no brief.

## Segurança

- **Não toca código de app.** `Modules/Crm/module.json` segue `active: 1`.
- Cadastro de **Cliente (drawer 760px)** continua funcionando pra biz=4 (Larissa) e demais tenants.
- **Reversível:** basta remover o banner.

## Pendente (decisão permanente do Wagner)

(a) renomear `Modules/Crm` → `Modules/Cliente` pra matar a confusão de nome; e/ou (b) separar/deprecar o pipeline-legacy mantendo só o cadastro de Cliente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)