### PR TITLE
fix(crm): avisar "já existe cadastro" em vez de erro 500 ao salvar CNPJ duplicado

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -217,7 +217,40 @@ class ClienteAutosaveController extends Controller
             return response()->json(['errors' => $validator->errors()], 422);
         }
 
-        return $this->updateAndRespond($contact, $validator->validated());
+        $validated = $validator->validated();
+
+        // Unicidade CPF/CNPJ por business (unique key `uk_contacts_biz_tax` =
+        // business_id + tax_number). Sem este pre-check o save estoura
+        // `1062 Duplicate entry` -> 500 cru. Avisar claramente que ja existe
+        // cadastro (Wagner 2026-06-08). Escopo Tier 0: so olha o mesmo business.
+        //
+        // withTrashed(): a unique key cobre linhas SOFT-DELETED, entao um contato
+        // excluido continua "segurando" o CNPJ. O caso real do Wagner foi
+        // exatamente esse (holder arquivado as 15:59) -- precisamos enxergar o
+        // trashed pra explicar, senao o pre-check passa e o save 500a mesmo assim.
+        if (! empty($validated['tax_number'])) {
+            $existing = Contact::withTrashed()
+                ->where('business_id', $contact->business_id)
+                ->where('tax_number', $validated['tax_number'])
+                ->where('id', '!=', $contact->id)
+                ->first();
+
+            if ($existing !== null) {
+                $nome = trim((string) ($existing->name ?? ''));
+                $ref = $nome !== '' ? $nome : ('cadastro #' . $existing->id);
+                $msg = $existing->trashed()
+                    ? 'Já existe um cadastro arquivado/excluído com este CPF/CNPJ (' . $ref . '). Restaure o cadastro existente em vez de criar outro.'
+                    : 'Já existe um cadastro com este CPF/CNPJ: ' . $ref . '.';
+
+                // Chave `doc` = alias PT-BR que o IdentificacaoTab usa pra exibir
+                // o erro sob o campo; `tax_number` = canon pra outros callers.
+                return response()->json([
+                    'errors' => ['doc' => [$msg], 'tax_number' => [$msg]],
+                ], 422);
+            }
+        }
+
+        return $this->updateAndRespond($contact, $validated);
     }
 
     /**
@@ -560,7 +593,25 @@ class ClienteAutosaveController extends Controller
      */
     private function updateAndRespond(Contact $contact, array $data): JsonResponse
     {
-        $contact->update($data);
+        // Backstop pra qualquer unique key (ex: uk_contacts_biz_tax = CPF/CNPJ
+        // duplicado, ou race entre o pre-check e o save). Nunca devolver 500 cru
+        // num autosave -- traduzir pra mensagem clara que o drawer ja sabe exibir.
+        try {
+            $contact->update($data);
+        } catch (\Illuminate\Database\UniqueConstraintViolationException $e) {
+            if (array_key_exists('tax_number', $data)) {
+                $msg = 'Já existe um cadastro com este CPF/CNPJ neste negócio.';
+
+                // `doc` pro IdentificacaoTab exibir sob o campo; `tax_number` canon.
+                return response()->json([
+                    'errors' => ['doc' => [$msg], 'tax_number' => [$msg]],
+                ], 422);
+            }
+
+            return response()->json([
+                'errors' => ['_' => ['Já existe um cadastro com estes dados.']],
+            ], 422);
+        }
 
         return response()->json([
             'success' => true,

--- a/tests/Feature/Cliente/ClienteAutosaveDuplicateTaxTest.php
+++ b/tests/Feature/Cliente/ClienteAutosaveDuplicateTaxTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Regressão Wagner 2026-06-08 — cadastro de empresa (cliente PJ) dava
+ * "erro 500" ao salvar o CNPJ.
+ *
+ * Causa raiz: unique key `uk_contacts_biz_tax` (business_id + tax_number) cobre
+ * inclusive linhas SOFT-DELETED. Wagner excluiu um contato e tentou cadastrar
+ * outro com o mesmo CNPJ -> a linha arquivada ainda "segura" o CNPJ ->
+ * `updateAndRespond()` fazia `$contact->update()` sem try/catch ->
+ * `UniqueConstraintViolationException` (1062) virava 500 cru, sem dizer ao
+ * usuário que já existe cadastro.
+ *
+ * Fix:
+ *  1. Pre-check em identificacao() com withTrashed() — acha o holder mesmo
+ *     arquivado e devolve 422 com mensagem clara (chave `doc` p/ o
+ *     IdentificacaoTab exibir sob o campo + `tax_number` canon).
+ *  2. Backstop try/catch em updateAndRespond() — nunca mais 500 cru.
+ *
+ * GUARDs estruturais (file_get_contents, sem DB) — mesmo padrão do
+ * ClienteAutosaveAliasesPtBrTest.php.
+ */
+
+function readClienteAutosaveSource(): string
+{
+    return file_get_contents(
+        __DIR__ . '/../../../Modules/Crm/Http/Controllers/ClienteAutosaveController.php'
+    );
+}
+
+// ─── GUARD 1: pre-check de unicidade com withTrashed ──────────────────────
+
+test('GUARD 1 — identificacao() faz pre-check de CNPJ duplicado com withTrashed()', function () {
+    $src = readClienteAutosaveSource();
+
+    expect($src)
+        ->toContain('withTrashed()')
+        ->toContain("->where('tax_number', \$validated['tax_number'])")
+        // escopo Tier 0 — só o mesmo business (ADR 0093)
+        ->toContain("->where('business_id', \$contact->business_id)")
+        // não confunde o próprio contato com duplicata
+        ->toContain("->where('id', '!=', \$contact->id)");
+});
+
+// ─── GUARD 2: mensagem distingue arquivado de ativo ───────────────────────
+
+test('GUARD 2 — mensagem diferencia cadastro arquivado/excluído de ativo', function () {
+    $src = readClienteAutosaveSource();
+
+    expect($src)
+        ->toContain('$existing->trashed()')
+        ->toContain('arquivado/excluído com este CPF/CNPJ')
+        ->toContain('Restaure o cadastro existente');
+});
+
+// ─── GUARD 3: erro devolvido sob `doc` (frontend) E `tax_number` (canon) ───
+
+test('GUARD 3 — erro 422 sai sob doc + tax_number (IdentificacaoTab lê errors[doc])', function () {
+    $src = readClienteAutosaveSource();
+
+    // o pre-check devolve as duas chaves
+    expect($src)->toMatch("/'errors' => \\['doc' => \\[\\\$msg\\], 'tax_number' => \\[\\\$msg\\]\\]/");
+});
+
+// ─── GUARD 4: backstop try/catch no save (anti-500 cru) ───────────────────
+
+test('GUARD 4 — updateAndRespond() captura UniqueConstraintViolationException', function () {
+    $src = readClienteAutosaveSource();
+
+    // bloco do método
+    preg_match('/private function updateAndRespond\(.*?(?=\n    (?:private|public|protected) function )/s', $src, $m);
+    $block = $m[0] ?? '';
+
+    expect($block)
+        ->toContain('try {')
+        ->toContain('$contact->update($data);')
+        ->toContain('catch (\Illuminate\Database\UniqueConstraintViolationException $e)')
+        ->toContain('Já existe um cadastro com este CPF/CNPJ neste negócio.');
+});


### PR DESCRIPTION
## Problema (reportado pelo Wagner, 2026-06-08)

Cadastrar uma empresa (cliente PJ) dava **erro 500** ao salvar o CNPJ. O motivo real: **já existe um cadastro com aquele CNPJ**, mas o sistema não avisava — só estourava 500.

### Causa raiz

`ClienteAutosaveController@updateAndRespond()` fazia `$contact->update()` **sem try/catch**. Quando `tax_number` colide com a unique key `uk_contacts_biz_tax` (`business_id` + `tax_number`):

```
SQLSTATE[23000]: 1062 Duplicate entry '1-29.155.419/0001-02' for key 'uk_contacts_biz_tax'
route: cliente.autosave.identificacao
```

→ `UniqueConstraintViolationException` não tratada → **500 cru**.

O validator só checava formato + mod 11, **nunca unicidade**.

### O detalhe que pegou

A unique key cobre **linhas soft-deleted**. No caso real, o Wagner **excluiu** um contato (id 47038, arquivado às 15:59) e tentou cadastrar outro com o mesmo CNPJ — a linha arquivada continuava "segurando" o CNPJ. Um pre-check com Eloquent comum (que esconde excluídos) **não** pegaria.

## Correção

1. **Pre-check** em `identificacao()` com `withTrashed()` — acha o detentor mesmo arquivado e devolve **422 com mensagem clara**, distinguindo:
   - arquivado → *"Já existe um cadastro arquivado/excluído com este CPF/CNPJ (NOME). Restaure o cadastro existente em vez de criar outro."*
   - ativo → *"Já existe um cadastro com este CPF/CNPJ: NOME."*
   - Escopo Tier 0 (ADR 0093): só olha o mesmo `business_id`.
2. **Backstop** `try/catch (UniqueConstraintViolationException)` em `updateAndRespond()` — nunca mais 500 cru (cobre race entre pre-check e save).
3. Erro devolvido sob a chave **`doc`** (que o `IdentificacaoTab` lê pra exibir sob o campo) **+ `tax_number`** canon.

## Verificação (produção, biz=1)
- Simulei o pre-check contra o holder real arquivado → retorna a mensagem "arquivado" com o nome ✓
- Frontend `IdentificacaoTab` lê `errors.doc[0]` e exibe sob o campo CNPJ ✓
- Lint php84 ✓

## Arquivos
- `Modules/Crm/Http/Controllers/ClienteAutosaveController.php` — pre-check + backstop
- `tests/Feature/Cliente/ClienteAutosaveDuplicateTaxTest.php` — 4 GUARDs de regressão

🤖 Generated with [Claude Code](https://claude.com/claude-code)