### PR TITLE
feat(cliente): duplo-clique na linha de venda abre a venda

### DIFF
--- a/resources/js/Pages/Cliente/_show/SalesTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SalesTab.tsx
@@ -310,7 +310,13 @@ export default function SalesTab({
                 </thead>
                 <tbody>
                   {salesData.data.map((s) => (
-                    <tr key={s.id} className="border-b border-border hover:bg-muted/40" data-testid={`sales-row-${s.id}`}>
+                    <tr
+                      key={s.id}
+                      className="border-b border-border hover:bg-muted/40 cursor-pointer select-none"
+                      data-testid={`sales-row-${s.id}`}
+                      onDoubleClick={() => { window.location.href = `/sells/${s.id}`; }}
+                      title="Duplo-clique para abrir a venda"
+                    >
                       <td className="px-4 py-2.5 text-xs text-muted-foreground tabular-nums">{formatDate(s.transaction_date)}</td>
                       <td className="px-4 py-2.5">
                         <a href={`/sells/${s.id}`} className="font-medium text-foreground hover:underline">

--- a/tests/Feature/Cliente/Show/SalesTabTest.php
+++ b/tests/Feature/Cliente/Show/SalesTabTest.php
@@ -99,3 +99,13 @@ test('SalesTab.tsx — empty state PT-BR', function () {
         ->toContain('Ajuste os filtros ou registre uma nova venda.')
         ->toContain('data-testid="sales-empty"');
 });
+
+test('SalesTab.tsx — duplo-clique na linha abre a venda', function () {
+    $tsxPath = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/SalesTab.tsx';
+    $contents = file_get_contents($tsxPath);
+
+    expect($contents)
+        ->toContain('onDoubleClick={() => { window.location.href = `/sells/${s.id}`; }}')
+        ->toContain('cursor-pointer')
+        ->toContain('Duplo-clique para abrir a venda');
+});


### PR DESCRIPTION
## Pedido (Wagner)
> apareceu, duplo clic da abrir a venda?

Pós-fix das vendas no drawer (#2437), abrir a venda por **duplo-clique na linha** — o gesto natural. Antes só dava pra abrir clicando no nº da fatura (link) ou no ícone da coluna "Ações".

## Mudança
- `onDoubleClick` na `<tr>` → navega pra `/sells/{id}` (mesma navegação dos links já existentes, que continuam funcionando pro single-click/teclado).
- `cursor-pointer` + `select-none` + `title="Duplo-clique para abrir a venda"` (affordance + evita seleção de texto no duplo-clique).
- Guard de teste em `SalesTabTest`.

Vale pros dois modos do SalesTab (drawer self-fetch **e** Show.tsx full-page).

## Validação local
- `tsc --noEmit`: zero erros novos no arquivo
- `eslint`: **4 errors + 4 warnings = idêntico ao baseline `main`** (o onDoubleClick na `<tr>` não dispara as regras a11y ativas) — sem regressão no ratchet
- cor-crua (R1) = **32** inalterado → UI Lint ratchet ok
- `php -l` no teste: ok

## Acessibilidade
Duplo-clique é progressive enhancement; o caminho acessível (link no nº da fatura + botão "Ações" com aria-label, ambos navegáveis por teclado) permanece intacto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)