### PR TITLE
ci(identidade): gates rodam em todo PR — pré-requisito do muro de cor (ADR 0263)

### DIFF
--- a/.github/workflows/adr-lint.yml
+++ b/.github/workflows/adr-lint.yml
@@ -13,10 +13,10 @@ on:
       - 'tests/Feature/Memory/AdrFrontmatterLinterTest.php'
       - '.github/workflows/adr-lint.yml'
   pull_request:
-    paths:
-      - 'memory/decisions/**'
-      - 'tests/Feature/Memory/AdrFrontmatterLinterTest.php'
-      - '.github/workflows/adr-lint.yml'
+    # SEM path filter de propósito (ADR 0263): roda em TODO PR. O linter valida o corpus
+    # inteiro de ADRs (verde no main = passa trivial em PR que não toca ADR). Rodar sempre
+    # permite que 'ADR frontmatter' seja required + enforce_admins SEM o deadlock de
+    # "Expected" que travava PRs sem ADR (incidente 2026-06-08).
 
 concurrency:
   group: adr-lint-${{ github.ref }}

--- a/.github/workflows/conformance-gate.yml
+++ b/.github/workflows/conformance-gate.yml
@@ -27,16 +27,9 @@ on:
       - '.foundation-guard-files.json'
       - '.github/workflows/conformance-gate.yml'
   pull_request:
-    paths:
-      # Cor-crua (ratchet) escopa sells-cowork*; o invariante --accent varre TODO resources/css/*.css
-      # (token de marca vive em cockpit.css/fin-cowork.css/cowork-*-bundle.css) — gatilho cobre os dois.
-      - 'resources/css/**/*.css'
-      - 'scripts/conformance-gate.mjs'
-      - 'scripts/foundation-guard.mjs'
-      - '.conformance-baseline.json'
-      - '.foundation-guard-baseline.json'
-      - '.foundation-guard-files.json'
-      - '.github/workflows/conformance-gate.yml'
+    # SEM path filter de propósito (ADR 0263): roda em TODO PR. O gate é ratchet — sem
+    # mudança de CSS ele passa trivial. Rodar sempre permite torná-lo REQUIRED (muro da
+    # identidade de cor) sem o deadlock de "Expected" que trava PRs sem CSS (incidente 2026-06-08).
 
 concurrency:
   group: conformance-gate-${{ github.ref }}

--- a/.github/workflows/governance-gate-umbrella.yml
+++ b/.github/workflows/governance-gate-umbrella.yml
@@ -33,6 +33,8 @@ jobs:
         run: npm ci
       - name: Índice de ADR em dia + supersede íntegra
         run: node scripts/governance/adr-index-generate.mjs --check
+      - name: Paleta de cor em dia (PALETA.html == cockpit.css)
+        run: node scripts/governance/palette-generate.mjs --check
       - name: memory-health (enforce — segredo novo / colisão / ressurreição bloqueiam)
         run: node scripts/governance/memory-health.mjs
       - name: Meta-teste dos scripts de governança (controle-negativo)

--- a/.github/workflows/ui-lint.yml
+++ b/.github/workflows/ui-lint.yml
@@ -21,12 +21,9 @@ on:
       - 'config/ui-lint-baseline.json'
       - '.github/workflows/ui-lint.yml'
   pull_request:
-    paths:
-      - 'resources/js/**'
-      - 'resources/css/**'
-      - 'app/Console/Commands/UiLintCommand.php'
-      - 'config/ui-lint-baseline.json'
-      - '.github/workflows/ui-lint.yml'
+    # SEM path filter de propósito (ADR 0263): roda em TODO PR. O lint é ratchet — sem
+    # mudança de .tsx/.css ele passa trivial. Rodar sempre permite torná-lo REQUIRED (muro
+    # da identidade) sem o deadlock de "Expected" que trava PRs sem UI (incidente 2026-06-08).
 
 concurrency:
   group: ui-lint-${{ github.ref }}


### PR DESCRIPTION
**Precisa da sua revisão (CODEOWNERS `.github/`).** Este é o pré-requisito pro "muro de verdade" da identidade de cor.

## Problema (incidente 2026-06-08)
Tornar os gates de cor `required` + ligar `enforce_admins` **travou todo PR** que não toca CSS/TSX: gates path-filtered viram "Expected" pra sempre. O `ADR frontmatter` (já required) tem o mesmo defeito — só não travava porque admin furava.

## Conserto
Os gates de identidade passam a **rodar em TODO PR** (removendo o path-filter de `pull_request`). São ratchet/validação de corpus → sem mudança relevante, **passam trivial**. Assim podem ser `required` + `enforce_admins` **sem deadlock**.

- `adr-lint.yml` (ADR frontmatter)
- `conformance-gate.yml` (cor-crua + foundation-guard)
- `ui-lint.yml` (R1 Tailwind)
- `governance-gate-umbrella.yml` — + `--check` da paleta (PALETA.html não diverge do cockpit.css)

## Custo
Esses 3 gates passam a rodar em **todo** PR (uns minutos a mais por PR). É o preço do muro.

## Depois do merge
Eu re-adiciono `conformance` + `ui-lint` aos required + religo `enforce_admins` → muro fechado (ADR 0263), sem travar o repo. Verifico num PR seguinte que ninguém fica "Expected".

🤖 Generated with [Claude Code](https://claude.com/claude-code)