### PR TITLE
fix(financeiro): botão "Cobrar" do Unificado abre wizard pré-preenchido (US-FIN-054)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/CobrancaController.php
+++ b/Modules/Financeiro/Http/Controllers/CobrancaController.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Titulo;
 use Modules\PaymentGateway\Contracts\PaymentGatewayContract;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Exceptions\CardDeclinedException;
@@ -84,11 +85,60 @@ class CobrancaController extends Controller
             'accounts' => $this->listarContasDestino($businessId),
             'gateways' => $query->gateways($businessId),
 
+            // US-FIN-054 — deep-link "Cobrar" do Financeiro Unificado pré-abre o
+            // wizard com os dados do título a receber. null quando ausente.
+            'prefill' => $this->resolvePrefill($request, $businessId),
+
             // Defer props caras (Inertia::defer DEFAULT — RUNBOOK pattern)
             'cobrancas' => Inertia::defer(fn () => $query->listar($businessId, $filtros)),
             'kpis' => Inertia::defer(fn () => $query->kpis($businessId, $hoje)),
             'funil' => Inertia::defer(fn () => $query->funil($businessId, $hoje)),
         ]);
+    }
+
+    /**
+     * US-FIN-054 — Pré-preenchimento do wizard a partir de um título a receber.
+     *
+     * Disparado pelo deep-link `/financeiro/cobranca?cobrar_titulo=ID` (botão
+     * "Cobrar" do drawer do Financeiro Unificado). Resolve server-side (fonte
+     * única) e devolve shape pro wizard pré-abrir já preenchido.
+     *
+     * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093): título filtrado por
+     * business_id + global scope do Model. Só `tipo=receber` (boleto é cobrança
+     * de quem nos deve). Retorna null se ausente/não encontrado/cross-tenant.
+     *
+     * Escopo Onda A: pré-preenche tipo/contato/valor/vencimento. O elo de
+     * mão dupla título↔cobrança (origem_id pra baixa automática ao pagar) é
+     * Onda B — ver ADR de integração título↔cobrança (US-FIN-054 §relacionado).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function resolvePrefill(Request $request, int $businessId): ?array
+    {
+        $tituloId = $request->integer('cobrar_titulo');
+        if ($tituloId <= 0) {
+            return null;
+        }
+
+        $titulo = Titulo::query()
+            ->where('business_id', $businessId)
+            ->where('tipo', 'receber')
+            ->find($tituloId);
+
+        if (! $titulo) {
+            return null;
+        }
+
+        $valorAberto = (float) ($titulo->valor_aberto ?: $titulo->valor_total);
+
+        return [
+            'titulo_id' => $titulo->id,
+            'tipo' => 'boleto',
+            'contato' => $titulo->cliente_descricao,
+            'valor' => number_format($valorAberto, 2, ',', ''),
+            'vencimento' => optional($titulo->vencimento)->toDateString(),
+            'descricao' => 'Título a receber #'.($titulo->numero ?: $titulo->id),
+        ];
     }
 
     /**

--- a/Modules/Financeiro/Tests/Feature/CobrancaControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/CobrancaControllerTest.php
@@ -6,6 +6,7 @@ use App\Business;
 use App\Role;
 use App\User;
 use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Titulo;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Spatie\Permission\Models\Permission;
@@ -321,4 +322,71 @@ it('POST /cobranca/cartao exige card_last4 com exatos 4 dígitos', function () {
             'card_exp_year' => '2028',
         ])
         ->assertSessionHasErrors(['card_last4']);
+});
+
+// ─── US-FIN-054 — deep-link "Cobrar" do Unificado pré-preenche o wizard ───────
+
+it('prefill: ?cobrar_titulo=ID popula prefill com dados do título a receber', function () {
+    $titulo = Titulo::create([
+        'business_id' => $this->business->id,
+        'numero' => 'T-PREFILL-001',
+        'tipo' => 'receber',
+        'status' => 'aberto',
+        'cliente_descricao' => 'CLIENTE PREFILL TESTE',
+        'valor_total' => 500.00,
+        'valor_aberto' => 500.00,
+        'moeda' => 'BRL',
+        'emissao' => now()->subDay()->toDateString(),
+        'vencimento' => now()->addDays(10)->toDateString(),
+        'competencia_mes' => now()->format('Y-m'),
+        'origem' => 'manual',
+        'created_by' => $this->user->id,
+    ]);
+
+    $this->actingAs($this->user)
+        ->withSession(['user.business_id' => $this->business->id, 'business.id' => $this->business->id])
+        ->get('/financeiro/cobranca?cobrar_titulo='.$titulo->id)
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page
+            ->where('prefill.titulo_id', $titulo->id)
+            ->where('prefill.tipo', 'boleto')
+            ->where('prefill.contato', 'CLIENTE PREFILL TESTE')
+            ->where('prefill.valor', '500,00')
+            ->where('prefill.vencimento', $titulo->vencimento->toDateString())
+        );
+});
+
+it('prefill: sem cobrar_titulo → prefill null', function () {
+    $this->actingAs($this->user)
+        ->withSession(['user.business_id' => $this->business->id, 'business.id' => $this->business->id])
+        ->get('/financeiro/cobranca')
+        ->assertInertia(fn ($page) => $page->where('prefill', null));
+});
+
+it('prefill Tier 0 IRREVOGÁVEL: título de outro business não vaza (prefill null)', function () {
+    $otherBiz = Business::query()->firstOrCreate(['id' => 99], ['name' => 'Other Biz', 'currency_id' => 1]);
+
+    $tituloOutro = Titulo::withoutGlobalScopes()->create([
+        'business_id' => $otherBiz->id,
+        'numero' => 'T-CROSS-TENANT',
+        'tipo' => 'receber',
+        'status' => 'aberto',
+        'cliente_descricao' => 'NEVER SHOULD APPEAR PREFILL',
+        'valor_total' => 99999.00,
+        'valor_aberto' => 99999.00,
+        'moeda' => 'BRL',
+        'emissao' => now()->subDay()->toDateString(),
+        'vencimento' => now()->addDays(10)->toDateString(),
+        'competencia_mes' => now()->format('Y-m'),
+        'origem' => 'manual',
+        'created_by' => $this->user->id,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->withSession(['user.business_id' => $this->business->id, 'business.id' => $this->business->id])
+        ->get('/financeiro/cobranca?cobrar_titulo='.$tituloOutro->id);
+
+    $response->assertOk()
+        ->assertInertia(fn ($page) => $page->where('prefill', null));
+    expect($response->getContent())->not->toContain('NEVER SHOULD APPEAR PREFILL');
 });

--- a/resources/js/Pages/Financeiro/Cobranca/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.charter.md
@@ -11,7 +11,7 @@ related_us: [US-PG-F3-COBRANCA]
 related_prototype: prototipo Cowork "payment-gateway-ui" F1+F1.5 aprovado [W] 2026-05-19 (Chat Cowork live)
 related_decisions: COWORK_HANDOFF.paymentgateway-ui.md (F1 score 96/93/93)
 tier: A
-charter_version: 1
+charter_version: 2
 supersedes: /financeiro/boletos
 ---
 
@@ -37,6 +37,7 @@ Eliana acompanha **toda a cobrança gerada (boleto · pix · pix automático · 
 - **Tabela densa** (text-[12.5px] tabular-nums): vencimento + relativo · Pagador + doc mascarado + origem · chip composto gateway+tipo · Conta destino · nosso nº · valor · status badge com ícone lucide · ações row hover
 - **Drawer detalhe condicional por tipo** (520px): boleto (linha digitável + cód barras) · PIX cob (BR Code + QR fake) · PIX recv (mandato BCB) · Cartão (last4 + 3DS)
 - **Sheet "Nova cobrança"** wizard 4 steps (Tipo → Pagador → Valores → Revisar) — dispara `PaymentGatewayContract::emitirX()` (Onda 4 backend)
+- **Deep-link "Cobrar" (US-FIN-054)**: `?cobrar_titulo=ID` (vindo do drawer do Financeiro Unificado) pré-abre o wizard já preenchido (tipo=boleto + contato + valor + vencimento do título). Resolvido server-side via `CobrancaController::resolvePrefill` (Tier 0 scoped). Substitui o botão "Cobrar" quebrado que apontava pra rota 404 `/cobranca/recorrente/nova`
 - **Sheet "Remessa/Retorno"** CNAB 240 — C6 driver (Onda 5 backlog)
 - **AI panel ✦ "Resumir mês"** — narrativa MRR + inadimplência + distribuição gateway + insights
 - **Cheat sheet** overlay `?` — atalhos teclado documentados
@@ -122,6 +123,9 @@ it('filtra por status/tipo/gateway/account/origem via querystring')
 it('Tier 0 IRREVOGÁVEL: Cobranca respeita business_id global scope')
 it('redirect 301 /financeiro/boletos → /financeiro/cobranca')
 it('não dispara mutação em GET /cobranca (read-only puro)')
+it('prefill: ?cobrar_titulo=ID popula prefill com dados do título a receber')
+it('prefill: sem cobrar_titulo → prefill null')
+it('prefill Tier 0: título de outro business não vaza (prefill null)')
 ```
 
 ---
@@ -153,3 +157,4 @@ it('não dispara mutação em GET /cobranca (read-only puro)')
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-19 | Wagner [W] + Claude Code [CL] | F3 PaymentGateway UI Tela 1 entregue — substitui /financeiro/boletos. Escopo expandido pix+card+pix_recv+subscription_license. Cowork F1.5 score 96/100. Bundle CSS canon `cowork-payment-gateway-bundle.css` aplicado inteiro (regra Wagner 2026-05-18). |
+| 2026-06-08 | Wagner [W] + Claude Code [CL] | US-FIN-054 — deep-link `?cobrar_titulo=ID` pré-abre o wizard preenchido a partir do título a receber do Financeiro Unificado. Conserta o botão "Cobrar" que apontava pra rota 404 `/cobranca/recorrente/nova` (morto desde 2026-05-28). +3 Pest GUARDs (incl. cross-tenant Tier 0). |

--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -37,7 +37,7 @@ import {
   brl, brlNoSign, cn, fmtDate, fmtDateRel, piiMask, lsGet, lsSet, copiar,
   DRIVERS, TIPOS, ORIGENS,
   type Cobranca, type Account, type Gateway, type CobrancaKpis, type CobrancaFunil,
-  type CobrancaFiltros, type OrigemType,
+  type CobrancaFiltros, type OrigemType, type PrefillCobranca,
 } from './_lib/cobranca-shared';
 
 interface Props {
@@ -49,6 +49,7 @@ interface Props {
   filtros: CobrancaFiltros;
   isSaasBusiness: boolean;
   today: string;
+  prefill?: PrefillCobranca | null;
 }
 
 const KPI_FALLBACK: CobrancaKpis = {
@@ -68,7 +69,7 @@ const FUNIL_FALLBACK: CobrancaFunil = {
   mandatos_cancelados: 0,
 };
 
-function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], filtros, isSaasBusiness, today }: Props) {
+function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], filtros, isSaasBusiness, today, prefill = null }: Props) {
   // Hotfix Inertia::defer first paint: kpis/funil podem ser undefined até resolver.
   kpis = kpis ?? KPI_FALLBACK;
   funil = funil ?? FUNIL_FALLBACK;
@@ -87,7 +88,8 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
   const setOrigemFilterLs = useCallback((v: string) => { setOrigemFilter(v); lsSet('origem', v); }, []);
 
   const [drawer, setDrawer] = useState<Cobranca | null>(null);
-  const [novaOpen, setNovaOpen] = useState(false);
+  // US-FIN-054 — deep-link ?cobrar_titulo=ID pré-abre o wizard já preenchido.
+  const [novaOpen, setNovaOpen] = useState(Boolean(prefill));
   const [remessaOpen, setRemessaOpen] = useState(false);
   const [cheatOpen, setCheatOpen] = useState(false);
   const [aiOpen, setAiOpen] = useState(false);
@@ -428,7 +430,7 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
       </div>
 
       {drawer && <DrawerCobranca cob={drawer} accounts={accounts} today={today} onClose={() => setDrawer(null)} />}
-      {novaOpen && <SheetNovaCobranca accounts={accounts} onClose={() => setNovaOpen(false)} />}
+      {novaOpen && <SheetNovaCobranca accounts={accounts} prefill={prefill} onClose={() => setNovaOpen(false)} />}
       {remessaOpen && <SheetRemessaRetorno onClose={() => setRemessaOpen(false)} />}
       {cheatOpen && <CheatSheet onClose={() => setCheatOpen(false)} />}
       {aiOpen && <AiResumoMes kpis={kpis} cobs={cobrancas ?? []} onClose={() => setAiOpen(false)} />}

--- a/resources/js/Pages/Financeiro/Cobranca/_components/SheetNovaCobranca.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/_components/SheetNovaCobranca.tsx
@@ -9,7 +9,7 @@ import {
 import { Btn, Field, GatewayTipoChip } from './atoms';
 import {
   brl, cn, fmtDate, DRIVERS,
-  type CobrancaTipo, type Account, type GatewayKey,
+  type CobrancaTipo, type Account, type GatewayKey, type PrefillCobranca,
 } from '../_lib/cobranca-shared';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
@@ -18,6 +18,8 @@ import {
 interface Props {
   accounts: Account[];
   onClose: () => void;
+  /** US-FIN-054 — pré-preenchimento vindo do deep-link "Cobrar" do Unificado. */
+  prefill?: PrefillCobranca | null;
 }
 
 const TIPOS_DISPONIVEIS: Array<{ id: CobrancaTipo; label: string; desc: string; icon: ReactNode; highlight?: boolean }> = [
@@ -29,12 +31,13 @@ const TIPOS_DISPONIVEIS: Array<{ id: CobrancaTipo; label: string; desc: string; 
 
 const STEPS = ['Tipo', 'Pagador', 'Valores', 'Revisar'];
 
-export default function SheetNovaCobranca({ accounts, onClose }: Props) {
+export default function SheetNovaCobranca({ accounts, onClose, prefill = null }: Props) {
   const [step, setStep] = useState(1);
-  const [tipo, setTipo] = useState<CobrancaTipo | null>(null);
-  const [contato, setContato] = useState('');
-  const [valor, setValor] = useState('');
+  const [tipo, setTipo] = useState<CobrancaTipo | null>(prefill?.tipo ?? null);
+  const [contato, setContato] = useState(prefill?.contato ?? '');
+  const [valor, setValor] = useState(prefill?.valor ?? '');
   const [vencimento, setVencimento] = useState(() => {
+    if (prefill?.vencimento) return prefill.vencimento;
     const d = new Date();
     d.setDate(d.getDate() + 7);
     return d.toISOString().slice(0, 10);
@@ -72,6 +75,7 @@ export default function SheetNovaCobranca({ accounts, onClose }: Props) {
       vencimento,
       account_id: account,
       payer_name: contato || null,
+      descricao: prefill?.descricao ?? undefined,
       idempotency_key: typeof crypto !== 'undefined' && crypto.randomUUID
         ? crypto.randomUUID()
         : `${Date.now()}-${Math.random().toString(36).slice(2)}`,

--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -6,6 +6,21 @@ import { toast } from 'sonner';
 export type CobrancaTipo = 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card';
 export type CobrancaStatus = 'emitida' | 'paga' | 'vencida' | 'cancelada' | 'erro' | 'pending';
 export type OrigemType = 'sale' | 'invoice' | 'subscription_license';
+
+/**
+ * Pré-preenchimento do wizard "Nova cobrança" vindo de deep-link
+ * (?cobrar_titulo=ID a partir do drawer do Financeiro Unificado — US-FIN-054).
+ * Resolvido server-side em CobrancaController::resolvePrefill (Tier 0 scoped).
+ */
+export interface PrefillCobranca {
+  titulo_id: number;
+  tipo: CobrancaTipo;
+  contato: string | null;
+  valor: string | null;       // BR string "500,00" — wizard parseia com replace(',', '.')
+  vencimento: string | null;  // Y-m-d
+  descricao: string | null;
+}
+
 export type GatewayKey =
   // API REST drivers
   | 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pagarme'

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1924,7 +1924,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     </Button>
                   )}
                   {selected.kind === 'receivable' && (selected.status !== 'recebido') && (
-                    <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Cobrar contraparte" onClick={() => router.visit(`/cobranca/recorrente/nova?titulo=${selected.id}`)}>
+                    <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Cobrar contraparte" onClick={() => router.visit(`/financeiro/cobranca?cobrar_titulo=${selected.id}`)}>
                       <span aria-hidden>✉</span>
                       <span className="ml-1">Cobrar</span>
                     </Button>


### PR DESCRIPTION
## Problema (US-FIN-054)

O botão **"Cobrar"** no drawer de título a receber do **Financeiro Unificado** apontava pra `/cobranca/recorrente/nova` — rota que **nunca existiu**. Resultado: **404** ao tentar cobrar a partir do título. Link morto desde `7c7a6e5ab` (28/mai/2026). Confirmado em prod biz=1.

## Correção (Onda A — deep-link + prefill)

O botão agora faz `router.visit('/financeiro/cobranca?cobrar_titulo=' + id)`. O `CobrancaController::index` resolve o título **server-side** (Tier 0 scoped, só `tipo=receber`) e devolve a prop `prefill`, que **pré-abre o wizard "Nova cobrança"** já preenchido (tipo=boleto + contato + valor em aberto + vencimento).

### Arquivos
| Arquivo | Mudança |
|---|---|
| `Unificado/Index.tsx` | onClick do "Cobrar" → deep-link (mata o 404) |
| `CobrancaController.php` | prop `prefill` + `resolvePrefill()` (business_id scoped, `whereNull(deleted_at)` via SoftDeletes) |
| `Cobranca/Index.tsx` | aceita `prefill`, auto-abre o wizard |
| `SheetNovaCobranca.tsx` | inicializa estado do `prefill` + carrega `descricao` |
| `cobranca-shared.ts` | tipo `PrefillCobranca` |
| `CobrancaControllerTest.php` | **+3 Pest GUARDs** (prefill OK · sem param → null · **cross-tenant Tier 0 → null**) |
| `Index.charter.md` | Goal + 3 GUARDs + charter_version 2 + histórico |

## Fora de escopo (vira ADR — US-FIN-054 §relacionado)
- **Ponte de mão dupla** título↔cobrança: baixa automática no `fin_titulo` ao pagar, pra **todos os tenants** (hoje o listener só roda biz=1, só no pagamento, com `origem='manual'`).
- **Unificação de credenciais**: `rb_boleto_credentials` vs `fin_contas_bancarias` vs `payment_gateway_credentials` — é o que deixa o "Conta destino" do wizard **vazio** em biz=1 mesmo com Inter vivo. Enquanto não resolvido, o wizard abre preenchido mas a emissão ponta-a-ponta depende de uma conta destino com gateway ativo.

## Validação
- ⚠️ **Pest não rodado localmente** (worktree sem `vendor/`); CI valida (charter-gate + Pest + typecheck).
- ⏳ **Gate visual F3 pendente** — Wagner aprova o screenshot do wizard pré-preenchido antes do merge (ADR 0107/0114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)