### PR TITLE
fix(cliente): abrir a venda via Inertia (Sells/Show estilizada, não partial cru)

### DIFF
--- a/resources/js/Pages/Cliente/_show/SalesTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SalesTab.tsx
@@ -14,7 +14,7 @@
 //    ficava preso no skeleton — as vendas nunca apareciam (fix 2026-06-08).
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { router } from '@inertiajs/react';
+import { Link, router } from '@inertiajs/react';
 import { AlertTriangle, ChevronLeft, ChevronRight, ExternalLink, Filter, Search, ShoppingCart, X } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
@@ -314,14 +314,14 @@ export default function SalesTab({
                       key={s.id}
                       className="border-b border-border hover:bg-muted/40 cursor-pointer select-none"
                       data-testid={`sales-row-${s.id}`}
-                      onDoubleClick={() => { window.location.href = `/sells/${s.id}`; }}
+                      onDoubleClick={() => router.visit(`/sells/${s.id}`)}
                       title="Duplo-clique para abrir a venda"
                     >
                       <td className="px-4 py-2.5 text-xs text-muted-foreground tabular-nums">{formatDate(s.transaction_date)}</td>
                       <td className="px-4 py-2.5">
-                        <a href={`/sells/${s.id}`} className="font-medium text-foreground hover:underline">
+                        <Link href={`/sells/${s.id}`} className="font-medium text-foreground hover:underline">
                           {s.invoice_no}
-                        </a>
+                        </Link>
                         {s.ref_no && <span className="ml-2 text-[10px] text-muted-foreground">({s.ref_no})</span>}
                         {s.location_name && (
                           <div className="text-[10px] text-muted-foreground mt-0.5">{s.location_name}</div>
@@ -339,9 +339,9 @@ export default function SalesTab({
                       </td>
                       <td className="px-4 py-2.5 text-right">
                         <Button variant="ghost" size="sm" asChild>
-                          <a href={`/sells/${s.id}`} aria-label={`Ver venda ${s.invoice_no}`}>
+                          <Link href={`/sells/${s.id}`} aria-label={`Ver venda ${s.invoice_no}`}>
                             <ExternalLink size={14} />
-                          </a>
+                          </Link>
                         </Button>
                       </td>
                     </tr>

--- a/tests/Feature/Cliente/Show/SalesTabTest.php
+++ b/tests/Feature/Cliente/Show/SalesTabTest.php
@@ -105,7 +105,23 @@ test('SalesTab.tsx — duplo-clique na linha abre a venda', function () {
     $contents = file_get_contents($tsxPath);
 
     expect($contents)
-        ->toContain('onDoubleClick={() => { window.location.href = `/sells/${s.id}`; }}')
+        ->toContain('onDoubleClick={() => router.visit(`/sells/${s.id}`)}')
         ->toContain('cursor-pointer')
         ->toContain('Duplo-clique para abrir a venda');
+});
+
+test('SalesTab.tsx — abre a venda via Inertia (X-Inertia → Sells/Show estilizada), não <a> cru', function () {
+    // SellController@show só renderiza a tela moderna Sells/Show quando há header
+    // X-Inertia; `<a href>`/window.location caem no partial Blade legado cru.
+    // Por isso link da fatura + ícone Ações + duplo-clique usam navegação Inertia.
+    $tsxPath = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/SalesTab.tsx';
+    $contents = file_get_contents($tsxPath);
+
+    expect($contents)
+        ->toContain("import { Link, router } from '@inertiajs/react'")
+        ->toContain('<Link href={`/sells/${s.id}`}')
+        ->toContain('router.visit(`/sells/${s.id}`)')
+        // Não pode voltar pro <a href> cru nem window.location (partial feio).
+        ->not->toContain('<a href={`/sells/${s.id}`}')
+        ->not->toContain('window.location.href = `/sells/${s.id}`');
 });


### PR DESCRIPTION
## Sintoma (Wagner)
> ficou uma merda

Ao abrir a venda pela aba Vendas do cadastro de cliente, caía num **partial Blade legado sem CSS/layout** (texto preto cru) em vez da tela de venda estilizada.

## Causa raiz
`SellController@show` (linha ~2390) só renderiza a tela moderna `Sells/Show` quando a requisição tem o header **`X-Inertia`**:
```php
if (request()->header('X-Inertia')) {
    return Inertia::render('Sells/Show', ...);  // tela bonita
}
// senão → cai no partial Blade legado cru
```
O link do nº da fatura (`<a href>`) e o duplo-clique (`window.location.href`) faziam navegação **full-page sem o header** → fallback Blade cru.

## Fix
Navegação via **Inertia** (envia `X-Inertia` → abre `Sells/Show`):
- Nº da fatura: `<a href>` → `<Link href>`
- Ícone "Ações": `<a href>` → `<Link href>`
- Duplo-clique na linha: `window.location.href` → `router.visit`

## Validação local
- `tsc`: zero erro novo em SalesTab (incl. `<Link>` dentro de `<Button asChild>`)
- `eslint`: 4 err + 4 warn = **idêntico ao baseline** · cor-crua = 32 inalterado
- `php -l` no teste: ok · guard novo trava regressão pro `<a>`/window.location

## Pós-deploy
Confirmar no drawer: abrir cliente com vendas → Vendas → clicar/duplo-clique numa venda deve abrir a `Sells/Show` estilizada (não o texto cru).

🤖 Generated with [Claude Code](https://claude.com/claude-code)