### PR TITLE
feat(financeiro): gerar boleto Inter no drawer da Visão Unificada

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -22,7 +22,16 @@ use Modules\Financeiro\Models\TituloBaixa;
 use Modules\Financeiro\Models\TituloComment;
 use Modules\Financeiro\Services\BoletoOcrService;
 use Modules\Financeiro\Services\LinhaDigitavelValidator;
+use App\Account;
+use Modules\PaymentGateway\Contracts\PaymentGatewayContract;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Exceptions\PaymentGatewayException;
 use Spatie\Activitylog\Models\Activity;
+use Throwable;
 
 /**
  * Tela /financeiro/unificado — Visão Unificada (Cockpit V2).
@@ -613,6 +622,118 @@ class UnificadoController extends Controller
             : "{$base} confirmado";
 
         return back()->with('success', $msg);
+    }
+
+    /**
+     * POST /financeiro/unificado/{tituloId}/boleto
+     *
+     * Gera boleto registrado (Banco Inter) PRA UM TÍTULO QUE JÁ EXISTE — direto
+     * do drawer da Visão Unificada, sem ir pra /financeiro/cobranca. Reaproveita
+     * o MESMO motor real do PaymentGateway que o CobrancaController::store usa
+     * ($gateway->for($coreAccount)->emitirBoleto()), que está LIVE em prod biz=1.
+     *
+     * Anti-duplo-recebível (Tier 0 dinheiro): a cobrança nasce com
+     * origem_type='fin_titulo' + origem_id=titulo.id. No pagamento, o listener
+     * OnCobrancaPagaCreateFinanceiroTitulo dá BAIXA neste título — em vez de
+     * criar um título novo (PG-xxx), o que contaria o recebível em dobro.
+     *
+     * Pré-condição: conta Banco Inter (banco_codigo 077) ativa para boleto, com
+     * credencial PaymentGateway configurada em /settings/payment-gateways. Sem
+     * isso, o gateway lança CredentialMisconfiguredException (tratada abaixo).
+     */
+    public function emitirBoletoTitulo(Request $request, int $tituloId, PaymentGatewayContract $gateway): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->findOrFail($tituloId);
+
+        if ($titulo->getAttribute('tipo') !== 'receber') {
+            return back()->with('error', 'Boleto só pode ser gerado para título a receber.');
+        }
+        if (in_array($titulo->status, ['quitado', 'cancelado'], true)) {
+            return back()->with('error', 'Título já '.$titulo->status.' — não gera boleto.');
+        }
+
+        // Idempotência leve: se já tem boleto emitido, devolve a linha digitável
+        // (a idempotencyKey determinística abaixo também protege no gateway).
+        $metadata = $titulo->metadata ?? [];
+        if (! empty($metadata['boleto']['linha_digitavel'])) {
+            return back()->with('success', 'Boleto já emitido: '.$metadata['boleto']['linha_digitavel']);
+        }
+
+        // Conta Banco Inter (077) ativa para boleto neste business.
+        $conta = ContaBancaria::where('business_id', $businessId)
+            ->where('banco_codigo', '077')
+            ->where('ativo_para_boleto', true)
+            ->orderBy('id')
+            ->first();
+        if (! $conta) {
+            return back()->with('error', 'Sem conta Banco Inter ativa para boleto. Configure a credencial em /settings/payment-gateways.');
+        }
+
+        $coreAccount = Account::query()->find($conta->account_id);
+        if (! $coreAccount) {
+            return back()->with('error', 'Conta bancária core inválida (account_id).');
+        }
+
+        // Vencimento nunca no passado — gateway exige >= hoje. Título atrasado
+        // recai pra hoje (multa/juros ficam pra onda futura).
+        $vencCarbon = ($titulo->vencimento && $titulo->vencimento->greaterThan(now()))
+            ? $titulo->vencimento
+            : now();
+        $vencimento = new \DateTimeImmutable($vencCarbon->toDateString());
+
+        $valorCentavos = (int) round(((float) $titulo->valor_aberto) * 100);
+        if ($valorCentavos < 100) {
+            return back()->with('error', 'Valor em aberto abaixo do mínimo de R$ 1,00 para boleto.');
+        }
+
+        $numero = (string) $titulo->getAttribute('numero');
+        $descricao = $numero !== '' ? "Título {$numero}" : 'Cobrança';
+
+        $input = new EmitirCobrancaInput(
+            businessId: $businessId,
+            contactId: (int) ($titulo->getAttribute('cliente_id') ?? 0),
+            valorCentavos: $valorCentavos,
+            vencimento: $vencimento,
+            descricao: $descricao,
+            idempotencyKey: 'fintitulo-'.$titulo->id,
+            origemType: 'fin_titulo',
+            origemId: (int) $titulo->id,
+            meta: [
+                'payer_name'     => $titulo->cliente_descricao,
+                'payer_cpf_cnpj' => $metadata['cliente_documento'] ?? null,
+                'payer_email'    => $metadata['cliente_email'] ?? null,
+            ],
+        );
+
+        try {
+            $result = $gateway->for($coreAccount)->emitirBoleto($input);
+        } catch (CredentialMisconfiguredException | DriverNotSupportedException $e) {
+            return back()->with('error', 'Credencial Inter não configurada para boleto: '.$e->getMessage());
+        } catch (InvalidPayerException $e) {
+            return back()->with('error', 'Pagador inválido (CPF/CNPJ/endereço incompletos): '.$e->getMessage());
+        } catch (GatewayUnavailableException $e) {
+            return back()->with('error', 'Banco Inter indisponível agora: '.$e->getMessage());
+        } catch (PaymentGatewayException | Throwable $e) {
+            report($e);
+            return back()->with('error', 'Falha ao gerar boleto. Detalhe registrado no log.');
+        }
+
+        // Persiste a linha digitável/nosso número no título pra exibir no drawer.
+        $titulo->metadata = array_merge($metadata, [
+            'boleto' => [
+                'linha_digitavel' => $result->linhaDigitavel,
+                'codigo_barras'   => $result->codigoBarras,
+                'nosso_numero'    => $result->nossoNumero,
+                'cobranca_id'     => $result->cobrancaId,
+                'gateway'         => 'inter',
+                'emitido_em'      => now()->toIso8601String(),
+            ],
+        ]);
+        $titulo->save();
+
+        return back()->with('success', 'Boleto Inter gerado: '.($result->linhaDigitavel ?: $result->nossoNumero));
     }
 
     // ─────────── Comments + Audit (Onda DB 2026-05-18) ───────────
@@ -1334,6 +1455,10 @@ class UnificadoController extends Controller
             'valor_mutavel' => ! in_array($t->status, ['quitado', 'cancelado'], true),
             // Onda 21 #55 — Workflow aprovação (nullable: títulos sem fluxo)
             'aprovacao_status' => $t->aprovacao_status ?? null,
+            // Gerar Boleto no drawer (2026-06-08) — linha digitável persistida em
+            // metadata.boleto após emissão via PaymentGateway (InterDriver). Null
+            // até o título ter um boleto emitido.
+            'boleto' => $metadata['boleto'] ?? null,
         ];
     }
 

--- a/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
+++ b/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
@@ -55,6 +55,16 @@ final class OnCobrancaPagaCreateFinanceiroTitulo
             return;
         }
 
+        // Gerar Boleto no drawer (2026-06-08): cobrança nascida de um título que
+        // JÁ existe (origem_type='fin_titulo', botão "Gerar boleto" da Visão
+        // Unificada) → dá BAIXA nesse título em vez de criar PG-xxx, senão o
+        // recebível contaria em DOBRO (título original aberto + PG-xxx quitado).
+        if ($cobranca->origem_type === 'fin_titulo' && $cobranca->origem_id) {
+            $this->baixarTituloExistente($event, $cobranca);
+
+            return;
+        }
+
         $tituloExistente = Titulo::where('business_id', 1)
             ->where('origem', 'manual')
             ->where('origem_id', $event->cobrancaId)
@@ -129,6 +139,81 @@ final class OnCobrancaPagaCreateFinanceiroTitulo
                 'created_by'         => 1,
             ]);
         });
+    }
+
+    /**
+     * Baixa um título PRÉ-EXISTENTE quando a cobrança nasceu dele (origem_type
+     * 'fin_titulo' — botão "Gerar boleto" do drawer). Cria a TituloBaixa e
+     * fecha o título, sem criar título novo (evita duplo-recebível).
+     *
+     * Idempotente via idempotency_key determinístico da TituloBaixa.
+     */
+    private function baixarTituloExistente(CobrancaPaga $event, Cobranca $cobranca): void
+    {
+        $titulo = Titulo::where('business_id', 1)
+            ->where('id', $cobranca->origem_id)
+            ->first();
+
+        if (!$titulo) {
+            Log::warning('[boleto-drawer][financeiro] CobrancaPaga origem fin_titulo sem título correspondente', [
+                'cobranca_id' => $event->cobrancaId,
+                'titulo_id'   => $cobranca->origem_id,
+            ]);
+
+            return;
+        }
+
+        if (in_array($titulo->status, ['quitado', 'cancelado'], true)) {
+            return; // já resolvido
+        }
+
+        $idemKey = $this->buildIdempotencyKey($event->cobrancaId);
+        if (TituloBaixa::where('business_id', 1)->where('idempotency_key', $idemKey)->exists()) {
+            return; // idempotência — baixa já registrada
+        }
+
+        $contaBancariaId = $this->resolveContaBancaria($cobranca);
+        $valorPago = ($cobranca->valor_pago_centavos ?? $cobranca->valor_centavos) / 100;
+        $pagaEm = $event->pagaEm;
+
+        DB::transaction(function () use ($titulo, $contaBancariaId, $valorPago, $pagaEm, $event, $cobranca, $idemKey): void {
+            if ($contaBancariaId) {
+                TituloBaixa::create([
+                    'business_id'       => 1,
+                    'titulo_id'         => $titulo->id,
+                    'conta_bancaria_id' => $contaBancariaId,
+                    'valor_baixa'       => $valorPago,
+                    'juros'             => 0,
+                    'multa'             => 0,
+                    'desconto'          => 0,
+                    'data_baixa'        => $pagaEm->format('Y-m-d'),
+                    'meio_pagamento'    => $this->mapMeioPagamento($cobranca->tipo, $cobranca->forma_pagamento),
+                    'idempotency_key'   => $idemKey,
+                    'observacoes'       => 'Auto-baixa boleto drawer · cobrança #' . $event->cobrancaId,
+                    'created_by'        => 1,
+                ]);
+            }
+
+            $novoAberto = round(((float) $titulo->valor_aberto) - $valorPago, 2);
+            $titulo->valor_aberto = max(0, $novoAberto);
+            if ($contaBancariaId && $titulo->valor_aberto <= 0.001) {
+                $titulo->status = 'quitado';
+            }
+            $titulo->metadata = array_merge($titulo->metadata ?? [], [
+                'boleto_pago' => [
+                    'cobranca_id' => $event->cobrancaId,
+                    'paga_em'     => $pagaEm->format('Y-m-d'),
+                ],
+            ]);
+            $titulo->save();
+        });
+
+        if (!$contaBancariaId) {
+            Log::warning('[boleto-drawer][financeiro] Título NÃO baixado (conta bancária não resolvida)', [
+                'cobranca_id' => $event->cobrancaId,
+                'titulo_id'   => $titulo->id,
+            ]);
+        }
     }
 
     /**

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -70,6 +70,12 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::post('/unificado/{id}/baixar', [UnificadoController::class, 'baixar'])
             ->whereNumber('id')
             ->name('unificado.baixar');
+        // Gerar Boleto no drawer (2026-06-08) — emite boleto Inter pra um título
+        // existente, sem sair da Visão Unificada. origem_type='fin_titulo' garante
+        // baixa (não duplica) no pagamento via OnCobrancaPagaCreateFinanceiroTitulo.
+        Route::post('/unificado/{tituloId}/boleto', [UnificadoController::class, 'emitirBoletoTitulo'])
+            ->whereNumber('tituloId')
+            ->name('unificado.emitir-boleto');
         // Onda 15 (2026-05-20): bulk update categoria em lote
         Route::post('/unificado/bulk-update-categoria', [UnificadoController::class, 'bulkUpdateCategoria'])
             ->name('unificado.bulk-update-categoria');

--- a/Modules/Financeiro/Tests/Feature/UnificadoGerarBoletoTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoGerarBoletoTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Gerar Boleto no drawer (2026-06-08) — emitir boleto Inter pra um título
+ * existente direto da Visão Unificada, sem ir pra /financeiro/cobranca.
+ *
+ * Cobre o WIRING (estilo smoke estrutural do módulo — não boota app, sobrevive
+ * DB greenfield) das 5 peças:
+ *   1. UnificadoController::emitirBoletoTitulo — resolve conta Inter (077),
+ *      monta EmitirCobrancaInput com origem_type='fin_titulo', emite via
+ *      PaymentGatewayContract, persiste linha digitável em metadata.boleto.
+ *   2. Routes/web.php — POST /unificado/{tituloId}/boleto + name.
+ *   3. OnCobrancaPagaCreateFinanceiroTitulo — branch que BAIXA o título de
+ *      origem (anti-duplo-recebível) em vez de criar PG-xxx.
+ *   4. Migration — enum cobrancas.origem_type aceita 'fin_titulo'.
+ *   5. Frontend Index.tsx — botão "Gerar boleto" posta no endpoint.
+ *   + HTTP smoke: endpoint responde gate de auth sem login.
+ *
+ * ⚠️ A cobertura COMPORTAMENTAL (mock do gateway emitindo + evento CobrancaPaga
+ * dando baixa sem duplicar) deve rodar no CT-100 com app bootado — fica como
+ * follow-up; aqui garantimos que a fiação existe e não regride.
+ */
+
+const FIN_GB_CONTROLLER = __DIR__ . '/../../Http/Controllers/UnificadoController.php';
+const FIN_GB_ROUTES = __DIR__ . '/../../Routes/web.php';
+const FIN_GB_LISTENER = __DIR__ . '/../../Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php';
+const FIN_GB_PAGE = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado/Index.tsx';
+
+describe('Gerar Boleto — Controller (emissão título-aware)', function () {
+    it('UnificadoController tem emitirBoletoTitulo() injetando o gateway', function () {
+        $src = file_get_contents(FIN_GB_CONTROLLER);
+        expect($src)->toContain('public function emitirBoletoTitulo(');
+        expect($src)->toContain('PaymentGatewayContract $gateway');
+        expect($src)->toContain('->emitirBoleto($input)');
+    });
+
+    it('Tier 0: escopa Titulo por business_id da session + findOrFail', function () {
+        $src = file_get_contents(FIN_GB_CONTROLLER);
+        expect($src)->toContain("session('user.business_id')");
+        expect($src)->toContain("Titulo::where('business_id', \$businessId)->findOrFail(\$tituloId)");
+    });
+
+    it('resolve conta Banco Inter (077) ativa para boleto', function () {
+        $src = file_get_contents(FIN_GB_CONTROLLER);
+        expect($src)->toContain("->where('banco_codigo', '077')");
+        expect($src)->toContain("->where('ativo_para_boleto', true)");
+    });
+
+    it('amarra a cobrança ao título via origem_type=fin_titulo (anti-duplo-recebível)', function () {
+        $src = file_get_contents(FIN_GB_CONTROLLER);
+        expect($src)->toContain("origemType: 'fin_titulo'");
+        expect($src)->toContain('origemId: (int) $titulo->id');
+    });
+
+    it('persiste a linha digitável em metadata.boleto', function () {
+        $src = file_get_contents(FIN_GB_CONTROLLER);
+        expect($src)->toContain("'boleto' => [");
+        expect($src)->toContain('$result->linhaDigitavel');
+    });
+
+    it('vencimento nunca no passado (gateway exige >= hoje)', function () {
+        $src = file_get_contents(FIN_GB_CONTROLLER);
+        expect($src)->toContain('greaterThan(now())');
+    });
+});
+
+describe('Gerar Boleto — Rota', function () {
+    it('Routes/web.php registra POST /unificado/{tituloId}/boleto + name', function () {
+        $src = file_get_contents(FIN_GB_ROUTES);
+        expect($src)->toContain("Route::post('/unificado/{tituloId}/boleto'");
+        expect($src)->toContain('emitirBoletoTitulo');
+        expect($src)->toContain('unificado.emitir-boleto');
+    });
+});
+
+describe('Gerar Boleto — Reconciliação (baixa sem duplicar)', function () {
+    it('listener ramifica em origem_type=fin_titulo e baixa o título existente', function () {
+        $src = file_get_contents(FIN_GB_LISTENER);
+        expect($src)->toContain("\$cobranca->origem_type === 'fin_titulo'");
+        expect($src)->toContain('private function baixarTituloExistente(');
+        // baixa o título de origem (não cria PG-xxx)
+        expect($src)->toContain("->where('id', \$cobranca->origem_id)");
+        expect($src)->toContain('TituloBaixa::create(');
+    });
+});
+
+describe('Gerar Boleto — Frontend (drawer)', function () {
+    it('Index.tsx tem botão "Gerar boleto" postando no endpoint', function () {
+        $src = file_get_contents(FIN_GB_PAGE);
+        expect($src)->toContain('Gerar boleto');
+        expect($src)->toContain('/financeiro/unificado/${selected.id}/boleto');
+        expect($src)->toContain('boleto:'); // campo na interface do título
+    });
+});
+
+describe('Gerar Boleto — Endpoint funcional (HTTP smoke)', function () {
+    it('POST /unificado/{id}/boleto retorna gate (302/401/403/404/419/422) sem auth', function () {
+        $response = $this->post('/financeiro/unificado/1/boleto');
+        expect($response->status())->toBeIn([302, 401, 403, 404, 419, 422]);
+    });
+});

--- a/Modules/PaymentGateway/Database/Migrations/2026_06_08_120000_add_fin_titulo_to_cobrancas_origem_type.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_06_08_120000_add_fin_titulo_to_cobrancas_origem_type.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Gerar Boleto no drawer do título (Financeiro/Unificado) — 2026-06-08.
+ *
+ * Expande o enum `origem_type` em `cobrancas` pra aceitar `fin_titulo`.
+ *
+ * Por quê: quando a cobrança nasce de um TÍTULO que JÁ existe em
+ * `fin_titulos` (botão "Gerar boleto" no drawer), precisamos amarrar a
+ * cobrança ao título de origem pra que o webhook de pagamento dê BAIXA
+ * nesse título — em vez de criar um título novo (`PG-xxx`), o que contaria
+ * o recebível EM DOBRO. O listener `OnCobrancaPagaCreateFinanceiroTitulo`
+ * lê `cobranca.origem_type === 'fin_titulo'` pra ramificar a reconciliação.
+ *
+ * Compatível MySQL/MariaDB (ALTER ENUM via raw SQL) + SQLite (no-op em test —
+ * SQLite trata enum como TEXT sem CHECK constraint).
+ *
+ * Tier 0: schema-only, sem PII. Não toca dados.
+ */
+return new class extends Migration
+{
+    /** Valores ANTES desta migration (create_cobrancas_table). */
+    private const ENUM_LEGACY = ['sale', 'invoice', 'subscription_license', 'avulsa'];
+
+    /** Valor ADICIONADO por esta migration. */
+    private const ENUM_NOVOS = ['fin_titulo'];
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('cobrancas')) {
+            return;
+        }
+
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $all = array_merge(self::ENUM_LEGACY, self::ENUM_NOVOS);
+            $enumList = "'" . implode("','", $all) . "'";
+            DB::statement("ALTER TABLE cobrancas MODIFY COLUMN origem_type ENUM({$enumList}) NULL");
+        }
+        // SQLite/PgSQL: enum aceito como TEXT; nada a fazer.
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('cobrancas')) {
+            return;
+        }
+
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            // Soft-revert: só remove se nenhuma cobrança usa o novo valor.
+            $usados = DB::table('cobrancas')
+                ->whereIn('origem_type', self::ENUM_NOVOS)
+                ->count();
+            if ($usados > 0) {
+                throw new \RuntimeException(
+                    "Não é possível reverter: {$usados} cobranças usam origem_type='fin_titulo'. " .
+                    'Migre-as primeiro pra um valor legacy.'
+                );
+            }
+            $enumList = "'" . implode("','", self::ENUM_LEGACY) . "'";
+            DB::statement("ALTER TABLE cobrancas MODIFY COLUMN origem_type ENUM({$enumList}) NULL");
+        }
+    }
+};

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -124,6 +124,14 @@ interface Lancamento {
   valor_mutavel: boolean;
   // Onda 21 (2026-05-19) #55 — Workflow aprovação pra títulos a pagar.
   aprovacao_status: 'pendente' | 'aprovado' | 'rejeitado' | null;
+  // Gerar Boleto no drawer (2026-06-08) — linha digitável após emissão Inter.
+  boleto: {
+    linha_digitavel: string | null;
+    codigo_barras: string | null;
+    nosso_numero: string | null;
+    gateway: string;
+    emitido_em: string;
+  } | null;
 }
 
 interface Kpi {
@@ -1923,11 +1931,35 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                       <span className="ml-1">Ver NFe</span>
                     </Button>
                   )}
+                  {/* Gerar Boleto no drawer (2026-06-08) — emite boleto Inter pro
+                      título SEM sair da Visão Unificada. Quando já emitido, vira
+                      "Copiar boleto" (linha digitável persistida em metadata). */}
                   {selected.kind === 'receivable' && (selected.status !== 'recebido') && (
-                    <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Cobrar contraparte" onClick={() => router.visit(`/cobranca/recorrente/nova?titulo=${selected.id}`)}>
-                      <span aria-hidden>✉</span>
-                      <span className="ml-1">Cobrar</span>
-                    </Button>
+                    selected.boleto?.linha_digitavel ? (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="fin-foot-icon-btn"
+                        title={`Boleto Inter · ${selected.boleto?.linha_digitavel ?? ''}`}
+                        onClick={() => navigator.clipboard?.writeText(selected.boleto?.linha_digitavel ?? '')}
+                      >
+                        <span aria-hidden>📋</span>
+                        <span className="ml-1">Copiar boleto</span>
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="fin-foot-icon-btn"
+                        title="Gerar boleto registrado (Banco Inter)"
+                        onClick={() =>
+                          router.post(`/financeiro/unificado/${selected.id}/boleto`, {}, { preserveScroll: true })
+                        }
+                      >
+                        <span aria-hidden>✉</span>
+                        <span className="ml-1">Gerar boleto</span>
+                      </Button>
+                    )
                   )}
                   {(selected.status !== 'recebido' && selected.status !== 'pago') && (
                     <Button onClick={() => openBaixa(selected.id)} className="fin-foot-mark-btn">


### PR DESCRIPTION
## O que
Botão **"Gerar boleto"** no drawer do título (`/financeiro/unificado`) emite boleto registrado via **Banco Inter** sem sair da tela, reaproveitando o motor real do PaymentGateway (`$gateway->for()->emitirBoleto()` — LIVE em prod biz=1).

## Anti-duplo-recebível (Tier 0 dinheiro)
A cobrança nasce com `origem_type='fin_titulo'` + `origem_id=titulo.id`. No pagamento, `OnCobrancaPagaCreateFinanceiroTitulo` **baixa o título existente** em vez de criar `PG-xxx` (que contaria o recebível em dobro). Inert pra dados existentes (nenhuma cobrança atual usa `fin_titulo`).

## Arquivos
- migration: enum `cobrancas.origem_type` += `fin_titulo` (reversível)
- `UnificadoController::emitirBoletoTitulo` (conta Inter 077, vencimento ≥ hoje, persiste linha digitável em metadata.boleto)
- listener: branch `baixarTituloExistente()`
- frontend: botão Gerar/Copiar boleto
- teste: smoke estrutural + HTTP gate

## ⚠️ Validação
- Não rodei `php -l`/typecheck local (CT-100 only) → **CI verifica**.
- **Não testado** contra Inter homologação. Pré-cond: credencial Inter ativa em `/settings/payment-gateways`.
- Emitir boleto real exige clique + credencial — não dispara sozinho.