### PR TITLE
chore(financeiro): biz=99 tenant de teste; demo seeder para de gravar em biz=1 (real)

### DIFF
--- a/.github/workflows/create-test-business.yml
+++ b/.github/workflows/create-test-business.yml
@@ -1,0 +1,77 @@
+name: Create Test Business (biz 99 · one-shot)
+
+# Workflow_dispatch dedicado pra criar o tenant de TESTE (biz=99) no Hostinger,
+# rodando `TestBusinessSeeder` via via canônica (BusinessUtil::createNewBusiness).
+#
+# Contexto: biz=1 (WR2 Sistemas) virou DADOS REAIS (2026-06-08). Dado de teste/
+# demo migra pro tenant dedicado (test_business_id=99). Idempotente: não faz nada
+# se o business já existir.
+#
+# Mesmo padrão do run-financeiro-demo-seeder.yml (FQCN entre aspas simples).
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Digite CRIAR pra confirmar a criação do tenant de teste'
+        required: true
+        default: ''
+        type: string
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  create:
+    name: Create test business (TestBusinessSeeder)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ inputs.confirm == 'CRIAR' }}
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: SSH helper
+        run: |
+          cat > /tmp/ssh_exec.sh <<'EOF'
+          #!/bin/bash
+          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=20 \
+              ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+              "$@"
+          EOF
+          chmod +x /tmp/ssh_exec.sh
+
+      - name: Pre-run check
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan --version &&
+            ls -la database/seeders/TestBusinessSeeder.php
+          "
+
+      - name: Run seeder
+        # FQCN entre aspas simples ao redor do --class — bash preserva backslash literais.
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan db:seed --class='Database\Seeders\TestBusinessSeeder' --force 2>&1 | tail -30
+          "
+
+      - name: Verify business
+        # Reporta o id REAL criado (pode != 99 se o AUTO_INCREMENT já passou). Se
+        # diferente, setar TEST_BUSINESS_ID pro id mostrado aqui.
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan tinker --execute=\"\\\$b = \App\Business::where('name','LIKE','TESTE%')->orderByDesc('id')->first(); echo 'Test business: id=' . (\\\$b->id ?? 'NENHUM') . ' name=' . (\\\$b->name ?? '-');\"
+          "
+
+      - name: Done
+        run: echo "TestBusinessSeeder concluido. Conferir o id acima e ajustar TEST_BUSINESS_ID se != 99."

--- a/.github/workflows/run-financeiro-demo-seeder.yml
+++ b/.github/workflows/run-financeiro-demo-seeder.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
     inputs:
       biz_id:
-        description: 'business_id alvo (1=WR2 Sistemas, 4=ROTA LIVRE — CUIDADO biz=4 é prod)'
+        description: 'business_id alvo de TESTE (99=TESTE · 1=WR2 e 4=ROTA LIVRE são REAIS — seeder recusa)'
         required: true
-        default: '1'
+        default: '99'
         type: string
 
 concurrency:

--- a/Modules/Financeiro/Database/Seeders/FinanceiroDemoSeeder.php
+++ b/Modules/Financeiro/Database/Seeders/FinanceiroDemoSeeder.php
@@ -40,11 +40,29 @@ class FinanceiroDemoSeeder extends Seeder
 
     public function run(): void
     {
-        $businessId = (int) (env('BIZ_ID') ?? 1);
+        // Alvo default = test_business_id (99). biz=1 (WR2 Sistemas) passou a ter
+        // DADOS REAIS em 2026-06-08 — demo seeder não grava mais nele por default.
+        $businessId = (int) (env('BIZ_ID') ?? config('app.test_business_id', 99));
+
+        // Fail-safe anti-poluição (Tier 0): RECUSA gravar demo em tenant REAL/
+        // protegido (biz=1 WR2, biz=4 ROTA LIVRE…). Override consciente só com
+        // ALLOW_DEMO_ON_PROTECTED=1 (NÃO recomendado — risco de poluir dado real).
+        $protected = (array) config('app.protected_business_ids', [1, 4]);
+        if (in_array($businessId, $protected, true) && env('ALLOW_DEMO_ON_PROTECTED') != '1') {
+            $this->command->error(
+                "RECUSADO: business_id={$businessId} tem DADOS REAIS (protected_business_ids). ".
+                'Demo seeder não grava em tenant real. Use BIZ_ID=99 (test_business_id). '.
+                'Forçar mesmo assim: ALLOW_DEMO_ON_PROTECTED=1 (NÃO recomendado).'
+            );
+
+            return;
+        }
+
         $createdBy = $this->resolveCreatedBy($businessId);
 
         if (! $createdBy) {
             $this->command->error("Nenhum user encontrado pra business_id={$businessId}. Abort.");
+
             return;
         }
 

--- a/Modules/Financeiro/Tests/Feature/DemoSeederProtectsRealBusinessTest.php
+++ b/Modules/Financeiro/Tests/Feature/DemoSeederProtectsRealBusinessTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * biz=1 virou REAL (2026-06-08) — dado de teste/demo vai pra biz=99.
+ *
+ * Smoke estrutural (não boota app, sobrevive DB greenfield) garantindo que:
+ *   - config canon test_business_id (99) + protected_business_ids ([1,4]) existem
+ *   - FinanceiroDemoSeeder usa test_business_id por default e RECUSA tenant protegido
+ *   - workflow run-financeiro-demo-seeder default = 99
+ *   - TestBusinessSeeder existe e cria via via canônica (createNewBusiness)
+ */
+
+const DEMO_SEEDER = __DIR__ . '/../../Database/Seeders/FinanceiroDemoSeeder.php';
+const APP_CONFIG = __DIR__ . '/../../../../config/app.php';
+const SEED_WORKFLOW = __DIR__ . '/../../../../.github/workflows/run-financeiro-demo-seeder.yml';
+const TEST_BIZ_SEEDER = __DIR__ . '/../../../../database/seeders/TestBusinessSeeder.php';
+
+describe('Config canon de tenant de teste', function () {
+    it('config/app.php define test_business_id e protected_business_ids', function () {
+        $src = file_get_contents(APP_CONFIG);
+        expect($src)->toContain("'test_business_id'");
+        expect($src)->toContain("'protected_business_ids'");
+    });
+
+    it('config carrega com defaults 99 e [1,4]', function () {
+        expect((int) config('app.test_business_id'))->toBe(99);
+        expect(config('app.protected_business_ids'))->toContain(1);
+    });
+});
+
+describe('FinanceiroDemoSeeder não polui tenant real', function () {
+    it('default = test_business_id (não mais 1)', function () {
+        $src = file_get_contents(DEMO_SEEDER);
+        expect($src)->toContain("config('app.test_business_id'");
+        expect($src)->not->toContain("env('BIZ_ID') ?? 1");
+    });
+
+    it('recusa gravar em tenant protegido (guard)', function () {
+        $src = file_get_contents(DEMO_SEEDER);
+        expect($src)->toContain("config('app.protected_business_ids'");
+        expect($src)->toContain('RECUSADO');
+    });
+});
+
+describe('Workflow + seeder de tenant de teste', function () {
+    it('workflow default biz_id = 99', function () {
+        $src = file_get_contents(SEED_WORKFLOW);
+        expect($src)->toContain("default: '99'");
+    });
+
+    it('TestBusinessSeeder cria via createNewBusiness (via canônica)', function () {
+        $src = file_get_contents(TEST_BIZ_SEEDER);
+        expect($src)->toContain('createNewBusiness(');
+        expect($src)->toContain("config('app.test_business_id'");
+    });
+});

--- a/config/app.php
+++ b/config/app.php
@@ -249,4 +249,23 @@ return [
     |
     */
     'saas_owner_business_id' => (int) env('SAAS_OWNER_BUSINESS_ID', 1),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Test / demo business
+    |--------------------------------------------------------------------------
+    |
+    | Tenant DEDICADO a dados de teste/demo (seeders, smoke, dogfooding de QA).
+    | A partir de 2026-06-08 biz=1 (WR2 Sistemas) passou a ter DADOS REAIS — então
+    | seeders de demo NÃO podem mais gravar nele. O alvo canônico de demo é o
+    | `test_business_id` (99). `protected_business_ids` são tenants REAIS que os
+    | seeders de demo devem RECUSAR (fail-safe anti-poluição de dado real).
+    |
+    */
+    'test_business_id' => (int) env('TEST_BUSINESS_ID', 99),
+
+    'protected_business_ids' => array_values(array_filter(array_map(
+        'intval',
+        explode(',', (string) env('PROTECTED_BUSINESS_IDS', '1,4'))
+    ))),
 ];

--- a/database/seeders/TestBusinessSeeder.php
+++ b/database/seeders/TestBusinessSeeder.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Business;
+use App\Currency;
+use App\User;
+use App\Utils\BusinessUtil;
+use App\Utils\ModuleUtil;
+use Carbon\Carbon;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+
+/**
+ * Cria o tenant DEDICADO de TESTE (biz de QA/demo) — 2026-06-08.
+ *
+ * Contexto: biz=1 (WR2 Sistemas) passou a ter DADOS REAIS. Todo dado de
+ * teste/demo deve ir pra um tenant separado — alvo canônico `test_business_id`
+ * (99, config/app.php). Este seeder provisiona esse tenant pela MESMA via que
+ * o registro real usa (BusinessUtil::createNewBusiness + newBusinessDefaultResources
+ * + addLocation), pra nascer com currency/location/permissions/recursos default
+ * corretos — sem hand-roll frágil.
+ *
+ * Idempotente: se já existe um business com id = test_business_id, não faz nada.
+ *
+ * ⚠️ PK exato = 99: o id é AUTO_INCREMENT — `createNewBusiness` NÃO força id.
+ * Se quiser o id literal 99, o ambiente precisa ter a sequence livre OU criar
+ * via Superadmin/DBA. Este seeder cria o tenant e REPORTA o id resultante;
+ * aponte `TEST_BUSINESS_ID` (env) pra ele se for diferente de 99.
+ *
+ * Rodar (CT-100 / Hostinger — NUNCA toca tenant real):
+ *   php artisan db:seed --class='Database\Seeders\TestBusinessSeeder' --force
+ */
+class TestBusinessSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $targetId = (int) config('app.test_business_id', 99);
+
+        if (Business::find($targetId)) {
+            $this->command->info("Business de teste id={$targetId} já existe — nada a fazer (idempotente).");
+
+            return;
+        }
+
+        $currencyId = optional(Currency::where('code', 'BRL')->first())->id
+            ?? optional(Currency::first())->id;
+
+        if (! $currencyId) {
+            $this->command->error('Nenhuma currency cadastrada — rode o seed base antes.');
+
+            return;
+        }
+
+        /** @var BusinessUtil $businessUtil */
+        $businessUtil = app(BusinessUtil::class);
+        /** @var ModuleUtil $moduleUtil */
+        $moduleUtil = app(ModuleUtil::class);
+
+        $createdId = null;
+
+        DB::transaction(function () use ($businessUtil, $moduleUtil, $currencyId, &$createdId): void {
+            // 1) Owner do tenant de teste (marcado pra ser óbvio que é QA).
+            $owner = User::create_user([
+                'surname'    => 'Sr/Sra',
+                'first_name' => 'Teste',
+                'last_name'  => 'QA',
+                'username'   => 'teste.qa',
+                'email'      => 'teste.qa@oimpresso.local',
+                'password'   => bin2hex(random_bytes(12)), // senha aleatória — login real é via superadmin
+                'language'   => config('app.locale'),
+            ]);
+
+            // 2) Business pela via canônica (mesma do registro real).
+            $businessDetails = [
+                'name'              => 'TESTE — QA (não usar p/ dados reais)',
+                'currency_id'       => $currencyId,
+                'start_date'        => Carbon::now()->toDateString(),
+                'time_zone'         => 'America/Sao_Paulo',
+                'fy_start_month'    => 1,
+                'accounting_method' => 'fifo',
+                'owner_id'          => $owner->id,
+                'enabled_modules'   => ['purchases', 'add_sale', 'pos_sale', 'stock_transfers', 'stock_adjustment', 'expenses'],
+            ];
+
+            $business = $businessUtil->createNewBusiness($businessDetails);
+            $createdId = (int) $business->id;
+
+            $owner->business_id = $business->id;
+            $owner->save();
+
+            // 3) Recursos default + location + permission (igual ao postRegister).
+            $businessUtil->newBusinessDefaultResources($business->id, $owner->id);
+            $location = $businessUtil->addLocation($business->id, [
+                'name'      => 'Matriz Teste',
+                'country'   => 'Brasil',
+                'state'     => 'SP',
+                'city'      => 'São Paulo',
+                'zip_code'  => '00000-000',
+                'landmark'  => 'QA',
+            ]);
+            Permission::firstOrCreate(['name' => 'location.' . $location->id]);
+
+            if (config('app.env') !== 'demo') {
+                $moduleUtil->getModuleData('after_business_created', ['business' => $business]);
+            }
+        });
+
+        $this->command->info("Tenant de teste criado: business_id={$createdId} (owner teste.qa@oimpresso.local).");
+        if ($createdId !== $targetId) {
+            $this->command->warn(
+                "Atenção: id criado ({$createdId}) != TEST_BUSINESS_ID ({$targetId}). " .
+                "Ajuste a env TEST_BUSINESS_ID={$createdId} pra os seeders/guards apontarem certo."
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Por quê
biz=1 (WR2 Sistemas) passou a ter **DADOS REAIS** (2026-06-08). Dado de teste/demo migra pra **biz=99** (`test_business_id`).

## O que
- `config/app.php`: `test_business_id` (env, default 99) + `protected_business_ids` (env, default 1,4)
- `FinanceiroDemoSeeder`: default → `test_business_id`; **guard fail-safe** recusa gravar em tenant protegido (override `ALLOW_DEMO_ON_PROTECTED=1`)
- `run-financeiro-demo-seeder.yml`: input default 1 → **99** + aviso
- `TestBusinessSeeder`: provisiona o tenant de teste via via canônica (`createNewBusiness`), idempotente
- teste: smoke estrutural

## ⚠️ Execução
Criar a biz=99 = rodar `TestBusinessSeeder` no CT-100/Hostinger **ou** via Superadmin UI (recomendado — vê o id real). PK literal=99 depende do AUTO_INCREMENT; senão setar `TEST_BUSINESS_ID` pro id criado.