### PR TITLE
fix(ci): restaura ratchet PHPStan em main (gerar-boleto + demo-seeder)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -26,7 +26,6 @@ use App\Account;
 use Modules\PaymentGateway\Contracts\PaymentGatewayContract;
 use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
 use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
-use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
 use Modules\PaymentGateway\Exceptions\InvalidPayerException;
 use Modules\PaymentGateway\Exceptions\PaymentGatewayException;
@@ -678,7 +677,8 @@ class UnificadoController extends Controller
 
         // Vencimento nunca no passado — gateway exige >= hoje. Título atrasado
         // recai pra hoje (multa/juros ficam pra onda futura).
-        $vencCarbon = ($titulo->vencimento && $titulo->vencimento->greaterThan(now()))
+        // vencimento é cast 'date' (Carbon não-nulo). Atrasado → recai pra hoje.
+        $vencCarbon = $titulo->vencimento->greaterThan(now())
             ? $titulo->vencimento
             : now();
         $vencimento = new \DateTimeImmutable($vencCarbon->toDateString());
@@ -709,7 +709,10 @@ class UnificadoController extends Controller
 
         try {
             $result = $gateway->for($coreAccount)->emitirBoleto($input);
-        } catch (CredentialMisconfiguredException | DriverNotSupportedException $e) {
+        } catch (CredentialMisconfiguredException $e) {
+            // DriverNotSupportedException não chega aqui (Inter suporta boleto); se
+            // chegar via for(), cai no catch Throwable abaixo. Catch específico
+            // removido pra não regredir o ratchet PHPStan (dead catch).
             return back()->with('error', 'Credencial Inter não configurada para boleto: '.$e->getMessage());
         } catch (InvalidPayerException $e) {
             return back()->with('error', 'Pagador inválido (CPF/CNPJ/endereço incompletos): '.$e->getMessage());

--- a/Modules/PaymentGateway/Models/Cobranca.php
+++ b/Modules/PaymentGateway/Models/Cobranca.php
@@ -25,6 +25,11 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * declarado em module.json.lgpd_compliance, retention 5y, redactor habilitado.
  *
  * ADR 0170 Onda 2.
+ *
+ * @property string|null $origem_type Origem (sale|invoice|subscription_license|avulsa|fin_titulo).
+ *           String livre — enum expandido por migration via raw SQL (invisível ao larastan,
+ *           que senão infere o union antigo e marca `=== 'fin_titulo'` como sempre-falso).
+ * @property int|null $origem_id
  */
 class Cobranca extends Model
 {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5493,7 +5493,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 1
+			count: 2
 			path: Modules/Financeiro/Database/Seeders/FinanceiroDemoSeeder.php
 
 		-


### PR DESCRIPTION
Fix-forward: main ficou vermelho no PHPStan/Larastan após #2452 mergear sem o fix de typing + #2453 adicionar 2º env() no demo seeder. 4 erros novos vs baseline bloqueando os PRs de todos. Resolve dead-catch + 2 condições &&-redundantes (typing) + bump baseline do demo seeder (env toggles intencionais). Refs US-FIN-054. 🤖 Generated with [Claude Code](https://claude.com/claude-code)