### PR TITLE
feat(cliente): abas Pagamentos/Pontos/Assinaturas carregam no drawer (self-fetch)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -178,6 +178,187 @@ class ContactController extends Controller
     }
 
     /**
+     * Fix 2026-06-08 — Endpoint JSON dos pagamentos do contato pro PaymentsTab self-fetch.
+     *
+     * O legado GET /contacts/payments/{id} devolve Blade HTML (modal DataTable),
+     * deixando a aba "Pagamentos" do drawer presa em "Aguardando wiring". Este
+     * entrega JSON limpo no shape do `PaymentRow` (PaymentsTab.tsx).
+     *
+     * Multi-tenant Tier 0 (ADR 0093): contato resolvido DENTRO do business +
+     * scope business_id em transaction_payments. PII §LGPD: bank_account_number
+     * mascarado (nunca em claro).
+     *
+     * GET /cliente/{id}/payments-json
+     */
+    public function paymentsJson($id)
+    {
+        if (! auth()->user()->can('customer.view') && ! auth()->user()->can('customer.view_own')
+            && ! auth()->user()->can('supplier.view') && ! auth()->user()->can('supplier.view_own')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        $payments = TransactionPayment::leftJoin('transactions as t', 'transaction_payments.transaction_id', '=', 't.id')
+            ->leftJoin('transaction_payments as parent_payment', 'transaction_payments.parent_id', '=', 'parent_payment.id')
+            ->where('transaction_payments.business_id', $business_id)
+            ->whereNull('transaction_payments.parent_id')
+            ->where('transaction_payments.payment_for', $id)
+            ->select(
+                'transaction_payments.id',
+                'transaction_payments.amount',
+                'transaction_payments.is_return',
+                'transaction_payments.method',
+                'transaction_payments.paid_on',
+                'transaction_payments.payment_ref_no',
+                'transaction_payments.parent_id',
+                't.invoice_no',
+                't.ref_no',
+                't.type as transaction_type',
+                't.id as transaction_id',
+                'transaction_payments.cheque_number',
+                'transaction_payments.card_transaction_number',
+                'transaction_payments.bank_account_number',
+                'parent_payment.payment_ref_no as parent_payment_ref_no',
+            )
+            ->groupBy('transaction_payments.id')
+            ->orderByDesc('transaction_payments.paid_on')
+            ->get()
+            ->map(fn ($p) => [
+                'id' => (int) $p->id,
+                'paid_on' => $p->paid_on ? \Illuminate\Support\Carbon::parse($p->paid_on)->toIso8601String() : null,
+                'payment_ref_no' => (string) ($p->payment_ref_no ?? ''),
+                'parent_payment_ref_no' => $p->parent_payment_ref_no,
+                'amount' => (float) $p->amount,
+                'is_return' => (int) $p->is_return,
+                'method' => (string) ($p->method ?? ''),
+                'invoice_no' => $p->invoice_no,
+                'ref_no' => $p->ref_no,
+                'transaction_id' => $p->transaction_id !== null ? (int) $p->transaction_id : null,
+                'transaction_type' => $p->transaction_type,
+                'cheque_number' => $p->cheque_number,
+                'card_transaction_number' => $p->card_transaction_number,
+                // PII (ADR 0093 §LGPD): nunca devolver número de conta em claro.
+                'bank_account_number' => $p->bank_account_number
+                    ? '****' . substr((string) $p->bank_account_number, -4)
+                    : null,
+                'parent_id' => $p->parent_id !== null ? (int) $p->parent_id : null,
+            ])
+            ->all();
+
+        return response()->json(['payments' => $payments]);
+    }
+
+    /**
+     * Fix 2026-06-08 — Endpoint JSON dos pontos (reward points) pro RewardPointsTab
+     * self-fetch. Espelha o defer 'reward_points' do show() (mesmo shape/limite).
+     * Tier 0: contato DENTRO do business + scope business_id no histórico.
+     *
+     * GET /cliente/{id}/rewards-json
+     */
+    public function rewardsJson($id)
+    {
+        if (! auth()->user()->can('customer.view') && ! auth()->user()->can('customer.view_own')
+            && ! auth()->user()->can('supplier.view') && ! auth()->user()->can('supplier.view_own')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+        $contact = $this->contactUtil->getContactInfo($business_id, $id);
+
+        $enabled = request()->session()->get('business.enable_rp') == 1
+            && in_array($contact->type, ['customer', 'both'], true);
+
+        if (! $enabled) {
+            return response()->json(['enabled' => false, 'rp_name' => '', 'summary' => null, 'history' => []]);
+        }
+
+        return response()->json([
+            'enabled' => true,
+            'rp_name' => (string) (request()->session()->get('business.rp_name') ?? 'Pontos'),
+            'summary' => [
+                'total_earned' => (int) ($contact->total_rp ?? 0),
+                'total_used' => (int) ($contact->total_rp_used ?? 0),
+                'total_expired' => (int) ($contact->total_rp_expired ?? 0),
+                'balance' => (int) (((int) ($contact->total_rp ?? 0)) - ((int) ($contact->total_rp_used ?? 0)) - ((int) ($contact->total_rp_expired ?? 0))),
+            ],
+            'history' => Transaction::where('transactions.business_id', $business_id)
+                ->where('transactions.contact_id', $id)
+                ->where(function ($q) {
+                    $q->where('transactions.rp_earned', '>', 0)
+                      ->orWhere('transactions.rp_redeemed', '>', 0);
+                })
+                ->orderByDesc('transactions.transaction_date')
+                ->limit(100)
+                ->get(['id', 'invoice_no', 'transaction_date', 'final_total', 'rp_earned', 'rp_redeemed', 'rp_redeemed_amount'])
+                ->map(fn ($tx) => [
+                    'id' => (int) $tx->id,
+                    'invoice_no' => (string) ($tx->invoice_no ?? ''),
+                    'transaction_date' => optional($tx->transaction_date)->toIso8601String(),
+                    'final_total' => (float) $tx->final_total,
+                    'rp_earned' => (int) ($tx->rp_earned ?? 0),
+                    'rp_redeemed' => (int) ($tx->rp_redeemed ?? 0),
+                    'rp_redeemed_amount' => (float) ($tx->rp_redeemed_amount ?? 0),
+                ])
+                ->all(),
+        ]);
+    }
+
+    /**
+     * Fix 2026-06-08 — Endpoint JSON das assinaturas pro SubscriptionsTab self-fetch.
+     * Espelha o defer 'subscriptions' do show() (recur is_recurring=1, pai da série).
+     * Tier 0: contato DENTRO do business + scope business_id.
+     *
+     * GET /cliente/{id}/subscriptions-json
+     */
+    public function subscriptionsJson($id)
+    {
+        if (! auth()->user()->can('customer.view') && ! auth()->user()->can('customer.view_own')
+            && ! auth()->user()->can('supplier.view') && ! auth()->user()->can('supplier.view_own')) {
+            abort(403, 'Unauthorized action.');
+        }
+
+        $business_id = request()->session()->get('user.business_id');
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        return response()->json(
+            Transaction::where('transactions.business_id', $business_id)
+                ->where('transactions.contact_id', $id)
+                ->where('transactions.is_recurring', 1)
+                ->whereNull('transactions.recur_parent_id')
+                ->leftJoin('business_locations as bl_sub', 'transactions.location_id', '=', 'bl_sub.id')
+                ->orderByDesc('transactions.transaction_date')
+                ->limit(100)
+                ->get([
+                    'transactions.id',
+                    'transactions.subscription_no',
+                    'transactions.transaction_date',
+                    'transactions.recur_interval',
+                    'transactions.recur_interval_type',
+                    'transactions.recur_repetitions',
+                    'transactions.recur_stopped_on',
+                    'bl_sub.name as location_name',
+                ])
+                ->map(fn ($s) => [
+                    'id' => (int) $s->id,
+                    'subscription_no' => (string) ($s->subscription_no ?? ''),
+                    'transaction_date' => optional($s->transaction_date)->toIso8601String(),
+                    'recur_interval' => (int) ($s->recur_interval ?? 0),
+                    'recur_interval_type' => (string) ($s->recur_interval_type ?? ''),
+                    'recur_repetitions' => (int) ($s->recur_repetitions ?? 0),
+                    'recur_stopped_on' => optional($s->recur_stopped_on)->toIso8601String(),
+                    'location_name' => $s->location_name,
+                    'generated_count' => (int) Transaction::where('business_id', $business_id)
+                        ->where('recur_parent_id', $s->id)
+                        ->count(),
+                ])
+                ->all()
+        );
+    }
+
+    /**
      * Wave Onda 1 PR D 2026-05-26 — Paginador de veículos do contato (frota Martinho).
      *
      * Multi-tenant Tier 0 (ADR 0093): business_id scope obrigatório.

--- a/resources/js/Pages/Cliente/_drawer/OssTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/OssTab.tsx
@@ -191,8 +191,10 @@ export default function OssTab({
         {active === 'persons' && (
           <PessoasContatoTab contactId={contact.id} contact_persons={undefined} />
         )}
-        {active === 'subscriptions' && <SubscriptionsTab subscriptions={undefined} />}
-        {active === 'rewards' && <RewardPointsTab reward_points={undefined} />}
+        {/* Fix 2026-06-08: passa contactId pro self-fetch (sem prop = busca o endpoint JSON,
+            em vez de ficar preso no skeleton "Carregando…"). */}
+        {active === 'subscriptions' && <SubscriptionsTab contactId={contact.id} />}
+        {active === 'rewards' && <RewardPointsTab contactId={contact.id} />}
       </div>
     </div>
   );

--- a/resources/js/Pages/Cliente/_show/PaymentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/PaymentsTab.tsx
@@ -102,7 +102,9 @@ export default function PaymentsTab({ contactId, payments: paymentsProp, canView
     setLoading(true);
     setError(null);
 
-    fetch(`/contacts/payments/${contactId}`, {
+    // Fix 2026-06-08: endpoint JSON dedicado (/cliente/{id}/payments-json) — o legado
+    // /contacts/payments/{id} devolvia Blade HTML, deixando a aba presa em "Aguardando wiring".
+    fetch(`/cliente/${contactId}/payments-json`, {
       headers: {
         'X-Requested-With': 'XMLHttpRequest',
         Accept: 'application/json',
@@ -111,11 +113,9 @@ export default function PaymentsTab({ contactId, payments: paymentsProp, canView
     })
       .then(async (res) => {
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        // Endpoint legacy retorna blade HTML — futuro: criar getContactPaymentsJson(). Por agora extrai JSON se vier.
         const ct = res.headers.get('content-type') ?? '';
         if (!ct.includes('application/json')) {
-          // Fallback: backend ainda é blade. Wave A entrega só estrutura; parent wiring fará Inertia::defer.
-          throw new Error('Endpoint legacy retorna HTML — aguardando wiring Inertia::defer no parent.');
+          throw new Error('Resposta inesperada do servidor (esperava JSON).');
         }
         return res.json();
       })

--- a/resources/js/Pages/Cliente/_show/RewardPointsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/RewardPointsTab.tsx
@@ -1,6 +1,7 @@
 // Onda Final.E — Tab Reward Points (pontos fidelidade).
 // Condicional business.enable_rp. Mostra saldo + histórico ganhos/resgates.
 
+import { useEffect, useState } from 'react';
 import { Link } from '@inertiajs/react';
 import { Gift, ExternalLink } from 'lucide-react';
 
@@ -29,7 +30,10 @@ export interface RewardPointsPayload {
 }
 
 export interface RewardPointsTabProps {
+  /** Modo Inertia (Show.tsx full-page): payload vindo via Inertia::defer. */
   reward_points?: RewardPointsPayload;
+  /** Modo self-fetch (drawer Cliente/Index → OssTab): busca via /cliente/{id}/rewards-json. */
+  contactId?: number;
 }
 
 const formatBRL = (v: number) =>
@@ -42,7 +46,63 @@ const formatDate = (iso: string | null) => {
   return new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' }).format(d);
 };
 
-export default function RewardPointsTab({ reward_points }: RewardPointsTabProps) {
+export default function RewardPointsTab({ reward_points: rewardProp, contactId }: RewardPointsTabProps) {
+  const [data, setData] = useState<RewardPointsPayload | null>(rewardProp ?? null);
+  const [loading, setLoading] = useState(rewardProp === undefined);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Modo Inertia (Show.tsx): payload veio via prop, não busca.
+    if (rewardProp !== undefined) {
+      setData(rewardProp);
+      setLoading(false);
+      return;
+    }
+    // Modo self-fetch (drawer): sem prop → busca o endpoint JSON.
+    if (!contactId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/cliente/${contactId}/rewards-json`, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((j: RewardPointsPayload) => {
+        if (cancelled) return;
+        setData(j);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError('Não foi possível carregar os pontos.');
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contactId, rewardProp]);
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center text-xs text-muted-foreground" data-testid="rewards-tab-skeleton">
+        Carregando pontos…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center text-xs text-muted-foreground" data-testid="rewards-tab-error">
+        {error}
+      </div>
+    );
+  }
+
+  const reward_points = data;
   if (!reward_points) {
     return (
       <div className="p-8 text-center text-xs text-muted-foreground" data-testid="rewards-tab-skeleton">

--- a/resources/js/Pages/Cliente/_show/SubscriptionsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SubscriptionsTab.tsx
@@ -1,6 +1,7 @@
 // Onda Final.D — Tab Assinaturas (transactions is_recurring=1).
 // Paridade com Blade sale_pos/partials/subscriptions_table.
 
+import { useEffect, useState } from 'react';
 import { Link } from '@inertiajs/react';
 import { Recycle, ExternalLink } from 'lucide-react';
 
@@ -17,7 +18,10 @@ export interface SubscriptionItem {
 }
 
 export interface SubscriptionsTabProps {
+  /** Modo Inertia (Show.tsx full-page): lista vinda via Inertia::defer. */
   subscriptions?: SubscriptionItem[];
+  /** Modo self-fetch (drawer Cliente/Index → OssTab): busca via /cliente/{id}/subscriptions-json. */
+  contactId?: number;
 }
 
 const INTERVAL_LABELS: Record<string, string> = {
@@ -43,7 +47,63 @@ const formatInterval = (n: number, type: string) => {
   return `a cada ${n} ${unit}${n === 1 ? '' : type === 'months' ? 'es' : 's'}`;
 };
 
-export default function SubscriptionsTab({ subscriptions }: SubscriptionsTabProps) {
+export default function SubscriptionsTab({ subscriptions: subsProp, contactId }: SubscriptionsTabProps) {
+  const [data, setData] = useState<SubscriptionItem[] | null>(subsProp ?? null);
+  const [loading, setLoading] = useState(subsProp === undefined);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Modo Inertia (Show.tsx): lista veio via prop, não busca.
+    if (subsProp !== undefined) {
+      setData(subsProp);
+      setLoading(false);
+      return;
+    }
+    // Modo self-fetch (drawer): sem prop → busca o endpoint JSON.
+    if (!contactId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/cliente/${contactId}/subscriptions-json`, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((j: SubscriptionItem[]) => {
+        if (cancelled) return;
+        setData(Array.isArray(j) ? j : []);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError('Não foi possível carregar as assinaturas.');
+        setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contactId, subsProp]);
+
+  if (loading) {
+    return (
+      <div className="p-8 text-center text-xs text-muted-foreground" data-testid="subscriptions-tab-skeleton">
+        Carregando assinaturas…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center text-xs text-muted-foreground" data-testid="subscriptions-tab-error">
+        {error}
+      </div>
+    );
+  }
+
+  const subscriptions = data;
   if (!subscriptions) {
     return (
       <div className="p-8 text-center text-xs text-muted-foreground" data-testid="subscriptions-tab-skeleton">

--- a/routes/web.php
+++ b/routes/web.php
@@ -306,6 +306,16 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::get('/cliente/{id}/sales-json', [ContactController::class, 'salesJson'])
         ->name('cliente.sales.json')->whereNumber('id');
 
+    // Fix 2026-06-08 — pagamentos/pontos/assinaturas do cliente (drawer Operações). JSON.
+    // Mesmas abas que ficavam vazias/"aguardando wiring" no drawer por falta de fonte
+    // self-fetch (recebiam prop undefined). Tier 0 multi-tenant: scope no controller.
+    Route::get('/cliente/{id}/payments-json', [ContactController::class, 'paymentsJson'])
+        ->name('cliente.payments.json')->whereNumber('id');
+    Route::get('/cliente/{id}/rewards-json', [ContactController::class, 'rewardsJson'])
+        ->name('cliente.rewards.json')->whereNumber('id');
+    Route::get('/cliente/{id}/subscriptions-json', [ContactController::class, 'subscriptionsJson'])
+        ->name('cliente.subscriptions.json')->whereNumber('id');
+
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);
     Route::resource('taxonomies', TaxonomyController::class);
 

--- a/tests/Feature/Cliente/ClienteDrawerTabsSelfFetchTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerTabsSelfFetchTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fix 2026-06-08 — self-fetch das abas Pagamentos/Pontos/Assinaturas do drawer.
+ *
+ * Mesma classe de bug do SalesTab (#2437): no drawer 760px (ADR 0179) essas abas
+ * recebiam prop undefined e ficavam presas no skeleton ("Carregando…") ou em
+ * "Aguardando wiring" (PaymentsTab apontava pro legado /contacts/payments/{id}
+ * que devolve Blade HTML). Endpoints JSON dedicados + self-fetch no mount resolvem.
+ *
+ * GUARDs estruturais (file_get_contents) + auth-gate graceful-skip por endpoint.
+ * Refs: ADR 0093 (multi-tenant Tier 0) · ADR 0179 (drawer 760) · companheiro de
+ * ClienteSalesJsonEndpointTest.
+ */
+
+// ─── GUARD 1: rotas registradas ───────────────────────────────────────────
+
+test('GUARD 1 — routes/web.php registra payments/rewards/subscriptions-json', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../routes/web.php');
+
+    expect($contents)
+        ->toContain("Route::get('/cliente/{id}/payments-json', [ContactController::class, 'paymentsJson'])")
+        ->toContain("Route::get('/cliente/{id}/rewards-json', [ContactController::class, 'rewardsJson'])")
+        ->toContain("Route::get('/cliente/{id}/subscriptions-json', [ContactController::class, 'subscriptionsJson'])");
+});
+
+// ─── GUARD 2: métodos com tenant scope + permissão + PII ──────────────────
+
+test('GUARD 2 — paymentsJson/rewardsJson/subscriptionsJson com business_id scope + permissão', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../app/Http/Controllers/ContactController.php');
+
+    expect($contents)
+        ->toContain('public function paymentsJson($id)')
+        ->toContain('public function rewardsJson($id)')
+        ->toContain('public function subscriptionsJson($id)')
+        // Tier 0 (ADR 0093): 404 cross-tenant nos três antes de qualquer dado.
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        ->toContain("auth()->user()->can('customer.view')")
+        // PII §LGPD: número de conta NUNCA em claro.
+        ->toContain("'bank_account_number' => \$p->bank_account_number")
+        ->toContain("'****' . substr((string) \$p->bank_account_number, -4)")
+        // Shapes esperados pelos componentes.
+        ->toContain("response()->json(['payments' => \$payments])")
+        ->toContain("'enabled' => true,")
+        ->toContain("'is_recurring', 1");
+});
+
+// ─── GUARD 3: componentes fazem self-fetch via contactId ──────────────────
+
+test('GUARD 3 — RewardPointsTab/SubscriptionsTab self-fetch + PaymentsTab aponta pro JSON', function () {
+    $rewards = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_show/RewardPointsTab.tsx');
+    $subs = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_show/SubscriptionsTab.tsx');
+    $payments = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_show/PaymentsTab.tsx');
+
+    expect($rewards)
+        ->toContain('contactId?: number')
+        ->toContain('/cliente/${contactId}/rewards-json')
+        ->toContain('useEffect(');
+
+    expect($subs)
+        ->toContain('contactId?: number')
+        ->toContain('/cliente/${contactId}/subscriptions-json')
+        ->toContain('useEffect(');
+
+    expect($payments)
+        // Não usa mais o legado que devolvia HTML ("Aguardando wiring").
+        ->toContain('/cliente/${contactId}/payments-json')
+        ->not->toContain('/contacts/payments/${contactId}');
+});
+
+// ─── GUARD 4: OssTab passa contactId pras abas (dispara self-fetch) ───────
+
+test('GUARD 4 — OssTab passa contactId pro Rewards/Subscriptions (não mais undefined)', function () {
+    $contents = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx');
+
+    expect($contents)
+        ->toContain('<SubscriptionsTab contactId={contact.id} />')
+        ->toContain('<RewardPointsTab contactId={contact.id} />')
+        ->not->toContain('subscriptions={undefined}')
+        ->not->toContain('reward_points={undefined}');
+});
+
+// ─── GUARD 5: endpoints não vazam sem auth (integração graceful-skip) ─────
+
+test('GUARD 5 — endpoints JSON não vazam sem auth', function () {
+    if (! \Illuminate\Support\Facades\Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql.');
+    }
+
+    foreach (['payments-json', 'rewards-json', 'subscriptions-json'] as $ep) {
+        $response = $this->get("/cliente/1/{$ep}");
+        expect(in_array($response->status(), [302, 401, 403, 404], true))->toBeTrue();
+    }
+});


### PR DESCRIPTION
## Contexto
Follow-up do #2437 (SalesTab) e #2455 (links). Spot-check revelou que as abas **Pagamentos / Pontos / Assinaturas** do drawer não exibiam dados — recebiam prop `undefined` e ficavam presas no skeleton; Pagamentos mostrava **"Aguardando wiring"** porque o legado `/contacts/payments/{id}` devolve Blade HTML (não JSON). Mesma classe de bug do SalesTab.

## Mudança
**Backend — 3 endpoints JSON** (Tier 0: 404 cross-tenant + permissão `customer/supplier.view`; PII §LGPD: `bank_account_number` mascarado):
- `GET /cliente/{id}/payments-json` — shape `PaymentRow`
- `GET /cliente/{id}/rewards-json` — espelha o defer `reward_points` do `show()`
- `GET /cliente/{id}/subscriptions-json` — espelha o defer `subscriptions` do `show()`

**Frontend — self-fetch no mount quando a prop está ausente** (modo Inertia do `Show.tsx` full-page **intacto**):
- `PaymentsTab` aponta pro novo endpoint JSON (fim do "Aguardando wiring")
- `RewardPointsTab` / `SubscriptionsTab` ganham `contactId` + fetch (espelham `PaymentsTab`/`SalesTab`)
- `OssTab` passa `contactId` em vez de prop `undefined`

**Teste:** `ClienteDrawerTabsSelfFetchTest` (5 guards: rotas, tenant scope/PII, self-fetch, OssTab wiring, auth gate).

## Validação local
- `php -l` (controller/routes/test): OK
- `eslint` per-file = **baseline** (Payments 2, Rewards 1, Subs 1, OssTab 1 — inalterados)
- `tsc`: zero erro novo nos 4 arquivos · cor-crua inalterada
- Pest roda no CI

## Pós-deploy
Abrir cliente com pagamentos/pontos/assinaturas no drawer → as 3 abas devem listar dados (não mais skeleton/"Aguardando wiring").

🤖 Generated with [Claude Code](https://claude.com/claude-code)