### PR TITLE
ci(governance): F2 — flip casos:check + dominio:check pra always-run → required (ADR 0264/0261)

### DIFF
--- a/.github/workflows/casos-gate.yml
+++ b/.github/workflows/casos-gate.yml
@@ -4,27 +4,17 @@ name: Casos-coverage ratchet (trio-de-tela + caso↔teste)
 # (charter.md + casos.md); todo UC-* precisa de >=1 teste citando o id. Ratchet: FALHA só
 # se a contagem de violações AUMENTAR vs baseline (legado absorvido; encolher é sempre OK).
 #
-# FASE 1 (ADR 0264 + ADR 0261): este workflow RODA e reporta a dívida, mas NÃO é required
-# status check ainda — vira `required` na Fase 2 (flip consciente, após [W] ver a dívida),
-# convertendo pra always-run + skip-as-pass (padrão ADR 0261 Alavanca 2).
+# FASE 2 (ADR 0264 + ADR 0261, flip [W] 2026-06-09): ALWAYS-RUN → required status check.
+# O ratchet é node:fs puro (~12s) e SEMPRE reporta verde quando nada regrediu — por isso é
+# seguro como `required` sem deadlock (padrão ADR 0261 Alavanca 2: always-run > path-scoped
+# required). Tirar o filtro `paths:` é o flip: o check passa a reportar em TODO PR.
 #
 # Node puro (node:fs), sem deps, sem npm ci. Comando local: npm run casos:check
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'resources/js/Pages/**'
-      - 'scripts/casos-coverage-guard.mjs'
-      - 'scripts/casos-coverage-baseline.json'
-      - '.github/workflows/casos-gate.yml'
   pull_request:
-    paths:
-      - 'resources/js/Pages/**'
-      - 'scripts/casos-coverage-guard.mjs'
-      - 'scripts/casos-coverage-baseline.json'
-      - 'tests/casosGuard.spec.ts'
-      - '.github/workflows/casos-gate.yml'
 
 concurrency:
   group: casos-gate-${{ github.ref }}
@@ -63,17 +53,3 @@ jobs:
           echo "  3. Se for legado movido/refatorado conscientemente: npm run casos:baseline:write"
           echo ""
           echo "Refs: ADR 0264 (G-1/G-2) · ADR 0261 (enforcement faseado) · ADR 0256 (catraca)"
-
-  meta-test:
-    name: meta-teste do casos-guard (vitest)
-    # O gate só "vale" se o controle-negativo que o prova roda no CI (método ADR 0258).
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-      - name: Install deps
-        run: npm ci
-      - name: Controle-negativo do casos-guard (físico)
-        run: npm run test:casos-guard

--- a/.github/workflows/casos-meta-gate.yml
+++ b/.github/workflows/casos-meta-gate.yml
@@ -1,0 +1,32 @@
+name: Casos-guard meta-teste (vitest)
+
+# O gate casos:check só "vale" se o controle-negativo que o prova roda no CI (método ADR 0258).
+# Path-scoped: roda só quando o guard, o spec ou o baseline mudam (não em todo PR — o ratchet
+# sempre-rodando do casos-gate.yml é separado e barato; este aqui faz npm ci, por isso scoped).
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/casos-coverage-guard.mjs'
+      - 'scripts/casos-coverage-baseline.json'
+      - 'tests/casosGuard.spec.ts'
+      - '.github/workflows/casos-meta-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/casos-coverage-guard.mjs'
+      - 'tests/casosGuard.spec.ts'
+
+jobs:
+  meta-test:
+    name: meta-teste do casos-guard (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Install deps
+        run: npm ci
+      - name: Controle-negativo do casos-guard (físico)
+        run: npm run test:casos-guard

--- a/.github/workflows/dominio-gate.yml
+++ b/.github/workflows/dominio-gate.yml
@@ -5,29 +5,17 @@ name: Dominio-dict ratchet (coerência de domínio)
 # É a camada que a alucinação "locação de caçamba" (ADR 0265) atravessou — nenhum gate
 # pegava enum incoerente. Ratchet: FALHA só em divergência NOVA vs baseline.
 #
-# FASE 1 (ADR 0264 + ADR 0261): roda e reporta a dívida, NÃO é required ainda. Ex.: o
-# baseline atual carrega `order_type=locacao` como débito; o PR de erradicação (ADR 0265)
-# baixa o enum e a divergência zera sozinha. Vira required na Fase 2 (flip consciente).
+# FASE 2 (ADR 0264 + ADR 0261, flip [W] 2026-06-09): ALWAYS-RUN → required status check.
+# Ratchet node:fs puro (~12s), SEMPRE reporta verde quando nada regrediu → seguro como
+# `required` sem deadlock (ADR 0261 Alavanca 2). Tirar `paths:` é o flip. O baseline carrega
+# `order_type=locacao` como débito; o PR de erradicação (ADR 0265) zera a divergência.
 #
 # Node puro (node:fs), sem deps, sem npm ci. Comando local: npm run dominio:check
 
 on:
   push:
     branches: [main]
-    paths:
-      - 'Modules/**/Database/Migrations/**'
-      - 'memory/dominio/**'
-      - 'scripts/domain-dict-guard.mjs'
-      - 'scripts/domain-dict-baseline.json'
-      - '.github/workflows/dominio-gate.yml'
   pull_request:
-    paths:
-      - 'Modules/**/Database/Migrations/**'
-      - 'memory/dominio/**'
-      - 'scripts/domain-dict-guard.mjs'
-      - 'scripts/domain-dict-baseline.json'
-      - 'tests/dominioGuard.spec.ts'
-      - '.github/workflows/dominio-gate.yml'
 
 concurrency:
   group: dominio-gate-${{ github.ref }}
@@ -65,17 +53,3 @@ jobs:
           echo "  2. Se a mudança de domínio é legítima: atualize o dicionário + npm run dominio:baseline:write"
           echo ""
           echo "Refs: ADR 0264 (G-4) · ADR 0265 (erradica locação) · ADR 0261 (enforcement faseado)"
-
-  meta-test:
-    name: meta-teste do dominio-guard (vitest)
-    # O gate só "vale" se o controle-negativo que o prova roda no CI (método ADR 0258).
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-      - name: Install deps
-        run: npm ci
-      - name: Controle-negativo do dominio-guard (físico)
-        run: npm run test:dominio-guard

--- a/.github/workflows/dominio-meta-gate.yml
+++ b/.github/workflows/dominio-meta-gate.yml
@@ -1,0 +1,32 @@
+name: Dominio-guard meta-teste (vitest)
+
+# O gate dominio:check só "vale" se o controle-negativo que o prova roda no CI (método ADR 0258).
+# Path-scoped: roda só quando o guard, o spec ou o baseline mudam (o ratchet sempre-rodando do
+# dominio-gate.yml é separado e barato; este faz npm ci, por isso scoped).
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/domain-dict-guard.mjs'
+      - 'scripts/domain-dict-baseline.json'
+      - 'tests/dominioGuard.spec.ts'
+      - '.github/workflows/dominio-meta-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/domain-dict-guard.mjs'
+      - 'tests/dominioGuard.spec.ts'
+
+jobs:
+  meta-test:
+    name: meta-teste do dominio-guard (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Install deps
+        run: npm ci
+      - name: Controle-negativo do dominio-guard (físico)
+        run: npm run test:dominio-guard


### PR DESCRIPTION
## O que é (F2 — você autorizou: "aceito a")

Fase 2 do enforcement faseado (ADR 0264 + ADR 0261): os gates `casos:check` e `dominio:check` deixam de ser informativos e viram **required status check** no `main`.

### Mudança
- **`casos-gate.yml` + `dominio-gate.yml`:** removido o `paths:` → **always-run**. O ratchet é `node:fs` puro (~12s) e **sempre reporta verde quando nada regrediu** — por isso é seguro como required **sem deadlock** (a lição-mãe do ADR 0261: path-scoped required = "Expected — waiting" eterno; always-run resolve).
- **Meta-testes** (`tests/*Guard.spec.ts`, que fazem `npm ci`) movidos pra workflows próprios **path-scoped** (`casos-meta-gate.yml` + `dominio-meta-gate.yml`) — só rodam quando o guard/spec muda, não encarecem todo PR. Continuam sendo o **controle-negativo permanente** (ADR 0258): provam que trio novo falha, enum fora do dicionário falha, glue do ALTER concatenado, `down()` ignorado.

### Passo final (pós-merge, `gh api`)
Adicionar a `required_status_checks` do `main`:
- `Casos-coverage · ratchet (trio + rastreabilidade)`
- `Dominio-dict · ratchet (enum ⇔ dicionário)`

### Controle-negativo (DoD F2)
Em vez de um PR-canário descartável, os **meta-testes físicos** são o controle-negativo **permanente** — rodam no CI e falhariam se o guard parasse de pegar (a) página sem casos.md, (b) enum fora do dicionário, (c) UC sem teste. Já verde em #2463.

A partir daqui: **novo código não regride o baseline**. Tela nova nasce com trio; enum novo nasce no dicionário; `locacao` não volta (falha mecânica).

Refs: ADR 0264 · ADR 0261 (Alavanca 2 always-run+skip-as-pass) · ADR 0258 (meta-teste)

🤖 Generated with [Claude Code](https://claude.com/claude-code)