### PR TITLE
feat(governance): casos:check G-5 — metadata viva (owner + last_run + Status por UC)

### DIFF
--- a/scripts/casos-coverage-baseline.json
+++ b/scripts/casos-coverage-baseline.json
@@ -1,14 +1,15 @@
 {
   "_meta": {
-    "generated_at": "2026-06-09T12:13:41.492Z",
-    "gate": "casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade)",
+    "generated_at": "2026-06-09T13:25:07.805Z",
+    "gate": "casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata viva)",
     "stats": {
       "pages": 277,
       "casos_files": 1,
       "ucs_declared": 10,
       "missing_charter": 144,
       "missing_casos": 276,
-      "orphan_ucs": 10
+      "orphan_ucs": 5,
+      "metadata_issues": 0
     },
     "nota": "Violações ATUAIS fotografadas (débito legado). Gate falha só em violação NOVA vs este baseline (ratchet). Encolher é sempre OK. Regravar conscientemente: npm run casos:baseline:write",
     "refs": [
@@ -438,15 +439,10 @@
     "trio:missing-charter:resources/js/Pages/team-mcp/Tasks/Index.tsx",
     "trio:missing-charter:resources/js/Pages/Vestuario/Etiquetas/Index.tsx",
     "trio:missing-charter:resources/js/Pages/Whatsapp/Templates/Index.tsx",
-    "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-01",
-    "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-02",
-    "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-03",
     "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-04",
     "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-05",
-    "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-06",
     "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-07",
     "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-08",
-    "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-09",
     "uc-orphan:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-10"
   ]
 }

--- a/scripts/casos-coverage-guard.mjs
+++ b/scripts/casos-coverage-guard.mjs
@@ -10,12 +10,16 @@
 // (charter/casos/teste/proibições) viram MÁQUINA, não disciplina (ADR 0264, lei da
 // catraca ADR 0256). Censo @main 2026-06-09: 277 páginas roteadas, 138 charter, 1 casos.md.
 //
-// Este guard cobre 2 das 4 camadas:
+// Este guard cobre 3 camadas:
 //   G-1 TRIO-DE-TELA  : toda .tsx ROTEADA em resources/js/Pages/** (exclui _components/)
 //                       DEVE ter, ao lado, <Nome>.charter.md E <Nome>.casos.md.
 //   G-2 RASTREABILIDADE: todo UC-* declarado num *.casos.md DEVE ser citado por >=1 teste
 //                       (string do ID em Tests/**, tests/**, ou spec Playwright e2e/**).
 //                       UC órfão (caso no papel sem teste que o defenda) = violação.
+//   G-5 METADATA VIVA : cada *.casos.md DEVE carregar `owner` (quem fez) + `last_run`
+//                       (quando, data) + `Status:` por UC (se está ativa/passa). É o que
+//                       faz a spec "saber de si" e não apodrecer. Trava PRESENÇA (frescor
+//                       de last_run é manual — pode mentir; carimbo automático = futuro).
 //
 // =====================================================================================
 // RATCHET / BASELINE — gêmeo de pageheader-migration-guard.mjs + no-mock-in-prod.mjs
@@ -142,6 +146,50 @@ function orphanUcViolations(ucDecls, testCorpus) {
 }
 
 // ---------------------------------------------------------------------------
+// G-5 — metadata viva (quem fez · quando · status por UC)
+// ---------------------------------------------------------------------------
+// É o que [W] mais valoriza na estrutura de spec: cada casos.md "sabe de si" — owner
+// (quem), last_run (quando) e Status por UC (se está ativa/passa). Sem isso a spec
+// apodrece (vira convenção esquecível). Aqui isso vira LEI (ratchet).
+//
+// Trava PRESENÇA, não FRESCOR: last_run é manual e PODE MENTIR (uma data antiga não
+// significa que rodou). Carimbar a data automaticamente quando o teste roda é evolução
+// futura (precisa o runner escrever de volta no arquivo) — fora do escopo deste guard.
+const DATE_RE = /^["']?\d{4}-\d{2}-\d{2}["']?$/;
+
+function frontmatterBlock(content) {
+  const m = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  return m ? m[1] : null;
+}
+function fmField(fm, key) {
+  if (!fm) return null;
+  const m = fm.match(new RegExp(`^${key}\\s*:\\s*(.+)$`, 'm'));
+  return m ? m[1].trim() : null;
+}
+
+function metadataViolations(casosFiles) {
+  const violations = [];
+  for (const file of casosFiles) {
+    const content = readFileSync(resolve(ROOT, file), 'utf8');
+    const fm = frontmatterBlock(content);
+    const owner = fmField(fm, 'owner');
+    const lastRun = fmField(fm, 'last_run');
+    if (!owner) violations.push(`meta:missing-owner:${file}`);
+    if (!lastRun || !DATE_RE.test(lastRun)) violations.push(`meta:missing-last_run:${file}`);
+
+    // Status por UC — cada heading "## UC-XX ..." precisa de um "Status:" no bloco
+    // (até o próximo "## "). É o "se está ativa / passa" que [W] valoriza.
+    const blocks = content.split(/^##\s+/m).slice(1);
+    for (const block of blocks) {
+      const head = block.match(/^(UC-[A-Z]*\d+[a-zA-Z]?)\b/);
+      if (!head) continue;
+      if (!/Status\s*[:：]/.test(block)) violations.push(`meta:uc-no-status:${file}#${head[1].toUpperCase()}`);
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
 // Cálculo
 // ---------------------------------------------------------------------------
 function computeViolations() {
@@ -152,8 +200,9 @@ function computeViolations() {
 
   const trio = trioViolations(pages);
   const orphans = orphanUcViolations(ucDecls, testCorpus);
+  const meta = metadataViolations(casosFiles);
 
-  const all = [...trio, ...orphans].sort((a, b) => a.localeCompare(b));
+  const all = [...trio, ...orphans, ...meta].sort((a, b) => a.localeCompare(b));
   return {
     violations: all,
     stats: {
@@ -163,6 +212,7 @@ function computeViolations() {
       missing_charter: trio.filter((v) => v.startsWith('trio:missing-charter')).length,
       missing_casos: trio.filter((v) => v.startsWith('trio:missing-casos')).length,
       orphan_ucs: orphans.length,
+      metadata_issues: meta.length,
     },
   };
 }
@@ -193,6 +243,7 @@ function main() {
     console.log(`Telas SEM charter.md: ${stats.missing_charter}`);
     console.log(`Telas SEM casos.md:   ${stats.missing_casos}`);
     console.log(`UCs órfãos (sem teste): ${stats.orphan_ucs}`);
+    console.log(`Metadata viva faltando (owner/last_run/Status por UC): ${stats.metadata_issues}`);
     console.log(`\nTOTAL de violações (débito): ${violations.length}`);
     console.log('\n→ F1 fotografa isso no baseline (não-bloqueante). F3 ratchet zera tela-a-tela.');
     process.exit(0);
@@ -202,7 +253,7 @@ function main() {
     const out = {
       _meta: {
         generated_at: new Date().toISOString(),
-        gate: 'casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade)',
+        gate: 'casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata viva)',
         stats,
         nota: 'Violações ATUAIS fotografadas (débito legado). Gate falha só em violação NOVA vs este baseline (ratchet). Encolher é sempre OK. Regravar conscientemente: npm run casos:baseline:write',
         refs: ['ADR 0264', 'ADR 0261', 'ADR 0256'],
@@ -231,6 +282,8 @@ function main() {
     console.error(
       `\nTela NOVA precisa do trio: <Nome>.tsx + <Nome>.charter.md + <Nome>.casos.md (ADR 0264 G-1).` +
         `\nUC NOVO precisa de teste citando o id (ADR 0264 G-2).` +
+        `\nmeta:* → o casos.md precisa de frontmatter \`owner:\` (quem) + \`last_run: "AAAA-MM-DD"\` (quando)` +
+        `\n         e cada \`## UC-XX\` precisa de uma linha \`Status:\` (se está ativa/passa) — ADR 0264 G-5.` +
         `\nSe for legado movido/refatorado conscientemente: npm run casos:baseline:write`,
     );
     process.exit(1);

--- a/tests/casosGuard.spec.ts
+++ b/tests/casosGuard.spec.ts
@@ -102,3 +102,42 @@ describe('casos:check — G-2 rastreabilidade caso↔teste (físico)', () => {
     expect(out).toMatch(/Sem violações novas/);
   });
 });
+
+describe('casos:check — G-5 metadata viva (quem · quando · status) (físico)', () => {
+  it('SENSIBILIDADE: casos.md sem owner/last_run e UC sem Status falham', () => {
+    // baseline limpo com uma tela compliant.
+    write(page('M'), 'x');
+    write('resources/js/Pages/M/Index.charter.md', '# c');
+    write('resources/js/Pages/M/Index.casos.md', '---\nowner: wagner\nlast_run: "2026-06-09"\n---\n## UC-01 · x\n- **Status: ✅**');
+    write('tests/MTest.php', '<?php // UC-01');
+    run('--write-baseline');
+    // tela nova com casos.md SEM frontmatter + UC sem Status.
+    write(page('N'), 'x');
+    write('resources/js/Pages/N/Index.charter.md', '# c');
+    write('resources/js/Pages/N/Index.casos.md', '## UC-02 · y');
+    write('tests/NTest.php', '<?php // UC-02');
+    const out = runExpectFail('');
+    expect(out).toMatch(/meta:missing-owner:resources\/js\/Pages\/N\/Index\.casos\.md/);
+    expect(out).toMatch(/meta:missing-last_run:resources\/js\/Pages\/N\/Index\.casos\.md/);
+    expect(out).toMatch(/meta:uc-no-status:resources\/js\/Pages\/N\/Index\.casos\.md#UC-02/);
+  });
+
+  it('ESPECIFICIDADE: casos.md com owner+last_run+Status por UC NÃO gera meta-violação', () => {
+    write(page('Z'), 'x');
+    write('resources/js/Pages/Z/Index.charter.md', '# c');
+    write('resources/js/Pages/Z/Index.casos.md', '---\nowner: wagner\nlast_run: "2026-06-09"\n---\n## UC-09 · ok\n- **Status: 🧪**');
+    write('tests/ZTest.php', '<?php // UC-09');
+    run('--write-baseline');
+    const out = run('--json');
+    expect(out).toMatch(/"metadata_issues": 0/);
+  });
+
+  it('SENSIBILIDADE: last_run com formato inválido (não-data) falha', () => {
+    write(page('D'), 'x');
+    write('resources/js/Pages/D/Index.charter.md', '# c');
+    write('resources/js/Pages/D/Index.casos.md', '---\nowner: wagner\nlast_run: ontem\n---\n## UC-01 · x\n- **Status: ✅**');
+    write('tests/DTest.php', '<?php // UC-01');
+    const out = runExpectFail('--json'); // sem baseline → tudo novo
+    expect(out).toMatch(/meta:missing-last_run:resources\/js\/Pages\/D\/Index\.casos\.md/);
+  });
+});


### PR DESCRIPTION
## O que é (continuação — fecha o buraco que [W] apontou)

Sua pergunta: *"cada spec nova fica sabendo quem fez, quando fez, se está ativa? isso foi o melhor ganho... isso sobrevive ao tempo?"*

**Resposta honesta:** essa metadata (`owner`/`last_run`/`Status` por UC) era **convenção** — o gate só travava que o arquivo existe + UC tem teste, **não a metadata**. Ou seja, o que você mais valoriza **podia apodrecer**. Este PR **trava por máquina** (G-5).

## G-5 — metadata viva
Todo `*.casos.md` agora DEVE ter:
- frontmatter **`owner:`** (quem fez)
- frontmatter **`last_run: "AAAA-MM-DD"`** (quando, data válida)
- uma linha **`Status:`** em cada `## UC-XX` (se está ativa/passa)

Falta de qualquer um = violação nova → **CI bloqueia** (o `casos:check` já é required, F2). Ratchet: legado absorvido, tela nova obrigada. **Espalha pra todas** as specs conforme o F3 fecha o trio tela-a-tela.

## Honestidade — o que G-5 NÃO faz (seus "negativos")
- **Trava PRESENÇA, não FRESCOR:** `last_run` é manual e **pode mentir** (data antiga ≠ rodou de verdade). Carimbo automático ao rodar o teste é evolução futura (o runner teria que escrever de volta no arquivo).
- **`Status: ✅` é declarado, não derivado:** G-2 garante que o UC **tem teste**, não que **passa verde** com aquele status (L-24 "presença ≠ correção" — vale pro próprio casos).

## Bônus medido
O débito de **UC órfão caiu 10→6** — o spec Playwright UC-06 (F1b) passou a citar UC-01/02/03/06 → traçados. Baseline apertado **430→426** pra travar o ganho (a catraca não deixa voltar).

## Validação
- `casos:check` verde (426, metadata_issues=0 — a Oficina casos.md já era compliant).
- Meta-teste físico (`casosGuard.spec.ts`): G-5 sensibilidade (sem owner/last_run/Status falha · last_run não-data falha) + especificidade (compliant → 0). **Replayados via node** antes do CI.

Refs: ADR 0264 (G-5 estende G-1/G-2) · ADR 0256 (catraca) · L-24

🤖 Generated with [Claude Code](https://claude.com/claude-code)