### PR TITLE
feat(governance): casos:check G-7 — Status derivado do verde (Salto #2, F1)

### DIFF
--- a/.github/workflows/casos-gate.yml
+++ b/.github/workflows/casos-gate.yml
@@ -1,8 +1,11 @@
 name: Casos-coverage ratchet (trio-de-tela + caso↔teste)
 
-# Gate G-1/G-2 da Governança executável (ADR 0264). Toda .tsx roteada precisa do trio
-# (charter.md + casos.md); todo UC-* precisa de >=1 teste citando o id. Ratchet: FALHA só
-# se a contagem de violações AUMENTAR vs baseline (legado absorvido; encolher é sempre OK).
+# Gate G-1/G-2/G-5/G-6/G-7 da Governança executável (ADR 0264). Toda .tsx roteada precisa
+# do trio (charter.md + casos.md); todo UC-* precisa de >=1 teste citando o id (G-1/G-2);
+# metadata viva owner/last_run/Status (G-5); frescor via git (G-6); e o `Status: ✅` por UC
+# tem que bater com o veredito REAL do teste — manifesto scripts/casos-test-results.json
+# gerado por `npm run casos:results` (G-7, Salto #2). Ratchet: FALHA só se a contagem de
+# violações AUMENTAR vs baseline (legado absorvido; encolher é sempre OK).
 #
 # FASE 2 (ADR 0264 + ADR 0261, flip [W] 2026-06-09): ALWAYS-RUN → required status check.
 # O ratchet é node:fs puro (~12s) e SEMPRE reporta verde quando nada regrediu — por isso é

--- a/.github/workflows/casos-meta-gate.yml
+++ b/.github/workflows/casos-meta-gate.yml
@@ -9,13 +9,18 @@ on:
     paths:
       - 'scripts/casos-coverage-guard.mjs'
       - 'scripts/casos-coverage-baseline.json'
+      - 'scripts/casos-results-collect.mjs'
+      - 'scripts/casos-test-results.json'
       - 'tests/casosGuard.spec.ts'
+      - 'tests/casosResultsCollect.spec.ts'
       - '.github/workflows/casos-meta-gate.yml'
   push:
     branches: [main]
     paths:
       - 'scripts/casos-coverage-guard.mjs'
+      - 'scripts/casos-results-collect.mjs'
       - 'tests/casosGuard.spec.ts'
+      - 'tests/casosResultsCollect.spec.ts'
 
 jobs:
   meta-test:
@@ -28,5 +33,7 @@ jobs:
           node-version: '24'
       - name: Install deps
         run: npm ci
-      - name: Controle-negativo do casos-guard (físico)
-        run: npm run test:casos-guard
+      - name: Controle-negativo do casos-guard + coletor (físico)
+        run: |
+          npm run test:casos-guard
+          npm run test:casos-results

--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -61,6 +61,22 @@ jobs:
           npx wait-on http://127.0.0.1:8000 --timeout 60000 || sleep 10
           npm run e2e:check
 
+      # Salto #2 / G-7: coleta o JUnit do Playwright (test-results/) → manifesto por-UC.
+      # Roda SEMPRE (mesmo se o E2E falhou: a falha É o veredito que o G-7 quer registrar).
+      # Sobe como ARTIFACT — NÃO commita (o manifesto commitado é atualizado conscientemente
+      # pelo dev via `npm run casos:results`, idioma baseline/ratchet; ADR 0264 G-7).
+      - name: Coletar veredito por-UC (casos:results)
+        if: always()
+        run: npm run casos:results || true
+
+      - name: Upload manifesto de veredito (casos-test-results)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: casos-test-results
+          path: scripts/casos-test-results.json
+          retention-days: 14
+
       - name: Upload trace/report on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ tests/eval/results/*.json
 # Cache/scratch local — NÃO versionar (design fetch + prancheta de design-grading)
 /_design_fetch/
 /_preview/
+
+# Test-results JUnit (Salto #2 / G-7) — efêmero; o manifesto derivado (scripts/casos-test-results.json) é o que se commita
+test-results/
+playwright-report/

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "casos:check": "node scripts/casos-coverage-guard.mjs",
     "casos:report": "node scripts/casos-coverage-guard.mjs --report",
     "casos:baseline:write": "node scripts/casos-coverage-guard.mjs --write-baseline",
+    "casos:results": "node scripts/casos-results-collect.mjs",
     "dominio:check": "node scripts/domain-dict-guard.mjs",
     "dominio:report": "node scripts/domain-dict-guard.mjs --report",
     "dominio:baseline:write": "node scripts/domain-dict-guard.mjs --write-baseline",
@@ -61,6 +62,7 @@
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts",
     "test:adr-governance": "vitest run tests/governanceAdrScripts.spec.ts",
     "test:casos-guard": "vitest run tests/casosGuard.spec.ts",
+    "test:casos-results": "vitest run tests/casosResultsCollect.spec.ts",
     "test:dominio-guard": "vitest run tests/dominioGuard.spec.ts"
   },
   "devDependencies": {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,11 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  // JUnit alimenta o coletor casos:results (Salto #2 / G-7 Status derivado): o UC-id no
+  // título do teste vira o <testcase name> que o coletor lê → manifesto por-UC.
+  reporter: process.env.CI
+    ? [['github'], ['list'], ['junit', { outputFile: 'test-results/playwright-junit.xml' }]]
+    : [['list'], ['junit', { outputFile: 'test-results/playwright-junit.xml' }]],
   // Login uma vez → storageState reusado pelos specs (rota é auth-gated).
   globalSetup: './e2e/global-setup.ts',
   use: {

--- a/scripts/casos-coverage-baseline.json
+++ b/scripts/casos-coverage-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-09T13:54:01.902Z",
-    "gate": "casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata viva + G-6 frescor)",
+    "generated_at": "2026-06-09T14:39:39.394Z",
+    "gate": "casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata + G-6 frescor + G-7 status derivado)",
     "stats": {
       "pages": 277,
       "casos_files": 1,
@@ -10,7 +10,10 @@
       "missing_casos": 276,
       "orphan_ucs": 5,
       "metadata_issues": 0,
-      "stale_cases": 1
+      "stale_cases": 1,
+      "status_lies": 0,
+      "status_unverified": 8,
+      "status_stale": 0
     },
     "nota": "Violações ATUAIS fotografadas (débito legado). Gate falha só em violação NOVA vs este baseline (ratchet). Encolher é sempre OK. Regravar conscientemente: npm run casos:baseline:write",
     "refs": [
@@ -21,6 +24,14 @@
   },
   "violations": [
     "stale:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-01",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-02",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-03",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-04",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-05",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-07",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-09",
+    "status:unverified:resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md#UC-10",
     "trio:missing-casos:resources/js/Pages/_Showcase/Components.tsx",
     "trio:missing-casos:resources/js/Pages/_Showcase/OndaF.tsx",
     "trio:missing-casos:resources/js/Pages/Admin/FeatureFlags/Index.tsx",

--- a/scripts/casos-coverage-guard.mjs
+++ b/scripts/casos-coverage-guard.mjs
@@ -22,6 +22,10 @@
 //   G-6 FRESCOR       : se o <Nome>.tsx tem commit MAIS NOVO que o `last_run`, os casos
 //                       estão STALE (tela mudou sem revalidar). Sinal amarrado à mudança
 //                       de CÓDIGO via git (melhor que wall-clock). Resolve "last_run mente".
+//   G-7 STATUS DERIVADO (Salto #2): o `Status: ✅` declarado por UC tem que bater com o
+//                       VEREDITO REAL do teste (manifesto scripts/casos-test-results.json,
+//                       gerado por `casos:results` a partir do JUnit). ✅ + teste-falhou =
+//                       lies; ✅ sem teste verde = unverified. Fecha "o Status pode mentir".
 //
 // =====================================================================================
 // RATCHET / BASELINE — gêmeo de pageheader-migration-guard.mjs + no-mock-in-prod.mjs
@@ -48,6 +52,7 @@ import { execSync } from 'node:child_process';
 const ROOT = process.cwd();
 const PAGES_DIR = resolve(ROOT, 'resources/js/Pages');
 const BASELINE_PATH = resolve(ROOT, 'scripts/casos-coverage-baseline.json');
+const MANIFEST_PATH = resolve(ROOT, 'scripts/casos-test-results.json'); // G-7: veredito por-UC (Salto #2)
 const TEST_DIRS = ['Modules', 'tests', 'app', 'e2e']; // onde um UC-id pode ser referenciado por teste
 
 const MODE_WRITE = process.argv.includes('--write-baseline');
@@ -249,6 +254,65 @@ function stalenessViolations(casosFiles) {
 }
 
 // ---------------------------------------------------------------------------
+// G-7 — STATUS DERIVADO DO VERDE (Salto #2): o `Status: ✅` declarado tem que bater
+//       com o veredito REAL do teste (manifesto scripts/casos-test-results.json).
+// ---------------------------------------------------------------------------
+// Fecha o limite honesto do G-5 (trava presença do Status, mas o valor pode MENTIR). O
+// veredito por-UC vem de RODAR a suíte (reporter JUnit → coletor casos:results → manifesto);
+// este gate só LÊ o manifesto commitado (offline, rápido, required-safe — não roda teste,
+// não acopla ao job lento; evita o deadlock que o ADR 0261 proíbe).
+//
+//   status:lies:<file>#<uc>          declara ✅ mas o teste FALHOU (mentira — alto sinal)
+//   status:unverified:<file>#<uc>    declara ✅ mas nenhum teste verde provou (skip/sem entrada)
+//   status:stale-results:<file>#<uc> ✅ provado, mas a tela mudou DEPOIS do teste (revalidar)
+//
+// Só ✅ é uma AFIRMAÇÃO que exige prova. 🧪/⬜/❌ são não-afirmações honestas → sem violação.
+// Sem manifesto (bootstrap) → G-7 dorme (gracioso). F1 não-bloqueante: baseline absorve.
+function loadManifest() {
+  if (!existsSync(MANIFEST_PATH)) return null;
+  try { return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')); } catch { return null; }
+}
+
+function declaredStatus(block) {
+  const m = block.match(/Status\s*[:：]\s*([^\n]*)/);
+  if (!m) return null;
+  const line = m[1];
+  if (line.includes('✅')) return 'green';
+  if (line.includes('❌')) return 'broken';
+  if (line.includes('🧪')) return 'testing';
+  if (line.includes('⬜')) return 'unverified';
+  return 'other';
+}
+
+function statusViolations(casosFiles, manifest) {
+  if (!manifest) return []; // sem manifesto → gate dorme (gracioso, F1 bootstrap).
+  const ucs = manifest.ucs || {};
+  const shallow = isShallowRepo();
+  const violations = [];
+  for (const file of casosFiles) {
+    const content = readFileSync(resolve(ROOT, file), 'utf8');
+    const tsx = file.replace(/\.casos\.md$/, '.tsx');
+    const tsxDate = (!shallow && existsSync(resolve(ROOT, tsx))) ? gitCommitDate(tsx) : null;
+    const blocks = content.split(/^##\s+/m).slice(1);
+    for (const block of blocks) {
+      const head = block.match(/^(UC-[A-Z]*\d+[a-zA-Z]?)\b/);
+      if (!head) continue;
+      if (declaredStatus(block) !== 'green') continue; // só ✅ precisa de prova
+      const uc = head[1].toUpperCase();
+      const entry = ucs[uc];
+      if (!entry || !entry.verdict || entry.verdict === 'skip') {
+        violations.push(`status:unverified:${file}#${uc}`);
+      } else if (entry.verdict === 'fail') {
+        violations.push(`status:lies:${file}#${uc}`);
+      } else if (entry.verdict === 'pass' && tsxDate && entry.ran_at && entry.ran_at < tsxDate) {
+        violations.push(`status:stale-results:${file}#${uc}`);
+      }
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
 // Cálculo
 // ---------------------------------------------------------------------------
 function computeViolations() {
@@ -261,8 +325,9 @@ function computeViolations() {
   const orphans = orphanUcViolations(ucDecls, testCorpus);
   const meta = metadataViolations(casosFiles);
   const stale = stalenessViolations(casosFiles);
+  const status = statusViolations(casosFiles, loadManifest());
 
-  const all = [...trio, ...orphans, ...meta, ...stale].sort((a, b) => a.localeCompare(b));
+  const all = [...trio, ...orphans, ...meta, ...stale, ...status].sort((a, b) => a.localeCompare(b));
   return {
     violations: all,
     stats: {
@@ -274,6 +339,9 @@ function computeViolations() {
       orphan_ucs: orphans.length,
       metadata_issues: meta.length,
       stale_cases: stale.length,
+      status_lies: status.filter((v) => v.startsWith('status:lies')).length,
+      status_unverified: status.filter((v) => v.startsWith('status:unverified')).length,
+      status_stale: status.filter((v) => v.startsWith('status:stale-results')).length,
     },
   };
 }
@@ -306,6 +374,9 @@ function main() {
     console.log(`UCs órfãos (sem teste): ${stats.orphan_ucs}`);
     console.log(`Metadata viva faltando (owner/last_run/Status por UC): ${stats.metadata_issues}`);
     console.log(`Casos STALE (tela mudou depois do last_run — frescor G-6): ${stats.stale_cases}`);
+    console.log(`Status MENTE (✅ declarado vs teste FALHOU — G-7): ${stats.status_lies}`);
+    console.log(`Status SEM PROVA (✅ declarado sem teste verde — G-7): ${stats.status_unverified}`);
+    console.log(`Status com RESULTADO velho (✅ provado, tela mudou depois — G-7): ${stats.status_stale}`);
     console.log(`\nTOTAL de violações (débito): ${violations.length}`);
     console.log('\n→ F1 fotografa isso no baseline (não-bloqueante). F3 ratchet zera tela-a-tela.');
     process.exit(0);
@@ -315,7 +386,7 @@ function main() {
     const out = {
       _meta: {
         generated_at: new Date().toISOString(),
-        gate: 'casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata viva + G-6 frescor)',
+        gate: 'casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata + G-6 frescor + G-7 status derivado)',
         stats,
         nota: 'Violações ATUAIS fotografadas (débito legado). Gate falha só em violação NOVA vs este baseline (ratchet). Encolher é sempre OK. Regravar conscientemente: npm run casos:baseline:write',
         refs: ['ADR 0264', 'ADR 0261', 'ADR 0256'],
@@ -347,6 +418,9 @@ function main() {
         `\nmeta:* → o casos.md precisa de frontmatter \`owner:\` (quem) + \`last_run: "AAAA-MM-DD"\` (quando)` +
         `\n         e cada \`## UC-XX\` precisa de uma linha \`Status:\` (se está ativa/passa) — ADR 0264 G-5.` +
         `\nstale:* → a tela (.tsx) mudou DEPOIS do \`last_run\` — revalide os casos e bumpe o \`last_run\` (ADR 0264 G-6).` +
+        `\nstatus:lies:* → o UC declara \`Status: ✅\` mas o teste FALHOU (manifesto). Conserte o teste ou seja honesto (❌). G-7.` +
+        `\nstatus:unverified:* → \`Status: ✅\` sem teste verde que prove. Rode a suíte + \`npm run casos:results\`, ou baixe pra 🧪/⬜. G-7.` +
+        `\nstatus:stale-results:* → ✅ provado, mas a tela mudou depois do teste — re-rode + \`npm run casos:results\`. G-7.` +
         `\nSe for legado movido/refatorado conscientemente: npm run casos:baseline:write`,
     );
     process.exit(1);

--- a/scripts/casos-results-collect.mjs
+++ b/scripts/casos-results-collect.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+// scripts/casos-results-collect.mjs — Coletor de test-results → manifesto por-UC (Salto #2,
+//                                     infra do Gate G-7 "Status derivado do verde", ADR 0264).
+//
+// =====================================================================================
+// POR QUE EXISTE
+// =====================================================================================
+// O G-5 (casos:check) trava a PRESENÇA do `Status:` por UC, mas o valor (✅/🧪/⬜/❌) é
+// DECLARADO por humano e pode MENTIR (diz ✅ sem teste verde por trás). O Salto #2 deriva
+// o Status do RESULTADO REAL do teste — não por regex de fonte, mas RODANDO a suíte e
+// lendo o relatório de máquina (JUnit). Os testes já carregam o UC-id no TÍTULO
+// (ex.: `test('UC-06 · gate de etapa…')`), então o `name` do <testcase> entrega o id.
+//
+//   runners → reporter JUnit → test-results/*.xml → [este coletor] → scripts/casos-test-results.json
+//
+// Formato único JUnit pra todos os runners (Pest --log-junit · vitest --reporter=junit ·
+// Playwright reporter:junit). Um parser só (node:fs + regex, sem dep — idioma dos guards).
+//
+// VEREDITO por UC (agregado de todos os <testcase> que citam o id no nome):
+//   fail  se ALGUM testcase do UC falhou (<failure>/<error>)
+//   pass  se ≥1 rodou e NENHUM falhou (skip não conta como pass)
+//   skip  se todos os testcases do UC foram pulados (<skipped>)
+//
+// SEGURANÇA: se NENHUM test-results for encontrado, NÃO sobrescreve o manifesto existente
+// (não apaga veredito real por uma rodada vazia) — avisa e sai 0. O gate G-7 lê o
+// manifesto COMMITADO (offline, rápido, required-safe) — separar produção (lenta) da
+// checagem (rápida) evita o deadlock que o ADR 0261 proíbe.
+//
+// USO:
+//   node scripts/casos-results-collect.mjs                 # lê test-results/, grava manifesto
+//   node scripts/casos-results-collect.mjs --results <dir> # diretório de results alternativo
+//   node scripts/casos-results-collect.mjs --seed-empty    # cria manifesto vazio (bootstrap F1)
+//
+// Refs: ADR 0264 (G-5/G-7) · ADR 0261 (enforcement faseado, não-deadlock) · ADR 0256 (catraca).
+
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const MANIFEST_PATH = resolve(ROOT, 'scripts/casos-test-results.json');
+
+const argv = process.argv.slice(2);
+const SEED_EMPTY = argv.includes('--seed-empty');
+const resultsIdx = argv.indexOf('--results');
+const RESULTS_DIR = resolve(ROOT, resultsIdx >= 0 ? argv[resultsIdx + 1] : 'test-results');
+
+const norm = (p) => relative(ROOT, p).replace(/\\/g, '/');
+
+// UC-id canônico — MESMO regex do casos-coverage-guard.mjs (consistência).
+const UC_RE = /\bUC-[A-Z]{0,3}\d{1,3}[a-zA-Z]?\b/g;
+
+function walk(dir, filter, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'node_modules' || e.name === 'vendor' || e.name === '.git') continue;
+      walk(full, filter, acc);
+    } else if (e.isFile() && filter(full, e.name)) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+// Data (YYYY-MM-DD) do testsuite (atributo timestamp), se houver — pra alimentar ran_at.
+function suiteDate(xml) {
+  const m = xml.match(/<testsuite[^>]*\btimestamp="(\d{4}-\d{2}-\d{2})/);
+  return m ? m[1] : null;
+}
+
+// Extrai [{ name, status }] de um XML JUnit. status ∈ pass|fail|skip.
+function parseTestcases(xml) {
+  const out = [];
+  // Casa <testcase .../> (self-closing) OU <testcase ...>…</testcase>.
+  const re = /<testcase\b([^>]*?)(\/>|>([\s\S]*?)<\/testcase>)/g;
+  for (const m of xml.matchAll(re)) {
+    const attrs = m[1];
+    const inner = m[3] || '';
+    const nameMatch = attrs.match(/\bname="([^"]*)"/);
+    if (!nameMatch) continue;
+    const name = nameMatch[1];
+    let status = 'pass';
+    if (/<(failure|error)\b/.test(inner)) status = 'fail';
+    else if (/<skipped\b/.test(inner)) status = 'skip';
+    out.push({ name, status });
+  }
+  return out;
+}
+
+// Agregação por UC com contadores: fail domina; senão pass (≥1) vence skip; senão skip.
+function collect() {
+  const files = walk(RESULTS_DIR, (full, name) => name.endsWith('.xml'));
+  const ucAgg = {}; // uc -> { pass, fail, skip, date }
+  let parsedAny = false;
+
+  for (const f of files) {
+    let xml;
+    try { xml = readFileSync(f, 'utf8'); } catch { continue; }
+    parsedAny = true;
+    const date = suiteDate(xml);
+    for (const { name, status } of parseTestcases(xml)) {
+      const ids = new Set([...name.matchAll(UC_RE)].map((x) => x[0].toUpperCase()));
+      for (const uc of ids) {
+        const a = (ucAgg[uc] ??= { pass: 0, fail: 0, skip: 0, date: null });
+        a[status] += 1;
+        if (date && (!a.date || date > a.date)) a.date = date;
+      }
+    }
+  }
+
+  // veredito final por UC.
+  const ucs = {};
+  for (const [uc, a] of Object.entries(ucAgg)) {
+    const verdict = a.fail > 0 ? 'fail' : a.pass > 0 ? 'pass' : 'skip';
+    ucs[uc] = { verdict, ran_at: a.date, tests: a.pass + a.fail + a.skip };
+  }
+
+  return { ucs, parsedAny, sources: files.map(norm) };
+}
+
+function writeManifest(ucs, sources) {
+  const stats = { ucs: Object.keys(ucs).length, pass: 0, fail: 0, skip: 0 };
+  for (const { verdict } of Object.values(ucs)) stats[verdict] += 1;
+  const out = {
+    _meta: {
+      generated_at: new Date().toISOString(),
+      gate: 'casos status derivado (ADR 0264 G-7 — Status por UC vem do veredito real do teste)',
+      sources,
+      stats,
+      nota: 'Veredito por-UC derivado dos relatórios JUnit (test-results/). Lido offline pelo casos:check G-7. Regerar quando a suíte rodar: npm run casos:results. UC sem entrada aqui = sem prova capturada (G-7 marca ✅ declarado como unverified).',
+      refs: ['ADR 0264', 'ADR 0261', 'ADR 0256'],
+    },
+    ucs,
+  };
+  writeFileSync(MANIFEST_PATH, JSON.stringify(out, null, 2) + '\n');
+  return stats;
+}
+
+function main() {
+  if (SEED_EMPTY) {
+    const stats = writeManifest({}, []);
+    console.log(`✅ Manifesto SEMENTE (vazio) gravado → ${norm(MANIFEST_PATH)} (${stats.ucs} UCs).`);
+    process.exit(0);
+  }
+
+  const { ucs, parsedAny, sources } = collect();
+
+  if (!parsedAny) {
+    console.error(
+      `⚠️  Nenhum test-results JUnit em ${norm(RESULTS_DIR)}/ — manifesto NÃO sobrescrito ` +
+        `(preserva veredito real). Rode a suíte com reporter JUnit antes (ex.: npm run e2e:check).`,
+    );
+    process.exit(0); // não-fatal: rodada vazia não é erro, só não atualiza.
+  }
+
+  const stats = writeManifest(ucs, sources);
+  console.log(
+    `✅ Manifesto gravado: ${stats.ucs} UCs (${stats.pass} pass · ${stats.fail} fail · ${stats.skip} skip) ` +
+      `de ${sources.length} relatório(s) → ${norm(MANIFEST_PATH)}`,
+  );
+  process.exit(0);
+}
+
+main();

--- a/scripts/casos-test-results.json
+++ b/scripts/casos-test-results.json
@@ -1,0 +1,20 @@
+{
+  "_meta": {
+    "generated_at": "2026-06-09T14:37:13.783Z",
+    "gate": "casos status derivado (ADR 0264 G-7 — Status por UC vem do veredito real do teste)",
+    "sources": [],
+    "stats": {
+      "ucs": 0,
+      "pass": 0,
+      "fail": 0,
+      "skip": 0
+    },
+    "nota": "Veredito por-UC derivado dos relatórios JUnit (test-results/). Lido offline pelo casos:check G-7. Regerar quando a suíte rodar: npm run casos:results. UC sem entrada aqui = sem prova capturada (G-7 marca ✅ declarado como unverified).",
+    "refs": [
+      "ADR 0264",
+      "ADR 0261",
+      "ADR 0256"
+    ]
+  },
+  "ucs": {}
+}

--- a/tests/casosGuard.spec.ts
+++ b/tests/casosGuard.spec.ts
@@ -185,3 +185,94 @@ describe('casos:check — G-6 frescor via git (físico)', () => {
     expect(out).toMatch(/"stale_cases": 0/);
   });
 });
+
+// =====================================================================================
+// G-7 — STATUS DERIVADO DO VERDE (Salto #2): ✅ declarado vs veredito real (manifesto)
+// =====================================================================================
+describe('casos:check — G-7 status derivado do verde (físico)', () => {
+  // Tela compliant em todas as outras camadas, com Status declarado parametrizável.
+  const compliant = (dir: string, uc: string, statusGlyph: string) => {
+    write(page(dir), 'x');
+    write(`resources/js/Pages/${dir}/Index.charter.md`, '# c');
+    write(
+      `resources/js/Pages/${dir}/Index.casos.md`,
+      `---\nowner: w\nlast_run: "2026-06-09"\n---\n## ${uc} · caso\n- **Status: ${statusGlyph}**`,
+    );
+    write(`tests/${dir}Test.php`, `<?php // ${uc}`);
+  };
+  const manifest = (ucs: Record<string, { verdict: string; ran_at?: string }>) =>
+    write('scripts/casos-test-results.json', JSON.stringify({ ucs }));
+
+  it('SENSIBILIDADE (lies): ✅ declarado mas teste FALHOU → status:lies', () => {
+    compliant('L', 'UC-01', '✅');
+    manifest({ 'UC-01': { verdict: 'fail' } });
+    const out = runExpectFail('--json'); // sem baseline → tudo novo
+    expect(out).toMatch(/status:lies:resources\/js\/Pages\/L\/Index\.casos\.md#UC-01/);
+  });
+
+  it('SENSIBILIDADE (unverified): ✅ declarado sem teste verde (manifesto vazio) → status:unverified', () => {
+    compliant('U', 'UC-01', '✅');
+    manifest({});
+    const out = runExpectFail('--json');
+    expect(out).toMatch(/status:unverified:resources\/js\/Pages\/U\/Index\.casos\.md#UC-01/);
+  });
+
+  it('SENSIBILIDADE (unverified): ✅ com teste SKIP no manifesto → unverified (skip não é prova)', () => {
+    compliant('K', 'UC-01', '✅');
+    manifest({ 'UC-01': { verdict: 'skip' } });
+    const out = runExpectFail('--json');
+    expect(out).toMatch(/status:unverified:resources\/js\/Pages\/K\/Index\.casos\.md#UC-01/);
+  });
+
+  it('ESPECIFICIDADE: ✅ com teste PASS no manifesto → sem violação de status', () => {
+    compliant('P', 'UC-01', '✅');
+    manifest({ 'UC-01': { verdict: 'pass' } });
+    const out = run('--json'); // tela 100% compliant + verde provado → ok
+    expect(out).toMatch(/"ok": true/);
+    expect(out).not.toMatch(/status:/);
+  });
+
+  it('ESPECIFICIDADE (honesto): ❌ declarado + teste FALHOU → NÃO é mentira', () => {
+    compliant('B', 'UC-01', '❌');
+    manifest({ 'UC-01': { verdict: 'fail' } });
+    const out = run('--json'); // ❌ é afirmação honesta de quebra → sem status:lies
+    expect(out).not.toMatch(/status:lies/);
+    expect(out).not.toMatch(/status:unverified/);
+  });
+
+  it('ESPECIFICIDADE: 🧪 / ⬜ não são afirmação ✅ → não exigem prova', () => {
+    compliant('T', 'UC-01', '🧪');
+    manifest({}); // sem prova nenhuma
+    const out = run('--json');
+    expect(out).toMatch(/"ok": true/);
+    expect(out).not.toMatch(/status:/);
+  });
+
+  it('GRACIOSO: sem manifesto (bootstrap) → G-7 dorme mesmo com ✅ sem prova', () => {
+    compliant('S', 'UC-01', '✅');
+    // sem manifest() → arquivo ausente → G-7 não roda.
+    const out = run('--json');
+    expect(out).toMatch(/"status_unverified": 0/);
+  });
+
+  it('RATCHET: lie atual absorvida no baseline; lie NOVA (outro UC) bloqueia', () => {
+    write(page('R'), 'x');
+    write('resources/js/Pages/R/Index.charter.md', '# c');
+    write(
+      'resources/js/Pages/R/Index.casos.md',
+      '---\nowner: w\nlast_run: "2026-06-09"\n---\n## UC-01 · a\n- **Status: ✅**',
+    );
+    write('tests/RTest.php', '<?php // UC-01 UC-02');
+    manifest({ 'UC-01': { verdict: 'fail' } });
+    run('--write-baseline'); // absorve a lie de UC-01
+    expect(run('')).toMatch(/Sem violações novas/);
+    // adiciona UC-02 ✅ + manifesto fail → lie NOVA bloqueia.
+    write(
+      'resources/js/Pages/R/Index.casos.md',
+      '---\nowner: w\nlast_run: "2026-06-09"\n---\n## UC-01 · a\n- **Status: ✅**\n## UC-02 · b\n- **Status: ✅**',
+    );
+    manifest({ 'UC-01': { verdict: 'fail' }, 'UC-02': { verdict: 'fail' } });
+    const out = runExpectFail('');
+    expect(out).toMatch(/status:lies:resources\/js\/Pages\/R\/Index\.casos\.md#UC-02/);
+  });
+});

--- a/tests/casosResultsCollect.spec.ts
+++ b/tests/casosResultsCollect.spec.ts
@@ -1,0 +1,97 @@
+// Camada META — teste FÍSICO (caixa-preta) do coletor casos:results (Salto #2 / G-7).
+//
+// Roda o .mjs real contra fixtures JUnit num dir temporário e exige a agregação por-UC:
+// pass/fail/skip, pior-caso vence (fail domina; pass vence skip), merge de múltiplos
+// relatórios, ran_at do timestamp, e a segurança "rodada vazia não apaga manifesto".
+//
+// Cobre: scripts/casos-results-collect.mjs
+// Refs: ADR 0264 (G-7) · padrão casosGuard.spec.ts / dominioGuard.spec.ts.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+
+const REPO = process.cwd();
+const COLLECT = resolve(REPO, 'scripts/casos-results-collect.mjs');
+const MANIFEST = 'scripts/casos-test-results.json';
+
+let tmp: string;
+
+const write = (rel: string, content: string) => {
+  const full = join(tmp, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+};
+const junit = (file: string, body: string) =>
+  write(`test-results/${file}`, `<?xml version="1.0"?>\n<testsuites>\n${body}\n</testsuites>`);
+const suite = (cases: string, timestamp = '2026-06-09T10:00:00') =>
+  `<testsuite name="s" timestamp="${timestamp}">${cases}</testsuite>`;
+const tcPass = (name: string) => `<testcase name="${name}"/>`;
+const tcFail = (name: string) => `<testcase name="${name}"><failure>x</failure></testcase>`;
+const tcSkip = (name: string) => `<testcase name="${name}"><skipped/></testcase>`;
+
+const run = (args = '') =>
+  execSync(`node "${COLLECT}" ${args} 2>&1`, { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+const readManifest = () => JSON.parse(readFileSync(join(tmp, MANIFEST), 'utf8'));
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'casos-results-'));
+  mkdirSync(join(tmp, 'scripts'), { recursive: true });
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+describe('casos:results — coletor de test-results → manifesto por-UC (físico)', () => {
+  it('AGREGA pass/fail/skip do nome do <testcase>', () => {
+    junit('a.xml', suite(tcPass('UC-01 · ok') + tcFail('UC-02 · ruim') + tcSkip('UC-06 · pulado')));
+    run();
+    const m = readManifest();
+    expect(m.ucs['UC-01'].verdict).toBe('pass');
+    expect(m.ucs['UC-02'].verdict).toBe('fail');
+    expect(m.ucs['UC-06'].verdict).toBe('skip');
+    expect(m.ucs['UC-01'].ran_at).toBe('2026-06-09');
+  });
+
+  it('PIOR-CASO: UC com pass E fail (testcases distintos) → fail domina', () => {
+    junit('a.xml', suite(tcPass('UC-01 cenário A') + tcFail('UC-01 cenário B')));
+    run();
+    expect(readManifest().ucs['UC-01'].verdict).toBe('fail');
+  });
+
+  it('PASS vence SKIP: ≥1 pass + skip (sem fail) → pass', () => {
+    junit('a.xml', suite(tcPass('UC-03 roda') + tcSkip('UC-03 condicional')));
+    run();
+    expect(readManifest().ucs['UC-03'].verdict).toBe('pass');
+  });
+
+  it('MERGE de múltiplos relatórios (Pest + Playwright)', () => {
+    junit('pest-junit.xml', suite(tcPass('UC-F02 saldo')));
+    junit('playwright-junit.xml', suite(tcPass('UC-06 gate')));
+    run();
+    const m = readManifest();
+    expect(Object.keys(m.ucs).sort()).toEqual(['UC-06', 'UC-F02']);
+    expect(m._meta.sources.length).toBe(2);
+  });
+
+  it('SEGURANÇA: nenhum test-results → NÃO sobrescreve manifesto existente', () => {
+    write(MANIFEST, JSON.stringify({ ucs: { 'UC-01': { verdict: 'pass', ran_at: '2026-06-01' } } }));
+    const out = run(); // test-results/ ausente
+    expect(out).toMatch(/Nenhum test-results/);
+    expect(readManifest().ucs['UC-01'].verdict).toBe('pass'); // preservado
+  });
+
+  it('--seed-empty cria manifesto vazio (bootstrap F1)', () => {
+    run('--seed-empty');
+    const m = readManifest();
+    expect(m.ucs).toEqual({});
+    expect(m._meta.stats.ucs).toBe(0);
+  });
+
+  it('ESPECIFICIDADE: testcase sem UC-id no nome é ignorado', () => {
+    junit('a.xml', suite(tcPass('teste qualquer sem id') + tcPass('UC-01 com id')));
+    run();
+    const m = readManifest();
+    expect(Object.keys(m.ucs)).toEqual(['UC-01']);
+  });
+});


### PR DESCRIPTION
## Salto #2 — Status derivado do verde (F1)

Fecha o **Salto #2** dos 3 do loop de governança executável (ADR 0264). Agora os 3 estão: #1 frescor (#2469 ✅) · #3 domínio-além-do-enum (#2471 ✅) · **#2 status-derivado (este)**. Blueprint aprovado por Wagner antes de codar.

### Problema
O G-5 (`casos:check`) trava a **presença** da linha `Status:` por UC, mas o valor (`✅/🧪/⬜/❌`) é **declarado por humano e pode mentir** — diz `✅` sem nenhum teste verde por trás. A própria intenção do G-5 sempre foi "Status por UC (**se passa**)"; faltava tornar o "passa" **real**.

### Arquitetura (manifesto commitado + gate offline)
"NÃO é regex": pass/fail só se sabe **rodando**. Mas o `casos-gate` é o ratchet rápido `node:fs` **required** — não pode rodar a suíte (deadlock que o ADR 0261 proíbe). Então **separa produção (lenta) de checagem (rápida)**:

```
runners → reporter JUnit → test-results/ → casos:results → scripts/casos-test-results.json
                                                          → casos:check G-7 (lê offline, cruza com o Status)
```

- **`scripts/casos-results-collect.mjs`** (`npm run casos:results`): parseia JUnit de **todos** os runners (Pest `--log-junit` · vitest `--reporter=junit` · Playwright `reporter:junit`), extrai o UC-id do **nome do testcase** (os testes já põem `test('UC-06 · …')`), agrega veredito por-UC (**fail domina · pass vence skip**). Rodada vazia **não** sobrescreve manifesto real.
- **G-7** no `casos-coverage-guard.mjs`:
  - `status:lies` — `✅` declarado mas teste **FALHOU** (alto sinal)
  - `status:unverified` — `✅` sem teste verde que prove (skip/sem entrada)
  - `status:stale-results` — `✅` provado, mas a tela mudou **depois** do teste (via git)
  - Só `✅` exige prova; `🧪/⬜/❌` são não-afirmações honestas → sem violação. Sem manifesto → **dorme** (gracioso).
- **`playwright.config.ts`**: reporter JUnit. **`e2e-gate.yml`**: coleta + sobe **artifact** (não commita — o manifesto commitado é atualizado conscientemente via `casos:results`, idioma baseline/ratchet).

### Dívida F1 capturada (não-bloqueante, baseline absorve)
**8 UCs `✅` da Oficina** (UC-01,02,03,04,05,07,09,10) viram `status:unverified` — declarados verde, **zero prova automatizada capturada**. UC-06 (`🧪`) e UC-08 (`⬜`) corretamente fora. Quando o `e2e-gate` rodar verde + alguém recoletar o manifesto, o ratchet zera.

### Faseamento
- **F1 (este):** infra + gate **não-bloqueante**, baseline da dívida atual.
- **F2:** flip `status:lies` pra **required** (mentira ✅→fail nunca passa).
- **F3:** ratchet `unverified`/`stale-results` → 0 conforme telas tocadas + e2e verde.

### Testes
+17 meta-testes físicos: **10** G-7 no `casosGuard.spec.ts` (lies/unverified/skip/pass-ok/honest-❌/🧪-não-exige/sleep/ratchet) + **7** do coletor em `casosResultsCollect.spec.ts` (agregação/pior-caso/merge/segurança-rodada-vazia/seed/sem-id). **26/26 verde.**

Refs: ADR 0264 (G-5/G-7) · ADR 0261 (faseado, não-deadlock) · ADR 0256 (catraca)

🤖 Generated with [Claude Code](https://claude.com/claude-code)