### PR TITLE
refactor(oficina): erradica order_type=locacao dead-code (G-7 ratchet zera) + P4 fixtures

### DIFF
--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -21,9 +21,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  *   - OS Simples (Martinho · sub-vertical 4 mecânica pesada caminhão basculante): aberta → em_servico → concluida
  *   - OS Complexa (Vargas · sub-vertical 2 recapagem · V1): aberta → orcamento → aprovada → em_producao → concluida → entregue
  *
- * order_type extension migration 2026_05_12_220002 (schema preservado nullable pós-ADR 0194):
+ * order_type enum {manutencao, mecanica} (locação erradicada — ADR 0265):
  * - order_type=manutencao → fluxo Martinho mecânica pesada (predominante prod biz=164) — sub-vertical 4 default
- * - order_type=locacao → schema sub-vertical 3 hipotético locação caçamba container (sem cliente real ancorado pós-ADR 0194 — pré-correção dizia "fluxo Martinho caçamba avulsa")
+ * - order_type=mecanica   → fluxo de reparo de caminhão (ADR 0194 · oficina_mecanica_os)
  *
  * Multi-tenant Tier 0 (ADR 0093): global scope obrigatório.
  *
@@ -45,9 +45,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property \Illuminate\Support\Carbon|null $delivered_at
  * @property string|null  $notes
  *
- * @property-read bool    $is_overdue       Accessor — locação ativa com expected_return_date passada
+ * @property-read bool    $is_overdue       Accessor — sempre false (locação erradicada, ADR 0265; atraso de reparo vive no Controller via expected_completion)
  * @property-read int     $dias_locacao     Accessor — dias decorridos desde entered_at
- * @property-read float   $valor_receber    Accessor — daily_rate × dias_locacao
+ * @property-read float   $valor_receber    Accessor — sempre 0.0 (locação erradicada, ADR 0265; valor de reparo = total_items)
  *
  * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-001
  */
@@ -96,12 +96,6 @@ class ServiceOrder extends Model
         'completed_at'          => 'datetime',
         'delivered_at'          => 'datetime',
     ];
-
-    /** Stages considerados "ativos" pra locação (não-terminais). */
-    private const RENTAL_ACTIVE_STATUSES = ['aberta', 'locada', 'em_servico'];
-
-    /** Stages terminais (concluida, cancelada, recolhida). */
-    private const RENTAL_TERMINAL_STATUSES = ['concluida', 'cancelada', 'recolhida'];
 
     // ------------------------------------------------------------------
     // Global scope multi-tenant Tier 0 (ADR 0093)
@@ -213,25 +207,16 @@ class ServiceOrder extends Model
     // ------------------------------------------------------------------
 
     /**
-     * Locação ativa com expected_return_date passada → atrasada.
+     * Atraso de locação — conceito erradicado (ADR 0265: Oficina é reparo, não locação).
      *
-     * Apenas relevante pra order_type=locacao em status não-terminal.
+     * Sempre `false`: não existe mais o tipo de OS de locação. O accessor é mantido porque
+     * o payload é consumido pelo kanban de Caçambas (ProducaoOficina, FSM `locada` LIVE prod —
+     * dívida F3 charter v4) e pela ServiceOrders Index. O atraso de REPARO é calculado por
+     * `expected_completion` na camada de Controller (ServiceOrderController), não aqui.
      */
     public function getIsOverdueAttribute(): bool
     {
-        if ($this->order_type !== 'locacao') {
-            return false;
-        }
-
-        if ($this->expected_return_date === null) {
-            return false;
-        }
-
-        if (in_array($this->status, self::RENTAL_TERMINAL_STATUSES, true)) {
-            return false;
-        }
-
-        return $this->expected_return_date->isPast();
+        return false;
     }
 
     /**
@@ -250,25 +235,16 @@ class ServiceOrder extends Model
     }
 
     /**
-     * Valor a receber pela locação ativa = daily_rate × dias_locacao.
+     * Valor a receber por locação — conceito erradicado (ADR 0265: Oficina é reparo).
      *
-     * Retorna 0.0 se daily_rate null OU não é locação OU já terminal.
+     * Sempre `0.0`: não existe mais o tipo de OS de locação. Mantido porque o payload é
+     * consumido pelo kanban de Caçambas (ProducaoOficina, FSM `locada` LIVE prod — dívida F3)
+     * e pela ServiceOrders Index. O valor de REPARO sai de `total_items` (peças + mão-de-obra),
+     * computado pelo ServiceOrderObserver::computeFinalTotal.
      */
     public function getValorReceberAttribute(): float
     {
-        if ($this->order_type !== 'locacao') {
-            return 0.0;
-        }
-
-        if ($this->daily_rate === null) {
-            return 0.0;
-        }
-
-        if (in_array($this->status, self::RENTAL_TERMINAL_STATUSES, true)) {
-            return 0.0;
-        }
-
-        return round((float) $this->daily_rate * $this->dias_locacao, 2);
+        return 0.0;
     }
 
     /**
@@ -309,20 +285,5 @@ class ServiceOrder extends Model
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs()
             ->useLogName('oficinaauto.service_order');
-    }
-
-    // ------------------------------------------------------------------
-    // Scopes
-    // ------------------------------------------------------------------
-
-    /**
-     * Locações ativas (order_type=locacao + status não-terminal).
-     *
-     * Base do dashboard "Caçambas em campo agora".
-     */
-    public function scopeRentalsAtivas(Builder $query): Builder
-    {
-        return $query->where('order_type', 'locacao')
-                     ->whereNotIn('status', self::RENTAL_TERMINAL_STATUSES);
     }
 }

--- a/Modules/OficinaAuto/Entities/Vehicle.php
+++ b/Modules/OficinaAuto/Entities/Vehicle.php
@@ -143,15 +143,6 @@ class Vehicle extends Model
     }
 
     /**
-     * Histórico de locações (apenas order_type=locacao).
-     */
-    public function rentals(): HasMany
-    {
-        return $this->hasMany(ServiceOrder::class, 'vehicle_id')
-                    ->where('order_type', 'locacao');
-    }
-
-    /**
      * Histórico de manutenções (apenas order_type=manutencao).
      */
     public function maintenances(): HasMany
@@ -221,29 +212,5 @@ class Vehicle extends Model
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs()
             ->useLogName('oficinaauto.vehicle');
-    }
-
-    // ------------------------------------------------------------------
-    // Scopes
-    // ------------------------------------------------------------------
-
-    /**
-     * Veículos com locação ativa em atraso (expected_return_date passou).
-     *
-     * Join com service_orders pra detectar OS locação não-concluída onde
-     * expected_return_date < hoje.
-     */
-    public function scopeOverdue(Builder $query): Builder
-    {
-        return $query->whereExists(function ($sub) {
-            $sub->select(\DB::raw(1))
-                ->from('service_orders')
-                ->whereColumn('service_orders.vehicle_id', 'vehicles.id')
-                ->where('service_orders.order_type', 'locacao')
-                ->whereNotIn('service_orders.status', ['concluida', 'cancelada', 'recolhida'])
-                ->whereNotNull('service_orders.expected_return_date')
-                ->whereDate('service_orders.expected_return_date', '<', now()->toDateString())
-                ->whereNull('service_orders.deleted_at');
-        });
     }
 }

--- a/Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
+++ b/Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
@@ -182,15 +182,13 @@ class AprovacaoOsController extends Controller
     }
 
     /**
-     * Valor total estimado (best-effort V0 — quando US-OFICINA-006 mapear
-     * transaction_id → final_total, usar).
+     * Valor total estimado (best-effort V0).
+     *
+     * Locação erradicada (ADR 0265): sem fluxo de diária, não há valor estimável aqui.
+     * Quando US-OFICINA-006 mapear transaction_id → final_total, retornar esse valor.
      */
     private function valorTotal(ServiceOrder $os): ?float
     {
-        if ($os->order_type === 'locacao' && $os->daily_rate !== null) {
-            return (float) $os->daily_rate * max(1, $os->dias_locacao);
-        }
-
         return null;
     }
 }

--- a/Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
+++ b/Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
@@ -173,22 +173,13 @@ class AprovacaoOsController extends Controller
             'entered_at'          => $os->entered_at?->toIso8601String(),
             'expected_completion' => $os->expected_completion?->toIso8601String(),
             'notes'               => $os->notes,
-            'valor_total'         => $this->valorTotal($os),
+            // valor_total: locação erradicada (ADR 0265) — sem fluxo de diária, sem valor
+            // estimável aqui. Quando US-OFICINA-006 mapear transaction_id → final_total, usar.
+            'valor_total'         => null,
             'vehicle'             => $os->vehicle ? [
                 'plate'        => $os->vehicle->plate,
                 'vehicle_type' => $os->vehicle->vehicle_type,
             ] : null,
         ];
-    }
-
-    /**
-     * Valor total estimado (best-effort V0).
-     *
-     * Locação erradicada (ADR 0265): sem fluxo de diária, não há valor estimável aqui.
-     * Quando US-OFICINA-006 mapear transaction_id → final_total, retornar esse valor.
-     */
-    private function valorTotal(ServiceOrder $os): ?float
-    {
-        return null;
     }
 }

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -47,9 +47,10 @@ class ServiceOrderController extends Controller
      * Schema::hasColumn fallback porque colunas Wave 5-A (order_type / delivery_address /
      * expected_return_date / daily_rate) podem não estar migradas ainda nessa branch.
      *
-     * Filtros aceitos:
-     *  - ?status=locacao_ativa | manutencao_ativa | concluida_mes | atrasada | all
-     *  - ?type=locacao | manutencao | all
+     * Filtros aceitos (locação erradicada — ADR 0265):
+     *  - ?status=manutencao_ativa | concluida_mes | atrasada | all
+     *    (atrasada = OS não-terminal com expected_completion vencida — atraso de reparo)
+     *  - ?type=manutencao | mecanica | all
      *  - ?q=<busca em number/cliente/vehicle>
      */
     public function index(Request $request): Response
@@ -94,14 +95,8 @@ class ServiceOrderController extends Controller
         }
 
         // ──────── Filter status (semântico) ────────
-        $base->when($statusFilter !== '' && $statusFilter !== 'all', function ($qb) use ($statusFilter, $hasOrderType, $hasReturnDate) {
+        $base->when($statusFilter !== '' && $statusFilter !== 'all', function ($qb) use ($statusFilter, $hasOrderType) {
             switch ($statusFilter) {
-                case 'locacao_ativa':
-                    if ($hasOrderType) {
-                        $qb->where('order_type', 'locacao');
-                    }
-                    $qb->whereNotIn('status', ['concluida', 'cancelada']);
-                    break;
                 case 'manutencao_ativa':
                     if ($hasOrderType) {
                         $qb->where('order_type', 'manutencao');
@@ -114,18 +109,11 @@ class ServiceOrderController extends Controller
                         ->whereYear('updated_at', now()->year);
                     break;
                 case 'atrasada':
-                    if ($hasOrderType) {
-                        $qb->where('order_type', 'locacao');
-                    }
-                    $qb->whereNotIn('status', ['concluida', 'cancelada']);
-                    if ($hasReturnDate) {
-                        $qb->whereNotNull('expected_return_date')
-                            ->whereDate('expected_return_date', '<', now()->toDateString());
-                    } else {
-                        // Fallback: sem expected_return_date usa expected_completion
-                        $qb->whereNotNull('expected_completion')
-                            ->whereDate('expected_completion', '<', now()->toDateString());
-                    }
+                    // Atraso de REPARO (ADR 0265 — locação erradicada): OS não-terminal
+                    // com expected_completion vencida. Espelha buildServiceOrderKpisPayload.
+                    $qb->whereNotIn('status', ['concluida', 'cancelada'])
+                        ->whereNotNull('expected_completion')
+                        ->whereDate('expected_completion', '<', now()->toDateString());
                     break;
                 default:
                     // status livre legado: aberta/em_servico/etc
@@ -207,7 +195,7 @@ class ServiceOrderController extends Controller
                 'stage'  => $stageFilter,
                 'q'      => $q,
             ],
-            'kpis' => Inertia::defer(fn () => $this->buildServiceOrderKpisPayload($hasOrderType, $hasReturnDate)),
+            'kpis' => Inertia::defer(fn () => $this->buildServiceOrderKpisPayload($hasOrderType)),
             // Gap #3 estado-da-arte FSM screen — chips por stage estilo Linear.
             // Defer porque é COUNT por stage (~8 stages × cacamba_* processos).
             'stages' => Inertia::defer(fn () => $this->buildStagesPayload($hasCurrentStage)),
@@ -491,23 +479,22 @@ class ServiceOrderController extends Controller
      * Extraído pra helper + Inertia::defer no index() pra pular execução quando
      * partial reload `only:['orders']` não pede kpis (RUNBOOK-inertia-defer-pattern).
      */
-    private function buildServiceOrderKpisPayload(bool $hasOrderType, bool $hasReturnDate): array
+    private function buildServiceOrderKpisPayload(bool $hasOrderType): array
     {
         $kpiBase = fn () => ServiceOrder::query();
 
-        if ($hasOrderType) {
-            $locacoesAtivas = $kpiBase()
-                ->where('order_type', 'locacao')
-                ->whereNotIn('status', ['concluida', 'cancelada'])
-                ->count();
+        // Locação erradicada (ADR 0265): KPI mantida em 0 só pelo contrato do payload
+        // — o frontend (ServiceOrders/Index) ainda consome a chave. A remoção visual do
+        // card/chip "Locações ativas" é dívida F3 (RUNBOOK-erradicacao-locacao.md P5).
+        $locacoesAtivas = 0;
 
+        if ($hasOrderType) {
             $manutencaoAtivas = $kpiBase()
                 ->where('order_type', 'manutencao')
                 ->whereNotIn('status', ['concluida', 'cancelada'])
                 ->count();
         } else {
             // Fallback pré-Wave 5-A: tudo ainda não tem tipo, agrupa em "manutenção"
-            $locacoesAtivas = 0;
             $manutencaoAtivas = $kpiBase()
                 ->whereNotIn('status', ['concluida', 'cancelada'])
                 ->count();
@@ -519,20 +506,13 @@ class ServiceOrderController extends Controller
             ->whereYear('updated_at', now()->year)
             ->count();
 
-        if ($hasReturnDate && $hasOrderType) {
-            $atrasadas = $kpiBase()
-                ->where('order_type', 'locacao')
-                ->whereNotIn('status', ['concluida', 'cancelada'])
-                ->whereNotNull('expected_return_date')
-                ->whereDate('expected_return_date', '<', now()->toDateString())
-                ->count();
-        } else {
-            $atrasadas = $kpiBase()
-                ->whereNotIn('status', ['concluida', 'cancelada'])
-                ->whereNotNull('expected_completion')
-                ->whereDate('expected_completion', '<', now()->toDateString())
-                ->count();
-        }
+        // Atraso de REPARO (ADR 0265 — locação erradicada): OS não-terminal com
+        // expected_completion vencida. Mesma regra do filtro ?status=atrasada.
+        $atrasadas = $kpiBase()
+            ->whereNotIn('status', ['concluida', 'cancelada'])
+            ->whereNotNull('expected_completion')
+            ->whereDate('expected_completion', '<', now()->toDateString())
+            ->count();
 
         return [
             'locacoes_ativas'   => $locacoesAtivas,

--- a/Modules/OficinaAuto/Observers/ServiceOrderObserver.php
+++ b/Modules/OficinaAuto/Observers/ServiceOrderObserver.php
@@ -28,8 +28,7 @@ use Modules\OficinaAuto\Entities\ServiceOrder;
  *   (a) skip se `$so->transaction_id !== null` (já tem venda derivada)
  *   (b) skip se Transaction::where('os_ref', "SO-{id}")->where('business_id', X) existe
  *
- * Cálculo `final_total`:
- *   - locação (order_type='locacao'): `daily_rate × dias_locacao` (accessor `valor_receber`)
+ * Cálculo `final_total` (locação erradicada — ADR 0265, só fluxo de reparo):
  *   - manutenção (order_type='manutencao'): `sum(items.valor_total)` agregando peças +
  *     mão-de-obra + serviços terceiros via `ServiceOrder::items()` hasMany (US-OFICINA-027
  *     2026-05-26 · ADR 0194 §"Critério validação"). Backward compat: OS sem items lançados
@@ -108,7 +107,7 @@ class ServiceOrderObserver
             return;
         }
 
-        // Compute final_total: locação usa accessor valor_receber · manutenção zero (manual depois).
+        // Compute final_total: reparo soma items (peças + mão-de-obra); 0 se sem items (manual depois).
         $finalTotal = $this->computeFinalTotal($so);
 
         try {
@@ -181,11 +180,7 @@ class ServiceOrderObserver
 
     private function computeFinalTotal(ServiceOrder $so): float
     {
-        if ($so->order_type === 'locacao') {
-            // Accessor `valor_receber` = daily_rate × dias_locacao (definido na entity)
-            return (float) ($so->valor_receber ?? 0);
-        }
-
+        // Locação erradicada (ADR 0265): só existe o caminho de reparo.
         // order_type='manutencao' (Martinho sub-vertical 4 mecânica pesada CNAE 4520 — ADR 0194):
         // soma valor_total de todos itens (peça + mão-de-obra + serviço terceiro) via
         // hasMany ServiceOrder::items() — schema oficina_service_order_items entregue em

--- a/Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php
@@ -55,7 +55,7 @@ it('Cenário 1 — fluxo Simples Martinho: aberta → em_servico → concluida (
     $os = ServiceOrder::create([
         'business_id' => BIZ_WAGNER_FSM,
         'vehicle_id'  => $vehicle->id,
-        'order_type'  => 'locacao',
+        'order_type'  => 'manutencao', // locação erradicada (ADR 0265); cenário testa fluxo de status, não o tipo
         'status'      => 'aberta',
         'entered_at'  => now(),
         'daily_rate'  => '150.00',
@@ -110,54 +110,11 @@ it('Cenário 2 — fluxo Complexa Vargas: aberta → orcamento → aprovada → 
     Vehicle::withoutGlobalScopes()->where('plate', 'FSM002')->forceDelete();
 });
 
-it('Cenário 3 — locação ativa retorna is_overdue=true quando expected_return_date passada', function () {
-    session(['user.business_id' => BIZ_WAGNER_FSM]);
-
-    $vehicle = createFsmVehicle('FSM003');
-    $os = ServiceOrder::create([
-        'business_id'          => BIZ_WAGNER_FSM,
-        'vehicle_id'           => $vehicle->id,
-        'order_type'           => 'locacao',
-        'status'               => 'em_servico',
-        'entered_at'           => now()->subDays(10),
-        'expected_return_date' => now()->subDays(2)->toDateString(),
-        'daily_rate'           => '180.00',
-    ]);
-
-    expect($os->fresh()->is_overdue)->toBeTrue();
-
-    // Após terminal status, is_overdue volta a false
-    $os->update(['status' => 'concluida', 'completed_at' => now()]);
-    expect($os->fresh()->is_overdue)->toBeFalse();
-})->afterEach(function () {
-    ServiceOrder::withoutGlobalScopes()->whereHas('vehicle', fn ($q) => $q->withoutGlobalScopes()->where('plate', 'FSM003'))->forceDelete();
-    Vehicle::withoutGlobalScopes()->where('plate', 'FSM003')->forceDelete();
-});
-
-it('Cenário 4 — accessor valor_receber calcula daily_rate × dias_locacao em locação ativa', function () {
-    session(['user.business_id' => BIZ_WAGNER_FSM]);
-
-    $vehicle = createFsmVehicle('FSM004');
-    $os = ServiceOrder::create([
-        'business_id' => BIZ_WAGNER_FSM,
-        'vehicle_id'  => $vehicle->id,
-        'order_type'  => 'locacao',
-        'status'      => 'em_servico',
-        'entered_at'  => now()->subDays(7),
-        'daily_rate'  => '200.00',
-    ]);
-
-    $fresh = $os->fresh();
-    expect($fresh->dias_locacao)->toBe(7);
-    expect($fresh->valor_receber)->toBe(1400.00);
-
-    // Após terminal status, valor_receber zera (locação encerrada)
-    $os->update(['status' => 'concluida', 'completed_at' => now()]);
-    expect($os->fresh()->valor_receber)->toBe(0.0);
-})->afterEach(function () {
-    ServiceOrder::withoutGlobalScopes()->whereHas('vehicle', fn ($q) => $q->withoutGlobalScopes()->where('plate', 'FSM004'))->forceDelete();
-    Vehicle::withoutGlobalScopes()->where('plate', 'FSM004')->forceDelete();
-});
+// Cenários 3 e 4 (is_overdue / valor_receber de locação ativa) REMOVIDOS — locação
+// erradicada (ADR 0265). Os accessors `is_overdue`/`valor_receber` agora são sempre
+// false/0.0 (cobertura do estado pós-erradicação fica em CacambaSchemaTest, casos
+// order_type=manutencao). Atraso de reparo vive no ServiceOrderController via
+// expected_completion. Repontuar o kanban de Caçambas é dívida F3 charter v4.
 
 it('Cenário 5 — isolamento multi-tenant: transição em biz=1 não vaza pra biz=99', function () {
     session(['user.business_id' => BIZ_WAGNER_FSM]);

--- a/Modules/OficinaAuto/Tests/Feature/ImportFirebirdMartinhoCommandTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ImportFirebirdMartinhoCommandTest.php
@@ -102,6 +102,9 @@ it('dry-run não modifica DB mesmo com payload válido', function () {
                 'ordem_id'    => 'FB-DRYRUN-001',
                 'placa'       => PLATE_W27_IMP_PREFIX . 'DRY',
                 'veiculo_id'  => '99',
+                // INPUT legado Firebird: 'locacao' é dado de ORIGEM (não enum do app). O importer
+                // normaliza via normalizeOrderType → 'manutencao' (ADR 0265). Mantido de propósito
+                // pra cobrir a tolerância a dado legado. Dry-run: nada é gravado no DB.
                 'order_type'  => 'locacao',
                 'status'      => 'concluida',
                 'entered_at'  => '2025-01-10 08:00:00',

--- a/Modules/OficinaAuto/Tests/Feature/ProducaoBoxFilterTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ProducaoBoxFilterTest.php
@@ -55,7 +55,7 @@ function boxCreateVehicleWithOs(int $bizId, ?string $box, string $status = 'loca
     $order = ServiceOrder::withoutGlobalScopes()->create([
         'business_id' => $bizId,
         'vehicle_id'  => $vehicle->id,
-        'order_type'  => 'locacao',
+        'order_type'  => 'manutencao', // locação erradicada (ADR 0265); order_type incidental — teste é de box_label
         'status'      => 'aberta',
         'entered_at'  => now(),
         'box_label'   => $box,
@@ -69,7 +69,7 @@ function boxCreateVehicleWithOs(int $bizId, ?string $box, string $status = 'loca
 function boxCleanup(int $bizId): void
 {
     Vehicle::withoutGlobalScopes()->where('business_id', $bizId)->where('plate', 'like', 'BOX%')->forceDelete();
-    ServiceOrder::withoutGlobalScopes()->where('business_id', $bizId)->where('order_type', 'locacao')->forceDelete();
+    ServiceOrder::withoutGlobalScopes()->where('business_id', $bizId)->where('order_type', 'manutencao')->forceDelete();
 }
 
 // ─── Specs ────────────────────────────────────────────────────────────────

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderHistoryControllerTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderHistoryControllerTest.php
@@ -112,7 +112,7 @@ function ohcCreateOs(int $bizId): ServiceOrder
     return ServiceOrder::withoutGlobalScopes()->create([
         'business_id' => $bizId,
         'vehicle_id'  => $vehicle->id,
-        'order_type'  => 'locacao',
+        'order_type'  => 'manutencao', // locação erradicada (ADR 0265); incidental ao teste de histórico
         'status'      => 'aberta',
         'entered_at'  => now(),
         'daily_rate'  => '150.00',

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexStageFilterTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexStageFilterTest.php
@@ -88,7 +88,7 @@ function osfCreateOs(int $bizId, ?int $stageId = null): ServiceOrder
     return ServiceOrder::withoutGlobalScopes()->create([
         'business_id'      => $bizId,
         'vehicle_id'       => $vehicle->id,
-        'order_type'       => 'locacao',
+        'order_type'       => 'manutencao', // locação erradicada (ADR 0265); incidental — roteamento FSM é via current_stage_id
         'status'           => 'aberta',
         'entered_at'       => now(),
         'daily_rate'       => '150.00',

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderStagePipelineTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderStagePipelineTest.php
@@ -100,7 +100,7 @@ function ospCreateOs(int $bizId, ?int $stageId = null): ServiceOrder
     return ServiceOrder::withoutGlobalScopes()->create([
         'business_id'      => $bizId,
         'vehicle_id'       => $vehicle->id,
-        'order_type'       => 'locacao',
+        'order_type'       => 'manutencao', // locação erradicada (ADR 0265); incidental — roteamento FSM é via current_stage_id
         'status'           => 'aberta',
         'entered_at'       => now(),
         'current_stage_id' => $stageId,

--- a/Modules/OficinaAuto/Tests/Feature/WhatsAppAprovacaoPinTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/WhatsAppAprovacaoPinTest.php
@@ -94,7 +94,7 @@ it('Cenário 2 — OS sem status orcamento NÃO deve receber link aprovação (a
     $osSimples = ServiceOrder::create([
         'business_id' => BIZ_WAGNER_WPP,
         'vehicle_id'  => $vehicle->id,
-        'order_type'  => 'locacao',
+        'order_type'  => 'manutencao', // locação erradicada (ADR 0265); incidental ao teste de aprovação WhatsApp
         'status'      => 'em_servico',
         'entered_at'  => now(),
     ]);

--- a/scripts/domain-dict-baseline.json
+++ b/scripts/domain-dict-baseline.json
@@ -1,12 +1,12 @@
 {
   "_meta": {
-    "generated_at": "2026-06-09T14:16:47.666Z",
+    "generated_at": "2026-06-09T15:25:32.466Z",
     "gate": "dominio:check (ADR 0264 G-4 — dicionário de domínio ⇔ enum de migration + código, Salto #3)",
     "stats": {
       "modules_with_dict": 1,
       "modules_with_enums": 21,
       "divergences": 0,
-      "code_divergences": 1,
+      "code_divergences": 0,
       "modules_no_dict": 20
     },
     "nota": "Divergências ATUAIS fotografadas (débito): enum⇔dicionário E valores de domínio hardcoded no código (Salto #3). Gate falha só em divergência NOVA (ratchet). order_type=locacao zera quando a erradicação (ADR 0265) remover o valor do enum E das ramificações de código.",
@@ -37,7 +37,6 @@
     "dominio:module-no-dict:TeamMcp",
     "dominio:module-no-dict:Vestuario",
     "dominio:module-no-dict:Whatsapp",
-    "dominio:module-no-dict:Woocommerce",
-    "dominio:undeclared-code-value:OficinaAuto:order_type:locacao"
+    "dominio:module-no-dict:Woocommerce"
   ]
 }

--- a/tests/Feature/Domain/Fsm/SideEffects/OficinaAutoSideEffectsTest.php
+++ b/tests/Feature/Domain/Fsm/SideEffects/OficinaAutoSideEffectsTest.php
@@ -108,7 +108,7 @@ function oaSideHelperServiceOrder(int $bizId, int $vehicleId, string $status = '
 
 it('1. IniciarLocacaoCacamba — vehicle vira locada + current_rental_id = SO.id', function () {
     $vehicle = oaSideHelperVehicle(1, 'LOC1001');
-    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'locacao');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'manutencao');
 
     Log::spy();
 
@@ -127,7 +127,7 @@ it('1. IniciarLocacaoCacamba — vehicle vira locada + current_rental_id = SO.id
 
 it('2. RecolherCacamba — vehicle vira disponivel + current_rental_id null', function () {
     $vehicle = oaSideHelperVehicle(1, 'REC1001', 'locada');
-    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'locacao');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'em_servico', 'manutencao');
     DB::table('vehicles')->where('id', $vehicle->id)->update(['current_rental_id' => $so->id]);
 
     Log::spy();
@@ -252,7 +252,7 @@ it('8. cross-tenant — SideEffect biz=99 NÃO afeta vehicles biz=1 (Tier 0 isol
 
     // Setup biz=99 + SO biz=99 referenciando vehicle biz=99
     $vehicle99 = oaSideHelperVehicle(99, 'BIZ9901', 'disponivel');
-    $so99 = oaSideHelperServiceOrder(99, $vehicle99->id, 'aberta', 'locacao');
+    $so99 = oaSideHelperServiceOrder(99, $vehicle99->id, 'aberta', 'manutencao');
 
     (new IniciarLocacaoCacamba())->execute($so99);
 
@@ -276,7 +276,7 @@ it('8b. cross-tenant — SideEffect bloqueia se ServiceOrder.business_id != Vehi
     $so->vehicle_id = $vehicle1->id; // ← cross-tenant violation
     $so->status = 'aberta';
     $so->save();
-    DB::table('service_orders')->where('id', $so->id)->update(['order_type' => 'locacao']);
+    DB::table('service_orders')->where('id', $so->id)->update(['order_type' => 'manutencao']);
     $so->refresh();
 
     expect(fn () => (new IniciarLocacaoCacamba())->execute($so))
@@ -289,7 +289,7 @@ it('8b. cross-tenant — SideEffect bloqueia se ServiceOrder.business_id != Vehi
 
 it('9. idempotência — chamar 2× IniciarLocacaoCacamba resulta no mesmo state', function () {
     $vehicle = oaSideHelperVehicle(1, 'IDP1001');
-    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'locacao');
+    $so = oaSideHelperServiceOrder(1, $vehicle->id, 'aberta', 'manutencao');
 
     (new IniciarLocacaoCacamba())->execute($so);
     $first = DB::table('vehicles')->where('id', $vehicle->id)->first();

--- a/tests/Feature/Modules/OficinaAuto/CacambaSchemaTest.php
+++ b/tests/Feature/Modules/OficinaAuto/CacambaSchemaTest.php
@@ -145,7 +145,7 @@ it('ServiceOrder dias_locacao calcula dias decorridos desde entered_at', functio
     $os = ServiceOrder::create([
         'business_id'           => BIZ_WAGNER_CAC,
         'vehicle_id'            => $v->id,
-        'order_type'            => 'locacao',
+        'order_type'            => 'manutencao', // locação erradicada (ADR 0265); dias_locacao independe do tipo
         'status'                => 'aberta',
         'entered_at'            => now()->subDays(7),
         'expected_return_date'  => now()->addDays(3)->toDateString(),
@@ -173,7 +173,7 @@ it('ServiceOrder dias_locacao retorna 0 quando entered_at é null', function () 
     $os = ServiceOrder::create([
         'business_id' => BIZ_WAGNER_CAC,
         'vehicle_id'  => $v->id,
-        'order_type'  => 'locacao',
+        'order_type'  => 'manutencao', // locação erradicada (ADR 0265); dias_locacao independe do tipo
         'status'      => 'aberta',
         // entered_at NULL
     ]);
@@ -186,59 +186,11 @@ it('ServiceOrder dias_locacao retorna 0 quando entered_at é null', function () 
     Vehicle::withoutGlobalScopes()->where('plate', 'CAC006')->forceDelete();
 });
 
-it('ServiceOrder is_overdue=true quando expected_return_date passou e status ativo', function () {
-    session(['user.business_id' => BIZ_WAGNER_CAC]);
-
-    $v = Vehicle::create([
-        'business_id'  => BIZ_WAGNER_CAC,
-        'plate'        => 'CAC007',
-        'vehicle_type' => 'cacamba_avulsa',
-    ]);
-
-    $os = ServiceOrder::create([
-        'business_id'          => BIZ_WAGNER_CAC,
-        'vehicle_id'           => $v->id,
-        'order_type'           => 'locacao',
-        'status'               => 'aberta',
-        'entered_at'           => now()->subDays(10),
-        'expected_return_date' => now()->subDays(3)->toDateString(), // venceu há 3 dias
-        'daily_rate'           => 50.00,
-    ]);
-
-    expect($os->is_overdue)->toBeTrue();
-})->afterEach(function () {
-    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
-        $q->select('id')->from('vehicles')->where('plate', 'CAC007');
-    })->forceDelete();
-    Vehicle::withoutGlobalScopes()->where('plate', 'CAC007')->forceDelete();
-});
-
-it('ServiceOrder is_overdue=false quando status terminal (concluida)', function () {
-    session(['user.business_id' => BIZ_WAGNER_CAC]);
-
-    $v = Vehicle::create([
-        'business_id'  => BIZ_WAGNER_CAC,
-        'plate'        => 'CAC008',
-        'vehicle_type' => 'cacamba_avulsa',
-    ]);
-
-    $os = ServiceOrder::create([
-        'business_id'          => BIZ_WAGNER_CAC,
-        'vehicle_id'           => $v->id,
-        'order_type'           => 'locacao',
-        'status'               => 'concluida', // terminal
-        'entered_at'           => now()->subDays(10),
-        'expected_return_date' => now()->subDays(3)->toDateString(),
-        'daily_rate'           => 50.00,
-    ]);
-
-    expect($os->is_overdue)->toBeFalse();
-})->afterEach(function () {
-    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
-        $q->select('id')->from('vehicles')->where('plate', 'CAC008');
-    })->forceDelete();
-    Vehicle::withoutGlobalScopes()->where('plate', 'CAC008')->forceDelete();
-});
+// Testes CAC007 (is_overdue=true em locação ativa) e CAC008 (is_overdue=false em
+// locação terminal) REMOVIDOS — locação erradicada (ADR 0265). O accessor `is_overdue`
+// agora é sempre false; a cobertura pós-erradicação (order_type=manutencao → false)
+// fica no teste CAC009 logo abaixo. Atraso de reparo vive no ServiceOrderController
+// via expected_completion; repontuar o kanban de Caçambas é dívida F3 charter v4.
 
 it('ServiceOrder is_overdue=false quando order_type=manutencao', function () {
     session(['user.business_id' => BIZ_WAGNER_CAC]);
@@ -266,33 +218,9 @@ it('ServiceOrder is_overdue=false quando order_type=manutencao', function () {
     Vehicle::withoutGlobalScopes()->where('plate', 'CAC009')->forceDelete();
 });
 
-it('ServiceOrder valor_receber = daily_rate × dias_locacao quando locação ativa', function () {
-    session(['user.business_id' => BIZ_WAGNER_CAC]);
-
-    $v = Vehicle::create([
-        'business_id'  => BIZ_WAGNER_CAC,
-        'plate'        => 'CAC010',
-        'vehicle_type' => 'cacamba_avulsa',
-    ]);
-
-    $os = ServiceOrder::create([
-        'business_id'          => BIZ_WAGNER_CAC,
-        'vehicle_id'           => $v->id,
-        'order_type'           => 'locacao',
-        'status'               => 'aberta',
-        'entered_at'           => now()->subDays(5),
-        'expected_return_date' => now()->addDays(2)->toDateString(),
-        'daily_rate'           => 80.00,
-    ]);
-
-    // 5 dias × R$ [redacted Tier 0] = R$ [redacted Tier 0]
-    expect($os->valor_receber)->toBe(400.00);
-})->afterEach(function () {
-    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
-        $q->select('id')->from('vehicles')->where('plate', 'CAC010');
-    })->forceDelete();
-    Vehicle::withoutGlobalScopes()->where('plate', 'CAC010')->forceDelete();
-});
+// Teste CAC010 (valor_receber = daily_rate × dias_locacao em locação ativa) REMOVIDO —
+// locação erradicada (ADR 0265). O accessor `valor_receber` agora é sempre 0.0; a
+// cobertura pós-erradicação fica no teste CAC011 abaixo. Valor de reparo = total_items.
 
 it('ServiceOrder valor_receber = 0.0 quando manutencao (não cobra diária)', function () {
     session(['user.business_id' => BIZ_WAGNER_CAC]);
@@ -339,40 +267,6 @@ it('Vehicle cross-tenant: biz=99 NÃO vê vehicles biz=1 (Tier 0 — ADR 0093)',
     Vehicle::withoutGlobalScopes()->where('plate', 'CAC012')->forceDelete();
 });
 
-it('ServiceOrder scope rentalsAtivas filtra apenas locações não-terminais', function () {
-    session(['user.business_id' => BIZ_WAGNER_CAC]);
-
-    $v = Vehicle::create([
-        'business_id'  => BIZ_WAGNER_CAC,
-        'plate'        => 'CAC013',
-        'vehicle_type' => 'cacamba_avulsa',
-    ]);
-
-    // 3 OS: 2 ativas (aberta + em_servico), 1 concluida, 1 manutenção (deve excluir)
-    ServiceOrder::create([
-        'business_id' => BIZ_WAGNER_CAC, 'vehicle_id' => $v->id,
-        'order_type'  => 'locacao', 'status' => 'aberta',
-        'entered_at'  => now(), 'daily_rate' => 50.00,
-    ]);
-    ServiceOrder::create([
-        'business_id' => BIZ_WAGNER_CAC, 'vehicle_id' => $v->id,
-        'order_type'  => 'locacao', 'status' => 'concluida',
-        'entered_at'  => now()->subDays(20), 'daily_rate' => 50.00,
-    ]);
-    ServiceOrder::create([
-        'business_id' => BIZ_WAGNER_CAC, 'vehicle_id' => $v->id,
-        'order_type'  => 'manutencao', 'status' => 'aberta',
-        'entered_at'  => now(),
-    ]);
-
-    $ativas = ServiceOrder::rentalsAtivas()->where('vehicle_id', $v->id)->get();
-
-    expect($ativas)->toHaveCount(1); // apenas a aberta locacao
-    expect($ativas->first()->status)->toBe('aberta');
-    expect($ativas->first()->order_type)->toBe('locacao');
-})->afterEach(function () {
-    ServiceOrder::withoutGlobalScopes()->where('vehicle_id', function ($q) {
-        $q->select('id')->from('vehicles')->where('plate', 'CAC013');
-    })->forceDelete();
-    Vehicle::withoutGlobalScopes()->where('plate', 'CAC013')->forceDelete();
-});
+// Teste do scope `rentalsAtivas` REMOVIDO — o scope foi removido do ServiceOrder
+// (locação erradicada, ADR 0265; nenhum consumidor de produção). Locações ativas
+// não existem mais como conceito.

--- a/tests/Feature/Modules/OficinaAuto/KanbanDragDropTest.php
+++ b/tests/Feature/Modules/OficinaAuto/KanbanDragDropTest.php
@@ -182,7 +182,7 @@ it('mapping locada → manutencao dispara FSM action enviar_manutencao', functio
     $stageManutencao = getStageKanbanDnd(BIZ_KANBAN_DND, 'cacamba_locacao', 'manutencao');
 
     $vehicle = makeVehicleKanbanDnd('KDND-A1', BIZ_KANBAN_DND);
-    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'locacao', $stageLocada->id);
+    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'manutencao', $stageLocada->id);
 
     // NOTA: FSM seeder cadastra enviar_manutencao a partir de 'disponivel' e 'recolhida',
     // não de 'locada' direto. O frontend resolveDragMapping aplica 'recolher' implícito
@@ -225,7 +225,7 @@ it('mapping aguardando → disponivel dispara FSM action recolher', function () 
     $stageRecolhida = getStageKanbanDnd(BIZ_KANBAN_DND, 'cacamba_locacao', 'recolhida');
 
     $vehicle = makeVehicleKanbanDnd('KDND-B1', BIZ_KANBAN_DND);
-    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'locacao', $stageLocada->id);
+    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'manutencao', $stageLocada->id);
 
     $request = Request::create(
         '/oficina-auto/service-orders/'.$order->id.'/fsm/execute',
@@ -258,7 +258,7 @@ it('mapping manutencao → disponivel dispara FSM action voltar_disponivel', fun
     $stageDisponivel = getStageKanbanDnd(BIZ_KANBAN_DND, 'cacamba_locacao', 'disponivel');
 
     $vehicle = makeVehicleKanbanDnd('KDND-C1', BIZ_KANBAN_DND);
-    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'locacao', $stageManutencao->id);
+    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'manutencao', $stageManutencao->id);
 
     $request = Request::create(
         '/oficina-auto/service-orders/'.$order->id.'/fsm/execute',
@@ -289,7 +289,7 @@ it('action key inexistente retorna 422 — defense pro mapping bloqueado client-
 
     $stageDisponivel = getStageKanbanDnd(BIZ_KANBAN_DND, 'cacamba_locacao', 'disponivel');
     $vehicle = makeVehicleKanbanDnd('KDND-D1', BIZ_KANBAN_DND);
-    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'locacao', $stageDisponivel->id);
+    $order = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'manutencao', $stageDisponivel->id);
 
     // Simula drop disponivel→pronta (mapping client-side bloqueia, mas server é última linha)
     $request = Request::create(
@@ -316,7 +316,7 @@ it('cross-tenant biz=99 NÃO pode disparar FSM action em OS biz=1', function () 
     setupKanbanDndBusiness(BIZ_KANBAN_DND);
     $stage = getStageKanbanDnd(BIZ_KANBAN_DND, 'cacamba_locacao', 'locada');
     $vehicle = makeVehicleKanbanDnd('KDND-E1', BIZ_KANBAN_DND);
-    $orderBiz1 = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'locacao', $stage->id);
+    $orderBiz1 = makeOrderKanbanDnd(BIZ_KANBAN_DND, $vehicle->id, 'manutencao', $stage->id);
 
     // Switch pra biz=99
     $userBiz99 = setupKanbanDndBusiness(BIZ_KANBAN_DND_CROSS);

--- a/tests/Feature/Modules/OficinaAuto/ProducaoOficinaIndexTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ProducaoOficinaIndexTest.php
@@ -78,6 +78,14 @@ it('Controller@index retorna props kanban (5 grupos) + kpis + filters', function
 });
 
 it('caçamba locada overdue cai em "aguardando" (não "locada")', function () {
+    $this->markTestSkipped(
+        'F3 charter v4 (dívida): o roteamento overdue→aguardando dependia de '
+        . 'order_type=locacao + accessor is_overdue, erradicado pela ADR 0265. Em produção '
+        . 'is_overdue já era sempre false (nenhuma OS order_type=locacao após a erradicação), '
+        . 'então o kanban nunca caía em aguardando. Repontuar o kanban de Caçambas para '
+        . 'atraso de reparo (expected_completion) é dívida F3 — RUNBOOK-erradicacao-locacao.md.'
+    );
+
     if (! Schema::hasColumn('vehicles', 'current_status')) {
         $this->markTestSkipped('current_status column missing — Wave 5 schema pending');
     }
@@ -99,7 +107,7 @@ it('caçamba locada overdue cai em "aguardando" (não "locada")', function () {
     $rentalOk = \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_PROD,
         'vehicle_id'           => $vehNoOverdue->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); teste skipado (dívida F3)
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(3),
         'expected_return_date' => now()->addDays(2)->toDateString(), // futuro = não overdue
@@ -118,7 +126,7 @@ it('caçamba locada overdue cai em "aguardando" (não "locada")', function () {
     $rentalOverdue = \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_PROD,
         'vehicle_id'           => $vehOverdue->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); teste skipado (dívida F3)
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(10),
         'expected_return_date' => now()->subDays(2)->toDateString(), // passado = overdue

--- a/tests/Feature/Modules/OficinaAuto/ProducaoOficinaRichUITest.php
+++ b/tests/Feature/Modules/OficinaAuto/ProducaoOficinaRichUITest.php
@@ -112,7 +112,7 @@ it('card payload V2 tem rental_notes, rental_created_at, atendente, daily_rate, 
     $rental = \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_RICH,
         'vehicle_id'           => $vehicle->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); current_status=locada (canônico) mantém o card na coluna
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(5),
         'expected_return_date' => now()->addDays(2)->toDateString(),
@@ -176,7 +176,7 @@ it('filter ?q=Construtora filtra por nome cliente (contact eager-loaded)', funct
         'business_id'          => BIZ_WAGNER_RICH,
         'vehicle_id'           => $vehicleA->id,
         'contact_id'           => $contact->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); current_status=locada (canônico) mantém o card na coluna
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(2),
         'expected_return_date' => now()->addDays(3)->toDateString(),
@@ -219,6 +219,13 @@ it('filter ?q=Construtora filtra por nome cliente (contact eager-loaded)', funct
 });
 
 it('valor_em_curso soma valor_receber das colunas locada + aguardando', function () {
+    $this->markTestSkipped(
+        'F3 charter v4 (dívida): valor_receber/is_overdue eram do modelo de locação '
+        . 'erradicado (ADR 0265) — agora sempre 0.0/false, então valor_em_curso=0 e nada cai '
+        . 'em aguardando. Em produção já era assim (nenhuma OS order_type=locacao). Repontuar '
+        . 'o valor/atraso de reparo no kanban de Caçambas é dívida F3 — RUNBOOK-erradicacao-locacao.md.'
+    );
+
     session(['user.business_id' => BIZ_WAGNER_RICH]);
     $this->actingAs(stubUserSuperadminRich());
 
@@ -233,7 +240,7 @@ it('valor_em_curso soma valor_receber das colunas locada + aguardando', function
     $rLocada = \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_RICH,
         'vehicle_id'           => $vehLocada->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); current_status=locada (canônico) mantém o card na coluna
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(3)->startOfDay(),
         'expected_return_date' => now()->addDays(2)->toDateString(),
@@ -253,7 +260,7 @@ it('valor_em_curso soma valor_receber das colunas locada + aguardando', function
     $rOver = \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_RICH,
         'vehicle_id'           => $vehOver->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); current_status=locada (canônico) mantém o card na coluna
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(7)->startOfDay(),
         'expected_return_date' => now()->subDays(2)->toDateString(),
@@ -284,6 +291,13 @@ it('valor_em_curso soma valor_receber das colunas locada + aguardando', function
 });
 
 it('V3 fallback — vehicle locada SEM current_rental_id pega rental órfão pra cair em aguardando se overdue', function () {
+    $this->markTestSkipped(
+        'F3 charter v4 (dívida): o fallback overdue→aguardando dependia do accessor is_overdue '
+        . '(modelo de locação erradicado, ADR 0265 — agora sempre false). Em produção já era inerte. '
+        . 'Repontuar o kanban de Caçambas para atraso de reparo (expected_completion) é dívida F3 — '
+        . 'RUNBOOK-erradicacao-locacao.md.'
+    );
+
     session(['user.business_id' => BIZ_WAGNER_RICH]);
     $this->actingAs(stubUserSuperadminRich());
 
@@ -302,7 +316,7 @@ it('V3 fallback — vehicle locada SEM current_rental_id pega rental órfão pra
     \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_RICH,
         'vehicle_id'           => $vehicle->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); current_status=locada (canônico) mantém o card na coluna
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(15)->startOfDay(),
         'expected_return_date' => now()->subDays(10)->toDateString(),
@@ -340,7 +354,7 @@ it('V3 fallback — atendente_nome cai pro Admin do business quando transaction.
     $rental = \Modules\OficinaAuto\Entities\ServiceOrder::withoutGlobalScopes()->create([ // SUPERADMIN: setup teste
         'business_id'          => BIZ_WAGNER_RICH,
         'vehicle_id'           => $vehicle->id,
-        'order_type'           => 'locacao',
+        'order_type'           => 'manutencao', // locação erradicada (ADR 0265); current_status=locada (canônico) mantém o card na coluna
         'status'               => 'aberta',
         'entered_at'           => now()->subDays(2),
         'expected_return_date' => now()->addDays(3)->toDateString(),

--- a/tests/Feature/Modules/OficinaAuto/ServiceOrderFsmActionControllerTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ServiceOrderFsmActionControllerTest.php
@@ -182,7 +182,7 @@ it('actions() retorna actions disponíveis pra OS locação stage disponivel', f
 
     $stage = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
     $vehicle = makeVehicleSofac('SOFAC-A1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stage->id);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stage->id);
 
     $controller = app(ServiceOrderFsmActionController::class);
     $response = $controller->actions($order);
@@ -228,7 +228,7 @@ it('actions() retorna in_pipeline=false pra OS sem current_stage_id', function (
     session(['user.business_id' => BIZ_WAGNER_SOFAC]);
 
     $vehicle = makeVehicleSofac('SOFAC-C1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', null);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', null);
 
     $controller = app(ServiceOrderFsmActionController::class);
     $response = $controller->actions($order);
@@ -251,7 +251,7 @@ it('execute() action recolher move stage + cria history entry', function () {
     $stageRecolhida = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'recolhida');
 
     $vehicle = makeVehicleSofac('SOFAC-D1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageLocada->id);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stageLocada->id);
 
     $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/execute', 'POST', [
         'action_key' => 'recolher',
@@ -297,7 +297,7 @@ it('execute() permission denied retorna 403', function () {
 
     $stageLocada = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'locada');
     $vehicle = makeVehicleSofac('SOFAC-E1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageLocada->id);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stageLocada->id);
 
     $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/execute', 'POST', [
         'action_key' => 'recolher',
@@ -325,7 +325,7 @@ it('execute() action invalida retorna 422', function () {
 
     $stageDisponivel = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
     $vehicle = makeVehicleSofac('SOFAC-F1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageDisponivel->id);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stageDisponivel->id);
 
     // 'concluir' não existe pro stage 'disponivel' do processo cacamba_locacao
     $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/execute', 'POST', [
@@ -348,7 +348,7 @@ it('startPipeline() cria entry sale_stage_history Pipeline iniciado', function (
     session(['user.business_id' => BIZ_WAGNER_SOFAC]);
 
     $vehicle = makeVehicleSofac('SOFAC-G1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', null);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', null);
 
     $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/start-pipeline', 'POST');
 
@@ -385,7 +385,7 @@ it('startPipeline() recusa OS já em pipeline (422)', function () {
 
     $stageDisponivel = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
     $vehicle = makeVehicleSofac('SOFAC-H1', BIZ_WAGNER_SOFAC);
-    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stageDisponivel->id);
+    $order = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stageDisponivel->id);
 
     $request = Request::create('/oficina-auto/service-orders/'.$order->id.'/fsm/start-pipeline', 'POST');
 
@@ -403,7 +403,7 @@ it('cross-tenant biz=99 NÃO acessa OS biz=1 (Tier 0 ADR 0093)', function () {
     setupSofacBusiness(BIZ_WAGNER_SOFAC);
     $stage = getStageSofac(BIZ_WAGNER_SOFAC, 'cacamba_locacao', 'disponivel');
     $vehicle = makeVehicleSofac('SOFAC-I1', BIZ_WAGNER_SOFAC);
-    $orderBiz1 = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'locacao', $stage->id);
+    $orderBiz1 = makeOrderSofac(BIZ_WAGNER_SOFAC, $vehicle->id, 'manutencao', $stage->id);
 
     // Switch pra biz=99
     $userBiz99 = setupSofacBusiness(BIZ_FICTICIO_SOFAC);

--- a/tests/Feature/Modules/OficinaAuto/ServiceOrdersIndexTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ServiceOrdersIndexTest.php
@@ -12,10 +12,10 @@ use Modules\OficinaAuto\Entities\Vehicle;
 /**
  * ServiceOrders Index Dashboard — KPIs, filtros e cross-tenant.
  *
- * Cobre o método `index()` reescrito pra dashboard de OS (locação + manutenção)
- * pré-reunião Martinho 13/maio. Usa Schema::hasColumn fallbacks porque colunas
- * Wave 5-A (order_type / expected_return_date / etc) podem não estar migradas
- * em todas branches durante consolidação paralela.
+ * Cobre o método `index()` do dashboard de OS de reparo (locação erradicada — ADR 0265).
+ * KPIs pós-erradicação: locacoes_ativas=0 (chave mantida pelo contrato do payload),
+ * manutencao_ativas, concluidas_mes, atrasadas (atraso de reparo via expected_completion).
+ * Usa Schema::hasColumn fallbacks porque colunas Wave 5-A podem não estar migradas.
  *
  * Convenção: biz=1 default (Wagner WR2), biz=99 cross-tenant fictício (ADR 0101).
  *
@@ -71,40 +71,28 @@ function cleanupSOI(string $platePrefix): void
 it('Index retorna 4 KPIs corretos (locacoes_ativas, manutencao_ativas, concluidas_mes, atrasadas)', function () {
     session(['user.business_id' => BIZ_WAGNER_SOI]);
 
-    $hasOrderType  = Schema::hasColumn('service_orders', 'order_type');
-    $hasReturnDate = Schema::hasColumn('service_orders', 'expected_return_date');
+    $hasOrderType = Schema::hasColumn('service_orders', 'order_type');
 
     $v = makeVehicleSOI('SOI001');
 
-    // Locação ativa, no prazo
-    $loc = makeOrderSOI([
+    // Manutenção ativa, no prazo
+    $man1 = makeOrderSOI([
         'vehicle_id' => $v->id,
         'status'     => 'em_servico',
     ]);
-    if ($hasOrderType)  { $loc->order_type = 'locacao'; }
-    if ($hasReturnDate) { $loc->expected_return_date = now()->addDays(5); }
-    $loc->save();
+    if ($hasOrderType) { $man1->order_type = 'manutencao'; }
+    $man1->expected_completion = now()->addDays(5);
+    $man1->save();
 
-    // Locação ATRASADA
+    // Manutenção ativa ATRASADA — atraso de REPARO via expected_completion (ADR 0265,
+    // locação erradicada; não há mais expected_return_date/locação como conceito)
     $atr = makeOrderSOI([
         'vehicle_id' => $v->id,
         'status'     => 'em_servico',
     ]);
-    if ($hasOrderType)  { $atr->order_type = 'locacao'; }
-    if ($hasReturnDate) {
-        $atr->expected_return_date = now()->subDays(3);
-    } else {
-        $atr->expected_completion = now()->subDays(3);
-    }
+    if ($hasOrderType) { $atr->order_type = 'manutencao'; }
+    $atr->expected_completion = now()->subDays(3);
     $atr->save();
-
-    // Manutenção ativa
-    $man = makeOrderSOI([
-        'vehicle_id' => $v->id,
-        'status'     => 'em_servico',
-    ]);
-    if ($hasOrderType) { $man->order_type = 'manutencao'; }
-    $man->save();
 
     // Concluída esse mês
     $con = makeOrderSOI([
@@ -116,14 +104,11 @@ it('Index retorna 4 KPIs corretos (locacoes_ativas, manutencao_ativas, concluida
     // Força updated_at no mês corrente
     DB::table('service_orders')->where('id', $con->id)->update(['updated_at' => now()]);
 
-    // Replica a lógica de KPI do controller (HTTP-test-free — sem Spatie/Auth setup).
-    // Pra evitar acoplamento com middleware, validamos as queries que o controller usa.
+    // Replica a lógica de KPI do controller pós-erradicação (ADR 0265):
+    //  - locacoes_ativas = 0 (locação não existe; chave mantida só pelo contrato do payload)
+    //  - atrasadas = ativas com expected_completion vencida (atraso de reparo)
     $kpis = [
-        'locacoes_ativas' => $hasOrderType
-            ? ServiceOrder::where('order_type', 'locacao')
-                ->whereNotIn('status', ['concluida', 'cancelada'])
-                ->count()
-            : 0,
+        'locacoes_ativas' => 0,
         'manutencao_ativas' => $hasOrderType
             ? ServiceOrder::where('order_type', 'manutencao')
                 ->whereNotIn('status', ['concluida', 'cancelada'])
@@ -133,49 +118,46 @@ it('Index retorna 4 KPIs corretos (locacoes_ativas, manutencao_ativas, concluida
             ->whereMonth('updated_at', now()->month)
             ->whereYear('updated_at', now()->year)
             ->count(),
+        'atrasadas' => ServiceOrder::whereNotIn('status', ['concluida', 'cancelada'])
+            ->whereNotNull('expected_completion')
+            ->whereDate('expected_completion', '<', now()->toDateString())
+            ->count(),
     ];
 
-    if ($hasOrderType) {
-        // Esperado: 2 locações ativas (loc + atr), 1 manutenção ativa, 1 concluída.
-        expect($kpis['locacoes_ativas'])->toBeGreaterThanOrEqual(2);
-        expect($kpis['manutencao_ativas'])->toBeGreaterThanOrEqual(1);
-    } else {
-        // Sem order_type: 3 ativas total (loc+atr+man) e 1 concluída
-        expect($kpis['manutencao_ativas'])->toBeGreaterThanOrEqual(3);
-    }
+    // Locação erradicada → sempre 0. 2 manutenções ativas (man1 + atr), 1 atrasada (atr), 1 concluída.
+    expect($kpis['locacoes_ativas'])->toBe(0);
+    expect($kpis['manutencao_ativas'])->toBeGreaterThanOrEqual(2);
+    expect($kpis['atrasadas'])->toBeGreaterThanOrEqual(1);
     expect($kpis['concluidas_mes'])->toBeGreaterThanOrEqual(1);
 })->afterEach(function () {
     cleanupSOI('SOI001');
 });
 
-it('Filter ?status=atrasada retorna apenas OS overdue', function () {
+it('Filter ?status=atrasada retorna apenas OS overdue (expected_completion vencida)', function () {
     session(['user.business_id' => BIZ_WAGNER_SOI]);
 
-    $hasOrderType  = Schema::hasColumn('service_orders', 'order_type');
-    $hasReturnDate = Schema::hasColumn('service_orders', 'expected_return_date');
-
-    if (! $hasOrderType || ! $hasReturnDate) {
-        $this->markTestSkipped('order_type ou expected_return_date ausentes — Wave 5-A não migrada');
+    if (! Schema::hasColumn('service_orders', 'order_type')) {
+        $this->markTestSkipped('order_type ausente — Wave 5-A não migrada');
     }
 
     $v = makeVehicleSOI('SOI002');
 
     // No prazo
     $ok = makeOrderSOI(['vehicle_id' => $v->id, 'status' => 'em_servico']);
-    $ok->order_type = 'locacao';
-    $ok->expected_return_date = now()->addDays(2);
+    $ok->order_type = 'manutencao';
+    $ok->expected_completion = now()->addDays(2);
     $ok->save();
 
-    // Atrasada
+    // Atrasada (atraso de REPARO — ADR 0265)
     $late = makeOrderSOI(['vehicle_id' => $v->id, 'status' => 'em_servico']);
-    $late->order_type = 'locacao';
-    $late->expected_return_date = now()->subDays(2);
+    $late->order_type = 'manutencao';
+    $late->expected_completion = now()->subDays(2);
     $late->save();
 
-    $atrasadas = ServiceOrder::where('order_type', 'locacao')
-        ->whereNotIn('status', ['concluida', 'cancelada'])
-        ->whereNotNull('expected_return_date')
-        ->whereDate('expected_return_date', '<', now()->toDateString())
+    // Mesma regra do controller pós-erradicação: ativa + expected_completion vencida
+    $atrasadas = ServiceOrder::whereNotIn('status', ['concluida', 'cancelada'])
+        ->whereNotNull('expected_completion')
+        ->whereDate('expected_completion', '<', now()->toDateString())
         ->pluck('id')
         ->toArray();
 
@@ -185,7 +167,7 @@ it('Filter ?status=atrasada retorna apenas OS overdue', function () {
     cleanupSOI('SOI002');
 });
 
-it('Filter ?type=locacao filtra apenas locações', function () {
+it('Filter ?type=manutencao filtra apenas manutenções (mecanica fora)', function () {
     session(['user.business_id' => BIZ_WAGNER_SOI]);
 
     if (! Schema::hasColumn('service_orders', 'order_type')) {
@@ -194,18 +176,19 @@ it('Filter ?type=locacao filtra apenas locações', function () {
 
     $v = makeVehicleSOI('SOI003');
 
-    $loc = makeOrderSOI(['vehicle_id' => $v->id, 'status' => 'em_servico']);
-    $loc->order_type = 'locacao';
-    $loc->save();
-
+    // order_type ∈ {manutencao, mecanica} pós-erradicação (ADR 0265) — locacao não existe mais
     $man = makeOrderSOI(['vehicle_id' => $v->id, 'status' => 'em_servico']);
     $man->order_type = 'manutencao';
     $man->save();
 
-    $somenteLocacao = ServiceOrder::where('order_type', 'locacao')->pluck('id')->toArray();
+    $mec = makeOrderSOI(['vehicle_id' => $v->id, 'status' => 'em_servico']);
+    $mec->order_type = 'mecanica';
+    $mec->save();
 
-    expect($somenteLocacao)->toContain($loc->id);
-    expect($somenteLocacao)->not->toContain($man->id);
+    $somenteManutencao = ServiceOrder::where('order_type', 'manutencao')->pluck('id')->toArray();
+
+    expect($somenteManutencao)->toContain($man->id);
+    expect($somenteManutencao)->not->toContain($mec->id);
 })->afterEach(function () {
     cleanupSOI('SOI003');
 });


### PR DESCRIPTION
## Contexto

O gate `dominio:check` G-7 (ADR 0264 Salto #3, via PR #2471) capturou **11 ramificações de código morto** que comparam/filtram `order_type` pelo valor extinto `locacao` — o enum já é `{manutencao, mecanica}` (ADR 0265), então essa lógica nunca executa em prod. Estavam absorvidas no baseline como `dominio:undeclared-code-value:OficinaAuto:order_type:locacao`. Esta é a **limpeza de dead-code** documentada no [RUNBOOK-erradicacao-locacao.md](../blob/main/memory/requisitos/OficinaAuto/RUNBOOK-erradicacao-locacao.md). Removidas as 11 → o ratchet zera a chave sozinho (`code_divergences 1→0`).

## Produção — behavior-preserving em prod
(`order_type` nunca foi `'locacao'` lá; as ramificações já retornavam constante)

| Arquivo | Mudança |
|---|---|
| `ServiceOrder` | `getIsOverdueAttribute`→`false`; `getValorReceberAttribute`→`0.0` (accessors mantidos pelo contrato do payload). Removidos `scopeRentalsAtivas` (sem consumidor) + consts `RENTAL_*` órfãs |
| `Vehicle` | Removidos `rentals()` + `scopeOverdue` (sem consumidor, locação-only) |
| `ServiceOrderObserver::computeFinalTotal` | Removido ramo morto `if locacao` (só sobra o caminho de reparo) |
| `AprovacaoOsController::valorTotal` | Ramo morto → `return null` |

## Reapontamento (decisão do Wagner) — ServiceOrders Index controller
- KPI/filtro **`atrasada`** deixa de filtrar `order_type=locacao` e passa a medir **atraso de REPARO** via `expected_completion` (OS não-terminal vencida).
- KPI **`locacoes_ativas`** fixada em `0` (chave mantida pelo contrato do frontend; remoção visual do card/chip = dívida F3, RUNBOOK P5).

## Limite Tier 0 respeitado
**NÃO** toquei nas FSM keys `disponivel/locada`, `vehicles.current_status='locada'`, `vehicle_type.cacamba_*`, nem nos componentes Caçamba — **dívida F3 charter v4** (RUNBOOK). O accessor `is_overdue` do kanban fica behavior-preserving (`false`), então o roteamento overdue→aguardando (que dependia do modelo de locação erradicado, **já inerte em prod**) virou testes **skipados apontando pra dívida F3**.

## P4 — fixtures `order_type='locacao'` em 13 arquivos de teste
- **Flip incidental → `manutencao`**: Box, History, StageFilter, StagePipeline, WhatsApp, SideEffects, KanbanDragDrop, ServiceOrderFsmAction, CacambaSchema (`dias_locacao`), FsmTransition C1.
- **Removidos** testes de comportamento erradicado: `is_overdue=true`, `valor_receber=daily×dias`, scope `rentalsAtivas`.
- **Skipados (dívida F3)**: roteamento overdue→aguardando do kanban LIVE.
- **Reescrito** `ServiceOrdersIndexTest` p/ nova semântica (`locacoes_ativas=0`, `atrasada` via `expected_completion`, `?type=manutencao|mecanica`).
- **Mantido** `'locacao'` como INPUT legado no ImportFirebird (normalizado → `manutencao`).

## Verificação
- ✅ `npm run dominio:check` — verde (código: 0; sem divergências novas)
- ✅ `npm run dominio:baseline:write` — chave `order_type:locacao` removida
- ✅ `npm run test:dominio-guard` — 16/16
- ⚠️ **`vendor/bin/pest` NÃO rodado**: ambiente desktop sem PHP (conforme RUNBOOK). Os testes OficinaAuto dão `skip` no SQLite do CI e **só rodam em MySQL local** — **validar `php artisan test --filter=OficinaAuto` (MySQL) antes do merge.**

Refs: ADR 0265 · ADR 0264 · #2471

🤖 Generated with [Claude Code](https://claude.com/claude-code)