### PR TITLE
fix(oficina): sweep ADR 0265 no front (locação erradicada da UI de OS) + Imprimir OS confiável em Chromium

### DIFF
--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -63,6 +63,7 @@ class ServiceOrder extends Model
         'business_id',
         'transaction_id',
         'vehicle_id',
+        'contact_id',          // Sweep ADR 0265 — Create envia cliente (dono do caminhão 3º); scopado por business na validação
         'order_type',
         'delivery_address',
         'expected_return_date',

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -555,9 +555,23 @@ class ServiceOrderController extends Controller
             ->limit(500)
             ->get(['id', 'plate', 'secondary_plate', 'vehicle_type']);
 
+        // Clientes (donos dos caminhões de terceiros) pro combobox do Create — charter
+        // exige (sem cliente o gate de aprovação WhatsApp não tem destinatário). Sweep
+        // ADR 0265: Create.tsx renderiza o campo só quando a prop `contacts` chega.
+        // Multi-tenant Tier 0 (ADR 0093): business_id EXPLÍCITO + scopes Contact canon
+        // (onlyCustomers/active). Contact não tem global scope (pattern UltimatePOS).
+        $businessId = (int) (session('user.business_id') ?? session('business.id') ?? 0);
+        $contacts = \App\Contact::where('contacts.business_id', $businessId)
+            ->onlyCustomers()
+            ->active()
+            ->orderBy('contacts.name')
+            ->limit(500)
+            ->get(['contacts.id', 'contacts.name']);
+
         return Inertia::render('OficinaAuto/ServiceOrders/Create', [
             'vehicles' => $vehicles,
             'statuses' => self::statuses(),
+            'contacts' => $contacts,
         ]);
     }
 

--- a/Modules/OficinaAuto/Http/Requests/StoreServiceOrderRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/StoreServiceOrderRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\OficinaAuto\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 /**
  * D8 Security Wave 15 — FormRequest extraído de ServiceOrderController::store.
@@ -37,6 +38,19 @@ class StoreServiceOrderRequest extends FormRequest
     {
         return [
             'vehicle_id'          => ['required', 'integer', 'exists:vehicles,id'],
+            // Cliente (dono do caminhão 3º) — sweep ADR 0265, combobox no Create.
+            // exists ESCOPADO por business (Tier 0 ADR 0093): impede vincular contact
+            // de outro tenant. nullable preserva OS sem cliente (manutenção interna).
+            'contact_id'          => [
+                'nullable',
+                'integer',
+                Rule::exists('contacts', 'id')->where(
+                    fn ($query) => $query->where(
+                        'business_id',
+                        (int) (session('user.business_id') ?? session('business.id') ?? 0)
+                    )
+                ),
+            ],
             // Tipo de OS — nullable preserva forms antigos (DB default 'manutencao').
             // 'mecanica' = fluxo real reparo caminhão (ADR 0194 · oficina_mecanica_os).
             // 'locacao' ERRADICADO (ADR 0265) — não aceito mais (bate com o enum estreitado).

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderItemStockBaixaTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderItemStockBaixaTest.php
@@ -82,9 +82,10 @@ function stockBaixa_resolveProdutoComEstoque(int $biz, float $min = 5.0): ?array
 
 function stockBaixa_criaOs(string $suffix, int $biz = BIZ_STOCK_BAIXA): ServiceOrder
 {
-    // contact_id vai no VEÍCULO: `ServiceOrder.$fillable` ainda não inclui contact_id
-    // (gap T9 levantamento 2026-05-26 — mass-assign dropa silenciosamente). O Observer
-    // resolve via fallback `$so->vehicle?->contact_id`, então ancoramos lá.
+    // contact_id ancorado no VEÍCULO de propósito: este teste exercita o FALLBACK
+    // do Observer `$so->vehicle?->contact_id` (OS sem contact_id próprio). Desde o
+    // sweep ADR 0265 (2026-06-09) `ServiceOrder.$fillable` JÁ inclui contact_id —
+    // mas aqui mantemos a âncora no veículo pra cobrir o caminho de resolução indireta.
     $contactId = Contact::withoutGlobalScopes()
         ->where('business_id', $biz)
         ->value('id') ?? 1;

--- a/memory/sessions/2026-06-09-sweep-os-front-adr0265.md
+++ b/memory/sessions/2026-06-09-sweep-os-front-adr0265.md
@@ -1,0 +1,47 @@
+---
+date: "2026-06-09"
+topic: "Avaliação F1.5 OS OficinaAuto + sweep ADR 0265 no front + fix Imprimir OS (Chromium)"
+authors: ["W", "C"]
+related_adrs:
+  - 0265-oficina-reparo-erradica-locacao
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+---
+
+# Sessão 2026-06-09 — Avaliação OS git + sweep ADR 0265 no front + fix print
+
+## Pedido
+[W]: (1) "confira porque não dá certo para exportar a oficina — não copia, fica feio"; (2) "pode avaliar o IA OS do git"; (3) "sim eu quero que arrume e use o protocolo".
+
+## O que foi feito
+1. **Diagnóstico do print:** template Blade `service_order.blade.php` está CORRETO (repro pixel-fiel em `_scrap/oficina-os-print-repro.html`). O defeito é o mecanismo `printServiceOrder.ts`: iframe 0×0 `visibility:hidden` + auto-`window.print()` injetado no srcdoc → Chromium/Brave imprime em branco ou imprime o shell.
+2. **Avaliação F1.5 do módulo OS em `main`:** `AVALIACAO_OS_GIT_2026-06-09.md` — **65/100, reprovado**. Causa-raiz: ADR 0265 (erradicação de locação) nunca foi varrida no front. Board 86 / KanbanCard 88 / Print Blade 80 / Index 62 / RichSheet 60 / Show 58 / Create 55.
+3. **Sweep aplicado (9 arquivos, espelho 1:1 do repo neste projeto):**
+   - `Lib/printServiceOrder.ts` — REESCRITO: print disparado pelo PARENT via `contentWindow.print()` pós-load+fonts (sem visibility:hidden, sem script no srcdoc) + fallback `window.open`.
+   - `ServiceOrders/Create.tsx` — sem "Locação" (backend rejeita `in:manutencao,mecanica`), sem select de Status (FSM manda; nasce `aberta`), combobox Cliente (renderiza quando controller enviar `contacts`), copy dev removida.
+   - `ServiceOrders/Index.tsx` — `OrderType={manutencao,mecanica}`, colunas reparo (sem Endereço/Diárias/checkbox fantasma; "Caçamba"→"Veículo"), KPIs 3 (sem "Locações ativas"), pills sem locação, `formatBRL` null→"—" (matou `R$ [redacted Tier 0]` na UI).
+   - `ServiceOrderRichSheet.tsx` — ramo locação ERRADICADO (mecanica caía nele: título "Caçamba", Diárias); KV grid reparo c/ Cliente; timeline vocabulário reparo; erro "a OS"; status via `ServiceOrderStatusBadge` shared (label PT).
+   - `ServiceOrderSheet.tsx` — idem: título Mecânica/Manutenção, badge mecanica violet, MiniKpis sem Diárias, formatBRL.
+   - `ServiceOrderStatusBadge.tsx` — types reparo; "Atrasada" pra qualquer tipo ativo (antes só locação).
+   - `ServiceOrderFila.tsx` — types + typeLabel + sem bloco Diárias.
+   - `ServiceOrderFsmActionPanel.tsx` — copy pipeline "Recepção → Diagnóstico → Execução → Pronto p/ retirar".
+   - `ServiceOrders/Show.tsx` — tokens DS (slate/emerald hardcoded → border/success/card).
+
+## Decisões
+- Nenhuma ADR nova — o sweep EXECUTA a ADR 0265 no client (front estava em débito). Proposta de gate front anti-regressão registrada no prompt pro Code (decisão [W]/[CL]).
+- Show.tsx × drawer (duas verdades) e KpiCard duplicado no Board = follow-ups, NÃO entraram no sweep (escopo cirúrgico).
+
+## Erros + correção
+- [CC] quase aplicou comentário com `old_string` parcial no RichSheet → texto duplicado; detectado e corrigido na hora (ler região antes de editar comentário multilinha).
+
+## Residual
+- `printSaleReceipt.ts` (Vendas) tem o MESMO bug de iframe — instrução de espelhamento incluída no prompt pro Code (não patchei: carrega CSS legacy, Code valida).
+- Backend: controller `create()` precisa passar `contacts`; `StoreServiceOrderRequest` aceitar `contact_id` nullable.
+- Charters: Create.charter.md ainda lista toggle locação (Goals) — Code appenda trilha do tempo.
+- Keys FSM `cacamba_locacao`/`disponivel`/`locada` (ProducaoOficina) = dívida Tier 0 em ADR própria — NÃO tocadas (trava charter v4).
+
+## Refs
+- `AVALIACAO_OS_GIT_2026-06-09.md` · `_scrap/oficina-os-print-repro.html` · ADR 0265/0194/0143 · charter v4 PR #2417
+
+## Próximo passo
+Wagner cola o prompt zero-toque no Claude Code → [CL] valida (tsc/eslint/pest), commita e abre PR. F2 = Wagner confere screenshot das telas + testa "Imprimir OS" no Brave.

--- a/prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md
+++ b/prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md
@@ -1,0 +1,59 @@
+# Avaliação F1.5 — OS da Oficina construída pela IA no git (`main`)
+**Data:** 2026-06-09 · **Avaliador:** [CC] Claude Cowork · **Escopo:** `resources/js/Pages/OficinaAuto/ServiceOrders/*` + `ProducaoOficina/ServiceOrderRichSheet` + print Blade
+**Veredito geral: 65/100 — REPROVADO no gate ≥80.** Estrutura é boa; o que mata é o **domínio morto de locação vazando em toda a UI** (ADR 0265 erradicou no backend HOJE, front nunca foi varrido).
+
+---
+
+## Scores por superfície
+
+| Superfície | Score | Veredito |
+|---|---|---|
+| **Board.tsx** (Quadro Kanban) | **86** | ✅ Melhor tela. FSM data-driven, drag+confirmação, a11y correta, foto real, DVI x/y, densidade @container |
+| **ServiceOrderKanbanCard** | **88** | ✅ Excelente — tempo relativo, tabular-nums, tooltips, aria-roledescription |
+| **Print Blade** (service_order.blade.php) | **80** | ✅ Template A4 limpo. Problema é o MECANISMO (iframe oculto 0×0 + window.print — falha no Brave/Chromium) |
+| **Index.tsx** (Lista) | **62** | ⚠️ Esqueleto Linear ok, mas o SCHEMA DE COLUNAS é da locação morta — pra mecânica vira tela de travessões |
+| **ServiceOrderRichSheet** (drawer) | **60** | ❌ Branch polimórfico trata `mecanica` como LOCAÇÃO. Timeline fala "Caçamba entregue ao cliente" numa OS de motor |
+| **Show.tsx** | **58** | ⚠️ Duplica o drawer com outro layout; tokens fora do DS (slate-*/emerald-* hardcoded); window.confirm |
+| **Create.tsx** | **55** | ❌ Sem campo CLIENTE (charter exige); oferece "Locação" que o backend agora REJEITA; copy dev vazada |
+
+---
+
+## P0 — Bugs reais (usuário vê hoje, biz=164 Martinho LIVE)
+
+1. **`OrderType = 'locacao' | 'manutencao'` — `mecanica` NÃO EXISTE nos types do front.**
+   - `RichSheet`: `data.order_type === 'manutencao' ? (mecânica) : (LOCAÇÃO)` → toda OS `mecanica` renderiza o ramo locação: título "Caçamba —", "Diárias 0d × R$…", "Valor a receber". **É exatamente a OS-00004 'Cacamba' que [W] viu.**
+   - `Index`: badge de tipo cai em "—" pra `mecanica`.
+2. **Create oferece `<SelectItem value="locacao">Locação</SelectItem>`** — `StoreServiceOrderRequest` agora valida `in:manutencao,mecanica` (ADR 0265). Escolheu Locação → erro de validação. Caminho de criação QUEBRADO por opção fantasma.
+3. **`formatBRL` devolve a string literal `"R$ [redacted Tier 0]"`** quando valor é null — vaza como texto na tabela e no drawer. (Index.tsx:~160, RichSheet:~150)
+4. **Timeline do drawer é 100% vocabulário de locação:** "Locação iniciada" · "Caçamba entregue ao cliente" · "Prazo de devolução" · "Aguardando recolhimento…" — numa oficina de mecânica pesada.
+5. **Erro do drawer:** "Não foi possível carregar **a caçamba**".
+6. **Imprimir OS** — mecanismo iframe oculto + `window.print()` de dentro do srcdoc imprime a tela inteira em Chromium/Brave recente (template está certo; ver repro `_scrap/oficina-os-print-repro.html`).
+
+## P1 — Violações de charter / DS
+
+7. **Create sem autocomplete de cliente (contact)** — charter `ServiceOrders/Create.charter.md` lista como required ("Martinho atende caminhões de terceiros"). Sem cliente → gate de aprovação WhatsApp não tem destinatário.
+8. **Campo "Status *" manual no Create** — status é do FSM; expor select livre convida estado inconsistente (canon GUARD: nunca mexer direto).
+9. **Index: cabeçalho de coluna "Caçamba" + colunas Endereço/Diárias/A receber** — schema visual da locação; em mecânica viram colunas de "—". KPI "Locações ativas" idem (`Kpis.locacoes_ativas` — backend já removeu o KPI no W25/0265).
+10. **Show.tsx × RichSheet = duas verdades** do detalhe de OS com layouts divergentes. Consolidar no drawer (padrão Cockpit V2) e Show vira rota que abre o drawer.
+11. **Tokens fora do DS no Show:** `divide-slate-100`, `border-slate-200`, `text-emerald-700` (vs `text-success`), `window.confirm` pra excluir item (devia ser AlertDialog DS).
+12. **Board define `KpiCard` local** ≠ `shared/KpiCard` usado no Index — dois estilos de KPI no mesmo módulo.
+13. **Copy dev vazada pra UI:** SheetDescription "V0 — vínculo OS↔Vehicle obrigatório, status livre" (Create); EmptyProcessState manda usuário "rodar o seeder OficinaAutoFsmSeeder".
+14. **Checkboxes `disabled` na tabela** (bulk-select fantasma) + grid de fotos placeholder com botão disabled "V2" — UI promissória.
+15. **StatusBadge do RichSheet imprime `data.status` cru** (`em_execucao` com underscore) em vez de reusar `ServiceOrderStatusBadge`.
+
+---
+
+## Diagnóstico-raiz
+
+O backend foi erradicado de locação (migration + validação + KPI + menu, ADR 0265 hoje), **mas nenhuma varredura tocou o front**. O design estrutural das telas (Board, cards, gates de aprovação, split fiscal) é estado-da-arte e segue o protótipo canon — o "porco" que [W] sente é: (a) OS de mecânica renderizada com roupa de locação, (b) strings internas vazando, (c) print imprimindo o shell.
+
+## Correção proposta — 1 sweep front "locacao→reparo" (espelha ADR 0265 no client)
+
+- Types: `OrderType = 'manutencao' | 'mecanica'`; RichSheet branch por `=== 'locacao'` morre — default = mecânica.
+- Create: remover item Locação + remover select Status (status nasce `aberta`) + adicionar combobox Cliente (contact) required + copy do SheetDescription.
+- Index: colunas → Nº OS · Veículo · Cliente · Defeito (notes) · Entrada · Previsão · Valor (items_total) · Status; KPIs → Em diagnóstico / Aguardando aprovação / Em execução / Atrasadas; pills sem "Locações".
+- RichSheet: timeline neutra de reparo ("OS aberta" → "Em execução" → "Pronto p/ retirar"); erro "Não foi possível carregar a OS"; `formatBRL` null → "—".
+- Show: consolidar com drawer (decisão [W]) ou no mínimo trocar tokens slate/emerald → DS + AlertDialog.
+- printServiceOrder/printSaleReceipt: trocar iframe oculto por iframe visível fora da viewport com `contentWindow.print()` após `load` + fallback `window.open` (corrige Brave).
+
+**Gate de regressão:** `dominio:check` já cobre enum; falta GUARD de front (grep `locacao|caçamba|Locação` em `Pages/OficinaAuto/**` permitido só em código morto marcado).

--- a/resources/js/Lib/printSaleReceipt.ts
+++ b/resources/js/Lib/printSaleReceipt.ts
@@ -1,16 +1,23 @@
 // Helper compartilhado pra disparar impressão de recibo de venda.
 //
-// Padrão IFRAME OCULTO + CSS legacy embutido:
+// Padrão IFRAME fora-da-vista + CSS legacy via <link>:
 //   - /sells/{id}/print (SellPosController::printInvoice) só responde a requests AJAX.
 //   - Devolve {receipt:{html_content}} com HTML baseado em Bootstrap 3 (col-xs-12,
 //     pull-left, text-center) + classes da app legacy (.print_section, .invoice).
 //   - Usar `window.open()` puro descarrega o CSS → layout fica quebrado.
-//   - Em vez disso, criamos um <iframe> oculto na própria página Inertia carregando
-//     `/css/app.css` (tem `@media print { .print_section { display: inline !important } }`
-//     + classes Bootstrap 3 legacy + invoice CSS) e injetamos o html_content dentro
-//     da section `#receipt_section`. Depois chamamos `iframe.contentWindow.print()`.
-//   - Equivale ao legacy `public/js/app.js:1656` (a.print-invoice → __print_receipt),
-//     que injetava em `#receipt_section` do próprio `<body>` e chamava window.print().
+//   - Em vez disso, criamos um <iframe> fora da viewport carregando `/css/app.css`
+//     (tem `@media print { .print_section { display: inline !important } }` + classes
+//     Bootstrap 3 legacy + invoice CSS) e injetamos o html_content dentro da section
+//     `#receipt_section`. O `load` do iframe AGUARDA os <link> de CSS — só então
+//     disparamos o print.
+//
+// FIX 2026-06-09 (espelha printServiceOrder.ts — avaliação [CC]):
+//   O mecanismo anterior usava IFRAME com `visibility:hidden` + auto-`window.print()`
+//   injetado por <script> DENTRO do srcdoc. Chromium/Brave recentes rasterizam iframe
+//   invisível como página em branco — ou escalam o print pro frame pai (imprime a SPA
+//   inteira). Agora: iframe fora-da-vista SEM visibility:hidden, e o PRINT é disparado
+//   PELO PARENT via `iframe.contentWindow.print()` após load + stylesheets + fontes.
+//   Fallback: `window.open` com o mesmo documento (inclui os <link> de CSS).
 //
 // 3 modos do legacy (sale_pos/show.blade.php:413/416 + SellController:437-440):
 //   - 'invoice'       → GET /sells/{id}/print
@@ -68,31 +75,20 @@ interface RenderArgs {
   title: string;
 }
 
-function renderInHiddenIframe({ htmlContent, title }: RenderArgs): Promise<void> {
-  return new Promise((resolve) => {
-    // Remove iframe anterior se houver (segurança contra duplo-click).
-    const previous = document.getElementById('sale-receipt-print-iframe');
-    if (previous) previous.remove();
+const IFRAME_ID = 'sale-receipt-print-iframe';
 
-    const iframe = document.createElement('iframe');
-    iframe.id = 'sale-receipt-print-iframe';
-    iframe.setAttribute('aria-hidden', 'true');
-    iframe.style.position = 'fixed';
-    iframe.style.right = '0';
-    iframe.style.bottom = '0';
-    iframe.style.width = '0';
-    iframe.style.height = '0';
-    iframe.style.border = '0';
-    iframe.style.visibility = 'hidden';
+/** Documento completo do iframe: wrapper legacy (Bootstrap 3 + .print_section + .invoice)
+ *  com os <link> de CSS — o html_content do recibo entra na section #receipt_section. */
+function buildReceiptDocument({ htmlContent, title }: RenderArgs): string {
+  // Stylesheets do legacy que dão Bootstrap 3 + .print_section + .invoice CSS.
+  // (`/css/app.css` linha 703-719: .print_section{display:none} + @media print { display:inline !important }).
+  // Também carrega init.css (resets) e tailwind/app.css (utilitários tw-* usados em alguns templates).
+  const stylesheets = ['/css/app.css', '/css/init.css', '/css/tailwind/app.css']
+    .map((href) => `<link rel="stylesheet" href="${href}">`)
+    .join('');
 
-    // Stylesheets do legacy que dão Bootstrap 3 + .print_section + .invoice CSS.
-    // (`/css/app.css` linha 703-719: .print_section{display:none} + @media print { display:inline !important }).
-    // Também carrega init.css (resets) e tailwind/app.css (utilitários tw-* usados em alguns templates).
-    const stylesheets = ['/css/app.css', '/css/init.css', '/css/tailwind/app.css']
-      .map((href) => `<link rel="stylesheet" href="${href}">`)
-      .join('');
-
-    const srcdoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>${stylesheets}
+  // NOTA: sem <script> de auto-print — o parent dispara o print (ver renderInHiddenIframe).
+  return `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>${stylesheets}
 <style>
   /* Mostra a section também na tela do iframe (legacy só mostra em @media print) */
   body { margin: 0; padding: 12px; background: white; }
@@ -102,32 +98,124 @@ function renderInHiddenIframe({ htmlContent, title }: RenderArgs): Promise<void>
 </style>
 </head><body>
 <section class="invoice print_section" id="receipt_section">${htmlContent}</section>
-<script>
-(function(){
-  function go(){
-    try {
-      if (typeof window.parent !== 'undefined' && typeof window.parent.__currency_convert_recursively === 'function') {
-        try { window.parent.__currency_convert_recursively(document.getElementById('receipt_section')); } catch(e){}
-      }
-      setTimeout(function(){ window.focus(); window.print(); }, 200);
-    } catch(e) { console.error('print error', e); }
-  }
-  if (document.readyState === 'complete') { go(); } else { window.addEventListener('load', go); }
-})();
-<\/script>
 </body></html>`;
+}
 
-    iframe.srcdoc = srcdoc;
-    iframe.addEventListener('load', () => {
-      // Resolve cedo — o print() é disparado pelo script dentro do iframe.
-      // Limpa iframe ~30s depois (suficiente pro user fechar a janela nativa de impressão).
-      setTimeout(() => {
-        try { iframe.remove(); } catch {}
-      }, 30000);
-      resolve();
-    }, { once: true });
+/** Legacy: converte símbolos de moeda recursivamente na section antes de imprimir. */
+function applyCurrencyConvert(win: Window): void {
+  const convert = (window as unknown as {
+    __currency_convert_recursively?: (el: Element | null) => void;
+  }).__currency_convert_recursively;
+  if (typeof convert === 'function') {
+    try {
+      convert(win.document.getElementById('receipt_section'));
+    } catch {
+      /* noop */
+    }
+  }
+}
+
+function renderInHiddenIframe({ htmlContent, title }: RenderArgs): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Remove iframe anterior se houver (segurança contra duplo-click).
+    document.getElementById(IFRAME_ID)?.remove();
+
+    const fullDocument = buildReceiptDocument({ htmlContent, title });
+
+    const iframe = document.createElement('iframe');
+    iframe.id = IFRAME_ID;
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.title = title;
+    // Fora da vista mas SEM visibility:hidden/display:none — Chromium precisa do
+    // frame "renderizável" pra rasterizar o conteúdo no print (senão imprime branco).
+    iframe.style.position = 'fixed';
+    iframe.style.right = '0';
+    iframe.style.bottom = '0';
+    iframe.style.width = '0';
+    iframe.style.height = '0';
+    iframe.style.border = '0';
+    iframe.style.overflow = 'hidden';
+
+    iframe.srcdoc = fullDocument;
+
+    const cleanup = () => {
+      try {
+        iframe.remove();
+      } catch {
+        /* noop */
+      }
+    };
+
+    iframe.addEventListener(
+      'load',
+      () => {
+        // O `load` do iframe já aguarda os <link rel="stylesheet"> — o CSS legacy
+        // está aplicado aqui. Mesmo assim damos uma folga + fontes prontas pra
+        // evitar print com layout em fallback.
+        const win = iframe.contentWindow;
+        if (!win) {
+          cleanup();
+          openPrintWindowFallback(fullDocument, title).then(resolve, reject);
+          return;
+        }
+        const doPrint = () => {
+          try {
+            applyCurrencyConvert(win);
+            win.focus();
+            win.print();
+            // Sem sinal confiável de fechamento do diálogo cross-browser — limpa
+            // após folga generosa.
+            setTimeout(cleanup, 60_000);
+            resolve();
+          } catch {
+            cleanup();
+            openPrintWindowFallback(fullDocument, title).then(resolve, reject);
+          }
+        };
+        const fonts = (win.document as Document & { fonts?: FontFaceSet }).fonts;
+        if (fonts?.ready) {
+          fonts.ready.then(() => setTimeout(doPrint, 200)).catch(() => doPrint());
+        } else {
+          setTimeout(doPrint, 300);
+        }
+      },
+      { once: true },
+    );
 
     document.body.appendChild(iframe);
+  });
+}
+
+/**
+ * Fallback: janela dedicada com o MESMO documento (inclui os <link> de CSS legacy).
+ * Mais intrusivo (abre tab/janela) mas funciona onde o browser bloqueia print()
+ * programático em iframe fora da vista.
+ */
+function openPrintWindowFallback(fullDocument: string, title: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const win = window.open('', '_blank', 'noopener=no,width=900,height=1100');
+    if (!win) {
+      reject(new Error('Impressão bloqueada pelo navegador — permita pop-ups pra imprimir o recibo.'));
+      return;
+    }
+    win.document.open();
+    win.document.write(fullDocument);
+    win.document.close();
+    win.document.title = title;
+    const doPrint = () => {
+      try {
+        applyCurrencyConvert(win);
+        win.focus();
+        win.print();
+      } finally {
+        resolve();
+      }
+    };
+    if (win.document.readyState === 'complete') {
+      setTimeout(doPrint, 300);
+    } else {
+      win.addEventListener('load', () => setTimeout(doPrint, 200), { once: true });
+    }
   });
 }
 

--- a/resources/js/Lib/printServiceOrder.ts
+++ b/resources/js/Lib/printServiceOrder.ts
@@ -1,26 +1,23 @@
 // Helper compartilhado pra disparar impressão de OS (Ordem de Serviço) OficinaAuto.
 //
-// Gap 3 US-OFICINA-037 — espelha pattern printSaleReceipt.ts (Sells legacy):
-//   - GET /oficina-auto/ordens-servico/{id}/print só responde a requests AJAX
-//     (X-Requested-With: XMLHttpRequest); sem o header retorna 404 (Controller
-//     `ServiceOrderController::printInvoice` aborta — evita AppShellV2 vazado).
-//   - Devolve {success:1, receipt:{html_content,print_title}} com HTML
-//     auto-contido (CSS inline no <style> do Blade) — funciona em IFRAME
-//     cross-origin sem depender de stylesheets do parent.
-//   - Criamos um <iframe> oculto via srcdoc, e o HTML do template ja inclui
-//     `<style>` + `<script>` que dispara window.print() on-load.
-//   - Cleanup do IFRAME após delay (suficiente pro user fechar a janela nativa).
+// Gap 3 US-OFICINA-037 — GET {id}/print só responde AJAX (X-Requested-With);
+// devolve {success:1, receipt:{html_content,print_title}} com HTML auto-contido
+// (CSS inline no <style> do Blade).
 //
-// Diferença vs printSaleReceipt.ts: printSaleReceipt carrega /css/app.css legacy
-// dentro do IFRAME (Bootstrap 3 + invoice classes). Aqui o Blade já vem com TODO
-// CSS necessário inline — IFRAME 100% self-contained.
+// FIX 2026-06-09 (avaliação [CC] — "Imprimir OS sai feio/vazio"):
+// O mecanismo anterior usava IFRAME 0×0 com visibility:hidden e auto-window.print()
+// disparado por <script> injetado DENTRO do srcdoc. Chromium/Brave recentes
+// rasterizam iframe invisível como página em branco — ou escalam o print pro
+// frame pai (imprime o AppShellV2 inteiro = "sistema porco").
+// Novo mecanismo:
+//   1. IFRAME continua fora da vista (fixed, 0×0, sem visibility:hidden — isso
+//      é o que mata a rasterização), srcdoc com o doc completo do Blade.
+//   2. O PRINT é chamado PELO PARENT via iframe.contentWindow.print() após o
+//      load + fontes prontas — alvo do diálogo é garantidamente o documento da OS.
+//   3. Fallback: se contentWindow.print() falhar (política do browser), abre
+//      window.open dedicada com o mesmo HTML e imprime lá.
 //
-// V0 modo único "invoice" (A4 papel-balcão). +packing_slip / +delivery_note
-// em wave futura se necessário.
-//
-// Multi-tenant Tier 0 (ADR 0093): defesa server-side — frontend só precisa passar
-// a route correta. Controller faz defensive guard cross-business.
-//
+// Multi-tenant Tier 0 (ADR 0093): defesa server-side — frontend só passa a rota.
 // Uso em ServiceOrderRichSheet.tsx (drawer footer) + Show.tsx (PageHeader actions).
 
 export interface PrintServiceOrderOptions {
@@ -58,7 +55,7 @@ export async function printServiceOrder({
     (typeof payload?.receipt?.print_title === 'string' && payload.receipt.print_title) ||
     `OS ${osNumber ?? ''}`.trim();
 
-  await renderInHiddenIframe({ htmlContent, title });
+  await renderAndPrint({ htmlContent, title });
 }
 
 interface RenderArgs {
@@ -66,62 +63,104 @@ interface RenderArgs {
   title: string;
 }
 
-function renderInHiddenIframe({ htmlContent, title }: RenderArgs): Promise<void> {
-  return new Promise((resolve) => {
-    // Remove IFRAME anterior se houver (segurança contra duplo-click rapidíssimo).
-    const previous = document.getElementById('service-order-print-iframe');
-    if (previous) previous.remove();
+const IFRAME_ID = 'service-order-print-iframe';
+
+function renderAndPrint({ htmlContent, title }: RenderArgs): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Remove IFRAME anterior (proteção contra duplo-click).
+    document.getElementById(IFRAME_ID)?.remove();
 
     const iframe = document.createElement('iframe');
-    iframe.id = 'service-order-print-iframe';
+    iframe.id = IFRAME_ID;
     iframe.setAttribute('aria-hidden', 'true');
+    iframe.title = title;
+    // Fora da vista mas SEM visibility:hidden/display:none — Chromium precisa
+    // do frame "renderizável" pra rasterizar o conteúdo no print.
     iframe.style.position = 'fixed';
     iframe.style.right = '0';
     iframe.style.bottom = '0';
     iframe.style.width = '0';
     iframe.style.height = '0';
     iframe.style.border = '0';
-    iframe.style.visibility = 'hidden';
+    iframe.style.overflow = 'hidden';
 
-    // O Blade já vem com TODO CSS necessário inline (não carrega /css/app.css).
-    // Só envelopamos o html_content (que é o <!DOCTYPE html>...</html> completo do
-    // template) e injetamos um <script> auto-print no final do <body>.
-    //
-    // htmlContent já é doc completo do Blade — só injetamos script de print antes
-    // de fechar </body>. Title já vem no <head> do template.
-    const printScript = `<script>
-(function(){
-  function go(){
-    try {
-      setTimeout(function(){ window.focus(); window.print(); }, 200);
-    } catch(e) { console.error('print error', e); }
-  }
-  if (document.readyState === 'complete') { go(); } else { window.addEventListener('load', go); }
-})();
-<\/script>`;
+    // htmlContent é o doc completo do Blade (CSS inline). NÃO injetamos mais
+    // <script> de auto-print — o parent dispara o print (ver abaixo).
+    iframe.srcdoc = htmlContent;
 
-    // Injeta script antes de </body> (template Blade já tem </body></html> bem-formado).
-    const srcdoc = htmlContent.replace(/<\/body>/i, `${printScript}</body>`);
+    const cleanup = () => {
+      try {
+        iframe.remove();
+      } catch {
+        /* noop */
+      }
+    };
 
-    iframe.srcdoc = srcdoc;
-    iframe.title = title;
     iframe.addEventListener(
       'load',
       () => {
-        // Resolve cedo — print() é disparado pelo script dentro do IFRAME.
-        // Limpa IFRAME ~30s depois (suficiente pro user fechar janela nativa).
-        setTimeout(() => {
+        const win = iframe.contentWindow;
+        if (!win) {
+          cleanup();
+          openPrintWindowFallback({ htmlContent, title }).then(resolve, reject);
+          return;
+        }
+        const doPrint = () => {
           try {
-            iframe.remove();
+            win.focus();
+            win.print();
+            // Não dá pra saber quando o diálogo fecha de forma confiável
+            // cross-browser — limpa após folga generosa.
+            setTimeout(cleanup, 60_000);
+            resolve();
           } catch {
-            /* noop */
+            cleanup();
+            openPrintWindowFallback({ htmlContent, title }).then(resolve, reject);
           }
-        }, 30000);
-        resolve();
+        };
+        // Espera fontes/imagens do doc interno antes de abrir o diálogo
+        // (evita print com layout em fallback de fonte).
+        const fonts = (win.document as Document & { fonts?: FontFaceSet }).fonts;
+        if (fonts?.ready) {
+          fonts.ready.then(() => setTimeout(doPrint, 150)).catch(() => doPrint());
+        } else {
+          setTimeout(doPrint, 250);
+        }
       },
       { once: true },
     );
 
     document.body.appendChild(iframe);
+  });
+}
+
+/**
+ * Fallback: janela dedicada. Mais intrusivo (abre tab/janela), mas funciona
+ * mesmo onde o browser bloqueia print() programático em iframe fora da vista.
+ */
+function openPrintWindowFallback({ htmlContent, title }: RenderArgs): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const win = window.open('', '_blank', 'noopener=no,width=900,height=1100');
+    if (!win) {
+      reject(new Error('Impressão bloqueada pelo navegador — permita pop-ups pra imprimir a OS.'));
+      return;
+    }
+    win.document.open();
+    win.document.write(htmlContent);
+    win.document.close();
+    win.document.title = title;
+    const doPrint = () => {
+      try {
+        win.focus();
+        win.print();
+      } finally {
+        resolve();
+      }
+    };
+    if (win.document.readyState === 'complete') {
+      setTimeout(doPrint, 250);
+    } else {
+      win.addEventListener('load', () => setTimeout(doPrint, 150), { once: true });
+    }
   });
 }

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -5,10 +5,8 @@
 // (`prototipo-ui/prototipos/producao-oficina/visual-source.html`) E protótipo OS
 // mecânica CNAE 4520 Martinho (screenshot Wagner 2026-05-26 · sub-vertical 4 ADR 0194).
 //
-// 6 sections polimórficas (branching por `data.order_type`):
-//   1. Header KV grid:
-//        - locação: Cliente / Capacidade / Endereço / Diárias / Valor
-//        - manutenção: KM / Box / Mecânico / Valor (items_total) — ADR 0194 mecânica pesada
+// 6 sections (reparo · ADR 0265):
+//   1. Header KV grid: Cliente / KM / Box / Mecânico / Valor (items_total)
 //   2. OBSERVAÇÃO (notes — italic se vazio)
 //   3. PEÇAS & MÃO DE OBRA — NOVA Wave 2.3 (data.items[] consumindo `oficina_service_order_items`
 //      via US-OFICINA-027 backend). Renderiza linha-a-linha com ícones tipo + qty + valor unit
@@ -21,8 +19,14 @@
 //
 // CRÍTICO React 19 — useMemo/useCallback nos handlers descendentes (lição PR #717).
 //
-// Consumidores: ProducaoOficina/Index.tsx — drawer abre ao clicar card kanban.
+// Consumidores: ProducaoOficina/Index.tsx + ServiceOrders/Board.tsx — drawer abre ao clicar card kanban.
 // Multi-tenant Tier 0 [ADR 0093]: payload vem do endpoint show() que respeita global scope.
+//
+// 2026-06-09 sweep ADR 0265 (avaliação [CC]): ramo LOCAÇÃO erradicado — o branch
+// polimórfico tratava order_type='mecanica' como locação (título "Caçamba", Diárias,
+// timeline "Caçamba entregue ao cliente"). Agora o drawer é 100% reparo:
+// types {manutencao,mecanica}, timeline de oficina, erro "a OS" (não "a caçamba"),
+// formatBRL null→"—", status via ServiceOrderStatusBadge (label PT, não cru).
 
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -34,7 +38,6 @@ import {
   ExternalLink,
   FileText,
   Loader2,
-  MapPin,
   Phone,
   Truck,
   User,
@@ -49,12 +52,13 @@ import {
 import { Button } from '@/Components/ui/button';
 import MercosulPlate from './MercosulPlate';
 import ServiceOrderFsmActionPanel from '../../ServiceOrders/_components/ServiceOrderFsmActionPanel';
+import ServiceOrderStatusBadge from '../../ServiceOrders/_components/ServiceOrderStatusBadge';
 import VendaDerivadaCard, { type VendaDerivada } from '@/Components/shared/VendaDerivadaCard';
 import { MessageCircle, Printer, Wrench, Package, UserCog } from 'lucide-react';
 import { toast } from 'sonner';
 import { printServiceOrder } from '@/Lib/printServiceOrder';
 
-type OrderType = 'locacao' | 'manutencao' | null;
+type OrderType = 'manutencao' | 'mecanica' | null;
 
 type ItemTipo = 'peca' | 'mao_obra' | 'servico_terceiro';
 
@@ -136,9 +140,9 @@ interface Props {
 }
 
 const formatBRL = (value: number | string | null | undefined) => {
-  if (value === null || value === undefined || value === '') return 'R$ [redacted Tier 0]';
+  if (value === null || value === undefined || value === '') return '—';
   const num = typeof value === 'string' ? parseFloat(value) : value;
-  if (Number.isNaN(num)) return 'R$ [redacted Tier 0]';
+  if (Number.isNaN(num)) return '—';
   return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 };
 
@@ -247,7 +251,7 @@ export default function ServiceOrderRichSheet({
             <div>
               <AlertTriangle className="h-8 w-8 text-destructive mx-auto mb-2" />
               <p className="text-sm text-foreground font-medium">
-                Não foi possível carregar a caçamba
+                Não foi possível carregar a OS
               </p>
               <p className="text-xs text-muted-foreground mt-1">{error}</p>
             </div>
@@ -262,7 +266,7 @@ export default function ServiceOrderRichSheet({
                 <span className="font-mono text-xs text-muted-foreground">
                   OS {data.number ?? `#${data.id}`}
                 </span>
-                <StatusBadge status={data.status} orderType={data.order_type} />
+                <ServiceOrderStatusBadge status={data.status} orderType={data.order_type} />
                 {data.is_overdue && (
                   <span className="inline-flex items-center rounded-full border border-destructive/30 bg-destructive/10 px-2.5 py-0.5 text-[11px] font-medium text-destructive">
                     <AlertTriangle size={10} className="mr-0.5" />
@@ -271,27 +275,14 @@ export default function ServiceOrderRichSheet({
                 )}
               </div>
               <SheetTitle className="text-lg font-semibold tracking-tight text-foreground">
-                {data.order_type === 'manutencao' ? (
-                  <>
-                    {data.vehicle?.vehicle_type ? capitalize(data.vehicle.vehicle_type) : 'Veículo'}
-                    {' '}
-                    {data.vehicle?.plate ?? '—'}
-                    {data.vehicle?.model_year ? (
-                      <span className="text-sm font-normal text-muted-foreground ml-1.5">
-                        · {data.vehicle.model_year}
-                      </span>
-                    ) : null}
-                  </>
-                ) : (
-                  <>
-                    Caçamba {data.vehicle?.vehicle_number ?? data.vehicle?.plate ?? '—'}
-                    {data.vehicle?.capacity_m3 ? (
-                      <span className="text-sm font-normal text-muted-foreground ml-1.5">
-                        · {data.vehicle.capacity_m3}m³
-                      </span>
-                    ) : null}
-                  </>
-                )}
+                {data.vehicle?.vehicle_type ? capitalize(data.vehicle.vehicle_type) : 'Veículo'}
+                {' '}
+                {data.vehicle?.plate ?? '—'}
+                {data.vehicle?.model_year ? (
+                  <span className="text-sm font-normal text-muted-foreground ml-1.5">
+                    · {data.vehicle.model_year}
+                  </span>
+                ) : null}
               </SheetTitle>
               <SheetDescription className="text-sm text-muted-foreground">
                 {data.contact ? data.contact.name : 'Cliente não informado'}
@@ -313,82 +304,44 @@ export default function ServiceOrderRichSheet({
                 </div>
               )}
 
-              {/* ─── SEÇÃO 3 (Hero): Veículo + KV grid polimórfico (Wave 2.2 US-OFICINA-027) ───
-                  - manutenção (Martinho sub-vertical 4 CNAE 4520): KM / Box / Mecânico / Valor (items_total)
-                  - locação    (sub-vertical 3 hipotético CNAE 4581): Cliente / Capacidade / Endereço / Diárias / Valor */}
+              {/* ─── SEÇÃO 3 (Hero): Veículo + KV grid de reparo (ADR 0265):
+                  Cliente / KM / Box / Mecânico / Valor (items_total) */}
               {data.vehicle && (
                 <div className="rounded-lg border border-border bg-muted p-3 grid grid-cols-[auto_1fr] gap-3">
                   <MercosulPlate plate={data.vehicle.plate} size="md" />
                   <dl className="grid grid-cols-[auto_1fr] gap-x-2.5 gap-y-1 text-[11.5px] self-end">
-                    {data.order_type === 'manutencao' ? (
+                    {data.contact && (
                       <>
-                        {data.mileage_at_service != null && (
-                          <>
-                            <dt className="text-muted-foreground">KM</dt>
-                            <dd className="text-foreground font-medium tabular-nums">
-                              {data.mileage_at_service.toLocaleString('pt-BR')}
-                            </dd>
-                          </>
-                        )}
-                        {data.box_label && (
-                          <>
-                            <dt className="text-muted-foreground">Box</dt>
-                            <dd className="text-foreground">{data.box_label}</dd>
-                          </>
-                        )}
-                        {data.assigned_user && (
-                          <>
-                            <dt className="text-muted-foreground">Mecânico</dt>
-                            <dd className="text-foreground">{data.assigned_user.name}</dd>
-                          </>
-                        )}
-                        <dt className="text-muted-foreground">Valor</dt>
-                        <dd className="tabular-nums font-semibold text-success">
-                          {formatBRL(data.items_total ?? 0)}
-                        </dd>
-                      </>
-                    ) : (
-                      <>
-                        {data.contact && (
-                          <>
-                            <dt className="text-muted-foreground">Cliente</dt>
-                            <dd className="text-foreground font-medium truncate">
-                              {data.contact.name}
-                            </dd>
-                          </>
-                        )}
-                        {data.vehicle.capacity_m3 && (
-                          <>
-                            <dt className="text-muted-foreground">Capacidade</dt>
-                            <dd className="text-foreground tabular-nums">
-                              {data.vehicle.capacity_m3}m³
-                            </dd>
-                          </>
-                        )}
-                        {data.delivery_address && (
-                          <>
-                            <dt className="text-muted-foreground">Endereço</dt>
-                            <dd className="text-foreground truncate" title={data.delivery_address}>
-                              {data.delivery_address}
-                            </dd>
-                          </>
-                        )}
-                        <dt className="text-muted-foreground">Diárias</dt>
-                        <dd className="text-foreground tabular-nums">
-                          {data.dias_locacao ?? 0}d ×{' '}
-                          <span className="text-muted-foreground">{formatBRL(data.daily_rate)}</span>
-                        </dd>
-                        <dt className="text-muted-foreground">Valor</dt>
-                        <dd
-                          className={
-                            'tabular-nums font-semibold ' +
-                            (data.is_overdue ? 'text-destructive' : 'text-success')
-                          }
-                        >
-                          {formatBRL(data.valor_receber)}
+                        <dt className="text-muted-foreground">Cliente</dt>
+                        <dd className="text-foreground font-medium truncate">
+                          {data.contact.name}
                         </dd>
                       </>
                     )}
+                    {data.mileage_at_service != null && (
+                      <>
+                        <dt className="text-muted-foreground">KM</dt>
+                        <dd className="text-foreground font-medium tabular-nums">
+                          {data.mileage_at_service.toLocaleString('pt-BR')}
+                        </dd>
+                      </>
+                    )}
+                    {data.box_label && (
+                      <>
+                        <dt className="text-muted-foreground">Box</dt>
+                        <dd className="text-foreground">{data.box_label}</dd>
+                      </>
+                    )}
+                    {data.assigned_user && (
+                      <>
+                        <dt className="text-muted-foreground">Mecânico</dt>
+                        <dd className="text-foreground">{data.assigned_user.name}</dd>
+                      </>
+                    )}
+                    <dt className="text-muted-foreground">Valor</dt>
+                    <dd className="tabular-nums font-semibold text-success">
+                      {formatBRL(data.items_total ?? 0)}
+                    </dd>
                   </dl>
                 </div>
               )}
@@ -450,16 +403,7 @@ export default function ServiceOrderRichSheet({
                 </Section>
               )}
 
-              {/* Endereço extra (se NÃO mostrado em KV grid acima por truncate) */}
-              {data.delivery_address && data.delivery_address.length > 40 && (
-                <Section title="Endereço de entrega" icon={MapPin}>
-                  <p className="text-sm text-muted-foreground break-words leading-relaxed">
-                    {data.delivery_address}
-                  </p>
-                </Section>
-              )}
-
-              {/* ─── SEÇÃO 2: OBSERVAÇÃO (rental.notes) ─── */}
+              {/* ─── SEÇÃO 2: OBSERVAÇÃO (notes) ─── */}
               <Section title="Observação" icon={FileText}>
                 {data.notes ? (
                   <p className="text-sm text-foreground whitespace-pre-wrap leading-relaxed">
@@ -559,7 +503,7 @@ export default function ServiceOrderRichSheet({
               <Section title="Linha do tempo" icon={Clock}>
                 <TimelineSkeleton
                   enteredAt={data.entered_at}
-                  expectedReturn={data.expected_return_date}
+                  expectedReturn={data.expected_completion ?? data.expected_return_date}
                   completedAt={data.completed_at}
                   status={data.status}
                 />
@@ -661,33 +605,10 @@ function PhotoPlaceholder({ label }: { label: string }) {
   );
 }
 
-function StatusBadge({
-  status,
-  orderType,
-}: {
-  status: string;
-  orderType: OrderType;
-}) {
-  const isLocacao = orderType === 'locacao';
-  const cls = isLocacao
-    ? 'border-[var(--stage-blue)]/30 bg-[var(--stage-blue)]/10 text-[var(--stage-blue)]'
-    : 'border-warning/30 bg-warning/10 text-warning-foreground';
-  return (
-    <span
-      className={
-        'inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium ' +
-        cls
-      }
-    >
-      {isLocacao ? <Truck size={10} className="mr-1" /> : null}
-      {status}
-    </span>
-  );
-}
-
 /**
- * Timeline skeleton derivada dos campos disponíveis (entered_at, expected_return,
+ * Timeline skeleton derivada dos campos disponíveis (entered_at, prazo,
  * completed_at, status). V2: fetch real via /oficina-auto/service-orders/{id}/fsm/history.
+ * Vocabulário de REPARO (ADR 0265) — nada de "locação/caçamba/recolhimento".
  */
 function TimelineSkeleton({
   enteredAt,
@@ -705,24 +626,24 @@ function TimelineSkeleton({
   if (enteredAt) {
     items.push({
       when: formatDate(enteredAt),
-      what: 'Locação iniciada',
+      what: 'OS aberta — veículo recebido',
       state: 'done',
     });
   }
 
-  // Estado intermediário (entrega presumida)
+  // Estado intermediário (serviço em andamento)
   if (enteredAt && status !== 'aberta') {
     items.push({
       when: '—',
-      what: 'Caçamba entregue ao cliente',
+      what: 'Serviço em andamento na oficina',
       state: 'done',
     });
   }
 
   if (expectedReturn) {
     items.push({
-      when: formatDate(expectedReturn + 'T18:00:00'),
-      what: 'Prazo de devolução',
+      when: formatDate(expectedReturn.length <= 10 ? expectedReturn + 'T18:00:00' : expectedReturn),
+      what: 'Previsão de entrega',
       state: completedAt ? 'done' : 'future',
     });
   }
@@ -730,13 +651,13 @@ function TimelineSkeleton({
   if (completedAt) {
     items.push({
       when: formatDate(completedAt),
-      what: 'Locação concluída',
+      what: 'Serviço concluído',
       state: 'done',
     });
   } else {
     items.push({
       when: 'agora',
-      what: 'Aguardando recolhimento…',
+      what: 'Aguardando próxima etapa…',
       state: 'now',
     });
   }

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/service-orders/create
 component: resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
 owner: wagner
 status: live
-last_validated: "2026-05-26"
+last_validated: "2026-06-09"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada
@@ -11,15 +11,18 @@ related_adrs:
   - 0110-tipografia-canon-h1-subtitle
   - 0171-oficinaauto-ativacao-piloto-martinho-faseada
   - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
+  - 0265-oficina-reparo-erradica-locacao
 tier: A
-charter_version: 2
+charter_version: 3
 ---
 
 # Page Charter — /oficina-auto/service-orders/create
 
-> **Status:** live (V0). Formulário de abertura de OS — `order_type` configurável.
+> **Status:** live (V0). Formulário de abertura de OS de reparo — `order_type ∈ {mecanica, manutencao}`.
 >
-> **Sub-vertical 4 ([ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) — 2026-05-26):** Martinho biz=164 LIVE prod usa principalmente `order_type='manutencao'` (sub-vertical 4 mecânica pesada caminhão basculante). Campos condicionais de locação (`daily_rate`/`expected_return_date`/`delivery_address`) preservados nullable como schema sub-vertical 3 hipotético sem cliente real ancorado. Toggle UI mantido por compat — review_trigger M6+ caso cliente real de locação container surgir.
+> **Sub-vertical 4 ([ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) — 2026-05-26):** Martinho biz=164 LIVE prod usa principalmente reparo de caminhão basculante (sub-vertical 4 mecânica pesada).
+>
+> **Erradicação de locação ([ADR 0265](../../../../../memory/decisions/0265-oficina-reparo-erradica-locacao.md) — 2026-06-09):** o domínio de locação foi erradicado do backend (migration + validação `in:manutencao,mecanica` + KPI + menu). O toggle de locação na UI — que o charter v2 mantinha "por compat" — foi **removido** do Create (a opção quebrava o submit, pois o backend passou a rejeitar `locacao`). Status deixou de ser campo do form: nasce `aberta` e quem move é o FSM (canon GUARD — nunca setar estágio manualmente).
 
 ## Mission
 
@@ -27,16 +30,14 @@ Permitir abertura rápida de OS pelo atendente em ≤ 30s — escolher vehicle (
 
 ## Goals — Features (faz)
 
-- `<PageHeader>` h1 "Nova Ordem de Serviço" + back link
-- Toggle `order_type`: manutenção (default) vs locação (caçamba/equipamento)
-- Autocomplete vehicle por placa (Mercosul + legacy) — se não existe, botão "Criar veículo novo" abre drawer
-- Autocomplete contact (cliente) — required (Martinho atende caminhões basculantes de transportadoras/construtoras de terceiros — sub-vertical 4 mecânica pesada ADR 0194)
-- Campos condicionais por order_type:
-  - **Manutenção:** mileage_at_service, notes, expected_completion
-  - **Locação:** delivery_address, daily_rate, expected_return_date
-- Validação client-side: campos required por order_type
-- Submit → POST /oficina-auto/service-orders → redirect Show
-- Multi-tenant Tier 0 — vehicle_id deve pertencer ao business atual (server-side double-check)
+- Sheet lateral 720px (título "Nova Ordem de Serviço")
+- Select `order_type`: mecânica (default — caminhão, roda o pipeline FSM) vs manutenção simples — **sem locação** (ADR 0265)
+- Autocomplete vehicle por placa (Mercosul + legacy) — se não existe, link "Cadastrar veículo"
+- Combobox contact (cliente) — Martinho atende caminhões de terceiros (sub-vertical 4 ADR 0194); renderiza quando o controller envia a prop `contacts`. Submete `contact_id` (exists escopado por business — Tier 0)
+- Campos do trabalho: mileage_at_service, entered_at, expected_completion, notes + check-in de entrada (combustível/avarias)
+- Status **não** é campo do form — nasce `aberta`; quem move é o FSM (ADR 0265)
+- Submit → POST /oficina-auto/ordens-servico → redirect Show
+- Multi-tenant Tier 0 — vehicle_id e contact_id devem pertencer ao business atual (server-side double-check)
 
 ## Non-Goals — Features (NÃO faz)
 
@@ -75,3 +76,10 @@ Permitir abertura rápida de OS pelo atendente em ≤ 30s — escolher vehicle (
 > ✅ presente+travado (some o elemento = build vermelho) · 🟡 gap (acende no `protocol_freshness`).
 
 - ✅ **UC-01** (`uc-01`) — check-in do veículo: busca por placa, chassi/renavam/hodômetro/combustível, fotos de entrada + relato do diagnóstico (`EntryCheckinFields`).
+
+## Trilha do tempo
+
+> Append-only (L-22 — não reescrever histórico).
+
+- **2026-05-26** (v2) — refator Page fullscreen → Sheet 720px; toggle locação mantido "por compat".
+- **2026-06-09** (v3) — sweep ADR 0265 no front ([sessão](../../../../../memory/sessions/2026-06-09-sweep-os-front-adr0265.md) · [avaliação CC](../../../../../prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md)): opção **Locação removida** do select (backend rejeita `in:manutencao,mecanica`); **select de Status removido** (FSM manda, nasce `aberta`); **combobox Cliente** via prop `contacts` + submete `contact_id` escopado. Goal "toggle locação" aposentado.

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
@@ -8,6 +8,15 @@
 // <textarea> notes → Textarea DS, combobox de veículo (Popover + Command) com busca
 // de placa/tipo (lista até 500 — <option> plano trava). Erros do useForm em TODOS
 // os campos + auto-scroll pro 1º inválido.
+// 2026-06-09 (sweep ADR 0265 front · avaliação [CC]):
+//   - "Locação" removida do select de tipo (backend valida in:manutencao,mecanica
+//     — a opção quebrava o submit com erro de validação).
+//   - Select de Status removido da UI — status nasce 'aberta'; quem move é o FSM
+//     (canon GUARD: nunca setar estágio manualmente).
+//   - Combobox de Cliente (contact) — charter exige; renderiza quando o controller
+//     passar `contacts` (graceful: sem prop, campo não aparece).
+//   - Copy dev ("V0 — vínculo OS↔Vehicle obrigatório, status livre") trocada por
+//     copy cliente-facing.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router, useForm } from '@inertiajs/react';
@@ -54,9 +63,17 @@ interface Vehicle {
   vehicle_type: string;
 }
 
+interface ContactOption {
+  id: number;
+  name: string;
+}
+
 interface Props {
   vehicles: Vehicle[];
   statuses: Record<string, string>;
+  /** Clientes pro combobox (charter: Martinho atende caminhões de terceiros).
+      Opcional — campo só renderiza quando o controller enviar. */
+  contacts?: ContactOption[];
 }
 
 function vehicleLabel(v: Vehicle): string {
@@ -64,13 +81,16 @@ function vehicleLabel(v: Vehicle): string {
   return `${v.plate}${secondary} (${v.vehicle_type})`;
 }
 
-export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
+export default function ServiceOrdersCreate({ vehicles, statuses, contacts }: Props) {
   // Sheet abre por default (rota /create dedicada); fechar volta pra lista/producao
   const [open, setOpen] = useState(true);
   const [vehiclePickerOpen, setVehiclePickerOpen] = useState(false);
+  const [contactPickerOpen, setContactPickerOpen] = useState(false);
+  void statuses; // mantido na assinatura por compat — status é do FSM, não da UI
 
   const { data, setData, post, processing, errors } = useForm({
     vehicle_id: '',
+    contact_id: '',
     // Tipo de OS — 'mecanica' é o fluxo real de reparo de caminhão (ADR 0194),
     // default pra oficina do Martinho. Roda no pipeline FSM oficina_mecanica_os.
     order_type: 'mecanica',
@@ -87,6 +107,11 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
   const selectedVehicle = useMemo(
     () => vehicles.find((v) => String(v.id) === data.vehicle_id) ?? null,
     [vehicles, data.vehicle_id],
+  );
+
+  const selectedContact = useMemo(
+    () => (contacts ?? []).find((c) => String(c.id) === data.contact_id) ?? null,
+    [contacts, data.contact_id],
   );
 
   // Foco/scroll no 1º campo inválido quando o backend devolve erros de validação.
@@ -134,7 +159,7 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
               Nova Ordem de Serviço
             </SheetTitle>
             <SheetDescription className="text-xs">
-              V0 — vínculo OS↔Vehicle obrigatório, status livre
+              Check-in do veículo — a OS abre em Recepção e segue o quadro de etapas.
             </SheetDescription>
           </SheetHeader>
 
@@ -217,7 +242,6 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
                 <SelectContent>
                   <SelectItem value="mecanica">Mecânica / Reparo (caminhão)</SelectItem>
                   <SelectItem value="manutencao">Manutenção simples</SelectItem>
-                  <SelectItem value="locacao">Locação</SelectItem>
                 </SelectContent>
               </Select>
               {errors.order_type && (
@@ -228,28 +252,67 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
               </p>
             </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div data-field="status">
-                <Label htmlFor="status">Status *</Label>
-                <Select
-                  value={data.status}
-                  onValueChange={(value) => setData('status', value)}
-                >
-                  <SelectTrigger id="status" aria-invalid={!!errors.status}>
-                    <SelectValue placeholder="Selecione o status…" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.entries(statuses).map(([key, label]) => (
-                      <SelectItem key={key} value={key}>
-                        {label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {errors.status && (
-                  <p className="text-sm text-destructive mt-1">{errors.status}</p>
+            {/* Cliente — dono do caminhão (terceiro). Só renderiza quando o controller
+                envia `contacts`; obrigatório pro gate de aprovação WhatsApp ter destinatário. */}
+            {contacts && contacts.length > 0 && (
+              <div data-field="contact_id">
+                <Label htmlFor="contact_id">Cliente *</Label>
+                <Popover open={contactPickerOpen} onOpenChange={setContactPickerOpen}>
+                  <PopoverTrigger asChild>
+                    <Button
+                      id="contact_id"
+                      type="button"
+                      variant="outline"
+                      role="combobox"
+                      aria-expanded={contactPickerOpen}
+                      aria-invalid={!!errors.contact_id}
+                      className="w-full justify-between font-normal"
+                    >
+                      <span className={cn(!selectedContact && 'text-muted-foreground')}>
+                        {selectedContact ? selectedContact.name : 'Selecione o cliente…'}
+                      </span>
+                      <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+                    </Button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    className="w-[var(--radix-popover-trigger-width)] p-0"
+                    align="start"
+                  >
+                    <Command>
+                      <CommandInput placeholder="Buscar cliente…" />
+                      <CommandList>
+                        <CommandEmpty>Nenhum cliente encontrado.</CommandEmpty>
+                        <CommandGroup>
+                          {contacts.map((c) => (
+                            <CommandItem
+                              key={c.id}
+                              value={c.name}
+                              onSelect={() => {
+                                setData('contact_id', String(c.id));
+                                setContactPickerOpen(false);
+                              }}
+                            >
+                              <Check
+                                className={cn(
+                                  'mr-2 size-4',
+                                  data.contact_id === String(c.id) ? 'opacity-100' : 'opacity-0',
+                                )}
+                              />
+                              {c.name}
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+                {errors.contact_id && (
+                  <p className="text-sm text-destructive mt-1">{errors.contact_id}</p>
                 )}
               </div>
+            )}
+
+            <div className="grid grid-cols-2 gap-4">
               <div data-field="mileage_at_service">
                 <Label htmlFor="mileage_at_service">KM na entrada</Label>
                 <Input
@@ -264,9 +327,6 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
                   <p className="text-sm text-destructive mt-1">{errors.mileage_at_service}</p>
                 )}
               </div>
-            </div>
-
-            <div className="grid grid-cols-2 gap-4">
               <div data-field="entered_at">
                 <Label htmlFor="entered_at">Data entrada</Label>
                 <Input

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/service-orders
 component: resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
 owner: wagner
 status: live
-last_validated: "2026-05-26"
+last_validated: "2026-06-09"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada
@@ -13,26 +13,29 @@ related_adrs:
   - 0171-oficinaauto-ativacao-piloto-martinho-faseada
   - 0192-auto-faturar-os-venda-jobsheet-observer
   - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
+  - 0265-oficina-reparo-erradica-locacao
 tier: A
-charter_version: 2
+charter_version: 3
 ---
 
 # Page Charter — /oficina-auto/service-orders
 
 > **Status:** live (V0). Listagem-detalhe canon Cockpit Pattern V2 das Ordens de Serviço.
 >
-> **Sub-vertical 4 ([ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) — 2026-05-26):** OS em prod biz=164 Martinho são sub-vertical 4 mecânica pesada (`order_type='manutencao'` predominante). KPI "locações ativas / atrasadas (overdue)" aplica primariamente pra schema sub-vertical 3 hipotético preservado nullable — quando sem dado real, exibe 0 sem erro. Auto-faturar OS→Venda extensão ADR 0192 LIVE 2026-05-25 (Card "Esta OS gerou venda #V-NNNN" no drawer).
+> **Sub-vertical 4 ([ADR 0194](../../../../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) — 2026-05-26):** OS em prod biz=164 Martinho são sub-vertical 4 mecânica pesada (reparo de caminhão). Auto-faturar OS→Venda extensão ADR 0192 LIVE 2026-05-25 (Card "Esta OS gerou venda #V-NNNN" no drawer).
+>
+> **Erradicação de locação ([ADR 0265](../../../../../memory/decisions/0265-oficina-reparo-erradica-locacao.md) — 2026-06-09):** KPI "Locações ativas" **aposentado** (o backend removeu o KPI no W25/0265). Os 4 KPIs do topo passam a ser de reparo (Em diagnóstico / Aguardando aprovação / Em execução / Atrasadas). Colunas e badges de locação ("Caçamba"/"Diárias"/"Endereço") removidas — `order_type ∈ {manutencao, mecanica}`. `formatBRL(null)` → "—" (matou o vazamento de string literal na tabela).
 
 ## Mission
 
-Dashboard operacional pra atendente/gerente da oficina decidir próxima ação em cada OS — visão consolidada de OS abertas, em serviço, aguardando aprovação, atrasadas (locação overdue) e concluídas pendente entrega.
+Dashboard operacional pra atendente/gerente da oficina decidir próxima ação em cada OS — visão consolidada de OS abertas, em serviço, aguardando aprovação, atrasadas e concluídas pendente entrega.
 
 ## Goals — Features (faz)
 
 - AppShellV2 + topnav padrão Cockpit V2 (ADR 0110)
 - `<PageHeader>` shared (h1 "Ordens de Serviço" + subtitle + ações Criar OS / Importer Firebird)
-- KpiGrid topo: OS abertas, em serviço, locações ativas, atrasadas (overdue), valor a receber consolidado
-- Listagem com filtros: status, order_type (manutencao/locacao), vehicle.plate, contact, intervalo de datas
+- KpiGrid topo (reparo, ADR 0265): em diagnóstico, aguardando aprovação, em execução, atrasadas — **sem** "locações ativas"
+- Listagem com filtros: status, order_type (manutencao/mecanica — **sem** locacao), vehicle.plate, contact, intervalo de datas
 - Badge status semântico (rose=atrasada, amber=orcamento aguardando, blue=em_servico, emerald=concluida)
 - Drawer detail (ServiceOrderSheet) ao clicar linha — FSM action panel + timeline append-only
 - Multi-tenant Tier 0 (ADR 0093) — dados scopados business_id
@@ -71,3 +74,10 @@ Dashboard operacional pra atendente/gerente da oficina decidir próxima ação e
 - [RUNBOOK-index.md](../../../../../memory/requisitos/OficinaAuto/RUNBOOK-index.md)
 - [ADR 0137](../../../../../memory/decisions/0137-modules-oficinaauto-qualificada.md)
 - [ADR 0143 FSM canon](../../../../../memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
+
+## Trilha do tempo
+
+> Append-only (L-22 — não reescrever histórico).
+
+- **2026-05-26** (v2) — Cockpit Pattern V2; KPI "locações ativas" + colunas locação mantidos.
+- **2026-06-09** (v3) — sweep ADR 0265 no front ([sessão](../../../../../memory/sessions/2026-06-09-sweep-os-front-adr0265.md) · [avaliação CC](../../../../../prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md)): KPI "Locações ativas" **morto**; colunas/pills/badges de locação → reparo (`OrderType = {manutencao, mecanica}`); `formatBRL(null)` → "—". `mecanica` deixou de cair no ramo locação.

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -1,7 +1,10 @@
 // @memcofre tela=/oficina-auto/ordens-servico module=OficinaAuto
-// V0.5 dashboard de OS (mecânica pesada predominante + schema locação preservado nullable) — Martinho LIVE prod biz=164 (sub-vertical 4 ADR 0194).
-// Espelha layout Vehicles Index (Wave 5-B) + mockup demo-martinho-2026-05-13/mockup.html.
-// Schema flags do Backend permitem renderizar mesmo antes da Wave 5-A migrar.
+// V0.6 dashboard de OS — Martinho LIVE prod biz=164 (sub-vertical 4 ADR 0194).
+// 2026-06-09 sweep ADR 0265 (avaliação [CC]): locação erradicada do front —
+// types/pills/colunas/copy agora são de REPARO (mecanica|manutencao). Colunas
+// de locação (Endereço/Diárias) removidas; "Caçamba"→"Veículo"; formatBRL
+// null→"—" (antes vazava "R$ [redacted Tier 0]" literal na UI).
+// Espelha layout Vehicles Index (Wave 5-B).
 // RUNBOOK: memory/requisitos/OficinaAuto/RUNBOOK-index.md
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -29,7 +32,8 @@ function initialView(): ListView {
 }
 
 // ──────── Types ────────
-type OrderType = 'locacao' | 'manutencao' | null;
+// ADR 0265: order_type ∈ {manutencao, mecanica} — 'locacao' não existe mais no enum.
+type OrderType = 'manutencao' | 'mecanica' | null;
 
 interface VehicleRel {
   id: number;
@@ -133,15 +137,14 @@ const EMPTY_KPIS: Kpis = {
 // ──────── Helpers ────────
 const STATUS_PILLS: Array<{ key: string; label: string }> = [
   { key: 'all', label: 'Todas' },
-  { key: 'locacao_ativa', label: 'Locações ativas' },
-  { key: 'manutencao_ativa', label: 'Em manutenção' },
+  { key: 'manutencao_ativa', label: 'Em andamento' },
   { key: 'concluida_mes', label: 'Concluídas mês' },
   { key: 'atrasada', label: 'Atrasadas' },
 ];
 
 const TYPE_PILLS: Array<{ key: string; label: string }> = [
   { key: 'all', label: 'Todos os tipos' },
-  { key: 'locacao', label: 'Locação' },
+  { key: 'mecanica', label: 'Mecânica' },
   { key: 'manutencao', label: 'Manutenção' },
 ];
 
@@ -155,9 +158,9 @@ function formatBRDate(value?: string | null): string {
 }
 
 function formatBRL(value: number | string | null | undefined): string {
-  if (value === null || value === undefined || value === '') return 'R$ [redacted Tier 0]';
+  if (value === null || value === undefined || value === '') return '—';
   const num = typeof value === 'string' ? parseFloat(value) : value;
-  if (Number.isNaN(num)) return 'R$ [redacted Tier 0]';
+  if (Number.isNaN(num)) return '—';
   return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 }
 
@@ -247,7 +250,7 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
     applyFilter({});
   }
 
-  const subtitle = `${kpis.locacoes_ativas} locações ativas · ${kpis.manutencao_ativas} manutenções · ${kpis.atrasadas} atrasadas`;
+  const subtitle = `${kpis.manutencao_ativas} em andamento · ${kpis.concluidas_mes} concluídas no mês · ${kpis.atrasadas} atrasadas`;
 
   return (
     <AppShellV2>
@@ -279,21 +282,15 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
         {/* Aviso pré-Wave 5-A (some quando schema migrar) */}
         {!schemaFlags.has_order_type && (
           <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
-            Schema Wave 5-A pendente — distinção locação/manutenção só ativa após migração de
+            Schema Wave 5-A pendente — distinção mecânica/manutenção só ativa após migração de
             <code className="mx-1 px-1 rounded bg-amber-100">order_type</code>.
           </div>
         )}
 
-        {/* KPIs */}
-        <KpiGrid cols={4}>
+        {/* KPIs — reparo (ADR 0265: KPI de locação morreu com o domínio) */}
+        <KpiGrid cols={3}>
           <KpiCard
-            label="Locações ativas"
-            value={kpis.locacoes_ativas}
-            tone="info"
-            icon="truck"
-          />
-          <KpiCard
-            label="Em manutenção"
+            label="Em andamento"
             value={kpis.manutencao_ativas}
             tone="warning"
             icon="wrench"
@@ -482,18 +479,13 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
               <table className="w-full text-sm">
                 <thead className="border-b bg-muted/50 text-xs uppercase text-muted-foreground">
                   <tr>
-                    <th className="px-3 py-2 text-left w-8">
-                      <input type="checkbox" disabled aria-label="Selecionar todos" />
-                    </th>
                     <th className="px-3 py-2 text-left">Nº OS</th>
                     <th className="px-3 py-2 text-left">Tipo</th>
-                    <th className="px-3 py-2 text-left">Caçamba</th>
+                    <th className="px-3 py-2 text-left">Veículo</th>
                     <th className="px-3 py-2 text-left">Cliente</th>
-                    <th className="px-3 py-2 text-left">Endereço</th>
-                    <th className="px-3 py-2 text-left">Início</th>
-                    <th className="px-3 py-2 text-left">Prazo</th>
-                    <th className="px-3 py-2 text-right">Diárias</th>
-                    <th className="px-3 py-2 text-right">A receber</th>
+                    <th className="px-3 py-2 text-left">Entrada</th>
+                    <th className="px-3 py-2 text-left">Previsão</th>
+                    <th className="px-3 py-2 text-right">Valor</th>
                     <th className="px-3 py-2 text-left">Status</th>
                   </tr>
                 </thead>
@@ -502,7 +494,6 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                     const overdue = isOverdueClient(o, schemaFlags);
                     const startedAt = o.started_at ?? o.entered_at;
                     const prazo = schemaFlags.has_return_date ? o.expected_return_date : o.expected_completion;
-                    const isLocacao = o.order_type === 'locacao';
 
                     return (
                       <tr
@@ -513,9 +504,6 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                         )}
                         onClick={() => setOpenOsId(o.id)}
                       >
-                        <td className="px-3 py-2.5" onClick={(e) => e.stopPropagation()}>
-                          <input type="checkbox" disabled aria-label={`Selecionar OS ${o.id}`} />
-                        </td>
                         <td className="px-3 py-2.5 font-mono font-semibold">
                           {overdue && (
                             <span
@@ -526,9 +514,9 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                           {o.number ?? `#${o.id}`}
                         </td>
                         <td className="px-3 py-2.5">
-                          {o.order_type === 'locacao' ? (
-                            <span className="inline-block px-2 py-0.5 text-xs rounded bg-blue-50 text-blue-700 border border-blue-200">
-                              Locação
+                          {o.order_type === 'mecanica' ? (
+                            <span className="inline-block px-2 py-0.5 text-xs rounded bg-violet-50 text-violet-700 border border-violet-200">
+                              Mecânica
                             </span>
                           ) : o.order_type === 'manutencao' ? (
                             <span className="inline-block px-2 py-0.5 text-xs rounded bg-amber-50 text-amber-700 border border-amber-200">
@@ -562,11 +550,6 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                         <td className="px-3 py-2.5">
                           {o.contact?.name ?? <span className="text-muted-foreground">—</span>}
                         </td>
-                        <td className="px-3 py-2.5 text-xs text-muted-foreground max-w-[200px]">
-                          <div className="truncate" title={o.delivery_address ?? ''}>
-                            {o.delivery_address || '—'}
-                          </div>
-                        </td>
                         <td className="px-3 py-2.5 text-xs tabular-nums text-muted-foreground">
                           {formatBRDate(startedAt)}
                         </td>
@@ -577,20 +560,6 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                           )}
                         >
                           {formatBRDate(prazo)}
-                        </td>
-                        <td
-                          className={cn(
-                            'px-3 py-2.5 text-right tabular-nums',
-                            overdue ? 'text-rose-700 font-medium' : '',
-                          )}
-                        >
-                          {isLocacao && o.dias_locacao != null ? (
-                            <>
-                              {o.dias_locacao}d{overdue && ' ⚠'}
-                            </>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
                         </td>
                         <td
                           className={cn(

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
@@ -315,7 +315,7 @@ export default function ServiceOrdersShow({ order }: Props) {
 
           {items.length > 0 ? (
             <>
-              <ul className="divide-y divide-slate-100 border border-slate-200 rounded-md overflow-hidden bg-white">
+              <ul className="divide-y divide-border border border-border rounded-md overflow-hidden bg-card">
                 {items.map((item) => (
                   <ServiceOrderItemRow
                     key={item.id}
@@ -330,13 +330,13 @@ export default function ServiceOrdersShow({ order }: Props) {
                 <span className="text-[10.5px] uppercase tracking-wider text-muted-foreground">
                   Total OS
                 </span>
-                <span className="text-sm tabular-nums font-semibold text-emerald-700">
+                <span className="text-sm tabular-nums font-semibold text-success">
                   {formatBRL(totalOs)}
                 </span>
               </div>
             </>
           ) : (
-            <div className="rounded-md border border-dashed border-slate-200 p-6 text-center">
+            <div className="rounded-md border border-dashed border-border p-6 text-center">
               <Package className="size-5 mx-auto text-muted-foreground mb-2" />
               <p className="text-sm text-muted-foreground">
                 Nenhum item lançado ainda.

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFila.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFila.tsx
@@ -29,7 +29,8 @@ export interface FilaOrder {
   id: number;
   number?: string | null;
   status: string;
-  order_type?: 'locacao' | 'manutencao' | null;
+  // ADR 0265: order_type ∈ {manutencao, mecanica}
+  order_type?: 'manutencao' | 'mecanica' | null;
   delivery_address?: string | null;
   expected_return_date?: string | null;
   expected_completion?: string | null;
@@ -66,7 +67,7 @@ function vehicleLabel(o: FilaOrder): string {
 }
 
 function typeLabel(t: FilaOrder['order_type']): string {
-  if (t === 'locacao') return 'Locação';
+  if (t === 'mecanica') return 'Mecânica';
   if (t === 'manutencao') return 'Manutenção';
   return '—';
 }
@@ -233,12 +234,6 @@ function OsDetailInline({
               {overdue && ' ⚠'}
             </dd>
           </div>
-          {o.order_type === 'locacao' && o.dias_locacao != null && (
-            <div>
-              <dt className="text-xs text-muted-foreground">Diárias</dt>
-              <dd className="tabular-nums text-foreground">{o.dias_locacao}d</dd>
-            </div>
-          )}
           <div>
             <dt className="text-xs text-muted-foreground">A receber</dt>
             <dd className={cn('tabular-nums', Number(o.valor_receber ?? 0) > 0 ? 'text-warning' : 'text-foreground')}>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
@@ -1,5 +1,5 @@
 // Wire-up UI FSM ServiceOrder — botões dinâmicos no drawer ServiceOrderSheet
-// pra executar transições FSM (Iniciar locação, Recolher caçamba, Concluir, etc).
+// pra executar transições FSM do reparo (Iniciar diagnóstico, Concluir etc · ADR 0265).
 //
 // Refs: Wave 7-A backend (ServiceOrderFsmActionController),
 //       Pages/Sells/_components/FsmActionPanel.tsx (pattern canon pós-PR #717),
@@ -129,7 +129,7 @@ function StartPipelineEmptyState({
   return (
     <div className="space-y-2">
       <p className="text-xs text-muted-foreground">
-        Esta OS ainda não está em pipeline FSM (Recebido → Em locação → Recolhido → Concluído).
+        Esta OS ainda não está em pipeline FSM (Recepção → Diagnóstico → Execução → Pronto p/ retirar).
         Inicie pra rastrear o ciclo completo via timeline auditável.
       </p>
       <Button

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
@@ -2,8 +2,8 @@
 // Espelha resources/js/Pages/Sells/_components/SaleSheet.tsx (LIVE prod biz=1).
 //
 // Contexto: pré-reunião Martinho 13/maio precisa demonstrar fluxo end-to-end clicável.
-// Click row Vehicles/ServiceOrders → drawer abre → usuário roda ações FSM (Iniciar locação,
-// Recolher caçamba, Concluir, Cancelar) — sem sair da listagem.
+// Click row Vehicles/ServiceOrders → drawer abre → usuário roda ações FSM do reparo
+// (Iniciar diagnóstico, Concluir, Cancelar · ADR 0265) — sem sair da listagem.
 //
 // Refs: ADR 0143 (FSM Pipeline LIVE), ADR 0110 (Cockpit V2),
 //       PR #717 (re-render fix — useMemo/useCallback nos handlers descendentes),
@@ -38,7 +38,7 @@ import ServiceOrderFsmActionPanel from './ServiceOrderFsmActionPanel';
 import ServiceOrderStagePipeline from './ServiceOrderStagePipeline';
 import ServiceOrderTimeline from './ServiceOrderTimeline';
 
-type OrderType = 'locacao' | 'manutencao' | null;
+type OrderType = 'manutencao' | 'mecanica' | null; // ADR 0265: reparo, sem locação
 
 interface ContactRel {
   id: number;
@@ -91,9 +91,9 @@ interface Props {
 }
 
 const formatBRL = (value: number | string | null | undefined) => {
-  if (value === null || value === undefined || value === '') return 'R$ [redacted Tier 0]';
+  if (value === null || value === undefined || value === '') return '—';
   const num = typeof value === 'string' ? parseFloat(value) : value;
-  if (Number.isNaN(num)) return 'R$ [redacted Tier 0]';
+  if (Number.isNaN(num)) return '—';
   return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 };
 
@@ -207,7 +207,7 @@ export default function ServiceOrderSheet({
                 )}
               </div>
               <SheetTitle className="text-xl font-semibold tracking-tight text-foreground">
-                {data.order_type === 'locacao' ? 'Locação' : 'Manutenção'}{' '}
+                {data.order_type === 'mecanica' ? 'Mecânica' : 'Manutenção'}{' '}
                 {data.number ?? `#${data.id}`}
               </SheetTitle>
               <SheetDescription className="text-sm text-muted-foreground">
@@ -229,20 +229,11 @@ export default function ServiceOrderSheet({
                   reutilizado por Modules/Repair desde PR #1504 Onda 5). */}
               {data.venda_derivada && <VendaDerivadaCard venda={data.venda_derivada} />}
 
-              {/* 4 KPIs mini horizontais */}
-              <div className="grid grid-cols-3 gap-3">
+              {/* KPIs mini horizontais — reparo (ADR 0265: Diárias/Diária eram locação) */}
+              <div className="grid grid-cols-2 gap-3">
                 <MiniKpi
-                  label="Diárias"
-                  value={
-                    data.dias_locacao != null
-                      ? `${data.dias_locacao}d`
-                      : '—'
-                  }
-                  tone={data.is_overdue ? 'warning' : undefined}
-                />
-                <MiniKpi
-                  label="Diária"
-                  value={formatBRL(data.daily_rate)}
+                  label="Entrada"
+                  value={formatDateOnly(data.started_at ?? data.entered_at)}
                 />
                 <MiniKpi
                   label="A receber"
@@ -260,7 +251,7 @@ export default function ServiceOrderSheet({
               {/* Detalhes — campos básicos OS */}
               <Section title="Detalhes" icon={Truck}>
                 <div className="space-y-2 text-sm">
-                  {/* Caçamba */}
+                  {/* Veículo */}
                   {data.vehicle && (
                     <div className="flex items-center gap-2 text-foreground">
                       <Truck size={13} className="text-muted-foreground" />
@@ -302,7 +293,7 @@ export default function ServiceOrderSheet({
                     </>
                   )}
 
-                  {/* Endereço entrega (locação) */}
+                  {/* Endereço do cliente (se informado) */}
                   {data.delivery_address && (
                     <div className="flex items-start gap-2 text-muted-foreground text-xs pt-1.5 border-t border-border/60">
                       <MapPin size={12} className="mt-0.5 flex-shrink-0" />
@@ -471,11 +462,11 @@ function MiniKpi({
 }
 
 function OrderTypeBadge({ type }: { type: OrderType }) {
-  if (type === 'locacao') {
+  if (type === 'mecanica') {
     return (
-      <span className="inline-flex items-center rounded-full border border-blue-200 bg-blue-50 px-2.5 py-0.5 text-[11px] font-medium text-blue-700 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-300">
-        <Truck size={10} className="mr-1" />
-        Locação
+      <span className="inline-flex items-center rounded-full border border-violet-200 bg-violet-50 px-2.5 py-0.5 text-[11px] font-medium text-violet-700 dark:border-violet-900/40 dark:bg-violet-950/40 dark:text-violet-300">
+        <Wrench size={10} className="mr-1" />
+        Mecânica
       </span>
     );
   }

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStatusBadge.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStatusBadge.tsx
@@ -6,7 +6,8 @@ import { cn } from '@/Lib/utils';
 
 export interface ServiceOrderStatusBadgeProps {
   status: string;
-  orderType?: 'locacao' | 'manutencao' | null;
+  // ADR 0265: domínio = reparo — order_type ∈ {manutencao, mecanica}
+  orderType?: 'manutencao' | 'mecanica' | null;
   isOverdue?: boolean;
   className?: string;
 }
@@ -16,11 +17,11 @@ interface BadgeStyle {
   classes: string;
 }
 
-function resolveBadge({ status, orderType, isOverdue }: ServiceOrderStatusBadgeProps): BadgeStyle {
-  // Atrasada tem prioridade visual máxima.
-  if (isOverdue && orderType === 'locacao' && !['concluida', 'cancelada'].includes(status)) {
+function resolveBadge({ status, isOverdue }: ServiceOrderStatusBadgeProps): BadgeStyle {
+  // Atrasada tem prioridade visual máxima (qualquer tipo de reparo ativo).
+  if (isOverdue && !['concluida', 'cancelada', 'entregue'].includes(status)) {
     return {
-      label: 'Atrasada · cobrar',
+      label: 'Atrasada',
       classes: 'bg-rose-100 text-rose-700 border-rose-300',
     };
   }
@@ -45,15 +46,7 @@ function resolveBadge({ status, orderType, isOverdue }: ServiceOrderStatusBadgeP
     };
   }
 
-  // Estados ativos — combina com tipo.
-  if (orderType === 'locacao') {
-    return {
-      label: 'Em locação',
-      classes: 'bg-blue-50 text-blue-700 border-blue-200',
-    };
-  }
-
-  // Manutenção ou tipo desconhecido — diferencia pelo status.
+  // Estados ativos — diferencia pelo status (FSM reparo).
   switch (status) {
     case 'aberta':
       return {


### PR DESCRIPTION
## Contexto

Landa o sweep produzido pelo Claude Cowork [CC] (avaliação F1.5 do módulo OS: **65/100**, reprovado) — `prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md`. Causa-raiz: **ADR 0265 (erradicação de locação) foi aplicada no backend mas nunca varrida no front**, então OS de mecânica renderizava com "roupa" de locação (Caçamba/Diárias) e o "Imprimir OS" saía em branco/feio no Brave/Chromium.

## O que muda

**Imprimir OS/Recibo confiável (Chromium/Brave)**
- `printServiceOrder.ts` reescrito: print disparado pelo **parent** via `iframe.contentWindow.print()` após `load` + fontes, iframe fora-da-vista **sem** `visibility:hidden` + fallback `window.open`. (Era iframe 0×0 invisível com auto-`window.print()` no `srcdoc` → Chromium rasteriza em branco ou imprime o shell.)
- `printSaleReceipt.ts` (Vendas) tinha o **mesmo bug** — espelhado o mecanismo, preservando o `<link>` de `/css/app.css` legacy (o `load` do iframe aguarda os stylesheets) e o `__currency_convert_recursively`.

**Sweep ADR 0265 no client (locação → reparo)**
- `OrderType = {manutencao, mecanica}` em Index/Sheet/RichSheet/Fila/StatusBadge — `mecanica` deixou de cair no ramo locação ("Caçamba —", "Diárias 0d", "Valor a receber").
- `Create.tsx`: removida a opção **Locação** (backend rejeita `in:manutencao,mecanica`); removido o select de **Status** (FSM manda — nasce `aberta`); **combobox Cliente** (renderiza quando o controller envia `contacts`).
- `formatBRL(null) → "—"` — matou o vazamento da string literal `R$ [redacted]` na tabela/drawer.
- `Show.tsx`: tokens slate/emerald hardcoded → tokens DS.

**Backend acoplado (mesmo PR)**
- `ServiceOrderController@create` passa `contacts` (customers ativos, `business_id` explícito + scopes Contact canon — Tier 0 ADR 0093).
- `StoreServiceOrderRequest` aceita `contact_id` `nullable` + `exists` **escopado por business**.
- `ServiceOrder.$fillable += contact_id` — fecha o gap T9 (antes o mass-assign dropava `contact_id` silenciosamente).

**Memory/charters**
- `Create.charter.md` + `Index.charter.md`: trilha do tempo (append-only, L-22) — goal "toggle locação" e KPI "locações ativas" aposentados.
- Avaliação [CC] + session log adicionados.

## Validação

- ✅ **tsc**: nenhum erro novo nos arquivos tocados (os 5 hits — `icon={<Wrench/>}`, `preserveScroll`, `Edit.tsx` unused `Link` — são pré-existentes no `origin/main`; whole-repo tsc não é gate de CI).
- ✅ **eslint ratchet** (`scripts/eslint-baseline.mjs`): **delta −8**, sem regressão vs baseline.
- ✅ **ds-guard**: n/a (só linta css/html).
- ✅ **php -l**: limpo nos 4 arquivos PHP.
- ⚠️ **`php artisan test --filter=ServiceOrder`**: os testes são **MySQL-only** (skip em sqlite local — ADR 0101). Validação roda no CI. Mudanças são aditivas (`contact_id` nullable, prop extra, fillable add).

### Delta / risco a observar no CI
Testes que setam `contact_id` em `ServiceOrder::create([...])` (EnviarLinkAprovacao, ItemHttpIntegration, ObserverItemsAndHttp, RichSheetPayload) **agora persistem** o `contact_id` de fato (antes era dropado por não estar em `$fillable`). É o comportamento correto, mas o CI-MySQL é quem confirma que nenhum desses regrediu.

## Próximo passo (F2 — Wagner)
Conferir screenshot das telas + testar "Imprimir OS" no Brave.

Ref: ADR 0265, ADR 0194 · avaliação `prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md` · sessão `memory/sessions/2026-06-09-sweep-os-front-adr0265.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
