### PR TITLE
ci(e2e): G-3 primeiro run verde — harness MySQL+schema-squash + manifesto real (ADR 0264 T1)

### DIFF
--- a/.github/workflows/e2e-gate.yml
+++ b/.github/workflows/e2e-gate.yml
@@ -3,9 +3,17 @@ name: E2E Playwright (UCs críticos) — G-3 NÃO-required
 # Gate G-3 da Governança executável (ADR 0264): E2E de comportamento nos UCs críticos.
 #
 # ⚠️ workflow_dispatch (MANUAL) por enquanto — o harness boota o app real (PHP+DB+build+serve)
-# e o primeiro run verde ainda não foi validado (sem stack no agente desktop). Manter MANUAL +
-# NÃO-required evita travar todo merge num gate ainda-não-estável (lição dura ADR 0261).
-# Quando verde-estável: trocar pra `pull_request` + promover a required junto com casos/dominio.
+# e o primeiro run verde está sendo validado. Manter MANUAL + NÃO-required evita travar todo
+# merge num gate ainda-não-estável (lição dura ADR 0261). Quando verde-estável (2 runs verdes
+# seguidos): trocar `workflow_dispatch` → `pull_request` + promover a required junto de
+# casos/dominio (ADR 0264 T2).
+#
+# Boot do app: MESMO padrão PROVADO do visual-regression.yml (gate verde em main) —
+# MySQL 8.0 service + schema-squash (database/schema/mysql-schema.sql) + seed mínimo de
+# tenant biz=1 (VisregTenantSeeder). NÃO usa sqlite :memory: (morre entre `migrate` e o
+# `artisan serve`, que é OUTRO processo → DB vazio servido). Login via rota env-guarded
+# `/_visreg-login/{id}` (Auth::loginUsingId, NUNCA em produção) — pula os gates de
+# subscription/trial do form de login UltimatePOS (robusto cross-process).
 
 on:
   workflow_dispatch:
@@ -18,47 +26,115 @@ jobs:
   e2e:
     name: E2E Playwright · UCs críticos (não-required)
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: oimpresso_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=20
+
     env:
-      DB_CONNECTION: sqlite
-      DB_DATABASE: ':memory:'
       PLAYWRIGHT_BASE_URL: http://127.0.0.1:8000
+      # Login cross-process via /_visreg-login/{id} (env-guarded, não-prod). 1 = admin do
+      # VisregTenantSeeder (business_id=1, role Admin#1 = todas as abilities via Gate::before).
+      E2E_BYPASS_LOGIN_ID: '1'
+
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
+          # SEM `opentelemetry`: a auto-instrumentação opentelemetry-auto-laravel acessa
+          # contexto OTel não-inicializado e quebra queries DB em telas autenticadas. O
+          # gate de comportamento não precisa de telemetria (mesma decisão do visual-regression).
           php-version: '8.4'
-          extensions: sqlite3, pdo_sqlite, mbstring, bcmath, intl
+          extensions: mbstring, dom, fileinfo, pdo_mysql, gd, bcmath, intl
+          coverage: none
 
-      - name: Composer install
-        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Wait for MySQL ready
+        run: |
+          for i in {1..30}; do
+            if mysqladmin ping -h127.0.0.1 -uroot -proot --silent; then echo "MySQL ready"; break; fi
+            echo "Waiting MySQL... $i"; sleep 2
+          done
 
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: npm
 
-      - name: NPM ci + build Inertia
-        run: |
-          npm ci
-          npm run build:inertia
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-      - name: App bootstrap (env + key + migrate + seed biz=1)
+      - name: Composer install
+        # --ignore-platform-req=ext-opentelemetry: o pacote exige a ext no platform check
+        # mas a removemos de propósito (Setup PHP). Degrada gracioso sem ela.
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts --ignore-platform-req=ext-opentelemetry
+
+      - name: NPM ci
+        run: npm ci
+
+      - name: App bootstrap (.env + key + schema-squash migrate + seed biz=1)
+        # SCHEMA-SQUASH: `migrate` carrega database/schema/mysql-schema.sql (squash do staging
+        # saudável) ANTES de replayar — bypassa a podridão de fresh-migrate (mesma estratégia
+        # provada do visual-regression / financeiro-pest). Seed mínimo do tenant biz=1 (ADR 0101).
         run: |
-          cp .env.example .env || true
+          mkdir -p storage/framework/cache storage/framework/views storage/framework/sessions storage/framework/testing storage/logs bootstrap/cache
+          cat > .env <<'EOF'
+          APP_NAME=oimpresso-e2e
+          APP_KEY=
+          APP_ENV=testing
+          APP_DEBUG=true
+          APP_URL=http://127.0.0.1:8000
+          LOG_CHANNEL=stderr
+          DB_CONNECTION=mysql
+          DB_HOST=127.0.0.1
+          DB_PORT=3306
+          DB_DATABASE=oimpresso_test
+          DB_USERNAME=root
+          DB_PASSWORD=root
+          CACHE_DRIVER=array
+          QUEUE_CONNECTION=sync
+          SESSION_DRIVER=file
+          MAIL_MAILER=array
+          BCRYPT_ROUNDS=4
+          TELESCOPE_ENABLED=false
+          VIEW_COMPILED_PATH=storage/framework/views
+          EOF
           php artisan key:generate --force
+          php artisan package:discover --ansi
           php artisan migrate --force
-          # Seed do piloto OficinaAuto (biz=1 dev — ADR 0101). Ajustar o seeder conforme o real.
-          php artisan db:seed --class="Modules\\OficinaAuto\\Database\\Seeders\\OficinaAutoDatabaseSeeder" --force || true
+          php artisan db:seed --force
+          php artisan db:seed --class=Database\\Seeders\\VisregTenantSeeder --force
+          echo "=== seed check ==="
+          php artisan tinker --execute="echo 'business='.\App\Business::count().' users='.\App\User::count();"
+
+      - name: Build Inertia
+        run: npm run build:inertia
 
       - name: Playwright install (chromium)
         run: npm run e2e:install
 
       - name: Serve app + run E2E
         run: |
-          php artisan serve --host=127.0.0.1 --port=8000 &
-          npx wait-on http://127.0.0.1:8000 --timeout 60000 || sleep 10
+          php artisan serve --host=127.0.0.1 --port=8000 > storage/logs/serve.log 2>&1 &
+          npx wait-on http://127.0.0.1:8000 --timeout 90000
           npm run e2e:check
 
       # Salto #2 / G-7: coleta o JUnit do Playwright (test-results/) → manifesto por-UC.
@@ -77,10 +153,13 @@ jobs:
           path: scripts/casos-test-results.json
           retention-days: 14
 
-      - name: Upload trace/report on failure
+      - name: Upload trace/report + serve log on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: playwright-report
-          path: playwright-report/
+          name: e2e-failure-logs
+          path: |
+            playwright-report/
+            test-results/
+            storage/logs/serve.log
           retention-days: 7

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -2,25 +2,38 @@ import { chromium, type FullConfig } from '@playwright/test';
 import { mkdirSync } from 'node:fs';
 
 // Login uma vez e salva o storageState pra os specs (a tela ProducaoOficina é auth-gated,
-// stack UltimatePOS). Credenciais via env (E2E_USER / E2E_PASS) — no CI vêm do seed de
-// biz=1 dev (ADR 0101: biz=1 nunca é cliente real). Locators resilientes (label/role).
-export default async function globalSetup(config: FullConfig) {
+// stack UltimatePOS). Dois caminhos (harness, NÃO assert — não afrouxa spec, L-24):
+//
+//   (A) CI / bypass: E2E_BYPASS_LOGIN_ID setado → rota env-guarded `/_visreg-login/{id}`
+//       (Auth::loginUsingId, NUNCA em produção — routes/web.php). Pula os gates de
+//       subscription/trial do form UltimatePOS, que falhariam num tenant mínimo seedado.
+//       É o caminho ROBUSTO cross-process (mesma rota do visual-regression, US-GOV-013).
+//   (B) Local: form de login real com E2E_USER / E2E_PASS (dev biz=1, ADR 0101).
+//
+// Locators resilientes (label/role) no caminho (B).
+export default async function globalSetup(_config: FullConfig) {
   const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://127.0.0.1:8000';
-  const user = process.env.E2E_USER ?? 'admin@oimpresso.test';
-  const pass = process.env.E2E_PASS ?? 'password';
+  const bypassId = process.env.E2E_BYPASS_LOGIN_ID;
 
   mkdirSync('e2e/.auth', { recursive: true });
 
   const browser = await chromium.launch();
   const page = await browser.newPage();
-  await page.goto(`${baseURL}/login`);
 
-  // UltimatePOS login: campos username/password (fallback por type/name).
-  const userField = page.getByLabel(/usu[aá]rio|username|e-?mail/i).or(page.locator('input[name="username"], input[name="email"]')).first();
-  const passField = page.getByLabel(/senha|password/i).or(page.locator('input[type="password"]')).first();
-  await userField.fill(user);
-  await passField.fill(pass);
-  await page.getByRole('button', { name: /entrar|login|sign in/i }).click();
+  if (bypassId) {
+    // (A) bypass env-guarded — loga o user por id no subprocesso do server → cookie de sessão.
+    await page.goto(`${baseURL}/_visreg-login/${bypassId}?to=/`);
+  } else {
+    // (B) form de login real (local).
+    const user = process.env.E2E_USER ?? 'admin@oimpresso.test';
+    const pass = process.env.E2E_PASS ?? 'password';
+    await page.goto(`${baseURL}/login`);
+    const userField = page.getByLabel(/usu[aá]rio|username|e-?mail/i).or(page.locator('input[name="username"], input[name="email"]')).first();
+    const passField = page.getByLabel(/senha|password/i).or(page.locator('input[type="password"]')).first();
+    await userField.fill(user);
+    await passField.fill(pass);
+    await page.getByRole('button', { name: /entrar|login|sign in/i }).click();
+  }
 
   await page.waitForLoadState('networkidle');
   await page.context().storageState({ path: 'e2e/.auth/state.json' });

--- a/scripts/casos-test-results.json
+++ b/scripts/casos-test-results.json
@@ -1,13 +1,15 @@
 {
   "_meta": {
-    "generated_at": "2026-06-09T14:37:13.783Z",
+    "generated_at": "2026-06-09T20:24:54.445Z",
     "gate": "casos status derivado (ADR 0264 G-7 — Status por UC vem do veredito real do teste)",
-    "sources": [],
+    "sources": [
+      "test-results/playwright-junit.xml"
+    ],
     "stats": {
-      "ucs": 0,
-      "pass": 0,
+      "ucs": 4,
+      "pass": 3,
       "fail": 0,
-      "skip": 0
+      "skip": 1
     },
     "nota": "Veredito por-UC derivado dos relatórios JUnit (test-results/). Lido offline pelo casos:check G-7. Regerar quando a suíte rodar: npm run casos:results. UC sem entrada aqui = sem prova capturada (G-7 marca ✅ declarado como unverified).",
     "refs": [
@@ -16,5 +18,26 @@
       "ADR 0256"
     ]
   },
-  "ucs": {}
+  "ucs": {
+    "UC-01": {
+      "verdict": "pass",
+      "ran_at": "2026-06-09",
+      "tests": 1
+    },
+    "UC-02": {
+      "verdict": "pass",
+      "ran_at": "2026-06-09",
+      "tests": 1
+    },
+    "UC-03": {
+      "verdict": "pass",
+      "ran_at": "2026-06-09",
+      "tests": 1
+    },
+    "UC-06": {
+      "verdict": "skip",
+      "ran_at": "2026-06-09",
+      "tests": 1
+    }
+  }
 }


### PR DESCRIPTION
## O quê

Fecha o **elo aberto do ADR 0264 G-3**: o e2e-gate (E2E Playwright dos UCs críticos) **nunca tinha rodado verde**. Rebuild do harness + commit do manifesto real do 1º run verde.

## Por quê

O harness antigo era inrodável:
- `sqlite :memory:` **morre entre `migrate` e `artisan serve`** (processos distintos → DB vazio servido).
- `cp .env.example .env` — **`.env.example` não existe** no repo.

## Como

Reescrito no **mesmo padrão PROVADO** do `visual-regression.yml` (verde em main):
- MySQL 8.0 service + **schema-squash** (`database/schema/mysql-schema.sql`) + seed mínimo tenant biz=1 (`VisregTenantSeeder`).
- `.env` heredoc + `serve` + `wait-on 90s`.
- Login via rota **env-guarded** `/_visreg-login/{id}` (`Auth::loginUsingId`, NUNCA em produção) — pula os gates de subscription/trial do form UltimatePOS. `global-setup.ts` ganha o caminho bypass mantendo o form como fallback local.
- **Specs intactos** (L-24 — conserta o harness, não o teste).

## Prova — run #27233429304 (ref `feat/g3-e2e-first-green`) 🟢

Manifesto coletado do JUnit do Playwright (`casos:results`):

| UC | verdict |
|---|---|
| UC-01 (ver o pátio · 5 colunas) | ✅ pass |
| UC-02 (6 KPIs) | ✅ pass |
| UC-03 (busca filtra) | ✅ pass |
| UC-06 (gate de etapa) | ⏭️ skip (sem card seedado; declarado 🧪 — não exige prova G-7) |

`ucs=4 · pass=3 · fail=0`. **DoD-1 atingido** (ucs≥3, os ✅ de UC-01/02/03 deixam de ser unverified). `casos:check` local: débito **−3**, zero violação nova.

## Não-objetivos / próximo

- Mantido `workflow_dispatch` + **NÃO-required** (ADR 0261: não promover gate instável). O flip pra `required` é o T2, **só após 2 runs verdes seguidos** + PR-canário negativo.
- Specs Vendas (UC-V05) / Financeiro (UC-F02) = ratchet F3 (T4).

Refs: ADR 0264 (G-3/G-7) · ADR 0261 (enforcement faseado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)