### PR TITLE
feat(oficina): drawer OS V2 — DVI semáforo inline (OS-V2-2) + Fotos & Laudo upload real (OS-V2-1)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -661,6 +661,22 @@ class ServiceOrderController extends Controller
                     'notes'          => $item->notes,
                 ])->values()->all(),
                 'items_total' => (float) $order->total_items,
+                // F3 OS-V2-2 — itens DVI (Vistoria Digital) pra o semáforo inline editável
+                // do drawer ServiceOrderRichSheet (DviInlineEditor). Mesmo shape do branch
+                // Inertia (Show), + sort_order pra ordenação estável. `budget_item_id` (em
+                // metadata) sinaliza item já convertido em linha de orçamento.
+                'dvi_items' => $order->dviInspectionItems
+                    ->sortBy([['sort_order', 'asc'], ['id', 'asc']])
+                    ->map(fn (OaInspectionItem $dvi) => [
+                        'id'                => (int) $dvi->id,
+                        'categoria'         => (string) $dvi->categoria,
+                        'descricao'         => (string) $dvi->descricao,
+                        'severity'          => (string) $dvi->severity,
+                        'recomendacao'      => $dvi->recomendacao,
+                        'valor_recomendado' => $dvi->valor_recomendado !== null ? (float) $dvi->valor_recomendado : null,
+                        'sort_order'        => (int) $dvi->sort_order,
+                        'budget_item_id'    => is_array($dvi->metadata) ? ($dvi->metadata['budget_item_id'] ?? null) : null,
+                    ])->values()->all(),
                 // ADR 0192 · V0 core shape (Onda 5). FASE B (items_list / items_summary /
                 // fiscal NF-e) fica pra wave futura — exige join sell_lines + NfeBrasil
                 // que já existe no equivalente Modules/Repair/ProducaoOficinaController

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -684,14 +684,19 @@ class ServiceOrderController extends Controller
                 // é signed quando bucket=sensitive (defesa em profundidade).
                 'laudo_photos' => $order->arquivos
                     ->sortBy([['created_at', 'asc'], ['id', 'asc']])
-                    ->map(fn (\Modules\Arquivos\Entities\Arquivo $a) => [
-                        'id'          => (int) $a->id,
-                        'label'       => (string) ($a->original_name ?? ''),
-                        'mime_type'   => (string) $a->mime_type,
-                        'size_bytes'  => (int) $a->size_bytes,
-                        'display_url' => (string) $a->display_url,
-                        'created_at'  => $a->created_at?->toIso8601String(),
-                    ])->values()->all(),
+                    ->map(function ($a) {
+                        // closure sem tipo no param + @var: relação HasArquivos é MorphMany
+                        // sem generic (Larastan tipa Model, não Arquivo — dívida US-ARQ-TYPE).
+                        /** @var \Modules\Arquivos\Entities\Arquivo $a */
+                        return [
+                            'id'          => (int) $a->id,
+                            'label'       => (string) ($a->original_name ?? ''),
+                            'mime_type'   => (string) $a->mime_type,
+                            'size_bytes'  => (int) $a->size_bytes,
+                            'display_url' => (string) $a->display_url,
+                            'created_at'  => $a->created_at?->toIso8601String(),
+                        ];
+                    })->values()->all(),
                 // ADR 0192 · V0 core shape (Onda 5). FASE B (items_list / items_summary /
                 // fiscal NF-e) fica pra wave futura — exige join sell_lines + NfeBrasil
                 // que já existe no equivalente Modules/Repair/ProducaoOficinaController

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -598,6 +598,8 @@ class ServiceOrderController extends Controller
             'assignedUser:id,first_name,last_name,surname',
             // US-OFICINA-040 — itens DVI pra seção "Vistoria → orçamento" no Show
             'dviInspectionItems',
+            // F3 OS-V2-1 — fotos do laudo OS-level (Fotos & Laudo) pro drawer + print
+            'arquivos',
         ]);
 
         // Accept-aware: drawer ServiceOrderSheet faz fetch JSON via header.
@@ -676,6 +678,19 @@ class ServiceOrderController extends Controller
                         'valor_recomendado' => $dvi->valor_recomendado !== null ? (float) $dvi->valor_recomendado : null,
                         'sort_order'        => (int) $dvi->sort_order,
                         'budget_item_id'    => is_array($dvi->metadata) ? ($dvi->metadata['budget_item_id'] ?? null) : null,
+                    ])->values()->all(),
+                // F3 OS-V2-1 — fotos do laudo OS-level (Fotos & Laudo) pra o drawer.
+                // `label` = original_name (legenda editável no lightbox). display_url
+                // é signed quando bucket=sensitive (defesa em profundidade).
+                'laudo_photos' => $order->arquivos
+                    ->sortBy([['created_at', 'asc'], ['id', 'asc']])
+                    ->map(fn (\Modules\Arquivos\Entities\Arquivo $a) => [
+                        'id'          => (int) $a->id,
+                        'label'       => (string) ($a->original_name ?? ''),
+                        'mime_type'   => (string) $a->mime_type,
+                        'size_bytes'  => (int) $a->size_bytes,
+                        'display_url' => (string) $a->display_url,
+                        'created_at'  => $a->created_at?->toIso8601String(),
                     ])->values()->all(),
                 // ADR 0192 · V0 core shape (Onda 5). FASE B (items_list / items_summary /
                 // fiscal NF-e) fica pra wave futura — exige join sell_lines + NfeBrasil
@@ -897,6 +912,8 @@ class ServiceOrderController extends Controller
                 'items',
                 'dviInspectionItems',
                 'assignedUser:id,first_name,last_name,surname',
+                // F3 OS-V2-1 — fotos do laudo OS-level entram na folha A4 ("Fotos da vistoria")
+                'arquivos',
             ]);
 
             $business = \App\Business::find($businessId);

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderPhotoController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderPhotoController.php
@@ -53,11 +53,17 @@ class ServiceOrderPhotoController extends Controller
     {
         $this->authorize('view', $order);
 
+        // map() com closure SEM tipo no param + @var: a relação HasArquivos é
+        // MorphMany sem generic (Larastan tipa a coleção como Model, não Arquivo —
+        // dívida US-ARQ-TYPE no trait). O @var estreita pra Arquivo sem mexer no trait.
         $fotos = $order->arquivos()
             ->orderBy('created_at')
             ->orderBy('id')
             ->get()
-            ->map(fn (Arquivo $a) => $this->shape($a))
+            ->map(function ($a) {
+                /** @var Arquivo $a */
+                return $this->shape($a);
+            })
             ->all();
 
         return response()->json(['fotos' => $fotos]);

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderPhotoController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderPhotoController.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Modules\Arquivos\Entities\Arquivo;
+use Modules\Arquivos\Services\ArquivosService;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Http\Requests\StoreServiceOrderPhotoRequest;
+use Modules\OficinaAuto\Http\Requests\UpdateServiceOrderPhotoLabelRequest;
+
+/**
+ * ServiceOrderPhotoController — CRUD HTTP das fotos do laudo OS-level (Fotos & Laudo).
+ *
+ * F3 OS-V2-1 (fila TELAS_REVIEW_QUEUE · 2026-06-09). Porta pro drawer real o
+ * protótipo Cowork aprovado [W] 2026-06-09: zona de upload (vazio/enviando/preenchido)
+ * + lightbox com legenda editável. As fotos entram no laudo impresso A4
+ * ("Fotos da vistoria").
+ *
+ * Distinto do DviInspectionController::uploadPhoto (foto POR item DVI · morphTo
+ * OaInspectionItem): aqui o anexo é da própria ServiceOrder (morphTo ServiceOrder
+ * via trait HasArquivos). $order->arquivos() == fotos do laudo da OS (nada mais
+ * anexa direto na OS hoje).
+ *
+ * Endpoints (Routes/web.php):
+ *   GET    /oficina-auto/ordens-servico/{order}/fotos              → index (200)
+ *   POST   /oficina-auto/ordens-servico/{order}/fotos              → store (201)
+ *   PATCH  /oficina-auto/ordens-servico/{order}/fotos/{arquivo}    → updateLabel (200)
+ *   DELETE /oficina-auto/ordens-servico/{order}/fotos/{arquivo}    → destroy (204)
+ *
+ * Defesa em profundidade (multi-tenant Tier 0 · [ADR 0093]):
+ *  1. Policy view/update(ServiceOrder) — Spatie permission + sameTenant guard
+ *  2. Global scope Arquivo (business_id) — cross-tenant fechado no Model
+ *  3. Cross-owner guard — arquivo `arquivable` PRECISA ser esta ServiceOrder
+ *
+ * @see Modules/OficinaAuto/Entities/ServiceOrder.php (use HasArquivos)
+ * @see memory/sessions/2026-06-09-avaliacao-os-sweep-fila-v2.md
+ */
+class ServiceOrderPhotoController extends Controller
+{
+    public function __construct(
+        private ArquivosService $arquivos,
+    ) {
+    }
+
+    /**
+     * Lista as fotos do laudo da OS (ordem cronológica de upload).
+     */
+    public function index(ServiceOrder $order): JsonResponse
+    {
+        $this->authorize('view', $order);
+
+        $fotos = $order->arquivos()
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get()
+            ->map(fn (Arquivo $a) => $this->shape($a))
+            ->all();
+
+        return response()->json(['fotos' => $fotos]);
+    }
+
+    /**
+     * Anexa foto à OS (laudo geral). 201 + payload do arquivo criado.
+     */
+    public function store(StoreServiceOrderPhotoRequest $request, ServiceOrder $order): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        $arquivo = $this->arquivos->attach(
+            $order,
+            $request->file('photo'),
+            ['context' => 'oficina-auto-laudo-photo'],
+        );
+
+        return response()->json(['foto' => $this->shape($arquivo)], 201);
+    }
+
+    /**
+     * Atualiza a legenda (label → original_name) de uma foto do laudo. 200.
+     */
+    public function updateLabel(UpdateServiceOrderPhotoLabelRequest $request, ServiceOrder $order, Arquivo $arquivo): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        $this->guardOwnership($order, $arquivo);
+
+        $arquivo->original_name = (string) $request->validated()['label'];
+        $arquivo->save();
+
+        return response()->json(['foto' => $this->shape($arquivo->fresh())]);
+    }
+
+    /**
+     * Soft-delete de uma foto do laudo. 204 sem body.
+     */
+    public function destroy(ServiceOrder $order, Arquivo $arquivo): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        $this->guardOwnership($order, $arquivo);
+
+        $this->arquivos->softDelete($arquivo);
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Cross-owner guard — o arquivo morphTo PRECISA ser esta ServiceOrder.
+     * Fecha /ordens-servico/1/fotos/{arquivo_da_OS_2} mesmo dentro do mesmo business.
+     */
+    private function guardOwnership(ServiceOrder $order, Arquivo $arquivo): void
+    {
+        abort_unless(
+            $arquivo->arquivable_type === ServiceOrder::class
+            && (int) $arquivo->arquivable_id === (int) $order->id,
+            404
+        );
+    }
+
+    /**
+     * Shape canônico de Arquivo pra JSON API (espelha frontend LaudoPhotoSection).
+     *
+     * `label` = original_name (legenda editável). NÃO expõe storage_path/MD5/
+     * business_id (defesa em profundidade — display_url é signed se sensitive).
+     *
+     * @return array{id:int, label:string, mime_type:string, size_bytes:int, display_url:string, created_at:string|null}
+     */
+    private function shape(Arquivo $arquivo): array
+    {
+        return [
+            'id'          => (int) $arquivo->id,
+            'label'       => (string) ($arquivo->original_name ?? ''),
+            'mime_type'   => (string) $arquivo->mime_type,
+            'size_bytes'  => (int) $arquivo->size_bytes,
+            'display_url' => (string) $arquivo->display_url,
+            'created_at'  => $arquivo->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Http/Requests/StoreServiceOrderPhotoRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/StoreServiceOrderPhotoRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * F3 OS-V2-1 — FormRequest pra upload de foto do laudo OS-level (Fotos & Laudo).
+ *
+ * Diferente do UploadDviPhotoRequest (foto POR item DVI): aqui a foto é anexada à
+ * própria ServiceOrder (morph polimórfico via HasArquivos), compondo o laudo geral
+ * da vistoria que entra na folha A4 impressa ("Fotos da vistoria").
+ *
+ * Espelha o protótipo Cowork aprovado [W] 2026-06-09 (seção "Fotos & Laudo" do
+ * drawer · oficina-page.jsx). Persona Técnico Repair (tablet, câmera traseira).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): business_id auto-fill via ArquivosService::attach
+ * (lê session). Request nunca injeta business_id.
+ *
+ * Validação: required file, image MIME whitelist, max 10MB (HEIC iPhone ~3-4MB).
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\ServiceOrderPhotoController::store
+ * @see Modules\Arquivos\Services\ArquivosService::attach
+ */
+class StoreServiceOrderPhotoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'photo' => [
+                'required',
+                'file',
+                'mimes:jpeg,jpg,png,webp,heic,heif',
+                'mimetypes:image/jpeg,image/png,image/webp,image/heic,image/heif',
+                'max:10240', // 10 MB em kilobytes
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'photo.required'  => 'Arquivo de foto obrigatório.',
+            'photo.file'      => 'Upload inválido — não é um arquivo.',
+            'photo.mimes'     => 'Formato inválido. Use JPEG, PNG, WebP, HEIC ou HEIF.',
+            'photo.mimetypes' => 'Tipo MIME inválido. Apenas imagens (jpeg/png/webp/heic/heif).',
+            'photo.max'       => 'Foto excede 10 MB. Reduza a qualidade antes de subir.',
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Http/Requests/UpdateServiceOrderPhotoLabelRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/UpdateServiceOrderPhotoLabelRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * F3 OS-V2-1 — edita a legenda (label) de uma foto do laudo OS-level.
+ *
+ * Protótipo Cowork (lightbox · oficina-page.jsx): legenda editável que persiste.
+ * A legenda mapeia em `Arquivo.original_name` (Arquivo não tem coluna caption
+ * dedicada; original_name é a string exibível canônica — getDisplayNameAttribute).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): scope + cross-guard no controller.
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\ServiceOrderPhotoController::updateLabel
+ */
+class UpdateServiceOrderPhotoLabelRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'label' => ['required', 'string', 'max:180'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'label.required' => 'Legenda obrigatória.',
+            'label.max'      => 'Legenda muito longa (máx. 180 caracteres).',
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -8,6 +8,7 @@ use Modules\OficinaAuto\Http\Controllers\ProducaoOficinaController;
 use Modules\OficinaAuto\Http\Controllers\Public\AprovacaoOsController;
 use Modules\OficinaAuto\Http\Controllers\ServiceOrderController;
 use Modules\OficinaAuto\Http\Controllers\ServiceOrderItemController;
+use Modules\OficinaAuto\Http\Controllers\ServiceOrderPhotoController;
 use Modules\OficinaAuto\Http\Controllers\VehicleController;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -198,6 +199,32 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
             [DviInspectionController::class, 'deletePhoto'])
             ->middleware('throttle:30,1')
             ->name('oficinaauto.orders.dvi.photo.delete');
+
+        // ─────────────────────────────────────────────────────────────────────
+        // F3 OS-V2-1 — Fotos & Laudo OS-level (anexo da própria ServiceOrder via
+        // HasArquivos · distinto da foto POR item DVI acima). Entram no laudo A4
+        // impresso ("Fotos da vistoria"). Protótipo Cowork aprovado [W] 2026-06-09:
+        // zona drag&drop (vazio/enviando/preenchido) + lightbox com legenda editável.
+        // Multi-tenant Tier 0 (ADR 0093) via ArquivosService + cross-owner guard.
+        // ─────────────────────────────────────────────────────────────────────
+        Route::get('ordens-servico/{order}/fotos',
+            [ServiceOrderPhotoController::class, 'index'])
+            ->name('oficinaauto.orders.fotos.index');
+
+        Route::post('ordens-servico/{order}/fotos',
+            [ServiceOrderPhotoController::class, 'store'])
+            ->middleware('throttle:30,1')
+            ->name('oficinaauto.orders.fotos.store');
+
+        Route::patch('ordens-servico/{order}/fotos/{arquivo}',
+            [ServiceOrderPhotoController::class, 'updateLabel'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.fotos.update');
+
+        Route::delete('ordens-servico/{order}/fotos/{arquivo}',
+            [ServiceOrderPhotoController::class, 'destroy'])
+            ->middleware('throttle:30,1')
+            ->name('oficinaauto.orders.fotos.destroy');
     });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/Modules/OficinaAuto/SCOPE.md
+++ b/Modules/OficinaAuto/SCOPE.md
@@ -9,6 +9,7 @@ contains:
   - "ServiceOrderController — CRUD + printInvoice (Gap 3 US-OFICINA-037 · GET /ordens-servico/{order}/print AJAX-only · A4 nota-fiscal-like papel-balcão Martinho sub-vertical 4 CNAE 4520 · ADR 0194)."
   - "ServiceOrderItemController — CRUD HTTP de items lançados na OS (peça/mão-obra/serviço terceiro). Wave 1.3 US-OFICINA-027 — alimenta drawer ServiceOrderRichSheet seção PEÇAS & MÃO DE OBRA + Observer ::computeFinalTotal."
   - "DviInspectionController — CRUD HTTP de items DVI (Vistoria Digital · semáforo ok/atenção/crítico). Wave 3 US-OFICINA-035 — wedge competitivo vs RepairShopr/mHelpDesk."
+  - "ServiceOrderPhotoController — CRUD HTTP das fotos do laudo OS-level (Fotos & Laudo · F3 OS-V2-1). Anexo polimórfico da própria ServiceOrder via HasArquivos (distinto da foto POR item DVI em OaInspectionItem). Alimenta o drawer ServiceOrderRichSheet + seção 'Fotos da vistoria' no print A4."
   - "VehicleController"
   - "ServiceOrderFsmActionController (app/Http/Controllers — shared FSM canon, espelha SaleFsmActionController)"
 not_contains:

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderLaudoPhotoTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderLaudoPhotoTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+use App\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\Arquivos\Entities\Arquivo;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * F3 OS-V2-1 — Fotos & Laudo OS-level (ServiceOrderPhotoController).
+ *
+ * Cobre o porte do protótipo Cowork aprovado [W] 2026-06-09: upload de foto
+ * anexada à própria ServiceOrder (HasArquivos morphTo), legenda editável e
+ * presença no laudo A4 impresso.
+ *
+ * Defesa Tier 0 [ADR 0093]:
+ *   - store/destroy escopados por business (sameTenant policy + global scope Arquivo)
+ *   - cross-owner guard: arquivo de outra OS na rota desta OS → 404
+ *   - reject non-image (FormRequest mimes/mimetypes)
+ *
+ * MySQL-only (ADR 0101): schema UltimatePOS + tabelas arquivos*. Skip em sqlite —
+ * roda no CI (mesmo padrão de ServiceOrderRichSheetPayloadTest).
+ *
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderPhotoController.php
+ */
+
+const BIZ_LAUDO = 1;
+const BIZ_LAUDO_OUTRO = 2;
+const PLATE_LAUDO_PREFIX = 'LAUDO';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('arquivos')) {
+        $this->markTestSkipped('Rode as migrations do Modules/Arquivos primeiro (ADR 0123)');
+    }
+    Storage::fake(config('arquivos.disk_default', 'local'));
+});
+
+function laudo_criaOs(string $suffix, int $biz = BIZ_LAUDO): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_LAUDO_PREFIX . $suffix,
+        'vehicle_type' => 'caminhao',
+        'model_year'   => 2021,
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => 'manutencao',
+        'status'      => 'aberta',
+        'contact_id'  => 1,
+    ]);
+}
+
+function laudo_user(int $biz = BIZ_LAUDO): User
+{
+    $user = User::factory()->create(['business_id' => $biz]);
+    $user->givePermissionTo('superadmin');
+
+    return $user;
+}
+
+function laudo_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', 'like', PLATE_LAUDO_PREFIX . $suffix . '%')
+        ->pluck('id')
+        ->toArray();
+
+    if (empty($vehicles)) {
+        return;
+    }
+
+    $osIds = ServiceOrder::withoutGlobalScopes()
+        ->whereIn('vehicle_id', $vehicles)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($osIds)) {
+        Arquivo::withoutGlobalScopes()
+            ->where('arquivable_type', ServiceOrder::class)
+            ->whereIn('arquivable_id', $osIds)
+            ->forceDelete();
+        ServiceOrder::withoutGlobalScopes()->whereIn('id', $osIds)->forceDelete();
+    }
+
+    Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+}
+
+// ---------------------------------------------------------------------------
+// store
+// ---------------------------------------------------------------------------
+
+it('store anexa foto à OS escopada por business → 201 + arquivo morphTo ServiceOrder', function () {
+    session(['user.business_id' => BIZ_LAUDO]);
+    $os = laudo_criaOs('A');
+    $user = laudo_user();
+
+    $response = $this->actingAs($user)->post(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos",
+        ['photo' => UploadedFile::fake()->image('correia.jpg', 800, 600)],
+    );
+
+    $response->assertCreated();
+    expect($response->json('foto.label'))->toBe('correia.jpg');
+    expect($response->json('foto'))->toHaveKeys(['id', 'label', 'mime_type', 'size_bytes', 'display_url', 'created_at']);
+
+    // Arquivo anexado à OS (morphTo) + escopado no business da sessão.
+    $arquivo = Arquivo::withoutGlobalScopes()
+        ->where('arquivable_type', ServiceOrder::class)
+        ->where('arquivable_id', $os->id)
+        ->first();
+    expect($arquivo)->not->toBeNull();
+    expect((int) $arquivo->business_id)->toBe(BIZ_LAUDO);
+})->afterEach(fn () => laudo_cleanup('A'));
+
+it('store rejeita arquivo que não é imagem → 422', function () {
+    session(['user.business_id' => BIZ_LAUDO]);
+    $os = laudo_criaOs('B');
+    $user = laudo_user();
+
+    $response = $this->actingAs($user)->postJson(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos",
+        ['photo' => UploadedFile::fake()->create('orcamento.pdf', 120, 'application/pdf')],
+    );
+
+    $response->assertStatus(422);
+    $response->assertJsonValidationErrors('photo');
+
+    expect(
+        Arquivo::withoutGlobalScopes()
+            ->where('arquivable_type', ServiceOrder::class)
+            ->where('arquivable_id', $os->id)
+            ->count()
+    )->toBe(0);
+})->afterEach(fn () => laudo_cleanup('B'));
+
+// ---------------------------------------------------------------------------
+// multi-tenant + cross-owner guard
+// ---------------------------------------------------------------------------
+
+it('store em OS de outro business → 404 (global scope route binding)', function () {
+    // OS pertence ao business 2; sessão é business 1.
+    session(['user.business_id' => BIZ_LAUDO]);
+    $osOutro = laudo_criaOs('C', BIZ_LAUDO_OUTRO);
+    $user = laudo_user(BIZ_LAUDO);
+
+    $response = $this->actingAs($user)->post(
+        "/oficina-auto/ordens-servico/{$osOutro->id}/fotos",
+        ['photo' => UploadedFile::fake()->image('x.jpg')],
+    );
+
+    $response->assertNotFound();
+})->afterEach(fn () => laudo_cleanup('C'));
+
+it('cross-owner guard: arquivo de uma OS não pode ser apagado pela rota de outra OS → 404', function () {
+    session(['user.business_id' => BIZ_LAUDO]);
+    $osA = laudo_criaOs('D');
+    $osB = laudo_criaOs('D2');
+    $user = laudo_user();
+
+    // Sobe foto na OS B.
+    $up = $this->actingAs($user)->post(
+        "/oficina-auto/ordens-servico/{$osB->id}/fotos",
+        ['photo' => UploadedFile::fake()->image('b.jpg')],
+    );
+    $arquivoId = $up->json('foto.id');
+
+    // Tenta apagar pela rota da OS A → cross-owner guard → 404.
+    $del = $this->actingAs($user)->deleteJson(
+        "/oficina-auto/ordens-servico/{$osA->id}/fotos/{$arquivoId}",
+    );
+    $del->assertNotFound();
+
+    // Foto continua viva na OS B.
+    expect(Arquivo::withoutGlobalScopes()->whereKey($arquivoId)->whereNull('deleted_at')->exists())->toBeTrue();
+})->afterEach(function () {
+    laudo_cleanup('D');
+});
+
+// ---------------------------------------------------------------------------
+// updateLabel + destroy + index
+// ---------------------------------------------------------------------------
+
+it('updateLabel persiste a legenda (original_name) + destroy soft-deleta', function () {
+    session(['user.business_id' => BIZ_LAUDO]);
+    $os = laudo_criaOs('E');
+    $user = laudo_user();
+
+    $up = $this->actingAs($user)->post(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos",
+        ['photo' => UploadedFile::fake()->image('foto.jpg')],
+    );
+    $arquivoId = $up->json('foto.id');
+
+    // PATCH legenda
+    $patch = $this->actingAs($user)->patchJson(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos/{$arquivoId}",
+        ['label' => 'Correia dentada · antes'],
+    );
+    $patch->assertOk();
+    expect($patch->json('foto.label'))->toBe('Correia dentada · antes');
+
+    // index reflete a legenda
+    $index = $this->actingAs($user)->getJson("/oficina-auto/ordens-servico/{$os->id}/fotos");
+    $index->assertOk();
+    expect($index->json('fotos'))->toHaveCount(1);
+    expect($index->json('fotos.0.label'))->toBe('Correia dentada · antes');
+
+    // DELETE → 204 + soft-delete
+    $del = $this->actingAs($user)->deleteJson("/oficina-auto/ordens-servico/{$os->id}/fotos/{$arquivoId}");
+    $del->assertNoContent();
+    expect(Arquivo::withoutGlobalScopes()->whereKey($arquivoId)->whereNull('deleted_at')->exists())->toBeFalse();
+})->afterEach(fn () => laudo_cleanup('E'));
+
+// ---------------------------------------------------------------------------
+// payload do drawer + laudo no print A4
+// ---------------------------------------------------------------------------
+
+it('GET /service-orders/{id} JSON inclui laudo_photos após upload', function () {
+    session(['user.business_id' => BIZ_LAUDO]);
+    $os = laudo_criaOs('F');
+    $user = laudo_user();
+
+    $this->actingAs($user)->post(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos",
+        ['photo' => UploadedFile::fake()->image('laudo.jpg')],
+    )->assertCreated();
+
+    $response = $this->actingAs($user)->getJson("/oficina-auto/service-orders/{$os->id}");
+    $response->assertOk();
+    expect($response->json('laudo_photos'))->toBeArray()->toHaveCount(1);
+    expect($response->json('laudo_photos.0.label'))->toBe('laudo.jpg');
+})->afterEach(fn () => laudo_cleanup('F'));
+
+it('printInvoice A4 inclui a seção "Fotos da vistoria" com a legenda quando há fotos', function () {
+    session(['user.business_id' => BIZ_LAUDO]);
+    $os = laudo_criaOs('G');
+    $user = laudo_user();
+
+    $arquivoId = $this->actingAs($user)->post(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos",
+        ['photo' => UploadedFile::fake()->image('chassi.jpg')],
+    )->json('foto.id');
+
+    $this->actingAs($user)->patchJson(
+        "/oficina-auto/ordens-servico/{$os->id}/fotos/{$arquivoId}",
+        ['label' => 'Chassi lateral'],
+    )->assertOk();
+
+    $print = $this->actingAs($user)->getJson("/oficina-auto/ordens-servico/{$os->id}/print");
+    $print->assertOk();
+    $html = $print->json('receipt.html_content');
+    expect($html)->toContain('Fotos da vistoria');
+    expect($html)->toContain('Chassi lateral');
+})->afterEach(fn () => laudo_cleanup('G'));

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderRichSheetPayloadTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderRichSheetPayloadTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
 use Modules\OficinaAuto\Entities\ServiceOrder;
 use Modules\OficinaAuto\Entities\ServiceOrderItem;
 use Modules\OficinaAuto\Entities\Vehicle;
@@ -83,6 +84,7 @@ function rich_cleanup(string $suffix): void
         ->toArray();
 
     if (! empty($osIds)) {
+        OaInspectionItem::withoutGlobalScopes()->whereIn('service_order_id', $osIds)->forceDelete();
         ServiceOrderItem::withoutGlobalScopes()->whereIn('service_order_id', $osIds)->forceDelete();
         ServiceOrder::withoutGlobalScopes()->whereIn('id', $osIds)->forceDelete();
     }
@@ -190,3 +192,82 @@ it('GET /service-orders/{id} com assigned_user populado → name concatenado Ult
     // Concat trimmed: "Pedro Souza" (sem surname)
     expect($response->json('assigned_user.name'))->toBe('Pedro Souza');
 })->afterEach(fn () => rich_cleanup('C'));
+
+// ---------------------------------------------------------------------------
+// F3 OS-V2-2 — JSON payload com dvi_items[] pro semáforo inline do drawer
+// ---------------------------------------------------------------------------
+
+it('GET /service-orders/{id} JSON retorna dvi_items[] ordenado por sort_order com shape do semáforo', function () {
+    session(['user.business_id' => BIZ_RICH]);
+    $os = rich_criaOs('D');
+
+    // Cria 3 itens DVI fora de ordem de sort_order pra validar ordenação.
+    OaInspectionItem::withoutGlobalScopes()->create([
+        'business_id'       => BIZ_RICH,
+        'service_order_id'  => $os->id,
+        'categoria'         => 'correia',
+        'descricao'         => 'Correia dentada',
+        'severity'          => 'critico',
+        'recomendacao'      => 'trincada · troca imediata',
+        'valor_recomendado' => 480,
+        'sort_order'        => 2,
+    ]);
+    OaInspectionItem::withoutGlobalScopes()->create([
+        'business_id'       => BIZ_RICH,
+        'service_order_id'  => $os->id,
+        'categoria'         => 'fluidos',
+        'descricao'         => 'Motor · óleo + filtro',
+        'severity'          => 'ok',
+        'recomendacao'      => null,
+        'valor_recomendado' => null,
+        'sort_order'        => 0,
+    ]);
+    OaInspectionItem::withoutGlobalScopes()->create([
+        'business_id'       => BIZ_RICH,
+        'service_order_id'  => $os->id,
+        'categoria'         => 'freios',
+        'descricao'         => 'Freios dianteiros · pastilhas',
+        'severity'          => 'atencao',
+        'recomendacao'      => '3mm · vida útil 60%',
+        'valor_recomendado' => 145,
+        'sort_order'        => 1,
+    ]);
+
+    $user = User::factory()->create(['business_id' => BIZ_RICH]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->getJson("/oficina-auto/service-orders/{$os->id}");
+
+    $response->assertOk();
+
+    $dvi = $response->json('dvi_items');
+    expect($dvi)->toBeArray()->toHaveCount(3);
+
+    // Ordenação por sort_order ASC → óleo(0), pastilhas(1), correia(2)
+    expect($dvi[0]['descricao'])->toBe('Motor · óleo + filtro');
+    expect($dvi[0]['severity'])->toBe('ok');
+    expect($dvi[0]['valor_recomendado'])->toBeNull();
+
+    expect($dvi[1]['descricao'])->toBe('Freios dianteiros · pastilhas');
+    expect($dvi[1]['severity'])->toBe('atencao');
+    expect($dvi[1]['valor_recomendado'])->toBe(145.0);
+
+    expect($dvi[2]['severity'])->toBe('critico');
+    expect($dvi[2]['categoria'])->toBe('correia');
+    expect($dvi[2])->toHaveKeys(['id', 'categoria', 'descricao', 'severity', 'recomendacao', 'valor_recomendado', 'sort_order', 'budget_item_id']);
+})->afterEach(fn () => rich_cleanup('D'));
+
+it('GET /service-orders/{id} OS sem DVI → dvi_items=[] (backward compat)', function () {
+    session(['user.business_id' => BIZ_RICH]);
+    $os = rich_criaOs('E');
+
+    $user = User::factory()->create(['business_id' => BIZ_RICH]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->getJson("/oficina-auto/service-orders/{$os->id}");
+
+    $response->assertOk();
+    expect($response->json('dvi_items'))->toBeArray()->toHaveCount(0);
+})->afterEach(fn () => rich_cleanup('E'));

--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -108,8 +108,8 @@
 
 | Status | Tela | Prioridade | Refs |
 |---|---|---|---|
-| `[~]` | OS-V2-1 · Fotos & Laudo reais no drawer | **P1** | Hoje 3 placeholders + botão disabled. Upload real (câmera/arquivo) via Modules/Arquivos, thumbnails + lightbox, anexo sai no print A4. Persona Técnico Repair (touch ≥44px). |
-| `[~]` | OS-V2-2 · DVI inline com severidade | **P1** | Seção DVI no drawer (badge ok/atenção/crítico + valor por item alimentando gate). Depende: endpoint `DviInspectionController` (verificar shape). Padrão visual já no protótipo `producao-oficina`. |
+| `[x]` | OS-V2-1 · Fotos & Laudo reais no drawer | **P1** | ✅ F3 [CC] 2026-06-09 — upload OS-level real (3 estados + progresso XHR + lightbox legenda editável) via `ServiceOrderPhotoController` (HasArquivos morphTo OS) + seção "Fotos da vistoria" no print A4. Persona Técnico Repair (touch ≥44px). |
+| `[x]` | OS-V2-2 · DVI inline com severidade | **P1** | ✅ F3 [CC] 2026-06-09 — semáforo radiogroup 1-toque (ok/atenção/crítico, tokens DS) no drawer via `DviInlineEditor` + `dvi_items` no payload; CRUD reusa `DviInspectionController` + CTA "Pedir aprovação" (gate WhatsApp). |
 | `[~]` | OS-V2-3 · Gate "Pedir aprovação" hero no drawer | **P2** | Barra de total recomendado + CTA hero "Pedir aprovação" (WhatsApp `wa.me` sem PII). Portar barra do protótipo pro token do DS. |
 | `[~]` | OS-V2-4 · Linha do tempo FSM auditável | **P2** | Timeline real via histórico de transições FSM (quem/quando/de→pra), endpoint `fsm/history` previsto no código. Valor: auditoria de lead time. |
 

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
@@ -1,0 +1,562 @@
+// DviInlineEditor — Vistoria Digital (DVI) editável inline com semáforo de 1 toque.
+//
+// F3 OS-V2-2 (fila TELAS_REVIEW_QUEUE · 2026-06-09). Porta pro drawer real
+// (ServiceOrderRichSheet) o protótipo Cowork APROVADO [W] 2026-06-09
+// (`DviTraffic` + `DviEditor` em oficina-forms.jsx · `.ofc-traffic` em oficina-page.css).
+//
+// Substitui o `<select>` de status por um RADIOGROUP de 3 botões redondos
+// (ok/atenção/crítico · 24px · aria-checked · focus-visible · hover scale) — padrão
+// canon Shop-Ware/Tekmetric: persona Técnico Repair de tablet, mãos sujas, 1 toque.
+// NUNCA `<select>` nativo pra severidade. Tokens DS (success/warning/destructive),
+// nunca hex cru.
+//
+// Backend já existe (Wave 3 US-OFICINA-035):
+//   POST   /oficina-auto/ordens-servico/{order}/dvi          → cria item
+//   PUT    /oficina-auto/ordens-servico/{order}/dvi/{item}   → patch parcial
+//   DELETE /oficina-auto/ordens-servico/{order}/dvi/{item}   → soft-delete
+//   POST   /oficina-auto/ordens-servico/{order}/enviar-aprovacao → gate WhatsApp+PIN
+//
+// Delta do protótipo (relatado no PR): o backend separa `categoria` (enum 10) de
+// `descricao` (texto livre). O protótipo tem um campo "sistema" só. Resolvemos:
+// `descricao` é o texto do sistema editável inline; `categoria` é derivada por
+// keyword (deriveCategoria) — silenciosa, validada no enum pelo backend. O form de
+// adicionar oferece presets (SISTEMAS) que já trazem a categoria certa.
+//
+// CRÍTICO React 19 — useCallback nos handlers (lição PR #717).
+// CRÍTICO F3 LICOES_F3_FINANCEIRO_REJEITADO.md — sem emoji (lucide-react only),
+// sem auto-request on-mount, sem window.print, sem nova aba.
+// CRÍTICO multi-tenant Tier 0 [ADR 0093] — backend escopa business_id (frontend só consome).
+
+import { useCallback, useMemo, useState } from 'react';
+import { Check, Loader2, MessageCircle, Plus, Trash2, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/Components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+
+export type DviSeverity = 'ok' | 'atencao' | 'critico';
+
+export type DviCategoria =
+  | 'motor'
+  | 'freios'
+  | 'correia'
+  | 'bateria'
+  | 'pneus'
+  | 'suspensao'
+  | 'direcao'
+  | 'eletrica'
+  | 'fluidos'
+  | 'outro';
+
+export interface DviInlineItem {
+  id: number;
+  categoria: string;
+  descricao: string;
+  severity: string; // ok | atencao | critico
+  recomendacao: string | null;
+  valor_recomendado: number | null;
+  sort_order?: number;
+  budget_item_id?: number | null;
+}
+
+interface Props {
+  serviceOrderId: number;
+  initialItems: DviInlineItem[];
+  /** Dispara o gate de aprovação (status → orcamento → WhatsApp+PIN). */
+  onPedirAprovacao: () => void;
+  /** true enquanto o POST enviar-aprovacao está em voo (vem do drawer). */
+  approvalSending?: boolean;
+}
+
+// Presets de sistema → mapeiam o "sistema" do protótipo (DVI_SISTEMAS) na dupla
+// canônica do backend (descricao + categoria). Selecionar preenche ambos.
+const SISTEMAS: { label: string; categoria: DviCategoria }[] = [
+  { label: 'Motor · óleo + filtro', categoria: 'fluidos' },
+  { label: 'Motor · arrefecimento', categoria: 'motor' },
+  { label: 'Freios dianteiros · pastilhas', categoria: 'freios' },
+  { label: 'Freios traseiros · lonas/discos', categoria: 'freios' },
+  { label: 'Correia dentada', categoria: 'correia' },
+  { label: 'Bateria + sistema elétrico', categoria: 'bateria' },
+  { label: 'Pneus · dianteiros', categoria: 'pneus' },
+  { label: 'Pneus · traseiros', categoria: 'pneus' },
+  { label: 'Suspensão dianteira', categoria: 'suspensao' },
+  { label: 'Suspensão traseira', categoria: 'suspensao' },
+  { label: 'Direção · alinhamento', categoria: 'direcao' },
+  { label: 'Embreagem', categoria: 'motor' },
+  { label: 'Câmbio', categoria: 'motor' },
+  { label: 'Injeção', categoria: 'eletrica' },
+  { label: 'Escapamento', categoria: 'motor' },
+  { label: 'Iluminação', categoria: 'eletrica' },
+  { label: 'Ar-condicionado', categoria: 'eletrica' },
+  { label: 'Limpadores', categoria: 'eletrica' },
+];
+
+// Deriva a categoria enum a partir do texto livre do sistema (descricao). O backend
+// valida o enum; aqui só damos o melhor palpite pra filtros/relatórios futuros.
+function deriveCategoria(desc: string): DviCategoria {
+  const d = (desc || '').toLowerCase();
+  if (/bateria/.test(d)) return 'bateria';
+  if (/freio|pastilha|lona|disco|sangria/.test(d)) return 'freios';
+  if (/correia/.test(d)) return 'correia';
+  if (/pneu/.test(d)) return 'pneus';
+  if (/suspens|amortec|mola|bandeja|piv[oô]/.test(d)) return 'suspensao';
+  if (/dire[çc]|alinha|geometr|terminal/.test(d)) return 'direcao';
+  if (/el[ée]tr|inje[çc]|farol|ilumina|l[âa]mpada|fus[íi]|alternador|chicote|ar-?cond/.test(d))
+    return 'eletrica';
+  if (/[óo]leo|fluido|arrefec|[áa]gua|l[íi]quido|radiador|dot/.test(d)) return 'fluidos';
+  if (/motor|cabe[çc]ote|junta|vela|embreagem|c[âa]mbio|escapa|turbo/.test(d)) return 'motor';
+  return 'outro';
+}
+
+function csrfToken(): string {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+}
+
+const fmtBRL = (n: number | null | undefined) =>
+  (n ?? 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+// Semáforo de severidade — 3 botões redondos, 1 toque. Tokens semânticos
+// (success/warning/destructive), NUNCA <select> nativo (regra OS-V2-2).
+const SEV_BTN: Record<DviSeverity, { label: string; on: string; ring: string; hover: string }> = {
+  ok: {
+    label: 'OK',
+    on: 'bg-success border-success',
+    ring: 'ring-success/30',
+    hover: 'hover:border-success',
+  },
+  atencao: {
+    label: 'Atenção',
+    on: 'bg-warning border-warning',
+    ring: 'ring-warning/30',
+    hover: 'hover:border-warning',
+  },
+  critico: {
+    label: 'Crítico',
+    on: 'bg-destructive border-destructive',
+    ring: 'ring-destructive/30',
+    hover: 'hover:border-destructive',
+  },
+};
+const SEV_ORDER: DviSeverity[] = ['ok', 'atencao', 'critico'];
+
+function DviTraffic({
+  value,
+  onChange,
+  name,
+}: {
+  value: string;
+  onChange: (s: DviSeverity) => void;
+  name: string;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={`Severidade de ${name}`}
+      className="inline-flex items-center gap-1.5 self-center"
+    >
+      {SEV_ORDER.map((sev) => {
+        const cfg = SEV_BTN[sev];
+        const on = value === sev;
+        return (
+          <button
+            key={sev}
+            type="button"
+            role="radio"
+            aria-checked={on}
+            aria-label={cfg.label}
+            title={cfg.label}
+            onClick={() => onChange(sev)}
+            className={
+              'h-6 w-6 shrink-0 rounded-full border-2 transition-transform hover:scale-110 ' +
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ' +
+              (on ? `${cfg.on} ring-2 ${cfg.ring}` : `border-border bg-transparent ${cfg.hover}`)
+            }
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+interface Draft {
+  sistema: string;
+  severity: DviSeverity;
+  recomendacao: string;
+  valor: string;
+}
+
+const EMPTY_DRAFT: Draft = {
+  sistema: SISTEMAS[0]?.label ?? 'Outro',
+  severity: 'ok',
+  recomendacao: '',
+  valor: '',
+};
+
+export default function DviInlineEditor({
+  serviceOrderId,
+  initialItems,
+  onPedirAprovacao,
+  approvalSending = false,
+}: Props) {
+  // Estado local seeded uma vez por OS (drawer renderiza com key={data.id}).
+  const [items, setItems] = useState<DviInlineItem[]>(initialItems);
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [busy, setBusy] = useState(false);
+
+  const base = `/oficina-auto/ordens-servico/${serviceOrderId}/dvi`;
+
+  const sums = useMemo(() => {
+    const ok = items.filter((i) => i.severity === 'ok').length;
+    const atencao = items.filter((i) => i.severity === 'atencao').length;
+    const critico = items.filter((i) => i.severity === 'critico').length;
+    const total = items
+      .filter((i) => i.severity === 'atencao' || i.severity === 'critico')
+      .reduce((s, i) => s + (i.valor_recomendado ?? 0), 0);
+    return { ok, atencao, critico, total };
+  }, [items]);
+
+  const request = useCallback(
+    async (method: string, url: string, body?: Record<string, unknown>) => {
+      const resp = await fetch(url, {
+        method,
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': csrfToken(),
+          ...(body ? { 'Content-Type': 'application/json' } : {}),
+        },
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      if (!resp.ok) {
+        let msg = `HTTP ${resp.status}`;
+        try {
+          const j = await resp.json();
+          msg =
+            j?.message ??
+            j?.errors?.descricao?.[0] ??
+            j?.errors?.severity?.[0] ??
+            j?.errors?.categoria?.[0] ??
+            msg;
+        } catch {
+          /* sem JSON body */
+        }
+        throw new Error(msg);
+      }
+      return resp.status === 204 ? null : resp.json();
+    },
+    [],
+  );
+
+  const patchLocal = useCallback((id: number, patch: Partial<DviInlineItem>) => {
+    setItems((prev) => prev.map((it) => (it.id === id ? { ...it, ...patch } : it)));
+  }, []);
+
+  // Severidade — otimista + PUT {severity}, reverte no erro.
+  const handleSeverity = useCallback(
+    async (item: DviInlineItem, sev: DviSeverity) => {
+      if (item.severity === sev) return;
+      const prevSev = item.severity;
+      patchLocal(item.id, { severity: sev });
+      try {
+        await request('PUT', `${base}/${item.id}`, { severity: sev });
+      } catch (e) {
+        patchLocal(item.id, { severity: prevSev });
+        toast.error(e instanceof Error ? e.message : 'Falha ao salvar severidade.');
+      }
+    },
+    [base, request, patchLocal],
+  );
+
+  // Salva campo de texto/número no blur (só se mudou).
+  const saveField = useCallback(
+    async (item: DviInlineItem, patch: Partial<DviInlineItem>) => {
+      try {
+        await request('PUT', `${base}/${item.id}`, patch as Record<string, unknown>);
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : 'Falha ao salvar item.');
+      }
+    },
+    [base, request],
+  );
+
+  const handleRemove = useCallback(
+    async (item: DviInlineItem) => {
+      const snapshot = items;
+      setItems((prev) => prev.filter((it) => it.id !== item.id));
+      try {
+        await request('DELETE', `${base}/${item.id}`);
+      } catch (e) {
+        setItems(snapshot);
+        toast.error(e instanceof Error ? e.message : 'Falha ao remover item.');
+      }
+    },
+    [base, request, items],
+  );
+
+  const handleAdd = useCallback(async () => {
+    const descricao = draft.sistema.trim();
+    if (!descricao) return;
+    setBusy(true);
+    try {
+      const valor = parseFloat(draft.valor.replace(',', '.'));
+      const json = await request('POST', base, {
+        categoria: deriveCategoria(descricao),
+        descricao: descricao.slice(0, 150),
+        severity: draft.severity,
+        recomendacao: draft.recomendacao.trim() || null,
+        valor_recomendado: Number.isFinite(valor) && valor > 0 ? valor : null,
+        sort_order: items.length,
+      });
+      if (json?.item) {
+        const it = json.item as DviInlineItem;
+        setItems((prev) => [...prev, it]);
+      }
+      setDraft(EMPTY_DRAFT);
+      setAdding(false);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Falha ao adicionar item.');
+    } finally {
+      setBusy(false);
+    }
+  }, [base, draft, items.length, request]);
+
+  return (
+    <div className="space-y-2.5">
+      {/* Pills de contagem + botão adicionar */}
+      <div className="flex items-center gap-1.5">
+        <Pill tone="success" count={sums.ok} label="ok" />
+        <Pill tone="warning" count={sums.atencao} label="atenção" />
+        <Pill tone="destructive" count={sums.critico} label="crítico" />
+        {!adding && (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="ml-auto h-7 gap-1 text-xs"
+            onClick={() => setAdding(true)}
+          >
+            <Plus size={13} aria-hidden />
+            Item
+          </Button>
+        )}
+      </div>
+
+      {/* Estado vazio */}
+      {items.length === 0 && !adding && (
+        <p className="text-sm italic text-muted-foreground">
+          — vistoria ainda não iniciada.{' '}
+          <button
+            type="button"
+            className="font-medium text-primary not-italic hover:underline"
+            onClick={() => setAdding(true)}
+          >
+            Adicionar primeiro item
+          </button>
+        </p>
+      )}
+
+      {/* Lista editável */}
+      {items.length > 0 && (
+        <ul className="divide-y divide-border/60 overflow-hidden rounded-md border border-border bg-white">
+          {items.map((item) => (
+            <li
+              key={item.id}
+              className={
+                'grid grid-cols-[auto_1fr_72px_auto] items-center gap-2 px-2.5 py-2 ' +
+                (item.severity === 'critico' ? 'bg-destructive/5' : '')
+              }
+            >
+              <DviTraffic
+                value={item.severity}
+                name={item.descricao}
+                onChange={(s) => handleSeverity(item, s)}
+              />
+              <div className="min-w-0">
+                <input
+                  defaultValue={item.descricao}
+                  aria-label="Sistema vistoriado"
+                  className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-[12px] font-medium text-foreground outline-none hover:border-border focus:border-ring"
+                  onBlur={(e) => {
+                    const v = e.target.value.trim().slice(0, 150);
+                    if (v && v !== item.descricao) {
+                      patchLocal(item.id, { descricao: v });
+                      void saveField(item, { descricao: v, categoria: deriveCategoria(v) });
+                    }
+                  }}
+                />
+                <input
+                  defaultValue={item.recomendacao ?? ''}
+                  placeholder="observação · recomendação"
+                  aria-label="Observação / recomendação"
+                  className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-[10.5px] text-muted-foreground outline-none hover:border-border focus:border-ring"
+                  onBlur={(e) => {
+                    const v = e.target.value.trim().slice(0, 255);
+                    if (v !== (item.recomendacao ?? '')) {
+                      patchLocal(item.id, { recomendacao: v || null });
+                      void saveField(item, { recomendacao: v || null });
+                    }
+                  }}
+                />
+              </div>
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                defaultValue={item.valor_recomendado ?? ''}
+                aria-label="Valor recomendado em reais"
+                placeholder="R$"
+                className="w-full rounded border border-border/70 bg-background px-1.5 py-1 text-right text-[11px] tabular-nums outline-none focus:border-ring"
+                onBlur={(e) => {
+                  const raw = e.target.value.replace(',', '.');
+                  const v = raw === '' ? null : parseFloat(raw);
+                  const next = v != null && Number.isFinite(v) && v >= 0 ? v : null;
+                  if (next !== item.valor_recomendado) {
+                    patchLocal(item.id, { valor_recomendado: next });
+                    void saveField(item, { valor_recomendado: next });
+                  }
+                }}
+              />
+              <button
+                type="button"
+                onClick={() => handleRemove(item)}
+                title="Remover item da vistoria"
+                aria-label={`Remover ${item.descricao}`}
+                className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+              >
+                <Trash2 size={13} aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Form de adicionar */}
+      {adding && (
+        <div className="grid grid-cols-[1fr_auto] items-start gap-2 rounded-md border border-dashed border-primary/40 bg-primary/5 p-2.5">
+          <div className="space-y-2">
+            <Select
+              value={draft.sistema}
+              onValueChange={(v) => setDraft((d) => ({ ...d, sistema: v }))}
+            >
+              <SelectTrigger className="h-8 text-[12px]" aria-label="Sistema a vistoriar">
+                <SelectValue placeholder="Sistema a vistoriar" />
+              </SelectTrigger>
+              <SelectContent>
+                {SISTEMAS.map((s) => (
+                  <SelectItem key={s.label} value={s.label} className="text-[12px]">
+                    {s.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <div className="flex items-center gap-2">
+              <DviTraffic
+                value={draft.severity}
+                name="novo item"
+                onChange={(s) => setDraft((d) => ({ ...d, severity: s }))}
+              />
+              <input
+                value={draft.valor}
+                inputMode="decimal"
+                placeholder="R$"
+                aria-label="Valor recomendado"
+                className="w-20 rounded border border-border bg-background px-2 py-1 text-right text-[11px] tabular-nums outline-none focus:border-ring"
+                onChange={(e) => setDraft((d) => ({ ...d, valor: e.target.value }))}
+              />
+            </div>
+            <input
+              value={draft.recomendacao}
+              placeholder="observação · recomendação"
+              aria-label="Observação"
+              className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] outline-none focus:border-ring"
+              onChange={(e) => setDraft((d) => ({ ...d, recomendacao: e.target.value }))}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Button
+              type="button"
+              size="sm"
+              className="h-7 w-7 p-0"
+              disabled={busy || !draft.sistema.trim()}
+              onClick={handleAdd}
+              aria-label="Confirmar item"
+            >
+              {busy ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              className="h-7 w-7 p-0"
+              onClick={() => {
+                setAdding(false);
+                setDraft(EMPTY_DRAFT);
+              }}
+              aria-label="Cancelar"
+            >
+              <X size={13} />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Rodapé: total recomendado + CTA Pedir aprovação */}
+      <div className="flex items-center justify-between gap-3 pt-1">
+        <div>
+          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Total recomendado · cliente
+          </div>
+          <div className="text-base font-semibold tabular-nums text-foreground">
+            {fmtBRL(sums.total)}
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          className="h-8 gap-1.5"
+          disabled={approvalSending || items.length === 0}
+          onClick={onPedirAprovacao}
+          title="Envia o orçamento da vistoria por WhatsApp (link + PIN)"
+        >
+          {approvalSending ? (
+            <Loader2 size={14} className="animate-spin" aria-hidden />
+          ) : (
+            <MessageCircle size={14} aria-hidden />
+          )}
+          Pedir aprovação
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function Pill({
+  tone,
+  count,
+  label,
+}: {
+  tone: 'success' | 'warning' | 'destructive';
+  count: number;
+  label: string;
+}) {
+  const cls: Record<typeof tone, string> = {
+    success: 'bg-success/10 text-success-foreground',
+    warning: 'bg-warning/10 text-warning-foreground',
+    destructive: 'bg-destructive/10 text-destructive',
+  };
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] ${cls[tone]}`}
+    >
+      <b className="tabular-nums font-semibold">{count}</b>
+      {label}
+    </span>
+  );
+}

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
@@ -38,6 +38,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/Components/ui/select';
+import { Grid, Inline, Stack } from '@/Components/layout';
 
 export type DviSeverity = 'ok' | 'atencao' | 'critico';
 
@@ -330,7 +331,7 @@ export default function DviInlineEditor({
   return (
     <div className="space-y-2.5">
       {/* Pills de contagem + botão adicionar */}
-      <div className="flex items-center gap-1.5">
+      <Inline className="gap-1.5">
         <Pill tone="success" count={sums.ok} label="ok" />
         <Pill tone="warning" count={sums.atencao} label="atenção" />
         <Pill tone="destructive" count={sums.critico} label="crítico" />
@@ -346,7 +347,7 @@ export default function DviInlineEditor({
             Item
           </Button>
         )}
-      </div>
+      </Inline>
 
       {/* Estado vazio */}
       {items.length === 0 && !adding && (
@@ -366,13 +367,16 @@ export default function DviInlineEditor({
       {items.length > 0 && (
         <ul className="divide-y divide-border/60 overflow-hidden rounded-md border border-border bg-white">
           {items.map((item) => (
-            <li
+            <Grid
+              asChild
+              gap={2}
               key={item.id}
               className={
-                'grid grid-cols-[auto_1fr_72px_auto] items-center gap-2 px-2.5 py-2 ' +
+                'grid-cols-[auto_1fr_72px_auto] items-center px-2.5 py-2 ' +
                 (item.severity === 'critico' ? 'bg-destructive/5' : '')
               }
             >
+            <li>
               <DviTraffic
                 value={item.severity}
                 name={item.descricao}
@@ -428,19 +432,20 @@ export default function DviInlineEditor({
                 onClick={() => handleRemove(item)}
                 title="Remover item da vistoria"
                 aria-label={`Remover ${item.descricao}`}
-                className="grid h-7 w-7 place-items-center rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                className="grid place-items-center h-7 w-7 rounded text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
               >
                 <Trash2 size={13} aria-hidden />
               </button>
             </li>
+            </Grid>
           ))}
         </ul>
       )}
 
       {/* Form de adicionar */}
       {adding && (
-        <div className="grid grid-cols-[1fr_auto] items-start gap-2 rounded-md border border-dashed border-primary/40 bg-primary/5 p-2.5">
-          <div className="space-y-2">
+        <Inline align="start" gap={2} className="rounded-md border border-dashed border-primary/40 bg-primary/5 p-2.5">
+          <Stack gap={2} className="flex-1 min-w-0">
             <Select
               value={draft.sistema}
               onValueChange={(v) => setDraft((d) => ({ ...d, sistema: v }))}
@@ -456,7 +461,7 @@ export default function DviInlineEditor({
                 ))}
               </SelectContent>
             </Select>
-            <div className="flex items-center gap-2">
+            <Inline gap={2}>
               <DviTraffic
                 value={draft.severity}
                 name="novo item"
@@ -470,7 +475,7 @@ export default function DviInlineEditor({
                 className="w-20 rounded border border-border bg-background px-2 py-1 text-right text-[11px] tabular-nums outline-none focus:border-ring"
                 onChange={(e) => setDraft((d) => ({ ...d, valor: e.target.value }))}
               />
-            </div>
+            </Inline>
             <input
               value={draft.recomendacao}
               placeholder="observação · recomendação"
@@ -478,8 +483,8 @@ export default function DviInlineEditor({
               className="w-full rounded border border-border bg-background px-2 py-1 text-[11px] outline-none focus:border-ring"
               onChange={(e) => setDraft((d) => ({ ...d, recomendacao: e.target.value }))}
             />
-          </div>
-          <div className="flex flex-col gap-1">
+          </Stack>
+          <Stack gap={1}>
             <Button
               type="button"
               size="sm"
@@ -503,12 +508,12 @@ export default function DviInlineEditor({
             >
               <X size={13} />
             </Button>
-          </div>
-        </div>
+          </Stack>
+        </Inline>
       )}
 
       {/* Rodapé: total recomendado + CTA Pedir aprovação */}
-      <div className="flex items-center justify-between gap-3 pt-1">
+      <Inline justify="between" gap={3} className="pt-1">
         <div>
           <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             Total recomendado · cliente
@@ -532,7 +537,7 @@ export default function DviInlineEditor({
           )}
           Pedir aprovação
         </Button>
-      </div>
+      </Inline>
     </div>
   );
 }

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/LaudoPhotoSection.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/LaudoPhotoSection.tsx
@@ -1,0 +1,380 @@
+// LaudoPhotoSection — Fotos & Laudo OS-level com 3 estados + lightbox.
+//
+// F3 OS-V2-1 (fila TELAS_REVIEW_QUEUE · 2026-06-09). Porta pro drawer real
+// (ServiceOrderRichSheet) o protótipo Cowork APROVADO [W] 2026-06-09 (seção
+// "Fotos & Laudo" do Drawer · oficina-page.jsx · `.ofc-photos*`/`.ofc-lightbox`).
+//
+// 3 estados:
+//   VAZIO     — zona tracejada role=button (drag&drop + clique → picker image/*)
+//   ENVIANDO  — thumb esmaecida + barra de progresso REAL (XHR upload.onprogress)
+//   PREENCHIDO— grid 3 col, thumb com chip de legenda, tile "+" pra adicionar
+//
+// Lightbox: ampliar, legenda editável (PATCH original_name), Remover, Esc/clique-fora
+// fecha SÓ o lightbox (captura keydown — não fecha o Sheet drawer).
+//
+// Backend (F3 OS-V2-1): fotos anexadas à própria ServiceOrder (HasArquivos morphTo)
+// via ServiceOrderPhotoController. Entram no print A4 ("Fotos da vistoria").
+//   GET    /oficina-auto/ordens-servico/{order}/fotos
+//   POST   /oficina-auto/ordens-servico/{order}/fotos            (multipart `photo`)
+//   PATCH  /oficina-auto/ordens-servico/{order}/fotos/{arquivo}  ({label})
+//   DELETE /oficina-auto/ordens-servico/{order}/fotos/{arquivo}
+//
+// Touch ≥44px nos alvos (persona Técnico Repair · tablet).
+// CRÍTICO React 19 — useCallback nos handlers (lição PR #717).
+// CRÍTICO F3 LICOES_F3_FINANCEIRO_REJEITADO.md — sem emoji (lucide-react only),
+// sem auto-upload on-mount, sem window.print, sem nova aba.
+// CRÍTICO multi-tenant Tier 0 [ADR 0093] — backend escopa business_id (frontend consome).
+
+import { useCallback, useRef, useState } from 'react';
+import { Camera, ImagePlus, Loader2, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { Dialog, DialogContent, DialogTitle } from '@/Components/ui/dialog';
+
+export interface LaudoPhoto {
+  id: number;
+  label: string;
+  mime_type: string;
+  size_bytes: number;
+  display_url: string;
+  created_at: string | null;
+}
+
+interface LocalUpload {
+  tempId: string;
+  previewUrl: string;
+  name: string;
+  progress: number;
+}
+
+interface Props {
+  serviceOrderId: number;
+  initialPhotos: LaudoPhoto[];
+}
+
+function csrfToken(): string {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+}
+
+// Upload com progresso REAL (fetch não expõe upload.onprogress → XHR).
+function uploadWithProgress(
+  url: string,
+  file: File,
+  onProgress: (pct: number) => void,
+): Promise<{ foto?: LaudoPhoto }> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open('POST', url, true);
+    xhr.withCredentials = true;
+    xhr.setRequestHeader('Accept', 'application/json');
+    xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+    xhr.setRequestHeader('X-CSRF-TOKEN', csrfToken());
+    xhr.upload.onprogress = (e) => {
+      if (e.lengthComputable) onProgress(Math.min(96, Math.round((e.loaded / e.total) * 100)));
+    };
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(JSON.parse(xhr.responseText));
+        } catch {
+          resolve({});
+        }
+      } else {
+        let msg = `HTTP ${xhr.status}`;
+        try {
+          const j = JSON.parse(xhr.responseText);
+          msg = j?.message ?? j?.errors?.photo?.[0] ?? msg;
+        } catch {
+          /* sem JSON */
+        }
+        reject(new Error(msg));
+      }
+    };
+    xhr.onerror = () => reject(new Error('Erro de rede no upload.'));
+    const fd = new FormData();
+    fd.append('photo', file);
+    xhr.send(fd);
+  });
+}
+
+export default function LaudoPhotoSection({ serviceOrderId, initialPhotos }: Props) {
+  const [photos, setPhotos] = useState<LaudoPhoto[]>(initialPhotos);
+  const [uploads, setUploads] = useState<LocalUpload[]>([]);
+  const [dragOver, setDragOver] = useState(false);
+  const [lightboxId, setLightboxId] = useState<number | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const base = `/oficina-auto/ordens-servico/${serviceOrderId}/fotos`;
+
+  // Esc / clique-fora fecham SÓ o lightbox: o Radix Dialog é a camada topo da
+  // pilha DismissableLayer, então consome o Escape antes do Sheet drawer.
+
+  const addFiles = useCallback(
+    (files: FileList | File[]) => {
+      const imgs = Array.from(files).filter((f) => f.type && f.type.startsWith('image/'));
+      if (imgs.length === 0) {
+        toast.error('Apenas imagens são aceitas no laudo.');
+        return;
+      }
+      imgs.forEach((file, k) => {
+        const tempId = `up_${Date.now()}_${k}`;
+        const previewUrl = URL.createObjectURL(file);
+        setUploads((prev) => [...prev, { tempId, previewUrl, name: file.name, progress: 4 }]);
+
+        void uploadWithProgress(base, file, (pct) =>
+          setUploads((prev) => prev.map((u) => (u.tempId === tempId ? { ...u, progress: pct } : u))),
+        )
+          .then((res) => {
+            if (res.foto) {
+              setPhotos((prev) => [...prev, res.foto as LaudoPhoto]);
+            }
+            URL.revokeObjectURL(previewUrl);
+            setUploads((prev) => prev.filter((u) => u.tempId !== tempId));
+          })
+          .catch((err: Error) => {
+            URL.revokeObjectURL(previewUrl);
+            setUploads((prev) => prev.filter((u) => u.tempId !== tempId));
+            toast.error(`${file.name}: ${err.message}`);
+          });
+      });
+    },
+    [base],
+  );
+
+  const openPicker = useCallback(() => fileInputRef.current?.click(), []);
+
+  const onPicked = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files && e.target.files.length) addFiles(e.target.files);
+      e.target.value = '';
+    },
+    [addFiles],
+  );
+
+  const dragProps = {
+    onDragOver: (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(true);
+    },
+    onDragLeave: () => setDragOver(false),
+    onDrop: (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      if (e.dataTransfer.files) addFiles(e.dataTransfer.files);
+    },
+  };
+
+  const saveLabel = useCallback(
+    async (photo: LaudoPhoto, label: string) => {
+      const next = label.trim().slice(0, 180);
+      if (!next || next === photo.label) return;
+      // Otimista
+      setPhotos((prev) => prev.map((p) => (p.id === photo.id ? { ...p, label: next } : p)));
+      try {
+        const resp = await fetch(`${base}/${photo.id}`, {
+          method: 'PATCH',
+          credentials: 'same-origin',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN': csrfToken(),
+          },
+          body: JSON.stringify({ label: next }),
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      } catch {
+        setPhotos((prev) => prev.map((p) => (p.id === photo.id ? { ...p, label: photo.label } : p)));
+        toast.error('Falha ao salvar a legenda.');
+      }
+    },
+    [base],
+  );
+
+  const removePhoto = useCallback(
+    async (photo: LaudoPhoto) => {
+      const snapshot = photos;
+      setPhotos((prev) => prev.filter((p) => p.id !== photo.id));
+      setLightboxId(null);
+      try {
+        const resp = await fetch(`${base}/${photo.id}`, {
+          method: 'DELETE',
+          credentials: 'same-origin',
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+            'X-CSRF-TOKEN': csrfToken(),
+          },
+        });
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        toast.success('Foto removida do laudo.');
+      } catch {
+        setPhotos(snapshot);
+        toast.error('Falha ao remover a foto.');
+      }
+    },
+    [base, photos],
+  );
+
+  const isEmpty = photos.length === 0 && uploads.length === 0;
+  const doneCount = photos.length;
+  const lightbox = photos.find((p) => p.id === lightboxId) ?? null;
+
+  return (
+    <div className="space-y-2">
+      {isEmpty ? (
+        // ─── Estado VAZIO ───
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label="Adicionar fotos ao laudo"
+          onClick={openPicker}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              openPicker();
+            }
+          }}
+          {...dragProps}
+          className={
+            'flex min-h-[88px] cursor-pointer flex-col items-center justify-center gap-1.5 ' +
+            'rounded-lg border border-dashed p-4 text-center text-xs transition-colors ' +
+            (dragOver
+              ? 'border-primary bg-primary/5 text-primary'
+              : 'border-border text-muted-foreground hover:border-primary hover:bg-primary/5 hover:text-primary')
+          }
+        >
+          <Camera size={18} aria-hidden />
+          <span className="font-medium text-foreground">Sem fotos na OS</span>
+          <span>Toque pra fotografar ou arraste imagens — entram no laudo e na impressão</span>
+        </div>
+      ) : (
+        // ─── Estado PREENCHIDO / ENVIANDO ───
+        <div className="grid grid-cols-3 gap-1.5">
+          {photos.map((photo) => (
+            <button
+              key={photo.id}
+              type="button"
+              onClick={() => setLightboxId(photo.id)}
+              title={`${photo.label} · clique pra ampliar`}
+              aria-label={`Ampliar foto ${photo.label}`}
+              className="group relative aspect-square overflow-hidden rounded-md border border-border bg-muted/30 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <img
+                src={photo.display_url}
+                alt={photo.label}
+                loading="lazy"
+                className="h-full w-full object-cover"
+              />
+              {photo.label && (
+                <span className="absolute inset-x-1 bottom-1 truncate rounded bg-black/70 px-1.5 py-0.5 text-[9px] font-medium text-white">
+                  {photo.label}
+                </span>
+              )}
+            </button>
+          ))}
+
+          {uploads.map((u) => (
+            <div
+              key={u.tempId}
+              className="relative aspect-square overflow-hidden rounded-md border border-border bg-muted/30"
+              aria-label={`Enviando ${u.name}`}
+            >
+              <img src={u.previewUrl} alt="" className="h-full w-full object-cover opacity-45 saturate-50" />
+              <span className="absolute inset-x-1.5 bottom-1.5 grid place-items-center">
+                <span className="h-1 w-full overflow-hidden rounded-full bg-border">
+                  <span
+                    className="block h-full rounded-full bg-primary transition-all"
+                    style={{ width: `${u.progress}%` }}
+                  />
+                </span>
+              </span>
+              <Loader2
+                size={16}
+                className="absolute inset-0 m-auto animate-spin text-muted-foreground"
+                aria-hidden
+              />
+            </div>
+          ))}
+
+          {/* Tile "+" pra adicionar mais (≥44px de alvo) */}
+          <div
+            role="button"
+            tabIndex={0}
+            aria-label="Adicionar mais fotos"
+            onClick={openPicker}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                openPicker();
+              }
+            }}
+            {...dragProps}
+            className={
+              'grid aspect-square min-h-[44px] cursor-pointer place-items-center rounded-md ' +
+              'border border-dashed transition-colors ' +
+              (dragOver
+                ? 'border-primary bg-primary/5 text-primary'
+                : 'border-border text-muted-foreground hover:border-primary hover:bg-primary/5 hover:text-primary')
+            }
+          >
+            <ImagePlus size={16} aria-hidden />
+          </div>
+        </div>
+      )}
+
+      {doneCount > 0 && (
+        <p className="text-[10.5px] text-muted-foreground">
+          {doneCount} foto{doneCount === 1 ? '' : 's'} no laudo — {doneCount === 1 ? 'entra' : 'entram'} na impressão A4.
+        </p>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+        capture="environment"
+        multiple
+        onChange={onPicked}
+        className="sr-only"
+        aria-hidden
+      />
+
+      {/* ─── Lightbox (Radix Dialog — Esc/clique-fora fecham só esta camada) ─── */}
+      <Dialog open={lightbox !== null} onOpenChange={(o) => !o && setLightboxId(null)}>
+        <DialogContent className="max-w-3xl gap-0 overflow-hidden p-0">
+          <DialogTitle className="sr-only">Foto do laudo da OS</DialogTitle>
+          {lightbox && (
+            <>
+              <img
+                src={lightbox.display_url}
+                alt={lightbox.label}
+                className="max-h-[70vh] w-full bg-black object-contain"
+              />
+              <div className="flex items-center gap-2 border-t border-border px-3 py-2">
+                <input
+                  defaultValue={lightbox.label}
+                  aria-label="Legenda da foto"
+                  placeholder="legenda da foto"
+                  className="min-w-0 flex-1 rounded border border-transparent bg-transparent px-1.5 py-1 text-[12.5px] font-medium text-foreground outline-none hover:border-border focus:border-ring"
+                  onBlur={(e) => void saveLabel(lightbox, e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') (e.target as HTMLInputElement).blur();
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => void removePhoto(lightbox)}
+                  className="mr-6 inline-flex h-9 items-center gap-1 rounded-md px-2.5 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="Remover foto do laudo"
+                >
+                  <Trash2 size={14} aria-hidden />
+                  Remover
+                </button>
+              </div>
+            </>
+          )}
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/LaudoPhotoSection.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/LaudoPhotoSection.tsx
@@ -29,6 +29,7 @@ import { useCallback, useRef, useState } from 'react';
 import { Camera, ImagePlus, Loader2, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { Dialog, DialogContent, DialogTitle } from '@/Components/ui/dialog';
+import { Grid, Inline } from '@/Components/layout';
 
 export interface LaudoPhoto {
   id: number;
@@ -249,7 +250,7 @@ export default function LaudoPhotoSection({ serviceOrderId, initialPhotos }: Pro
         </div>
       ) : (
         // ─── Estado PREENCHIDO / ENVIANDO ───
-        <div className="grid grid-cols-3 gap-1.5">
+        <Grid cols={3} className="gap-1.5">
           {photos.map((photo) => (
             <button
               key={photo.id}
@@ -319,7 +320,7 @@ export default function LaudoPhotoSection({ serviceOrderId, initialPhotos }: Pro
           >
             <ImagePlus size={16} aria-hidden />
           </div>
-        </div>
+        </Grid>
       )}
 
       {doneCount > 0 && (
@@ -350,7 +351,7 @@ export default function LaudoPhotoSection({ serviceOrderId, initialPhotos }: Pro
                 alt={lightbox.label}
                 className="max-h-[70vh] w-full bg-black object-contain"
               />
-              <div className="flex items-center gap-2 border-t border-border px-3 py-2">
+              <Inline gap={2} className="border-t border-border px-3 py-2">
                 <input
                   defaultValue={lightbox.label}
                   aria-label="Legenda da foto"
@@ -370,7 +371,7 @@ export default function LaudoPhotoSection({ serviceOrderId, initialPhotos }: Pro
                   <Trash2 size={14} aria-hidden />
                   Remover
                 </button>
-              </div>
+              </Inline>
             </>
           )}
         </DialogContent>

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -60,6 +60,7 @@ import { MessageCircle, Printer, Wrench, Package, UserCog } from 'lucide-react';
 import { toast } from 'sonner';
 import { printServiceOrder } from '@/Lib/printServiceOrder';
 import DviInlineEditor, { type DviInlineItem } from './DviInlineEditor';
+import LaudoPhotoSection, { type LaudoPhoto } from './LaudoPhotoSection';
 
 type OrderType = 'manutencao' | 'mecanica' | null;
 
@@ -126,6 +127,8 @@ interface ServiceOrderDetail {
   items_total?: number | string;
   // F3 OS-V2-2 — itens DVI (Vistoria Digital) pro semáforo inline editável.
   dvi_items?: DviInlineItem[];
+  // F3 OS-V2-1 — fotos do laudo OS-level (Fotos & Laudo).
+  laudo_photos?: LaudoPhoto[];
   // D-09 (charter §2 TRAVADO) — venda derivada da OS (origem oficina · ADR 0192).
   // Backend ServiceOrderController::show() popula via shapeVendaDerivada() só quando
   // a OS já gerou Transaction (transição → concluída/pronto). null no resto.
@@ -461,6 +464,18 @@ export default function ServiceOrderRichSheet({
                 />
               </Section>
 
+              {/* ─── SEÇÃO FOTOS & LAUDO (F3 OS-V2-1) ───
+                  Upload OS-level real (3 estados + lightbox) via Modules/Arquivos.
+                  Antes de Peças (ordem do protótipo: vistoria → fotos → orçamento).
+                  key={data.id} re-seed o estado local ao trocar de OS. */}
+              <Section title="Fotos & Laudo" icon={Camera}>
+                <LaudoPhotoSection
+                  key={data.id}
+                  serviceOrderId={data.id}
+                  initialPhotos={data.laudo_photos ?? []}
+                />
+              </Section>
+
               {/* ─── SEÇÃO PEÇAS & MÃO DE OBRA (Wave 2.3 US-OFICINA-027) ───
                   Consome `data.items[]` populado pelo endpoint ServiceOrderController::show()
                   via relação ServiceOrder::items() (Wave 1.1). Lista peças + mão-de-obra +
@@ -514,25 +529,6 @@ export default function ServiceOrderRichSheet({
                     {data.order_type === 'manutencao' ? ' (cobrança não fechará automática)' : ''}
                   </p>
                 )}
-              </Section>
-
-              {/* ─── SEÇÃO 3: FOTOS & LAUDO (placeholders V2) ─── */}
-              <Section title="Fotos & Laudo" icon={Camera}>
-                <div className="grid grid-cols-3 gap-1.5">
-                  <PhotoPlaceholder label="entrega" />
-                  <PhotoPlaceholder label="local" />
-                  <PhotoPlaceholder label="assinatura" />
-                </div>
-                <Button
-                  size="sm"
-                  variant="ghost"
-                  className="mt-2 text-xs h-7"
-                  disabled
-                  title="Upload de foto — disponível em V2 (Modules/Arquivos integration)"
-                >
-                  <Camera size={11} className="mr-1.5" />
-                  + Adicionar foto
-                </Button>
               </Section>
 
               {/* ─── SEÇÃO 4: PIPELINE FSM (REUSO PR #729) ─── */}
@@ -630,23 +626,6 @@ function Section({
       </h3>
       {children}
     </section>
-  );
-}
-
-function PhotoPlaceholder({ label }: { label: string }) {
-  return (
-    <div
-      className="aspect-square rounded border border-border grid place-items-center text-center font-mono text-[9px] text-muted-foreground/60 leading-tight p-2"
-      style={{
-        background:
-          'repeating-linear-gradient(45deg, oklch(0.92 0.005 90) 0 8px, oklch(0.95 0.005 90) 8px 16px)',
-      }}
-      role="img"
-      aria-label={`Placeholder foto ${label}`}
-    >
-      FOTO
-      <br />·{label}
-    </div>
   );
 }
 

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -29,10 +29,12 @@
 // formatBRL null→"—", status via ServiceOrderStatusBadge (label PT, não cru).
 
 import { useCallback, useEffect, useState } from 'react';
+import { router } from '@inertiajs/react';
 import {
   AlertTriangle,
   Camera,
   CheckCircle2,
+  ClipboardCheck,
   Clock,
   Edit,
   ExternalLink,
@@ -57,6 +59,7 @@ import VendaDerivadaCard, { type VendaDerivada } from '@/Components/shared/Venda
 import { MessageCircle, Printer, Wrench, Package, UserCog } from 'lucide-react';
 import { toast } from 'sonner';
 import { printServiceOrder } from '@/Lib/printServiceOrder';
+import DviInlineEditor, { type DviInlineItem } from './DviInlineEditor';
 
 type OrderType = 'manutencao' | 'mecanica' | null;
 
@@ -121,6 +124,8 @@ interface ServiceOrderDetail {
   // Wave 2.3 US-OFICINA-027 — items lançados (peças + mão-de-obra + terceiros)
   items?: ServiceOrderItemRel[];
   items_total?: number | string;
+  // F3 OS-V2-2 — itens DVI (Vistoria Digital) pro semáforo inline editável.
+  dvi_items?: DviInlineItem[];
   // D-09 (charter §2 TRAVADO) — venda derivada da OS (origem oficina · ADR 0192).
   // Backend ServiceOrderController::show() popula via shapeVendaDerivada() só quando
   // a OS já gerou Transaction (transição → concluída/pronto). null no resto.
@@ -199,6 +204,7 @@ export default function ServiceOrderRichSheet({
   const [data, setData] = useState<ServiceOrderDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [approvalSending, setApprovalSending] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (!serviceOrderId) return;
@@ -233,6 +239,31 @@ export default function ServiceOrderRichSheet({
     void fetchData();
     onOrderChanged?.();
   }, [fetchData, onOrderChanged]);
+
+  // F3 OS-V2-2 — "Pedir aprovação" no editor DVI dispara o gate de aprovação
+  // (status → orcamento → ServiceOrderObserver despacha WhatsApp link + PIN).
+  // Reusa o pipeline existente de enviarAprovacao (espelha ApprovalGateCard via
+  // Inertia router.post pra processar o redirect/flash). Após sucesso, refetch
+  // pra refletir novo status no badge + Pipeline FSM.
+  const handlePedirAprovacao = useCallback(() => {
+    if (!data) return;
+    router.post(
+      `/oficina-auto/ordens-servico/${data.id}/enviar-aprovacao`,
+      {},
+      {
+        preserveScroll: true,
+        preserveState: true,
+        onStart: () => setApprovalSending(true),
+        onSuccess: () => {
+          toast.success('Orçamento da vistoria enviado para aprovação do cliente.');
+          void fetchData();
+          onOrderChanged?.();
+        },
+        onError: () => toast.error('Não foi possível enviar o pedido de aprovação.'),
+        onFinish: () => setApprovalSending(false),
+      },
+    );
+  }, [data, fetchData, onOrderChanged]);
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -414,6 +445,20 @@ export default function ServiceOrderRichSheet({
                     — sem observação registrada
                   </p>
                 )}
+              </Section>
+
+              {/* ─── SEÇÃO VISTORIA DIGITAL · DVI (F3 OS-V2-2) ───
+                  Semáforo inline editável de 1 toque (DviInlineEditor). Alimenta
+                  o orçamento (peças) e o gate de aprovação. key={data.id} garante
+                  re-seed do estado local quando troca de OS. */}
+              <Section title="Vistoria Digital · DVI" icon={ClipboardCheck}>
+                <DviInlineEditor
+                  key={data.id}
+                  serviceOrderId={data.id}
+                  initialItems={data.dvi_items ?? []}
+                  onPedirAprovacao={handlePedirAprovacao}
+                  approvalSending={approvalSending}
+                />
               </Section>
 
               {/* ─── SEÇÃO PEÇAS & MÃO DE OBRA (Wave 2.3 US-OFICINA-027) ───

--- a/resources/views/oficina_auto/print/service_order.blade.php
+++ b/resources/views/oficina_auto/print/service_order.blade.php
@@ -29,6 +29,9 @@
     $totalItems = (float) ($order->total_items ?? 0);
     $hasItems = $order->items && $order->items->count() > 0;
     $hasDvi = $order->dviInspectionItems && $order->dviInspectionItems->count() > 0;
+    // F3 OS-V2-1 — fotos do laudo OS-level (relação polimórfica arquivos()).
+    $laudoFotos = $order->relationLoaded('arquivos') ? $order->arquivos : collect();
+    $hasFotos = $laudoFotos->count() > 0;
 @endphp
 <!DOCTYPE html>
 <html lang="pt-BR">
@@ -228,6 +231,31 @@
             text-align: right;
             font-size: 9.5pt;
         }
+        /* ─── Fotos da vistoria (F3 OS-V2-1) ─── */
+        .os-photos {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 6px;
+        }
+        .os-photo {
+            margin: 0;
+            break-inside: avoid;
+            page-break-inside: avoid;
+        }
+        .os-photo img {
+            width: 100%;
+            aspect-ratio: 4 / 3;
+            object-fit: cover;
+            display: block;
+            border: 1px solid #ccc;
+            border-radius: 2px;
+        }
+        .os-photo figcaption {
+            font-size: 8pt;
+            color: #555;
+            margin-top: 2px;
+            word-break: break-word;
+        }
         .os-signature {
             margin-top: 28px;
             border-top: 1px solid #aaa;
@@ -425,11 +453,18 @@
             <div class="os-section-title">DVI · Vistoria Digital</div>
             <ul class="os-dvi-list">
                 @foreach ($order->dviInspectionItems as $dvi)
+                    @php
+                        $sevLabel = match ($dvi->severity ?? 'ok') {
+                            'atencao' => 'Atenção',
+                            'critico' => 'Crítico',
+                            default => 'OK',
+                        };
+                    @endphp
                     <li>
-                        <span class="os-dvi-sev {{ $dvi->severity ?? 'ok' }}">{{ ucfirst($dvi->severity ?? 'ok') }}</span>
+                        <span class="os-dvi-sev {{ $dvi->severity ?? 'ok' }}">{{ $sevLabel }}</span>
                         <span class="os-dvi-desc">
-                            <strong>{{ $dvi->item_name ?? $dvi->component ?? 'Item' }}</strong>
-                            @if (!empty($dvi->notes)) — {{ $dvi->notes }}@endif
+                            <strong>{{ $dvi->descricao ?? 'Item' }}</strong>
+                            @if (!empty($dvi->recomendacao)) — {{ $dvi->recomendacao }}@endif
                         </span>
                         <span class="os-dvi-value">
                             @if (!empty($dvi->valor_recomendado) && (float) $dvi->valor_recomendado > 0)
@@ -439,6 +474,26 @@
                     </li>
                 @endforeach
             </ul>
+        </div>
+    @endif
+
+    {{-- ════════════════════════════════════════════════════════════════
+         Zone 4b-bis — Fotos da vistoria (F3 OS-V2-1)
+         Fotos do laudo OS-level (anexo polimórfico da OS). Grid 3 colunas,
+         legenda (original_name) abaixo de cada foto. break-inside avoid pra
+         não cortar uma foto no meio entre páginas A4.
+         ════════════════════════════════════════════════════════════════ --}}
+    @if ($hasFotos)
+        <div class="os-section">
+            <div class="os-section-title">Fotos da vistoria</div>
+            <div class="os-photos">
+                @foreach ($laudoFotos as $foto)
+                    <figure class="os-photo">
+                        <img src="{{ $foto->display_url }}" alt="{{ $foto->original_name }}">
+                        <figcaption>{{ $foto->original_name }}</figcaption>
+                    </figure>
+                @endforeach
+            </div>
         </div>
     @endif
 


### PR DESCRIPTION
## O quê

F3 (port Cowork → Inertia real) dos dois P1 da fila `TELAS_REVIEW_QUEUE` para o drawer **ServiceOrderRichSheet** da Oficina. F1 produzido por [CC] e **F2 aprovado por [W] 2026-06-09** no protótipo `oimpresso.com.html` (drawer OS #8801).

- **OS-V2-2 — DVI inline com semáforo** (commit 1 · `7fec21361`)
- **OS-V2-1 — Fotos & Laudo upload real + print** (commit 2 · `f897e63e3`)
- marca os 2 itens `[x]` na fila (commit 3)

Refs: `prototipo-ui/TELAS_REVIEW_QUEUE.md` OS-V2-1/OS-V2-2 · `memory/sessions/2026-06-09-avaliacao-os-sweep-fila-v2.md` (já em main via #2480).

## Achado importante (não-duplicação)

O **backend já existia** em main (Wave 3 US-OFICINA-035): tabela `oa_inspection_items`, `DviInspectionController` (store/update/destroy/toOrcamento/uploadPhoto/deletePhoto), `DviInspectionService`, policy, rotas, e o backbone `Modules/Arquivos`. Esta PR é majoritariamente **frontend + exposição de payload**, reusando tudo — nada de backend DVI foi recriado.

## OS-V2-2 — DVI semáforo (`DviInlineEditor.tsx`)

- Semáforo **radiogroup de 3 botões redondos** (ok/atenção/crítico · 24px · `aria-checked` · `focus-visible` · hover scale) — **nunca `<select>`** pra severidade. Tokens DS (`success`/`warning`/`destructive`), zero hex.
- Por item: sistema editável inline, observação/recomendação, valor R$, remover. Pills de contagem + rodapé **"Total recomendado"** + CTA **"Pedir aprovação"** (dispara o `enviar-aprovacao` → gate WhatsApp+PIN existente). Estado vazio "vistoria ainda não iniciada".
- `show()` JSON agora expõe `dvi_items` pro drawer; CRUD reusa os endpoints existentes (optimista + revert no erro).

## OS-V2-1 — Fotos & Laudo (`LaudoPhotoSection.tsx` + `ServiceOrderPhotoController`)

- 3 estados: **VAZIO** (zona tracejada `role=button` · drag&drop + picker `image/*`), **ENVIANDO** (thumb esmaecida + **barra de progresso REAL** via `XHR upload.onprogress`), **PREENCHIDO** (grid 3 col · chip de legenda · tile "+").
- **Lightbox** (Radix Dialog — Esc/clique-fora fecham só a camada, não o Sheet): ampliar, legenda editável que persiste (PATCH `original_name`), Remover. Alvos touch **≥44px**.
- Backend novo: `ServiceOrderPhotoController` (index/store/updateLabel/destroy) sobre `$order->arquivos()` (HasArquivos morphTo **ServiceOrder** — distinto da foto POR item DVI, que morpha em `OaInspectionItem`). `show()` expõe `laudo_photos`.
- **Print A4**: fotos entram na folha (`service_order.blade.php`) — seção "Fotos da vistoria", grid 3 col, `figcaption` com legenda, `break-inside: avoid`. De passagem, **corrige bug latente** do bloco DVI do print (`item_name`/`component` inexistentes → `descricao`/`recomendacao` + label PT da severidade).

## Multi-tenant Tier 0 (ADR 0093)

`sameTenant` policy (`view`/`update`) + global scope `Arquivo` + **cross-owner guard** (arquivo de outra OS na rota desta OS → 404). `ArquivosService::attach` deriva `business_id` da sessão; o frontend nunca injeta.

## Deltas do protótipo (intenção visual mantida)

1. **DVI:** o backend separa `categoria`(enum 10) de `descricao`(texto 150); o protótipo tem um campo "sistema" só. `descricao` é o texto editável; `categoria` é **derivada por keyword** (`deriveCategoria`), validada no enum pelo backend. Presets (`SISTEMAS`) já trazem a categoria certa no form de adicionar.
2. **Fotos:** `Arquivo` não tem coluna caption → a legenda usa `original_name` (string exibível canônica). A foto do laudo é anexo **da OS** (não por item DVI).

## Testes

- `ServiceOrderRichSheetPayloadTest`: + `dvi_items[]` ordenado + backward-compat vazio.
- `ServiceOrderLaudoPhotoTest` (novo): store escopado por business, **reject non-image (422)**, OS de outro business (404), **cross-owner guard (404)**, updateLabel, destroy (soft), index, `laudo_photos` no payload, e **print A4 contém "Fotos da vistoria" + legenda**.

## Verificação local

- ✅ `tsc --noEmit` limpo nos 3 arquivos tocados (DviInlineEditor, LaudoPhotoSection, ServiceOrderRichSheet).
- ✅ `eslint` 0 erros / 0 warnings nos arquivos tocados (native `<select>` → DS `<Select>`; lightbox custom → Radix Dialog pra zerar a11y).
- ✅ `php -l` limpo em todos os PHP novos/alterados; Blade compila (`Blade::compileString` OK).
- ⏳ Pest MySQL-only (ADR 0101) **skipa em sqlite local** (mesmo padrão dos testes do módulo) → roda no **CI com MySQL**. 9 testes carregam e skipam limpo.
- ⏳ **Screenshot do drawer (gate F3):** ambiente local (MySQL/Herd/vite) está parado per sessão 2026-06-09 — **[W] aprova o screenshot** após subir o dev server (`npm run build:inertia` + hard refresh). 3 variantes a capturar: DVI semáforo, Fotos 3-estados, lightbox.

> Nota: `gh route:list` falha em main por uma referência pendente não-relacionada (`Modules\Financeiro\...ProvaVivaController`) — fora do escopo desta PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
