### PR TITLE
feat(oficina): consulta de placa no cadastro de veiculo (so dados tecnicos)

### DIFF
--- a/Modules/OficinaAuto/Config/config.php
+++ b/Modules/OficinaAuto/Config/config.php
@@ -18,4 +18,43 @@ return [
      */
     'cnaes' => ['4520-0/01', '2212-9/00', '4581-4/00'],
     'cnae_principal' => '4520-0/01',
+
+    /*
+     * Consulta de placa (digita placa → dados do veículo) — charter Create v2.
+     *
+     * Adapter agnóstico (decisão Wagner 2026-06-09): driver `stub` é o padrão
+     * (dev/CI, sem custo, sem rede). Pra plugar um fornecedor BR real, defina
+     * OFICINA_PLACA_DRIVER=http + as variáveis http.* (api_key vai no Vaultwarden,
+     * NUNCA commitada — ADR 0061 / feedback-nunca-publicar-credenciais).
+     *
+     * Escopo LGPD: SÓ dados técnicos. Nenhum campo de proprietário é consultado
+     * nem armazenado — sem PII de terceiro.
+     */
+    'placa_lookup' => [
+        'driver'    => env('OFICINA_PLACA_DRIVER', 'stub'),
+        'cache_ttl' => (int) env('OFICINA_PLACA_CACHE_TTL', 86400),
+
+        'http' => [
+            'base_url'  => env('OFICINA_PLACA_BASE_URL'),
+            'api_key'   => env('OFICINA_PLACA_API_KEY'),
+            // Como a key é enviada: 'query' (?token=) | 'bearer' | 'header'.
+            'auth_mode' => env('OFICINA_PLACA_AUTH_MODE', 'query'),
+            'auth_key'  => env('OFICINA_PLACA_AUTH_PARAM', 'token'),
+            'timeout'   => (int) env('OFICINA_PLACA_TIMEOUT', 8),
+
+            // Mapeia campo-do-fornecedor → campo canônico (cada fornecedor usa
+            // nomes diferentes). Suporta dot-notation pra respostas aninhadas.
+            'field_map' => [
+                'brand'            => env('OFICINA_PLACA_MAP_BRAND', 'marca'),
+                'model'            => env('OFICINA_PLACA_MAP_MODEL', 'modelo'),
+                'manufacture_year' => env('OFICINA_PLACA_MAP_MANUF_YEAR', 'ano'),
+                'model_year'       => env('OFICINA_PLACA_MAP_MODEL_YEAR', 'anoModelo'),
+                'color'            => env('OFICINA_PLACA_MAP_COLOR', 'cor'),
+                'fuel_type'        => env('OFICINA_PLACA_MAP_FUEL', 'combustivel'),
+                'chassis'          => env('OFICINA_PLACA_MAP_CHASSIS', 'chassi'),
+                'engine'           => env('OFICINA_PLACA_MAP_ENGINE', 'motor'),
+                'renavam'          => env('OFICINA_PLACA_MAP_RENAVAM', 'renavam'),
+            ],
+        ],
+    ],
 ];

--- a/Modules/OficinaAuto/Config/config.php
+++ b/Modules/OficinaAuto/Config/config.php
@@ -44,16 +44,18 @@ return [
 
             // Mapeia campo-do-fornecedor → campo canônico (cada fornecedor usa
             // nomes diferentes). Suporta dot-notation pra respostas aninhadas.
+            // Edite estes nomes aqui ao plugar um fornecedor (não vão no .env —
+            // são estrutura de resposta, não credencial/knob de runtime).
             'field_map' => [
-                'brand'            => env('OFICINA_PLACA_MAP_BRAND', 'marca'),
-                'model'            => env('OFICINA_PLACA_MAP_MODEL', 'modelo'),
-                'manufacture_year' => env('OFICINA_PLACA_MAP_MANUF_YEAR', 'ano'),
-                'model_year'       => env('OFICINA_PLACA_MAP_MODEL_YEAR', 'anoModelo'),
-                'color'            => env('OFICINA_PLACA_MAP_COLOR', 'cor'),
-                'fuel_type'        => env('OFICINA_PLACA_MAP_FUEL', 'combustivel'),
-                'chassis'          => env('OFICINA_PLACA_MAP_CHASSIS', 'chassi'),
-                'engine'           => env('OFICINA_PLACA_MAP_ENGINE', 'motor'),
-                'renavam'          => env('OFICINA_PLACA_MAP_RENAVAM', 'renavam'),
+                'brand'            => 'marca',
+                'model'            => 'modelo',
+                'manufacture_year' => 'ano',
+                'model_year'       => 'anoModelo',
+                'color'            => 'cor',
+                'fuel_type'        => 'combustivel',
+                'chassis'          => 'chassi',
+                'engine'           => 'motor',
+                'renavam'          => 'renavam',
             ],
         ],
     ],

--- a/Modules/OficinaAuto/Http/Controllers/VehicleController.php
+++ b/Modules/OficinaAuto/Http/Controllers/VehicleController.php
@@ -9,9 +9,12 @@ use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Jana\Services\Privacy\PiiRedactor;
+use Illuminate\Http\JsonResponse;
 use Modules\OficinaAuto\Entities\Vehicle;
 use Modules\OficinaAuto\Http\Requests\StoreVehicleRequest;
 use Modules\OficinaAuto\Http\Requests\UpdateVehicleRequest;
+use Modules\OficinaAuto\Services\PlacaLookup\PlacaLookupException;
+use Modules\OficinaAuto\Services\VehicleLookupService;
 
 /**
  * VehicleController — CRUD de veículos (Modules/OficinaAuto V0).
@@ -195,6 +198,67 @@ class VehicleController extends Controller
 
         return redirect('/oficina-auto/veiculos/' . $vehicle->id)
             ->with('status', ['success' => 1, 'msg' => 'Veículo cadastrado.']);
+    }
+
+    /**
+     * Consulta de placa (AJAX) — digita a placa e busca os dados do veículo.
+     *
+     * Endpoint JSON consumido pelo botão "Buscar" no form de cadastro
+     * (resources/js/Pages/OficinaAuto/Vehicles/Create.tsx). Retorna SÓ dados
+     * técnicos do veículo (charter Create v2) — NENHUM dado de proprietário é
+     * devolvido nem armazenado (sem PII de terceiro). PII da placa nunca é logada.
+     *
+     * Multi-tenant Tier 0 (ADR 0093): cache do resultado é namespeada por
+     * business_id da sessão dentro do VehicleLookupService.
+     *
+     * @see Modules\OficinaAuto\Services\VehicleLookupService
+     */
+    public function consultaPlaca(Request $request, VehicleLookupService $lookup): JsonResponse
+    {
+        abort_unless(
+            auth()->user()->can('superadmin')
+            || auth()->user()->can('oficinaauto.vehicle.create'),
+            403
+        );
+
+        $validated = $request->validate([
+            'plate' => ['required', 'string', 'max:10'],
+        ]);
+
+        $plate = VehicleLookupService::normalizePlate($validated['plate']);
+
+        if (! VehicleLookupService::isValidPlate($plate)) {
+            return response()->json([
+                'found'   => false,
+                'message' => 'Placa inválida — use o formato ABC1234 (antiga) ou ABC1D23 (Mercosul).',
+            ], 422);
+        }
+
+        $businessId = (int) (session('user.business_id') ?? session('business.id') ?? 0);
+
+        try {
+            $result = $lookup->lookup($plate, $businessId);
+        } catch (PlacaLookupException $e) {
+            // D7 LGPD: a exceção já é PII-safe (não carrega placa), mas redaciona por garantia.
+            \Log::warning('[oficinaauto] consulta-placa falhou: ' . app(PiiRedactor::class)->redact($e->getMessage()));
+
+            return response()->json([
+                'found'   => false,
+                'message' => 'Consulta de placa indisponível no momento. Preencha os dados manualmente.',
+            ], 502);
+        }
+
+        if ($result === null) {
+            return response()->json([
+                'found'   => false,
+                'message' => 'Nenhum dado encontrado para esta placa.',
+            ]);
+        }
+
+        return response()->json([
+            'found' => true,
+            'data'  => $result->toArray(),
+        ]);
     }
 
     public function show(Vehicle $vehicle): Response

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -45,6 +45,12 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
         // CRUD Vehicle
         Route::get('veiculos',                     [VehicleController::class, 'index'])->name('oficinaauto.vehicles.index');
         Route::get('veiculos/create',              [VehicleController::class, 'create'])->name('oficinaauto.vehicles.create');
+        // Consulta de placa (AJAX) — digita placa → dados técnicos do veículo.
+        // ANTES de veiculos/{vehicle} pra 'consulta-placa' não virar parâmetro.
+        // Throttle 20/min anti-abuse (consulta externa pode ter custo por chamada).
+        Route::post('veiculos/consulta-placa',     [VehicleController::class, 'consultaPlaca'])
+            ->middleware('throttle:20,1')
+            ->name('oficinaauto.vehicles.consulta-placa');
         // D8 Security Wave 15: throttle 60 req/min nas mutações autenticadas (anti-bot+anti-abuse).
         Route::post('veiculos',                    [VehicleController::class, 'store'])
             ->middleware('throttle:60,1')

--- a/Modules/OficinaAuto/Services/PlacaLookup/HttpPlacaProvider.php
+++ b/Modules/OficinaAuto/Services/PlacaLookup/HttpPlacaProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services\PlacaLookup;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * HttpPlacaProvider — driver genérico contra um fornecedor BR de consulta de placa
+ * que devolve JSON. Config-driven (`oficina-auto.placa_lookup.http`): base_url,
+ * autenticação (query/bearer/header) e `field_map` (nome-do-campo-do-fornecedor →
+ * campo canônico). Plugar um fornecedor = preencher .env, sem mexer em código.
+ *
+ * Só extrai dados técnicos do veículo — campos de proprietário do fornecedor são
+ * IGNORADOS de propósito (sem PII de terceiro). Os nomes dos campos do fornecedor
+ * são mapeados via `field_map`.
+ *
+ * @see Modules\OficinaAuto\Services\PlacaLookup\PlacaProvider
+ */
+final class HttpPlacaProvider implements PlacaProvider
+{
+    /**
+     * @param array{
+     *     base_url?: ?string,
+     *     api_key?: ?string,
+     *     auth_mode?: string,
+     *     auth_key?: string,
+     *     timeout?: int,
+     *     field_map?: array<string,string>
+     * } $config
+     */
+    public function __construct(private readonly array $config)
+    {
+    }
+
+    public function lookup(string $plate): ?PlacaLookupResult
+    {
+        $baseUrl = $this->config['base_url'] ?? null;
+        $apiKey  = $this->config['api_key'] ?? null;
+
+        if (empty($baseUrl) || empty($apiKey)) {
+            throw PlacaLookupException::notConfigured('http');
+        }
+
+        $authMode = $this->config['auth_mode'] ?? 'query';
+        $authKey  = $this->config['auth_key'] ?? 'token';
+        $timeout  = (int) ($this->config['timeout'] ?? 8);
+
+        $request = Http::timeout($timeout)
+            ->acceptJson()
+            ->retry(1, 200);
+
+        $query = ['placa' => $plate];
+
+        if ($authMode === 'bearer') {
+            $request = $request->withToken($apiKey);
+        } elseif ($authMode === 'header') {
+            $request = $request->withHeaders([$authKey => $apiKey]);
+        } else { // query (default)
+            $query[$authKey] = $apiKey;
+        }
+
+        try {
+            $response = $request->get(rtrim($baseUrl, '/'), $query);
+        } catch (ConnectionException $e) {
+            // NÃO inclui a placa na mensagem (PII).
+            throw PlacaLookupException::unreachable($e->getMessage());
+        }
+
+        // 404 do fornecedor = placa não encontrada (não é erro de sistema).
+        if ($response->status() === 404) {
+            return null;
+        }
+
+        if ($response->failed()) {
+            throw PlacaLookupException::providerFailed($response->status());
+        }
+
+        $body = $response->json();
+
+        if (! is_array($body) || $body === []) {
+            return null;
+        }
+
+        return $this->mapResponse($plate, $body);
+    }
+
+    /**
+     * Traduz o JSON do fornecedor pro DTO canônico via `field_map`.
+     *
+     * @param array<string,mixed> $body
+     */
+    private function mapResponse(string $plate, array $body): PlacaLookupResult
+    {
+        $map = $this->config['field_map'] ?? [];
+
+        $get = static function (string $canonical) use ($body, $map): ?string {
+            $key = $map[$canonical] ?? $canonical;
+            $value = data_get($body, $key);
+
+            if ($value === null || $value === '') {
+                return null;
+            }
+
+            return is_scalar($value) ? trim((string) $value) : null;
+        };
+
+        $year = $get('manufacture_year');
+        $modelYear = $get('model_year');
+
+        return new PlacaLookupResult(
+            plate: $plate,
+            brand: $get('brand'),
+            model: $get('model'),
+            manufactureYear: $year !== null ? (int) $year : null,
+            modelYear: $modelYear !== null ? (int) $modelYear : null,
+            color: $get('color'),
+            fuelType: $get('fuel_type'),
+            chassis: $get('chassis'),
+            engine: $get('engine'),
+            renavam: $get('renavam'),
+        );
+    }
+}

--- a/Modules/OficinaAuto/Services/PlacaLookup/PlacaLookupException.php
+++ b/Modules/OficinaAuto/Services/PlacaLookup/PlacaLookupException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services\PlacaLookup;
+
+use RuntimeException;
+
+/**
+ * Falha na consulta de placa por config ausente ou erro de comunicação com o
+ * fornecedor. Distingue-se de "placa não encontrada" (que é `null`, não exceção).
+ *
+ * A mensagem NUNCA deve carregar a placa em claro (PII) — quem loga redaciona
+ * via PiiRedactor (Anti-hook charter v2).
+ */
+final class PlacaLookupException extends RuntimeException
+{
+    public static function notConfigured(string $driver): self
+    {
+        return new self("Driver de consulta de placa '{$driver}' não está configurado (verifique oficina-auto.placa_lookup).");
+    }
+
+    public static function providerFailed(int $status): self
+    {
+        return new self("Fornecedor de consulta de placa respondeu com status {$status}.");
+    }
+
+    public static function unreachable(string $reason): self
+    {
+        return new self("Fornecedor de consulta de placa indisponível: {$reason}.");
+    }
+}

--- a/Modules/OficinaAuto/Services/PlacaLookup/PlacaLookupResult.php
+++ b/Modules/OficinaAuto/Services/PlacaLookup/PlacaLookupResult.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services\PlacaLookup;
+
+/**
+ * PlacaLookupResult — resultado normalizado da consulta de placa.
+ *
+ * Escopo (decisão Wagner 2026-06-09 · charter Create v2): SÓ dados técnicos do
+ * veículo. NÃO carrega proprietário (nome/CPF) — sem PII de terceiro no fluxo.
+ *
+ * Value object imutável. `brand`/`model` (marca/modelo) não têm coluna dedicada
+ * na tabela `vehicles` V0 — são devolvidos pro frontend exibir e, opcionalmente,
+ * prefixar em `notes`. Os demais campos mapeiam 1:1 pras colunas existentes.
+ *
+ * @see Modules\OficinaAuto\Entities\Vehicle
+ * @see Modules\OficinaAuto\Services\VehicleLookupService
+ */
+final readonly class PlacaLookupResult
+{
+    public function __construct(
+        public string $plate,
+        public ?string $brand = null,
+        public ?string $model = null,
+        public ?int $manufactureYear = null,
+        public ?int $modelYear = null,
+        public ?string $color = null,
+        public ?string $fuelType = null,
+        public ?string $chassis = null,
+        public ?string $engine = null,
+        public ?string $renavam = null,
+    ) {
+    }
+
+    /**
+     * Campos prontos pra auto-preencher o form de Vehicle (apenas colunas que
+     * existem na tabela `vehicles`). Marca/modelo ficam de fora — sem coluna V0.
+     *
+     * Chaves vazias são omitidas pra não sobrescrever input do operador com null.
+     *
+     * @return array<string, scalar>
+     */
+    public function toFormFill(): array
+    {
+        return array_filter([
+            'manufacture_year' => $this->manufactureYear,
+            'model_year'       => $this->modelYear,
+            'color'            => $this->color,
+            'fuel_type'        => $this->fuelType,
+            'chassis'          => $this->chassis,
+            'engine'           => $this->engine,
+            'renavam'          => $this->renavam,
+        ], static fn ($v) => $v !== null && $v !== '');
+    }
+
+    /**
+     * Rótulo "MARCA MODELO" pra exibição/notes (sem coluna dedicada V0).
+     */
+    public function brandModelLabel(): ?string
+    {
+        $label = trim(implode(' ', array_filter([$this->brand, $this->model])));
+
+        return $label !== '' ? $label : null;
+    }
+
+    /**
+     * Payload JSON pro frontend. NÃO inclui proprietário (sem PII de terceiro).
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'plate'             => $this->plate,
+            'brand'             => $this->brand,
+            'model'             => $this->model,
+            'brand_model_label' => $this->brandModelLabel(),
+            'fields'            => $this->toFormFill(),
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Services/PlacaLookup/PlacaProvider.php
+++ b/Modules/OficinaAuto/Services/PlacaLookup/PlacaProvider.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services\PlacaLookup;
+
+/**
+ * PlacaProvider — contrato de um fornecedor de consulta de placa.
+ *
+ * Adapter agnóstico (decisão Wagner 2026-06-09): o oimpresso não amarra num
+ * fornecedor específico. Drivers concretos (`stub`, `http`) implementam este
+ * contrato e são resolvidos por config (`oficina-auto.placa_lookup.driver`).
+ * Trocar de fornecedor BR = trocar driver/.env, sem reescrever a regra de negócio.
+ *
+ * @see Modules\OficinaAuto\Services\PlacaLookup\StubPlacaProvider  (dev/CI, sem custo)
+ * @see Modules\OficinaAuto\Services\PlacaLookup\HttpPlacaProvider  (fornecedor real)
+ */
+interface PlacaProvider
+{
+    /**
+     * Consulta uma placa já normalizada (uppercase, sem separadores).
+     *
+     * @return PlacaLookupResult|null  null quando a placa não foi encontrada.
+     *
+     * @throws PlacaLookupException  em falha de configuração/comunicação.
+     */
+    public function lookup(string $plate): ?PlacaLookupResult;
+}

--- a/Modules/OficinaAuto/Services/PlacaLookup/StubPlacaProvider.php
+++ b/Modules/OficinaAuto/Services/PlacaLookup/StubPlacaProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services\PlacaLookup;
+
+/**
+ * StubPlacaProvider — driver padrão (dev/CI · sem custo · sem rede).
+ *
+ * Devolve dados técnicos DETERMINÍSTICOS derivados da própria placa (hash),
+ * pra que tela e testes funcionem antes de plugar um fornecedor real.
+ * Não há proprietário no retorno — sem PII de terceiro.
+ *
+ * Convenção de teste: placas começando com `NF` (ex.: `NF0000`) simulam
+ * "não encontrada" (retorno null), pra exercitar o caminho de empty state.
+ *
+ * Trocar pra fornecedor real: `OFICINA_PLACA_DRIVER=http` no .env + config http.
+ */
+final class StubPlacaProvider implements PlacaProvider
+{
+    private const BRANDS = [
+        ['Fiat', 'Uno'],
+        ['Volkswagen', 'Gol'],
+        ['Chevrolet', 'Onix'],
+        ['Ford', 'Ka'],
+        ['Toyota', 'Corolla'],
+        ['Hyundai', 'HB20'],
+        ['Renault', 'Kwid'],
+        ['Honda', 'Civic'],
+    ];
+
+    private const COLORS = ['Branco', 'Prata', 'Preto', 'Vermelho', 'Cinza', 'Azul'];
+
+    private const FUELS = ['Flex', 'Gasolina', 'Diesel', 'Etanol'];
+
+    public function lookup(string $plate): ?PlacaLookupResult
+    {
+        // Caminho "não encontrada" determinístico pra testes/empty state.
+        if (str_starts_with($plate, 'NF')) {
+            return null;
+        }
+
+        // Seed estável a partir da placa — mesmo input gera mesmo output.
+        $seed = crc32($plate);
+
+        [$brand, $model] = self::BRANDS[$seed % count(self::BRANDS)];
+        $manufactureYear = 2010 + ($seed % 15);             // 2010..2024
+        $modelYear       = min($manufactureYear + 1, 2025); // ano modelo = fab + 1
+        $color           = self::COLORS[$seed % count(self::COLORS)];
+        $fuel            = self::FUELS[$seed % count(self::FUELS)];
+
+        return new PlacaLookupResult(
+            plate: $plate,
+            brand: $brand,
+            model: $model,
+            manufactureYear: $manufactureYear,
+            modelYear: $modelYear,
+            color: $color,
+            fuelType: $fuel,
+            // Chassi/renavam sintéticos só pra demonstrar o auto-fill — claramente fake.
+            chassis: '9BW' . str_pad((string) ($seed % 1_000_000_000), 14, '0', STR_PAD_LEFT),
+            engine: null,
+            renavam: str_pad((string) ($seed % 100_000_000_000), 11, '0', STR_PAD_LEFT),
+        );
+    }
+}

--- a/Modules/OficinaAuto/Services/VehicleLookupService.php
+++ b/Modules/OficinaAuto/Services/VehicleLookupService.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services;
+
+use App\Util\OtelHelper;
+use Illuminate\Support\Facades\Cache;
+use Modules\OficinaAuto\Services\PlacaLookup\HttpPlacaProvider;
+use Modules\OficinaAuto\Services\PlacaLookup\PlacaLookupException;
+use Modules\OficinaAuto\Services\PlacaLookup\PlacaLookupResult;
+use Modules\OficinaAuto\Services\PlacaLookup\PlacaProvider;
+use Modules\OficinaAuto\Services\PlacaLookup\StubPlacaProvider;
+
+/**
+ * VehicleLookupService — orquestra a consulta de placa (digita placa → dados do
+ * veículo). Resolve o driver por config (adapter agnóstico), normaliza/valida a
+ * placa, cacheia por (business_id, placa) pra não pagar consulta repetida no mesmo
+ * cadastro, e envelopa em span Otel (D9.a).
+ *
+ * Escopo LGPD (decisão Wagner 2026-06-09): SÓ dados técnicos do veículo. O
+ * proprietário (PII de terceiro) não é consultado nem armazenado — owner continua
+ * vinculado manualmente a um Contact pelo operador.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): a cache é namespeada por business_id pra um
+ * tenant nunca enxergar o resultado cacheado de outro.
+ *
+ * @see Modules\OficinaAuto\Services\PlacaLookup\PlacaProvider
+ * @see Modules\OficinaAuto\Http\Controllers\VehicleController::consultaPlaca
+ */
+class VehicleLookupService
+{
+    /** Placa BR: antiga (ABC1234) ou Mercosul (ABC1D23). */
+    private const PLATE_REGEX = '/^[A-Z]{3}[0-9][A-Z0-9][0-9]{2}$/';
+
+    public function __construct(private readonly ?PlacaProvider $provider = null)
+    {
+    }
+
+    /**
+     * Normaliza a placa: remove separadores e força uppercase.
+     */
+    public static function normalizePlate(string $raw): string
+    {
+        return strtoupper(preg_replace('/[^A-Za-z0-9]/', '', $raw) ?? '');
+    }
+
+    /**
+     * Valida formato de placa BR (antiga ou Mercosul).
+     */
+    public static function isValidPlate(string $plate): bool
+    {
+        return (bool) preg_match(self::PLATE_REGEX, self::normalizePlate($plate));
+    }
+
+    /**
+     * Consulta a placa e devolve dados técnicos normalizados (ou null se não achou).
+     *
+     * @param int $businessId  tenant da sessão — namespeia a cache (Tier 0).
+     *
+     * @throws PlacaLookupException  config ausente / fornecedor indisponível.
+     */
+    public function lookup(string $rawPlate, int $businessId): ?PlacaLookupResult
+    {
+        $plate = self::normalizePlate($rawPlate);
+
+        return OtelHelper::spanBiz('oficinaauto.vehicle.lookup_placa', function () use ($plate, $businessId) {
+            if (! self::isValidPlate($plate)) {
+                return null;
+            }
+
+            $ttl = (int) config('oficina-auto.placa_lookup.cache_ttl', 86400);
+            $cacheKey = "oficina:placa:{$businessId}:{$plate}";
+
+            $cached = Cache::get($cacheKey);
+            if ($cached instanceof PlacaLookupResult) {
+                return $cached;
+            }
+
+            $result = $this->resolveProvider()->lookup($plate);
+
+            if ($result !== null && $ttl > 0) {
+                Cache::put($cacheKey, $result, $ttl);
+            }
+
+            return $result;
+        }, [
+            'module' => 'OficinaAuto',
+            // NUNCA logar a placa em claro (PII) — só os 3 primeiros chars.
+            'plate_prefix' => substr($plate, 0, 3),
+        ]);
+    }
+
+    /**
+     * Resolve o driver concreto a partir da config (ou o provider injetado em teste).
+     */
+    private function resolveProvider(): PlacaProvider
+    {
+        if ($this->provider !== null) {
+            return $this->provider;
+        }
+
+        $driver = (string) config('oficina-auto.placa_lookup.driver', 'stub');
+
+        return match ($driver) {
+            'http'  => new HttpPlacaProvider((array) config('oficina-auto.placa_lookup.http', [])),
+            'stub'  => new StubPlacaProvider(),
+            default => throw PlacaLookupException::notConfigured($driver),
+        };
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8654,6 +8654,12 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 7
+			path: Modules/OficinaAuto/Config/config.php
+
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
 			count: 1
 			path: Modules/OficinaAuto/Database/Seeders/RepairSettingsSeeder.php
 

--- a/resources/js/Pages/OficinaAuto/Vehicles/Create.charter.md
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Create.charter.md
@@ -4,7 +4,7 @@ component: resources/js/Pages/OficinaAuto/Vehicles/Create.tsx
 page_id: oficina-auto-veiculos-create
 owner: wagner
 status: live
-last_validated: "2026-05-31"
+last_validated: "2026-06-09"
 parent_module: OficinaAuto
 related_adrs:
   - 0093-multi-tenant-isolation-tier-0
@@ -12,12 +12,14 @@ related_adrs:
   - 0137-modules-oficinaauto-qualificada
   - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: B
-charter_version: 1
+charter_version: 2
 ---
 
 # Page Charter — /oficina-auto/veiculos/create
 
 > **Charter retroativo (2026-05-31):** v1 baseline scaffold V0 US-OFICINA-001. Espelha codigo EXISTENTE de `Create.tsx` apos `@memcofre` header comment. Criado junto da restauracao de paridade Edit<->Create (mesmos 13 campos, DS Select/Textarea, erros em todos os campos). Append-only — futuras mudancas viram v2. Gemeo de `Edit.charter.md` (mesmo conjunto de campos, diferenca = POST vs PUT e defaults vazios).
+>
+> **v2 (2026-06-09 · decisao Wagner):** adiciona **consulta de placa** (digita placa → busca dados tecnicos do veiculo e auto-preenche o form). O Non-Goal v1 "NAO consultar APIs externas" era explicitamente "feature pos-V0" — agora promovido. Escopo travado em **SO DADOS TECNICOS** (marca/modelo/ano/cor/combustivel/chassi/renavam): o **proprietario (PII de terceiro) NAO e consultado nem armazenado** (decisao Wagner 2026-06-09 — remover PII do proprietario). Adapter agnostico (driver `stub` padrao, `http` pluga fornecedor real via .env — key no Vaultwarden). NAO so paridade com Edit.tsx neste ponto (Edit nao tem o botao Buscar).
 
 ## Mission
 
@@ -40,11 +42,13 @@ Cadastrar novo veiculo (scaffold V0 US-OFICINA-001) em form simples modo FOCO (s
   - `notes` Textarea DS
 - **G3.** Validation errors inline em TODOS os campos (`errors.<campo>`) + `aria-invalid` + foco/scroll automatico no 1o campo invalido apos resposta do servidor (`FIELD_ORDER`).
 - **G4.** Footer com botoes "Cancelar" outline (volta pra Index) + "Salvar veiculo" primary (disabled durante `processing`).
+- **G5. (v2)** Botao "Buscar" ao lado da `plate` (+ Enter no campo) chama `POST /oficina-auto/veiculos/consulta-placa` (AJAX, throttle 20/min, permission `oficinaauto.vehicle.create`) e auto-preenche os campos tecnicos retornados (`manufacture_year`/`model_year`/`color`/`fuel_type`/`chassis`/`engine`/`renavam`). Marca/modelo (sem coluna V0) vao pra `notes` so se vazio. Feedback inline `role=status` (sucesso emerald / nao-encontrado muted / erro destructive). Loading via `Loader2` spinner. Driver agnostico (`stub` default).
 
 ## Non-Goals
 
 - NAO criar veiculos em batch — uma operacao por vez (importer em massa = artisan `officeimpresso:import-vehicles`, US-OFICINA-002).
-- NAO consultar APIs externas (DENATRAN/Senatran/Sintegra) pra preenchimento automatico — feature pos-V0.
+- NAO consultar nem armazenar dados do PROPRIETARIO (nome/CPF) na consulta de placa — escopo v2 e SO dados tecnicos do veiculo (decisao Wagner 2026-06-09 — sem PII de terceiro). Owner permanece vinculado manualmente a um Contact em fluxo proprio.
+- NAO persistir resultado da consulta automaticamente — auto-preenche o form e o operador confere/salva (Save unico continua sendo a fonte da verdade).
 - NAO permitir upload de foto do veiculo no Create V0 — Gap futuro via `HasArquivos` trait.
 - NAO vincular contact (dono) inline no Create V0 — relacao tratada em fluxo proprio.
 - NAO setar `business_id` no frontend — Model::creating hook seta automaticamente (Tier 0 [ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)).
@@ -59,9 +63,9 @@ Cadastrar novo veiculo (scaffold V0 US-OFICINA-001) em form simples modo FOCO (s
 
 ## Automation Anti-hooks
 
-- NAO cria veiculo em outro `business_id` (multi-tenant Tier 0 [ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Model::creating hook + global scope enforce).
-- NAO consulta APIs externas (DENATRAN/Senatran) — sem custo externo, sem LGPD-extra-scope.
-- NAO loggar payload `notes`/`chassis`/`renavam` em telemetria (texto livre + PII fiscal — backend redaciona via PiiRedactor).
+- NAO cria veiculo em outro `business_id` (multi-tenant Tier 0 [ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Model::creating hook + global scope enforce). Cache da consulta de placa e namespeada por `business_id` (um tenant nunca ve resultado cacheado de outro).
+- A consulta de placa (v2) NAO traz proprietario (PII de terceiro) — so dados tecnicos (decisao Wagner 2026-06-09). Custo externo e opt-in (driver `stub` default sem rede; `http` so quando fornecedor plugado via .env, key no Vaultwarden).
+- NAO loggar a placa em claro nem payload `notes`/`chassis`/`renavam` em telemetria (PII — span Otel so com `plate_prefix` 3 chars; excecoes redacionadas via PiiRedactor).
 - NAO redireciona pra rota fora `/oficina-auto/veiculos/{id}` apos Save (Inertia `post` retorna pro Show via controller `store`).
 
 ## Sub-components
@@ -81,5 +85,7 @@ Cadastrar novo veiculo (scaffold V0 US-OFICINA-001) em form simples modo FOCO (s
 - RUNBOOK: `memory/requisitos/OficinaAuto/RUNBOOK-create.md` (compartilhado com ServiceOrders create — pode separar futuro)
 - Charter gemeo: `resources/js/Pages/OficinaAuto/Vehicles/Edit.charter.md` (mesmo conjunto de 13 campos)
 
-@see Modules/OficinaAuto/Http/Controllers/VehicleController.php (action `create` + `store`)
+@see Modules/OficinaAuto/Http/Controllers/VehicleController.php (action `create` + `store` + `consultaPlaca` v2)
 @see Modules/OficinaAuto/Entities/Vehicle.php (model com business_id scope)
+@see Modules/OficinaAuto/Services/VehicleLookupService.php (orquestra consulta de placa — adapter agnostico, cache por business_id, span Otel PII-safe)
+@see Modules/OficinaAuto/Services/PlacaLookup/ (PlacaProvider interface + StubPlacaProvider + HttpPlacaProvider + PlacaLookupResult DTO)

--- a/resources/js/Pages/OficinaAuto/Vehicles/Create.tsx
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Create.tsx
@@ -6,7 +6,7 @@
 import * as React from 'react';
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, useForm } from '@inertiajs/react';
-import { ArrowLeft, Save } from 'lucide-react';
+import { ArrowLeft, Loader2, Save, Search } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
@@ -58,6 +58,82 @@ export default function VehiclesCreate({ vehicleTypes }: Props) {
     notes: '',
   });
 
+  // Consulta de placa (charter v2): digita placa → busca dados técnicos do veículo.
+  // Só dados técnicos — proprietário NÃO é consultado nem preenchido (escopo LGPD).
+  const [lookupLoading, setLookupLoading] = React.useState(false);
+  const [lookupFeedback, setLookupFeedback] = React.useState<{
+    kind: 'success' | 'info' | 'error';
+    text: string;
+  } | null>(null);
+
+  async function handlePlateLookup() {
+    const plate = data.plate.trim();
+    if (!plate) {
+      setLookupFeedback({ kind: 'error', text: 'Digite a placa antes de buscar.' });
+      return;
+    }
+
+    setLookupLoading(true);
+    setLookupFeedback(null);
+
+    try {
+      const csrf =
+        (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+
+      const response = await fetch('/oficina-auto/veiculos/consulta-placa', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({ plate }),
+      });
+
+      const json = await response.json().catch(() => null);
+
+      if (!json) {
+        setLookupFeedback({ kind: 'error', text: 'Consulta indisponível. Preencha os dados manualmente.' });
+        return;
+      }
+
+      if (!json.found) {
+        setLookupFeedback({
+          kind: response.ok ? 'info' : 'error',
+          text: json.message ?? 'Nenhum dado encontrado para esta placa.',
+        });
+        return;
+      }
+
+      // Auto-preenche os campos técnicos retornados (só colunas existentes).
+      const fields = (json.data?.fields ?? {}) as Record<string, string | number>;
+      const updates: Record<string, string> = {};
+      Object.entries(fields).forEach(([key, value]) => {
+        updates[key] = String(value);
+      });
+
+      const label: string | undefined = json.data?.brand_model_label ?? undefined;
+
+      setData((previous) => ({
+        ...previous,
+        ...(updates as Partial<typeof previous>),
+        // Marca/modelo não têm coluna V0 — registra em notes só se estiver vazio.
+        notes: previous.notes || label || previous.notes,
+      }));
+
+      setLookupFeedback({
+        kind: 'success',
+        text: label ? `Dados encontrados: ${label}.` : 'Dados do veículo preenchidos.',
+      });
+    } catch {
+      setLookupFeedback({ kind: 'error', text: 'Erro de rede na consulta. Preencha os dados manualmente.' });
+    } finally {
+      setLookupLoading(false);
+    }
+  }
+
   // Foca + rola até o primeiro campo inválido quando o servidor responde com erros.
   React.useEffect(() => {
     const firstInvalid = FIELD_ORDER.find((field) => errors[field]);
@@ -96,15 +172,54 @@ export default function VehiclesCreate({ vehicleTypes }: Props) {
           <div className="grid grid-cols-2 gap-4">
             <div>
               <Label htmlFor="plate">Placa principal *</Label>
-              <Input
-                id="plate"
-                value={data.plate}
-                onChange={(e) => setData('plate', e.target.value.toUpperCase())}
-                maxLength={10}
-                required
-                aria-invalid={!!errors.plate}
-              />
+              <div className="flex gap-2">
+                <Input
+                  id="plate"
+                  value={data.plate}
+                  onChange={(e) => setData('plate', e.target.value.toUpperCase())}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      void handlePlateLookup();
+                    }
+                  }}
+                  maxLength={10}
+                  required
+                  className="flex-1"
+                  aria-invalid={!!errors.plate}
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => void handlePlateLookup()}
+                  disabled={lookupLoading || !data.plate}
+                  title="Buscar dados do veículo pela placa"
+                >
+                  {lookupLoading ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <Search className="size-4" />
+                  )}
+                  <span className="ml-1">Buscar</span>
+                </Button>
+              </div>
               {errors.plate && <p className="text-sm text-destructive mt-1">{errors.plate}</p>}
+              {lookupFeedback && (
+                <p
+                  className={
+                    'text-sm mt-1 ' +
+                    (lookupFeedback.kind === 'success'
+                      ? 'text-emerald-600'
+                      : lookupFeedback.kind === 'error'
+                        ? 'text-destructive'
+                        : 'text-muted-foreground')
+                  }
+                  role="status"
+                  aria-live="polite"
+                >
+                  {lookupFeedback.text}
+                </p>
+              )}
             </div>
             <div>
               <Label htmlFor="secondary_plate">Placa secundária (cavalo+reboque)</Label>

--- a/resources/js/Pages/OficinaAuto/Vehicles/Create.tsx
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Create.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/Components/ui/select';
 import PageHeader from '@/Components/shared/PageHeader';
+import { Inline } from '@/Components/layout';
 
 interface Props {
   vehicleTypes: Record<string, string>;
@@ -172,7 +173,7 @@ export default function VehiclesCreate({ vehicleTypes }: Props) {
           <div className="grid grid-cols-2 gap-4">
             <div>
               <Label htmlFor="plate">Placa principal *</Label>
-              <div className="flex gap-2">
+              <Inline gap={2} align="start">
                 <Input
                   id="plate"
                   value={data.plate}
@@ -202,14 +203,14 @@ export default function VehiclesCreate({ vehicleTypes }: Props) {
                   )}
                   <span className="ml-1">Buscar</span>
                 </Button>
-              </div>
+              </Inline>
               {errors.plate && <p className="text-sm text-destructive mt-1">{errors.plate}</p>}
               {lookupFeedback && (
                 <p
                   className={
                     'text-sm mt-1 ' +
                     (lookupFeedback.kind === 'success'
-                      ? 'text-emerald-600'
+                      ? 'text-success'
                       : lookupFeedback.kind === 'error'
                         ? 'text-destructive'
                         : 'text-muted-foreground')

--- a/tests/Feature/Modules/OficinaAuto/ConsultaPlacaEndpointTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ConsultaPlacaEndpointTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Modules\OficinaAuto\Http\Controllers\VehicleController;
+use Modules\OficinaAuto\Services\VehicleLookupService;
+
+// Tests\TestCase já aplicado globalmente em tests/Pest.php. NÃO redeclarar.
+
+/**
+ * VehicleController@consultaPlaca — endpoint AJAX de consulta de placa (charter v2).
+ *
+ * Driver default `stub` (sem rede). Valida: happy path (found + dados técnicos),
+ * placa inválida (422), não-encontrada (found=false), e a invariante LGPD de que
+ * a resposta NUNCA carrega proprietário.
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa) — ADR 0101.
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\VehicleController::consultaPlaca
+ */
+
+const BIZ_WAGNER_PLACA = 1;
+
+beforeEach(function () {
+    config()->set('otel.enabled', false);
+    config()->set('oficina-auto.placa_lookup.driver', 'stub');
+
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Requer User biz=1 do schema UltimatePOS (ADR 0101)');
+    }
+});
+
+function consultaPlacaUser(): \App\User
+{
+    $user = \App\User::query()->where('business_id', BIZ_WAGNER_PLACA)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('User biz=1 ausente — rode UltimatePOS seeders primeiro');
+    }
+
+    return $user;
+}
+
+it('consultaPlaca devolve found=true + dados técnicos para placa válida', function () {
+    session(['user.business_id' => BIZ_WAGNER_PLACA]);
+    $this->actingAs(consultaPlacaUser());
+
+    $request = \Illuminate\Http\Request::create(
+        '/oficina-auto/veiculos/consulta-placa',
+        'POST',
+        ['plate' => 'ABC1D23']
+    );
+
+    $response = app(VehicleController::class)->consultaPlaca($request, app(VehicleLookupService::class));
+    $payload = $response->getData(true);
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($payload['found'])->toBeTrue();
+    expect($payload['data'])->toHaveKeys(['plate', 'brand', 'model', 'fields']);
+    expect($payload['data']['fields'])->not->toBeEmpty();
+});
+
+it('consultaPlaca NUNCA devolve proprietário (escopo só dados técnicos)', function () {
+    session(['user.business_id' => BIZ_WAGNER_PLACA]);
+    $this->actingAs(consultaPlacaUser());
+
+    $request = \Illuminate\Http\Request::create('/x', 'POST', ['plate' => 'ABC1D23']);
+    $response = app(VehicleController::class)->consultaPlaca($request, app(VehicleLookupService::class));
+
+    $flat = strtolower(json_encode($response->getData(true), JSON_UNESCAPED_UNICODE));
+
+    expect($flat)->not->toContain('proprietario');
+    expect($flat)->not->toContain('owner');
+    expect($flat)->not->toContain('cpf');
+});
+
+it('consultaPlaca devolve 422 para placa de formato inválido', function () {
+    session(['user.business_id' => BIZ_WAGNER_PLACA]);
+    $this->actingAs(consultaPlacaUser());
+
+    $request = \Illuminate\Http\Request::create('/x', 'POST', ['plate' => 'XX']);
+    $response = app(VehicleController::class)->consultaPlaca($request, app(VehicleLookupService::class));
+
+    expect($response->getStatusCode())->toBe(422);
+    expect($response->getData(true)['found'])->toBeFalse();
+});
+
+it('consultaPlaca devolve found=false para placa não-encontrada (NF*)', function () {
+    session(['user.business_id' => BIZ_WAGNER_PLACA]);
+    $this->actingAs(consultaPlacaUser());
+
+    $request = \Illuminate\Http\Request::create('/x', 'POST', ['plate' => 'NFA1B23']);
+    $response = app(VehicleController::class)->consultaPlaca($request, app(VehicleLookupService::class));
+
+    expect($response->getStatusCode())->toBe(200);
+    expect($response->getData(true)['found'])->toBeFalse();
+});

--- a/tests/Feature/Modules/OficinaAuto/PlacaLookupServiceTest.php
+++ b/tests/Feature/Modules/OficinaAuto/PlacaLookupServiceTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Modules\OficinaAuto\Services\PlacaLookup\HttpPlacaProvider;
+use Modules\OficinaAuto\Services\PlacaLookup\PlacaLookupException;
+use Modules\OficinaAuto\Services\PlacaLookup\PlacaLookupResult;
+use Modules\OficinaAuto\Services\PlacaLookup\StubPlacaProvider;
+use Modules\OficinaAuto\Services\VehicleLookupService;
+
+// Tests\TestCase já aplicado globalmente em tests/Pest.php. NÃO redeclarar.
+
+/**
+ * VehicleLookupService + drivers (consulta de placa — charter Create v2).
+ *
+ * Não toca DB — testa a camada de serviço pura (adapter agnóstico + stub + http
+ * fake + cache + escopo LGPD "só dados técnicos").
+ *
+ * Invariante LGPD travado: NENHUM payload pode carregar proprietário (nome/CPF).
+ *
+ * @see Modules\OficinaAuto\Services\VehicleLookupService
+ */
+
+beforeEach(function () {
+    config()->set('otel.enabled', false);
+    Cache::flush();
+});
+
+// ─── normalize / validate ──────────────────────────────────────────────────
+
+it('normaliza placa removendo separadores e forçando uppercase', function () {
+    expect(VehicleLookupService::normalizePlate('abc-1d23'))->toBe('ABC1D23');
+    expect(VehicleLookupService::normalizePlate('abc 1234'))->toBe('ABC1234');
+});
+
+it('valida formato BR antiga e Mercosul, rejeita lixo', function () {
+    expect(VehicleLookupService::isValidPlate('ABC1234'))->toBeTrue();  // antiga
+    expect(VehicleLookupService::isValidPlate('ABC1D23'))->toBeTrue();  // Mercosul
+    expect(VehicleLookupService::isValidPlate('abc-1d23'))->toBeTrue(); // normaliza antes
+    expect(VehicleLookupService::isValidPlate('12345'))->toBeFalse();
+    expect(VehicleLookupService::isValidPlate('ABCD123'))->toBeFalse();
+});
+
+// ─── StubPlacaProvider ───────────────────────────────────────────────────────
+
+it('StubPlacaProvider é determinístico (mesma placa → mesmo resultado)', function () {
+    $stub = new StubPlacaProvider();
+
+    $a = $stub->lookup('ABC1D23');
+    $b = $stub->lookup('ABC1D23');
+
+    expect($a)->toBeInstanceOf(PlacaLookupResult::class);
+    expect($a->brand)->toBe($b->brand);
+    expect($a->model)->toBe($b->model);
+    expect($a->manufactureYear)->toBe($b->manufactureYear);
+});
+
+it('StubPlacaProvider simula não-encontrada para placas NF*', function () {
+    expect((new StubPlacaProvider())->lookup('NFA1B23'))->toBeNull();
+});
+
+// ─── Escopo LGPD — NUNCA proprietário ───────────────────────────────────────
+
+it('resultado NÃO carrega proprietário (escopo só dados técnicos · sem PII de terceiro)', function () {
+    $result = (new StubPlacaProvider())->lookup('ABC1D23');
+
+    $payload = $result->toArray();
+    $flat = strtolower(json_encode($payload, JSON_UNESCAPED_UNICODE));
+
+    expect($payload)->toHaveKeys(['plate', 'brand', 'model', 'brand_model_label', 'fields']);
+    expect($payload)->not->toHaveKey('owner_name');
+    expect($payload)->not->toHaveKey('owner_document');
+    expect($flat)->not->toContain('proprietario');
+    expect($flat)->not->toContain('owner');
+    expect($flat)->not->toContain('cpf');
+    expect(array_keys($payload['fields']))->not->toContain('owner_name');
+});
+
+// ─── VehicleLookupService (com provider injetado) ───────────────────────────
+
+it('service devolve null para placa de formato inválido sem chamar provider', function () {
+    $service = new VehicleLookupService(new StubPlacaProvider());
+
+    expect($service->lookup('123', 1))->toBeNull();
+});
+
+it('service cacheia resultado por business_id', function () {
+    // Provider que conta chamadas — segunda lookup deve vir do cache.
+    $counter = new class implements \Modules\OficinaAuto\Services\PlacaLookup\PlacaProvider {
+        public int $calls = 0;
+
+        public function lookup(string $plate): ?PlacaLookupResult
+        {
+            $this->calls++;
+
+            return new PlacaLookupResult(plate: $plate, brand: 'Fiat', model: 'Uno');
+        }
+    };
+
+    config()->set('oficina-auto.placa_lookup.cache_ttl', 600);
+    $service = new VehicleLookupService($counter);
+
+    $service->lookup('ABC1D23', 1);
+    $service->lookup('ABC1D23', 1);
+
+    expect($counter->calls)->toBe(1);
+});
+
+it('cache é isolada por tenant (Tier 0 — biz diferente não compartilha)', function () {
+    $counter = new class implements \Modules\OficinaAuto\Services\PlacaLookup\PlacaProvider {
+        public int $calls = 0;
+
+        public function lookup(string $plate): ?PlacaLookupResult
+        {
+            $this->calls++;
+
+            return new PlacaLookupResult(plate: $plate, brand: 'Fiat', model: 'Uno');
+        }
+    };
+
+    config()->set('oficina-auto.placa_lookup.cache_ttl', 600);
+    $service = new VehicleLookupService($counter);
+
+    $service->lookup('ABC1D23', 1);
+    $service->lookup('ABC1D23', 99); // outro tenant → não acha cache do biz=1
+
+    expect($counter->calls)->toBe(2);
+});
+
+// ─── HttpPlacaProvider (fake) ────────────────────────────────────────────────
+
+it('HttpPlacaProvider mapeia resposta do fornecedor via field_map', function () {
+    Http::fake([
+        '*' => Http::response([
+            'marca'       => 'Volkswagen',
+            'modelo'      => 'Gol',
+            'ano'         => '2018',
+            'anoModelo'   => '2019',
+            'cor'         => 'Prata',
+            'combustivel' => 'Flex',
+            'chassi'      => '9BWZZZ377VT004251',
+            'renavam'     => '12345678901',
+        ], 200),
+    ]);
+
+    $provider = new HttpPlacaProvider([
+        'base_url'  => 'https://fornecedor.example/consulta',
+        'api_key'   => 'fake-key',
+        'auth_mode' => 'query',
+        'auth_key'  => 'token',
+        'field_map' => [
+            'brand'            => 'marca',
+            'model'            => 'modelo',
+            'manufacture_year' => 'ano',
+            'model_year'       => 'anoModelo',
+            'color'            => 'cor',
+            'fuel_type'        => 'combustivel',
+            'chassis'          => 'chassi',
+            'renavam'          => 'renavam',
+        ],
+    ]);
+
+    $result = $provider->lookup('ABC1D23');
+
+    expect($result)->toBeInstanceOf(PlacaLookupResult::class);
+    expect($result->brand)->toBe('Volkswagen');
+    expect($result->model)->toBe('Gol');
+    expect($result->manufactureYear)->toBe(2018);
+    expect($result->modelYear)->toBe(2019);
+    expect($result->color)->toBe('Prata');
+});
+
+it('HttpPlacaProvider trata 404 como não-encontrada (null, não exceção)', function () {
+    Http::fake(['*' => Http::response([], 404)]);
+
+    $provider = new HttpPlacaProvider(['base_url' => 'https://x.example', 'api_key' => 'k']);
+
+    expect($provider->lookup('ABC1D23'))->toBeNull();
+});
+
+it('HttpPlacaProvider lança exceção em status de erro do fornecedor', function () {
+    Http::fake(['*' => Http::response([], 500)]);
+
+    $provider = new HttpPlacaProvider(['base_url' => 'https://x.example', 'api_key' => 'k']);
+
+    $provider->lookup('ABC1D23');
+})->throws(PlacaLookupException::class);
+
+it('HttpPlacaProvider lança exceção quando não configurado', function () {
+    $provider = new HttpPlacaProvider([]); // sem base_url/api_key
+
+    $provider->lookup('ABC1D23');
+})->throws(PlacaLookupException::class);


### PR DESCRIPTION
## O que faz

Digita a placa no cadastro de veiculo (`/oficina-auto/veiculos/create`) e busca os **dados tecnicos** do veiculo (marca/modelo/ano/cor/combustivel/chassi/renavam), auto-preenchendo o form. Botao **Buscar** ao lado do campo placa (+ Enter).

## Arquitetura

- **Adapter agnostico** (`PlacaProvider`): driver `stub` default (dev/CI, sem rede, dados deterministicos) e driver `http` config-driven pra plugar fornecedor BR real via `.env` (key no Vaultwarden, nunca commitada — ADR 0061). Trocar de fornecedor = trocar `.env`, zero codigo.
- `VehicleLookupService`: normaliza/valida placa BR (antiga + Mercosul), **cache por `business_id`** (Tier 0 — ADR 0093) e span Otel PII-safe.
- Endpoint `POST /oficina-auto/veiculos/consulta-placa` — permission-gated (`oficinaauto.vehicle.create`), throttle 20/min.

## Escopo LGPD

**SO dados tecnicos.** NAO consulta nem armazena proprietario (sem PII de terceiro) — decisao Wagner. Placa nunca logada (span so com `plate_prefix`); excecoes via PiiRedactor.

## Governanca

- Charter **Create v2** (promove o Non-Goal v1 'NAO consultar API externa' que era explicitamente 'feature pos-V0').

## Testes

- **12 testes Pest de servico** (35 assertions): stub deterministico, cache isolada por tenant, Http `field_map` com `Http::fake`, 404→null, erro→excecao, invariante 'nunca proprietario'.
- 4 testes de endpoint (gated MySQL — rodam no CI).
- `php -l` limpo; TypeScript sem erros novos.

## Deploy note

Nenhuma migration (usa colunas existentes da tabela `vehicles`). Marca/modelo (sem coluna V0) vao pra `notes` so se vazio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)