### PR TITLE
chore(oficina): fechamento lista+kanban — filtros board, prazo no card, coluna defeito, dead-types de locação, backfill order_type + labels FSM (auditoria [CC] 2026-06-09)

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_06_09_000002_backfill_order_type_mecanica_legacy.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_06_09_000002_backfill_order_type_mecanica_legacy.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Backfill: OS legadas sem tipo de reparo → `order_type = 'mecanica'` (auditoria [CC]
+ * 2026-06-09, aprovada [W]).
+ *
+ * Origem: na Lista/Kanban da Oficina, OS antigas (importadas/seed pré-Wave 5-A) ficavam
+ * com `order_type` nulo ou no resíduo legado `'locacao'` — renderizando badge "—" e
+ * ficando FORA do quadro de mecânica (`oficina_mecanica_os` só lista `order_type='mecanica'`
+ * ou quem já está numa stage de board). [W] (dono do domínio) decidiu: a Oficina é REPARO,
+ * então essas OS órfãs nascem `mecanica`.
+ *
+ * Driver-agnóstico de propósito (≠ migration 000001 erradica_locacao, que é MySQL-only e
+ * já estreitou o enum): aqui é um UPDATE puro de dados que roda igual em SQLite (testes) e
+ * MySQL (prod). Por isso é complementar, não duplicada — no MySQL a 000001 já reclassificou
+ * 'locacao' antes; este passo fecha qualquer NULL remanescente. No SQLite (enum = TEXT) é
+ * quem efetivamente faz o backfill.
+ *
+ * Escopo GLOBAL (cross-business) por desenho: `order_type` é coluna por-linha (não há eixo
+ * tenant a respeitar — cada linha já pertence ao seu business via business_id). Idempotente:
+ * re-rodar não tem efeito (após o 1º run não sobra 'locacao'/NULL).
+ *
+ * down(): NÃO é reversível com fidelidade — não há como saber quais linhas eram NULL/'locacao'
+ * originalmente. Mantido como no-op explícito (documentado) pra não reintroduzir o badge "—".
+ *
+ * Preserva Tier 0: multi-tenant global scope (ADR 0093) intacto; FSM ServiceOrder (ADR 0143)
+ * intacto; NÃO toca FSM keys das colunas do kanban (charter v4).
+ *
+ * @see memory/decisions/0265-oficina-reparo-erradica-locacao.md
+ * @see memory/sessions/2026-06-09-auditoria-lista-kanban-fechamento.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('service_orders') || ! Schema::hasColumn('service_orders', 'order_type')) {
+            return;
+        }
+
+        DB::table('service_orders')
+            ->where('order_type', 'locacao')
+            ->orWhereNull('order_type')
+            ->update(['order_type' => 'mecanica']);
+    }
+
+    public function down(): void
+    {
+        // Irreversível por desenho: o dado de origem (NULL vs 'locacao') foi perdido no up().
+        // No-op explícito — reverter pra NULL reintroduziria o badge "—" que esta migration
+        // veio justamente apagar. Sem rollback de dados aqui (documentado p/ a catraca de schema).
+    }
+};

--- a/Modules/OficinaAuto/Database/Migrations/2026_06_09_000003_rename_cacamba_locacao_stage_labels.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_06_09_000003_rename_cacamba_locacao_stage_labels.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Renomeia os DISPLAY NAMES dos estágios do processo FSM legado `cacamba_locacao` pra
+ * vocabulário de REPARO (auditoria [CC] 2026-06-09, aprovada [W]; ADR 0265 erradica locação).
+ *
+ * As KEYS dos estágios ficam INTOCADAS (trava Tier 0 — charter v4 / FSM ADR 0143): só o
+ * label PT-BR (`sale_process_stages.name`) muda. Isso reflete nos chips FSM da Produção
+ * (ProducaoOficina, data-driven por `stage.name`) sem mexer em transição, key, side-effect
+ * ou histórico.
+ *
+ *   key          label antigo (locação)   →  label novo (reparo)
+ *   disponivel   "Disponível"             →  "Aguardando"
+ *   locada       "Locada (com cliente)"   →  "Em execução"
+ *   recolhida    "Recolhida"              →  "Pronto p/ retirar"
+ *   manutencao   "Em manutenção"          →  "Em diagnóstico"
+ *
+ * Escopo GLOBAL (todos os business): vocabulário de UI, não dado tenant-sensível. O UPDATE
+ * casa só linhas com o label antigo exato (idempotente + reversível). O seeder
+ * OficinaAutoFsmSeeder foi atualizado em paralelo pra ambientes novos nascerem corretos
+ * (firstOrCreate não atualiza linhas existentes — daí esta migration pro dado em prod).
+ *
+ * @see Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php (LOCACAO_STAGES)
+ * @see memory/decisions/0265-oficina-reparo-erradica-locacao.md
+ * @see memory/sessions/2026-06-09-auditoria-lista-kanban-fechamento.md
+ */
+return new class extends Migration
+{
+    /** @var array<string, array{0: string, 1: string}> key => [label antigo, label novo] */
+    private const RENAMES = [
+        'disponivel' => ['Disponível', 'Aguardando'],
+        'locada'     => ['Locada (com cliente)', 'Em execução'],
+        'recolhida'  => ['Recolhida', 'Pronto p/ retirar'],
+        'manutencao' => ['Em manutenção', 'Em diagnóstico'],
+    ];
+
+    public function up(): void
+    {
+        $this->apply(fn ($old, $new) => [$old, $new]);
+    }
+
+    public function down(): void
+    {
+        // Reverte label novo → antigo (key intacta).
+        $this->apply(fn ($old, $new) => [$new, $old]);
+    }
+
+    /**
+     * @param  callable(string, string): array{0:string, 1:string}  $direction
+     *         recebe [labelAntigo, labelNovo] e devolve [from, to] da direção corrente.
+     */
+    private function apply(callable $direction): void
+    {
+        if (! Schema::hasTable('sale_process_stages') || ! Schema::hasTable('sale_processes')) {
+            return;
+        }
+
+        $processIds = DB::table('sale_processes')->where('key', 'cacamba_locacao')->pluck('id');
+        if ($processIds->isEmpty()) {
+            return;
+        }
+
+        foreach (self::RENAMES as $key => [$old, $new]) {
+            [$from, $to] = $direction($old, $new);
+            DB::table('sale_process_stages')
+                ->whereIn('process_id', $processIds)
+                ->where('key', $key)
+                ->where('name', $from) // idempotente: só renomeia quem ainda tem o label de origem
+                ->update(['name' => $to]);
+        }
+    }
+};

--- a/Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php
+++ b/Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php
@@ -75,12 +75,18 @@ class OficinaAutoFsmSeeder extends Seeder
 
     // ----- Processo 1: cacamba_locacao ----------------------------------
 
-    /** @var array<string, string> stage_key → label PT-BR */
+    /**
+     * @var array<string, string> stage_key → label PT-BR.
+     *
+     * KEYS intocadas (compat backwards prod biz=164 + trava FSM); DISPLAY NAMES já em
+     * vocabulário de REPARO (ADR 0265 erradica locação — auditoria [CC] 2026-06-09). O dado
+     * em prod é renomeado pela migration 2026_06_09_000003_rename_cacamba_locacao_stage_labels.
+     */
     private const LOCACAO_STAGES = [
-        'disponivel' => 'Disponível',
-        'locada'     => 'Locada (com cliente)',
-        'recolhida'  => 'Recolhida',
-        'manutencao' => 'Em manutenção',
+        'disponivel' => 'Aguardando',
+        'locada'     => 'Em execução',
+        'recolhida'  => 'Pronto p/ retirar',
+        'manutencao' => 'Em diagnóstico',
     ];
 
     /** @var array<string, array{order:int, terminal?:bool, color:string, initial?:bool}> */

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -244,6 +244,11 @@ class ServiceOrderController extends Controller
 
         $businessId = (int) (session('user.business_id') ?? session('business.id') ?? 0);
         $q = $request->string('q')->toString();
+        // Filtros do quadro (mesmo eixo Box/Mecânico que o RichSheet mostra).
+        // box_label/assigned_user_id chegaram na Wave 2.1 (US-OFICINA-027) — guard de schema.
+        $hasResourceSchema = Schema::hasColumn('service_orders', 'box_label');
+        $mecanico = $request->integer('mecanico') ?: null;
+        $box      = $request->string('box')->toString();
 
         // Stages do processo real do carro, ordenados (multi-tenant via business_id).
         $stages = \App\Domain\Fsm\Models\SaleProcessStage::query()
@@ -261,9 +266,25 @@ class ServiceOrderController extends Controller
         $stageKeyById = $stages->pluck('key', 'id');
         $boardStageIds = $boardStages->pluck('id');
 
-        // OS do carro: em pipeline (stage de board) OU recém-criadas sem pipeline
-        // (order_type=mecanica, current_stage_id null) — estas caem na coluna inicial
-        // com in_pipeline=false (drag desabilitado até abrir a OS e iniciar o pipeline).
+        // Membership do quadro: OS em pipeline (stage de board) OU recém-criadas sem
+        // pipeline (order_type=mecanica, current_stage_id null) — estas caem na coluna
+        // inicial com in_pipeline=false (drag desabilitado até abrir a OS e iniciar).
+        // Closure reusada pra montar as opções de filtro sobre o MESMO universo.
+        $boardMembership = function ($w) use ($boardStageIds) {
+            $w->whereIn('current_stage_id', $boardStageIds)
+                ->orWhere(function ($w2) {
+                    $w2->where('order_type', 'mecanica')->whereNull('current_stage_id');
+                });
+        };
+
+        // Opções dos selects (Box/Mecânico) — distinct sobre o universo do quadro, ANTES
+        // de aplicar box/mecanico (senão o select encolheria pra própria seleção).
+        [$boxOptions, $mecanicoOptions] = $this->buildBoardFilterOptions(
+            $boardMembership,
+            $businessId,
+            $hasResourceSchema,
+        );
+
         $orders = ServiceOrder::query()
             ->with([
                 'vehicle:id,plate,vehicle_type',
@@ -272,12 +293,11 @@ class ServiceOrderController extends Controller
                 'dviInspectionItems',
                 'dviInspectionItems.arquivos',
             ])
-            ->where(function ($w) use ($boardStageIds) {
-                $w->whereIn('current_stage_id', $boardStageIds)
-                    ->orWhere(function ($w2) {
-                        $w2->where('order_type', 'mecanica')->whereNull('current_stage_id');
-                    });
-            })
+            ->where($boardMembership)
+            // Filtro por mecânico (assigned_user_id) e/ou box (texto livre) — query (canon
+            // charter), não client-side. Guard de schema pra ambiente pré-Wave 2.1.
+            ->when($hasResourceSchema && $mecanico !== null, fn ($qb) => $qb->where('assigned_user_id', $mecanico))
+            ->when($hasResourceSchema && $box !== '', fn ($qb) => $qb->where('box_label', $box))
             ->when($q !== '', function ($qb) use ($q) {
                 $like = '%' . $q . '%';
                 $qb->where(function ($w) use ($like, $q) {
@@ -321,8 +341,61 @@ class ServiceOrderController extends Controller
             'columns'      => $columns,
             'kpis'         => $this->buildBoardKpis($columns),
             'process_seeded' => $boardStages->isNotEmpty(),
-            'filters'      => ['q' => $q],
+            'filters'      => ['q' => $q, 'mecanico' => $mecanico, 'box' => $box !== '' ? $box : null],
+            'filterOptions' => ['boxes' => $boxOptions, 'mecanicos' => $mecanicoOptions],
         ]);
+    }
+
+    /**
+     * Opções dos selects de filtro do quadro — boxes (texto livre) + mecânicos distintos
+     * entre as OS do universo do quadro (closure $membership). Mesmo eixo Box/Mecânico que
+     * o ServiceOrderRichSheet mostra. Global scope ServiceOrder já filtra business_id;
+     * mecânicos resolvidos com scope explícito por business (User não tem global scope).
+     *
+     * @param  \Closure  $membership  filtro de pertencimento ao quadro (reusa o do board)
+     * @return array{0: list<string>, 1: list<array{id:int, nome:string}>}
+     */
+    private function buildBoardFilterOptions(\Closure $membership, int $businessId, bool $hasResourceSchema): array
+    {
+        if (! $hasResourceSchema) {
+            return [[], []];
+        }
+
+        $boxes = ServiceOrder::query()
+            ->where($membership)
+            ->whereNotNull('box_label')
+            ->where('box_label', '!=', '')
+            ->distinct()
+            ->orderBy('box_label')
+            ->pluck('box_label')
+            ->values()
+            ->all();
+
+        $mechanicIds = ServiceOrder::query()
+            ->where($membership)
+            ->whereNotNull('assigned_user_id')
+            ->distinct()
+            ->pluck('assigned_user_id')
+            ->all();
+
+        $mecanicos = [];
+        if (! empty($mechanicIds)) {
+            $users = \App\User::query()
+                ->whereIn('id', $mechanicIds)
+                ->when($businessId > 0, fn ($qb) => $qb->where('business_id', $businessId))
+                ->orderBy('first_name')
+                ->get(['id', 'first_name', 'last_name', 'surname', 'username']);
+
+            foreach ($users as $u) {
+                $nome = trim((string) ($u->first_name ?? '') . ' ' . (string) ($u->last_name ?? ''));
+                if ($nome === '') {
+                    $nome = (string) ($u->surname ?? $u->username ?? '');
+                }
+                $mecanicos[] = ['id' => (int) $u->id, 'nome' => $nome !== '' ? $nome : '—'];
+            }
+        }
+
+        return [$boxes, $mecanicos];
     }
 
     /**

--- a/memory/sessions/2026-06-09-auditoria-lista-kanban-fechamento.md
+++ b/memory/sessions/2026-06-09-auditoria-lista-kanban-fechamento.md
@@ -1,0 +1,29 @@
+# Sessão 2026-06-09 (parte 2) — Auditoria Lista+Kanban pós-#2477 + chore de fechamento
+
+**Papel:** [CC] · **Pedido [W]:** "conferir o que falta na lista e kanban" → gerar ponte de fechamento.
+
+## Auditoria (Board.tsx + Index.tsx lidos no main)
+- **Board ~95%**: drag+FSM+confirm, foto, DVI x/y, MercosulPlate, 6 KPIs, busca, RichSheet — tudo portado.
+- **Index ~90%**: colunas reparo, Lista/Fila, pills, chips FSM, busca, paginação, drawer — ok pós-sweep.
+
+## Gaps → chore PR (esta ponte)
+1. Board: filtro/pivot por mecânico e box (dado já existe no drawer).
+2. Board: prazo restante visível no card atrasado/urgente (countdown discreto).
+3. Index: coluna Sintoma/Defeito (truncada) na tabela.
+4. Front dead-types de locação: delivery_address/daily_rate/dias_locacao/has_return_date/locacoes_ativas etc. em Index/Fila — remover (casa com PR #2475).
+5. Dados: backfill `order_type locacao|null → mecanica` (badge "—" nas OS legadas) + rename LABELS (não keys) dos estágios FSM cacamba_locacao.
+
+## Decisões [W] (2026-06-09)
+- **DESCARTADOS** (exploração do protótipo, não portar): mood calmo/pressão · densidade manual · view "Grade".
+
+## Status fila OS-V2
+F1 ✓ nos 4 itens; V2-1/V2-2 F2 ✓ + F3 merged (#2482 + gates); V2-3/V2-4 F1 verificado, aguardando F2 [W].
+
+## Adendo — comparação de drawers + batch 2 (aprovado [W] "aprovo")
+Drawer real ~85% do protótipo pós-#2482 (DVI semáforo + Fotos&Laudo portados ✓).
+[W] deu **F2 em OS-V2-3 e OS-V2-4** e aprovou registrar 2 gaps novos:
+**OS-V2-5 StageGate** (checklist de bloqueio por etapa — maior gap) e
+**OS-V2-6 lançar item inline** (Peças & Mão de obra read-only no drawer).
+Ponte F3 única gerada pros 4 (append em prototipo-ui-patch/COWORK_NOTES_APPEND_2026-06-09-b.md).
+Gate real SEM botões de simulação (demo-only do protótipo); estados derivam do status/timestamps da OS.
+Timeline real via /fsm/history (criar endpoint se faltar). Residual cosmético: Observação×Sintoma.

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
@@ -28,6 +28,9 @@ import { toast } from 'sonner';
 import { Plus, Search, LayoutGrid, List as ListIcon } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
+import {
+  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
+} from '@/Components/ui/select';
 import KanbanDndProvider from '@/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider';
 import DragConfirmDialog, {
   type PendingTransition,
@@ -56,11 +59,17 @@ interface BoardKpis {
   atrasadas: number;
 }
 
+interface MecanicoOption {
+  id: number;
+  nome: string;
+}
+
 interface Props {
   columns: BoardColumn[];
   kpis: BoardKpis;
   process_seeded: boolean;
-  filters: { q: string };
+  filters: { q: string; mecanico: number | null; box: string | null };
+  filterOptions: { boxes: string[]; mecanicos: MecanicoOption[] };
 }
 
 // ─── Drag mapping FSM (espelha oficina_mecanica_os do OficinaAutoFsmSeeder) ────
@@ -114,15 +123,31 @@ const STAGE_TRANSITIONS: Record<string, Record<string, AllowedMove>> = {
 
 // ─── Component ─────────────────────────────────────────────────────────────
 
-export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filters }: Props) {
+export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filters, filterOptions }: Props) {
   const [searchInput, setSearchInput] = useState(filters.q ?? '');
+
+  // Navega pro board mesclando os filtros atuais com o patch (query — canon charter).
+  // Limpa chaves vazias pra não poluir a URL ('' / null / undefined caem fora).
+  const applyBoardFilter = useCallback(
+    (patch: { q?: string; mecanico?: number | null; box?: string | null }) => {
+      const next: Record<string, string | number> = {};
+      const q = patch.q ?? filters.q ?? '';
+      const mecanico = patch.mecanico !== undefined ? patch.mecanico : filters.mecanico;
+      const box = patch.box !== undefined ? patch.box : filters.box;
+      if (q) next.q = q;
+      if (mecanico) next.mecanico = mecanico;
+      if (box) next.box = box;
+      router.get('/oficina-auto/ordens-servico/board', next, {
+        preserveState: true, preserveScroll: true, replace: true,
+      });
+    },
+    [filters.q, filters.mecanico, filters.box],
+  );
 
   useEffect(() => {
     if (searchInput === (filters.q ?? '')) return;
     const t = setTimeout(() => {
-      router.get('/oficina-auto/ordens-servico/board', { q: searchInput || undefined }, {
-        preserveState: true, preserveScroll: true, replace: true,
-      });
+      applyBoardFilter({ q: searchInput });
     }, 300);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -267,8 +292,8 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
           </div>
         </div>
 
-        {/* Filtro busca */}
-        <div className="bg-white border-b border-border px-6 py-2.5 flex items-center gap-3 sticky top-0 z-10">
+        {/* Filtro busca + selects compactos Mecânico/Box */}
+        <div className="bg-white border-b border-border px-6 py-2.5 flex items-center gap-3 sticky top-0 z-10 flex-wrap">
           <div className="flex items-center gap-2 flex-1 min-w-[240px] max-w-md">
             <Search size={14} className="text-muted-foreground flex-shrink-0" />
             <Input
@@ -280,6 +305,41 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
               aria-label="Buscar OS, placa ou cliente"
             />
           </div>
+
+          {filterOptions.mecanicos.length > 0 && (
+            <Select
+              value={filters.mecanico ? String(filters.mecanico) : 'all'}
+              onValueChange={(v) => applyBoardFilter({ mecanico: v === 'all' ? null : Number(v) })}
+            >
+              <SelectTrigger className="h-8 w-auto gap-1.5 text-xs" aria-label="Filtrar por mecânico">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Mecânico: todos</SelectItem>
+                {filterOptions.mecanicos.map((m) => (
+                  <SelectItem key={m.id} value={String(m.id)}>{m.nome}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
+          {filterOptions.boxes.length > 0 && (
+            <Select
+              value={filters.box ?? 'all'}
+              onValueChange={(v) => applyBoardFilter({ box: v === 'all' ? null : v })}
+            >
+              <SelectTrigger className="h-8 w-auto gap-1.5 text-xs" aria-label="Filtrar por box">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Box: todos</SelectItem>
+                {filterOptions.boxes.map((b) => (
+                  <SelectItem key={b} value={b}>{b}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+
           <span className="ml-auto text-sm text-muted-foreground" aria-live="polite">
             <span className="font-medium text-foreground">{kpis.total} {kpis.total === 1 ? 'OS' : 'OS'}</span>
             {kpis.atrasadas > 0 && (<><span className="mx-1.5 text-muted-foreground">·</span><span className="font-medium text-destructive">{kpis.atrasadas} atrasada{kpis.atrasadas === 1 ? '' : 's'}</span></>)}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -53,18 +53,17 @@ interface ServiceOrder {
   number?: string | null;
   status: string;
   order_type?: OrderType;
-  delivery_address?: string | null;
-  expected_return_date?: string | null;
+  // Atraso de reparo (ADR 0265): só expected_completion. Campos de locação
+  // (delivery_address/expected_return_date/daily_rate/dias_locacao) erradicados.
   expected_completion?: string | null;
-  daily_rate?: number | string | null;
   entered_at?: string | null;
   started_at?: string | null;
   completed_at?: string | null;
+  // Sintoma/defeito relatado na entrada da OS — 1ª linha exibida na coluna "Defeito".
+  notes?: string | null;
   vehicle?: VehicleRel | null;
   contact?: ContactRel | null;
-  // accessors Wave 5-A (vêm via $appends ou load explicit):
   is_overdue?: boolean;
-  dias_locacao?: number | null;
   valor_receber?: number | string | null;
 }
 
@@ -87,7 +86,6 @@ interface Filters {
 }
 
 interface Kpis {
-  locacoes_ativas: number;
   manutencao_ativas: number;
   concluidas_mes: number;
   atrasadas: number;
@@ -105,9 +103,6 @@ interface Stage {
 
 interface SchemaFlags {
   has_order_type: boolean;
-  has_return_date: boolean;
-  has_delivery_address: boolean;
-  has_daily_rate: boolean;
   has_number: boolean;
   has_started_at: boolean;
   has_contact: boolean;
@@ -128,7 +123,6 @@ interface Props {
 }
 
 const EMPTY_KPIS: Kpis = {
-  locacoes_ativas: 0,
   manutencao_ativas: 0,
   concluidas_mes: 0,
   atrasadas: 0,
@@ -164,15 +158,23 @@ function formatBRL(value: number | string | null | undefined): string {
   return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 }
 
-function isOverdueClient(o: ServiceOrder, flags: SchemaFlags): boolean {
+// Atraso de REPARO (ADR 0265 — locação erradicada): só expected_completion.
+function isOverdueClient(o: ServiceOrder): boolean {
   if (typeof o.is_overdue === 'boolean') return o.is_overdue;
   if (['concluida', 'cancelada'].includes(o.status)) return false;
-  const dateField = flags.has_return_date ? o.expected_return_date : o.expected_completion;
+  const dateField = o.expected_completion;
   if (!dateField) return false;
   const target = new Date(dateField.length >= 10 ? dateField.slice(0, 10) : dateField);
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   return target < today;
+}
+
+// 1ª linha do sintoma/defeito relatado (coluna "Defeito" + linha secundária da Fila).
+function firstLine(notes?: string | null): string {
+  if (!notes) return '';
+  const line = notes.split(/\r?\n/)[0]?.trim() ?? '';
+  return line;
 }
 
 // Gap #3 — paleta de cores Tailwind por stage.color (vinda do seeder OficinaAutoFsmSeeder).
@@ -467,10 +469,9 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
         ) : view === 'fila' ? (
           <ServiceOrderFila
             orders={orders.data}
-            isOverdue={(o) => isOverdueClient(o, schemaFlags)}
+            isOverdue={isOverdueClient}
             formatBRDate={formatBRDate}
             formatBRL={formatBRL}
-            hasReturnDate={schemaFlags.has_return_date}
             onOpenFull={setOpenOsId}
           />
         ) : (
@@ -483,6 +484,7 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                     <th className="px-3 py-2 text-left">Tipo</th>
                     <th className="px-3 py-2 text-left">Veículo</th>
                     <th className="px-3 py-2 text-left">Cliente</th>
+                    <th className="px-3 py-2 text-left">Defeito</th>
                     <th className="px-3 py-2 text-left">Entrada</th>
                     <th className="px-3 py-2 text-left">Previsão</th>
                     <th className="px-3 py-2 text-right">Valor</th>
@@ -491,9 +493,10 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                 </thead>
                 <tbody>
                   {orders.data.map((o) => {
-                    const overdue = isOverdueClient(o, schemaFlags);
+                    const overdue = isOverdueClient(o);
                     const startedAt = o.started_at ?? o.entered_at;
-                    const prazo = schemaFlags.has_return_date ? o.expected_return_date : o.expected_completion;
+                    const prazo = o.expected_completion;
+                    const defeito = firstLine(o.notes);
 
                     return (
                       <tr
@@ -549,6 +552,18 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                         </td>
                         <td className="px-3 py-2.5">
                           {o.contact?.name ?? <span className="text-muted-foreground">—</span>}
+                        </td>
+                        <td className="px-3 py-2.5">
+                          {defeito ? (
+                            <span
+                              className="block max-w-[28ch] truncate text-xs text-muted-foreground"
+                              title={defeito}
+                            >
+                              {defeito}
+                            </span>
+                          ) : (
+                            <span className="text-muted-foreground">—</span>
+                          )}
                         </td>
                         <td className="px-3 py-2.5 text-xs tabular-nums text-muted-foreground">
                           {formatBRDate(startedAt)}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFila.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFila.tsx
@@ -31,11 +31,12 @@ export interface FilaOrder {
   status: string;
   // ADR 0265: order_type ∈ {manutencao, mecanica}
   order_type?: 'manutencao' | 'mecanica' | null;
-  delivery_address?: string | null;
-  expected_return_date?: string | null;
+  // Atraso de reparo: só expected_completion (campos de locação erradicados, ADR 0265).
   expected_completion?: string | null;
   entered_at?: string | null;
   started_at?: string | null;
+  // Sintoma/defeito relatado na entrada — exibido na linha secundária da fila.
+  notes?: string | null;
   vehicle?: {
     id: number;
     plate: string;
@@ -45,7 +46,6 @@ export interface FilaOrder {
   } | null;
   contact?: { id: number; name: string } | null;
   is_overdue?: boolean;
-  dias_locacao?: number | null;
   valor_receber?: number | string | null;
 }
 
@@ -55,9 +55,14 @@ interface Props {
   isOverdue: (o: FilaOrder) => boolean;
   formatBRDate: (v?: string | null) => string;
   formatBRL: (v: number | string | null | undefined) => string;
-  hasReturnDate: boolean;
   /** Abre o drawer canônico (ServiceOrderSheet) pra edição/ações FSM. */
   onOpenFull: (id: number) => void;
+}
+
+// 1ª linha do sintoma/defeito relatado (linha secundária da fila).
+function defeitoLine(notes?: string | null): string {
+  if (!notes) return '';
+  return notes.split(/\r?\n/)[0]?.trim() ?? '';
 }
 
 function vehicleLabel(o: FilaOrder): string {
@@ -79,17 +84,16 @@ function FilaItem({
   overdue,
   onSelect,
   formatBRDate,
-  hasReturnDate,
 }: {
   o: FilaOrder;
   active: boolean;
   overdue: boolean;
   onSelect: () => void;
   formatBRDate: Props['formatBRDate'];
-  hasReturnDate: boolean;
 }) {
-  const prazo = hasReturnDate ? o.expected_return_date : o.expected_completion;
+  const prazo = o.expected_completion;
   const meta = [o.vehicle?.plate, typeLabel(o.order_type)].filter((s) => s && s !== '—').join(' · ');
+  const defeito = defeitoLine(o.notes);
   return (
     <button
       type="button"
@@ -111,6 +115,7 @@ function FilaItem({
       <div className="truncate text-xs text-muted-foreground">
         OS {o.number ?? `#${o.id}`} · {o.contact?.name ?? '—'}
       </div>
+      {defeito && <div className="mt-0.5 truncate text-[11px] text-muted-foreground" title={defeito}>{defeito}</div>}
       {meta && <div className="mt-0.5 truncate font-mono text-[11px] text-muted-foreground">{meta}</div>}
     </button>
   );
@@ -122,14 +127,12 @@ function FilaList({
   onSelect,
   isOverdue,
   formatBRDate,
-  hasReturnDate,
 }: {
   orders: FilaOrder[];
   selectedId: number | null;
   onSelect: (id: number) => void;
   isOverdue: Props['isOverdue'];
   formatBRDate: Props['formatBRDate'];
-  hasReturnDate: boolean;
 }) {
   const urgentes = orders.filter((o) => isOverdue(o));
   const demais = orders.filter((o) => !isOverdue(o));
@@ -149,7 +152,6 @@ function FilaList({
             overdue={isOverdue(o)}
             onSelect={() => onSelect(o.id)}
             formatBRDate={formatBRDate}
-            hasReturnDate={hasReturnDate}
           />
         ))}
       </div>
@@ -175,18 +177,17 @@ function OsDetailInline({
   overdue,
   formatBRDate,
   formatBRL,
-  hasReturnDate,
   onOpenFull,
 }: {
   o: FilaOrder;
   overdue: boolean;
   formatBRDate: Props['formatBRDate'];
   formatBRL: Props['formatBRL'];
-  hasReturnDate: boolean;
   onOpenFull: Props['onOpenFull'];
 }) {
-  const prazo = hasReturnDate ? o.expected_return_date : o.expected_completion;
+  const prazo = o.expected_completion;
   const inicio = o.started_at ?? o.entered_at;
+  const defeito = defeitoLine(o.notes);
   return (
     <div className="flex min-h-0 flex-col rounded-lg border bg-card">
       <header className="flex items-start justify-between gap-3 border-b px-4 py-3">
@@ -240,10 +241,10 @@ function OsDetailInline({
               {formatBRL(o.valor_receber)}
             </dd>
           </div>
-          {o.delivery_address && (
+          {defeito && (
             <div className="col-span-2 sm:col-span-3">
-              <dt className="text-xs text-muted-foreground">Endereço</dt>
-              <dd className="text-foreground">{o.delivery_address}</dd>
+              <dt className="text-xs text-muted-foreground">Defeito</dt>
+              <dd className="text-foreground">{o.notes}</dd>
             </div>
           )}
         </dl>
@@ -264,17 +265,15 @@ function AppsRail({
   overdue,
   formatBRDate,
   formatBRL,
-  hasReturnDate,
   onOpenFull,
 }: {
   o: FilaOrder;
   overdue: boolean;
   formatBRDate: Props['formatBRDate'];
   formatBRL: Props['formatBRL'];
-  hasReturnDate: boolean;
   onOpenFull: Props['onOpenFull'];
 }) {
-  const prazo = hasReturnDate ? o.expected_return_date : o.expected_completion;
+  const prazo = o.expected_completion;
   return (
     <aside className="hidden min-h-0 flex-col gap-3 xl:flex">
       <div className="px-1 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Apps vinculados</div>
@@ -335,7 +334,6 @@ export default function ServiceOrderFila({
   isOverdue,
   formatBRDate,
   formatBRL,
-  hasReturnDate,
   onOpenFull,
 }: Props) {
   const [selectedId, setSelectedId] = useState<number | null>(orders[0]?.id ?? null);
@@ -357,7 +355,6 @@ export default function ServiceOrderFila({
         onSelect={setSelectedId}
         isOverdue={isOverdue}
         formatBRDate={formatBRDate}
-        hasReturnDate={hasReturnDate}
       />
       {selected ? (
         <OsDetailInline
@@ -365,7 +362,6 @@ export default function ServiceOrderFila({
           overdue={isOverdue(selected)}
           formatBRDate={formatBRDate}
           formatBRL={formatBRL}
-          hasReturnDate={hasReturnDate}
           onOpenFull={onOpenFull}
         />
       ) : (
@@ -379,7 +375,6 @@ export default function ServiceOrderFila({
           overdue={isOverdue(selected)}
           formatBRDate={formatBRDate}
           formatBRL={formatBRL}
-          hasReturnDate={hasReturnDate}
           onOpenFull={onOpenFull}
         />
       )}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanCard.tsx
@@ -66,6 +66,31 @@ function relativeDays(iso: string | null): string | null {
   return months === 1 ? 'há 1 mês' : `há ${months} meses`;
 }
 
+// Chip de prazo restante — só aparece quando a OS está atrasada (destructive) ou
+// vence em < 24h (warning). Estático: recalcula no render, sem countdown animado.
+function deadlineChip(
+  iso: string | null,
+  isOverdue: boolean,
+): { label: string; overdue: boolean } | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const diffMs = d.getTime() - Date.now();
+
+  if (isOverdue || diffMs < 0) {
+    const lateMs = Math.abs(diffMs);
+    const days = Math.floor(lateMs / (1000 * 60 * 60 * 24));
+    const hours = Math.floor(lateMs / (1000 * 60 * 60));
+    return { label: days >= 1 ? `vencida há ${days}d` : `vencida há ${Math.max(1, hours)}h`, overdue: true };
+  }
+
+  const hoursLeft = diffMs / (1000 * 60 * 60);
+  if (hoursLeft < 24) {
+    return { label: `vence em ${Math.max(1, Math.ceil(hoursLeft))}h`, overdue: false };
+  }
+  return null;
+}
+
 function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }: Props) {
   const draggable = useDraggable({
     id: `so-${card.id}`,
@@ -83,6 +108,7 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
     : {};
 
   const entered = relativeDays(card.entered_at);
+  const deadline = deadlineChip(card.expected_completion, card.is_overdue);
   const hasDvi = card.dvi_total > 0;
   // [W] mod #2 — tooltip claro distinguindo o que o contador significa.
   const dviTooltip = hasDvi
@@ -205,6 +231,23 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
           </span>
         ) : null}
       </div>
+
+      {/* Prazo restante — chip discreto só quando atrasada (destructive) ou < 24h (warning) */}
+      {deadline ? (
+        <div className="mt-1.5 text-right">
+          <span
+            className={
+              'inline-flex items-center gap-0.5 text-[10px] font-semibold rounded px-1.5 py-0.5 border tabular-nums '
+              + (deadline.overdue
+                ? 'text-destructive bg-destructive/10 border-destructive/30'
+                : 'text-warning-foreground bg-warning/10 border-warning/30')
+            }
+            title="Prazo de entrega"
+          >
+            <Clock size={9} aria-hidden /> {deadline.label}
+          </span>
+        </div>
+      ) : null}
 
       {/* OS sem pipeline iniciado — dica discreta */}
       {!card.in_pipeline && (


### PR DESCRIPTION
## Contexto

Chore de fechamento da auditoria [CC] da Lista+Kanban da Oficina pós-#2477 (sweep ADR 0265). 5 itens pequenos + 1 de dados, aprovados por [W] 2026-06-09. Decisão [W]: mood calmo/pressão, densidade manual e view "Grade" do protótipo **descartados** (não portados).

Sessão: `memory/sessions/2026-06-09-auditoria-lista-kanban-fechamento.md`.

## O que entra (4 commits)

**1. `feat` — Board: filtros mecânico/box + chip de prazo** (`74c1d96`)
- Dois selects compactos (DS `<Select>`) na barra de busca — **Mecânico** / **Box** — populados pelo backend (distinct das OS do quadro, mesmo eixo Box/Mecânico do RichSheet). Filtram via **query** `?mecanico=&box=` (canon do charter), não client-side.
- `buildBoardFilterOptions` reusa a closure de membership do board pra as opções não encolherem pra própria seleção. Multi-tenant Tier 0 (ADR 0093) preservado.
- Schema **existe** (`assigned_user_id` + `box_label`, Wave 2.1) → coluna real, nada inventado.
- Card: chip discreto `tabular-nums` no rodapé — `vence em 4h` (warning, <24h) / `vencida há 2d` (destructive, overdue). Estático, sem countdown animado.

**2. `refactor` — Index/Fila: coluna Defeito + dead-types** (`f90487d`)
- Nova coluna **Defeito** (1ª linha das `notes`, truncada ~28ch + `title`) entre Cliente e Entrada; mesma linha na Fila + bloco no detalhe (substitui o antigo "Endereço" de locação).
- Removidos types/UI mortos de locação: `delivery_address`, `expected_return_date`, `daily_rate`, `dias_locacao`, `locacoes_ativas` (Kpis), `has_return_date`/`has_delivery_address`/`has_daily_rate` (SchemaFlags). `isOverdueClient` usa só `expected_completion`.
- **Escopo = Index + Fila** (item 4). `ServiceOrderSheet`/`ProducaoOficina`/`Vehicles` seguem com o payload de locação **intacto** — o `show()` JSON ainda os envia, e mexer neles abriria outra frente (fora desta ponte). #2475 (dead-code) já mergeado → sem conflito.

**3. `chore` — Dados: backfill + labels FSM** (`6bfc613`)
- Migration `000002`: `UPDATE service_orders SET order_type='mecanica' WHERE order_type='locacao' OR order_type IS NULL`. **Driver-agnóstico** (SQLite + MySQL) — complementar à `000001` erradica (MySQL-only). Apaga o badge "—" das OS legadas. `down()` = no-op documentado.
- Migration `000003` + seeder: renomeia **display names** dos estágios `cacamba_locacao` pra vocabulário de reparo (**keys INTOCADAS** — trava FSM/charter v4): Disponível→**Aguardando** · Locada (com cliente)→**Em execução** · Recolhida→**Pronto p/ retirar** · Em manutenção→**Em diagnóstico**. Reflete nos chips FSM data-driven (`ServiceOrderStagePipeline.stage.name` + Index Gap#3). Idempotente + reversível.

**4. `docs` — sessão [CC]** (`11c4b52`)

## Validação

- ✅ `tsc --noEmit` — zero erros novos nos arquivos tocados (os 3 erros remanescentes no Index são **pré-existentes** em `origin/main`; inclusive removi um 4º — o mismatch `hasReturnDate` na Fila).
- ✅ `eslint` nos 4 arquivos — limpo (0 erros, 0 warnings após trocar `<select>` nativo pelo DS `<Select>`).
- ✅ `php -l` nos 4 PHP tocados — sem erros de sintaxe.
- ✅ grep `daily_rate|dias_locacao|delivery_address|expected_return_date` em Index/Fila → só 1 hit (comentário histórico). Demais hits são ProducaoOficina/Sheet/Vehicles (fora de escopo).
- ⚠️ `php artisan test --filter=ServiceOrder` — **todos os testes de ServiceOrder são MySQL-only** (schema UltimatePOS, ADR 0101) e **skipam** no runner local SQLite `:memory:`. Validação funcional depende do **CI** (MySQL). `ServiceOrderBoardTest` cobre o board.

## Notas de ordenação (MySQL)

No MySQL, a `000001` (já mergeada) converte `locacao→manutencao` + estreita o enum antes da `000002` rodar — então em prod as OS legadas já saem do "—" como `manutencao` (badge preenchido). A `000002` garante o caso em SQLite/outros drivers e fecha qualquer `NULL`. O critério "badge preenchido nas OS #1-#4" fica satisfeito nos dois caminhos.

> Se CI verde, pode mergear (itens aprovados por [W]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
