### PR TITLE
feat(oficina): fechamento total do drawer de OS — OS-V2-3..6 (gate, timeline, StageGate, item inline)

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_06_09_130001_add_approval_tracking_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_06_09_130001_add_approval_tracking_to_service_orders.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * F3 OS-V2-3 — Rastreamento do gate de aprovação no service_orders.
+ *
+ * O drawer (DviInlineEditor · `DviGateFoot`) ganha 4 estados (none → pending →
+ * approved | declined). Esses estados DERIVAM do backend, não de simulação:
+ *
+ *   - `approval_requested_at` → carimbado em `enviarAprovacao` (status → orcamento +
+ *     re-envio "Cobrar"). Distingue `none` de `pending`.
+ *   - `approval_decided_at` + `approval_decision` → carimbados pelo fluxo público
+ *     `AprovacaoOsController` quando o cliente aprova/recusa via WhatsApp + PIN.
+ *     `approval_decision ∈ {approved, declined}` (NULL = sem decisão ainda).
+ *
+ * Antes desta migration o estado só dava pra inferir do `status` (orcamento/aprovada),
+ * sem timestamp de "WhatsApp há X" nem caminho de `declined` persistido. O serviço
+ * AprovacaoOsService já existia (token+PIN via cache); estas colunas complementam com
+ * a TRILHA de aprovação que a UI precisa.
+ *
+ * Idempotente (pattern padrão módulo Wave 7+) + nullable (OS antigas ficam `none`).
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: colunas per-OS, herdam o business_id da OS.
+ *
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php::enviarAprovacao
+ * @see Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
+ * @see resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('service_orders')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('service_orders', 'approval_requested_at')) {
+                $table->timestamp('approval_requested_at')
+                    ->nullable()
+                    ->after('delivered_at')
+                    ->comment('F3 OS-V2-3 — quando o orçamento foi enviado pro cliente (gate pending). Re-carimbado a cada "Cobrar".');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'approval_decided_at')) {
+                $table->timestamp('approval_decided_at')
+                    ->nullable()
+                    ->after('approval_requested_at')
+                    ->comment('F3 OS-V2-3 — quando o cliente decidiu (aprovou/recusou) via link público + PIN.');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'approval_decision')) {
+                $table->string('approval_decision', 20)
+                    ->nullable()
+                    ->after('approval_decided_at')
+                    ->comment('F3 OS-V2-3 — decisão do cliente: approved | declined | NULL (sem decisão).');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('service_orders')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            foreach (['approval_decision', 'approval_decided_at', 'approval_requested_at'] as $col) {
+                if (Schema::hasColumn('service_orders', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -43,11 +43,15 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property \Illuminate\Support\Carbon|null $expected_completion
  * @property \Illuminate\Support\Carbon|null $completed_at
  * @property \Illuminate\Support\Carbon|null $delivered_at
+ * @property \Illuminate\Support\Carbon|null $approval_requested_at  F3 OS-V2-3 — gate enviado (pending)
+ * @property \Illuminate\Support\Carbon|null $approval_decided_at    F3 OS-V2-3 — decisão do cliente
+ * @property string|null  $approval_decision  F3 OS-V2-3 — approved | declined | null
  * @property string|null  $notes
  *
  * @property-read bool    $is_overdue       Accessor — sempre false (locação erradicada, ADR 0265; atraso de reparo vive no Controller via expected_completion)
  * @property-read int     $dias_locacao     Accessor — dias decorridos desde entered_at
  * @property-read float   $valor_receber    Accessor — sempre 0.0 (locação erradicada, ADR 0265; valor de reparo = total_items)
+ * @property-read string  $approval_state   Accessor F3 OS-V2-3 — none|pending|approved|declined
  *
  * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-001
  */

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -78,6 +78,9 @@ class ServiceOrder extends Model
         'expected_completion',
         'completed_at',
         'delivered_at',
+        'approval_requested_at', // F3 OS-V2-3 — gate de aprovação (pending)
+        'approval_decided_at',   // F3 OS-V2-3 — decisão do cliente (approved/declined)
+        'approval_decision',     // F3 OS-V2-3 — approved | declined | null
         'notes',
     ];
 
@@ -95,6 +98,8 @@ class ServiceOrder extends Model
         'expected_completion'   => 'datetime',
         'completed_at'          => 'datetime',
         'delivered_at'          => 'datetime',
+        'approval_requested_at' => 'datetime', // F3 OS-V2-3
+        'approval_decided_at'   => 'datetime', // F3 OS-V2-3
     ];
 
     // ------------------------------------------------------------------
@@ -258,6 +263,34 @@ class ServiceOrder extends Model
         return round((float) $this->items()->sum('valor_total'), 2);
     }
 
+    /**
+     * Estado do gate de aprovação (F3 OS-V2-3) — fonte única consumida pelo drawer.
+     *
+     * Deriva de `status` + colunas de aprovação (NUNCA simulação no frontend):
+     *   - approved : OS já aprovada (status='aprovada') OU decisão registrada 'approved'
+     *   - declined : cliente recusou (approval_decision='declined') e ainda não reenviado
+     *   - pending  : orçamento enviado (approval_requested_at) e sem decisão, em orcamento
+     *   - none     : nada enviado ainda
+     *
+     * @return 'none'|'pending'|'approved'|'declined'
+     */
+    public function getApprovalStateAttribute(): string
+    {
+        if ($this->status === 'aprovada' || $this->approval_decision === 'approved') {
+            return 'approved';
+        }
+
+        if ($this->approval_decision === 'declined') {
+            return 'declined';
+        }
+
+        if ($this->approval_requested_at !== null && $this->status === 'orcamento') {
+            return 'pending';
+        }
+
+        return 'none';
+    }
+
     // ------------------------------------------------------------------
     // LGPD audit trail (D7.b — Wave 14)
     // ------------------------------------------------------------------
@@ -281,6 +314,7 @@ class ServiceOrder extends Model
                 'fuel_level_at_entry',
                 'entry_damages',
                 'completed_at',
+                'approval_decision', // F3 OS-V2-3 — decisão do cliente (audit trail LGPD)
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs()

--- a/Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
+++ b/Modules/OficinaAuto/Http/Controllers/Public/AprovacaoOsController.php
@@ -116,6 +116,10 @@ class AprovacaoOsController extends Controller
 
         // Rejeitar: cenário 5 do test — preserva em orcamento (idempotente).
         // Operador humano negocia depois. Loga pra audit ad-hoc.
+        // F3 OS-V2-3 — carimba a decisão `declined` (gate vira vermelho "Revisar e reenviar"
+        // no drawer). NÃO muda o status (segue orcamento) — só registra a trilha de decisão.
+        $this->registrarDecisao($os, 'declined');
+
         Log::info('[AprovacaoOsController] Cliente rejeitou OS via link público', [
             'os_id'       => $os->id,
             'business_id' => $os->business_id,
@@ -150,12 +154,43 @@ class AprovacaoOsController extends Controller
             return;
         }
 
-        $fresh->update(['status' => 'aprovada']);
+        // F3 OS-V2-3 — status → aprovada + carimba a decisão `approved` (gate verde
+        // "Autorizado" no drawer). saveQuietly nas colunas de gate evita re-trigger
+        // do Observer (que só reage a mudança de status — aqui status muda 1x).
+        $fresh->forceFill([
+            'status'              => 'aprovada',
+            'approval_decided_at' => now(),
+            'approval_decision'   => 'approved',
+        ])->save();
 
         Log::info('[AprovacaoOsController] OS aprovada via link público + PIN', [
             'os_id'       => $fresh->id,
             'business_id' => $fresh->business_id,
         ]);
+    }
+
+    /**
+     * Carimba a decisão do cliente nas colunas de gate (F3 OS-V2-3) SEM mudar status.
+     *
+     * Usado no caminho `declined` (status segue orcamento — operador renegocia).
+     * Re-busca sem scope (rota pública sem session) + lock pra consistência.
+     */
+    private function registrarDecisao(ServiceOrder $os, string $decisao): void
+    {
+        $fresh = ServiceOrder::withoutGlobalScopes() // SUPERADMIN: rota pública sem session
+            ->where('id', $os->id)
+            ->where('business_id', $os->business_id)
+            ->lockForUpdate()
+            ->first();
+
+        if ($fresh === null || $fresh->status !== 'orcamento') {
+            return;
+        }
+
+        $fresh->forceFill([
+            'approval_decided_at' => now(),
+            'approval_decision'   => $decisao,
+        ])->saveQuietly(); // saveQuietly — status não muda, sem Observer/WhatsApp
     }
 
     /**

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -663,6 +663,17 @@ class ServiceOrderController extends Controller
                     'notes'          => $item->notes,
                 ])->values()->all(),
                 'items_total' => (float) $order->total_items,
+                // F3 OS-V2-3 — estado do gate de aprovação (none/pending/approved/declined)
+                // + timestamps. O drawer (DviInlineEditor · DviGateFoot) deriva a barra de
+                // 4 estados DESTE payload — nunca de simulação client-side. `total` espelha o
+                // total recomendado da DVI (atenção+crítico), o número que o cliente aprovou.
+                'approval' => [
+                    'state'        => $order->approval_state,
+                    'total'        => (float) $order->dvi_breakdown['total_recomendado'],
+                    'requested_at' => $order->approval_requested_at?->toIso8601String(),
+                    'decided_at'   => $order->approval_decided_at?->toIso8601String(),
+                    'decision'     => $order->approval_decision,
+                ],
                 // F3 OS-V2-2 — itens DVI (Vistoria Digital) pra o semáforo inline editável
                 // do drawer ServiceOrderRichSheet (DviInlineEditor). Mesmo shape do branch
                 // Inertia (Show), + sort_order pra ordenação estável. `budget_item_id` (em
@@ -817,8 +828,28 @@ class ServiceOrderController extends Controller
             ]);
         }
 
-        // status → orcamento dispara o Observer (WhatsApp link + PIN ao cliente).
-        $order->update(['status' => 'orcamento']);
+        // F3 OS-V2-3 — distingue 1º envio de RE-envio ("Cobrar" / "Revisar e reenviar").
+        // O ServiceOrderObserver só dispara o WhatsApp quando o status MUDA pra orcamento;
+        // num re-envio (já em orcamento) precisamos disparar manualmente + limpar a chave
+        // de idempotência de 7d do Job pra forçar um novo envio.
+        $jaEmOrcamento = $order->status === 'orcamento';
+
+        // Carimba o gate: pending (requested_at) + zera decisão anterior (caso reenvio
+        // pós-declined → volta pra pending). status → orcamento (Observer envia WhatsApp).
+        $order->forceFill([
+            'status'                => 'orcamento',
+            'approval_requested_at' => now(),
+            'approval_decided_at'   => null,
+            'approval_decision'     => null,
+        ])->save();
+
+        if ($jaEmOrcamento) {
+            \Illuminate\Support\Facades\Cache::forget("oficina:approval_dispatched:{$order->id}");
+            \Modules\OficinaAuto\Jobs\EnviarLinkAprovacaoWhatsappJob::dispatch(
+                (int) $order->business_id,
+                (int) $order->id,
+            );
+        }
 
         return back()->with('status', [
             'success' => 1,

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -157,6 +157,15 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
             ->name('oficinaauto.service_orders.history');
 
         // ─────────────────────────────────────────────────────────────────────
+        // F3 OS-V2-5 — Gate (checklist de etapa) da próxima transição da OS.
+        // Frontend ServiceOrderStageGate.tsx consome no drawer (entre Peças e
+        // Pipeline FSM). O servidor enforça a mesma regra no fsm/execute (422).
+        // ─────────────────────────────────────────────────────────────────────
+        Route::get('service-orders/{order}/fsm/gate',
+            [ServiceOrderFsmActionController::class, 'gate'])
+            ->name('oficinaauto.service_orders.fsm.gate');
+
+        // ─────────────────────────────────────────────────────────────────────
         // Wave 3 — DVI (Vistoria Digital) US-OFICINA-035.
         // CAPTERRA-FICHA Repair gap #3 — wedge competitivo vs RepairShopr/mHelpDesk.
         // UI consumirá via fetch JSON em Wave 3b (depende drawer ServiceOrderRichSheet PR #1624).

--- a/Modules/OficinaAuto/Services/StageGateEvaluator.php
+++ b/Modules/OficinaAuto/Services/StageGateEvaluator.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services;
+
+use Modules\OficinaAuto\Entities\ServiceOrder;
+
+/**
+ * StageGateEvaluator — checklist de bloqueio por etapa (F3 OS-V2-5).
+ *
+ * Avalia, pra uma ServiceOrder + uma transição FSM (`action_key`), os requisitos que
+ * precisam estar satisfeitos ANTES da OS poder avançar. É o ESPELHO servidor do
+ * "Checklist de etapa" do drawer — a UI mostra, o backend ENFORÇA
+ * (`ServiceOrderFsmActionController::execute` bloqueia 422 quando há requisito
+ * bloqueante pendente, salvo override explícito de gerente/superadmin).
+ *
+ * Regras DATA-DRIVEN por transição (config `RULES` abaixo, keyed por process_key +
+ * action_key) — NUNCA hardcoded no componente React. Hoje a config vive como constante
+ * de módulo (revisável, versionada, server-side); migrar pra tabela/seeder fica trivial
+ * quando houver sinal de customização per-business (ADR 0105 — sem feature sem sinal).
+ *
+ * Tipos de requisito:
+ *   - `auto`   → calculado do estado real (DVI/fotos/itens/aprovação). BLOQUEIA.
+ *   - `manual` → conferência humana (advisory). NÃO bloqueia o servidor (o operador
+ *     confirma na UI via checkbox persistido local); fica como lembrete na checklist.
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: opera sobre uma ServiceOrder já scopada por
+ * business_id (Route Model Binding + global scope). Só lê relações.
+ *
+ * @see Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php (processo oficina_mecanica_os)
+ * @see app/Http/Controllers/ServiceOrderFsmActionController.php
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
+ */
+class StageGateEvaluator
+{
+    /**
+     * Config de requisitos por process_key → action_key → list de regras.
+     *
+     * Cobre o fluxo real de reparo `oficina_mecanica_os` (ADR 0194 · [W] 2026-06-02).
+     * Transições sem regra cadastrada => gate satisfeito (não bloqueia).
+     *
+     * @var array<string, array<string, list<array{key:string, label:string, type:string, blocking:bool}>>>
+     */
+    private const RULES = [
+        'oficina_mecanica_os' => [
+            // Diagnóstico → Aguardando aprovação: precisa da vistoria + foto + orçamento.
+            'enviar_orcamento' => [
+                ['key' => 'dvi_min',   'label' => 'Vistoria DVI com ≥ 1 item',        'type' => 'auto', 'blocking' => true],
+                ['key' => 'dvi_foto',  'label' => '≥ 1 foto na vistoria/laudo',        'type' => 'auto', 'blocking' => true],
+                ['key' => 'orcamento', 'label' => 'Orçamento com ≥ 1 item (peça/MO)',  'type' => 'auto', 'blocking' => true],
+            ],
+            // Aguardando aprovação → (peças|execução): exige aprovação do cliente registrada.
+            'aprovar_pedir_pecas' => [
+                ['key' => 'aprovado', 'label' => 'Aprovação do cliente registrada', 'type' => 'auto', 'blocking' => true],
+            ],
+            'aprovar_executar' => [
+                ['key' => 'aprovado', 'label' => 'Aprovação do cliente registrada', 'type' => 'auto', 'blocking' => true],
+            ],
+            // Execução → Pronto p/ retirar: conferência humana dos itens executados.
+            // Sem flag de "item concluído" no schema (ADR 0105 — sem sinal) → manual/advisory.
+            'concluir_servico' => [
+                ['key' => 'itens_exec', 'label' => 'Itens do serviço executados (conferir)', 'type' => 'manual', 'blocking' => false],
+                ['key' => 'tem_item',   'label' => 'Orçamento com ≥ 1 item lançado',        'type' => 'auto',   'blocking' => true],
+            ],
+        ],
+    ];
+
+    /**
+     * Avalia o gate de uma transição.
+     *
+     * @return array{
+     *   action_key:string,
+     *   requirements:list<array{key:string,label:string,type:string,ok:bool,blocking:bool}>,
+     *   blocking_unmet:int,
+     *   total:int,
+     *   done:int,
+     *   satisfied:bool
+     * }
+     */
+    public function evaluate(ServiceOrder $order, ?string $processKey, string $actionKey): array
+    {
+        $rules = self::RULES[$processKey ?? ''][$actionKey] ?? [];
+
+        if (empty($rules)) {
+            return [
+                'action_key'     => $actionKey,
+                'requirements'   => [],
+                'blocking_unmet' => 0,
+                'total'          => 0,
+                'done'           => 0,
+                'satisfied'      => true,
+            ];
+        }
+
+        $ctx = $this->context($order);
+
+        $requirements = [];
+        $blockingUnmet = 0;
+        $done = 0;
+
+        foreach ($rules as $rule) {
+            $ok = $this->checkRule($rule['key'], $ctx);
+            if ($ok) {
+                $done++;
+            }
+            if ($rule['blocking'] && ! $ok) {
+                $blockingUnmet++;
+            }
+            $requirements[] = [
+                'key'      => $rule['key'],
+                'label'    => $rule['label'],
+                'type'     => $rule['type'],
+                'ok'       => $ok,
+                'blocking' => $rule['blocking'],
+            ];
+        }
+
+        return [
+            'action_key'     => $actionKey,
+            'requirements'   => $requirements,
+            'blocking_unmet' => $blockingUnmet,
+            'total'          => count($rules),
+            'done'           => $done,
+            'satisfied'      => $blockingUnmet === 0,
+        ];
+    }
+
+    /**
+     * Snapshot do estado real da OS pros requisitos `auto`.
+     *
+     * @return array{dvi_count:int, dvi_photos:int, items_count:int, approval_state:string}
+     */
+    private function context(ServiceOrder $order): array
+    {
+        // loadMissing é idempotente — não re-busca relações já carregadas pelo Controller.
+        $order->loadMissing([
+            'dviInspectionItems',
+            'dviInspectionItems.arquivos',
+            'items',
+            'arquivos',
+        ]);
+
+        $dvi = $order->dviInspectionItems;
+
+        // Fotos: por item DVI (HasArquivos) OU foto OS-level (laudo). Qualquer uma conta.
+        $dviItemPhotos = (int) $dvi->sum(fn ($item) => $item->arquivos->count());
+        $laudoPhotos = (int) $order->arquivos->count();
+
+        return [
+            'dvi_count'      => $dvi->count(),
+            'dvi_photos'     => $dviItemPhotos + $laudoPhotos,
+            'items_count'    => $order->items->count(),
+            'approval_state' => $order->approval_state,
+        ];
+    }
+
+    /**
+     * @param  array{dvi_count:int, dvi_photos:int, items_count:int, approval_state:string}  $ctx
+     */
+    private function checkRule(string $key, array $ctx): bool
+    {
+        return match ($key) {
+            'dvi_min'    => $ctx['dvi_count'] >= 1,
+            'dvi_foto'   => $ctx['dvi_photos'] >= 1,
+            'orcamento'  => $ctx['items_count'] >= 1,
+            'tem_item'   => $ctx['items_count'] >= 1,
+            'aprovado'   => $ctx['approval_state'] === 'approved',
+            'itens_exec' => true, // manual/advisory — operador confere; não bloqueia servidor
+            default      => true,
+        };
+    }
+}

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderApprovalGateTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderApprovalGateTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\OficinaAuto\Jobs\EnviarLinkAprovacaoWhatsappJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * F3 OS-V2-3 — Gate de aprovação com ciclo de estados (none → pending → approved | declined).
+ *
+ * Cobre a TRILHA derivada do backend que o drawer (DviInlineEditor · DviGateFoot) espelha:
+ *  - enviarAprovacao carimba approval_requested_at → estado `pending`
+ *  - show() JSON expõe o bloco `approval` (state + total + timestamps)
+ *  - re-envio ("Cobrar") em OS já em orcamento re-dispara o WhatsApp (limpa idempotência)
+ *  - accessor approval_state deriva approved/declined das colunas de decisão
+ *
+ * Multi-tenant biz=1 (ADR 0101). MySQL-only (schema UltimatePOS).
+ */
+
+const BIZ_GATE = 1;
+const PLATE_GATE_PREFIX = 'WGATE';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+});
+
+function gate_user(): ?\App\User
+{
+    return \App\User::withoutGlobalScopes()->where('business_id', BIZ_GATE)->first();
+}
+
+function gate_criaOs(string $suffix, string $status = 'aberta'): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => BIZ_GATE,
+        'plate'        => PLATE_GATE_PREFIX . $suffix,
+        'vehicle_type' => 'automovel',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => BIZ_GATE,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => 'manutencao',
+        'status'      => $status,
+    ]);
+}
+
+function gate_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', PLATE_GATE_PREFIX . $suffix)
+        ->pluck('id')->toArray();
+    if (! empty($vehicles)) {
+        ServiceOrder::withoutGlobalScopes()->whereIn('vehicle_id', $vehicles)->forceDelete();
+        Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+    }
+}
+
+it('enviarAprovacao carimba approval_requested_at e o estado vira pending', function () {
+    Queue::fake();
+    session(['user.business_id' => BIZ_GATE]);
+    $user = gate_user();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = gate_criaOs('A', 'aberta');
+    expect($os->approval_state)->toBe('none');
+
+    $this->actingAs($user)->post("/oficina-auto/ordens-servico/{$os->id}/enviar-aprovacao")
+        ->assertRedirect();
+
+    $fresh = ServiceOrder::withoutGlobalScopes()->find($os->id);
+    expect($fresh->status)->toBe('orcamento');
+    expect($fresh->approval_requested_at)->not->toBeNull();
+    expect($fresh->approval_decision)->toBeNull();
+    expect($fresh->approval_state)->toBe('pending');
+    Queue::assertPushed(EnviarLinkAprovacaoWhatsappJob::class);
+})->afterEach(fn () => gate_cleanup('A'));
+
+it('show() JSON expõe o bloco approval com o estado derivado', function () {
+    session(['user.business_id' => BIZ_GATE]);
+    $user = gate_user();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = gate_criaOs('B', 'orcamento');
+    $os->forceFill(['approval_requested_at' => now()])->save();
+
+    $resp = $this->actingAs($user)
+        ->getJson("/oficina-auto/service-orders/{$os->id}");
+
+    $resp->assertOk();
+    $resp->assertJsonPath('approval.state', 'pending');
+    expect($resp->json('approval'))->toHaveKeys(['state', 'total', 'requested_at', 'decided_at', 'decision']);
+})->afterEach(fn () => gate_cleanup('B'));
+
+it('re-envio (Cobrar) em OS já em orcamento re-dispara o WhatsApp', function () {
+    Queue::fake();
+    session(['user.business_id' => BIZ_GATE]);
+    $user = gate_user();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = gate_criaOs('C', 'orcamento');
+    $os->forceFill(['approval_requested_at' => now()->subHour()])->save();
+    // Simula a chave de idempotência de 7d do Job já gravada (1º envio).
+    Cache::put("oficina:approval_dispatched:{$os->id}", true, now()->addDays(7));
+
+    $this->actingAs($user)->post("/oficina-auto/ordens-servico/{$os->id}/enviar-aprovacao")
+        ->assertRedirect();
+
+    // Cobrar limpa a idempotência + redispara o Job (Observer não dispara: status não muda).
+    expect(Cache::has("oficina:approval_dispatched:{$os->id}"))->toBeFalse();
+    Queue::assertPushed(EnviarLinkAprovacaoWhatsappJob::class);
+})->afterEach(fn () => gate_cleanup('C'));
+
+it('accessor approval_state deriva approved e declined das colunas de decisão', function () {
+    session(['user.business_id' => BIZ_GATE]);
+
+    $aprovada = gate_criaOs('D', 'aprovada');
+    $aprovada->forceFill(['approval_decided_at' => now(), 'approval_decision' => 'approved'])->saveQuietly();
+    expect($aprovada->fresh()->approval_state)->toBe('approved');
+
+    $recusada = gate_criaOs('E', 'orcamento');
+    $recusada->forceFill([
+        'approval_requested_at' => now()->subHour(),
+        'approval_decided_at'   => now(),
+        'approval_decision'     => 'declined',
+    ])->saveQuietly();
+    expect($recusada->fresh()->approval_state)->toBe('declined');
+})->afterEach(function () {
+    gate_cleanup('D');
+    gate_cleanup('E');
+});

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderStageGateTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderStageGateTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\OficinaAuto\Services\StageGateEvaluator;
+
+uses(Tests\TestCase::class);
+
+/**
+ * F3 OS-V2-5 — StageGate (checklist de etapa) ENFORÇADO no servidor.
+ *
+ * A regra-mãe do handoff: "gate é servidor, UI é espelho". Estes specs garantem que
+ * o ServiceOrderFsmActionController::execute BLOQUEIA (422) a transição quando há
+ * requisito bloqueante pendente — independentemente do que a UI mostra — e que o
+ * StageGateEvaluator deriva os requisitos data-driven por (process_key, action_key).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): execute cross-tenant → 404 (route model binding scope).
+ * MySQL-only (schema UltimatePOS · ADR 0101). User real biz=1 (HTTP passa middleware).
+ */
+
+const BIZ_GATE5 = 1;
+const BIZ_GATE5_OUTRO = 99;
+const PLATE_GATE5_PREFIX = 'WGAT5';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasColumn('service_orders', 'current_stage_id')) {
+        $this->markTestSkipped('Wave 7 migration current_stage_id pendente');
+    }
+});
+
+function sg5_user(): ?\App\User
+{
+    return \App\User::withoutGlobalScopes()->where('business_id', BIZ_GATE5)->first();
+}
+
+function sg5_criaOs(string $suffix, int $biz = BIZ_GATE5, string $orderType = 'mecanica'): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_GATE5_PREFIX . $suffix,
+        'vehicle_type' => 'caminhao',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => $orderType,
+        'status'      => 'aberta',
+        'entered_at'  => now(),
+    ]);
+}
+
+function sg5_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', PLATE_GATE5_PREFIX . $suffix)
+        ->pluck('id')->toArray();
+    if (! empty($vehicles)) {
+        ServiceOrder::withoutGlobalScopes()->whereIn('vehicle_id', $vehicles)->forceDelete();
+        Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+    }
+}
+
+// ─── Enforcement HTTP ───────────────────────────────────────────────────────
+
+it('bloqueia (422) enviar_orcamento sem DVI/foto/orçamento — gate é servidor', function () {
+    session(['user.business_id' => BIZ_GATE5]);
+    $user = sg5_user();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = sg5_criaOs('A'); // order_type=mecanica → process oficina_mecanica_os
+
+    $resp = $this->actingAs($user)
+        ->postJson("/oficina-auto/service-orders/{$os->id}/fsm/execute", [
+            'action_key' => 'enviar_orcamento',
+        ]);
+
+    $resp->assertStatus(422);
+    $resp->assertJsonPath('gate.satisfied', false);
+    expect($resp->json('gate.blocking_unmet'))->toBe(3);
+    expect($resp->json('error'))->toContain('Checklist de etapa');
+})->afterEach(fn () => sg5_cleanup('A'));
+
+it('execute cross-tenant é 404 (Tier 0) — OS de outra biz não é alcançável', function () {
+    session(['user.business_id' => BIZ_GATE5]);
+    $user = sg5_user();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = sg5_criaOs('B', BIZ_GATE5_OUTRO); // OS pertence ao biz=99
+
+    $this->actingAs($user)
+        ->postJson("/oficina-auto/service-orders/{$os->id}/fsm/execute", [
+            'action_key' => 'enviar_orcamento',
+        ])
+        ->assertNotFound();
+})->afterEach(fn () => sg5_cleanup('B'));
+
+// ─── Evaluator data-driven ──────────────────────────────────────────────────
+
+it('StageGateEvaluator deriva os 3 requisitos bloqueantes de enviar_orcamento', function () {
+    session(['user.business_id' => BIZ_GATE5]);
+
+    $os = sg5_criaOs('C');
+    $gate = app(StageGateEvaluator::class)->evaluate($os, 'oficina_mecanica_os', 'enviar_orcamento');
+
+    expect($gate['satisfied'])->toBeFalse();
+    expect($gate['total'])->toBe(3);
+    expect($gate['blocking_unmet'])->toBe(3);
+    expect(collect($gate['requirements'])->pluck('key')->all())
+        ->toBe(['dvi_min', 'dvi_foto', 'orcamento']);
+})->afterEach(fn () => sg5_cleanup('C'));
+
+it('StageGateEvaluator não bloqueia transição sem regra cadastrada (ex: cancelar_os)', function () {
+    session(['user.business_id' => BIZ_GATE5]);
+
+    $os = sg5_criaOs('D');
+    $gate = app(StageGateEvaluator::class)->evaluate($os, 'oficina_mecanica_os', 'cancelar_os');
+
+    expect($gate['satisfied'])->toBeTrue();
+    expect($gate['total'])->toBe(0);
+    expect($gate['requirements'])->toBe([]);
+})->afterEach(fn () => sg5_cleanup('D'));

--- a/app/Http/Controllers/ServiceOrderFsmActionController.php
+++ b/app/Http/Controllers/ServiceOrderFsmActionController.php
@@ -17,6 +17,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Services\StageGateEvaluator;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -97,8 +98,13 @@ class ServiceOrderFsmActionController extends Controller
 
         $user = auth()->user();
         $policy = app(StageActionPolicy::class);
+        $gateEvaluator = app(StageGateEvaluator::class);
 
-        $payload = $actions->map(function (SaleStageAction $a) use ($policy, $user, $order) {
+        $payload = $actions->map(function (SaleStageAction $a) use ($policy, $user, $order, $processKey, $gateEvaluator) {
+            // F3 OS-V2-5 — gate por action: a UI desabilita o botão de avançar + tooltip
+            // do que falta. O servidor enforça a MESMA regra em execute() (gate é servidor).
+            $gate = $gateEvaluator->evaluate($order, $processKey, $a->key);
+
             return [
                 'key' => $a->key,
                 'label' => $a->label,
@@ -111,6 +117,7 @@ class ServiceOrderFsmActionController extends Controller
                 'requires_confirmation' => (bool) $a->requires_confirmation,
                 'has_side_effect' => ! empty($a->side_effect_class),
                 'can_execute' => $policy->canExecute($user, $order, $a->key),
+                'gate' => $gate,
             ];
         });
 
@@ -152,7 +159,7 @@ class ServiceOrderFsmActionController extends Controller
     /**
      * Executa uma transição FSM na OS.
      */
-    public function execute(Request $request, ServiceOrder $order, ExecuteStageActionService $service): JsonResponse
+    public function execute(Request $request, ServiceOrder $order, ExecuteStageActionService $service, StageGateEvaluator $gateEvaluator): JsonResponse
     {
         if (! auth()->check()) {
             abort(Response::HTTP_UNAUTHORIZED);
@@ -167,14 +174,45 @@ class ServiceOrderFsmActionController extends Controller
         $validated = $request->validate([
             'action_key' => 'required|string|max:80',
             'payload'    => 'sometimes|array',
+            'override'   => 'sometimes|boolean',
         ]);
+
+        $payload = $validated['payload'] ?? [];
+
+        // F3 OS-V2-5 — gate de etapa ENFORÇADO no servidor (UI é espelho). Bloqueia 422
+        // quando há requisito bloqueante pendente, salvo override explícito de
+        // gerente/superadmin (registrado na trilha sale_stage_history).
+        $gate = $gateEvaluator->evaluate($order, $this->resolveProcessKey($order), $validated['action_key']);
+        if (! $gate['satisfied']) {
+            $user = auth()->user();
+            $canOverride = $user->can('superadmin')
+                || $user->hasRole(['gerente', 'gerente#' . $order->business_id]);
+            $override = (bool) ($validated['override'] ?? false);
+
+            if (! $override || ! $canOverride) {
+                return response()->json([
+                    'error'        => 'Checklist de etapa incompleto — ' . $gate['blocking_unmet'] . ' requisito(s) pendente(s).',
+                    'gate'         => $gate,
+                    'can_override' => $canOverride,
+                ], 422);
+            }
+
+            // Override autorizado — carimba na trilha (payload_snapshot) pra auditoria.
+            $payload['gate_override'] = true;
+            $payload['gate_unmet'] = collect($gate['requirements'])
+                ->where('blocking', true)
+                ->where('ok', false)
+                ->pluck('key')
+                ->values()
+                ->all();
+        }
 
         try {
             $history = $service->execute(
                 $order,
                 $validated['action_key'],
                 auth()->user(),
-                $validated['payload'] ?? [],
+                $payload,
             );
 
             return response()->json([
@@ -389,6 +427,106 @@ class ServiceOrderFsmActionController extends Controller
             'count' => $items->count(),
             'items' => $payload,
         ]);
+    }
+
+    /**
+     * F3 OS-V2-5 — Gate (checklist de etapa) da PRÓXIMA transição da OS.
+     *
+     * Resolve a action de avanço natural do stage atual (menor target sort_order > atual,
+     * incluindo o terminal positivo "entregue"; cancelamentos/garantia ficam de fora por
+     * terem sort_order maior que o avanço positivo) e devolve os requisitos do gate dela.
+     * O drawer (ServiceOrderStageGate) renderiza a checklist + CTA "Avançar" desta resposta.
+     *
+     * Multi-tenant Tier 0 (ADR 0093): ServiceOrder via global scope + permission view.
+     */
+    public function gate(ServiceOrder $order, StageGateEvaluator $gateEvaluator): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        abort_unless(
+            auth()->user()->can('superadmin')
+            || auth()->user()->can('oficinaauto.service_order.view'),
+            Response::HTTP_FORBIDDEN
+        );
+
+        $processKey = $this->resolveProcessKey($order);
+        $currentStageId = $order->current_stage_id ?? null;
+
+        if ($processKey === null || $currentStageId === null) {
+            return response()->json([
+                'service_order_id' => $order->id,
+                'in_pipeline'      => false,
+                'current_stage'    => null,
+                'forward_action'   => null,
+                'requirements'     => [],
+                'blocking_unmet'   => 0,
+                'total'            => 0,
+                'done'             => 0,
+                'satisfied'        => true,
+                'can_override'     => false,
+            ]);
+        }
+
+        $currentStage = SaleProcessStage::find($currentStageId);
+
+        // Action de avanço natural = menor target.sort_order ENTRE os maiores que o atual.
+        $forward = SaleStageAction::with('targetStage')
+            ->where('stage_id', $currentStageId)
+            ->get()
+            ->filter(fn (SaleStageAction $a) => $a->targetStage
+                && (int) $a->targetStage->sort_order > (int) ($currentStage?->sort_order ?? -1))
+            ->sortBy(fn (SaleStageAction $a) => (int) $a->targetStage->sort_order)
+            ->first();
+
+        if ($forward === null) {
+            return response()->json([
+                'service_order_id' => $order->id,
+                'in_pipeline'      => true,
+                'current_stage'    => [
+                    'key'         => $currentStage?->key,
+                    'name'        => $currentStage?->name,
+                    'color'       => $currentStage?->color,
+                    'is_terminal' => (bool) $currentStage?->is_terminal,
+                ],
+                'forward_action'   => null,
+                'requirements'     => [],
+                'blocking_unmet'   => 0,
+                'total'            => 0,
+                'done'             => 0,
+                'satisfied'        => true,
+                'can_override'     => false,
+            ]);
+        }
+
+        $gate = $gateEvaluator->evaluate($order, $processKey, $forward->key);
+
+        $user = auth()->user();
+        $canOverride = $user->can('superadmin')
+            || $user->hasRole(['gerente', 'gerente#' . $order->business_id]);
+
+        return response()->json(array_merge($gate, [
+            'service_order_id' => $order->id,
+            'in_pipeline'      => true,
+            'current_stage'    => [
+                'key'         => $currentStage?->key,
+                'name'        => $currentStage?->name,
+                'color'       => $currentStage?->color,
+                'is_terminal' => (bool) $currentStage?->is_terminal,
+            ],
+            'forward_action'   => [
+                'key'          => $forward->key,
+                'label'        => $forward->label,
+                'is_critical'  => (bool) ($forward->is_critical ?? false),
+                'target_stage' => $forward->targetStage ? [
+                    'key'   => $forward->targetStage->key,
+                    'name'  => $forward->targetStage->name,
+                    'color' => $forward->targetStage->color,
+                ] : null,
+            ],
+            'can_override'     => $canOverride,
+        ]));
     }
 
     /**

--- a/memory/sessions/2026-06-09-os-v2-fechamento-drawer.md
+++ b/memory/sessions/2026-06-09-os-v2-fechamento-drawer.md
@@ -1,0 +1,36 @@
+---
+date: "2026-06-09"
+topic: "Fechamento total do drawer de OS (ServiceOrderRichSheet) — OS-V2-3..6 (gate aprovação, timeline FSM, StageGate, item inline)"
+authors: [C, W]
+related_adrs: [0265-oficina-reparo-erradica-locacao, 0093-multi-tenant-isolation-tier-0, 0143-fsm-pipeline-live-prod-marco-2026-05-12, 0105-cliente-como-sinal-guiar-sem-mandar]
+---
+
+# Fechamento do drawer de OS — OS-V2-3..6 (F3)
+
+Branch `feat/oficina-os-drawer-fechamento` (off `origin/main` @ #2482). 4 itens F1-verificados e F2-aprovados por [W] 2026-06-09. Continuação do batch que landou OS-V2-1 (Fotos & Laudo) + OS-V2-2 (DVI inline) em [#2482](https://github.com/wagnerra23/oimpresso.com/pull/2482).
+
+## O que entrou
+
+- **OS-V2-3 · Gate de aprovação com ciclo de estados.** `DviGateFoot` (4 estados: none → pending → approved | declined) no `DviInlineEditor`, derivados do backend — migration `approval_requested_at`/`approval_decided_at`/`approval_decision` em `service_orders` + accessor `ServiceOrder::approval_state`. `enviarAprovacao` carimba `requested_at` e re-dispara WhatsApp no "Cobrar" (limpa a chave de idempotência de 7d do Job). `AprovacaoOsController` carimba a decisão (`approved`/`declined`). **Sem botões de simulação** (eram demo-only no protótipo).
+- **OS-V2-4 · Timeline FSM auditável.** Drawer passou a usar `ServiceOrderTimeline` real (endpoint **existente** `/service-orders/{id}/history`) com fallback pra `TimelineSkeleton` quando a OS antiga não tem histórico.
+- **OS-V2-5 · StageGate (checklist de etapa).** Seção nova entre Peças e Pipeline FSM (`ServiceOrderStageGate`). Requisitos data-driven por transição (`StageGateEvaluator`, config `oficina_mecanica_os`). **Gate ENFORÇADO no servidor**: `ServiceOrderFsmActionController::execute` retorna 422 quando há bloqueante pendente; a UI é espelho (FsmActionPanel desabilita + tooltip; CTA "Avançar" do StageGate). Override de gerente/superadmin registrado em `sale_stage_history.payload_snapshot`. Novo endpoint `GET /service-orders/{id}/fsm/gate`.
+- **OS-V2-6 · Lançar item inline.** "+ Adicionar item" abre o `ServiceOrderItemFormSheet` (nested, sem fechar o drawer) + Editar/Remover por item via `ServiceOrderItemRow`; refetch atualiza Total OS. Touch ≥44px.
+
+Testes Pest: `ServiceOrderApprovalGateTest` (4), `ServiceOrderStageGateTest` (4). MySQL-only (ADR 0101) — skipam local (sqlite), rodam no CI.
+
+## Deltas vs handoff (intenção preservada, infra real divergiu)
+
+1. **Timeline route** é `/service-orders/{id}/history` (já existia + tem teste), não `/fsm/history` como o handoff supôs. Reusei o existente.
+2. **Gate enforçado no controller do módulo** (`ServiceOrderFsmActionController`), não no `App\Domain\Fsm\ExecuteStageActionService` compartilhado — pra não arriscar o Sells (FSM LIVE prod biz=1). Continua server-authoritative.
+3. **Config do gate** vive como const de módulo (`StageGateEvaluator::RULES`), data-driven server-side, não em tabela/seeder (ADR 0105 — sem tabela nova sem sinal). Migrar pra DB é trivial depois.
+4. **"concluir_servico"** não tem flag "item concluído" no schema → regra manual/advisory + um bloqueante "≥1 item".
+5. Itens **manuais** da checklist persistem em localStorage (advisory, não bloqueiam o servidor) — espelha o protótipo.
+6. **"Revisar e reenviar"** (declined) re-envia direto (→pending); a DVI é editável a qualquer momento.
+7. **Item kebab** = ações inline Pencil/Trash (reuso de `ServiceOrderItemRow`, consistente com Show/Edit), não um menu kebab literal.
+8. **Eventos de aprovação na trilha**: aparecem como transições FSM quando feitas pelo pipeline (`enviar_orcamento`/`aprovar_*`/`recusar_orcamento`) + via estado do gate; a linha não-FSM do "Pedir aprovação" status-based não vira entry separada de `sale_stage_history` (deferido).
+9. **Sem screenshots** nesta sessão — o ambiente não roda o app Inertia + browser; gate visual fica pra [W] no preview/F3.
+10. O doc de sessão `2026-06-09-auditoria-lista-kanban-fechamento.md` do handoff retornou 404 (token expirado) — este log substitui.
+
+## Validação pré-CI
+
+`php -l` (8 arquivos) ✓ · `tsc --noEmit` sem erros nos arquivos tocados ✓ · ESLint 0 erros + 0 warnings novos no baseline (`path|rule` count) ✓ · Pest carrega os 2 arquivos sem colisão (8 skipped local sqlite) ✓.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8648,14 +8648,14 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 2
-			path: Modules/OficinaAuto/Config/retention.php
+			count: 7
+			path: Modules/OficinaAuto/Config/config.php
 
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 7
-			path: Modules/OficinaAuto/Config/config.php
+			count: 2
+			path: Modules/OficinaAuto/Config/retention.php
 
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8658,12 +8658,6 @@ parameters:
 			path: Modules/OficinaAuto/Database/Seeders/RepairSettingsSeeder.php
 
 		-
-			message: '#^Constant Modules\\OficinaAuto\\Entities\\ServiceOrder\:\:RENTAL_ACTIVE_STATUSES is unused\.$#'
-			identifier: classConstant.unused
-			count: 1
-			path: Modules/OficinaAuto/Entities/ServiceOrder.php
-
-		-
 			message: '#^Property Modules\\OficinaAuto\\Entities\\ServiceOrderItem\:\:\$valor_total \(string\) does not accept float\.$#'
 			identifier: assign.propertyType
 			count: 2
@@ -8774,12 +8768,6 @@ parameters:
 		-
 			message: '#^Fallback silencioso detectado\: `if \(empty/isset\)` com atribuição sem `Log\:\:warning` no mesmo bloco\. Adicione `\\Log\:\:warning\(''\<contexto\>'', \[\.\.\.\]\);` ANTES do assignment pra rastreabilidade\. Ver ADR 0212 Camada 2 \(pattern canon\) \+ AP\-18 no LICOES_F3\.$#'
 			identifier: oimpresso.silentFallback
-			count: 1
-			path: Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
-
-		-
-			message: '#^Método `Modules\\OficinaAuto\\Http\\Controllers\\ServiceOrderController\:\:create\(\)` faz Eloquent query \(1\) sem mencionar `business_id`/`businessId`/`BusinessScope` em nenhum lugar\. Tier 0 IRREVOGÁVEL \(ADR 0093\)\: toda query em Module Controller deve filtrar por tenant\. Use `\-\>where\(''business_id'', session\(''user\.business_id''\)\)` OR confirme `BusinessScope` global no Model \+ comentário explícito\. Ver T\-AP\-2 \+ T\-AP\-8 no LICOES_F3\.$#'
-			identifier: oimpresso.missingTenantScope
 			count: 1
 			path: Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
 
@@ -21824,7 +21812,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$color\.$#'
 			identifier: property.notFound
-			count: 5
+			count: 6
 			path: app/Http/Controllers/ServiceOrderFsmActionController.php
 
 		-
@@ -21836,7 +21824,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$key\.$#'
 			identifier: property.notFound
-			count: 6
+			count: 7
 			path: app/Http/Controllers/ServiceOrderFsmActionController.php
 
 		-
@@ -21848,7 +21836,13 @@ parameters:
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$name\.$#'
 			identifier: property.notFound
-			count: 5
+			count: 6
+			path: app/Http/Controllers/ServiceOrderFsmActionController.php
+
+		-
+			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$sort_order\.$#'
+			identifier: property.notFound
+			count: 2
 			path: app/Http/Controllers/ServiceOrderFsmActionController.php
 
 		-

--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -393,3 +393,38 @@ Fallback aceito se `bg-primary` ficar pesado em densidade alta da lista de conve
 ### Residual técnico (não-UI, registrar como chore)
 - Backfill `order_type='locacao'|null → 'mecanica'` nas OS legadas (badge "—" na lista).
 - Renomear LABELS (não keys) dos estágios FSM `cacamba_locacao` pra vocabulário de reparo.
+
+---
+
+## [2026-06-09] F0/F2 — Drawer de OS: fechamento total (batch 2) · aprovado [W]
+
+> Comparação drawer protótipo × `ServiceOrderRichSheet` real pós-#2482 (~85%).
+> [W] deu F2 nos F1 verificados de OS-V2-3/V2-4 e aprovou registrar + executar os 2 gaps novos.
+> Ponte F3 única gerada pra [CL] com os 4 itens.
+
+### OS-V2-3 · Gate "Pedir aprovação" com ciclo de estados — P1 · F2 ✓
+Barra hero abaixo da DVI: none (escura "Total recomendado"+CTA) → pending (âmbar
+"Aguardando · WhatsApp há X" + Cobrar) → approved (verde "Autorizado") | declined
+(vermelha "Revisar e reenviar" → reabre). Estado real vem do status da OS /
+approval_requested_at / approval_decided_at — sem botões de simulação (demo-only).
+
+### OS-V2-4 · Linha do tempo FSM auditável — P1 (era P2; subiu com F2) · F2 ✓
+Substituir TimelineSkeleton pelo fetch do histórico FSM real
+(`/oficina-auto/service-orders/{id}/fsm/history` — criar se não existir, lendo
+sale_stage_history/equivalente): quem · quando · de→pra com chips de transição.
+Eventos de aprovação (enviado/aprovado/recusado) e fotos entram na trilha.
+
+### OS-V2-5 · StageGate — checklist de bloqueio por etapa — P1 · NOVO
+Seção "Checklist de etapa" no drawer: requisitos pra avançar a etapa atual
+(ex.: Diagnóstico→orçamento exige DVI com ≥1 item e foto; Aguardando aprovação→
+execução exige aprovação registrada). Itens com check verde/pendente; botão
+"Avançar etapa" desabilitado com tooltip do que falta. Regras data-driven por
+transição (config no FSM/seeder), não hardcoded no componente.
+
+### OS-V2-6 · Lançar item inline no drawer — P2 · NOVO
+Na seção Peças & Mão de obra: botão "+ Adicionar item" abrindo o
+ServiceOrderItemFormSheet (já existe) sem sair do drawer; editar/remover item
+existente inline (kebab ou swipe). Total OS atualiza via refetch.
+
+### Residual conhecido (não bloqueia)
+- "Observação" vs "Sintoma reportado" — cosmético, campo único no schema.

--- a/prototipo-ui/TELAS_REVIEW_QUEUE.md
+++ b/prototipo-ui/TELAS_REVIEW_QUEUE.md
@@ -104,14 +104,16 @@
 
 ## 🟡 F0 batch — Drawer de OS V2 (ServiceOrderRichSheet · Oficina) (2026-06-09)
 
-> Pedido completo no bloco F0 de [`COWORK_NOTES.md`](COWORK_NOTES.md) (`[2026-06-09] F0 — Fila V2 do drawer de OS`). Origem: avaliação F1.5 [`AVALIACAO_OS_GIT_2026-06-09.md`](AVALIACAO_OS_GIT_2026-06-09.md) + conferência pós-merge [#2477](https://github.com/wagnerra23/oimpresso.com/pull/2477). Vinculado [ADR 0265](../memory/decisions/0265-oficina-reparo-erradica-locacao.md). O drawer `ServiceOrderRichSheet` já espelha o protótipo canon; os 4 itens abaixo são os gaps V2 declarados no próprio código. Prioridade por impacto no balcão do Martinho (biz=164 LIVE).
+> Pedido completo no bloco F0 de [`COWORK_NOTES.md`](COWORK_NOTES.md) (`[2026-06-09] F0 — Fila V2 do drawer de OS`). Origem: avaliação F1.5 [`AVALIACAO_OS_GIT_2026-06-09.md`](AVALIACAO_OS_GIT_2026-06-09.md) + conferência pós-merge [#2477](https://github.com/wagnerra23/oimpresso.com/pull/2477). Vinculado [ADR 0265](../memory/decisions/0265-oficina-reparo-erradica-locacao.md). O drawer `ServiceOrderRichSheet` já espelha o protótipo canon; os 6 itens abaixo são os gaps V2 (4 originais + V2-5/V2-6 abertos no batch 2 de 2026-06-09). **Fechamento total landado: OS-V2-1..6 todos `[x]`.** Prioridade por impacto no balcão do Martinho (biz=164 LIVE).
 
 | Status | Tela | Prioridade | Refs |
 |---|---|---|---|
 | `[x]` | OS-V2-1 · Fotos & Laudo reais no drawer | **P1** | ✅ F3 [CC] 2026-06-09 — upload OS-level real (3 estados + progresso XHR + lightbox legenda editável) via `ServiceOrderPhotoController` (HasArquivos morphTo OS) + seção "Fotos da vistoria" no print A4. Persona Técnico Repair (touch ≥44px). |
 | `[x]` | OS-V2-2 · DVI inline com severidade | **P1** | ✅ F3 [CC] 2026-06-09 — semáforo radiogroup 1-toque (ok/atenção/crítico, tokens DS) no drawer via `DviInlineEditor` + `dvi_items` no payload; CRUD reusa `DviInspectionController` + CTA "Pedir aprovação" (gate WhatsApp). |
-| `[~]` | OS-V2-3 · Gate "Pedir aprovação" hero no drawer | **P2** | Barra de total recomendado + CTA hero "Pedir aprovação" (WhatsApp `wa.me` sem PII). Portar barra do protótipo pro token do DS. |
-| `[~]` | OS-V2-4 · Linha do tempo FSM auditável | **P2** | Timeline real via histórico de transições FSM (quem/quando/de→pra), endpoint `fsm/history` previsto no código. Valor: auditoria de lead time. |
+| `[x]` | OS-V2-3 · Gate "Pedir aprovação" com ciclo de estados | **P1** | ✅ F3 [CC] 2026-06-09 (F2 [W]) — `DviGateFoot` 4 estados (none→pending→approved\|declined) no `DviInlineEditor`, derivados do backend (`ServiceOrder::approval_state` + colunas `approval_requested_at`/`approval_decided_at`/`approval_decision`). "Cobrar" re-dispara WhatsApp; "Revisar e reenviar" volta pra pending. Sem botões de simulação. |
+| `[x]` | OS-V2-4 · Linha do tempo FSM auditável | **P1** | ✅ F3 [CC] 2026-06-09 (F2 [W]) — `ServiceOrderTimeline` real (quem/quando/de→pra com chips) via endpoint existente `/service-orders/{id}/history`; fallback skeleton derivado quando OS antiga sem histórico. |
+| `[x]` | OS-V2-5 · StageGate — checklist de bloqueio por etapa | **P1** | ✅ F3 [CC] 2026-06-09 (F2 [W]) — seção "Checklist de etapa" (`ServiceOrderStageGate`) entre Peças e Pipeline FSM; requisitos data-driven por transição (`StageGateEvaluator`), gate ENFORÇADO no servidor (`fsm/execute` → 422) + UI espelho (FsmActionPanel desabilita). Override gerente/superadmin registrado na trilha. |
+| `[x]` | OS-V2-6 · Lançar item inline no drawer | **P2** | ✅ F3 [CC] 2026-06-09 (F2 [W]) — "+ Adicionar item" abre `ServiceOrderItemFormSheet` nested (sem fechar o drawer) + Editar/Remover por item (`ServiceOrderItemRow`); refetch atualiza Total OS. Touch ≥44px. |
 
 > **Residual técnico (chore, não-UI):** backfill `order_type='locacao'\|null → 'mecanica'` nas OS legadas (badge "—" na lista) · renomear LABELS (não keys) dos estágios FSM `cacamba_locacao` pro vocabulário de reparo.
 

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/DviInlineEditor.tsx
@@ -65,13 +65,42 @@ export interface DviInlineItem {
   budget_item_id?: number | null;
 }
 
+// F3 OS-V2-3 — estado do gate de aprovação, derivado do backend (ServiceOrder::approval_state).
+export type ApprovalState = 'none' | 'pending' | 'approved' | 'declined';
+
+export interface ApprovalInfo {
+  state: ApprovalState;
+  total: number;
+  requested_at: string | null;
+  decided_at: string | null;
+  decision: string | null;
+}
+
 interface Props {
   serviceOrderId: number;
   initialItems: DviInlineItem[];
-  /** Dispara o gate de aprovação (status → orcamento → WhatsApp+PIN). */
+  /**
+   * Dispara o gate de aprovação (status → orcamento → WhatsApp+PIN). O MESMO handler
+   * serve "Pedir aprovação" (none), "Cobrar" (pending) e "Revisar e reenviar" (declined) —
+   * o backend re-carimba `approval_requested_at` e re-dispara o WhatsApp.
+   */
   onPedirAprovacao: () => void;
   /** true enquanto o POST enviar-aprovacao está em voo (vem do drawer). */
   approvalSending?: boolean;
+  /** F3 OS-V2-3 — estado do gate vindo do backend (null = none). */
+  approval?: ApprovalInfo | null;
+}
+
+// Tempo relativo curto pro gate ("há 12 min" / "há 3h" / "há 2d").
+function gateRel(iso: string | null | undefined): string {
+  if (!iso) return '';
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return '';
+  const min = Math.max(1, Math.round((Date.now() - then) / 60000));
+  if (min < 60) return `há ${min} min`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `há ${h}h`;
+  return `há ${Math.round(h / 24)}d`;
 }
 
 // Presets de sistema → mapeiam o "sistema" do protótipo (DVI_SISTEMAS) na dupla
@@ -203,6 +232,7 @@ export default function DviInlineEditor({
   initialItems,
   onPedirAprovacao,
   approvalSending = false,
+  approval = null,
 }: Props) {
   // Estado local seeded uma vez por OS (drawer renderiza com key={data.id}).
   const [items, setItems] = useState<DviInlineItem[]>(initialItems);
@@ -512,33 +542,151 @@ export default function DviInlineEditor({
         </Inline>
       )}
 
-      {/* Rodapé: total recomendado + CTA Pedir aprovação */}
-      <Inline justify="between" gap={3} className="pt-1">
-        <div>
-          <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-            Total recomendado · cliente
+      {/* Rodapé: gate de aprovação com ciclo de estados (F3 OS-V2-3).
+          none → pending → approved | declined. Derivado do backend (approval). */}
+      <DviGateFoot
+        total={sums.total}
+        itemsCount={items.length}
+        approval={approval}
+        sending={approvalSending}
+        onPedirAprovacao={onPedirAprovacao}
+      />
+    </div>
+  );
+}
+
+// F3 OS-V2-3 — barra hero do gate de aprovação com 4 estados (espelha DviGateFoot do
+// protótipo Cowork aprovado [W] 2026-06-09). Sem botões de simulação demo: o estado
+// vem do backend (status da OS + approval_requested_at / approval_decided_at).
+function DviGateFoot({
+  total,
+  itemsCount,
+  approval,
+  sending,
+  onPedirAprovacao,
+}: {
+  total: number;
+  itemsCount: number;
+  approval: ApprovalInfo | null;
+  sending: boolean;
+  onPedirAprovacao: () => void;
+}) {
+  const state: ApprovalState = approval?.state ?? 'none';
+  // Em pending/approved/declined o valor exibido é o que o cliente recebeu (backend);
+  // em none usa o total recomendado vivo da DVI.
+  const shownTotal = state === 'none' ? total : (approval?.total ?? total);
+
+  const spinnerOr = (icon: React.ReactNode) =>
+    sending ? <Loader2 size={14} className="animate-spin" aria-hidden /> : icon;
+
+  if (state === 'pending') {
+    return (
+      <Inline
+        justify="between"
+        gap={3}
+        className="rounded-md border border-warning/40 bg-warning/10 px-3 py-2 pt-2"
+      >
+        <div className="min-w-0">
+          <div className="truncate text-[10px] font-semibold uppercase tracking-wider text-warning-foreground">
+            Aguardando aprovação · WhatsApp {gateRel(approval?.requested_at)}
           </div>
           <div className="text-base font-semibold tabular-nums text-foreground">
-            {fmtBRL(sums.total)}
+            {fmtBRL(shownTotal)}
           </div>
         </div>
         <Button
           type="button"
           size="sm"
+          variant="outline"
           className="h-8 gap-1.5"
-          disabled={approvalSending || items.length === 0}
+          disabled={sending}
           onClick={onPedirAprovacao}
-          title="Envia o orçamento da vistoria por WhatsApp (link + PIN)"
+          title="Reenvia o link de aprovação por WhatsApp"
         >
-          {approvalSending ? (
-            <Loader2 size={14} className="animate-spin" aria-hidden />
-          ) : (
-            <MessageCircle size={14} aria-hidden />
-          )}
-          Pedir aprovação
+          {spinnerOr(<MessageCircle size={14} aria-hidden />)}
+          Cobrar
         </Button>
       </Inline>
-    </div>
+    );
+  }
+
+  if (state === 'approved') {
+    return (
+      <Inline
+        justify="between"
+        gap={3}
+        className="rounded-md border border-success/40 bg-success/10 px-3 py-2"
+      >
+        <div className="min-w-0">
+          <div className="truncate text-[10px] font-semibold uppercase tracking-wider text-success-foreground">
+            Aprovado pelo cliente {gateRel(approval?.decided_at)}
+          </div>
+          <div className="text-base font-semibold tabular-nums text-foreground">
+            {fmtBRL(shownTotal)}
+          </div>
+        </div>
+        <span className="inline-flex shrink-0 items-center gap-1.5 text-sm font-semibold text-success">
+          <Check size={15} aria-hidden />
+          Autorizado
+        </span>
+      </Inline>
+    );
+  }
+
+  if (state === 'declined') {
+    return (
+      <Inline
+        justify="between"
+        gap={3}
+        className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2"
+      >
+        <div className="min-w-0">
+          <div className="truncate text-[10px] font-semibold uppercase tracking-wider text-destructive">
+            Cliente recusou {gateRel(approval?.decided_at)}
+          </div>
+          <div className="text-base font-semibold tabular-nums text-foreground">
+            {fmtBRL(shownTotal)}
+          </div>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="h-8 gap-1.5"
+          disabled={sending}
+          onClick={onPedirAprovacao}
+          title="Revise o orçamento e reenvie o link de aprovação"
+        >
+          {spinnerOr(<MessageCircle size={14} aria-hidden />)}
+          Revisar e reenviar
+        </Button>
+      </Inline>
+    );
+  }
+
+  // none — barra padrão "Total recomendado · cliente" + CTA Pedir aprovação.
+  return (
+    <Inline justify="between" gap={3} className="pt-1">
+      <div>
+        <div className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Total recomendado · cliente
+        </div>
+        <div className="text-base font-semibold tabular-nums text-foreground">
+          {fmtBRL(shownTotal)}
+        </div>
+      </div>
+      <Button
+        type="button"
+        size="sm"
+        className="h-8 gap-1.5"
+        disabled={sending || itemsCount === 0}
+        onClick={onPedirAprovacao}
+        title="Envia o orçamento da vistoria por WhatsApp (link + PIN)"
+      >
+        {spinnerOr(<MessageCircle size={14} aria-hidden />)}
+        Pedir aprovação
+      </Button>
+    </Inline>
   );
 }
 

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -39,6 +39,7 @@ import {
   Edit,
   ExternalLink,
   FileText,
+  ListChecks,
   Loader2,
   Phone,
   Truck,
@@ -55,12 +56,19 @@ import { Button } from '@/Components/ui/button';
 import MercosulPlate from './MercosulPlate';
 import ServiceOrderFsmActionPanel from '../../ServiceOrders/_components/ServiceOrderFsmActionPanel';
 import ServiceOrderStatusBadge from '../../ServiceOrders/_components/ServiceOrderStatusBadge';
+import ServiceOrderTimeline from '../../ServiceOrders/_components/ServiceOrderTimeline';
+import ServiceOrderStageGate from '../../ServiceOrders/_components/ServiceOrderStageGate';
 import VendaDerivadaCard, { type VendaDerivada } from '@/Components/shared/VendaDerivadaCard';
-import { MessageCircle, Printer, Wrench, Package, UserCog } from 'lucide-react';
+import { MessageCircle, Printer, Package } from 'lucide-react';
 import { toast } from 'sonner';
 import { printServiceOrder } from '@/Lib/printServiceOrder';
-import DviInlineEditor, { type DviInlineItem } from './DviInlineEditor';
+import DviInlineEditor, { type DviInlineItem, type ApprovalInfo } from './DviInlineEditor';
 import LaudoPhotoSection, { type LaudoPhoto } from './LaudoPhotoSection';
+import ServiceOrderItemRow, {
+  type ServiceOrderItemDto,
+} from '../../ServiceOrders/_components/ServiceOrderItemRow';
+import ServiceOrderItemFormSheet from '../../ServiceOrders/_components/ServiceOrderItemFormSheet';
+import { Plus } from 'lucide-react';
 
 type OrderType = 'manutencao' | 'mecanica' | null;
 
@@ -129,6 +137,8 @@ interface ServiceOrderDetail {
   dvi_items?: DviInlineItem[];
   // F3 OS-V2-1 — fotos do laudo OS-level (Fotos & Laudo).
   laudo_photos?: LaudoPhoto[];
+  // F3 OS-V2-3 — estado do gate de aprovação (none/pending/approved/declined).
+  approval?: ApprovalInfo | null;
   // D-09 (charter §2 TRAVADO) — venda derivada da OS (origem oficina · ADR 0192).
   // Backend ServiceOrderController::show() popula via shapeVendaDerivada() só quando
   // a OS já gerou Transaction (transição → concluída/pronto). null no resto.
@@ -180,24 +190,6 @@ const capitalize = (s: string | null | undefined) => {
   return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 };
 
-const ITEM_TIPO_LABEL: Record<ItemTipo, string> = {
-  peca: 'Peça',
-  mao_obra: 'Mão de obra',
-  servico_terceiro: 'Serviço terceiro',
-};
-
-const ITEM_TIPO_ICON: Record<ItemTipo, typeof Wrench> = {
-  peca: Package,
-  mao_obra: Wrench,
-  servico_terceiro: UserCog,
-};
-
-const toFloat = (value: number | string | null | undefined): number => {
-  if (value === null || value === undefined || value === '') return 0;
-  const n = typeof value === 'string' ? parseFloat(value) : value;
-  return Number.isNaN(n) ? 0 : n;
-};
-
 export default function ServiceOrderRichSheet({
   serviceOrderId,
   open,
@@ -208,6 +200,10 @@ export default function ServiceOrderRichSheet({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [approvalSending, setApprovalSending] = useState(false);
+  // F3 OS-V2-6 — lançar/editar/remover item inline sem fechar o drawer.
+  const [itemFormOpen, setItemFormOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<ServiceOrderItemDto | null>(null);
+  const [itemBusy, setItemBusy] = useState(false);
 
   const fetchData = useCallback(async () => {
     if (!serviceOrderId) return;
@@ -243,6 +239,57 @@ export default function ServiceOrderRichSheet({
     onOrderChanged?.();
   }, [fetchData, onOrderChanged]);
 
+  // F3 OS-V2-6 — abre o ServiceOrderItemFormSheet (nested) em modo criar/editar.
+  const handleItemAdd = useCallback(() => {
+    setEditingItem(null);
+    setItemFormOpen(true);
+  }, []);
+
+  const handleItemEdit = useCallback((item: ServiceOrderItemDto) => {
+    setEditingItem(item);
+    setItemFormOpen(true);
+  }, []);
+
+  // Após salvar (POST/PUT) refetch do drawer — items_total atualiza + Observer recompõe.
+  const handleItemSaved = useCallback(() => {
+    setItemFormOpen(false);
+    setEditingItem(null);
+    void fetchData();
+    onOrderChanged?.();
+  }, [fetchData, onOrderChanged]);
+
+  // Remover item: DELETE + refetch (Controller tem Policy update + scope Tier 0).
+  const handleItemDelete = useCallback(
+    async (item: ServiceOrderItemDto) => {
+      if (!data) return;
+      setItemBusy(true);
+      try {
+        const meta = document.querySelector('meta[name="csrf-token"]');
+        const res = await fetch(
+          `/oficina-auto/ordens-servico/${data.id}/items/${item.id}`,
+          {
+            method: 'DELETE',
+            credentials: 'same-origin',
+            headers: {
+              Accept: 'application/json',
+              'X-Requested-With': 'XMLHttpRequest',
+              'X-CSRF-TOKEN': meta?.getAttribute('content') ?? '',
+            },
+          },
+        );
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        toast.success('Item removido.');
+        void fetchData();
+        onOrderChanged?.();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : 'Falha ao remover item.');
+      } finally {
+        setItemBusy(false);
+      }
+    },
+    [data, fetchData, onOrderChanged],
+  );
+
   // F3 OS-V2-2 — "Pedir aprovação" no editor DVI dispara o gate de aprovação
   // (status → orcamento → ServiceOrderObserver despacha WhatsApp link + PIN).
   // Reusa o pipeline existente de enviarAprovacao (espelha ApprovalGateCard via
@@ -269,6 +316,7 @@ export default function ServiceOrderRichSheet({
   }, [data, fetchData, onOrderChanged]);
 
   return (
+    <>
     <Sheet open={open} onOpenChange={onOpenChange}>
       <SheetContent
         side="right"
@@ -461,6 +509,7 @@ export default function ServiceOrderRichSheet({
                   initialItems={data.dvi_items ?? []}
                   onPedirAprovacao={handlePedirAprovacao}
                   approvalSending={approvalSending}
+                  approval={data.approval ?? null}
                 />
               </Section>
 
@@ -486,33 +535,15 @@ export default function ServiceOrderRichSheet({
                 {data.items && data.items.length > 0 ? (
                   <>
                     <ul className="divide-y divide-border border border-border rounded-md overflow-hidden bg-white">
-                      {data.items.map((item) => {
-                        const Icon = ITEM_TIPO_ICON[item.tipo];
-                        const qtd = toFloat(item.quantidade);
-                        const vu = toFloat(item.valor_unitario);
-                        const total = toFloat(item.valor_total);
-                        return (
-                          <li
-                            key={item.id}
-                            className="px-3 py-2 grid grid-cols-[auto_1fr_auto] gap-2 items-center text-[11.5px]"
-                          >
-                            <Icon size={14} className="text-muted-foreground shrink-0" aria-hidden />
-                            <div className="min-w-0">
-                              <div className="text-foreground font-medium truncate">
-                                {item.descricao}
-                              </div>
-                              <div className="text-muted-foreground text-[10.5px]">
-                                {ITEM_TIPO_LABEL[item.tipo]} · {qtd.toLocaleString('pt-BR', { maximumFractionDigits: 3 })}
-                                {' × '}
-                                {formatBRL(vu)}
-                              </div>
-                            </div>
-                            <div className="text-foreground tabular-nums font-medium">
-                              {formatBRL(total)}
-                            </div>
-                          </li>
-                        );
-                      })}
+                      {data.items.map((item) => (
+                        <ServiceOrderItemRow
+                          key={item.id}
+                          item={item}
+                          onEdit={handleItemEdit}
+                          onDelete={handleItemDelete}
+                          busy={itemBusy}
+                        />
+                      ))}
                     </ul>
                     <div className="mt-2 flex items-center justify-between px-1">
                       <span className="text-[10.5px] uppercase tracking-wider text-muted-foreground">
@@ -529,6 +560,32 @@ export default function ServiceOrderRichSheet({
                     {data.order_type === 'manutencao' ? ' (cobrança não fechará automática)' : ''}
                   </p>
                 )}
+
+                {/* F3 OS-V2-6 — lançar item inline (abre ServiceOrderItemFormSheet nested,
+                    sem fechar o drawer). Touch ≥44px (h-11). */}
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  className="mt-2 h-11 w-full gap-1.5 sm:h-9"
+                  onClick={handleItemAdd}
+                  disabled={itemBusy}
+                >
+                  <Plus size={14} aria-hidden />
+                  Adicionar item
+                </Button>
+              </Section>
+
+              {/* ─── SEÇÃO CHECKLIST DE ETAPA (F3 OS-V2-5) ───
+                  Requisitos da próxima transição FSM (gate ENFORÇADO no servidor). Entre
+                  Peças e Pipeline FSM. CTA "Avançar" só habilita quando os bloqueantes
+                  passam; gerente/superadmin pode override (registrado na trilha). */}
+              <Section title="Checklist de etapa" icon={ListChecks}>
+                <ServiceOrderStageGate
+                  serviceOrderId={data.id}
+                  enabled={open}
+                  onChanged={handleFsmTransition}
+                />
               </Section>
 
               {/* ─── SEÇÃO 4: PIPELINE FSM (REUSO PR #729) ─── */}
@@ -540,13 +597,23 @@ export default function ServiceOrderRichSheet({
                 />
               </Section>
 
-              {/* ─── SEÇÃO 5: LINHA DO TEMPO (placeholder skeleton V2) ─── */}
+              {/* ─── SEÇÃO 5: LINHA DO TEMPO FSM AUDITÁVEL (F3 OS-V2-4) ───
+                  Histórico real de transições (quem · quando · de→pra com chips) lido de
+                  sale_stage_history via /service-orders/{id}/history. Eventos de aprovação
+                  e pipeline entram na trilha. OS antiga sem histórico cai na skeleton
+                  derivada das datas (fallback). */}
               <Section title="Linha do tempo" icon={Clock}>
-                <TimelineSkeleton
-                  enteredAt={data.entered_at}
-                  expectedReturn={data.expected_completion ?? data.expected_return_date}
-                  completedAt={data.completed_at}
-                  status={data.status}
+                <ServiceOrderTimeline
+                  serviceOrderId={data.id}
+                  enabled={open}
+                  fallback={
+                    <TimelineSkeleton
+                      enteredAt={data.entered_at}
+                      expectedReturn={data.expected_completion ?? data.expected_return_date}
+                      completedAt={data.completed_at}
+                      status={data.status}
+                    />
+                  }
                 />
               </Section>
             </div>
@@ -604,6 +671,19 @@ export default function ServiceOrderRichSheet({
         )}
       </SheetContent>
     </Sheet>
+
+    {/* F3 OS-V2-6 — drawer nested pra criar/editar item (não fecha o drawer-mãe).
+        onSaved refaz o fetch do drawer (items_total atualiza). */}
+    {data && (
+      <ServiceOrderItemFormSheet
+        serviceOrderId={data.id}
+        item={editingItem}
+        open={itemFormOpen}
+        onOpenChange={setItemFormOpen}
+        onSaved={handleItemSaved}
+      />
+    )}
+    </>
   );
 }
 

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
@@ -14,6 +14,7 @@ import {
   Check,
   CircleSlash,
   Loader2,
+  Lock,
   Play,
   Zap,
   X,
@@ -30,6 +31,15 @@ interface FsmStage {
   is_terminal?: boolean;
 }
 
+// F3 OS-V2-5 — gate (checklist de etapa) da action, vindo do backend.
+interface FsmActionGate {
+  requirements: Array<{ key: string; label: string; type: string; ok: boolean; blocking: boolean }>;
+  blocking_unmet: number;
+  total: number;
+  done: number;
+  satisfied: boolean;
+}
+
 interface FsmAction {
   key: string;
   label: string;
@@ -38,6 +48,8 @@ interface FsmAction {
   requires_confirmation: boolean;
   has_side_effect: boolean;
   can_execute: boolean;
+  /** F3 OS-V2-5 — gate da transição (UI desabilita o botão quando não satisfeito). */
+  gate?: FsmActionGate;
 }
 
 interface ActionsResponse {
@@ -307,29 +319,44 @@ export default function ServiceOrderFsmActionPanel({
         </p>
       ) : (
         <div className="flex flex-wrap gap-2">
-          {actionsExecutable.map((action) => (
-            <Button
-              key={action.key}
-              size="sm"
-              variant={action.is_critical ? 'destructive' : 'default'}
-              onClick={() => executeAction(action)}
-              disabled={executing}
-              title={
-                action.target_stage
-                  ? `Move pra: ${action.target_stage.name}`
-                  : 'Ação que não transita stage'
-              }
-              className="text-xs"
-            >
-              {action.is_critical ? (
-                <AlertTriangle size={12} className="mr-1" />
-              ) : (
-                <Play size={12} className="mr-1" />
-              )}
-              {action.label}
-              {action.has_side_effect && <Zap size={12} className="ml-1 opacity-70" />}
-            </Button>
-          ))}
+          {actionsExecutable.map((action) => {
+            // F3 OS-V2-5 — gate não satisfeito desabilita o botão + tooltip do que falta.
+            // O avanço (com override quando aplicável) acontece na seção "Checklist de etapa".
+            const gateBlocked = action.gate ? !action.gate.satisfied : false;
+            const unmetLabels = action.gate
+              ? action.gate.requirements
+                  .filter((r) => r.blocking && !r.ok)
+                  .map((r) => r.label)
+                  .join(' · ')
+              : '';
+            return (
+              <Button
+                key={action.key}
+                size="sm"
+                variant={action.is_critical ? 'destructive' : 'default'}
+                onClick={() => executeAction(action)}
+                disabled={executing || gateBlocked}
+                title={
+                  gateBlocked
+                    ? `Checklist de etapa pendente: ${unmetLabels}`
+                    : action.target_stage
+                      ? `Move pra: ${action.target_stage.name}`
+                      : 'Ação que não transita stage'
+                }
+                className="text-xs"
+              >
+                {gateBlocked ? (
+                  <Lock size={12} className="mr-1" />
+                ) : action.is_critical ? (
+                  <AlertTriangle size={12} className="mr-1" />
+                ) : (
+                  <Play size={12} className="mr-1" />
+                )}
+                {action.label}
+                {action.has_side_effect && <Zap size={12} className="ml-1 opacity-70" />}
+              </Button>
+            );
+          })}
         </div>
       )}
 

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
@@ -1,0 +1,330 @@
+// ServiceOrderStageGate — "Checklist de etapa" (F3 OS-V2-5).
+//
+// Mostra os requisitos da PRÓXIMA transição FSM da OS e bloqueia o avanço até que os
+// requisitos BLOQUEANTES estejam satisfeitos — espelho do gate ENFORÇADO no servidor
+// (ServiceOrderFsmActionController::execute valida a MESMA regra). Porta o conceito
+// StageGate do protótipo Cowork aprovado [W] 2026-06-09 (oficina-forms.jsx).
+//
+// Fonte da verdade: GET /oficina-auto/service-orders/{id}/fsm/gate. O CTA "Avançar"
+// dispara POST /fsm/execute {action_key} — quando o gerente/superadmin tem can_override,
+// um caminho secundário permite avançar com override (registrado na trilha).
+//
+// Requisitos:
+//   - auto   → puxados do sistema (DVI/fotos/itens/aprovação). Bloqueiam.
+//   - manual → conferência humana (checkbox persistido local). Advisory, não bloqueia.
+//
+// CRÍTICO React 19 — useCallback nos handlers. Multi-tenant Tier 0 [ADR 0093]: backend escopa.
+
+import { useCallback, useEffect, useState } from 'react';
+import { ArrowRight, Check, Loader2, Lock } from 'lucide-react';
+import { toast } from 'sonner';
+import { Checkbox } from '@/Components/ui/checkbox';
+
+interface GateRequirement {
+  key: string;
+  label: string;
+  type: 'auto' | 'manual' | string;
+  ok: boolean;
+  blocking: boolean;
+}
+
+interface ForwardAction {
+  key: string;
+  label: string;
+  is_critical: boolean;
+  target_stage: { key: string; name: string; color: string | null } | null;
+}
+
+interface GateResponse {
+  in_pipeline: boolean;
+  current_stage: { key: string; name: string; color: string | null; is_terminal: boolean } | null;
+  forward_action: ForwardAction | null;
+  requirements: GateRequirement[];
+  blocking_unmet: number;
+  total: number;
+  done: number;
+  satisfied: boolean;
+  can_override: boolean;
+}
+
+interface Props {
+  serviceOrderId: number;
+  enabled: boolean;
+  /** Chamado após avançar a etapa — drawer pai refetch (status/itens/timeline). */
+  onChanged?: () => void;
+}
+
+function csrfToken(): string {
+  return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
+}
+
+// Checks manuais (advisory) persistidos por OS — não afetam o gate do servidor.
+function readManual(osId: number): Record<string, boolean> {
+  try {
+    return JSON.parse(localStorage.getItem(`oficina:stageGate:${osId}`) || '{}');
+  } catch {
+    return {};
+  }
+}
+
+export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChanged }: Props) {
+  const [data, setData] = useState<GateResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [executing, setExecuting] = useState(false);
+  const [manual, setManual] = useState<Record<string, boolean>>({});
+
+  const fetchGate = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/oficina-auto/service-orders/${serviceOrderId}/fsm/gate`, {
+        headers: { Accept: 'application/json' },
+        credentials: 'same-origin',
+      });
+      if (res.status === 403) {
+        setError('Sem permissão pra ver o checklist de etapa.');
+        setData(null);
+        return;
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setData((await res.json()) as GateResponse);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erro ao carregar checklist');
+    } finally {
+      setLoading(false);
+    }
+  }, [serviceOrderId]);
+
+  useEffect(() => {
+    if (!enabled || !serviceOrderId) return;
+    setManual(readManual(serviceOrderId));
+    void fetchGate();
+  }, [enabled, serviceOrderId, fetchGate]);
+
+  const setManualCheck = useCallback(
+    (key: string, checked: boolean) => {
+      setManual((prev) => {
+        const next = { ...prev, [key]: checked };
+        try {
+          localStorage.setItem(`oficina:stageGate:${serviceOrderId}`, JSON.stringify(next));
+        } catch {
+          /* ignore quota */
+        }
+        return next;
+      });
+    },
+    [serviceOrderId],
+  );
+
+  const advance = useCallback(
+    async (actionKey: string, override: boolean) => {
+      setExecuting(true);
+      try {
+        const res = await fetch(`/oficina-auto/service-orders/${serviceOrderId}/fsm/execute`, {
+          method: 'POST',
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': csrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({ action_key: actionKey, ...(override ? { override: true } : {}) }),
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          toast.error(json?.error ?? `HTTP ${res.status}`);
+          // Re-sincroniza o gate (pode ter mudado o que falta).
+          void fetchGate();
+          return;
+        }
+        toast.success(override ? 'Etapa avançada (override registrado).' : 'Etapa avançada.');
+        await fetchGate();
+        onChanged?.();
+      } catch (e) {
+        toast.error(e instanceof Error ? e.message : 'Falha ao avançar etapa.');
+      } finally {
+        setExecuting(false);
+      }
+    },
+    [serviceOrderId, fetchGate, onChanged],
+  );
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 size={14} className="animate-spin" />
+        Carregando checklist…
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-xs text-muted-foreground italic">{error}</p>;
+  }
+
+  if (!data || !data.in_pipeline) {
+    return (
+      <p className="text-xs text-muted-foreground italic">
+        Inicie o pipeline FSM (abaixo) pra ver o checklist da próxima etapa.
+      </p>
+    );
+  }
+
+  if (!data.forward_action) {
+    return (
+      <p className="text-xs text-muted-foreground italic">
+        OS no fim do fluxo — sem checklist de avanço.
+      </p>
+    );
+  }
+
+  const forward = data.forward_action;
+  // Sem requisitos cadastrados: avanço livre (sem checklist) — mostra só o CTA.
+  const items = data.requirements.map((r) => ({
+    ...r,
+    displayOk: r.type === 'manual' ? !!manual[r.key] : r.ok,
+  }));
+  const total = items.length;
+  const doneDisplay = items.filter((i) => i.displayOk).length;
+  const pct = total > 0 ? Math.round((doneDisplay / total) * 100) : 100;
+  const ready = data.satisfied; // só requisitos BLOQUEANTES contam pro servidor
+
+  return (
+    <div
+      className={
+        'rounded-lg border p-3 ' +
+        (ready ? 'border-success/40 bg-success/5' : 'border-border bg-muted/30')
+      }
+    >
+      {/* Cabeçalho: ícone + "Gate p/ X" + done/total + pct */}
+      <div className="flex items-start gap-2.5">
+        <span
+          className={
+            'grid h-7 w-7 shrink-0 place-items-center rounded-full ' +
+            (ready ? 'bg-success/15 text-success' : 'bg-destructive/10 text-destructive')
+          }
+          aria-hidden
+        >
+          {ready ? <Check size={14} /> : <Lock size={13} />}
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="text-[12.5px] font-medium text-foreground">
+            Avançar p/ “{forward?.label}”
+          </div>
+          {total > 0 && (
+            <div className={'text-[10.5px] ' + (ready ? 'text-success' : 'text-muted-foreground')}>
+              {doneDisplay}/{total} requisitos ·{' '}
+              {ready ? 'tudo pronto, pode avançar' : 'OS bloqueada até completar a checklist'}
+            </div>
+          )}
+        </div>
+        {total > 0 && (
+          <span
+            className={
+              'shrink-0 text-[13px] font-semibold tabular-nums ' +
+              (ready ? 'text-success' : 'text-destructive')
+            }
+          >
+            {pct}%
+          </span>
+        )}
+      </div>
+
+      {total > 0 && (
+        <>
+          {/* Barra de progresso */}
+          <div className="mt-2.5 h-1 overflow-hidden rounded-full bg-border">
+            <div
+              className={'h-full rounded-full transition-all ' + (ready ? 'bg-success' : 'bg-destructive')}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+
+          {/* Lista de requisitos */}
+          <ul className="mt-2.5 space-y-1">
+            {items.map((it) => (
+              <li
+                key={it.key}
+                className={
+                  'flex items-center gap-2 rounded-md px-2 py-1.5 text-[11.5px] ' +
+                  (it.displayOk ? 'bg-success/10 text-success' : 'bg-muted text-foreground')
+                }
+              >
+                {it.type === 'manual' ? (
+                  <div className="flex w-full items-center gap-2">
+                    <Checkbox
+                      checked={it.displayOk}
+                      onCheckedChange={(c) => setManualCheck(it.key, c === true)}
+                      aria-label={it.label}
+                      className="h-3.5 w-3.5 shrink-0"
+                    />
+                    <span className="flex-1">{it.label}</span>
+                    <span className="text-[9.5px] italic text-muted-foreground">conferir</span>
+                  </div>
+                ) : (
+                  <>
+                    <span
+                      className={
+                        'grid h-3.5 w-3.5 shrink-0 place-items-center rounded-full border text-[9px] ' +
+                        (it.displayOk
+                          ? 'border-success bg-success text-white'
+                          : 'border-border bg-background text-muted-foreground')
+                      }
+                      aria-hidden
+                    >
+                      {it.displayOk ? <Check size={9} /> : '○'}
+                    </span>
+                    <span className="flex-1">{it.label}</span>
+                    <span className="text-[9.5px] italic text-muted-foreground">auto</span>
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {/* CTA de avanço */}
+      {ready ? (
+        <button
+          type="button"
+          disabled={executing}
+          onClick={() => forward && advance(forward.key, false)}
+          className="mt-3 inline-flex h-9 w-full items-center justify-center gap-1.5 rounded-md bg-success text-sm font-medium text-white transition-colors hover:bg-success/90 disabled:opacity-60"
+        >
+          {executing ? <Loader2 size={14} className="animate-spin" /> : <ArrowRight size={14} />}
+          {forward?.label}
+        </button>
+      ) : (
+        <>
+          <button
+            type="button"
+            disabled
+            className="mt-3 inline-flex h-9 w-full cursor-not-allowed items-center justify-center gap-1.5 rounded-md border border-dashed border-border bg-muted text-sm font-medium text-muted-foreground"
+            title={items
+              .filter((i) => i.blocking && !i.ok)
+              .map((i) => i.label)
+              .join(' · ')}
+          >
+            <Lock size={13} />
+            {data.blocking_unmet}{' '}
+            {data.blocking_unmet === 1 ? 'requisito pendente' : 'requisitos pendentes'}
+          </button>
+          {data.can_override && (
+            <button
+              type="button"
+              disabled={executing}
+              onClick={() => forward && advance(forward.key, true)}
+              className="mt-1.5 inline-flex w-full items-center justify-center gap-1 text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-60"
+            >
+              {executing ? <Loader2 size={12} className="animate-spin" /> : null}
+              Avançar mesmo assim (responsável)
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { ArrowRight, Check, Loader2, Lock } from 'lucide-react';
 import { toast } from 'sonner';
 import { Checkbox } from '@/Components/ui/checkbox';
+import { Inline } from '@/Components/layout';
 
 interface GateRequirement {
   key: string;
@@ -153,10 +154,10 @@ export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChang
 
   if (loading) {
     return (
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+      <Inline className="text-xs text-muted-foreground">
         <Loader2 size={14} className="animate-spin" />
         Carregando checklist…
-      </div>
+      </Inline>
     );
   }
 
@@ -199,7 +200,7 @@ export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChang
       }
     >
       {/* Cabeçalho: ícone + "Gate p/ X" + done/total + pct */}
-      <div className="flex items-start gap-2.5">
+      <Inline align="start" className="gap-2.5">
         <span
           className={
             'grid h-7 w-7 shrink-0 place-items-center rounded-full ' +
@@ -230,7 +231,7 @@ export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChang
             {pct}%
           </span>
         )}
-      </div>
+      </Inline>
 
       {total > 0 && (
         <>
@@ -253,7 +254,7 @@ export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChang
                 }
               >
                 {it.type === 'manual' ? (
-                  <div className="flex w-full items-center gap-2">
+                  <Inline className="w-full">
                     <Checkbox
                       checked={it.displayOk}
                       onCheckedChange={(c) => setManualCheck(it.key, c === true)}
@@ -262,7 +263,7 @@ export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChang
                     />
                     <span className="flex-1">{it.label}</span>
                     <span className="text-[9.5px] italic text-muted-foreground">conferir</span>
-                  </div>
+                  </Inline>
                 ) : (
                   <>
                     <span

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStageGate.tsx
@@ -59,10 +59,13 @@ function csrfToken(): string {
   return document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') ?? '';
 }
 
+// Prefixo canônico multi-tenant Tier 0 (R3 · AP3): oimpresso.<modulo>.*
+const stageGateKey = (osId: number) => `oimpresso.oficinaauto.stageGate.${osId}`;
+
 // Checks manuais (advisory) persistidos por OS — não afetam o gate do servidor.
 function readManual(osId: number): Record<string, boolean> {
   try {
-    return JSON.parse(localStorage.getItem(`oficina:stageGate:${osId}`) || '{}');
+    return JSON.parse(localStorage.getItem(stageGateKey(osId)) || '{}');
   } catch {
     return {};
   }
@@ -108,7 +111,7 @@ export default function ServiceOrderStageGate({ serviceOrderId, enabled, onChang
       setManual((prev) => {
         const next = { ...prev, [key]: checked };
         try {
-          localStorage.setItem(`oficina:stageGate:${serviceOrderId}`, JSON.stringify(next));
+          localStorage.setItem(stageGateKey(serviceOrderId), JSON.stringify(next));
         } catch {
           /* ignore quota */
         }

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderTimeline.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderTimeline.tsx
@@ -47,6 +47,12 @@ interface TimelineResponse {
 interface Props {
   serviceOrderId: number;
   enabled: boolean;
+  /**
+   * F3 OS-V2-4 — render alternativo quando o histórico FSM real está VAZIO (OS antiga
+   * sem transições registradas). O drawer passa a TimelineSkeleton derivada das datas
+   * (entered/prazo/completed) pra não deixar a seção careca.
+   */
+  fallback?: React.ReactNode;
 }
 
 const STAGE_COLOR_MAP: Record<string, string> = {
@@ -86,7 +92,7 @@ const formatDate = (iso: string | null) => {
   }
 };
 
-export default function ServiceOrderTimeline({ serviceOrderId, enabled }: Props) {
+export default function ServiceOrderTimeline({ serviceOrderId, enabled, fallback }: Props) {
   const [items, setItems] = useState<TimelineItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -159,10 +165,14 @@ export default function ServiceOrderTimeline({ serviceOrderId, enabled }: Props)
   }
 
   if (items.length === 0) {
+    // F3 OS-V2-4 — OS antiga sem histórico FSM: cai pra timeline derivada (skeleton).
+    if (fallback) {
+      return <>{fallback}</>;
+    }
     return (
       <p className="text-xs text-muted-foreground">
         Nenhuma transição registrada ainda. Inicie o pipeline FSM ou execute uma
-        ação (iniciar locação, recolher caçamba, concluir) — aparecem aqui.
+        ação (iniciar diagnóstico, concluir serviço, entregar) — aparecem aqui.
       </p>
     );
   }


### PR DESCRIPTION
## Fechamento total do drawer de OS — OS-V2-3..6 (F3)

4 itens F1-verificados e **F2 aprovados por [W] 2026-06-09**, fechando o `ServiceOrderRichSheet` (continuação de #2482 que landou OS-V2-1/2).

| Item | O que entrou |
|---|---|
| **OS-V2-3** Gate de aprovação | `DviGateFoot` 4 estados (none → pending → approved \| declined) no `DviInlineEditor`, derivados do backend (migration `approval_requested_at`/`approval_decided_at`/`approval_decision` + accessor `ServiceOrder::approval_state`). "Cobrar" re-dispara WhatsApp (limpa idempotência 7d do Job); decisão carimbada no fluxo público. Sem botões de simulação. |
| **OS-V2-4** Timeline FSM | Drawer usa o `ServiceOrderTimeline` real (`/service-orders/{id}/history`) com fallback skeleton p/ OS antiga sem histórico. |
| **OS-V2-5** StageGate | Seção "Checklist de etapa" (`ServiceOrderStageGate`) entre Peças e Pipeline FSM; requisitos data-driven (`StageGateEvaluator`), **gate enforçado no servidor** (`fsm/execute` → 422), UI espelho (FsmActionPanel desabilita), override gerente/superadmin na trilha. Novo `GET /fsm/gate`. |
| **OS-V2-6** Item inline | "+ Adicionar item" abre `ServiceOrderItemFormSheet` nested + Editar/Remover por item; refetch atualiza Total OS. Touch ≥44px. |

### Testes
- `ServiceOrderApprovalGateTest` (4) · `ServiceOrderStageGateTest` (4) — MySQL-only (ADR 0101), rodam no CI.

### Validação pré-CI (local)
`php -l` 8 arquivos ✓ · `tsc --noEmit` sem erros nos arquivos tocados ✓ · ESLint 0 erros + 0 warnings novos no baseline ✓ · Pest carrega sem colisão ✓. **Sem screenshots** — ambiente não roda o app Inertia+browser; gate visual fica pra [W] no preview.

### Deltas vs handoff (intenção preservada)
1. Timeline usa rota **existente** `/history` (não `/fsm/history`).
2. Gate enforçado no **controller do módulo** (não no `ExecuteStageActionService` compartilhado) p/ não arriscar o Sells LIVE prod — continua server-authoritative.
3. Config do gate como **const de módulo** (`StageGateEvaluator::RULES`), não tabela/seeder (ADR 0105).
4. `concluir_servico`: sem flag "item concluído" no schema → regra manual/advisory + bloqueante "≥1 item".
5. Itens manuais da checklist = localStorage advisory (não bloqueiam servidor).
6. "Revisar e reenviar" (declined) re-envia direto (→pending).
7. Item "kebab" = ações inline Pencil/Trash (reuso `ServiceOrderItemRow`, consistente com Show/Edit).
8. Eventos de aprovação na trilha: via transições FSM quando feitas pelo pipeline + estado do gate; linha não-FSM do "Pedir aprovação" deferida.
9. Doc de sessão do handoff retornou 404 (token expirado) → novo session log substitui.

Refs: OS-V2-3..6 · F2 [W] 2026-06-09 · [ADR 0265](memory/decisions/0265-oficina-reparo-erradica-locacao.md), [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md), [ADR 0143](memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md), [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
