### PR TITLE
fix(deploy): OPcache step usa composer do PATH + Maintenance OFF if:always() (fix outage #2484)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,15 +176,24 @@ jobs:
         # dump-autoload --no-dev REMOVIA as classes dev do classmap → boot (php artisan up)
         # tentava carregar o provider e não achava → 500. Agora alinhado com o dump-autoload
         # principal (mantém dev + ignora platform-req ext-opentelemetry do Hostinger).
+        # 2026-06-09 (fix outage #2484 deploy): trocado `/usr/local/bin/composer` por
+        # `composer` (PATH). O binário hardcoded /usr/local/bin é antigo e NÃO entende
+        # `--ignore-platform-req=ext-opentelemetry` → imprime o HELP do dump-autoload e
+        # sai 1 (mesmo sintoma do incidente 2026-05-26). O step "Composer install" acima
+        # usa `composer` (PATH, 2.x) com a MESMA flag e funciona — agora alinhado.
         run: |
           /tmp/ssh_exec.sh "
             set -o pipefail &&
             cd /home/u906587222/domains/oimpresso.com/public_html &&
-            /usr/local/bin/composer dump-autoload --optimize --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 &&
+            composer dump-autoload --optimize --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 &&
             find app bootstrap config routes -name '*.php' -exec touch {} + 2>&1 | tail -3
           "
 
+      # if: always() — rede de segurança: um deploy que falhe em QUALQUER step anterior
+      # (ex: OPcache 2026-06-09 → site preso em 503) NUNCA pode deixar o site em manutenção.
+      # `php artisan up` é idempotente; rodar sempre garante que o site volta.
       - name: Maintenance mode OFF
+        if: always()
         run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan up"
 
       - name: Reset OPcache via HTTP (LSPHP/LiteSpeed) — opcional


### PR DESCRIPTION
## Causa do 503 no deploy do #2484

O step **"Force OPcache invalidate"** chamava `/usr/local/bin/composer dump-autoload --ignore-platform-req=ext-opentelemetry`. Esse binário hardcoded (composer antigo) **não entende a flag** → imprime o HELP do `dump-autoload` e sai **1** (mesmo sintoma catalogado no incidente 2026-05-26). Como o step falhou, o step seguinte **"Maintenance mode OFF" foi pulado** → o site ficou preso em **503 (maintenance)** até recovery manual (`deploy.yml` com `extra_artisan=up`).

O migrate em si **rodou OK** (item 5 do #2484 aplicado na prod); o problema foi só o pós-migrate.

## Fixes

1. **OPcache step** — `/usr/local/bin/composer` → `composer` (PATH, 2.x). O step "Composer install" logo acima usa `composer` com a **mesma** flag `--ignore-platform-req=ext-opentelemetry` e funciona; agora estão alinhados.
2. **"Maintenance mode OFF"** ganha **`if: always()`** — rede de segurança: um deploy que falhe em **qualquer** step anterior nunca mais pode deixar o site em 503. `php artisan up` é idempotente.

## Validação
- ✅ YAML parseado (js-yaml) — 21 steps, "Maintenance mode OFF" com `if: always()`.
- ⚠️ Só valida de verdade no **próximo deploy.yml**. Site está **UP (200)** agora; sem urgência de re-deploy.

Refs: incidente deploy #2484 2026-06-09

🤖 Generated with [Claude Code](https://claude.com/claude-code)
