### PR TITLE
fix(deploy): OPcache cache-bust redundante nunca bloqueia o smoke gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -176,16 +176,24 @@ jobs:
         # dump-autoload --no-dev REMOVIA as classes dev do classmap → boot (php artisan up)
         # tentava carregar o provider e não achava → 500. Agora alinhado com o dump-autoload
         # principal (mantém dev + ignora platform-req ext-opentelemetry do Hostinger).
-        # 2026-06-09 (fix outage #2484 deploy): trocado `/usr/local/bin/composer` por
-        # `composer` (PATH). O binário hardcoded /usr/local/bin é antigo e NÃO entende
-        # `--ignore-platform-req=ext-opentelemetry` → imprime o HELP do dump-autoload e
-        # sai 1 (mesmo sintoma do incidente 2026-05-26). O step "Composer install" acima
-        # usa `composer` (PATH, 2.x) com a MESMA flag e funciona — agora alinhado.
+        # 2026-06-09 (fix outage #2484): trocou `/usr/local/bin/composer` por `composer`
+        # (PATH) achando ser versão do binário. NÃO resolveu — o deploy do PR #2485
+        # (run 27240100705, main JÁ com aquele fix) FALHOU de novo aqui (HELP + exit 1),
+        # `touch` nunca rodou e o "Smoke test" seguinte foi PULADO (sem validar prod).
+        #
+        # 2026-06-09 (fix definitivo): duas correções —
+        #   1. Espelhar EXATAMENTE o comando do step "Composer install" que funcionou no
+        #      MESMO run: `-o --classmap-authoritative --no-interaction --no-scripts`. O
+        #      `--no-scripts` evita re-disparar o post-autoload-dump (package:discover).
+        #   2. Este dump-autoload é REDUNDANTE — o classmap autoritativo JÁ foi gerado no
+        #      step "Composer install" (com pipefail, falha lá não é silenciosa). Aqui o que
+        #      importa é o `touch` que invalida o OPcache. Por isso: SEM `set -o pipefail`
+        #      neste step + `;` (não `&&`) antes do `touch` → o `touch` SEMPRE roda e este
+        #      cache-bust redundante NUNCA mais bloqueia o smoke gate.
         run: |
           /tmp/ssh_exec.sh "
-            set -o pipefail &&
             cd /home/u906587222/domains/oimpresso.com/public_html &&
-            composer dump-autoload --optimize --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 &&
+            composer dump-autoload -o --classmap-authoritative --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 ;
             find app bootstrap config routes -name '*.php' -exec touch {} + 2>&1 | tail -3
           "
 


### PR DESCRIPTION
## Problema

O step `Force OPcache invalidate` do `deploy.yml` **falha em todo deploy** e, por falhar no meio da cadeia, **pula o `Smoke test`** seguinte — o deploy nunca valida prod sozinho.

Evidência: deploy do PR #2485 ([run 27240100705](https://github.com/wagnerra23/oimpresso.com/actions/runs/27240100705), `main` **já com** o fix #2484/#2486): `composer dump-autoload --optimize --ignore-platform-req=…` imprimiu o HELP e saiu 1; com `set -o pipefail` o `&&` curto-circuitou → `touch` não rodou → smoke pulado. (Prod ficou saudável só porque validei na mão: /login 200, / 200, migration aplicada.)

A troca pra `composer` (PATH) do #2484 **não** resolveu — a diferença real é o comando, não o binário.

## Fix
1. Espelha **exatamente** o `dump-autoload` do step `Composer install` que funciona no mesmo run: `-o --classmap-authoritative --no-interaction --no-scripts`.
2. Remove `set -o pipefail` deste step **redundante** (o classmap autoritativo já é gerado, com pipefail, no `Composer install`) e usa `;` antes do `touch` → o `touch` (a real invalidação de OPcache) **sempre** roda e este cache-bust **nunca mais bloqueia o smoke gate**.

Ref ADR 0216. Workflow é `workflow_dispatch` (manual) — mergear não dispara deploy; vale no próximo deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)