### PR TITLE
feat(financeiro): drawer Unificado 3 camadas — hero fixo + lentes + Lente Fiscal [F2 PR-3]

### DIFF
--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -3999,10 +3999,7 @@
 }
 
 .fin-cowork .fsm-stepper.fsm-full .fsm-step.done .fsm-step-num {
-  /* PR-3 F2 (2026-06-10) — white cru → token (--accent-fg), fallback keyword
-     (drawer é portal fora de .cockpit; var pode não resolver). Espelha o fix
-     do F1 financeiro.css §fsm-step done. */
-  background: var(--fsm-color); color: var(--accent-fg, white); border-color: var(--fsm-color);
+  background: var(--fsm-color); color: var(--accent-fg, white); border-color: var(--fsm-color); /* PR-3 F2: white→token, fallback keyword (portal fora de .cockpit) */
 }
 .fin-cowork .fsm-stepper.fsm-full .fsm-step.current .fsm-step-num {
   background: var(--surface); color: var(--fsm-color-dim);
@@ -4363,8 +4360,7 @@
 }
 .fin-cowork .fin-comment-new button {
   align-self: flex-end;
-  /* PR-3 F2 (2026-06-10) — white cru → token (espelha F1 fin-comment-new). */
-  background: var(--accent); color: var(--accent-fg, white);
+  background: var(--accent); color: var(--accent-fg, white); /* PR-3 F2: white→token */
   border: none; padding: 5px 12px; border-radius: 5px;
   font-family: inherit; font-size: 11.5px; font-weight: 600;
   cursor: pointer;

--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -3999,7 +3999,10 @@
 }
 
 .fin-cowork .fsm-stepper.fsm-full .fsm-step.done .fsm-step-num {
-  background: var(--fsm-color); color: white; border-color: var(--fsm-color);
+  /* PR-3 F2 (2026-06-10) — white cru → token (--accent-fg), fallback keyword
+     (drawer é portal fora de .cockpit; var pode não resolver). Espelha o fix
+     do F1 financeiro.css §fsm-step done. */
+  background: var(--fsm-color); color: var(--accent-fg, white); border-color: var(--fsm-color);
 }
 .fin-cowork .fsm-stepper.fsm-full .fsm-step.current .fsm-step-num {
   background: var(--surface); color: var(--fsm-color-dim);
@@ -4360,7 +4363,8 @@
 }
 .fin-cowork .fin-comment-new button {
   align-self: flex-end;
-  background: var(--accent); color: white;
+  /* PR-3 F2 (2026-06-10) — white cru → token (espelha F1 fin-comment-new). */
+  background: var(--accent); color: var(--accent-fg, white);
   border: none; padding: 5px 12px; border-radius: 5px;
   font-family: inherit; font-size: 11.5px; font-weight: 600;
   cursor: pointer;

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -12,13 +12,14 @@ related_prototype: canon REAL public/cowork-preview/Oimpresso ERP - Chat.html (a
 canon_method: Bundle copy CSS 9054 LOC inteiro (regra Tier 0 feedback-cowork-bundle-aplicar-inteiro) — Ondas 12-21
 runbook: memory/requisitos/Financeiro/RUNBOOK-unificado.md
 tier: A
-charter_version: 14
+charter_version: 15
 ---
 
 # Page Charter — /financeiro/unificado
 
 > **Status:** F3 entregue (PR #349). Charter retroativo (sessão 2026-05-09 audit) — sem `Index.charter.md` original, divergências do ADR ui/0002 documentadas abaixo.
 > Persona: **Eliana [E]** — financeiro escritório, densidade alta, atalhos teclado.
+> **v15 (2026-06-10):** drawer 3 camadas F2 (ver Goals — hero fixo + lentes + Lente Fiscal).
 > **v14 (2026-06-10):** US-FIN-029 ENTREGUE — header "3 lentes" (ver Goals). Pacote F2 aprovado [W] 2026-06-10 ("aprovado", sessão Cowork).
 > **v10 (2026-05-31):** integrado o feedback de [W] da sessão Cowork (handoff de design) — anti-patterns de densidade do header + direção "3 lentes" registrada como intenção **pendente** (ainda **não** aplicada ao live; ver Backlog US-FIN-029). Origem: charter Cowork `Financeiro.charter.md` v1 (superada por este v10 canônico).
 
@@ -33,6 +34,8 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 ## Goals — Features (faz)
 
 - **Header "3 lentes" (US-FIN-029)** (2026-06-10, charter v14, direção [W] 2026-05-31 aprovada / F2 [W] 2026-06-10): segmented **Caixa · A receber · A pagar** no header (pattern pill do Fluxo) é a **camada 1** do filtro grosso — `?lente=caixa|receber|pagar`, clamp default `caixa`, deep-link funciona. Chips lifecycle **refinam DENTRO da lente**; chip incompatível com a lente não renderiza. **KPI-click seta a lente** correspondente (drill-down ADR ui/0002 preservado: "Recebido"→lente receber+chip re, "A pagar"→lente pagar+chip ap, hero→caixa+ar/ap). Backend: `parseFilters()['lente']` + interseção lifecycle∩lente (interseção vazia = lente inteira, defense-in-depth). O menu `···` e o topnav compartilhado **já estavam entregues** via `FinanceiroSubNav` (`_shared/`, ADR 0180 Fase 5, PR #1365) — gatilho US-FIN-TOPNAV-COMPONENT já satisfeito antes desta US. MWART: `memory/requisitos/Financeiro/unificado-3-lentes-visual-comparison.md`. Cobertura `UnificadoLentesGuardTest` (clamp · lente→estados · inválida→caixa · Tier 0 · GET sem mutação).
+
+- **Drawer 3 camadas (F2 PR-3)** (2026-06-10, charter v15, padrão F2-aprovado [W] 2026-06-10): hero do título virou **Camada 1 fixa fora do scroll** (header → hero → tabs → corpo) — label de estado uppercase (destructive se atrasado) · valor mono tabular grande com prefixo/centavos pequenos · chip + vencimento com urgência em palavras à direita · **FSM compacto** 4 etapas (Lançado→Conferido→Conciliado→Liquidado). Seções viram **lentes** (ícone primary/10 + título + chip de status): Conciliação (conciliada = box discreto bg muted + check, não banda verde) e **Lente Fiscal** nova (ISS retido 5% · No DAS do mês ≈6%, estimativa Simples Nacional + link pra sub-tela Impostos & obrigações). KV empilhado do grid 2-col (Onda 18) validado e mantido. 2 `white` crus do bundle tokenizados (`--accent-fg`). Referência F1: `financeiro-page.jsx` Drawer do protótipo Cowork.
 
 - **Diálogo de baixa + coluna Conta** (2026-06-03, charter v12, pedido [W]): o botão **Recebi/Paguei** agora abre **`FinBaixaSheet`** pra escolher **valor** (suporta baixa **parcial**), **conta bancária** de destino, **forma de pagamento** e **plano de contas** — antes era baixa instantânea (1ª conta, valor cheio, meio fixo). Backend `baixar()` aceita os campos (valida `conta_bancaria_id` no business — anti cross-tenant — e enum do meio) com defaults legacy preservados (body vazio = baixa rápida; espaço/bulk seguem instantâneos). Nova **coluna "Conta"** na tabela. `shapeTitulo` expõe `valor_aberto`. Cobertura `UnificadoBaixaDialogGuardTest` (5 GUARDs: valor_aberto, escolhas, parcial, cross-tenant, legacy).
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -36,6 +36,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sh
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
 import PageHeader from '@/Components/shared/PageHeader';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { Grid, Inline, Stack } from '@/Components/layout';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 import KpiCard from '@/Components/shared/KpiCard';
 import { FinPillFrescor } from './_components/FinPillFrescor';
@@ -647,13 +648,15 @@ function DrawerLens({ icon: Icon, title, status, tone = 'muted', children }: {
 }) {
   return (
     <section className="border-t border-border/60 pt-4">
-      <header className="flex items-center gap-2 mb-2.5">
-        <span className="w-[22px] h-[22px] rounded-md grid place-items-center bg-primary/10 text-primary shrink-0" aria-hidden>
-          <Icon size={12} />
-        </span>
-        <h4 className="text-[12.5px] font-semibold text-foreground">{title}</h4>
-        {status && <span className="ml-auto"><DrawerLensChip tone={tone}>{status}</DrawerLensChip></span>}
-      </header>
+      <Inline asChild gap={2} className="mb-2.5">
+        <header>
+          <span className="w-[22px] h-[22px] rounded-md grid place-items-center bg-primary/10 text-primary shrink-0" aria-hidden>
+            <Icon size={12} />
+          </span>
+          <h4 className="text-[12.5px] font-semibold text-foreground">{title}</h4>
+          {status && <span className="ml-auto"><DrawerLensChip tone={tone}>{status}</DrawerLensChip></span>}
+        </header>
+      </Inline>
       {children}
     </section>
   );
@@ -1741,34 +1744,34 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 const stage = settled ? 3 : selected.conferido_at ? 1 : 0;
                 return (
                   <div className="shrink-0 px-5 pt-3 pb-3.5 border-b border-border">
-                    <div className="flex items-end justify-between gap-3">
+                    <Inline align="end" justify="between" gap={3}>
                       <div className="min-w-0">
                         <div className={`text-[10.5px] uppercase tracking-[0.1em] font-semibold ${labelTone}`}>
                           {settled ? 'Liquidado' : isIn ? 'A receber' : 'A pagar'}
                         </div>
-                        <div className="mt-0.5 flex items-baseline">
+                        <Inline align="baseline" gap={0} className="mt-0.5">
                           <span className="text-[13.5px] text-muted-foreground font-mono whitespace-nowrap mr-1">{isIn ? '+ R$' : '− R$'}</span>
                           <span className={`text-[length:var(--fs-9,38px)] leading-none font-semibold tracking-tight font-mono tabular-nums ${isIn ? 'text-success-foreground' : 'text-foreground'}`}>{intPart}</span>
                           <span className="text-[13.5px] text-muted-foreground font-mono">,{decPart}</span>
-                        </div>
+                        </Inline>
                       </div>
-                      <div className="flex flex-col items-end gap-1.5 shrink-0 pb-0.5">
-                        <div className="flex items-center gap-1.5">
+                      <Stack gap={1} align="end" className="gap-1.5 shrink-0 pb-0.5">
+                        <Inline gap={1} className="gap-1.5">
                           <StatusPill s={selected.status} />
                           <FinPillFrescor row={{ due: selected.vencimento, paid_at: settled ? selected.liquidacao : null, vencimento: selected.vencimento }} />
-                        </div>
+                        </Inline>
                         <div className="text-[12.5px] text-muted-foreground tabular-nums whitespace-nowrap">
                           {settled
                             ? <>liq. <b className="font-medium text-foreground">{selected.liquidacao || '—'}</b></>
                             : <>vence <b className="font-medium text-foreground">{fmtBr(selected.vencimento)}</b>{relText && <> · <span className={relCls}>{relText}</span></>}</>}
                         </div>
-                      </div>
-                    </div>
-                    <div className="mt-3 flex items-center" role="img" aria-label={`Etapa do ciclo: ${etapas[stage]}`}>
+                      </Stack>
+                    </Inline>
+                    <Inline gap={0} className="mt-3" role="img" aria-label={`Etapa do ciclo: ${etapas[stage]}`}>
                       {etapas.map((lbl, i) => (
                         <React.Fragment key={lbl}>
                           {i > 0 && <span className={`h-px flex-1 mx-1.5 ${i <= stage ? 'bg-primary' : 'bg-border'}`} aria-hidden />}
-                          <span className="flex items-center gap-1" aria-hidden>
+                          <span className="inline-flex items-center gap-1" aria-hidden>
                             <span className={
                               'w-[15px] h-[15px] rounded-full grid place-items-center text-[9px] font-semibold border ' +
                               (i < stage
@@ -1783,7 +1786,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                           </span>
                         </React.Fragment>
                       ))}
-                    </div>
+                    </Inline>
                   </div>
                 );
               })()}
@@ -1958,7 +1961,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     return (
                       <DrawerLens icon={Landmark} title="Conciliação extrato" status={settled ? '100% match' : 'aguardando'} tone={settled ? 'pos' : 'muted'}>
                         {settled ? (
-                          <div className="rounded-md border border-border bg-muted px-3 py-2 flex items-start gap-2.5">
+                          <Inline align="start" gap={2} className="gap-2.5 rounded-md border border-border bg-muted px-3 py-2">
                             <span className="w-[18px] h-[18px] rounded-full grid place-items-center bg-success/15 text-success-foreground shrink-0 mt-px" aria-hidden>
                               <Check size={11} />
                             </span>
@@ -1966,7 +1969,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                               <div className="font-medium text-foreground">Conciliado com extrato bancário</div>
                               <div className="text-muted-foreground tabular-nums">{selected.liquidacao || '—'} · {brl(selected.valor)} · 100% match</div>
                             </div>
-                          </div>
+                          </Inline>
                         ) : (
                           <div className="rounded-md border border-border px-3 py-2.5 text-[12.5px] text-muted-foreground flex items-start gap-2.5">
                             <span className="text-muted-foreground mt-0.5" aria-hidden>✦</span>
@@ -1991,7 +1994,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     const das = isIn ? (selected.valor ?? 0) * 0.06 : 0;
                     return (
                       <DrawerLens icon={Percent} title="Fiscal" status={hasNf ? 'NF vinculada' : 'sem NF'} tone={hasNf ? 'pos' : 'warn'}>
-                        <div className="grid grid-cols-2 gap-x-5">
+                        <Grid cols={2} gap={0} className="gap-x-5">
                           <div>
                             <div className="text-[10.5px] uppercase tracking-[0.08em] text-muted-foreground">{isIn ? 'NF-e de saída' : 'Documento fiscal'}</div>
                             <div className="text-[13px] text-foreground font-medium truncate">
@@ -2002,17 +2005,17 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                             <div className="text-[10.5px] uppercase tracking-[0.08em] text-muted-foreground">Regime</div>
                             <div className="text-[13px] text-foreground font-medium">Simples Nacional</div>
                           </div>
-                        </div>
+                        </Grid>
                         {isIn && (
                           <div className="mt-1.5 border-t border-border/60">
-                            <div className="flex items-baseline justify-between py-[5px] border-b border-border/60">
+                            <Inline align="baseline" justify="between" gap={0} className="py-[5px] border-b border-border/60">
                               <span className="text-[12.5px] text-muted-foreground">ISS retido · 5%</span>
                               <span className="text-[12.5px] font-mono tabular-nums font-medium">{brl(iss)}</span>
-                            </div>
-                            <div className="flex items-baseline justify-between py-[5px]">
+                            </Inline>
+                            <Inline align="baseline" justify="between" gap={0} className="py-[5px]">
                               <span className="text-[12.5px] text-muted-foreground">No DAS do mês · ≈ 6%</span>
                               <span className="text-[12.5px] font-mono tabular-nums font-medium text-warning-foreground">{brl(das)}</span>
-                            </div>
+                            </Inline>
                           </div>
                         )}
                         <p className="text-[10.5px] text-muted-foreground pt-1.5 leading-relaxed">

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -646,7 +646,7 @@ function DrawerLens({ icon: Icon, title, status, tone = 'muted', children }: {
   children: ReactNode;
 }) {
   return (
-    <section className="border-t border-stone-100 pt-4">
+    <section className="border-t border-border/60 pt-4">
       <header className="flex items-center gap-2 mb-2.5">
         <span className="w-[22px] h-[22px] rounded-md grid place-items-center bg-primary/10 text-primary shrink-0" aria-hidden>
           <Icon size={12} />
@@ -1968,8 +1968,8 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                             </div>
                           </div>
                         ) : (
-                          <div className="rounded-md border border-stone-200 px-3 py-2.5 text-[12.5px] text-stone-600 flex items-start gap-2.5">
-                            <span className="text-stone-500 mt-0.5" aria-hidden>✦</span>
+                          <div className="rounded-md border border-border px-3 py-2.5 text-[12.5px] text-muted-foreground flex items-start gap-2.5">
+                            <span className="text-muted-foreground mt-0.5" aria-hidden>✦</span>
                             <div>
                               Sem match no extrato. Ao liquidar, o sistema procura linhas próximas (±R$ [redacted Tier 0] e ±2 dias) e sugere conciliação automática.
                             </div>
@@ -2004,13 +2004,13 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                           </div>
                         </div>
                         {isIn && (
-                          <div className="mt-1.5 border-t border-stone-100">
-                            <div className="flex items-baseline justify-between py-[5px] border-b border-stone-100">
-                              <span className="text-[12.5px] text-stone-600">ISS retido · 5%</span>
+                          <div className="mt-1.5 border-t border-border/60">
+                            <div className="flex items-baseline justify-between py-[5px] border-b border-border/60">
+                              <span className="text-[12.5px] text-muted-foreground">ISS retido · 5%</span>
                               <span className="text-[12.5px] font-mono tabular-nums font-medium">{brl(iss)}</span>
                             </div>
                             <div className="flex items-baseline justify-between py-[5px]">
-                              <span className="text-[12.5px] text-stone-600">No DAS do mês · ≈ 6%</span>
+                              <span className="text-[12.5px] text-muted-foreground">No DAS do mês · ≈ 6%</span>
                               <span className="text-[12.5px] font-mono tabular-nums font-medium text-warning-foreground">{brl(das)}</span>
                             </div>
                           </div>

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -17,7 +17,7 @@ import React, { useState, useMemo, useCallback, useEffect, type ReactNode } from
 // Onda 12 (2026-05-19) — paridade 100% canon REAL (/cowork-preview/Oimpresso ERP - Chat.html):
 // emoji → lucide-react nos 8 botões + Download icon adicional + remoção FinMonthDigest
 // (não-canon) + summary numérica footer + KPI hero dark.
-import { Search, Plus, Sparkles, CheckSquare, Check, Play, Printer, RefreshCw, FolderOpen, Download, ChevronDown, TrendingUp, TrendingDown, Camera, Landmark, Link as LinkIcon, Eye, FileText } from 'lucide-react';
+import { Search, Plus, Sparkles, CheckSquare, Check, Play, Printer, RefreshCw, FolderOpen, Download, ChevronDown, TrendingUp, TrendingDown, Camera, Landmark, Eye, FileText, Percent, type LucideIcon } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -624,6 +624,41 @@ function useSparkline30d(): SparkPoint[] | null {
 
 // US-FIN-029 — KPI-click agora seta lente + lifecycle coerentes (clicar "A pagar"
 // entra na lente pagar refinada em 'ap'). Drill-down ADR ui/0002 preservado.
+// ── Drawer F2 (PACOTE-FINANCEIRO-F2 PR-3, [W] "aprovado" 2026-06-10) ──────────────────
+// Seção "lente de domínio" do drawer: ícone em quadradinho primary/10 + título sm
+// semibold + chip de status calmo à direita. Referência F1: LensSection em
+// financeiro-page.jsx do protótipo Cowork. Tokens semânticos do @theme (inertia.css) —
+// o drawer é portal FORA de .cockpit, então var(--accent) etc não resolvem aqui.
+function DrawerLensChip({ tone, children }: { tone: 'pos' | 'warn' | 'muted'; children: ReactNode }) {
+  const cls = {
+    pos: 'bg-success/10 text-success-foreground',
+    warn: 'bg-warning/10 text-warning-foreground',
+    muted: 'bg-muted text-muted-foreground',
+  }[tone];
+  return <span className={`inline-flex items-center h-[19px] px-2 rounded-full text-[10.5px] font-medium ${cls}`}>{children}</span>;
+}
+
+function DrawerLens({ icon: Icon, title, status, tone = 'muted', children }: {
+  icon: LucideIcon;
+  title: string;
+  status?: string | null;
+  tone?: 'pos' | 'warn' | 'muted';
+  children: ReactNode;
+}) {
+  return (
+    <section className="border-t border-stone-100 pt-4">
+      <header className="flex items-center gap-2 mb-2.5">
+        <span className="w-[22px] h-[22px] rounded-md grid place-items-center bg-primary/10 text-primary shrink-0" aria-hidden>
+          <Icon size={12} />
+        </span>
+        <h4 className="text-[12.5px] font-semibold text-foreground">{title}</h4>
+        {status && <span className="ml-auto"><DrawerLensChip tone={tone}>{status}</DrawerLensChip></span>}
+      </header>
+      {children}
+    </section>
+  );
+}
+
 function KpiBar({ kpis, lancamentos, onKpiSelect }: { kpis: Kpi; lancamentos: Lancamento[]; onKpiSelect: (lente: LenteId, lifecycle: LifecycleId[]) => void }) {
   // Onda 8 Cowork: hero card dark green com sparkline + 4 secundários canon.
   // Saldo previsto = posição final do mês (Recebido + AReceber - Pago - APagar).
@@ -1670,6 +1705,89 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 </div>
               </SheetHeader>
 
+              {/* PR-3 F2 ([W] "aprovado" 2026-06-10) — Camada 1 "O FATO" FIXA fora do
+                  scroll (ordem canon: header → hero → tabs → corpo). Gabarito Prova
+                  Viva 9.75 / protótipo financeiro-page.jsx Drawer: label de estado
+                  uppercase (destructive se atrasado) · valor mono tabular grande com
+                  prefixo/centavos pequenos (whitespace-nowrap no prefixo) · chip +
+                  vencimento à direita · FSM compacto. Substitui o hero que rolava
+                  junto com o corpo. */}
+              {(() => {
+                const settled = selected.status === 'recebido' || selected.status === 'pago';
+                const isIn = selected.kind === 'receivable';
+                const labelTone =
+                  selected.status === 'atrasado' ? 'text-destructive'
+                  : selected.status === 'vencendo' ? 'text-warning-foreground'
+                  : 'text-muted-foreground';
+                const [intPart, decPart] = (selected.valor ?? 0)
+                  .toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+                  .split(',');
+                // Urgência em palavras (uma linha calma, não pill redundante).
+                const hojeMs = new Date(new Date().toDateString()).getTime();
+                const vencMs = selected.vencimento ? new Date(`${selected.vencimento}T00:00:00`).getTime() : NaN;
+                const delta = Number.isNaN(vencMs) ? null : Math.round((vencMs - hojeMs) / 86400000);
+                const relText = settled || delta === null ? null
+                  : delta < 0 ? `${-delta} ${-delta === 1 ? 'dia' : 'dias'} em atraso`
+                  : delta === 0 ? 'vence hoje'
+                  : `em ${delta} ${delta === 1 ? 'dia' : 'dias'}`;
+                const relCls = delta !== null && delta < 0 ? 'text-destructive font-medium'
+                  : delta !== null && delta <= 3 ? 'text-warning-foreground font-medium'
+                  : 'text-muted-foreground';
+                const fmtBr = (d: string | null | undefined) => (d ? d.split('-').reverse().join('/') : '—');
+                // FSM compacto — etapas do ciclo do título (espelha finFsmStage do
+                // protótipo: liquidado=3 · conferido=1 · lançado=0; conciliação real
+                // ainda não vive no shape → estágio 2 fica no caminho, não asserido).
+                const etapas = ['Lançado', 'Conferido', 'Conciliado', 'Liquidado'];
+                const stage = settled ? 3 : selected.conferido_at ? 1 : 0;
+                return (
+                  <div className="shrink-0 px-5 pt-3 pb-3.5 border-b border-border">
+                    <div className="flex items-end justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className={`text-[10.5px] uppercase tracking-[0.1em] font-semibold ${labelTone}`}>
+                          {settled ? 'Liquidado' : isIn ? 'A receber' : 'A pagar'}
+                        </div>
+                        <div className="mt-0.5 flex items-baseline">
+                          <span className="text-[13.5px] text-muted-foreground font-mono whitespace-nowrap mr-1">{isIn ? '+ R$' : '− R$'}</span>
+                          <span className={`text-[length:var(--fs-9,38px)] leading-none font-semibold tracking-tight font-mono tabular-nums ${isIn ? 'text-success-foreground' : 'text-foreground'}`}>{intPart}</span>
+                          <span className="text-[13.5px] text-muted-foreground font-mono">,{decPart}</span>
+                        </div>
+                      </div>
+                      <div className="flex flex-col items-end gap-1.5 shrink-0 pb-0.5">
+                        <div className="flex items-center gap-1.5">
+                          <StatusPill s={selected.status} />
+                          <FinPillFrescor row={{ due: selected.vencimento, paid_at: settled ? selected.liquidacao : null, vencimento: selected.vencimento }} />
+                        </div>
+                        <div className="text-[12.5px] text-muted-foreground tabular-nums whitespace-nowrap">
+                          {settled
+                            ? <>liq. <b className="font-medium text-foreground">{selected.liquidacao || '—'}</b></>
+                            : <>vence <b className="font-medium text-foreground">{fmtBr(selected.vencimento)}</b>{relText && <> · <span className={relCls}>{relText}</span></>}</>}
+                        </div>
+                      </div>
+                    </div>
+                    <div className="mt-3 flex items-center" role="img" aria-label={`Etapa do ciclo: ${etapas[stage]}`}>
+                      {etapas.map((lbl, i) => (
+                        <React.Fragment key={lbl}>
+                          {i > 0 && <span className={`h-px flex-1 mx-1.5 ${i <= stage ? 'bg-primary' : 'bg-border'}`} aria-hidden />}
+                          <span className="flex items-center gap-1" aria-hidden>
+                            <span className={
+                              'w-[15px] h-[15px] rounded-full grid place-items-center text-[9px] font-semibold border ' +
+                              (i < stage
+                                ? 'bg-primary border-primary text-primary-foreground'
+                                : i === stage
+                                  ? 'bg-background border-primary text-primary shadow-[0_0_0_3px] shadow-primary/15'
+                                  : 'bg-background border-border text-muted-foreground')
+                            }>
+                              {i < stage ? '✓' : i + 1}
+                            </span>
+                            <span className={`text-[10.5px] ${i === stage ? 'text-primary font-semibold' : i < stage ? 'text-foreground' : 'text-muted-foreground'}`}>{lbl}</span>
+                          </span>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+                );
+              })()}
+
               {/* Nav de abas — Cowork canon V2.1 (3 abas: Detalhes/IA/Editar) */}
               <nav className="fin-drawer-tabs" role="tablist" aria-label="Visualização do título">
                 <button
@@ -1731,37 +1849,8 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                   permite o footer (irmão, fora do scroll) ficar sticky-bottom. */}
               {drawerTab === 'detalhes' && (
                 <div className="mt-3 px-5 pb-4 space-y-5 text-[13px] flex-1 overflow-y-auto min-h-0">
-                  {/* Onda 17 (2026-05-20) — Hierarquia visual canon: UPPERCASE label colorido
-                      por status + date 22px BIG + amount 34px BIG (verde se receivable, stone
-                      se payable) + StatusPill + FrescorPill inline.
-                      Match prototype financeiro-app.jsx:772-806. */}
-                  {(() => {
-                    const settled = selected.status === 'recebido' || selected.status === 'pago';
-                    const labelTone =
-                      selected.status === 'atrasado' ? 'text-rose-700'
-                      : selected.status === 'vencendo' ? 'text-amber-700'
-                      : 'text-stone-500';
-                    return (
-                      <div>
-                        <div className={`text-[11px] uppercase tracking-widest font-medium ${labelTone}`}>
-                          {settled ? 'Liquidado' : 'Vencimento'}
-                        </div>
-                        <div className="mt-1 flex items-baseline gap-2">
-                          <div className="text-[22px] font-semibold tracking-tight tabular-nums">
-                            {settled && selected.liquidacao ? selected.liquidacao : selected.vencimento_label}
-                          </div>
-                        </div>
-                        <div className="mt-3 flex items-baseline gap-2 flex-wrap">
-                          <div className={`text-[34px] font-semibold tracking-tight tabular-nums ${selected.kind === 'receivable' ? 'text-emerald-700' : 'text-destructive'}`}>
-                            {selected.kind === 'receivable' ? '+ ' : '− '}{brl(selected.valor)}
-                          </div>
-                          <StatusPill s={selected.status} />
-                          <FinPillFrescor row={{ due: selected.vencimento, paid_at: settled ? selected.liquidacao : null, vencimento: selected.vencimento }} />
-                        </div>
-                      </div>
-                    );
-                  })()}
-
+                  {/* PR-3 F2 (2026-06-10) — o hero (Onda 17) saiu daqui e virou Camada 1
+                      FIXA fora do scroll, entre o header e as tabs (ver acima). */}
                   <FinConferidoToggle rowId={selected.id} conferido={conferido} />
 
                   {/* Onda 18 (2026-05-20) — Grid 2-col canon match prototype financeiro-app.jsx:808-831.
@@ -1861,31 +1950,79 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-[12.5px] text-stone-700">{selected.observacao}</div>
                   )}
 
-                  {/* Onda 19 (2026-05-20) — Bloco Conciliação extrato canon match prototype
-                      financeiro-app.jsx:833-851. Settled = green card "Conciliado com extrato",
-                      not settled = stone card "Sem match. Ao liquidar...". */}
+                  {/* PR-3 F2 (2026-06-10) — Conciliação vira LENTE (ícone primary/10 +
+                      chip de status) e o estado conciliado vira box DISCRETO (bg muted +
+                      check pequeno), não banda verde — padrão F2-aprovado [W]. */}
                   {(() => {
                     const settled = selected.status === 'recebido' || selected.status === 'pago';
                     return (
-                      <div className="border-t border-stone-100 pt-4">
-                        <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Conciliação extrato</div>
+                      <DrawerLens icon={Landmark} title="Conciliação extrato" status={settled ? '100% match' : 'aguardando'} tone={settled ? 'pos' : 'muted'}>
                         {settled ? (
-                          <div className="mt-2 rounded-md border border-emerald-200 bg-emerald-50/60 px-3 py-2.5 flex items-start gap-2.5">
-                            <LinkIcon className="h-4 w-4 text-emerald-700 mt-0.5" aria-hidden />
-                            <div className="text-[12.5px]">
-                              <div className="text-emerald-800 font-medium">Conciliado com extrato bancário</div>
-                              <div className="text-emerald-700/80">{selected.liquidacao || '—'} · {brl(selected.valor)} · 100% match</div>
+                          <div className="rounded-md border border-border bg-muted px-3 py-2 flex items-start gap-2.5">
+                            <span className="w-[18px] h-[18px] rounded-full grid place-items-center bg-success/15 text-success-foreground shrink-0 mt-px" aria-hidden>
+                              <Check size={11} />
+                            </span>
+                            <div className="text-[12.5px] min-w-0">
+                              <div className="font-medium text-foreground">Conciliado com extrato bancário</div>
+                              <div className="text-muted-foreground tabular-nums">{selected.liquidacao || '—'} · {brl(selected.valor)} · 100% match</div>
                             </div>
                           </div>
                         ) : (
-                          <div className="mt-2 rounded-md border border-stone-200 px-3 py-2.5 text-[12.5px] text-stone-600 flex items-start gap-2.5">
+                          <div className="rounded-md border border-stone-200 px-3 py-2.5 text-[12.5px] text-stone-600 flex items-start gap-2.5">
                             <span className="text-stone-500 mt-0.5" aria-hidden>✦</span>
                             <div>
                               Sem match no extrato. Ao liquidar, o sistema procura linhas próximas (±R$ [redacted Tier 0] e ±2 dias) e sugere conciliação automática.
                             </div>
                           </div>
                         )}
-                      </div>
+                      </DrawerLens>
+                    );
+                  })()}
+
+                  {/* PR-3 F2 (2026-06-10) — Lente FISCAL: NF + impostos estimados (Simples
+                      Nacional, regime caixa). Estimativa VISUAL — apuração oficial no módulo
+                      Fiscal; guia consolidada na sub-tela Impostos & obrigações (F2 PR-2).
+                      Referência F1: LenteFiscal em financeiro-page.jsx (ISS 5% serviços
+                      gráficos · DAS ≈6% sobre o recebido). */}
+                  {(() => {
+                    const isIn = selected.kind === 'receivable';
+                    const hasNf = !!selected.nfe_numero;
+                    const iss = isIn ? (selected.valor ?? 0) * 0.05 : 0;
+                    const das = isIn ? (selected.valor ?? 0) * 0.06 : 0;
+                    return (
+                      <DrawerLens icon={Percent} title="Fiscal" status={hasNf ? 'NF vinculada' : 'sem NF'} tone={hasNf ? 'pos' : 'warn'}>
+                        <div className="grid grid-cols-2 gap-x-5">
+                          <div>
+                            <div className="text-[10.5px] uppercase tracking-[0.08em] text-muted-foreground">{isIn ? 'NF-e de saída' : 'Documento fiscal'}</div>
+                            <div className="text-[13px] text-foreground font-medium truncate">
+                              {hasNf ? <span className="font-mono tabular-nums">{selected.nfe_numero}</span> : <span className="text-warning-foreground">não emitida</span>}
+                            </div>
+                          </div>
+                          <div>
+                            <div className="text-[10.5px] uppercase tracking-[0.08em] text-muted-foreground">Regime</div>
+                            <div className="text-[13px] text-foreground font-medium">Simples Nacional</div>
+                          </div>
+                        </div>
+                        {isIn && (
+                          <div className="mt-1.5 border-t border-stone-100">
+                            <div className="flex items-baseline justify-between py-[5px] border-b border-stone-100">
+                              <span className="text-[12.5px] text-stone-600">ISS retido · 5%</span>
+                              <span className="text-[12.5px] font-mono tabular-nums font-medium">{brl(iss)}</span>
+                            </div>
+                            <div className="flex items-baseline justify-between py-[5px]">
+                              <span className="text-[12.5px] text-stone-600">No DAS do mês · ≈ 6%</span>
+                              <span className="text-[12.5px] font-mono tabular-nums font-medium text-warning-foreground">{brl(das)}</span>
+                            </div>
+                          </div>
+                        )}
+                        <p className="text-[10.5px] text-muted-foreground pt-1.5 leading-relaxed">
+                          Estimativa — apuração e guia na sub-tela{' '}
+                          <button type="button" className="font-medium underline underline-offset-2 hover:text-primary" onClick={() => router.visit('/financeiro/impostos')}>
+                            Impostos &amp; obrigações
+                          </button>{' '}
+                          · oficial no módulo Fiscal.
+                        </p>
+                      </DrawerLens>
                     );
                   })()}
 


### PR DESCRIPTION
## PACOTE-FINANCEIRO-F2 · PR-3 (drawer)

> **Stacked sobre #2494 (PR-1)** — mesmo arquivo `Unificado/Index.tsx`. Mergear PR-1 primeiro; este retargeta pra main automaticamente.

Padrão F2-aprovado **[W] 2026-06-10** (referência: `financeiro-page.jsx` Drawer + `financeiro.css` do protótipo Cowork). Não-Tier-0.

### 1 · Hero fixo fora do scroll (header → hero → tabs → corpo)
- Label de estado uppercase (**destructive** se atrasado, warning se vencendo)
- Valor **mono tabular grande** (`--fs-9` com fallback 38px) com prefixo `+ R$/− R$` e centavos pequenos (`whitespace-nowrap` no prefixo)
- Chip (StatusPill + Frescor) + vencimento com urgência em palavras à direita ("vence 12/06 · em 2 dias")
- **FSM compacto** 4 etapas (Lançado → Conferido → Conciliado → Liquidado), espelha `finFsmStage` do protótipo

### 2 · KV empilhado — validado @main, NÃO refeito
O grid 2-col do live (Onda 18) já era label-muted-em-cima/valor-embaixo (PROTOCOL §10.4).

### 3 · Lentes
`DrawerLens`: ícone em quadradinho `primary/10` + título sm semibold + chip de status calmo. Conciliação conciliada virou **box discreto** (bg muted + check pequeno) — não banda verde.

### 4 · Lente Fiscal (nova)
Linhas justify-between mono `ISS retido · 5%` e `No DAS do mês · ≈6%` (Simples Nacional, estimativa, receivable only) + link pra **Impostos & obrigações** (F2 PR-2, segue na fila) + disclaimer.

### 5 · Token fixes (Regra 6 — validados no main antes)
2 `white` crus tokenizados → `var(--accent-fg, white)` (`.fsm-step.done .fsm-step-num` + `.fin-comment-new button`), espelhando o F1. `trouble-icon` não tinha white cru no live (n/a).

### Gates
conformance-gate `--all` ✅ · foundation-guard ✅ · eslint 22→20 problemas (−2 warnings emerald, erro restante é pré-existente) · tsc zero erro novo.

### F1.5 — screenshots @1280/@1440 pendentes de ambiente com dados (anexar antes do merge).

Refs: CYCLE-08 · PACOTE-FINANCEIRO-F2 · #2494

🤖 Generated with [Claude Code](https://claude.com/claude-code)