### PR TITLE
fix(financeiro): Impostos — data legacy com timestamp renderizava '18 00:00:00/12'

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ImpostosController.php
+++ b/Modules/Financeiro/Http/Controllers/ImpostosController.php
@@ -98,7 +98,9 @@ class ImpostosController extends Controller
                 'det' => 'título '.$t->numero.' no caixa unificado',
                 'competencia' => (string) $t->competencia_mes,
                 'competencia_label' => $this->compLabel((string) $t->competencia_mes),
-                'vencimento' => (string) $t->vencimento,
+                // Legacy WR traz vencimento com timestamp ("2026-12-18 00:00:00") —
+                // normaliza pra date-only senão o front renderiza "18 00:00:00/12".
+                'vencimento' => substr((string) $t->vencimento, 0, 10),
                 'valor' => (float) $t->valor_total,
                 'status' => $t->status === 'quitado' ? 'paga'
                     : ((string) $t->vencimento < $hoje ? 'atrasada' : 'a_vencer'),

--- a/resources/js/Pages/Financeiro/Impostos/Index.tsx
+++ b/resources/js/Pages/Financeiro/Impostos/Index.tsx
@@ -68,7 +68,8 @@ const brlK = (v: number) => {
   return brl(v);
 };
 
-const dataBr = (d: string) => (d ? d.split('-').reverse().slice(0, 2).join('/') : '—');
+// Defensivo: aceita date-only E datetime legacy (corta o timestamp antes de formatar).
+const dataBr = (d: string) => (d ? d.slice(0, 10).split('-').reverse().slice(0, 2).join('/') : '—');
 
 // Status pill — tons semânticos calmos via tokens do @theme (zero cor crua).
 const GUIA_STATUS: Record<GuiaStatus, { label: string; cls: string }> = {


### PR DESCRIPTION
Smoke de produção pós-deploy do F2 pegou: títulos migrados do WR têm `vencimento` com timestamp (`2026-12-18 00:00:00`) e o `dataBr()` assumia date-only → KPI "Próxima obrigação" e coluna Venc. renderizavam `18 00:00:00/12`.

Fix nos 2 lados (defense in depth): controller normaliza `substr(0,10)` no histórico de guias; `dataBr()` corta o timestamp antes de formatar.

Evidência: screenshot do smoke em https://oimpresso.com/financeiro/impostos (sessão 2026-06-10).

🤖 Generated with [Claude Code](https://claude.com/claude-code)