### PR TITLE
test(guard): self-schema tests sqlite-only

### DIFF
--- a/Modules/KB/Tests/Helpers.php
+++ b/Modules/KB/Tests/Helpers.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 /*
@@ -48,6 +49,13 @@ use Illuminate\Support\Facades\Schema;
  */
 function kbBootstrapSchema(): void
 {
+    // SELF-SCHEMA (cria/dropa tabelas vivas, incl. users/roles/permissions) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) dropa tabelas vivas — incidente 2026-06-10.
+    // test() em vez de $this: helper Pest fora do binding do TestCase.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     // Externals mínimos — só campos usados nas FKs/queries.
     Schema::dropIfExists('kb_bridge_state');
     Schema::dropIfExists('kb_comments');

--- a/Modules/NfeBrasil/Tests/Feature/EmitirNFSeJobTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EmitirNFSeJobTest.php
@@ -30,6 +30,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::dropIfExists('nfse_emissoes');
     Schema::dropIfExists('users');
 

--- a/Modules/RecurringBilling/Tests/Feature/CancelarCobrancaAsaasJobTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/CancelarCobrancaAsaasJobTest.php
@@ -47,6 +47,12 @@ class FakeAsaasChargeStub extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php
@@ -18,6 +18,12 @@ uses(Tests\TestCase::class);
  * Padrão SQLite-stub (mesmo DomainModelsTest) — UPos legacy quebra com migrations.
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     foreach ([
         'rb_subscription_events', 'rb_subscription_favorites', 'rb_subscription_notes',
         'rb_subscriptions', 'rb_plans', 'users', 'contacts',

--- a/Modules/RecurringBilling/Tests/Feature/RefundCobrancaAsaasJobTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/RefundCobrancaAsaasJobTest.php
@@ -42,6 +42,12 @@ class FakeAsaasRefundChargeStub extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/Modules/Repair/Tests/Feature/RepairFsmActionControllerTest.php
+++ b/Modules/Repair/Tests/Feature/RepairFsmActionControllerTest.php
@@ -32,6 +32,12 @@ use Spatie\Permission\PermissionRegistrar;
 uses(Tests\TestCase::class);
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     // JobSheet usa Spatie LogsActivity (FSM history + status). Sem `activity_log`
     // o teste explode em SQLSTATE 1. Schema espelha vendor/spatie/laravel-activitylog.
     Schema::create('activity_log', function (Blueprint $t) {

--- a/Modules/Repair/Tests/Feature/Wave25RepairFsmCanonExpandedTest.php
+++ b/Modules/Repair/Tests/Feature/Wave25RepairFsmCanonExpandedTest.php
@@ -50,6 +50,12 @@ use Spatie\Permission\PermissionRegistrar;
 uses(Tests\TestCase::class);
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/Modules/Whatsapp/Tests/Feature/AutoLinkContactTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AutoLinkContactTest.php
@@ -32,6 +32,12 @@ uses(Tests\TestCase::class);
  *  009. Phone curto (<8 dígitos) NÃO faz query (anti false-positive)
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     // Bridge events do MessageObserver / Conversation observers que disparam
     // em save() — em test isolado sem MessageObserver registrado, evita
     // surprise side-effects.

--- a/Modules/Whatsapp/Tests/Feature/AutoPrefixSenderNameTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AutoPrefixSenderNameTest.php
@@ -21,6 +21,12 @@ uses(Tests\TestCase::class);
  *   7. Sanitização — caracteres não-alfa removidos do nome
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::dropIfExists('users');
     Schema::create('users', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/BackfillChannelAccessCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BackfillChannelAccessCommandTest.php
@@ -32,6 +32,12 @@ uses(Tests\TestCase::class);
  * @see Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     foreach ([
         'model_has_permissions', 'model_has_roles', 'role_has_permissions',
         'permissions', 'roles',

--- a/Modules/Whatsapp/Tests/Feature/EmployeePerformanceRebuilderTest.php
+++ b/Modules/Whatsapp/Tests/Feature/EmployeePerformanceRebuilderTest.php
@@ -24,6 +24,12 @@ uses(Tests\TestCase::class);
  *   9. SLA breach contado quando >4h
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     foreach (['employee_performance', 'customer_memory', 'messages', 'conversations', 'users', 'business'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/InboxCleanupTest.php
+++ b/Modules/Whatsapp/Tests/Feature/InboxCleanupTest.php
@@ -33,6 +33,12 @@ uses(Tests\TestCase::class);
  * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     foreach (['messages', 'conversations', 'channels', 'users'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
@@ -23,6 +23,12 @@ uses(Tests\TestCase::class);
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     foreach ([
         'macro_variants', 'macros',
         'model_has_permissions', 'model_has_roles', 'role_has_permissions',

--- a/Modules/Whatsapp/Tests/Feature/RegisterWhatsappPermissionsCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/RegisterWhatsappPermissionsCommandTest.php
@@ -28,6 +28,12 @@ uses(Tests\TestCase::class);
  * @see Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand
  */
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     foreach ([
         'model_has_permissions', 'model_has_roles', 'role_has_permissions',
         'permissions', 'roles',

--- a/tests/Feature/Console/FsmBulkStartPipelineCommandTest.php
+++ b/tests/Feature/Console/FsmBulkStartPipelineCommandTest.php
@@ -28,6 +28,12 @@ use Modules\Jana\Scopes\ScopeByBusiness;
  */
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/CancelarVendaCascadeSideEffectTest.php
+++ b/tests/Feature/Domain/Fsm/CancelarVendaCascadeSideEffectTest.php
@@ -47,6 +47,12 @@ class CancelTestSubject extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/CurrentStageIdBypassObserverTest.php
+++ b/tests/Feature/Domain/Fsm/CurrentStageIdBypassObserverTest.php
@@ -64,6 +64,12 @@ class FsmObserverTestSubject extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     // Reset singleton entre cenários — flags de teste anterior não vazam
     FsmAuthorizationFlag::reset();
 

--- a/tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php
+++ b/tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php
@@ -67,6 +67,12 @@ class FakeRefundCobrancaAsaasJobStub
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/GateEmissaoPorVendaTest.php
+++ b/tests/Feature/Domain/Fsm/GateEmissaoPorVendaTest.php
@@ -41,6 +41,12 @@ class FakeSaleSubject extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/MultiTenantIsolationTest.php
+++ b/tests/Feature/Domain/Fsm/MultiTenantIsolationTest.php
@@ -21,6 +21,12 @@ use Spatie\Permission\PermissionRegistrar;
  */
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/ProcessoVendaComProducaoTest.php
+++ b/tests/Feature/Domain/Fsm/ProcessoVendaComProducaoTest.php
@@ -46,6 +46,12 @@ class ProducaoTestSubject extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/SaleHistoryControllerTest.php
+++ b/tests/Feature/Domain/Fsm/SaleHistoryControllerTest.php
@@ -26,6 +26,12 @@ use Spatie\Permission\PermissionRegistrar;
  */
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/StockReservationsTest.php
+++ b/tests/Feature/Domain/Fsm/StockReservationsTest.php
@@ -36,6 +36,12 @@ class StockResTestSubject extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/TransactionDocumentTest.php
+++ b/tests/Feature/Domain/Fsm/TransactionDocumentTest.php
@@ -33,6 +33,12 @@ class FakeFiscalDoc extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php
+++ b/tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php
@@ -48,6 +48,12 @@ class FsmCriticalTestSubject extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Jobs/CancelarCobrancaInterJobTest.php
+++ b/tests/Feature/Jobs/CancelarCobrancaInterJobTest.php
@@ -44,6 +44,12 @@ class FakeInterCharge extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Jobs/RefundCobrancaInterJobTest.php
+++ b/tests/Feature/Jobs/RefundCobrancaInterJobTest.php
@@ -33,6 +33,12 @@ class FakeInterRefundCharge extends Model
 }
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();

--- a/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
@@ -14,6 +14,12 @@ use Modules\Jana\Mcp\Tools\WhatsActiveTool;
  */
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('mcp_cc_sessions', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->string('session_uuid', 36)->unique();

--- a/tests/Feature/Modules/Copiloto/TenancyLeakTest.php
+++ b/tests/Feature/Modules/Copiloto/TenancyLeakTest.php
@@ -15,6 +15,12 @@ use Spatie\Permission\PermissionRegistrar;
  */
 
 beforeEach(function () {
+    // SELF-SCHEMA (cria/dropa tabelas vivas no afterEach) — SQLITE-ONLY.
+    // Contra MySQL real (staging CT 100) o afterEach DROPA tabelas vivas — incidente 2026-06-10.
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        $this->markTestSkipped('Self-schema (cria/dropa tabelas vivas) — SQLite-only; vs MySQL real dropa staging. Incidente 2026-06-10.');
+    }
+
     Schema::create('users', function (Blueprint $table) {
         $table->increments('id');
         $table->string('surname')->default('');


### PR DESCRIPTION
## O que

Guard de driver em **29 arquivos Pest self-schema** (criam `Schema::create('users'…)` no `beforeEach` e `Schema::dropIfExists` de `users`/`roles`/`permissions`/`sale_*` no `afterEach`): `markTestSkipped` quando o driver não é sqlite, **antes** de qualquer `Schema::create`.

## Por quê

**Incidente real 2026-06-10:** `ExecuteStageActionServiceTest` rodado contra MySQL real (staging CT 100, receita RUNBOOK-staging-ct100.md) **dropou** `sale_stage_actions`/`sale_stage_action_roles`/`sale_stage_history` do `oimpresso_staging`. Restaurado via `up()` das migrations `2026_05_11_12000{3,4,5}` + `2026_05_12_010001` + re-seed dos seeders FSM — mas o histórico de auditoria do staging foi perdido.

`ExecuteStageActionServiceTest` já foi blindado no PR `fix/oficina-fio-usavel-adr0265` (usado como modelo aqui).

## Como

- **28 tests** — guard no topo do primeiro `beforeEach` (todos sem namespace, `DB` resolve via alias global, igual ao modelo)
- **`Modules/KB/Tests/Helpers.php`** — guard dentro de `kbBootstrapSchema()` via `test()->markTestSkipped()` (helper Pest sem `$this`), cobrindo os ~10 tests KB que o chamam no `beforeEach`; `use DB` adicionado

## Validação

- `php -l` verde nos 29 arquivos
- guard precede o primeiro `Schema::create`/`dropIfExists` real em todos (verificado por script)
- diff = só inserções (176 linhas, zero ruído CRLF)
- CI roda sqlite → **nada deixa de rodar no gate**; skip só dispara em MySQL real

🤖 Generated with [Claude Code](https://claude.com/claude-code)