### PR TITLE
feat(whatsapp): US-WA-303 composer completo — templates + macros + variáveis (PR-2/10)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -15,6 +15,7 @@ use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Entities\WhatsappTemplate;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
 /**
@@ -144,6 +145,7 @@ class CaixaUnificadaController extends Controller
             'availableAccounts' => Inertia::defer(fn () => $this->buildAvailableAccountsPayload($businessId, $userId)),
             'availableTags' => Inertia::defer(fn () => $this->buildAvailableTagsPayload($businessId)),
             'availableAssignees' => Inertia::defer(fn () => $this->buildAvailableAssigneesPayload($businessId)),
+            'availableTemplates' => Inertia::defer(fn () => $this->buildAvailableTemplatesPayload($businessId)),
 
             // ─── Eager: estados de UI leves ───
             'businessId' => $businessId,
@@ -460,6 +462,35 @@ class CaixaUnificadaController extends Controller
                 'label' => $t->label,
                 'color' => $t->color,
             ])->all();
+    }
+
+    /**
+     * US-WA-303 — templates prontos pra envio (picker ⌘T do composer).
+     *
+     * Shape espelha `ReadyTemplate` do frontend legacy (TemplatePicker reusado).
+     * Só status ready (`LOCAL` Z-API/Baileys + `APPROVED` Meta) — picker filtra
+     * por provider do canal da thread no client. Tier 0 ADR 0093: business atual.
+     *
+     * @return array<int, array{id: int, name: string, language: string, category: string, provider: string, status: string, body: string}>
+     */
+    protected function buildAvailableTemplatesPayload(int $businessId): array
+    {
+        return WhatsappTemplate::query()
+            ->where('business_id', $businessId)
+            ->whereIn('status', ['LOCAL', 'APPROVED'])
+            ->orderBy('name')
+            ->get()
+            ->map(fn (WhatsappTemplate $t) => [
+                'id' => $t->id,
+                'name' => $t->name,
+                'language' => $t->language,
+                'category' => $t->category,
+                'provider' => $t->provider,
+                'status' => $t->status,
+                // Body cru com placeholders {{1}}/{{nome}} — picker expande no preview
+                'body' => $t->expandBody([]),
+            ])
+            ->all();
     }
 
     /**

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -32,9 +32,25 @@ uses(Tests\TestCase::class);
  * NUNCA usar biz=4 (ROTA LIVRE cliente real) em tests — ADR 0101.
  */
 beforeEach(function () {
-    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users'] as $t) {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates'] as $t) {
         Schema::dropIfExists($t);
     }
+
+    // US-WA-303 — templates ready pro picker ⌘T (espelho da migration 2026_05_07_000004)
+    Schema::create('whatsapp_templates', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('provider', 20)->default('zapi');
+        $table->string('meta_template_id', 64)->nullable();
+        $table->string('name', 64);
+        $table->string('language', 10)->default('pt_BR');
+        $table->string('category', 20);
+        $table->string('status', 20);
+        $table->json('components');
+        $table->string('rejection_reason', 255)->nullable();
+        $table->timestamp('last_synced_at')->nullable();
+        $table->timestamps();
+    });
 
     // US-WA-302 — users mínima pro payload availableAssignees + endpoint assign
     // (pattern BackfillChannelAccessCommandTest + colunas de nome do App\User).
@@ -428,4 +444,49 @@ it('R-WA-CAIXA-UNIF-005 — assign atribui/remove operador + bloqueia cross-tena
     // Remove atribuição (null)
     $inbox->assign(cuctPatchRequest("/atendimento/inbox/{$conv->id}/assign", ['assigned_user_id' => null]), $conv->id);
     expect($conv->fresh()->assigned_user_id)->toBeNull();
+});
+
+// ============================================================================
+// 5. US-WA-303 — availableTemplates: só ready (LOCAL/APPROVED) + Tier 0
+// ============================================================================
+
+function cuctMakeTemplate(int $businessId, string $name, string $provider, string $status, string $body = 'Olá {{nome}}!'): void
+{
+    \Illuminate\Support\Facades\DB::table('whatsapp_templates')->insert([
+        'business_id' => $businessId,
+        'provider' => $provider,
+        'name' => $name,
+        'language' => 'pt_BR',
+        'category' => 'UTILITY',
+        'status' => $status,
+        'components' => json_encode([['type' => 'BODY', 'text' => $body]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('R-WA-CAIXA-UNIF-006 — availableTemplates só ready (LOCAL/APPROVED) do business atual (Tier 0)', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-006-uuid');
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    cuctMakeTemplate(1, 'boas_vindas', 'baileys', 'LOCAL', 'Olá {{nome}}, bem-vindo!');
+    cuctMakeTemplate(1, 'cobranca_hsm', 'meta_cloud', 'APPROVED');
+    cuctMakeTemplate(1, 'pendente_meta', 'meta_cloud', 'PENDING');   // não-ready → fora
+    cuctMakeTemplate(1, 'rejeitado', 'meta_cloud', 'REJECTED');      // não-ready → fora
+    cuctMakeTemplate(99, 'intruso_tpl', 'baileys', 'LOCAL');         // cross-tenant → fora
+
+    $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
+    $templates = cuctResolveDefer($props['availableTemplates']);
+
+    $names = collect($templates)->pluck('name')->all();
+    expect($names)->toContain('boas_vindas', 'cobranca_hsm')
+        ->and($names)->not->toContain('pendente_meta')
+        ->and($names)->not->toContain('rejeitado')
+        ->and($names)->not->toContain('intruso_tpl'); // Tier 0 ADR 0093
+
+    // Shape ReadyTemplate do frontend: body cru com placeholders preservados
+    $bv = collect($templates)->firstWhere('name', 'boas_vindas');
+    expect($bv['body'])->toBe('Olá {{nome}}, bem-vindo!')
+        ->and($bv['provider'])->toBe('baileys')
+        ->and($bv['status'])->toBe('LOCAL');
 });

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 2
+charter_version: 3
 permissao: whatsapp.access
 ---
 
@@ -81,7 +81,19 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 
 ### Composer
 - **Toggle Resp/Nota** inline (⌘⇧N) — replica `internalMode` do Cowork.
-- **Botões placeholder** ⌘T (Templates) e `/` (Macros) — TODOs honestos.
+- **Templates** (US-WA-303, 2026-06-10): botão abre `TemplatePicker` legacy
+  reusado, filtrado por provider do canal da thread (baileys/zapi/meta_cloud).
+  Envia `kind=template` via `atendimento.inbox.send`. Payload deferred
+  `availableTemplates` (só LOCAL/APPROVED, Tier 0).
+- **Macros `/`** (US-WA-303): dropdown lazy via `atendimento.macros.list`
+  (US-WA-048 backend reusado — NÃO cria tabela nova) + autocomplete inline
+  digitando `/` no input (Enter aplica a 1ª; Esc dispensa). Apply via
+  `atendimento.inbox.apply_macro` (MacroExecutor envia msg + aplica ações).
+- **Variáveis `{{}}`** (US-WA-303): botão `{}` insere `{{nome}}`/`{{telefone}}`/
+  `{{operador}}`; preview resolvido acima do input (verde=ok, vermelho=sem
+  valor → literal); substituição no send (nota interna fica literal).
+  TODO honesto: `{{empresa}}`/`{{os}}`/`{{saldo}}` esperam integrações
+  Repair/Financeiro das sections 5-6 da sidebar.
 - **Enviar/Anotar** verde-primary ou amarelo-nota.
 - **Disabled** quando preview (modo cliente) ou contato bloqueado.
 
@@ -140,10 +152,6 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - ❌ **Broadcast cross-canal** — placeholder; backlog (alta complexidade
   janela 24h Meta + opt-in LGPD).
 - ❌ **Mover conversa entre filas** — só leitura (fila vem de heurística).
-- ❌ **Templates picker no composer** — placeholder; reusar
-  `TemplatePicker` do legacy em PR seguinte.
-- ❌ **Macros / slash commands** no composer — placeholder; reusar dropdown
-  `/macros` do legacy em PR seguinte.
 - ❌ **Mídia outbound/inbound** UI — preserva legacy `MediaPreviewCard`
   durante coexistência. PR seguinte unifica.
 
@@ -212,6 +220,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-003 — user sem ACL no canal NÃO vê convs daquele canal` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-004 — availableAssignees só lista operadores do business atual (Tier 0)` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-005 — assign atribui/remove operador + bloqueia cross-tenant (Tier 0)` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-006 — availableTemplates só ready (LOCAL/APPROVED) do business atual (Tier 0)` | mesmo arquivo |
 
 ---
 
@@ -265,5 +274,6 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-303 Composer completo** (PR-2/10): Templates via `TemplatePicker` legacy filtrado por provider do canal + payload `availableTemplates` (LOCAL/APPROVED) · Macros dropdown + autocomplete `/` inline reusando backend US-WA-048 (`macros.list` + `apply_macro`) · Variáveis `{{nome}}`/`{{telefone}}`/`{{operador}}` com botão `{}`, preview verde/vermelho e substituição no send. Charter v3. Pest R-WA-CAIXA-UNIF-006. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas" — brief [CC] Caixa Unificada completa) | **US-WA-302 Assignee picker** (PR-1/10): section 2 da sidebar vira picker real (Popover operadores + avatar hue + remover atribuição). Backend: PATCH `atendimento.inbox.assign` (InboxController::assign, Tier 0 cross-tenant 422) + prop deferred `availableAssignees` + relação `Conversation::assignedUser`. Charter v2. Pest R-WA-CAIXA-UNIF-004/005. |
 | 2026-05-15 | Wagner + Opus 4.7 | Adicionado `<CustomerMemoryBlock>` (US-WA-VOZ-001/002/003 — PR #919) no topo do `ContextSidebarV4`. Lazy fetch `GET /atendimento/customer/{ext}/profile`. Mostra identidade Contact CRM, stats agregados, top 3 reclamações 30d com severity, external_sources Firebird, flags VIP/frágil, LGPD. Mesmo componente usado pelo Inbox legacy (`ConversationSidebar.tsx`) — atendente vê Customer 360 em qualquer tela durante cutover. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -69,6 +69,8 @@ interface Props {
   availableTags?: { id: number; slug: string; label: string; color: string }[];
   /** US-WA-302 — operadores atribuíveis (assignee picker da sidebar). */
   availableAssignees?: AssigneeItem[];
+  /** US-WA-303 — templates ready do business (picker ⌘T do composer). */
+  availableTemplates?: import('@/Pages/Whatsapp/_components/helpers').ReadyTemplate[];
 
   businessId: number;
   /**
@@ -95,7 +97,7 @@ interface Props {
 }
 
 export default function CaixaUnificadaIndex({
-  conversations, stats, availableChannels, availableAccounts, availableTags, availableAssignees,
+  conversations, stats, availableChannels, availableAccounts, availableTags, availableAssignees, availableTemplates,
   businessId: _businessId,
   statusFilter, channelTypeFilter, accountFilter, queueFilter: _queueFilter, q,
   thread, messages, centrifugoConfig,
@@ -440,6 +442,7 @@ export default function CaixaUnificadaIndex({
               messages={messages}
               channels={availableChannels ?? []}
               onResolve={resolveThread}
+              templates={availableTemplates ?? []}
             />
           ) : (
             <div className="h-full flex items-center justify-center bg-muted/15">

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -505,7 +505,9 @@ export default function ComposerV4({
               return v ? (
                 <span
                   key={i}
-                  className="inline-block px-1.5 rounded-full bg-emerald-100 text-emerald-900 font-medium"
+                  className="inline-block px-1.5 rounded-full font-medium"
+                  // Verde-pastel WA — mesmo par OKLCH das bubbles outbound do V4
+                  style={{ background: 'oklch(0.93 0.06 145)', color: 'oklch(0.25 0.10 145)' }}
                   title={part}
                 >
                   {v}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -2,8 +2,12 @@
 //
 // Replica visual `.om-input` do Cowork (inbox-page.css L558-614):
 //   - botão toggle Resp/Nota (⌘⇧N)
-//   - botão ⌘T (templates — placeholder, abre composer só mostra dialog futuro)
-//   - botão / (macros — placeholder)
+//   - botão ⌘T (templates — US-WA-303: TemplatePicker legacy reusado, filtrado
+//     por provider do canal da thread)
+//   - botão / (macros — US-WA-303: dropdown via atendimento.macros.list +
+//     autocomplete inline digitando "/" + apply via atendimento.inbox.apply_macro)
+//   - botão {} (variáveis — US-WA-303: {{nome}}/{{telefone}}/{{operador}} com
+//     preview resolvido acima do input; substituição no send)
 //   - input redondo arredondado pill
 //   - botão Enviar/Anotar com cor dinâmica (verde primary vs amarelo nota)
 //   - desabilitado quando isPreview e modo cliente (banner já avisa)
@@ -11,13 +15,48 @@
 //
 // Reusa POST `/atendimento/inbox/{id}/send` do legacy (US-WA-069 + ADR 0142
 // notas internas) — preserva contrato backend Tier 0 enquanto coexiste com Inbox.
+//
+// TODO honesto US-WA-303: {{empresa}}/{{os}}/{{saldo}} do protótipo (inbox-out.jsx)
+// dependem das sections OS/Saldo da sidebar que ainda são placeholder — entram
+// quando aquelas integrações (Repair/Financeiro) existirem. Resolver deixa
+// variável sem valor como literal (preview marca em vermelho).
 
-import { useState, useRef, useEffect } from 'react';
-import { useForm, router } from '@inertiajs/react';
-import { LayoutList, Send, FileText, Paperclip, Slash, X } from 'lucide-react';
+import { useState, useRef, useEffect, useMemo } from 'react';
+import { useForm, router, usePage } from '@inertiajs/react';
+import { Braces, LayoutList, Loader2, Send, FileText, Paperclip, Slash, X } from 'lucide-react';
 import { cn } from '@/Lib/utils';
+import { Inline } from '@/Components/layout';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/Components/ui/popover';
 import MicRecorder from '@/Pages/Whatsapp/_components/MicRecorder';
 import InteractiveMessageDialog from '@/Pages/Whatsapp/_components/InteractiveMessageDialog';
+import TemplatePicker from '@/Pages/Whatsapp/_components/TemplatePicker';
+import type { ReadyTemplate } from '@/Pages/Whatsapp/_components/helpers';
+
+/** US-WA-303: shape do item de GET atendimento.macros.list (US-WA-048). */
+interface MacroEntry {
+  id: number;
+  label: string;
+  shortcut: string | null;
+  body: string;
+  used_count: number;
+  body_preview: string;
+}
+
+/**
+ * US-WA-303: Channel.type → WhatsappTemplate.provider. Template só aparece
+ * no picker quando o provider casa com o driver do canal da thread (Meta HSM
+ * não vai por Baileys e vice-versa — contrato do InboxController::send).
+ */
+const PROVIDER_BY_CHANNEL_TYPE: Record<string, string> = {
+  whatsapp_baileys: 'baileys',
+  whatsapp_meta: 'meta_cloud',
+  meta_cloud: 'meta_cloud',
+  whatsapp_zapi: 'zapi',
+};
 
 interface Props {
   conversationId: number;
@@ -27,6 +66,11 @@ interface Props {
   channelLabel: string;
   /** Wave 4-B F1: tipo do channel (whatsapp_meta libera Interactive). */
   channelType?: string;
+  /** US-WA-303: templates ready do business (deferred — [] até resolver). */
+  templates?: ReadyTemplate[];
+  /** US-WA-303: dados da thread pro resolver de variáveis {{nome}}/{{telefone}}. */
+  contactName?: string;
+  contactPhone?: string;
 }
 
 /** Wave 4 F1: limite legal Tier 0 da caption (espelha InboxController::sendMedia). */
@@ -56,6 +100,7 @@ const ACCEPT_MIME = [
 
 export default function ComposerV4({
   conversationId, isPreview, isBlocked, channelShort, channelLabel, channelType,
+  templates = [], contactName, contactPhone,
 }: Props) {
   const [internalMode, setInternalMode] = useState(false);
   const [pendingFile, setPendingFile] = useState<File | null>(null);
@@ -68,6 +113,102 @@ export default function ComposerV4({
   // Wave 4-B F1: só whatsapp_meta libera Interactive (List/Button)
   const supportsInteractive = channelType === 'whatsapp_meta' || channelType === 'meta_cloud';
 
+  // ── US-WA-303: Templates ⌘T ─────────────────────────────────────────────
+  const [templatePickerOpen, setTemplatePickerOpen] = useState(false);
+  const [sendingTemplate, setSendingTemplate] = useState(false);
+  const channelProvider = channelType ? PROVIDER_BY_CHANNEL_TYPE[channelType] : undefined;
+  const channelTemplates = useMemo(
+    () => (channelProvider ? templates.filter(t => t.provider === channelProvider) : []),
+    [templates, channelProvider],
+  );
+
+  function sendTemplate(payload: { template_name: string; template_locale: string; template_params: string[] }) {
+    if (sendingTemplate || isBlocked || isPreview) return;
+    setSendingTemplate(true);
+    router.post(
+      route('atendimento.inbox.send', conversationId),
+      { kind: 'template', ...payload },
+      {
+        preserveScroll: true,
+        preserveState: true,
+        only: ['thread', 'messages', 'conversations', 'stats'],
+        onSuccess: () => setTemplatePickerOpen(false),
+        onFinish: () => setSendingTemplate(false),
+      },
+    );
+  }
+
+  // ── US-WA-303: Macros "/" (dropdown + autocomplete inline) ─────────────
+  // fetchMacros idempotente — busca 1x, cache local (pattern do Inbox legacy).
+  const [macrosOpen, setMacrosOpen] = useState(false);
+  const [macrosList, setMacrosList] = useState<MacroEntry[] | null>(null);
+  const [macrosLoading, setMacrosLoading] = useState(false);
+  const [applyingMacroId, setApplyingMacroId] = useState<number | null>(null);
+  const [slashDismissed, setSlashDismissed] = useState(false);
+
+  function fetchMacros() {
+    if (macrosList !== null || macrosLoading) return;
+    setMacrosLoading(true);
+    fetch(route('atendimento.macros.list'), {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+      .then(r => r.json())
+      .then((data: { macros: MacroEntry[] }) => setMacrosList(data.macros ?? []))
+      .catch(() => setMacrosList([]))
+      .finally(() => setMacrosLoading(false));
+  }
+
+  function applyMacro(macro: MacroEntry) {
+    if (applyingMacroId !== null || isBlocked || internalMode || isPreview) return;
+    setApplyingMacroId(macro.id);
+    router.post(
+      route('atendimento.inbox.apply_macro', { id: conversationId, macroId: macro.id }),
+      {},
+      {
+        preserveScroll: true,
+        preserveState: true,
+        only: ['thread', 'messages', 'conversations', 'stats'],
+        onSuccess: () => {
+          setMacrosOpen(false);
+          form.setData('body', '');
+          // Invalida cache pra refletir used_count na próxima abertura
+          setMacrosList(null);
+        },
+        onFinish: () => setApplyingMacroId(null),
+      },
+    );
+  }
+
+  // ── US-WA-303: Variáveis {{nome}}/{{telefone}}/{{operador}} ────────────
+  const page = usePage<{ auth?: { user?: { name?: string } | null } }>();
+  const operatorName = page.props.auth?.user?.name?.trim() || '';
+  const varEntries = useMemo(() => ([
+    { key: 'nome', label: 'Nome do contato', value: (contactName ?? '').trim() },
+    { key: 'telefone', label: 'Telefone do contato', value: (contactPhone ?? '').trim() },
+    { key: 'operador', label: 'Seu nome', value: operatorName },
+  ]), [contactName, contactPhone, operatorName]);
+
+  function resolveVars(text: string): string {
+    return text.replace(/\{\{(\w+)\}\}/g, (raw, key: string) => {
+      const v = varEntries.find(e => e.key === key.toLowerCase())?.value;
+      return v ? v : raw; // sem valor → mantém literal (preview marca em vermelho)
+    });
+  }
+
+  function insertVar(key: string) {
+    const input = inputRef.current;
+    const token = `{{${key}}}`;
+    const body = form.data.body;
+    if (input && typeof input.selectionStart === 'number') {
+      const pos = input.selectionStart;
+      form.setData('body', body.slice(0, pos) + token + body.slice(input.selectionEnd ?? pos));
+    } else {
+      form.setData('body', body + token);
+    }
+    requestAnimationFrame(() => input?.focus());
+  }
+
   const form = useForm<{
     kind: 'freeform' | 'template';
     body: string;
@@ -77,6 +218,24 @@ export default function ComposerV4({
     body: '',
     is_internal_note: false,
   });
+
+  // US-WA-303 — autocomplete slash: body começando com "/" filtra macros por
+  // shortcut. Enter aplica a 1ª. Esc dispensa (digitar de novo reabre).
+  const slashOpen = !internalMode && !slashDismissed && form.data.body.startsWith('/');
+  useEffect(() => {
+    if (slashOpen) fetchMacros();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [slashOpen]);
+  const slashMatches = useMemo(() => {
+    if (!slashOpen || !macrosList) return [];
+    const q = form.data.body.slice(1).toLowerCase().trim();
+    return macrosList
+      .filter(m => m.shortcut && (q === '' || m.shortcut.toLowerCase().startsWith(q)))
+      .slice(0, 6);
+  }, [slashOpen, macrosList, form.data.body]);
+
+  // US-WA-303 — preview de variáveis resolvidas acima do input
+  const hasVars = /\{\{\w+\}\}/.test(form.data.body);
 
   // Atalho ⌘⇧N — toggle modo nota
   useEffect(() => {
@@ -104,6 +263,9 @@ export default function ComposerV4({
 
     form.transform(data => ({
       ...data,
+      // US-WA-303 — substitui {{nome}}/{{telefone}}/{{operador}} no envio
+      // (nota interna fica literal — registro fiel do que o atendente digitou).
+      body: internalMode ? data.body : resolveVars(data.body),
       is_internal_note: internalMode,
     }));
 
@@ -322,6 +484,78 @@ export default function ComposerV4({
           {mediaError}
         </div>
       )}
+
+      {/* US-WA-303 — preview de variáveis resolvidas (Cowork om-var-preview).
+          Verde = resolvida, vermelho = sem valor (vai literal). */}
+      {hasVars && !internalMode && (
+        <Inline
+          gap={2}
+          align="baseline"
+          className="border-t bg-muted/30 px-3.5 py-1.5 text-[11px]"
+          data-testid="caixa-unif-composer-var-preview"
+        >
+          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold flex-shrink-0">
+            Preview
+          </small>
+          <span className="min-w-0 break-words">
+            {form.data.body.split(/(\{\{\w+\}\})/g).map((part, i) => {
+              const m = part.match(/^\{\{(\w+)\}\}$/);
+              if (!m) return <span key={i}>{part}</span>;
+              const v = varEntries.find(e => e.key === m[1]!.toLowerCase())?.value;
+              return v ? (
+                <span
+                  key={i}
+                  className="inline-block px-1.5 rounded-full bg-emerald-100 text-emerald-900 font-medium"
+                  title={part}
+                >
+                  {v}
+                </span>
+              ) : (
+                <span
+                  key={i}
+                  className="inline-block px-1.5 rounded-full bg-destructive/10 text-destructive font-mono"
+                  title={`Variável ${part} sem valor — vai literal`}
+                >
+                  {part}
+                </span>
+              );
+            })}
+          </span>
+        </Inline>
+      )}
+
+      {/* US-WA-303 — autocomplete slash (Cowork om-slash-pop): digite "/" */}
+      {slashOpen && slashMatches.length > 0 && (
+        <div
+          className="absolute bottom-full left-3.5 right-3.5 mb-1 bg-card border rounded-md shadow-lg max-h-56 overflow-y-auto z-10"
+          data-testid="caixa-unif-slash-pop"
+          role="listbox"
+          aria-label="Macros que casam com o atalho digitado"
+        >
+          {slashMatches.map((m, i) => (
+            <button
+              type="button"
+              key={m.id}
+              onClick={() => applyMacro(m)}
+              disabled={applyingMacroId !== null}
+              data-testid={`caixa-unif-slash-item-${m.id}`}
+              role="option"
+              aria-selected={i === 0}
+              className={cn(
+                'w-full text-left px-3 py-1.5 border-b last:border-b-0 hover:bg-muted disabled:opacity-45',
+                i === 0 && 'bg-muted/50',
+              )}
+            >
+              <span className="text-[11.5px] font-medium inline-flex items-center gap-1.5">
+                <span className="font-mono text-[10.5px] text-primary">/{m.shortcut}</span>
+                {m.label}
+                {i === 0 && <span className="text-[9.5px] text-muted-foreground ml-auto">Enter aplica</span>}
+              </span>
+              <span className="block text-[10.5px] text-muted-foreground truncate">{m.body_preview}</span>
+            </button>
+          ))}
+        </div>
+      )}
     <div
       className={cn(
         'flex items-center gap-1.5 border-t px-3.5 py-2.5 transition-colors',
@@ -361,25 +595,115 @@ export default function ComposerV4({
         {internalMode ? 'Nota' : 'Resp'}
       </button>
 
-      {/* Templates — placeholder (TODO US-WA-XXX: dialog templates) */}
+      {/* US-WA-303 — Templates do canal (TemplatePicker legacy reusado) */}
       <button
         type="button"
-        disabled={internalMode}
-        title="Templates (em breve)"
+        onClick={() => setTemplatePickerOpen(true)}
+        disabled={internalMode || !canType || !channelProvider}
+        title={channelProvider
+          ? `Templates do canal (${channelTemplates.length} ${channelTemplates.length === 1 ? 'disponível' : 'disponíveis'})`
+          : 'Canal não suporta templates'}
+        data-testid="caixa-unif-composer-templates"
         className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
       >
         <FileText size={12} aria-hidden />
       </button>
 
-      {/* Macros — placeholder (TODO US-WA-303 dropdown /macros) */}
-      <button
-        type="button"
-        disabled={internalMode}
-        title="Macros (em breve)"
-        className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+      {/* US-WA-303 — Macros (dropdown via atendimento.macros.list + apply) */}
+      <Popover
+        open={macrosOpen}
+        onOpenChange={(o) => {
+          setMacrosOpen(o);
+          if (o) fetchMacros();
+        }}
       >
-        <Slash size={12} aria-hidden />
-      </button>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            disabled={internalMode || !canType}
+            title="Macros — atalhos / com ações (digite / no input pra autocomplete)"
+            data-testid="caixa-unif-composer-macros"
+            className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+          >
+            <Slash size={12} aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" side="top" className="w-80 p-1.5">
+          <div className="text-[10px] uppercase tracking-[0.06em] text-muted-foreground font-semibold px-2 pt-1 pb-1.5">
+            Macros · digite <span className="font-mono">/</span> no input pra autocomplete
+          </div>
+          {macrosLoading ? (
+            <div className="px-2 py-3 text-[11px] text-muted-foreground inline-flex items-center gap-1.5">
+              <Loader2 size={12} className="animate-spin" aria-hidden /> Carregando…
+            </div>
+          ) : (macrosList ?? []).length === 0 ? (
+            <div className="px-2 py-2 text-[11px] text-muted-foreground italic">
+              Nenhuma macro cadastrada.{' '}
+              <a href={route('atendimento.macros.index')} className="underline">Criar em Macros →</a>
+            </div>
+          ) : (
+            <ul className="max-h-72 overflow-auto">
+              {(macrosList ?? []).map(m => (
+                <li key={m.id}>
+                  <button
+                    type="button"
+                    onClick={() => applyMacro(m)}
+                    disabled={applyingMacroId !== null}
+                    data-testid={`caixa-unif-composer-macro-${m.id}`}
+                    className="w-full px-2 py-1.5 text-left hover:bg-muted rounded disabled:opacity-45"
+                  >
+                    <span className="block text-[11.5px] font-medium">
+                      <span className="inline-flex items-center gap-1.5">
+                        {m.shortcut && <span className="font-mono text-[10.5px] text-primary">/{m.shortcut}</span>}
+                        {m.label}
+                        {applyingMacroId === m.id && <Loader2 size={11} className="animate-spin" aria-hidden />}
+                      </span>
+                    </span>
+                    <span className="block mt-0.5 text-[10.5px] text-muted-foreground truncate w-full">{m.body_preview}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </PopoverContent>
+      </Popover>
+
+      {/* US-WA-303 — Variáveis {} (insere {{nome}}/{{telefone}}/{{operador}}) */}
+      {!internalMode && (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={!canType}
+              title="Inserir variável no texto ({{nome}}, {{telefone}}, {{operador}})"
+              data-testid="caixa-unif-composer-vars"
+              className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+            >
+              <Braces size={12} aria-hidden />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" side="top" className="w-64 p-1.5">
+            <div className="text-[10px] uppercase tracking-[0.06em] text-muted-foreground font-semibold px-2 pt-1 pb-1.5">
+              Inserir variável
+            </div>
+            <ul>
+              {varEntries.map(v => (
+                <li key={v.key}>
+                  <button
+                    type="button"
+                    onClick={() => insertVar(v.key)}
+                    data-testid={`caixa-unif-composer-var-${v.key}`}
+                    className="w-full inline-flex items-center justify-between gap-2 px-2 py-1.5 text-[11.5px] hover:bg-muted rounded text-left"
+                  >
+                    <span className="font-mono text-[10.5px] text-primary">{`{{${v.key}}}`}</span>
+                    <span className="text-muted-foreground truncate">{v.value || v.label}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
+      )}
 
       {/* Wave 4 F1 — Anexar mídia (POST send_media via FormData) */}
       <input
@@ -426,10 +750,24 @@ export default function ComposerV4({
         ref={inputRef}
         type="text"
         value={form.data.body}
-        onChange={e => form.setData('body', e.target.value)}
+        onChange={e => {
+          form.setData('body', e.target.value);
+          // US-WA-303 — digitar de novo reabre autocomplete dispensado com Esc
+          if (slashDismissed) setSlashDismissed(false);
+        }}
         onKeyDown={e => {
+          if (e.key === 'Escape' && slashOpen) {
+            e.preventDefault();
+            setSlashDismissed(true);
+            return;
+          }
           if (e.key === 'Enter' && !e.shiftKey) {
             e.preventDefault();
+            // US-WA-303 — com autocomplete aberto, Enter aplica a 1ª macro
+            if (slashOpen && slashMatches.length > 0) {
+              applyMacro(slashMatches[0]!);
+              return;
+            }
             send();
           }
         }}
@@ -484,6 +822,15 @@ export default function ComposerV4({
         driverType={channelType as 'whatsapp_meta' | 'meta_cloud'}
       />
     )}
+
+    {/* US-WA-303 — TemplatePicker legacy reusado (kind=template no send) */}
+    <TemplatePicker
+      open={templatePickerOpen}
+      onOpenChange={setTemplatePickerOpen}
+      templates={channelTemplates}
+      onSend={sendTemplate}
+      sending={sendingTemplate}
+    />
     </div>
   );
 }

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -23,16 +23,19 @@ import {
 } from './helpers';
 import ComposerV4 from './ComposerV4';
 import CaptureFeedbackSheet, { type CaptureFeedbackInput } from '@/Pages/Whatsapp/_components/CaptureFeedbackSheet';
+import type { ReadyTemplate } from '@/Pages/Whatsapp/_components/helpers';
 
 interface Props {
   thread: CaixaUnifThread;
   messages: CaixaUnifMessage[];
   channels: ChannelCatalogItem[];
   onResolve?: () => void;
+  /** US-WA-303 — templates ready do business (picker do composer). */
+  templates?: ReadyTemplate[];
 }
 
 export default function ConversationThreadV4({
-  thread, messages, channels, onResolve,
+  thread, messages, channels, onResolve, templates = [],
 }: Props) {
   const threadRef = useRef<HTMLDivElement>(null);
 
@@ -374,6 +377,9 @@ export default function ConversationThreadV4({
         channelShort={channel?.short ?? thread.channel_label ?? 'Canal'}
         channelLabel={thread.channel_label ?? ''}
         channelType={thread.channel_type}
+        templates={templates}
+        contactName={thread.contact_name}
+        contactPhone={thread.customer_external_id}
       />
     </div>
   );


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-2 de 10

**US-WA-303 — Templates ⌘T + Macros `/` + Variáveis no composer**

### Validação §10.4 (o repo venceu o brief)
- **Macros: backend US-WA-048 já existia COMPLETO** (`MacrosController::list/apply` + `MacroExecutor` + variantes A/B) → REUSADO, **nenhuma tabela nova** (o brief sugeria criar `whatsapp_macros` se não existisse)
- Semântica do apply: MacroExecutor **envia a mensagem + aplica ações** server-side (≠ protótipo que só preenchia o input) — mantida a do repo

### O que muda
- **Templates**: botão abre `TemplatePicker` legacy reusado, filtrado por provider do canal (baileys/zapi/meta_cloud); envia `kind=template` via `atendimento.inbox.send`; payload deferred `availableTemplates` (só LOCAL/APPROVED)
- **Macros**: dropdown lazy (`macros.list`) + autocomplete inline digitando `/` (Enter aplica a 1ª, Esc dispensa) + apply via `apply_macro`
- **Variáveis**: `{}` insere `{{nome}}`/`{{telefone}}`/`{{operador}}` no cursor; preview resolvido acima do input (verde=ok, vermelho=sem valor→literal); substituição no send (nota interna fica literal)
- TODO honesto: `{{empresa}}`/`{{os}}`/`{{saldo}}` esperam integrações Repair/Financeiro (sections 5-6 da sidebar ainda placeholder)

### Tier 0
- `availableTemplates` where business_id explícito + Pest `R-WA-CAIXA-UNIF-006` (cross-tenant + só ready)

### Gates locais
- layout-primitives: zero delta · eslint: zero novo · conformance ✅ · tsc: zero novo

Charter → v3 (Goals composer, Non-Goals limpos, métricas vivas, histórico).

🤖 Generated with [Claude Code](https://claude.com/claude-code)