### PR TITLE
feat(whatsapp): US-WA-301 filas DB whatsapp_queues + painel QueuesSheet (PR-3/10)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_06_10_000001_create_whatsapp_queues_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_06_10_000001_create_whatsapp_queues_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-301 (ADR 0267) — filas de atendimento persistidas em DB.
+ *
+ * Substitui `config('whatsapp.queues')` estático (2 filas hardcoded) por
+ * tabela multi-tenant editável no painel "Filas" da Caixa Unificada V4.
+ * Seed lazy idempotente a partir do config no primeiro acesso por business
+ * (CaixaUnificadaController::ensureDefaultQueues — pattern ensureDefaultTags).
+ *
+ * `dist` e `members` são SÓ persistência nesta fase (roteamento automático
+ * round-robin/sticky é US futura — TODO honesto anti M-AP-2).
+ *
+ * Idempotente: hasTable guard — pode rodar 2× sem dropar.
+ *
+ * @see memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('whatsapp_queues')) {
+            return;
+        }
+
+        Schema::create('whatsapp_queues', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');
+            $table->string('slug', 40);
+            $table->string('label', 80);
+            $table->unsignedSmallInteger('hue')->default(220)
+                ->comment('0-360 OKLCH — chips/border-left da lista V4');
+            $table->unsignedInteger('sla_minutes')->nullable()
+                ->comment('SLA alvo 1a resposta; null = sem SLA');
+            $table->string('dist', 20)->default('manual')
+                ->comment('round_robin|sticky|manual — persistencia only nesta fase (ADR 0267)');
+            $table->json('trigger_tags')
+                ->comment('slugs de tags que disparam a fila (heuristica OR)');
+            $table->json('members')
+                ->comment('user_ids membros — persistencia only nesta fase (ADR 0267)');
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->unique(['business_id', 'slug'], 'wq_biz_slug_uniq');
+            $table->index('business_id', 'wq_biz_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_queues');
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappQueue.php
+++ b/Modules/Whatsapp/Entities/WhatsappQueue.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * WhatsappQueue — fila de atendimento persistida (US-WA-301 · ADR 0267).
+ *
+ * Multi-tenant Tier 0 (ADR 0093) via trait `HasBusinessScope`.
+ *
+ * Substitui `config('whatsapp.queues')` estático. Seed lazy idempotente a
+ * partir do config no primeiro acesso por business
+ * (`CaixaUnificadaController::ensureDefaultQueues`).
+ *
+ * `dist` e `members` são SÓ persistência nesta fase — roteamento automático
+ * (round-robin/sticky) é US futura (TODO honesto anti M-AP-2).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $slug
+ * @property string $label
+ * @property int $hue
+ * @property ?int $sla_minutes
+ * @property string $dist
+ * @property array $trigger_tags
+ * @property array $members
+ * @property int $sort_order
+ */
+class WhatsappQueue extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_queues';
+
+    public const DIST_MODES = ['round_robin', 'sticky', 'manual'];
+
+    protected $fillable = [
+        'business_id', 'slug', 'label', 'hue', 'sla_minutes',
+        'dist', 'trigger_tags', 'members', 'sort_order',
+    ];
+
+    protected $casts = [
+        'hue' => 'integer',
+        'sla_minutes' => 'integer',
+        'trigger_tags' => 'array',
+        'members' => 'array',
+        'sort_order' => 'integer',
+    ];
+
+    /**
+     * SLA humanizado pro shape `QueueConfig` do frontend ("45min", "1h", "4h").
+     */
+    public function slaHuman(): ?string
+    {
+        if ($this->sla_minutes === null || $this->sla_minutes <= 0) {
+            return null;
+        }
+        if ($this->sla_minutes < 60) {
+            return "{$this->sla_minutes}min";
+        }
+        $hours = intdiv($this->sla_minutes, 60);
+        $rest = $this->sla_minutes % 60;
+
+        return $rest === 0 ? "{$hours}h" : "{$hours}h{$rest}";
+    }
+
+    /**
+     * Converte SLA humano do config ("1h", "4h", "30min") pra minutos.
+     * Aceita também int/numeric-string (minutos diretos).
+     */
+    public static function slaToMinutes(mixed $sla): ?int
+    {
+        if ($sla === null || $sla === '') {
+            return null;
+        }
+        if (is_int($sla) || (is_string($sla) && ctype_digit($sla))) {
+            return (int) $sla;
+        }
+        if (is_string($sla) && preg_match('/^(?:(\d+)h)?(?:(\d+)(?:min)?)?$/', trim($sla), $m)) {
+            $minutes = ((int) ($m[1] ?? 0)) * 60 + (int) ($m[2] ?? 0);
+
+            return $minutes > 0 ? $minutes : null;
+        }
+
+        return null;
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -15,6 +15,7 @@ use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Entities\WhatsappQueue;
 use Modules\Whatsapp\Entities\WhatsappTemplate;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
 
@@ -146,6 +147,8 @@ class CaixaUnificadaController extends Controller
             'availableTags' => Inertia::defer(fn () => $this->buildAvailableTagsPayload($businessId)),
             'availableAssignees' => Inertia::defer(fn () => $this->buildAvailableAssigneesPayload($businessId)),
             'availableTemplates' => Inertia::defer(fn () => $this->buildAvailableTemplatesPayload($businessId)),
+            // US-WA-301 (ADR 0267) — rows completas pro painel "Filas" (Sheet CRUD)
+            'queuesAdmin' => Inertia::defer(fn () => $this->buildQueuesAdminPayload($businessId)),
 
             // ─── Eager: estados de UI leves ───
             'businessId' => $businessId,
@@ -165,10 +168,112 @@ class CaixaUnificadaController extends Controller
             'messages' => $messages,
             'centrifugoConfig' => $centrifugoConfig,
 
-            // Config static (custo zero — array em memória)
-            'queues' => (array) config('whatsapp.queues', []),
+            // US-WA-301 (ADR 0267) — filas agora vêm do DB (seed lazy do config
+            // na 1ª visita; fallback config se DB vazio). Shape QueueConfig compat.
+            'queues' => $this->getQueuesConfig($businessId),
             'defaultQueue' => (string) config('whatsapp.default_queue', 'comercial'),
+            'canManageQueues' => (bool) (auth()->user()?->can('whatsapp.settings.manage') ?? false),
         ]);
+    }
+
+    /** Cache per-request do mapa slug => QueueConfig (evita reler DB nos payloads). */
+    protected ?array $queuesConfigCache = null;
+
+    /**
+     * US-WA-301 (ADR 0267) — filas do business: DB com seed lazy + fallback config.
+     *
+     * Shape compat com `QueueConfig` do frontend (label/hue/sla/trigger_tags) —
+     * `sla` humanizado de `sla_minutes`. Princípio duro 8 (ADR 0094): se a
+     * leitura DB falhar/vier vazia, degrade gracioso pro config estático.
+     *
+     * @return array<string, array{label: string, hue: int, sla: ?string, trigger_tags: array<int, string>}>
+     */
+    protected function getQueuesConfig(int $businessId): array
+    {
+        if ($this->queuesConfigCache !== null) {
+            return $this->queuesConfigCache;
+        }
+
+        try {
+            $this->ensureDefaultQueues($businessId);
+            $rows = WhatsappQueue::query()
+                ->where('business_id', $businessId)
+                ->orderBy('sort_order')
+                ->orderBy('label')
+                ->get();
+        } catch (\Throwable) {
+            $rows = collect();
+        }
+
+        if ($rows->isEmpty()) {
+            return $this->queuesConfigCache = (array) config('whatsapp.queues', []);
+        }
+
+        return $this->queuesConfigCache = $rows
+            ->mapWithKeys(fn (WhatsappQueue $q) => [$q->slug => [
+                'label' => $q->label,
+                'hue' => $q->hue,
+                'sla' => $q->slaHuman(),
+                'trigger_tags' => (array) $q->trigger_tags,
+            ]])
+            ->all();
+    }
+
+    /**
+     * Seed lazy idempotente das filas default a partir de `config('whatsapp.queues')`
+     * (pattern ensureDefaultTags — migração sem quebra, ADR 0267).
+     */
+    protected function ensureDefaultQueues(int $businessId): void
+    {
+        $existing = WhatsappQueue::query()->where('business_id', $businessId)->count();
+        if ($existing > 0) {
+            return;
+        }
+        $sort = 10;
+        foreach ((array) config('whatsapp.queues', []) as $slug => $cfg) {
+            WhatsappQueue::query()->create([
+                'business_id' => $businessId,
+                'slug' => (string) $slug,
+                'label' => (string) ($cfg['label'] ?? ucfirst((string) $slug)),
+                'hue' => (int) ($cfg['hue'] ?? 220),
+                'sla_minutes' => WhatsappQueue::slaToMinutes($cfg['sla'] ?? null),
+                'dist' => 'manual',
+                'trigger_tags' => (array) ($cfg['trigger_tags'] ?? []),
+                'members' => [],
+                'sort_order' => $sort,
+            ]);
+            $sort += 10;
+        }
+    }
+
+    /**
+     * US-WA-301 — rows completas pro painel "Filas" (Sheet CRUD da V4).
+     *
+     * @return array<int, array{id: int, slug: string, label: string, hue: int, sla_minutes: ?int, sla: ?string, dist: string, trigger_tags: array<int, string>, sort_order: int, is_default: bool}>
+     */
+    protected function buildQueuesAdminPayload(int $businessId): array
+    {
+        $this->ensureDefaultQueues($businessId);
+        $defaultSlug = (string) config('whatsapp.default_queue', 'comercial');
+
+        return WhatsappQueue::query()
+            ->where('business_id', $businessId)
+            ->orderBy('sort_order')
+            ->orderBy('label')
+            ->get()
+            ->map(fn (WhatsappQueue $q) => [
+                'id' => $q->id,
+                'slug' => $q->slug,
+                'label' => $q->label,
+                'hue' => $q->hue,
+                'sla_minutes' => $q->sla_minutes,
+                'sla' => $q->slaHuman(),
+                'dist' => $q->dist,
+                'trigger_tags' => (array) $q->trigger_tags,
+                'sort_order' => $q->sort_order,
+                'is_default' => $q->slug === $defaultSlug,
+            ])
+            ->all();
     }
 
     /**
@@ -560,13 +665,17 @@ class CaixaUnificadaController extends Controller
     }
 
     /**
-     * Heurística tag → fila (paridade exata com InboxController::deriveQueueFromTags).
+     * Heurística tag → fila (paridade com InboxController::deriveQueueFromTags).
+     *
+     * US-WA-301 (ADR 0267): filas agora vêm de getQueuesConfig (DB com seed
+     * lazy + fallback config) — shape e semântica idênticos.
      *
      * @return array{slug: string, label: string, hue: int, sla: ?string}
      */
     protected function deriveQueueFromTags(array $tagSlugs): array
     {
-        $queues = (array) config('whatsapp.queues', []);
+        $businessId = (int) session('user.business_id');
+        $queues = $this->getQueuesConfig($businessId);
         $default = (string) config('whatsapp.default_queue', 'comercial');
         $matched = $default;
         foreach ($queues as $slug => $cfg) {

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -206,7 +206,19 @@ class CaixaUnificadaController extends Controller
         }
 
         if ($rows->isEmpty()) {
-            return $this->queuesConfigCache = (array) config('whatsapp.queues', []);
+            // Normaliza o config pro shape completo (PHPStan + consumidores
+            // acessam offsets direto sem ?? redundante).
+            $fallback = [];
+            foreach ((array) config('whatsapp.queues', []) as $slug => $cfg) {
+                $fallback[(string) $slug] = [
+                    'label' => (string) ($cfg['label'] ?? ucfirst((string) $slug)),
+                    'hue' => (int) ($cfg['hue'] ?? 220),
+                    'sla' => $cfg['sla'] ?? null,
+                    'trigger_tags' => (array) ($cfg['trigger_tags'] ?? []),
+                ];
+            }
+
+            return $this->queuesConfigCache = $fallback;
         }
 
         return $this->queuesConfigCache = $rows
@@ -679,7 +691,8 @@ class CaixaUnificadaController extends Controller
         $default = (string) config('whatsapp.default_queue', 'comercial');
         $matched = $default;
         foreach ($queues as $slug => $cfg) {
-            $triggers = (array) ($cfg['trigger_tags'] ?? []);
+            // Shape garantido por getQueuesConfig (offsets sempre presentes)
+            $triggers = $cfg['trigger_tags'];
             if ($triggers === []) {
                 continue;
             }
@@ -688,12 +701,13 @@ class CaixaUnificadaController extends Controller
                 break;
             }
         }
-        $cfg = $queues[$matched] ?? ['label' => ucfirst($matched), 'hue' => 0, 'sla' => null];
+        $cfg = $queues[$matched] ?? ['label' => ucfirst($matched), 'hue' => 0, 'sla' => null, 'trigger_tags' => []];
+
         return [
             'slug' => $matched,
-            'label' => (string) ($cfg['label'] ?? ucfirst($matched)),
-            'hue' => (int) ($cfg['hue'] ?? 0),
-            'sla' => $cfg['sla'] ?? null,
+            'label' => (string) $cfg['label'],
+            'hue' => (int) $cfg['hue'],
+            'sla' => $cfg['sla'],
         ];
     }
 

--- a/Modules/Whatsapp/Http/Controllers/Admin/QueuesController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/QueuesController.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Modules\Whatsapp\Entities\WhatsappQueue;
+
+/**
+ * QueuesController — CRUD do painel "Filas" da Caixa Unificada V4
+ * (US-WA-301 · ADR 0267).
+ *
+ * Sem página própria: o painel é um Sheet in-place na Caixa Unificada
+ * (`QueuesSheet.tsx`); aqui só mutações. Leitura vai nos props do
+ * CaixaUnificadaController (payload `queuesAdmin` deferred).
+ *
+ * Permission: `whatsapp.settings.manage` (mesma do painel Canais).
+ * Tier 0 ADR 0093: where business_id explícito em TODA query.
+ */
+class QueuesController extends Controller
+{
+    public function store(Request $request): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $data = $this->validatePayload($request, $businessId, null);
+
+        WhatsappQueue::query()->create(array_merge($data, [
+            'business_id' => $businessId,
+            'trigger_tags' => $data['trigger_tags'] ?? [],
+            'members' => [],
+        ]));
+
+        return back()->with('success', 'Fila criada.');
+    }
+
+    public function update(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $queue = WhatsappQueue::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        $data = $this->validatePayload($request, $businessId, $queue);
+        $queue->fill(array_merge($data, [
+            'trigger_tags' => $data['trigger_tags'] ?? [],
+        ]))->save();
+
+        return back()->with('success', 'Fila atualizada.');
+    }
+
+    public function destroy(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $queue = WhatsappQueue::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        // Fila default é o fallback da heurística tag→fila — não deleta (ADR 0267)
+        $defaultSlug = (string) config('whatsapp.default_queue', 'comercial');
+        if ($queue->slug === $defaultSlug) {
+            return back()->withErrors([
+                'queue' => "Fila \"{$queue->label}\" é a default ({$defaultSlug}) — fallback da heurística. Não pode ser removida.",
+            ]);
+        }
+
+        $queue->delete();
+
+        return back()->with('success', 'Fila removida.');
+    }
+
+    /**
+     * @return array{slug: string, label: string, hue: int, sla_minutes: ?int, dist: string, trigger_tags?: array<int, string>, sort_order: int}
+     */
+    protected function validatePayload(Request $request, int $businessId, ?WhatsappQueue $current): array
+    {
+        $data = $request->validate([
+            'label' => ['required', 'string', 'max:80'],
+            'slug' => ['nullable', 'string', 'max:40', 'regex:/^[a-z0-9-]+$/'],
+            'hue' => ['required', 'integer', 'min:0', 'max:360'],
+            'sla_minutes' => ['nullable', 'integer', 'min:1', 'max:10080'],
+            'dist' => ['required', Rule::in(WhatsappQueue::DIST_MODES)],
+            'trigger_tags' => ['nullable', 'array'],
+            'trigger_tags.*' => ['string', 'max:40'],
+            'sort_order' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        // Slug: imutável no update (referência estável pra default_queue e
+        // queue_override futura); auto-gerado do label no create quando ausente.
+        if ($current !== null) {
+            $data['slug'] = $current->slug;
+        } else {
+            $slug = $data['slug'] ?? Str::slug(Str::limit($data['label'], 36, ''));
+            $exists = WhatsappQueue::query()
+                ->where('business_id', $businessId)
+                ->where('slug', $slug)
+                ->exists();
+            if ($slug === '' || $exists) {
+                throw \Illuminate\Validation\ValidationException::withMessages([
+                    'slug' => $exists ? "Já existe fila com slug \"{$slug}\" neste business." : 'Slug inválido.',
+                ]);
+            }
+            $data['slug'] = $slug;
+        }
+
+        $data['sort_order'] = $data['sort_order'] ?? 0;
+
+        return $data;
+    }
+}

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -10,6 +10,7 @@ use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacroVariantsController;
 use Modules\Whatsapp\Http\Controllers\Admin\MetricsController;
+use Modules\Whatsapp\Http\Controllers\Admin\QueuesController;
 use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
 use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
 use Modules\Whatsapp\Http\Controllers\Api\CustomerProfileController;
@@ -339,6 +340,20 @@ Route::group([
         ->whereNumber('macro')->whereNumber('variant')
         ->middleware('can:whatsapp.settings.manage')
         ->name('atendimento.macros.variants.mark_winner');
+
+    // US-WA-301 (ADR 0267) — CRUD de filas do painel "Filas" da Caixa Unificada.
+    // Leitura vai nos props do CaixaUnificadaController; aqui só mutações.
+    Route::post('/filas', [QueuesController::class, 'store'])
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.filas.store');
+    Route::put('/filas/{id}', [QueuesController::class, 'update'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.filas.update');
+    Route::delete('/filas/{id}', [QueuesController::class, 'destroy'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.settings.manage')
+        ->name('atendimento.filas.destroy');
 
     // US-WA-021/041 (CYCLE-07 PR-3) — Dashboard métricas omnichannel
     // (gap P0 #4 do COMPARATIVO-MERCADO-2026-05-12). Lê snapshot diário

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -16,6 +16,7 @@ contains:
   - "Admin/ChannelsController — CRUD Channel polimórfico /atendimento/canais (ADR 0135 Fase 0, coexiste Settings legacy)"
   - "Admin/InboxController — UI omnichannel /atendimento/inbox lê schema novo (US-WA-067/069 ADR 0135)"
   - "Admin/CaixaUnificadaController — UI omnichannel V4 /atendimento/caixa-unificada redesign Cowork F3 MWART (PR-D 2026-05-15, coexiste Inbox legacy canary 7d)"
+  - "Admin/QueuesController — CRUD filas de atendimento whatsapp_queues (US-WA-301 ADR 0267, painel QueuesSheet da Caixa Unificada V4)"
   - "Admin/ClientFeedbackController — captura Voice of Customer canon a partir de bubble inbox (PR #1711 2026-05-27); ADR UI-0016 + ADR 0105 cliente-como-sinal"
   # API webhooks (US-WA-010/010b/002d)
   - "Api/MetaWebhookController — recebe events Meta Cloud (HMAC SHA-256 verify)"

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -32,9 +32,25 @@ uses(Tests\TestCase::class);
  * NUNCA usar biz=4 (ROTA LIVRE cliente real) em tests — ADR 0101.
  */
 beforeEach(function () {
-    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates'] as $t) {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates', 'whatsapp_queues'] as $t) {
         Schema::dropIfExists($t);
     }
+
+    // US-WA-301 (ADR 0267) — filas persistidas (espelho da migration 2026_06_10_000001)
+    Schema::create('whatsapp_queues', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('slug', 40);
+        $table->string('label', 80);
+        $table->unsignedSmallInteger('hue')->default(220);
+        $table->unsignedInteger('sla_minutes')->nullable();
+        $table->string('dist', 20)->default('manual');
+        $table->json('trigger_tags');
+        $table->json('members');
+        $table->unsignedInteger('sort_order')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'slug'], 'wq_biz_slug_uniq');
+    });
 
     // US-WA-303 — templates ready pro picker ⌘T (espelho da migration 2026_05_07_000004)
     Schema::create('whatsapp_templates', function ($table) {
@@ -489,4 +505,110 @@ it('R-WA-CAIXA-UNIF-006 — availableTemplates só ready (LOCAL/APPROVED) do bus
     expect($bv['body'])->toBe('Olá {{nome}}, bem-vindo!')
         ->and($bv['provider'])->toBe('baileys')
         ->and($bv['status'])->toBe('LOCAL');
+});
+
+// ============================================================================
+// 6. US-WA-301 (ADR 0267) — filas em DB: seed lazy + leitura DB + Tier 0 + CRUD
+// ============================================================================
+
+it('R-WA-CAIXA-UNIF-007 — filas: seed lazy idempotente do config + payload lê DB + Tier 0', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-007-uuid');
+    cuctMakeConv(1, $ch->id, ['financeiro']);
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    // Fila de OUTRO tenant pré-existente — não pode vazar nem inibir o seed
+    \Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()->create([
+        'business_id' => 99, 'slug' => 'intrusa', 'label' => 'Intrusa', 'hue' => 10,
+        'trigger_tags' => [], 'members' => [],
+    ]);
+
+    // 1ª visita seeda do config (comercial + financeiro)
+    $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
+    expect(array_keys($props['queues']))->toContain('comercial', 'financeiro')
+        ->and(array_keys($props['queues']))->not->toContain('intrusa') // Tier 0
+        ->and($props['queues']['financeiro']['hue'])->toBe(280)
+        ->and($props['queues']['financeiro']['sla'])->toBe('4h'); // 240min humanizado
+
+    // Idempotente: 2ª visita NÃO duplica
+    cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
+    $count = \Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()
+        ->where('business_id', 1)->count();
+    expect($count)->toBe(2);
+
+    // Edição no DB reflete no payload (prova que lê DB, não config)
+    \Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()
+        ->where('business_id', 1)->where('slug', 'financeiro')
+        ->update(['label' => 'Cobranças VIP', 'hue' => 300]);
+    $props2 = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
+    expect($props2['queues']['financeiro']['label'])->toBe('Cobranças VIP')
+        ->and($props2['queues']['financeiro']['hue'])->toBe(300);
+
+    // deriveQueueFromTags acompanha o DB (conv com tag financeiro)
+    $convs = cuctResolveDefer($props2['conversations']);
+    expect($convs['data'][0]['queue']['label'])->toBe('Cobranças VIP');
+
+    // queuesAdmin marca a default e expõe rows completas
+    $admin = cuctResolveDefer($props2['queuesAdmin']);
+    $comercial = collect($admin)->firstWhere('slug', 'comercial');
+    expect($comercial['is_default'])->toBeTrue()
+        ->and(collect($admin)->pluck('slug')->all())->not->toContain('intrusa');
+});
+
+it('R-WA-CAIXA-UNIF-008 — CRUD filas: store/update/destroy + default protegida + Tier 0', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-008-uuid');
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+    // Seed inicial
+    cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
+
+    $queuesCtrl = new \Modules\Whatsapp\Http\Controllers\Admin\QueuesController();
+
+    // STORE — slug auto do label
+    $storeReq = Request::create('/atendimento/filas', 'POST', [
+        'label' => 'Suporte Técnico', 'hue' => 150, 'sla_minutes' => 90,
+        'dist' => 'manual', 'trigger_tags' => ['suporte'],
+    ]);
+    $storeReq->setLaravelSession(app('session.store'));
+    $queuesCtrl->store($storeReq);
+    $created = \Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()
+        ->where('business_id', 1)->where('slug', 'suporte-tecnico')->first();
+    expect($created)->not->toBeNull()
+        ->and($created->sla_minutes)->toBe(90)
+        ->and($created->trigger_tags)->toBe(['suporte']);
+
+    // UPDATE — slug imutável, label/hue mudam
+    $updateReq = Request::create("/atendimento/filas/{$created->id}", 'PUT', [
+        'label' => 'Suporte N2', 'hue' => 200, 'sla_minutes' => null,
+        'dist' => 'round_robin', 'slug' => 'hack-tentativa',
+    ]);
+    $updateReq->setLaravelSession(app('session.store'));
+    $queuesCtrl->update($updateReq, $created->id);
+    $fresh = $created->fresh();
+    expect($fresh->label)->toBe('Suporte N2')
+        ->and($fresh->slug)->toBe('suporte-tecnico') // imutável
+        ->and($fresh->dist)->toBe('round_robin');
+
+    // DESTROY default bloqueado (comercial = config default_queue)
+    $comercial = \Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()
+        ->where('business_id', 1)->where('slug', 'comercial')->first();
+    $delReq = Request::create("/atendimento/filas/{$comercial->id}", 'DELETE');
+    $delReq->setLaravelSession(app('session.store'));
+    $queuesCtrl->destroy($delReq, $comercial->id);
+    expect(\Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()->find($comercial->id))
+        ->not->toBeNull(); // ainda existe
+
+    // DESTROY não-default funciona
+    $delReq2 = Request::create("/atendimento/filas/{$created->id}", 'DELETE');
+    $delReq2->setLaravelSession(app('session.store'));
+    $queuesCtrl->destroy($delReq2, $created->id);
+    expect(\Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()->find($created->id))->toBeNull();
+
+    // Tier 0 — mutar fila de outro tenant = 404 fail-loud
+    $alien = \Modules\Whatsapp\Entities\WhatsappQueue::withoutGlobalScopes()->create([
+        'business_id' => 99, 'slug' => 'alien', 'label' => 'Alien', 'hue' => 10,
+        'trigger_tags' => [], 'members' => [],
+    ]);
+    $alienReq = Request::create("/atendimento/filas/{$alien->id}", 'DELETE');
+    $alienReq->setLaravelSession(app('session.store'));
+    expect(fn () => $queuesCtrl->destroy($alienReq, $alien->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
 });

--- a/memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
+++ b/memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
@@ -9,7 +9,7 @@ lifecycle: ativo
 kind: per-schema
 decided_by: [W]
 decided_at: "2026-06-10"
-module: Whatsapp
+module: whatsapp
 quarter: 2026-Q2
 tags: [whatsapp, atendimento, caixa-unificada, filas, per-schema, multi-tenant]
 supersedes: []

--- a/memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
+++ b/memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
@@ -6,7 +6,7 @@ type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
-kind: per-schema
+kind: decision
 decided_by: [W]
 decided_at: "2026-06-10"
 module: whatsapp

--- a/memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
+++ b/memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
@@ -1,0 +1,88 @@
+---
+slug: 0267-whatsapp-queues-tabela-filas-atendimento
+number: 267
+title: "whatsapp_queues — filas de atendimento persistidas em DB (US-WA-301)"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: per-schema
+decided_by: [W]
+decided_at: "2026-06-10"
+module: Whatsapp
+quarter: 2026-Q2
+tags: [whatsapp, atendimento, caixa-unificada, filas, per-schema, multi-tenant]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: ["0093-multi-tenant-isolation-tier-0", "0135-omnichannel-inbox-arquitetura", "0114-prototipo-ui-cowork-loop-formalizado"]
+pii: false
+---
+
+# ADR 0267 — `whatsapp_queues`: filas de atendimento persistidas em DB
+
+> ADR per-schema (padrão charter Caixa Unificada §1: "Tabela DB nova = ADR
+> per-schema ANTES da migration"). Origem: brief [CC] Caixa Unificada completa
+> 2026-06-10, mandato [W] "vamos aplicar todas" (US-WA-301, roadmap §1 do
+> charter `/atendimento/caixa-unificada`).
+
+## Status
+
+Proposto — 2026-06-10 · [CL] sob mandato [W] "aplicar todas" (brief PR-3/10).
+
+## Contexto
+
+Filas da Caixa Unificada hoje são **estáticas** em `config('whatsapp.queues')`
+(2 filas hardcoded: comercial/financeiro) com heurística tag→fila derivada
+read-only no Controller (`deriveQueueFromTags`). Wagner quer painel admin pra
+criar/editar fila sem deploy: label, cor (hue), SLA, tags-gatilho, modo de
+distribuição e membros.
+
+## Decisão
+
+Criar tabela `whatsapp_queues`:
+
+| Coluna | Tipo | Notas |
+|---|---|---|
+| `id` | bigIncrements | PK |
+| `business_id` | unsignedInteger | **Tier 0 ADR 0093** — index + unique com slug |
+| `slug` | string(40) | identificador estável (compat `config('whatsapp.default_queue')`) |
+| `label` | string(80) | nome exibido |
+| `hue` | unsignedSmallInteger | 0-360 OKLCH (chips/border da lista, padrão V4 `oklch(0.62 0.13 hue)`) |
+| `sla_minutes` | unsignedInteger nullable | SLA alvo de 1ª resposta; null = sem SLA |
+| `dist` | string(20) default 'manual' | `round_robin` \| `sticky` \| `manual` — **só persistência nesta fase**; roteamento automático é US futura |
+| `trigger_tags` | json | slugs de tags que disparam a fila (heurística OR já existente) |
+| `members` | json | user_ids membros — **só persistência nesta fase** (round-robin futuro) |
+| `sort_order` | unsignedInteger default 0 | ordem no painel |
+| timestamps | | |
+
+- **Unique** `(business_id, slug)`.
+- **Seed lazy idempotente** a partir de `config('whatsapp.queues')` no primeiro
+  acesso por business (`ensureDefaultQueues` — mesmo pattern do
+  `ensureDefaultTags` US-WA-063). Migração sem quebra: business que nunca abriu
+  a tela ganha as filas default na primeira visita.
+- **Leitura com fallback**: Controller lê DB; se vazio (corrida/rollback),
+  fallback `config('whatsapp.queues')` — confiabilidade com fallback
+  (princípio duro 8, ADR 0094).
+- CRUD via permission `whatsapp.settings.manage` (mesma do painel Canais);
+  leitura via `whatsapp.access`.
+- Fila apontada por `config('whatsapp.default_queue')` não pode ser deletada
+  (é o fallback da heurística tag→fila).
+
+## Consequências
+
+- `deriveQueueFromTags` passa a usar filas do DB (shape compat com
+  `QueueConfig` do frontend — `sla` humanizado de `sla_minutes`).
+- `stats.queues_count` reflete DB.
+- Habilita US-WA-305 (mover conversa entre filas — `queue_override` na
+  conversa, ADR/migration próprio) e SLA pill (polish V2 §1).
+- `dist`/`members` ficam **dormentes** até US de roteamento automático —
+  TODO honesto, sem fingir round-robin que não roda (anti M-AP-2).
+
+## Alternativas consideradas
+
+1. **Continuar em config** — rejeitado: cada fila nova exige deploy; cliente
+   não consegue self-service.
+2. **Reusar `whatsapp_tags` com flag `is_queue`** — rejeitado: fila tem
+   atributos próprios (SLA, dist, members) e semântica 1:N com tags-gatilho;
+   misturar quebraria SoC (princípio duro 5).

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -303,4 +303,4 @@ _(íntegra)_
 | 0264 | aceito | ativo | meta | Governança executável: trio-de-tela + caso↔teste + domínio + E2E viram gates de  |
 | 0265 | aceito | ativo | errata | Oficina = reparo é o único domínio; erradicar resíduo de order_type=locacao; 'Ca |
 | 0266 | aceito | ativo | meta | Evals de comportamento dos agentes — golden set + replay cases + escada de auton |
-| 0267 | proposto | ativo | per-schema | whatsapp_queues — filas de atendimento persistidas em DB (US-WA-301) |
+| 0267 | proposto | ativo | decision | whatsapp_queues — filas de atendimento persistidas em DB (US-WA-301) |

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **271** arquivos · **256** números únicos · máx **0266**
-- **ADRs ATIVOS (lifecycle ativo): 231** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 211 · proposto 34 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 231 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **272** arquivos · **257** números únicos · máx **0267**
+- **ADRs ATIVOS (lifecycle ativo): 232** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 211 · proposto 35 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 232 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (271)
+## Todas as ADRs (272)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -303,3 +303,4 @@ _(íntegra)_
 | 0264 | aceito | ativo | meta | Governança executável: trio-de-tela + caso↔teste + domínio + E2E viram gates de  |
 | 0265 | aceito | ativo | errata | Oficina = reparo é o único domínio; erradicar resíduo de order_type=locacao; 'Ca |
 | 0266 | aceito | ativo | meta | Evals de comportamento dos agentes — golden set + replay cases + escada de auton |
+| 0267 | proposto | ativo | per-schema | whatsapp_queues — filas de atendimento persistidas em DB (US-WA-301) |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 3
+charter_version: 4
 permissao: whatsapp.access
 ---
 
@@ -118,6 +118,16 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - Stats expandida com counters per-tab (assigned/bot/awaiting_human/archived) — exibe badge contagem na tab quando > 0.
 - URL preservada via `replace: true` no router.get (não polui history).
 
+### Filas persistidas + painel (US-WA-301 · ADR 0267, 2026-06-10)
+- Tabela `whatsapp_queues` substitui `config('whatsapp.queues')` — seed lazy
+  idempotente do config na 1ª visita por business; fallback config se DB vazio.
+- Topnav "Filas" abre **QueuesSheet** (CRUD in-place): label, hue (dot OKLCH),
+  SLA em minutos, distribuição (persistida; roteamento é US futura),
+  tags-gatilho (chips das tags do business). Fila default protegida de delete.
+- Mutações via `atendimento.filas.*` (permission `whatsapp.settings.manage`);
+  leitura nos props (`queues` shape compat + `queuesAdmin` deferred).
+- Heurística tag→fila e `stats.queues_count` passam a ler o DB.
+
 ### Sidebar direita (8 sections)
 1. **Fila** — derivada via heurística tag→fila (read-only nesta passada).
 2. **Atribuído** — assignee picker real (US-WA-302, 2026-06-10): Popover com
@@ -146,9 +156,8 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - ❌ **Configurar Channel** — `/atendimento/canais` continua.
 - ❌ **Editar templates HSM** — `/whatsapp/templates`.
 - ❌ **Wizard de conexão** — `/atendimento/canais/{id}` show + tabs.
-- ❌ **Filas configuração real** — placeholder; config via
-  `config('whatsapp.queues')` (estática). UI de gerenciamento fica pra
-  PR seguinte (TODO US-WA-XXX).
+- ❌ **Roteamento automático de filas** (round-robin/sticky/members) —
+  `dist`/`members` são persistidos (ADR 0267) mas o roteamento é US futura.
 - ❌ **Broadcast cross-canal** — placeholder; backlog (alta complexidade
   janela 24h Meta + opt-in LGPD).
 - ❌ **Mover conversa entre filas** — só leitura (fila vem de heurística).
@@ -221,18 +230,16 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-004 — availableAssignees só lista operadores do business atual (Tier 0)` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-005 — assign atribui/remove operador + bloqueia cross-tenant (Tier 0)` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-006 — availableTemplates só ready (LOCAL/APPROVED) do business atual (Tier 0)` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-007 — filas: seed lazy idempotente do config + payload lê DB + Tier 0` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-008 — CRUD filas: store/update/destroy + default protegida + Tier 0` | mesmo arquivo |
 
 ---
 
 ## Roadmap — O que falta (priorizado pelo Wagner)
 
-### §1 Filas — UI de configuração (P1)
-Hoje filas vêm de `config('whatsapp.queues')` estático. Wagner quer painel
-admin pra criar/editar fila (label, hue, SLA, trigger_tags, distribuição
-round-robin/sticky/manual, members[]). Tabela DB nova `whatsapp_queues` +
-ADR per-schema antes de criar — não inventar.
-
-**US sugerida:** US-WA-XXX Filas DB + painel (~4-6h IA-pair).
+### §1 Filas — UI de configuração (P1) — ✅ ENTREGUE 2026-06-10 (US-WA-301)
+Tabela `whatsapp_queues` (ADR 0267) + QueuesSheet CRUD + seed lazy do config.
+Roteamento automático (dist/members) fica dormente até US futura.
 
 ### §2 Broadcast cross-canal (P2)
 Disparar mensagem template (Meta HSM ou Baileys freeform) pra N contatos
@@ -274,6 +281,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-301 Filas DB + painel** (PR-3/10): tabela `whatsapp_queues` (ADR 0267, per-schema antes da migration) + seed lazy idempotente do config + QueuesSheet CRUD (label/hue/SLA/dist/tags-gatilho, default protegida) + heurística tag→fila lê DB com fallback config. Topnav "Filas" deixa de ser disabled. Charter v4. Pest R-WA-CAIXA-UNIF-007/008. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-303 Composer completo** (PR-2/10): Templates via `TemplatePicker` legacy filtrado por provider do canal + payload `availableTemplates` (LOCAL/APPROVED) · Macros dropdown + autocomplete `/` inline reusando backend US-WA-048 (`macros.list` + `apply_macro`) · Variáveis `{{nome}}`/`{{telefone}}`/`{{operador}}` com botão `{}`, preview verde/vermelho e substituição no send. Charter v3. Pest R-WA-CAIXA-UNIF-006. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas" — brief [CC] Caixa Unificada completa) | **US-WA-302 Assignee picker** (PR-1/10): section 2 da sidebar vira picker real (Popover operadores + avatar hue + remover atribuição). Backend: PATCH `atendimento.inbox.assign` (InboxController::assign, Tier 0 cross-tenant 422) + prop deferred `availableAssignees` + relação `Conversation::assignedUser`. Charter v2. Pest R-WA-CAIXA-UNIF-004/005. |
 | 2026-05-15 | Wagner + Opus 4.7 | Adicionado `<CustomerMemoryBlock>` (US-WA-VOZ-001/002/003 — PR #919) no topo do `ContextSidebarV4`. Lazy fetch `GET /atendimento/customer/{ext}/profile`. Mostra identidade Contact CRM, stats agregados, top 3 reclamações 30d com severity, external_sources Firebird, flags VIP/frágil, LGPD. Mesmo componente usado pelo Inbox legacy (`ConversationSidebar.tsx`) — atendente vê Customer 360 em qualquer tela durante cutover. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -24,7 +24,7 @@
 // Reusa endpoints backend do legacy: POST /atendimento/inbox/{id}/send,
 // PATCH /atendimento/inbox/{id}, etc — sem duplicar contrato.
 
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { router, Deferred, Head } from '@inertiajs/react';
 import { Centrifuge } from 'centrifuge';
 import { ChevronDown, Inbox as InboxIcon, Loader2, MessageSquareText, Sparkles } from 'lucide-react';
@@ -42,6 +42,7 @@ import {
 } from '@/Components/ui/dropdown-menu';
 
 import ChannelChipsRow from './_components/ChannelChipsRow';
+import QueuesSheet from './_components/QueuesSheet';
 import ConversationListV4 from './_components/ConversationListV4';
 import ConversationThreadV4 from './_components/ConversationThreadV4';
 import ContextSidebarV4 from './_components/ContextSidebarV4';
@@ -71,6 +72,9 @@ interface Props {
   availableAssignees?: AssigneeItem[];
   /** US-WA-303 — templates ready do business (picker ⌘T do composer). */
   availableTemplates?: import('@/Pages/Whatsapp/_components/helpers').ReadyTemplate[];
+  /** US-WA-301 (ADR 0267) — rows completas pro painel Filas (Sheet CRUD). */
+  queuesAdmin?: import('./_components/helpers').QueueAdminItem[];
+  canManageQueues?: boolean;
 
   businessId: number;
   /**
@@ -98,12 +102,16 @@ interface Props {
 
 export default function CaixaUnificadaIndex({
   conversations, stats, availableChannels, availableAccounts, availableTags, availableAssignees, availableTemplates,
+  queuesAdmin, canManageQueues,
   businessId: _businessId,
   statusFilter, channelTypeFilter, accountFilter, queueFilter: _queueFilter, q,
   thread, messages, centrifugoConfig,
   queues, defaultQueue: _defaultQueue,
   within24h, unlinked, mediaInbound24h, inboundAging, orderBy, activeTagIds,
 }: Props) {
+  // US-WA-301 — painel Filas (Sheet in-place)
+  const [filasOpen, setFilasOpen] = useState(false);
+
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
     if (!centrifugoConfig) return;
@@ -330,11 +338,12 @@ export default function CaixaUnificadaIndex({
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          {/* US-WA-301 (ADR 0267) — painel Filas (Sheet CRUD, DB whatsapp_queues) */}
           <button
             type="button"
-            className="inline-flex items-center px-2.5 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors disabled:opacity-45"
-            disabled
-            title="Configurar filas (em breve)"
+            onClick={() => setFilasOpen(true)}
+            className="inline-flex items-center px-2.5 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+            title="Configurar filas de atendimento"
             data-testid="caixa-unif-topnav-filas"
           >
             Filas
@@ -461,6 +470,15 @@ export default function CaixaUnificadaIndex({
         </div>
 
         {/* Sidebar direita — só quando thread aberta */}
+        {/* US-WA-301 — painel Filas (Sheet CRUD whatsapp_queues) */}
+        <QueuesSheet
+          open={filasOpen}
+          onOpenChange={setFilasOpen}
+          queues={queuesAdmin ?? []}
+          availableTags={availableTags ?? []}
+          canManage={canManageQueues ?? false}
+        />
+
         {thread && (
           <Deferred data="availableChannels" fallback={null}>
             <ContextSidebarV4

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/QueuesSheet.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/QueuesSheet.tsx
@@ -1,0 +1,350 @@
+// QueuesSheet.tsx — painel "Filas" da Caixa Unificada V4 (US-WA-301 · ADR 0267).
+//
+// Sheet in-place (sem context switch) com CRUD das filas persistidas em
+// `whatsapp_queues`. Visual: chips hue como `QUEUES` do protótipo Cowork
+// (inbox-page.jsx) — dot OKLCH + label + SLA + tags-gatilho.
+//
+// `dist` é persistido mas o roteamento automático (round-robin/sticky) é US
+// futura — o select existe pra já capturar a intenção (TODO honesto ADR 0267).
+// `members` fica FORA da UI nesta fase (sem fingir feature — anti M-AP-2).
+//
+// Mutações via QueuesController (atendimento.filas.*) — permission
+// whatsapp.settings.manage (botão fica read-only sem ela).
+
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+import { Pencil, Plus, Trash2, X } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/Components/ui/sheet';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Inline, Stack } from '@/Components/layout';
+import { cn } from '@/Lib/utils';
+import type { ConvTag, QueueAdminItem } from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  queues: QueueAdminItem[];
+  availableTags: ConvTag[];
+  canManage: boolean;
+}
+
+const DIST_LABELS: Record<string, string> = {
+  manual: 'Manual',
+  round_robin: 'Round-robin (em breve)',
+  sticky: 'Sticky (em breve)',
+};
+
+interface FormState {
+  id: number | null;
+  label: string;
+  hue: number;
+  sla_minutes: string;
+  dist: string;
+  trigger_tags: string[];
+}
+
+const EMPTY_FORM: FormState = { id: null, label: '', hue: 220, sla_minutes: '', dist: 'manual', trigger_tags: [] };
+
+export default function QueuesSheet({ open, onOpenChange, queues, availableTags, canManage }: Props) {
+  const [form, setForm] = useState<FormState | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  const reloadOnly = ['queuesAdmin', 'queues', 'stats', 'conversations'];
+
+  function submit() {
+    if (!form || saving || !form.label.trim()) return;
+    setSaving(true);
+    const payload = {
+      label: form.label.trim(),
+      hue: form.hue,
+      sla_minutes: form.sla_minutes !== '' ? Number(form.sla_minutes) : null,
+      dist: form.dist,
+      trigger_tags: form.trigger_tags,
+    };
+    const opts = {
+      preserveScroll: true,
+      preserveState: true,
+      only: reloadOnly,
+      onSuccess: () => setForm(null),
+      onFinish: () => setSaving(false),
+    };
+    if (form.id !== null) {
+      router.put(route('atendimento.filas.update', form.id), payload, opts);
+    } else {
+      router.post(route('atendimento.filas.store'), payload, opts);
+    }
+  }
+
+  function remove(q: QueueAdminItem) {
+    if (q.is_default || saving) return;
+    if (!confirm(`Remover a fila "${q.label}"? Conversas voltam pra heurística tag→fila.`)) return;
+    setSaving(true);
+    router.delete(route('atendimento.filas.destroy', q.id), {
+      preserveScroll: true,
+      preserveState: true,
+      only: reloadOnly,
+      onFinish: () => setSaving(false),
+    });
+  }
+
+  function toggleTriggerTag(slug: string) {
+    if (!form) return;
+    setForm({
+      ...form,
+      trigger_tags: form.trigger_tags.includes(slug)
+        ? form.trigger_tags.filter(s => s !== slug)
+        : [...form.trigger_tags, slug],
+    });
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => { if (!o) setForm(null); onOpenChange(o); }}>
+      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Filas de atendimento</SheetTitle>
+          <SheetDescription>
+            Conversas entram na fila pela heurística de tags-gatilho. SLA alimenta
+            os indicadores da lista. Distribuição automática é etapa futura.
+          </SheetDescription>
+        </SheetHeader>
+
+        <Stack gap={2} className="mt-4">
+          {queues.length === 0 && (
+            <p className="text-[12px] text-muted-foreground italic">Carregando filas…</p>
+          )}
+          {queues.map(q => (
+            <div
+              key={q.id}
+              className="border rounded-md px-3 py-2"
+              data-testid={`caixa-unif-queue-row-${q.slug}`}
+            >
+              <Inline gap={2} align="center" justify="between">
+                <Inline gap={2} align="center" className="min-w-0">
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-full flex-shrink-0"
+                    style={{ background: `oklch(0.62 0.13 ${q.hue})` }}
+                    aria-hidden
+                  />
+                  <span className="min-w-0">
+                    <b className="block text-[12.5px] font-semibold truncate">
+                      {q.label}
+                      {q.is_default && (
+                        <span className="ml-1.5 text-[9.5px] font-medium text-muted-foreground bg-muted border rounded-full px-1.5">
+                          default
+                        </span>
+                      )}
+                    </b>
+                    <small className="block text-[10.5px] text-muted-foreground font-mono truncate">
+                      {q.slug}
+                      {q.sla ? ` · SLA ${q.sla}` : ' · sem SLA'}
+                      {` · ${DIST_LABELS[q.dist] ?? q.dist}`}
+                    </small>
+                  </span>
+                </Inline>
+                {canManage && (
+                  <Inline gap={1} align="center" className="flex-shrink-0">
+                    <button
+                      type="button"
+                      onClick={() => setForm({
+                        id: q.id,
+                        label: q.label,
+                        hue: q.hue,
+                        sla_minutes: q.sla_minutes !== null ? String(q.sla_minutes) : '',
+                        dist: q.dist,
+                        trigger_tags: q.trigger_tags,
+                      })}
+                      className="p-1.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                      title={`Editar fila ${q.label}`}
+                      data-testid={`caixa-unif-queue-edit-${q.slug}`}
+                    >
+                      <Pencil size={13} aria-hidden />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => remove(q)}
+                      disabled={q.is_default}
+                      className="p-1.5 rounded text-muted-foreground hover:text-destructive hover:bg-destructive/5 disabled:opacity-35 disabled:cursor-not-allowed"
+                      title={q.is_default ? 'Fila default não pode ser removida (fallback da heurística)' : `Remover fila ${q.label}`}
+                      data-testid={`caixa-unif-queue-delete-${q.slug}`}
+                    >
+                      <Trash2 size={13} aria-hidden />
+                    </button>
+                  </Inline>
+                )}
+              </Inline>
+              {q.trigger_tags.length > 0 && (
+                <Inline gap={1} wrap className="mt-1.5">
+                  {q.trigger_tags.map(slug => (
+                    <span
+                      key={slug}
+                      className="inline-block px-2 py-px text-[10px] font-mono rounded-full text-foreground"
+                      style={{ background: 'oklch(0.94 0.03 80)', border: '1px solid oklch(0.86 0.06 80)' }}
+                    >
+                      {slug}
+                    </span>
+                  ))}
+                </Inline>
+              )}
+            </div>
+          ))}
+
+          {canManage && form === null && (
+            <Button
+              type="button"
+              variant="outline"
+              className="gap-1.5"
+              onClick={() => setForm({ ...EMPTY_FORM })}
+              data-testid="caixa-unif-queue-new"
+            >
+              <Plus size={14} aria-hidden /> Nova fila
+            </Button>
+          )}
+
+          {canManage && form !== null && (
+            <Stack gap={3} className="border rounded-md p-3 bg-muted/20" data-testid="caixa-unif-queue-form">
+              <Inline gap={0} align="center" justify="between">
+                <b className="text-[12.5px] font-semibold">
+                  {form.id !== null ? 'Editar fila' : 'Nova fila'}
+                </b>
+                <button
+                  type="button"
+                  onClick={() => setForm(null)}
+                  className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                  title="Fechar formulário"
+                >
+                  <X size={13} aria-hidden />
+                </button>
+              </Inline>
+
+              <Stack gap={1}>
+                <Label htmlFor="queue-label" className="text-[11px]">Nome</Label>
+                <Input
+                  id="queue-label"
+                  value={form.label}
+                  onChange={e => setForm({ ...form, label: e.target.value })}
+                  placeholder="Ex.: Suporte técnico"
+                  data-testid="caixa-unif-queue-form-label"
+                />
+              </Stack>
+
+              <Inline gap={3} align="end">
+                <Stack gap={1} className="flex-1">
+                  <Label htmlFor="queue-hue" className="text-[11px]">Cor (hue 0-360)</Label>
+                  <Inline gap={2} align="center">
+                    <Input
+                      id="queue-hue"
+                      type="number"
+                      min={0}
+                      max={360}
+                      value={form.hue}
+                      onChange={e => setForm({ ...form, hue: Math.max(0, Math.min(360, Number(e.target.value) || 0)) })}
+                      data-testid="caixa-unif-queue-form-hue"
+                    />
+                    <span
+                      className="inline-block w-5 h-5 rounded-full border flex-shrink-0"
+                      style={{ background: `oklch(0.62 0.13 ${form.hue})` }}
+                      aria-hidden
+                    />
+                  </Inline>
+                </Stack>
+                <Stack gap={1} className="flex-1">
+                  <Label htmlFor="queue-sla" className="text-[11px]">SLA (minutos)</Label>
+                  <Input
+                    id="queue-sla"
+                    type="number"
+                    min={1}
+                    placeholder="sem SLA"
+                    value={form.sla_minutes}
+                    onChange={e => setForm({ ...form, sla_minutes: e.target.value })}
+                    data-testid="caixa-unif-queue-form-sla"
+                  />
+                </Stack>
+              </Inline>
+
+              <Stack gap={1}>
+                <Label className="text-[11px]">Distribuição</Label>
+                <Select value={form.dist} onValueChange={v => setForm({ ...form, dist: v })}>
+                  <SelectTrigger data-testid="caixa-unif-queue-form-dist">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {Object.entries(DIST_LABELS).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>{label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <small className="text-[10px] text-muted-foreground">
+                  Round-robin/sticky são capturados agora e ativam quando o roteamento automático existir (ADR 0267).
+                </small>
+              </Stack>
+
+              <Stack gap={1}>
+                <Label className="text-[11px]">Tags-gatilho</Label>
+                <Inline gap={1} wrap>
+                  {availableTags.length === 0 && (
+                    <small className="text-[10.5px] text-muted-foreground italic">Nenhuma tag cadastrada</small>
+                  )}
+                  {availableTags.map(t => {
+                    const active = form.trigger_tags.includes(t.slug);
+                    return (
+                      <button
+                        key={t.id}
+                        type="button"
+                        onClick={() => toggleTriggerTag(t.slug)}
+                        aria-pressed={active}
+                        data-testid={`caixa-unif-queue-form-tag-${t.slug}`}
+                        className={cn(
+                          'inline-flex items-center h-6 px-2 rounded-full border text-[10.5px] font-medium transition-colors',
+                          active
+                            ? 'bg-primary/10 border-primary text-primary'
+                            : 'bg-card border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground',
+                        )}
+                      >
+                        {t.label}
+                      </button>
+                    );
+                  })}
+                </Inline>
+              </Stack>
+
+              <Inline gap={2} justify="end">
+                <Button type="button" variant="ghost" onClick={() => setForm(null)}>
+                  Cancelar
+                </Button>
+                <Button
+                  type="button"
+                  onClick={submit}
+                  disabled={saving || !form.label.trim()}
+                  data-testid="caixa-unif-queue-form-save"
+                >
+                  {saving ? 'Salvando…' : form.id !== null ? 'Salvar fila' : 'Criar fila'}
+                </Button>
+              </Inline>
+            </Stack>
+          )}
+
+          {!canManage && (
+            <p className="text-[11px] text-muted-foreground">
+              Você não tem a permissão de configuração (whatsapp.settings.manage) — visualização apenas.
+            </p>
+          )}
+        </Stack>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -75,6 +75,24 @@ export interface QueueConfig {
   trigger_tags?: string[];
 }
 
+/**
+ * US-WA-301 (ADR 0267) — row completa de `whatsapp_queues` pro painel Filas
+ * (QueuesSheet CRUD). `dist`/`members` persistidos; roteamento automático é
+ * US futura.
+ */
+export interface QueueAdminItem {
+  id: number;
+  slug: string;
+  label: string;
+  hue: number;
+  sla_minutes: number | null;
+  sla: string | null;
+  dist: string;
+  trigger_tags: string[];
+  sort_order: number;
+  is_default: boolean;
+}
+
 export interface ConvTag {
   id: number;
   slug: string;


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-3 de 10

**US-WA-301 — Filas DB + painel de configuração** (charter roadmap §1, P1)

### ADR per-schema ANTES da migration (padrão charter §1)
- [ADR 0267](memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md) — `whatsapp_queues` (business_id, slug, label, hue, sla_minutes, dist, trigger_tags, members, sort_order; unique biz+slug)

### O que muda
- **Seed lazy idempotente** do `config('whatsapp.queues')` na 1ª visita por business (pattern `ensureDefaultTags` — migração sem quebra)
- **Controller lê DB com fallback config** (princípio duro 8 ADR 0094); heurística tag→fila e `stats.queues_count` acompanham
- **QueuesSheet** (Sheet in-place): CRUD label / hue com dot OKLCH / SLA em minutos / distribuição / tags-gatilho (chips). Fila default protegida de delete. Topnav "Filas" deixa de ser disabled
- Mutações `atendimento.filas.*` com `whatsapp.settings.manage`; slug imutável no update
- **TODO honesto** (anti M-AP-2): `dist`/`members` persistidos, roteamento automático round-robin/sticky é US futura — documentado no ADR

### Tier 0
- where business_id explícito em toda query + HasBusinessScope na entity
- Pest `R-WA-CAIXA-UNIF-007` (seed idempotente + payload lê DB + cross-tenant invisível) e `008` (CRUD + default protegida + delete cross-tenant 404)

### Gates locais
- layout-primitives ✅ zero delta · eslint baseline ✅ (-13) · tsc zero novo · índice ADR regenerado

Charter → v4 (Goals Filas, Non-Goals roteamento automático, roadmap §1 ✅, métricas vivas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)