### PR TITLE
fix(oficina): board cortado sob a sidebar - remove -m-6 orfao (+ sweep das 11 telas com o mesmo anti-pattern)

### DIFF
--- a/memory/LICOES_CC.md
+++ b/memory/LICOES_CC.md
@@ -181,6 +181,12 @@
 - **Regra:** quando a melhor ação é **clara, reversível e não-Tier-0**, **faço direto** e reporto — sem opção. Só pergunto quando é genuinamente **subjetivo/Tier-0** (estética, estratégia, prioridade, dinheiro, lei) **ou** ambíguo de verdade. "Quer que eu…?" em ação óbvia = erro meu.
 - **Ref:** L-15 (auto-gerar ponte sem perguntar); CLAUDE.md zero-touch; ADR 0243 R8 (Tier-0 = [W]; resto [CC] age).
 
+## L-26 — Margem negativa no root de página AppShellV2 "cancelando" padding que o shell NÃO tem = tela cortada sob a sidebar
+- **Erro (2026-06-10):** `Board.tsx` (OficinaAuto) com `-m-6 min-h-[calc(100vh-3rem)]` no root, assumindo que o AppShellV2 envolve a página com `p-6` — mas `.main-body` (cockpit.css) é flex column **sem padding**, e a topbar 3rem está extinta (hideTopbar default desde 2026-05-17). Margem negativa em scroll container cria overflow **inalcançável** à esquerda/topo → header, KPIs e 1ª coluna do kanban permanentemente cortados sob a sidebar. Descoberto por **[W] na tela, de novo** (escape de mecanismo — nenhum guard pegou). Sweep achou o mesmo padrão órfão em **11 telas** (Cliente/*, Modules/Index, Sells/*, Vehicles/Index).
+- **Sintoma:** tela "não encaixa" / cortada sob a sidebar em produção; scrollbar horizontal no main-body; conteúdo inalcançável mesmo rolando. O protótipo Cowork estava certo — a divergência era no port.
+- **Regra:** página de AppShellV2 **NUNCA** usa margem negativa no root pra "cancelar" padding do shell — o `.main-body` **não tem padding**. Kanban/grid largo **SEMPRE** rola por dentro (wrapper `overflow-x-auto` + `repeat(n, minmax(Xpx, 1fr))`), nunca estoura o shell. Antes de assumir padding/altura do shell, **ler cockpit.css** (canon `.prod-kanban` do protótipo: oficina-page.css).
+- **Ref:** [memory/sessions/2026-06-10-board-oficina-corte.md](sessions/2026-06-10-board-oficina-corte.md); PR #2508 (fix + sweep 11 telas); cockpit.css l.145-190; canon `.prod-kanban` (prototipo-ui styles.css l.3798); L-24 (escape pego por [W], não por mecanismo).
+
 > 1ª aplicação do loop da camada 5. Cada lição classificada: **MEC** (vira check) ou **JULG** (vira regra-carregada) + destino + status. Achado: **a maioria já se graduou** sem o loop ser nomeado; o valor agora é fechar as **pendentes** e comprimir o resto.
 
 | L | Classe | Destino da graduação | Status |

--- a/memory/sessions/2026-06-10-board-oficina-corte.md
+++ b/memory/sessions/2026-06-10-board-oficina-corte.md
@@ -1,0 +1,78 @@
+---
+date: "2026-06-10"
+hour: "15:00 BRT"
+topic: "Board Oficina cortado sob a sidebar em produção — diagnóstico Cowork + patch -m-6 órfão"
+authors: [W, C]
+outcomes:
+  - "Causa raiz: -m-6 no root assumindo p-6 que .main-body não tem + min-h topbar extinta + grid sem minmax/scroll interno"
+  - "Patch aplicado em Board.tsx (flex-1 + overflow-x-auto + repeat(n, minmax(228px,1fr)))"
+  - "Sweep do anti-pattern -m-6 em 11 telas restantes"
+  - "Lição L-26 registrada em memory/LICOES_CC.md"
+prs: [2508]
+us: []
+related_adrs: []
+---
+
+# Sessão 2026-06-10 — Board Oficina cortado em produção (diagnóstico + patch)
+
+## Pedido
+[W] mandou screenshot de oimpresso.com/oficina-auto/ordens-servico/board: tela cortada
+embaixo da sidebar, "não encaixa", e a sensação de que o design da Oficina Auto
+"não foi aplicado". Pediu comparação com o protótipo Cowork.
+
+## O que foi feito
+- Comparei oimpresso.com.html dos dois projetos Cowork (atual × 019dcfd3…): **idênticos**
+  (135 linhas, 7512 chars). O problema NÃO era o protótipo — era a tela real em produção.
+- Li `resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx`, `ServiceOrderKanbanColumn.tsx`,
+  `boardTone.ts`, `AppShellV2.tsx` e `cockpit.css` no repo.
+
+## Diagnóstico (causa raiz do corte)
+1. **`-m-6` no root do Board.tsx**: assume que o AppShellV2 envolve a página com p-6.
+   Mas `.main-body` (cockpit.css ~l.180) é flex column **sem padding**. Margem negativa
+   num scroll container cria overflow **inalcançável** à esquerda/topo → header
+   ("…cina · Quadro de OS"), KPIs e 1ª coluna ficam permanentemente cortados.
+2. **`min-h-[calc(100vh-3rem)]`**: assume topbar 3rem, mas hideTopbar=true é default
+   desde 2026-05-17.
+3. **`grid grid-cols-6`** sem minmax nem scroll interno: min-content dos cards estoura
+   a viewport → scrollbar horizontal no main-body, quadro espremido. Canon do protótipo
+   (.prod-kanban, oficina-page.css): `repeat(n, minmax(228px, 1fr))` + `overflow: auto`
+   — o quadro rola POR DENTRO, o shell nunca estoura.
+
+## Divergência visual registrada (decisão de [W], não corrigi)
+`boardTone.ts` usa paleta Tailwind crua multi-hue (amber/violet/emerald/rose/etc.) nos
+KPIs e colunas — diverge dos tokens do CLAUDE_DESIGN_BRIEFING (warn/pos/neg/accent-soft).
+O arquivo afirma que as cores foram [W]-aprovadas ("a cor exata aprovada") — então só
+registro: se [W] quiser o board com a cara do protótipo warm, o ponto único de mudança
+é boardTone.ts.
+
+## Entrega
+Patch zero-toque: `prototipo-ui-patch/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx`
+(diff mínimo: root `-m-6 … min-h-[calc(100vh-3rem)]` → `flex-1`; quadro com wrapper
+`overflow-x-auto` + gridTemplateColumns inline `repeat(n, minmax(228px,1fr))`;
+`gridColsClass` removido). URL pública + 1 prompt pro Claude Code no chat.
+
+## Erros + correção
+Nenhum erro novo de [CC] nesta sessão.
+
+## Residual
+- [CL] precisa commitar o patch (eu não escrevo no git).
+- Verificar depois do deploy se outras telas usam o mesmo anti-pattern `-m-6`
+  (grep por `-m-6` em resources/js/Pages — provável em ProducaoOficina).
+
+## Refs
+- Board.tsx @main (commit 3b560b86) · cockpit.css l.145-190 · oficina-page.css l.7-18
+- Protótipo canon: oficina-page.jsx / .prod-kanban (styles.css l.3798)
+
+## Faxina anti-token-burn ([W] autorizou: "tem que apagar os errados")
+115 arquivos mortos removidos: `_cowork-bundle/` (11), `_scrap/` (12),
+`prototipo-ui-patch/_processados/` (22) e ~70 pontes/patches/espelhos antigos no
+`prototipo-ui-patch/` (PROMPT_PARA_CODE_* de ondas mergeadas, vendas-*.jsx de maio,
+cópias locais de PROTOCOL/BRIEFING/GLOSSARY/COWORK_NOTES). Mantidos: pontes dos
+últimos ~3 dias (QUALIDADE-9, CAIXA-UNIFICADA, ERRADICA-LOCACAO-ACTIONS,
+PACOTE-FINANCEIRO-F2, PRIMITIVOS-LAYOUT-V2, W28, UC-GUARDS, CICLO-DIARIO,
+GOVERNANCA-FECHAR-G3-G7), charters/registros vivos (REGRAS_*, REGISTRY_*, MATRIZ_*,
+Oficina.charter, CobrancaRecorrente.charter), `resources/` (patches F1 recentes),
+`memory/`, `prototipos/` e pastas de estrutura. Regra nova: **L-39** em LICOES_CC.md.
+
+## Próximo passo
+Wagner cola o prompt no Claude Code → commit + push → conferir a tela no navegador.

--- a/resources/js/Pages/Cliente/Create.tsx
+++ b/resources/js/Pages/Cliente/Create.tsx
@@ -83,7 +83,7 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
   };
 
   return (
-    <div className="-m-6 min-h-[calc(100vh-3rem)] bg-muted/30">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto max-w-5xl px-8 pb-4 pt-6">
           <a

--- a/resources/js/Pages/Cliente/Edit.tsx
+++ b/resources/js/Pages/Cliente/Edit.tsx
@@ -107,7 +107,7 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
   };
 
   return (
-    <div className="-m-6 min-h-[calc(100vh-3rem)] bg-muted/30">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto max-w-5xl px-8 pb-4 pt-6">
           <a

--- a/resources/js/Pages/Cliente/Import.tsx
+++ b/resources/js/Pages/Cliente/Import.tsx
@@ -50,7 +50,7 @@ export default function ClienteImport(props: ClienteImportPageProps) {
 
   if (!props.zip_available) {
     return (
-      <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+      <div className="flex-1 bg-muted/30">
         <div className="container mx-auto px-8 py-12 max-w-2xl">
           <div className="rounded-lg border border-rose-200 bg-rose-50 p-6 text-rose-700">
             <h2 className="font-semibold flex items-center gap-2">
@@ -68,7 +68,7 @@ export default function ClienteImport(props: ClienteImportPageProps) {
   }
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-8 pt-6 pb-4 max-w-3xl">
           <div className="flex items-center gap-3 mb-2">

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -828,7 +828,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
        warm hue 90 espelha `.cockpit` /sells canon Cowork. Cria afinidade visual com cards
        brancos (mesma família temperatura) sem competir com filtros coloridos.
        Token `--color-page-cream` definido em resources/css/inertia.css @theme block. */
-    <div className="-m-6 bg-page-cream min-h-[calc(100vh-3rem)] py-4">
+    <div className="flex-1 bg-page-cream py-4">
      {/* Fluid layout — Wagner 2026-05-25: tabela contatos usa 100% da largura disponível
          (pattern Linear/Notion/Stripe Dashboard em listas). `w-full px-6` (24px respiro
          lateral) + `py-4` (16px respiro topo+rodapé) — Wagner pediu "respiro nas laterais

--- a/resources/js/Pages/Cliente/Ledger.tsx
+++ b/resources/js/Pages/Cliente/Ledger.tsx
@@ -96,7 +96,7 @@ export default function ClienteLedger(props: ClienteLedgerPageProps) {
   };
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-8 pt-6 pb-4 max-w-7xl">
           <div className="flex items-center gap-3 mb-2">

--- a/resources/js/Pages/Cliente/Map.tsx
+++ b/resources/js/Pages/Cliente/Map.tsx
@@ -43,7 +43,7 @@ export default function ClienteMap(props: ClienteMapPageProps) {
   );
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-8 pt-6 pb-4 max-w-7xl">
           <div className="flex items-center gap-3 mb-2">

--- a/resources/js/Pages/Cliente/Show.tsx
+++ b/resources/js/Pages/Cliente/Show.tsx
@@ -134,7 +134,7 @@ export default function ClienteShow(props: ClienteShowPageProps) {
   ];
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-8 pt-6 pb-4 max-w-6xl">
           <div className="flex items-center justify-between gap-3 mb-2">

--- a/resources/js/Pages/Modules/Index.tsx
+++ b/resources/js/Pages/Modules/Index.tsx
@@ -150,7 +150,7 @@ export default function ModulesIndex({ modules }: Props) {
   };
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="flex-1 bg-muted/30">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-8 pt-6 pb-4 max-w-7xl">
           <div className="flex items-start gap-4">

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
@@ -20,6 +20,19 @@
 // densidade compacta @container @1280 · "N OS" + distinção aguardando-peças × aprovação.
 //
 // Lição PR #717 — useMemo/useCallback nos handlers descendentes.
+//
+// FIX layout [CC] 2026-06-10 (reportado por [W] com screenshot — board cortado):
+//   1. Removido `-m-6` do root: AppShellV2 `.main-body` NÃO tem p-6 (é flex column
+//      sem padding — cockpit.css linha ~180). A margem negativa criava overflow
+//      INALCANÇÁVEL à esquerda/topo do scroll container → header/KPIs/1ª coluna
+//      permanentemente cortados embaixo da sidebar.
+//   2. Removido `min-h-[calc(100vh-3rem)]`: assumia topbar de 3rem, mas
+//      hideTopbar default = true desde 2026-05-17. Substituído por `flex-1`.
+//   3. Grid do quadro: `grid-cols-6` (1fr puro, min-content estoura a viewport)
+//      → `repeat(n, minmax(228px, 1fr))` + wrapper com overflow-x-auto.
+//      Espelha o canon do protótipo Cowork (.prod-kanban.ofc-5 em
+//      oficina-page.css: repeat(5, minmax(228px, 1fr)) + overflow auto):
+//      o quadro rola HORIZONTALMENTE POR DENTRO, o shell nunca estoura.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router } from '@inertiajs/react';
@@ -251,16 +264,17 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
     { id: 'atrasadas', label: 'Atrasadas', value: String(kpis.atrasadas), tone: 'rose' as const },
   ], [kpis]);
 
-  const gridColsClass = useMemo(() => {
-    const n = columns.length || 1;
-    // até 6 colunas mapeadas estaticamente (Tailwind precisa de classes literais)
-    return ({ 1: 'grid-cols-1', 2: 'grid-cols-2', 3: 'grid-cols-3', 4: 'grid-cols-4', 5: 'grid-cols-5', 6: 'grid-cols-6' } as Record<number, string>)[Math.min(n, 6)] ?? 'grid-cols-6';
-  }, [columns.length]);
+  // FIX [CC] 2026-06-10: colunas com largura mínima utilizável (canon do protótipo
+  // .prod-kanban: repeat(n, minmax(228px, 1fr))) — inline style em vez de classe
+  // Tailwind literal porque o nº de colunas é data-driven. O wrapper rola no eixo X.
+  const boardGridStyle = useMemo(() => ({
+    gridTemplateColumns: `repeat(${Math.max(columns.length, 1)}, minmax(228px, 1fr))`,
+  }), [columns.length]);
 
   return (
     <>
       <Head title="Oficina · Quadro de OS" />
-      <div className="-m-6 bg-muted/40 min-h-[calc(100vh-3rem)] @container/board">
+      <div className="flex-1 bg-muted/40 @container/board">
         {/* Topbar */}
         <header className="bg-white border-b border-border px-6 py-4 flex items-start justify-between gap-4 flex-wrap">
           <div className="min-w-0">
@@ -345,13 +359,14 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
           </span>
         </div>
 
-        {/* Quadro */}
-        <div className="p-6">
+        {/* Quadro — overflow-x-auto: o kanban rola por dentro, o shell nunca estoura
+            (espelha .prod-kanban do protótipo: overflow auto + minmax(228px, 1fr)) */}
+        <div className="p-6 overflow-x-auto">
           {!process_seeded ? (
             <EmptyProcessState />
           ) : (
             <KanbanDndProvider<ServiceOrderCardData, string> onMove={handleDragMove} renderPreview={renderPreview}>
-              <div className={'grid gap-4 ' + gridColsClass}>
+              <div className="grid gap-4 items-start" style={boardGridStyle}>
                 {columns.map((col) => (
                   <ServiceOrderKanbanColumn
                     key={col.key}

--- a/resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
@@ -219,7 +219,7 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
   return (
     <>
       <Head title="Veículos · Oficina Auto" />
-      <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+      <div className="flex-1 bg-muted/30">
         {/* Header — Cockpit V2 canon (h1 + subtitle + KPIs + filter pills) */}
         <div className="border-b border-border bg-background">
           <div className="container mx-auto px-8 pt-6 pb-4 max-w-7xl">

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -964,7 +964,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   }, []);
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)] flex flex-col">
+    <div className="flex-1 bg-muted/30 flex flex-col">
       {/* Header sticky no topo + abas seção (pattern Office/OS canon) */}
       <div className="sticky top-0 z-30 bg-background/95 backdrop-blur border-b border-border">
         <div className="container mx-auto px-8 pt-6 pb-3 max-w-7xl">

--- a/resources/js/Pages/Sells/Edit.tsx
+++ b/resources/js/Pages/Sells/Edit.tsx
@@ -451,7 +451,7 @@ export default function SellsEdit(props: SellsEditPageProps) {
     <>
       <Head title={`Editar venda #${headline.invoice_no}`} />
 
-      <div className="sells-cowork-edit -m-6 bg-muted/30 min-h-[calc(100vh-3rem)] flex flex-col">
+      <div className="sells-cowork-edit flex-1 bg-muted/30 flex flex-col">
         {/* Header sticky no topo + filter pills (KB-9.75 paridade Create pattern) */}
         <div className="sticky top-0 z-30 bg-background/95 backdrop-blur border-b border-border">
           <div className="container mx-auto px-8 pt-6 pb-3 max-w-7xl">


### PR DESCRIPTION
## O que

Fix do board da Oficina **cortado embaixo da sidebar** (reportado por [W] com screenshot). Patch pronto do [CC] Cowork, diff mínimo, auditado contra `cockpit.css` + canon `.prod-kanban` do protótipo.

### Board.tsx (commit 1 — patch [CC])
1. **root**: remove `-m-6` e `min-h-[calc(100vh-3rem)]` → `flex-1`. `.main-body` do AppShellV2 NÃO tem `p-6` (flex column sem padding, cockpit.css ~L180) — a margem negativa criava overflow inalcançável (header/KPIs/1ª coluna cortados). A topbar de 3rem não existe mais (`hideTopbar` default desde 2026-05-17).
2. **quadro**: wrapper `overflow-x-auto` + `gridTemplateColumns: repeat(n, minmax(228px,1fr))` — o kanban rola horizontalmente POR DENTRO, o shell nunca estoura. Espelha o canon `.prod-kanban` do protótipo Cowork.
3. remove `gridColsClass` (morto).

### Sweep (commit 2 — bonus do handoff)
`grep -rn "\-m-6" resources/js/Pages` achou o mesmo anti-pattern órfão em **11 telas** (todas AppShellV2): Cliente/{Index,Show,Edit,Create,Import,Map,Ledger}, Modules/Index, Sells/{Create,Edit}, OficinaAuto/Vehicles/Index. Correção mecânica idêntica (root → `flex-1`). ProducaoOficina não usa o padrão.

## Validação
- ✅ Diff do Board bate 1:1 com o handoff (nada além das 3 mudanças)
- ✅ Charter `Board.charter.md` respeitado — colunas seguem data-driven do payload (anti-hook "nunca hardcodar colunas")
- ✅ `npm run build:inertia` verde (14s)
- ✅ `tsc --noEmit`: zero erros novos em qualquer arquivo tocado (429 pré-existentes do baseline, nenhum nos 12 arquivos)
- ⚠️ Smoke visual pós-merge recomendado nas telas do sweep (mudança mecânica de 1 linha por tela, mesmo root)

Refs: CYCLE-08

🤖 Generated with [Claude Code](https://claude.com/claude-code)
