### PR TITLE
feat(whatsapp): US-WA-305 mover conversa entre filas — queue_override (PR-4/10)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_06_10_000002_add_queue_override_to_conversations.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_06_10_000002_add_queue_override_to_conversations.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-305 (charter §4 · consequência prevista no ADR 0267) — override manual
+ * de fila por conversa.
+ *
+ * Hoje a fila é DERIVADA read-only (heurística trigger_tags → fila). Wagner
+ * quer mover conversa de fila SEM re-tagar: `queue_override` (slug de
+ * `whatsapp_queues`) vence a heurística quando preenchido; NULL = volta pra
+ * derivação automática.
+ *
+ * String slug (não FK id) de propósito: filas são soft-config por business
+ * (slug estável, ADR 0267); deletar fila não quebra a conversa — slug órfão
+ * cai no fallback heurística no Controller.
+ *
+ * Idempotente: hasColumn guard.
+ *
+ * @see memory/decisions/0267-whatsapp-queues-tabela-filas-atendimento.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('conversations') || Schema::hasColumn('conversations', 'queue_override')) {
+            return;
+        }
+
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->string('queue_override', 40)->nullable()->after('assigned_user_id')
+                ->comment('US-WA-305: slug de whatsapp_queues que vence a heuristica tag→fila; NULL = automatica');
+        });
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('conversations') && Schema::hasColumn('conversations', 'queue_override')) {
+            Schema::table('conversations', function (Blueprint $table) {
+                $table->dropColumn('queue_override');
+            });
+        }
+    }
+};

--- a/Modules/Whatsapp/Entities/Conversation.php
+++ b/Modules/Whatsapp/Entities/Conversation.php
@@ -31,6 +31,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string $status
  * @property ?int $assigned_user_id
  * @property-read ?\App\User $assignedUser
+ * @property ?string $queue_override  US-WA-305: slug whatsapp_queues que vence heurística; NULL = automática
  * @property bool $bot_handling
  * @property ?\Carbon\CarbonImmutable $last_inbound_at
  * @property ?\Carbon\CarbonImmutable $last_outbound_at
@@ -82,7 +83,7 @@ class Conversation extends Model
     protected $fillable = [
         'business_id', 'channel_id', 'contact_id',
         'customer_external_id', 'contact_name',
-        'status', 'assigned_user_id', 'bot_handling',
+        'status', 'assigned_user_id', 'queue_override', 'bot_handling',
         'last_inbound_at', 'last_outbound_at', 'last_message_at',
         'unread_count', 'is_blocked',
         // US-WA-072 — denormalizado pra evitar N+1 em InboxController list

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -712,6 +712,34 @@ class CaixaUnificadaController extends Controller
     }
 
     /**
+     * US-WA-305 — fila efetiva da conversa: `queue_override` (manual) vence a
+     * heurística tag→fila quando preenchido E o slug ainda existe nas filas do
+     * business (slug órfão de fila deletada cai no fallback automático).
+     *
+     * @return array{slug: string, label: string, hue: int, sla: ?string}
+     */
+    protected function resolveQueue(Conversation $c, array $tagSlugs): array
+    {
+        $override = $c->queue_override;
+        if ($override !== null && $override !== '') {
+            $businessId = (int) session('user.business_id');
+            $queues = $this->getQueuesConfig($businessId);
+            if (isset($queues[$override])) {
+                $cfg = $queues[$override];
+
+                return [
+                    'slug' => $override,
+                    'label' => (string) ($cfg['label'] ?? ucfirst($override)),
+                    'hue' => (int) ($cfg['hue'] ?? 0),
+                    'sla' => $cfg['sla'] ?? null,
+                ];
+            }
+        }
+
+        return $this->deriveQueueFromTags($tagSlugs);
+    }
+
+    /**
      * Conversation pro componente lista (ConversationListV4).
      */
     protected function convToListArray(Conversation $c): array
@@ -737,7 +765,7 @@ class CaixaUnificadaController extends Controller
             'tags' => $c->relationLoaded('tags')
                 ? $c->tags->map(fn ($t) => ['id' => $t->id, 'slug' => $t->slug, 'label' => $t->label, 'color' => $t->color])->all()
                 : [],
-            'queue' => $this->deriveQueueFromTags($tagSlugs),
+            'queue' => $this->resolveQueue($c, $tagSlugs),
             // Preview-only — canal ainda em homologação (status != 'active')
             'preview_only' => ($channel?->status ?? 'active') !== 'active',
         ];
@@ -774,7 +802,10 @@ class CaixaUnificadaController extends Controller
             'tags' => $c->relationLoaded('tags')
                 ? $c->tags->map(fn ($t) => ['id' => $t->id, 'slug' => $t->slug, 'label' => $t->label, 'color' => $t->color])->all()
                 : [],
-            'queue' => $this->deriveQueueFromTags($tagSlugs),
+            'queue' => $this->resolveQueue($c, $tagSlugs),
+            // US-WA-305 — sidebar mostra se a fila é override manual ou heurística
+            'queue_is_override' => $c->queue_override !== null && $c->queue_override !== ''
+                && isset($this->getQueuesConfig((int) session('user.business_id'))[$c->queue_override]),
             'preview_only' => ($channel?->status ?? 'active') !== 'active',
         ];
     }

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -727,11 +727,12 @@ class CaixaUnificadaController extends Controller
             if (isset($queues[$override])) {
                 $cfg = $queues[$override];
 
+                // Shape garantido por getQueuesConfig — offsets sempre presentes
                 return [
                     'slug' => $override,
-                    'label' => (string) ($cfg['label'] ?? ucfirst($override)),
-                    'hue' => (int) ($cfg['hue'] ?? 0),
-                    'sla' => $cfg['sla'] ?? null,
+                    'label' => (string) $cfg['label'],
+                    'hue' => (int) $cfg['hue'],
+                    'sla' => $cfg['sla'],
                 ];
             }
         }

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -1116,6 +1116,52 @@ class InboxController extends Controller
     }
 
     /**
+     * US-WA-305: PATCH `/atendimento/inbox/{id}/queue` — move conversa entre
+     * filas (override manual que vence a heurística tag→fila, ADR 0267).
+     *
+     * `queue_slug: null` remove o override (volta pra derivação automática).
+     * Tier 0: slug precisa existir nas filas do MESMO business (whatsapp_queues
+     * com fallback config) — slug desconhecido = 422 fail-loud.
+     */
+    public function moveQueue(\Illuminate\Http\Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        // US-WA-069 defense-in-depth: user sem acesso ao canal não muta.
+        $this->ensureChannelAccessOrAbort($conversation, $businessId, $userId);
+
+        $payload = $request->validate([
+            'queue_slug' => ['nullable', 'string', 'max:40'],
+        ]);
+
+        $slug = $payload['queue_slug'] ?? null;
+        if ($slug !== null && $slug !== '') {
+            $knownInDb = \Modules\Whatsapp\Entities\WhatsappQueue::query()
+                ->where('business_id', $businessId)
+                ->where('slug', $slug)
+                ->exists();
+            $knownInConfig = array_key_exists($slug, (array) config('whatsapp.queues', []));
+            if (! $knownInDb && ! $knownInConfig) {
+                throw \Illuminate\Validation\ValidationException::withMessages([
+                    'queue_slug' => "Fila \"{$slug}\" não existe neste business.",
+                ]);
+            }
+            $conversation->queue_override = $slug;
+        } else {
+            $conversation->queue_override = null;
+        }
+        $conversation->save();
+
+        return back()->with('success', $conversation->queue_override !== null
+            ? 'Conversa movida de fila.'
+            : 'Fila voltou pra automática.');
+    }
+
+    /**
      * US-WA-064: GET `/atendimento/inbox/contacts/search?q=...` — busca
      * Contacts UltimatePOS do business atual filtrando por nome/mobile/landline.
      *

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -181,6 +181,13 @@ Route::group([
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.assign');
 
+    // US-WA-305: mover conversa entre filas (override manual vence heurística;
+    // null volta pra automática) — ADR 0267.
+    Route::patch('/inbox/{id}/queue', [InboxController::class, 'moveQueue'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.move_queue');
+
     // Wagner 2026-05-27 — Voice of Customer in-app capture (ADR UI-0016).
     // Captura feedback diretamente de mensagens do inbox WhatsApp.
     Route::post('/feedback/capture', [ClientFeedbackController::class, 'capture'])

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -140,6 +140,7 @@ beforeEach(function () {
         $table->string('contact_name', 120)->nullable();
         $table->string('status', 20)->default('open');
         $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->string('queue_override', 40)->nullable();
         $table->boolean('bot_handling')->default(false);
         $table->timestamp('last_inbound_at')->nullable();
         $table->timestamp('last_outbound_at')->nullable();
@@ -611,4 +612,47 @@ it('R-WA-CAIXA-UNIF-008 — CRUD filas: store/update/destroy + default protegida
     $alienReq->setLaravelSession(app('session.store'));
     expect(fn () => $queuesCtrl->destroy($alienReq, $alien->id))
         ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+// ============================================================================
+// 7. US-WA-305 — queue_override: mover entre filas vence heurística
+// ============================================================================
+
+it('R-WA-CAIXA-UNIF-009 — moveQueue: override vence heurística, null volta, slug inválido 422', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-009-uuid');
+    $conv = cuctMakeConv(1, $ch->id, ['financeiro']); // heurística → fila financeiro
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    $inbox = new \Modules\Whatsapp\Http\Controllers\Admin\InboxController();
+
+    // Baseline: heurística deriva financeiro
+    $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest(['thread' => $conv->id]));
+    expect($props['thread']['queue']['slug'])->toBe('financeiro')
+        ->and($props['thread']['queue_is_override'])->toBeFalse();
+
+    // Move pra comercial (override manual) — vence a heurística sem re-tagar
+    $inbox->moveQueue(cuctPatchRequest("/atendimento/inbox/{$conv->id}/queue", ['queue_slug' => 'comercial']), $conv->id);
+    expect($conv->fresh()->queue_override)->toBe('comercial');
+
+    $props2 = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest(['thread' => $conv->id]));
+    expect($props2['thread']['queue']['slug'])->toBe('comercial')
+        ->and($props2['thread']['queue_is_override'])->toBeTrue();
+
+    // Lista também reflete o override
+    $convs = cuctResolveDefer($props2['conversations']);
+    expect($convs['data'][0]['queue']['slug'])->toBe('comercial');
+
+    // Slug inexistente → 422 fail-loud (Tier 0 — não aceita fila de outro tenant)
+    expect(fn () => $inbox->moveQueue(
+        cuctPatchRequest("/atendimento/inbox/{$conv->id}/queue", ['queue_slug' => 'fila-fantasma']),
+        $conv->id,
+    ))->toThrow(\Illuminate\Validation\ValidationException::class);
+    expect($conv->fresh()->queue_override)->toBe('comercial'); // intacto
+
+    // null volta pra heurística
+    $inbox->moveQueue(cuctPatchRequest("/atendimento/inbox/{$conv->id}/queue", ['queue_slug' => null]), $conv->id);
+    expect($conv->fresh()->queue_override)->toBeNull();
+    $props3 = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest(['thread' => $conv->id]));
+    expect($props3['thread']['queue']['slug'])->toBe('financeiro')
+        ->and($props3['thread']['queue_is_override'])->toBeFalse();
 });

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 4
+charter_version: 5
 permissao: whatsapp.access
 ---
 
@@ -129,7 +129,10 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - Heurística tag→fila e `stats.queues_count` passam a ler o DB.
 
 ### Sidebar direita (8 sections)
-1. **Fila** — derivada via heurística tag→fila (read-only nesta passada).
+1. **Fila** — heurística tag→fila + **override manual** (US-WA-305, 2026-06-10):
+   Popover "mover" lista filas do business; PATCH `atendimento.inbox.move_queue`
+   grava `queue_override` (vence heurística sem re-tagar); badge "manual" +
+   opção "Voltar pra automática". Slug órfão de fila deletada cai no fallback.
 2. **Atribuído** — assignee picker real (US-WA-302, 2026-06-10): Popover com
    operadores do business (grant ativo OU `whatsapp.access`/`whatsapp.send`),
    avatar iniciais + hue determinístico, "remover atribuição". PATCH
@@ -160,7 +163,6 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
   `dist`/`members` são persistidos (ADR 0267) mas o roteamento é US futura.
 - ❌ **Broadcast cross-canal** — placeholder; backlog (alta complexidade
   janela 24h Meta + opt-in LGPD).
-- ❌ **Mover conversa entre filas** — só leitura (fila vem de heurística).
 - ❌ **Mídia outbound/inbound** UI — preserva legacy `MediaPreviewCard`
   durante coexistência. PR seguinte unifica.
 
@@ -232,6 +234,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-006 — availableTemplates só ready (LOCAL/APPROVED) do business atual (Tier 0)` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-007 — filas: seed lazy idempotente do config + payload lê DB + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-008 — CRUD filas: store/update/destroy + default protegida + Tier 0` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-009 — moveQueue: override vence heurística, null volta, slug inválido 422` | mesmo arquivo |
 
 ---
 
@@ -253,11 +256,9 @@ Dropdown no contexto da sidebar pra atribuir conv a operador específico.
 Reusa `assigned_user_id` nullable já existente em `conversations`.
 Endpoint PATCH `atendimento.inbox.assign` + payload `availableAssignees`.
 
-### §4 Mover conversa entre filas (P2)
-Hoje fila é derivada read-only via tag heurística. Mover = re-tagar.
-Wagner pode querer override manual sem mexer em tag.
-
-**US sugerida:** US-WA-XXX Manual queue override (~2h IA-pair).
+### §4 Mover conversa entre filas (P2) — ✅ ENTREGUE 2026-06-10 (US-WA-305)
+Coluna `queue_override` em conversations + PATCH `atendimento.inbox.move_queue`
++ Popover na section Fila. Override vence heurística; null volta pra automática.
 
 ### §5 Painel "Canais e contas" drawer
 Cowork tem drawer lateral com lista agrupada de canais (Baileys/Meta/Z-API
@@ -281,6 +282,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-305 Mover entre filas** (PR-4/10): coluna `queue_override` (migration idempotente, slug não-FK de propósito — fila deletada não quebra conversa) + `InboxController::moveQueue` (slug validado contra filas do business, 422 fail-loud) + Popover "mover" na section Fila com badge "manual" e volta pra automática. Charter v5. Pest R-WA-CAIXA-UNIF-009. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-301 Filas DB + painel** (PR-3/10): tabela `whatsapp_queues` (ADR 0267, per-schema antes da migration) + seed lazy idempotente do config + QueuesSheet CRUD (label/hue/SLA/dist/tags-gatilho, default protegida) + heurística tag→fila lê DB com fallback config. Topnav "Filas" deixa de ser disabled. Charter v4. Pest R-WA-CAIXA-UNIF-007/008. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-303 Composer completo** (PR-2/10): Templates via `TemplatePicker` legacy filtrado por provider do canal + payload `availableTemplates` (LOCAL/APPROVED) · Macros dropdown + autocomplete `/` inline reusando backend US-WA-048 (`macros.list` + `apply_macro`) · Variáveis `{{nome}}`/`{{telefone}}`/`{{operador}}` com botão `{}`, preview verde/vermelho e substituição no send. Charter v3. Pest R-WA-CAIXA-UNIF-006. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas" — brief [CC] Caixa Unificada completa) | **US-WA-302 Assignee picker** (PR-1/10): section 2 da sidebar vira picker real (Popover operadores + avatar hue + remover atribuição). Backend: PATCH `atendimento.inbox.assign` (InboxController::assign, Tier 0 cross-tenant 422) + prop deferred `availableAssignees` + relação `Conversation::assignedUser`. Charter v2. Pest R-WA-CAIXA-UNIF-004/005. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -59,6 +59,21 @@ export default function ContextSidebarV4({ thread, channels, queues, availableTa
   const activeTagIds = new Set(thread.tags.map(t => t.id));
   const [pickerOpen, setPickerOpen] = useState(false);
 
+  // US-WA-305 — mover conversa entre filas (PATCH /atendimento/inbox/{id}/queue)
+  const [queuePopOpen, setQueuePopOpen] = useState(false);
+  function moveToQueue(slug: string | null) {
+    router.patch(
+      route('atendimento.inbox.move_queue', thread.id),
+      { queue_slug: slug },
+      {
+        preserveScroll: true,
+        preserveState: true,
+        only: ['thread', 'conversations', 'stats'],
+        onSuccess: () => setQueuePopOpen(false),
+      },
+    );
+  }
+
   // US-WA-302 — atribuir/remover operador (PATCH /atendimento/inbox/{id}/assign)
   const [assignPopOpen, setAssignPopOpen] = useState(false);
   function assignTo(assigneeId: number | null) {
@@ -147,11 +162,66 @@ export default function ContextSidebarV4({ thread, channels, queues, availableTa
           <CustomerMemoryBlock customerExternalId={thread.customer_external_id} />
         )}
 
-        {/* 1. Fila */}
+        {/* 1. Fila — US-WA-305: select de override manual (vence heurística tag→fila) */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
-          <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
-            Fila
-          </small>
+          <Inline gap={0} align="center" justify="between">
+            <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
+              Fila
+            </small>
+            <Popover open={queuePopOpen} onOpenChange={setQueuePopOpen}>
+              <PopoverTrigger asChild>
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground hover:text-foreground transition-colors"
+                  title="Mover conversa pra outra fila (override manual)"
+                  data-testid="caixa-unif-ctx-queue-move"
+                >
+                  <Plus size={11} aria-hidden /> mover
+                </button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-60 p-1.5">
+                <div className="text-[10px] uppercase tracking-[0.06em] text-muted-foreground font-semibold px-2 pt-1 pb-1.5">
+                  Mover pra fila
+                </div>
+                <ul className="max-h-64 overflow-auto">
+                  {Object.entries(queues).map(([slug, cfg]) => {
+                    const active = thread.queue.slug === slug;
+                    return (
+                      <li key={slug}>
+                        <button
+                          type="button"
+                          onClick={() => moveToQueue(slug)}
+                          data-testid={`caixa-unif-ctx-queue-pick-${slug}`}
+                          className="w-full inline-flex items-center justify-between gap-2 px-2 py-1.5 text-[11.5px] hover:bg-muted rounded text-left"
+                        >
+                          <span className="inline-flex items-center gap-1.5 min-w-0">
+                            <span
+                              className="inline-block w-2 h-2 rounded-full flex-shrink-0"
+                              style={{ background: `oklch(0.55 0.13 ${cfg.hue})` }}
+                              aria-hidden
+                            />
+                            <span className="truncate">{cfg.label}</span>
+                            {cfg.sla && <small className="text-[10px] text-muted-foreground flex-shrink-0">SLA {cfg.sla}</small>}
+                          </span>
+                          {active && <Check size={13} className="text-primary flex-shrink-0" aria-label="Fila atual" />}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                {thread.queue_is_override && (
+                  <button
+                    type="button"
+                    onClick={() => moveToQueue(null)}
+                    data-testid="caixa-unif-ctx-queue-auto"
+                    className="w-full mt-1 px-2 py-1.5 text-[10.5px] text-muted-foreground hover:text-foreground hover:bg-muted rounded text-center transition-colors"
+                  >
+                    Voltar pra automática (heurística por tags)
+                  </button>
+                )}
+              </PopoverContent>
+            </Popover>
+          </Inline>
           <b className="inline-flex items-center gap-1.5 text-[12.5px] font-medium" data-testid="caixa-unif-ctx-queue">
             <span
               className="inline-block w-2 h-2 rounded-full flex-shrink-0"
@@ -159,6 +229,14 @@ export default function ContextSidebarV4({ thread, channels, queues, availableTa
               aria-hidden
             />
             {thread.queue.label}
+            {thread.queue_is_override && (
+              <span
+                className="inline-flex text-[9px] font-medium text-muted-foreground bg-muted border rounded-full px-1.5 flex-shrink-0"
+                title="Fila definida manualmente — vence a heurística por tags"
+              >
+                manual
+              </span>
+            )}
           </b>
           {queueCfg?.sla && (
             <small className="text-[11px] text-muted-foreground mt-0.5">

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -150,6 +150,8 @@ export interface CaixaUnifThread {
   created_at: string | null;
   tags: ConvTag[];
   queue: QueueDerived;
+  /** US-WA-305 — true quando a fila vem de override manual (não da heurística). */
+  queue_is_override: boolean;
   preview_only: boolean;
 }
 


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-4 de 10

**US-WA-305 — Mover conversa entre filas** (charter roadmap §4, P2). Depende do PR-3 (#2507, merged).

### O que muda
- Coluna `queue_override` em `conversations` (migration idempotente) — slug não-FK **de propósito**: deletar fila não quebra a conversa, slug órfão cai no fallback heurística
- **PATCH `/atendimento/inbox/{id}/queue`** (`InboxController::moveQueue`): slug validado contra `whatsapp_queues` do business (fallback config); `null` volta pra automática
- Section Fila da sidebar: Popover "mover" (filas com dot OKLCH + SLA), badge "manual" quando override ativo, "Voltar pra automática"
- `resolveQueue` no Controller — override vence heurística na lista E na thread; `queue_is_override` no payload

### Tier 0
- Slug desconhecido → 422 fail-loud (não aceita fila de outro tenant)
- `ensureChannelAccessOrAbort` defense-in-depth

### Pest
- `R-WA-CAIXA-UNIF-009` — override vence heurística / lista reflete / 422 / null volta

Charter → v5 (section 1, roadmap §4 ✅, Non-Goals limpos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)