### PR TITLE
feat(oficina): board com KPIs-filtro, menu Visão, atalhos de teclado, imprimir fila e capacidade de boxes — paridade onda 1 Cowork

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -437,6 +437,10 @@ class ServiceOrderController extends Controller
             && ! in_array($order->status, ['concluida', 'cancelada', 'entregue'], true)
             && $expected->isPast();
 
+        // box_label/assigned_user_id (Wave 2.1) podem não existir pré-migração — SELECT *
+        // não traz a coluna ausente e getAttribute devolve null (guard implícito).
+        $boxLabel = $order->getAttribute('box_label');
+
         return [
             'id'                => (int) $order->id,
             'number'            => 'OS-' . str_pad((string) $order->id, 5, '0', STR_PAD_LEFT),
@@ -449,6 +453,10 @@ class ServiceOrderController extends Controller
             'dvi_total'         => $dviTotal,
             'dvi_critico'       => $dviCritico,
             'valor'             => (float) $order->total_items,
+            // box + mechanic_id alimentam o re-pivot client-side do quadro (menu Visão:
+            // Foco Box/Mecânico) e a capacidade "x/y boxes" — Onda 1 paridade Cowork.
+            'box'               => is_string($boxLabel) && $boxLabel !== '' ? $boxLabel : null,
+            'mechanic_id'       => $order->getAttribute('assigned_user_id') !== null ? (int) $order->getAttribute('assigned_user_id') : null,
             'mechanic_name'     => $mechanicName ?: null,
             'mechanic_initials' => $mechanicInitials ?: null,
             'entered_at'        => $order->entered_at?->toIso8601String(),

--- a/resources/js/Lib/printOficinaFila.ts
+++ b/resources/js/Lib/printOficinaFila.ts
@@ -1,0 +1,136 @@
+// printOficinaFila — folha A4 "Fila da oficina" (lista de OS abertas do quadro).
+//
+// Port do protótipo Cowork homologado `oficina-print.js` (printFila) traduzido pro
+// stack real: HTML auto-contido montado client-side a partir dos cards JÁ filtrados
+// do Board (busca + KPI-filtro + selects), impresso via mecanismo canônico
+// printHtmlDocument (iframe fora da vista + fallback window.open — printServiceOrder.ts).
+//
+// Ordenação canon do protótipo: atrasadas primeiro, depois pela ordem das etapas.
+// CSS embutido no doc (folha preto-e-branco A4 — independe dos tokens da SPA).
+// Multi-tenant Tier 0 (ADR 0093): só imprime o que o board já entregou pro tenant.
+
+import { printHtmlDocument } from './printServiceOrder';
+
+export interface FilaPrintRow {
+  number: string;
+  etapa: string;
+  /** índice da etapa na ordem do quadro (pra ordenação) */
+  etapaIndex: number;
+  vehicle: string | null;
+  plate: string | null;
+  cliente: string | null;
+  mecanico: string | null;
+  box: string | null;
+  /** prazo formatado (dd/mm) ou null */
+  prazo: string | null;
+  valor: number;
+  atrasada: boolean;
+}
+
+export interface FilaPrintOptions {
+  /** descrição dos filtros ativos (ex.: "busca: ABC · KPI: Atrasadas") */
+  filtro?: string | null;
+}
+
+const esc = (s: unknown): string =>
+  String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c] as string));
+
+const brl = (n: number): string =>
+  'R$ ' + Number(n || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+const hoje = (): string =>
+  new Date().toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' });
+
+const agora = (): string =>
+  new Date().toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit' });
+
+// Folha A4 preto-e-branco — espelha a estrutura .ofc-sheet do protótipo
+// (brand head + nota de contexto + tabela + rodapé). Auto-contida de propósito.
+const SHEET_CSS = `
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: -apple-system, 'Segoe UI', Roboto, Arial, sans-serif; color: #111; background: #fff; }
+  .ofc-sheet { max-width: 190mm; margin: 0 auto; padding: 10mm 0; font-size: 11px; }
+  .ofc-sheet-top { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 2px solid #111; padding-bottom: 8px; margin-bottom: 10px; }
+  .ofc-sheet-brand { font-size: 17px; font-weight: 800; letter-spacing: -0.02em; }
+  .ofc-sheet-brand small { display: block; font-size: 10px; font-weight: 600; color: #555; letter-spacing: 0.06em; text-transform: uppercase; }
+  .ofc-sheet-doc { text-align: right; }
+  .ofc-sheet-doc .t { font-size: 13px; font-weight: 700; }
+  .ofc-sheet-doc .d { font-size: 10px; color: #555; margin-top: 2px; }
+  .ofc-sheet-note { font-size: 10.5px; color: #444; margin-bottom: 8px; }
+  .ofc-sheet-tbl { width: 100%; border-collapse: collapse; }
+  .ofc-sheet-tbl th { text-align: left; font-size: 9px; text-transform: uppercase; letter-spacing: 0.05em; color: #555; border-bottom: 1.5px solid #111; padding: 4px 6px; }
+  .ofc-sheet-tbl td { border-bottom: 1px solid #ddd; padding: 5px 6px; font-size: 10.5px; vertical-align: top; }
+  .ofc-sheet-tbl .num { text-align: right; font-variant-numeric: tabular-nums; white-space: nowrap; }
+  .ofc-sheet-tbl tr.urg td { font-weight: 700; }
+  .ofc-sheet-tbl tr.urg td:first-child::before { content: '⚠ '; }
+  .ofc-sheet-tbl tfoot td { border-top: 1.5px solid #111; border-bottom: none; font-weight: 700; padding-top: 6px; }
+  .ofc-sheet-empty { text-align: center; color: #777; font-style: italic; padding: 14px 0; }
+  .ofc-sheet-foot { display: flex; justify-content: space-between; margin-top: 14px; padding-top: 6px; border-top: 1px solid #ddd; font-size: 9px; color: #666; }
+  @page { size: A4 portrait; margin: 12mm; }
+  @media print { .ofc-sheet { padding: 0; } }
+`;
+
+/**
+ * Monta e imprime a folha "Fila da oficina" com as OS visíveis no quadro.
+ * `rows` já chegam filtradas (busca + KPI + selects) — esta função só ordena
+ * (atrasadas primeiro, depois etapa) e renderiza.
+ */
+export function printOficinaFila(rows: FilaPrintRow[], opts: FilaPrintOptions = {}): Promise<void> {
+  const list = [...rows].sort(
+    (a, b) => (Number(b.atrasada) - Number(a.atrasada)) || (a.etapaIndex - b.etapaIndex),
+  );
+
+  const bodyRows = list.map((os) => `
+    <tr class="${os.atrasada ? 'urg' : ''}">
+      <td>${esc(os.etapa)}</td>
+      <td class="num">${esc(os.number)}</td>
+      <td>${esc(os.vehicle ?? '—')}</td>
+      <td class="num">${esc(os.plate ?? '—')}</td>
+      <td>${esc(os.cliente ?? '—')}</td>
+      <td>${esc(os.mecanico ?? '—')}</td>
+      <td>${esc(os.box ?? '—')}</td>
+      <td>${esc(os.prazo ?? '—')}</td>
+      <td class="num">${os.valor > 0 ? esc(brl(os.valor)) : '—'}</td>
+    </tr>`).join('');
+
+  const total = list.reduce((a, os) => a + (os.valor || 0), 0);
+  const atrasadas = list.filter((os) => os.atrasada).length;
+
+  const htmlContent = `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="utf-8">
+<title>Fila da oficina</title>
+<style>${SHEET_CSS}</style>
+</head>
+<body>
+  <div class="ofc-sheet">
+    <div class="ofc-sheet-top">
+      <div class="ofc-sheet-brand">Oimpresso<small>Oficina Auto</small></div>
+      <div class="ofc-sheet-doc">
+        <div class="t">Fila da oficina</div>
+        <div class="d">${esc(hoje())}</div>
+      </div>
+    </div>
+
+    <div class="ofc-sheet-note">${list.length} ordem(ns) aberta(s)${atrasadas ? ` · ${atrasadas} atrasada(s)` : ''}${opts.filtro ? ` · filtro: ${esc(opts.filtro)}` : ''}</div>
+
+    <table class="ofc-sheet-tbl">
+      <thead><tr>
+        <th>Etapa</th><th class="num">OS</th><th>Veículo</th><th class="num">Placa</th>
+        <th>Cliente</th><th>Mecânico</th><th>Box</th><th>Prazo</th><th class="num">Valor</th>
+      </tr></thead>
+      <tbody>${bodyRows || '<tr><td colspan="9" class="ofc-sheet-empty">Nenhuma OS na fila.</td></tr>'}</tbody>
+      ${list.length ? `<tfoot><tr><td colspan="8">Total previsto em carteira</td><td class="num">${esc(brl(total))}</td></tr></tfoot>` : ''}
+    </table>
+
+    <div class="ofc-sheet-foot">
+      <span>Oimpresso ERP · Oficina Auto · Fila de produção</span>
+      <span>Emitido ${esc(agora())}</span>
+    </div>
+  </div>
+</body>
+</html>`;
+
+  return printHtmlDocument({ htmlContent, title: 'Fila da oficina' });
+}

--- a/resources/js/Lib/printServiceOrder.ts
+++ b/resources/js/Lib/printServiceOrder.ts
@@ -63,6 +63,15 @@ interface RenderArgs {
   title: string;
 }
 
+/**
+ * Mecanismo canônico de impressão de HTML auto-contido (iframe fora da vista +
+ * print pelo parent + fallback window.open). Exportado pra reuso por outros
+ * documentos da Oficina (ex.: printOficinaFila.ts) — estender, não recriar.
+ */
+export function printHtmlDocument(args: RenderArgs): Promise<void> {
+  return renderAndPrint(args);
+}
+
 const IFRAME_ID = 'service-order-print-iframe';
 
 function renderAndPrint({ htmlContent, title }: RenderArgs): Promise<void> {

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
@@ -33,24 +33,40 @@
 //      Espelha o canon do protótipo Cowork (.prod-kanban.ofc-5 em
 //      oficina-page.css: repeat(5, minmax(228px, 1fr)) + overflow auto):
 //      o quadro rola HORIZONTALMENTE POR DENTRO, o shell nunca estoura.
+//
+// ONDA 1 toolbar [CC] 2026-06-10 — paridade com o protótipo Cowork homologado:
+//   - KPIs clicáveis como filtro client-side (canon D-05) + chip "limpar filtro";
+//   - menu Visão (.ofc-adjust): Foco Etapa/Box/Mecânico (re-pivot client-side,
+//     drag desliga fora do foco Etapa) + Densidade compacto/padrão/detalhe,
+//     persistidos em localStorage. Pressão ficou FORA desta onda;
+//   - busca com botão limpar (×) + atalho "/";
+//   - atalhos de teclado (canon D-07): N nova OS · / busca · setas navegam ·
+//     Enter abre drawer · Esc fecha (ignorados enquanto digita);
+//   - "Imprimir fila" no header (ghost) — printOficinaFila.ts via mecanismo
+//     canônico printHtmlDocument (port do oficina-print.js);
+//   - coluna Em execução com ocupação "x/y boxes" no header.
+//   Onda 2 (PR separado): views Grade e Fila no toggle.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router } from '@inertiajs/react';
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { toast } from 'sonner';
-import { Plus, Search, LayoutGrid, List as ListIcon } from 'lucide-react';
+import { Plus, Search, LayoutGrid, List as ListIcon, Printer, SlidersHorizontal, X } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@/Components/ui/popover';
+import { Segmented } from '@/Components/ui/segmented';
 import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from '@/Components/ui/select';
+import { printOficinaFila, type FilaPrintRow } from '@/Lib/printOficinaFila';
 import KanbanDndProvider from '@/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider';
 import DragConfirmDialog, {
   type PendingTransition,
 } from '@/Pages/OficinaAuto/ProducaoOficina/_components/DragConfirmDialog';
 import ServiceOrderRichSheet from '@/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet';
 import ServiceOrderKanbanColumn from './_components/board/ServiceOrderKanbanColumn';
-import type { ServiceOrderCardData } from './_components/board/ServiceOrderKanbanCard';
+import type { BoardDensity, ServiceOrderCardData } from './_components/board/ServiceOrderKanbanCard';
 import { kpiTone, type KpiTone } from './_components/board/boardTone';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -83,6 +99,44 @@ interface Props {
   process_seeded: boolean;
   filters: { q: string; mecanico: number | null; box: string | null };
   filterOptions: { boxes: string[]; mecanicos: MecanicoOption[] };
+}
+
+// ─── Onda 1 paridade Cowork (canon D-05/D-07 + menu Visão) ───────────────────
+// KPI clicável filtra cards client-side (sem round-trip); menu Visão re-pivota
+// as colunas por Box/Mecânico e controla densidade; atalhos de teclado pra
+// Larissa (teclado-first). Pressão ficou FORA desta onda (decisão [W]).
+
+/** KPIs filtráveis → predicado (stage do card ou atraso). 'total' não filtra. */
+type KpiFilterKey = 'aprovacao' | 'pecas' | 'execucao' | 'pronto' | 'atrasadas';
+
+const KPI_FILTER_STAGE: Record<Exclude<KpiFilterKey, 'atrasadas'>, string> = {
+  aprovacao: 'aguardando_aprovacao',
+  pecas: 'aguardando_pecas',
+  execucao: 'em_execucao',
+  pronto: 'pronto_retirada',
+};
+
+const KPI_FILTER_LABEL: Record<KpiFilterKey, string> = {
+  aprovacao: 'Aguardando aprovação',
+  pecas: 'Aguardando peças',
+  execucao: 'Em execução',
+  pronto: 'Pronto p/ retirar',
+  atrasadas: 'Atrasadas',
+};
+
+type BoardFoco = 'etapa' | 'box' | 'mecanico';
+
+const FOCO_STORAGE_KEY = 'oficinaBoard.foco';
+const DENSIDADE_STORAGE_KEY = 'oficinaBoard.densidade';
+
+/** Coluna exibida no quadro — etapa FSM (foco Etapa) ou pivot Box/Mecânico. */
+interface DisplayColumn {
+  key: string;
+  name: string;
+  color: string | null;
+  cards: ServiceOrderCardData[];
+  emphasis: 'aprovacao' | 'pecas' | null;
+  capacity: string | null;
 }
 
 // ─── Drag mapping FSM (espelha oficina_mecanica_os do OficinaAutoFsmSeeder) ────
@@ -138,6 +192,36 @@ const STAGE_TRANSITIONS: Record<string, Record<string, AllowedMove>> = {
 
 export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filters, filterOptions }: Props) {
   const [searchInput, setSearchInput] = useState(filters.q ?? '');
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  // D-05 — filtro por KPI (client-side, clicar de novo limpa)
+  const [kpiFilter, setKpiFilter] = useState<KpiFilterKey | null>(null);
+  // D-07 — card focado pela navegação por setas (anel visível)
+  const [focusedId, setFocusedId] = useState<number | null>(null);
+
+  // Menu Visão — foco (pivot das colunas) + densidade, persistidos por operador
+  const [foco, setFocoState] = useState<BoardFoco>(() => {
+    const v = typeof window !== 'undefined' ? window.localStorage.getItem(FOCO_STORAGE_KEY) : null;
+    return v === 'box' || v === 'mecanico' ? v : 'etapa';
+  });
+  const [densidade, setDensidadeState] = useState<BoardDensity>(() => {
+    const v = typeof window !== 'undefined' ? window.localStorage.getItem(DENSIDADE_STORAGE_KEY) : null;
+    return v === 'compacto' || v === 'detalhe' ? v : 'padrao';
+  });
+  const setFoco = useCallback((v: BoardFoco) => {
+    setFocoState(v);
+    setFocusedId(null);
+    try { window.localStorage.setItem(FOCO_STORAGE_KEY, v); } catch { /* storage cheio/bloqueado — preferência só não persiste */ }
+  }, []);
+  const setDensidade = useCallback((v: BoardDensity) => {
+    setDensidadeState(v);
+    try { window.localStorage.setItem(DENSIDADE_STORAGE_KEY, v); } catch { /* idem */ }
+  }, []);
+
+  const kpiClick = useCallback((key: KpiFilterKey) => {
+    setKpiFilter((f) => (f === key ? null : key));
+    setFocusedId(null);
+  }, []);
 
   // Navega pro board mesclando os filtros atuais com o patch (query — canon charter).
   // Limpa chaves vazias pra não poluir a URL ('' / null / undefined caem fora).
@@ -256,20 +340,148 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
   ), []);
 
   const kpiCards = useMemo(() => [
-    { id: 'total', label: 'OS no quadro', value: String(kpis.total), tone: 'default' as const },
-    { id: 'aprovacao', label: 'Aguardando aprovação', value: String(kpis.aguardando_aprovacao), tone: 'amber' as const },
-    { id: 'pecas', label: 'Aguardando peças', value: String(kpis.aguardando_pecas), tone: 'violet' as const },
-    { id: 'execucao', label: 'Em execução', value: String(kpis.em_execucao), tone: 'default' as const },
-    { id: 'pronto', label: 'Pronto p/ retirar', value: String(kpis.pronto_retirada), tone: 'emerald' as const },
-    { id: 'atrasadas', label: 'Atrasadas', value: String(kpis.atrasadas), tone: 'rose' as const },
+    { id: 'total', label: 'OS no quadro', value: String(kpis.total), tone: 'default' as const, filterKey: null },
+    { id: 'aprovacao', label: 'Aguardando aprovação', value: String(kpis.aguardando_aprovacao), tone: 'amber' as const, filterKey: 'aprovacao' as const },
+    { id: 'pecas', label: 'Aguardando peças', value: String(kpis.aguardando_pecas), tone: 'violet' as const, filterKey: 'pecas' as const },
+    { id: 'execucao', label: 'Em execução', value: String(kpis.em_execucao), tone: 'default' as const, filterKey: 'execucao' as const },
+    { id: 'pronto', label: 'Pronto p/ retirar', value: String(kpis.pronto_retirada), tone: 'emerald' as const, filterKey: 'pronto' as const },
+    { id: 'atrasadas', label: 'Atrasadas', value: String(kpis.atrasadas), tone: 'rose' as const, filterKey: 'atrasadas' as const },
   ], [kpis]);
+
+  // D-05 — predicado do KPI ativo sobre (card, etapa). Client-side: o payload do
+  // board já está no browser; filtrar não round-tripa.
+  const cardMatchesKpi = useCallback((card: ServiceOrderCardData, stageKey: string): boolean => {
+    if (!kpiFilter) return true;
+    if (kpiFilter === 'atrasadas') return card.is_overdue;
+    return stageKey === KPI_FILTER_STAGE[kpiFilter];
+  }, [kpiFilter]);
+
+  // Etapa de origem de cada card (sobrevive ao pivot Box/Mecânico — usada no
+  // filtro por KPI de etapa e na folha "Imprimir fila").
+  const stageByCardId = useMemo(() => {
+    const m = new Map<number, { key: string; name: string; index: number }>();
+    columns.forEach((col, index) => col.cards.forEach((c) => m.set(c.id, { key: col.key, name: col.name, index })));
+    return m;
+  }, [columns]);
+
+  // Colunas exibidas — foco Etapa usa as colunas FSM; Box/Mecânico re-pivota
+  // client-side (cards já carregam box + mechanic_id do BoardController).
+  const displayColumns = useMemo<DisplayColumn[]>(() => {
+    if (foco === 'etapa') {
+      return columns.map((col) => ({
+        key: col.key,
+        name: col.name,
+        color: col.color,
+        cards: col.cards.filter((c) => cardMatchesKpi(c, col.key)),
+        emphasis: col.key === 'aguardando_aprovacao' ? 'aprovacao' as const : col.key === 'aguardando_pecas' ? 'pecas' as const : null,
+        // Capacidade da oficina (header da coluna Em execução): ocupação REAL,
+        // por isso usa col.cards (pré-filtro KPI) — y = boxes cadastrados.
+        capacity: col.key === 'em_execucao' && filterOptions.boxes.length > 0
+          ? `${col.cards.length}/${filterOptions.boxes.length} boxes`
+          : null,
+      }));
+    }
+
+    const visiveis = columns.flatMap((col) => col.cards.filter((c) => cardMatchesKpi(c, col.key)));
+    const pivotCol = (key: string, name: string, cards: ServiceOrderCardData[]): DisplayColumn => ({
+      key, name, color: null, cards, emphasis: null, capacity: null,
+    });
+
+    if (foco === 'box') {
+      return [
+        ...filterOptions.boxes.map((b) => pivotCol(`box-${b}`, b, visiveis.filter((c) => c.box === b))),
+        pivotCol('box-none', 'Sem box', visiveis.filter((c) => !c.box)),
+      ];
+    }
+
+    return [
+      ...filterOptions.mecanicos.map((m) => pivotCol(`mec-${m.id}`, m.nome, visiveis.filter((c) => c.mechanic_id === m.id))),
+      pivotCol('mec-none', 'Sem mecânico', visiveis.filter((c) => c.mechanic_id === null)),
+    ];
+  }, [columns, foco, cardMatchesKpi, filterOptions.boxes, filterOptions.mecanicos]);
+
+  // Ordem visível dos cards (coluna a coluna) — navegação por setas + contador "N OS"
+  const visibleCards = useMemo(() => displayColumns.flatMap((c) => c.cards), [displayColumns]);
+  const visibleCount = visibleCards.length;
+
+  // D-07 — atalhos de teclado (Larissa é teclado-first): N nova OS · / busca ·
+  // setas navegam cards · Enter abre o drawer · Esc limpa o foco (Radix já fecha
+  // drawer/popover no Esc). Ignora quando digitando em input/select/textarea.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // dnd-kit KeyboardSensor usa as setas durante o drag — não atropelar.
+      if (e.defaultPrevented) return;
+      const target = e.target as HTMLElement | null;
+      const tag = (target?.tagName ?? '').toLowerCase();
+      const typing = tag === 'input' || tag === 'textarea' || tag === 'select' || Boolean(target?.isContentEditable);
+      if (e.key === 'Escape') { setFocusedId(null); return; }
+      if (typing) return;
+      if (e.key === '/') { e.preventDefault(); searchRef.current?.focus(); return; }
+      if (e.key === 'n' || e.key === 'N') { e.preventDefault(); router.visit('/oficina-auto/ordens-servico/create'); return; }
+      if (e.key === 'Enter') {
+        if (focusedId !== null && visibleCards.some((c) => c.id === focusedId)) {
+          e.preventDefault();
+          setOpenOsId(focusedId);
+        }
+        return;
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowRight' || e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+        if (!visibleCards.length) return;
+        e.preventDefault();
+        const dir = e.key === 'ArrowDown' || e.key === 'ArrowRight' ? 1 : -1;
+        setFocusedId((prev) => {
+          const i = visibleCards.findIndex((c) => c.id === prev);
+          const next = i === -1
+            ? visibleCards[0]
+            : visibleCards[Math.min(visibleCards.length - 1, Math.max(0, i + dir))];
+          return next ? next.id : prev;
+        });
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visibleCards, focusedId]);
+
+  // Imprimir fila — folha A4 com as OS visíveis (busca + KPI + selects aplicados)
+  const handlePrintFila = useCallback(() => {
+    const rows: FilaPrintRow[] = visibleCards.map((c) => {
+      const stage = stageByCardId.get(c.id);
+      const prazo = c.expected_completion ? new Date(c.expected_completion) : null;
+      return {
+        number: c.number,
+        etapa: stage?.name ?? '—',
+        etapaIndex: stage?.index ?? 99,
+        vehicle: c.vehicle_type,
+        plate: c.plate,
+        cliente: c.cliente_nome,
+        mecanico: c.mechanic_name,
+        box: c.box,
+        prazo: prazo && !Number.isNaN(prazo.getTime())
+          ? prazo.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' })
+          : null,
+        valor: c.valor,
+        atrasada: c.is_overdue,
+      };
+    });
+    const filtroParts: string[] = [];
+    if (filters.q) filtroParts.push(`busca "${filters.q}"`);
+    if (kpiFilter) filtroParts.push(KPI_FILTER_LABEL[kpiFilter]);
+    if (filters.mecanico) {
+      const m = filterOptions.mecanicos.find((x) => x.id === filters.mecanico);
+      if (m) filtroParts.push(`mecânico ${m.nome}`);
+    }
+    if (filters.box) filtroParts.push(`box ${filters.box}`);
+    toast.info('Preparando impressão da fila…');
+    printOficinaFila(rows, { filtro: filtroParts.length ? filtroParts.join(' · ') : null })
+      .catch((e: unknown) => toast.error(e instanceof Error ? e.message : 'Falha ao imprimir a fila'));
+  }, [visibleCards, stageByCardId, filters.q, filters.mecanico, filters.box, kpiFilter, filterOptions.mecanicos]);
 
   // FIX [CC] 2026-06-10: colunas com largura mínima utilizável (canon do protótipo
   // .prod-kanban: repeat(n, minmax(228px, 1fr))) — inline style em vez de classe
   // Tailwind literal porque o nº de colunas é data-driven. O wrapper rola no eixo X.
   const boardGridStyle = useMemo(() => ({
-    gridTemplateColumns: `repeat(${Math.max(columns.length, 1)}, minmax(228px, 1fr))`,
-  }), [columns.length]);
+    gridTemplateColumns: `repeat(${Math.max(displayColumns.length, 1)}, minmax(228px, 1fr))`,
+  }), [displayColumns.length]);
 
   return (
     <>
@@ -290,6 +502,59 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
                 <ListIcon size={12} /> Lista
               </Link>
             </div>
+
+            {/* Menu Visão (canon .ofc-adjust do protótipo) — foco + densidade.
+                Pressão ficou FORA desta onda. */}
+            <Popover>
+              <PopoverTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={foco !== 'etapa' || densidade !== 'padrao' ? 'border-primary text-primary' : undefined}
+                  title="Ajustar visão (foco · densidade)"
+                  data-testid="board-visao-trigger"
+                >
+                  <SlidersHorizontal className="mr-1.5 h-3.5 w-3.5" /> Visão
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent align="end" className="w-72 space-y-3" role="menu" aria-label="Ajustar visão">
+                <div className="space-y-1.5">
+                  <span className="block text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Foco</span>
+                  <Segmented
+                    value={foco}
+                    onValueChange={(v) => setFoco(v as BoardFoco)}
+                    options={[
+                      { value: 'etapa', label: 'Etapa' },
+                      { value: 'box', label: 'Box', disabled: filterOptions.boxes.length === 0 },
+                      { value: 'mecanico', label: 'Mecânico', disabled: filterOptions.mecanicos.length === 0 },
+                    ]}
+                    aria-label="Foco das colunas"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <span className="block text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Densidade</span>
+                  <Segmented
+                    value={densidade}
+                    onValueChange={(v) => setDensidade(v as BoardDensity)}
+                    options={[
+                      { value: 'compacto', label: 'Compacto' },
+                      { value: 'padrao', label: 'Padrão' },
+                      { value: 'detalhe', label: 'Detalhe' },
+                    ]}
+                    aria-label="Densidade dos cards"
+                  />
+                </div>
+                {foco !== 'etapa' && (
+                  <p className="text-[11px] text-muted-foreground leading-snug">
+                    No foco {foco === 'box' ? 'Box' : 'Mecânico'} o arraste fica desligado — etapas mudam no foco Etapa ou pelo drawer da OS.
+                  </p>
+                )}
+              </PopoverContent>
+            </Popover>
+
+            <Button variant="ghost" size="sm" onClick={handlePrintFila} data-testid="board-print-fila">
+              <Printer className="mr-1.5 h-3.5 w-3.5" /> Imprimir fila
+            </Button>
             <Button asChild size="sm">
               <Link href="/oficina-auto/ordens-servico/create">
                 <Plus className="mr-1.5 h-4 w-4" /> Nova OS
@@ -298,10 +563,19 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
           </div>
         </header>
 
-        {/* KPIs compactos — densidade @container (@1280 expande colunas) */}
+        {/* KPIs compactos — densidade @container (@1280 expande colunas).
+            D-05: KPI clicável filtra os cards client-side (clicar de novo limpa). */}
         <div className="bg-white border-b border-border px-6 py-3">
           <div className={'grid grid-cols-2 @[700px]/board:grid-cols-3 @[1100px]/board:grid-cols-6 gap-2'}>
-            {kpiCards.map(({ id, ...kpi }) => <KpiCard key={id} {...kpi} />)}
+            {kpiCards.map(({ id, filterKey, ...kpi }) => (
+              <KpiCard
+                key={id}
+                {...kpi}
+                active={filterKey !== null && kpiFilter === filterKey}
+                dimmed={kpiFilter !== null && filterKey !== null && kpiFilter !== filterKey}
+                onClick={filterKey !== null ? () => kpiClick(filterKey) : undefined}
+              />
+            ))}
           </div>
         </div>
 
@@ -309,15 +583,42 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
         <div className="bg-white border-b border-border px-6 py-2.5 flex items-center gap-3 sticky top-0 z-10 flex-wrap">
           <div className="flex items-center gap-2 flex-1 min-w-[240px] max-w-md">
             <Search size={14} className="text-muted-foreground flex-shrink-0" />
-            <Input
-              type="search"
-              value={searchInput}
-              onChange={(e) => setSearchInput(e.target.value)}
-              placeholder="Buscar OS, placa ou cliente…"
-              className="h-8 border-border"
-              aria-label="Buscar OS, placa ou cliente"
-            />
+            <div className="relative flex-1">
+              <Input
+                ref={searchRef}
+                type="search"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Buscar OS, placa ou cliente…  ( / )"
+                className="h-8 border-border pr-7"
+                aria-label="Buscar OS, placa ou cliente (atalho /)"
+                aria-keyshortcuts="/"
+              />
+              {searchInput !== '' && (
+                <button
+                  type="button"
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                  onClick={() => setSearchInput('')}
+                  aria-label="Limpar busca"
+                  data-testid="board-search-clear"
+                >
+                  <X size={12} />
+                </button>
+              )}
+            </div>
           </div>
+
+          {/* D-05 — chip do KPI-filtro ativo (clicar limpa) */}
+          {kpiFilter && (
+            <button
+              type="button"
+              className="inline-flex items-center gap-1 text-[11px] font-medium text-primary bg-primary/10 border border-primary/30 rounded-full px-2 py-0.5 hover:bg-primary/15"
+              onClick={() => kpiClick(kpiFilter)}
+              data-testid="board-kpi-clear"
+            >
+              <X size={10} /> limpar filtro: {KPI_FILTER_LABEL[kpiFilter]}
+            </button>
+          )}
 
           {filterOptions.mecanicos.length > 0 && (
             <Select
@@ -354,7 +655,8 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
           )}
 
           <span className="ml-auto text-sm text-muted-foreground" aria-live="polite">
-            <span className="font-medium text-foreground">{kpis.total} {kpis.total === 1 ? 'OS' : 'OS'}</span>
+            <span className="font-medium text-foreground">{visibleCount} OS</span>
+            {kpiFilter && (<span className="ml-1 text-xs">de {kpis.total}</span>)}
             {kpis.atrasadas > 0 && (<><span className="mx-1.5 text-muted-foreground">·</span><span className="font-medium text-destructive">{kpis.atrasadas} atrasada{kpis.atrasadas === 1 ? '' : 's'}</span></>)}
           </span>
         </div>
@@ -367,14 +669,18 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
           ) : (
             <KanbanDndProvider<ServiceOrderCardData, string> onMove={handleDragMove} renderPreview={renderPreview}>
               <div className="grid gap-4 items-start" style={boardGridStyle}>
-                {columns.map((col) => (
+                {displayColumns.map((col) => (
                   <ServiceOrderKanbanColumn
                     key={col.key}
                     stageKey={col.key}
                     name={col.name}
                     color={col.color}
                     cards={col.cards}
-                    emphasis={col.key === 'aguardando_aprovacao' ? 'aprovacao' : col.key === 'aguardando_pecas' ? 'pecas' : null}
+                    emphasis={col.emphasis}
+                    capacity={col.capacity}
+                    density={densidade}
+                    focusedId={focusedId}
+                    dragDisabled={foco !== 'etapa'}
                     onCardClick={handleCardClick}
                   />
                 ))}
@@ -402,14 +708,50 @@ ServiceOrdersBoard.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>
 
 // ─── Subcomponents ───────────────────────────────────────────────────────────
 
-interface KpiCardProps { label: string; value: string; tone: KpiTone; }
+interface KpiCardProps {
+  label: string;
+  value: string;
+  tone: KpiTone;
+  /** D-05 — KPI ativo como filtro (anel primary + aria-pressed) */
+  active?: boolean;
+  /** D-05 — outro KPI está filtrando (esmaece este) */
+  dimmed?: boolean;
+  /** presente = KPI filtrável (vira role=button); ausente = só leitura (ex.: total) */
+  onClick?: () => void;
+}
 
-function KpiCard({ label, value, tone }: KpiCardProps) {
+function KpiCard({ label, value, tone, active = false, dimmed = false, onClick }: KpiCardProps) {
   const t = kpiTone(tone);
-  return (
-    <div className={`rounded-lg border px-3 py-2 flex flex-col gap-0.5 ${t.wrapper}`}>
+
+  const inner = (
+    <>
       <span className={`text-[10px] font-semibold uppercase tracking-wider truncate ${t.label}`}>{label}</span>
       <span className={`text-xl @[1100px]/board:text-2xl font-bold tabular-nums ${t.value}`}>{value}</span>
+    </>
+  );
+
+  // KPI filtrável é <button> de verdade (a11y nativa: foco, Enter/Space, aria-pressed)
+  if (onClick !== undefined) {
+    return (
+      <button
+        type="button"
+        className={
+          `rounded-lg border px-3 py-2 flex flex-col gap-0.5 text-left w-full cursor-pointer select-none transition-all hover:shadow-sm ${t.wrapper}`
+          + (active ? ' ring-2 ring-primary ring-offset-1' : '')
+          + (dimmed ? ' opacity-50' : '')
+        }
+        aria-pressed={active}
+        title={active ? 'Clique pra limpar o filtro' : `Filtrar o quadro: ${label}`}
+        onClick={onClick}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <div className={`rounded-lg border px-3 py-2 flex flex-col gap-0.5 ${t.wrapper}`}>
+      {inner}
     </div>
   );
 }

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanCard.tsx
@@ -13,11 +13,16 @@
 //
 // CRÍTICO React 19 — memo + handlers estáveis (lição PR #717).
 
-import { memo, type CSSProperties } from 'react';
+import { memo, useCallback, useEffect, useRef, type CSSProperties } from 'react';
 import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
-import { ClipboardCheck, AlertTriangle, Clock, Wrench, Camera } from 'lucide-react';
+import { ClipboardCheck, AlertTriangle, Clock, Wrench, Camera, Warehouse } from 'lucide-react';
 import MercosulPlate from '@/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate';
+
+// Densidade do card (menu Visão — Onda 1 paridade Cowork): compacto esconde
+// sintoma+foto (triagem rápida de fila grande); detalhe respira (foto maior,
+// sintoma sem truncar, chip do box). Tipo mora aqui (não no boardTone — intocado).
+export type BoardDensity = 'compacto' | 'padrao' | 'detalhe';
 
 export interface ServiceOrderCardData {
   id: number;
@@ -31,6 +36,8 @@ export interface ServiceOrderCardData {
   dvi_total: number;
   dvi_critico: number;
   valor: number;
+  box: string | null;
+  mechanic_id: number | null;
   mechanic_name: string | null;
   mechanic_initials: string | null;
   entered_at: string | null;
@@ -46,6 +53,12 @@ interface Props {
   stageKey: string;
   /** classe Tailwind do border-top colorido por etapa */
   topBorderClass: string;
+  /** densidade do menu Visão (default padrao = visual atual) */
+  density?: BoardDensity;
+  /** anel de foco da navegação por setas (D-07 — teclado-first) */
+  focused?: boolean;
+  /** desliga o drag (foco Box/Mecânico — colunas não são etapas FSM) */
+  dragDisabled?: boolean;
   onClick: (card: ServiceOrderCardData) => void;
 }
 
@@ -91,10 +104,11 @@ function deadlineChip(
   return null;
 }
 
-function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }: Props) {
+function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, density = 'padrao', focused = false, dragDisabled = false, onClick }: Props) {
+  const canDrag = card.in_pipeline && !dragDisabled;
   const draggable = useDraggable({
     id: `so-${card.id}`,
-    disabled: !card.in_pipeline,
+    disabled: !canDrag,
     data: {
       subjectId: card.id,
       currentColumn: stageKey,
@@ -102,6 +116,17 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
     },
   });
   const { attributes, listeners, setNodeRef, transform, isDragging } = draggable;
+
+  // Anel de foco da navegação por setas (D-07) — mantém o card focado à vista
+  // dentro do scroll da coluna sem roubar o foco DOM da busca.
+  const elRef = useRef<HTMLDivElement | null>(null);
+  const setRefs = useCallback((node: HTMLDivElement | null) => {
+    elRef.current = node;
+    setNodeRef(node);
+  }, [setNodeRef]);
+  useEffect(() => {
+    if (focused) elRef.current?.scrollIntoView({ block: 'nearest', inline: 'nearest' });
+  }, [focused]);
 
   const dragStyle: CSSProperties = transform
     ? { transform: CSS.Translate.toString(transform) }
@@ -118,18 +143,19 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
 
   return (
     <div
-      ref={setNodeRef}
+      ref={setRefs}
       style={dragStyle}
-      {...(card.in_pipeline ? attributes : {})}
-      {...(card.in_pipeline ? listeners : {})}
+      {...(canDrag ? attributes : {})}
+      {...(canDrag ? listeners : {})}
       className={
         'relative rounded border border-t-2 border-border ' + topBorderClass + ' '
         + 'bg-white p-2.5 transition-colors '
         + (isDragging
           ? 'opacity-50 cursor-grabbing ring-2 ring-primary/60 ring-offset-1'
-          : card.in_pipeline
+          : canDrag
             ? 'cursor-grab active:cursor-grabbing hover:shadow-sm hover:border-muted-foreground/40'
             : 'cursor-pointer hover:border-muted-foreground/30')
+        + (focused && !isDragging ? ' ring-2 ring-primary ring-offset-1' : '')
       }
       onClick={(e) => {
         if (isDragging) { e.preventDefault(); return; }
@@ -163,13 +189,14 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
         </div>
       </div>
 
-      {/* [W] mod #1 — foto REAL (sem placeholder de texto). Sem foto → não renderiza. */}
-      {card.thumb_url ? (
+      {/* [W] mod #1 — foto REAL (sem placeholder de texto). Sem foto → não renderiza.
+          Densidade: compacto esconde a foto; detalhe amplia. */}
+      {card.thumb_url && density !== 'compacto' ? (
         <div className="mb-2 rounded overflow-hidden border border-border bg-muted/40">
           <img
             src={card.thumb_url}
             alt={`Foto da OS ${card.number}`}
-            className="w-full h-16 object-cover @[340px]:h-20"
+            className={density === 'detalhe' ? 'w-full h-24 object-cover' : 'w-full h-16 object-cover @[340px]:h-20'}
             loading="lazy"
           />
         </div>
@@ -188,9 +215,12 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
         </div>
       </div>
 
-      {/* Defeito / observação */}
-      {card.notes ? (
-        <p className="text-[12px] text-foreground leading-snug mb-2 line-clamp-2" title={card.notes}>
+      {/* Defeito / observação — compacto esconde; detalhe respira (clamp maior) */}
+      {card.notes && density !== 'compacto' ? (
+        <p
+          className={'text-[12px] text-foreground leading-snug mb-2 ' + (density === 'detalhe' ? 'line-clamp-4' : 'line-clamp-2')}
+          title={card.notes}
+        >
           {card.notes}
         </p>
       ) : null}
@@ -222,6 +252,12 @@ function ServiceOrderKanbanCardImpl({ card, stageKey, topBorderClass, onClick }:
                 {card.mechanic_initials}
               </span>
               <span className="truncate max-w-[80px]">{card.mechanic_name}</span>
+            </span>
+          ) : null}
+          {/* Detalhe mostra o box alocado (extra do menu Visão) */}
+          {density === 'detalhe' && card.box ? (
+            <span className="inline-flex items-center gap-1 text-[10.5px] text-muted-foreground" title={`Box ${card.box}`}>
+              <Warehouse size={10} aria-hidden /> {card.box}
             </span>
           ) : null}
         </div>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanColumn.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanColumn.tsx
@@ -9,6 +9,7 @@
 
 import { memo, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
+import { Inline } from '@/Components/layout';
 import ServiceOrderKanbanCard, { type BoardDensity, type ServiceOrderCardData } from './ServiceOrderKanbanCard';
 import { toneForColor, emphasisClass } from './boardTone';
 
@@ -58,7 +59,7 @@ function ServiceOrderKanbanColumnImpl({ stageKey, name, color, cards, emphasis, 
           <span className={`w-2 h-2 rounded-full flex-shrink-0 ${tone.dot}`} />
           <h3 className="text-sm font-semibold text-foreground truncate">{name}</h3>
         </div>
-        <div className="flex items-center gap-1.5 flex-shrink-0">
+        <Inline gap={1} className="gap-1.5 flex-shrink-0">
           {capacity ? (
             <span
               className="text-[10px] font-medium text-muted-foreground tabular-nums whitespace-nowrap"
@@ -75,7 +76,7 @@ function ServiceOrderKanbanColumnImpl({ stageKey, name, color, cards, emphasis, 
           >
             {cards.length}
           </span>
-        </div>
+        </Inline>
       </header>
 
       <div className="p-2 space-y-2 max-h-[calc(100vh-260px)] overflow-y-auto @[1280px]/board:max-h-[calc(100vh-300px)]" style={{ scrollbarWidth: 'thin' }}>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanColumn.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanColumn.tsx
@@ -9,7 +9,7 @@
 
 import { memo, useCallback } from 'react';
 import { useDroppable } from '@dnd-kit/core';
-import ServiceOrderKanbanCard, { type ServiceOrderCardData } from './ServiceOrderKanbanCard';
+import ServiceOrderKanbanCard, { type BoardDensity, type ServiceOrderCardData } from './ServiceOrderKanbanCard';
 import { toneForColor, emphasisClass } from './boardTone';
 
 interface Props {
@@ -19,10 +19,18 @@ interface Props {
   cards: ServiceOrderCardData[];
   /** distingue visualmente a coluna de aguardando-aprovação × aguardando-peças ([W] mod #4) */
   emphasis?: 'aprovacao' | 'pecas' | null;
+  /** ocupação "x/y boxes" no header (coluna Em execução — Onda 1 paridade Cowork) */
+  capacity?: string | null;
+  /** densidade do menu Visão (repassada aos cards) */
+  density?: BoardDensity;
+  /** id do card com anel de foco da navegação por setas (D-07) */
+  focusedId?: number | null;
+  /** desliga o drag dos cards (foco Box/Mecânico — colunas não são etapas FSM) */
+  dragDisabled?: boolean;
   onCardClick: (card: ServiceOrderCardData) => void;
 }
 
-function ServiceOrderKanbanColumnImpl({ stageKey, name, color, cards, emphasis, onCardClick }: Props) {
+function ServiceOrderKanbanColumnImpl({ stageKey, name, color, cards, emphasis, capacity, density = 'padrao', focusedId, dragDisabled = false, onCardClick }: Props) {
   const handleClick = useCallback((c: ServiceOrderCardData) => onCardClick(c), [onCardClick]);
 
   const { setNodeRef, isOver } = useDroppable({
@@ -50,13 +58,24 @@ function ServiceOrderKanbanColumnImpl({ stageKey, name, color, cards, emphasis, 
           <span className={`w-2 h-2 rounded-full flex-shrink-0 ${tone.dot}`} />
           <h3 className="text-sm font-semibold text-foreground truncate">{name}</h3>
         </div>
-        <span
-          className={'text-xs px-1.5 py-0.5 rounded tabular-nums flex-shrink-0 font-semibold ' + tone.badge}
-          aria-label={`${cards.length} ${cards.length === 1 ? 'OS' : 'OS'}`}
-          data-testid={`board-count-${stageKey}`}
-        >
-          {cards.length}
-        </span>
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          {capacity ? (
+            <span
+              className="text-[10px] font-medium text-muted-foreground tabular-nums whitespace-nowrap"
+              title="Boxes ocupados / boxes da oficina"
+              data-testid={`board-capacity-${stageKey}`}
+            >
+              {capacity}
+            </span>
+          ) : null}
+          <span
+            className={'text-xs px-1.5 py-0.5 rounded tabular-nums flex-shrink-0 font-semibold ' + tone.badge}
+            aria-label={`${cards.length} ${cards.length === 1 ? 'OS' : 'OS'}`}
+            data-testid={`board-count-${stageKey}`}
+          >
+            {cards.length}
+          </span>
+        </div>
       </header>
 
       <div className="p-2 space-y-2 max-h-[calc(100vh-260px)] overflow-y-auto @[1280px]/board:max-h-[calc(100vh-300px)]" style={{ scrollbarWidth: 'thin' }}>
@@ -69,6 +88,9 @@ function ServiceOrderKanbanColumnImpl({ stageKey, name, color, cards, emphasis, 
               card={c}
               stageKey={stageKey}
               topBorderClass={tone.topBorder}
+              density={density}
+              focused={focusedId === c.id}
+              dragDisabled={dragDisabled}
               onClick={handleClick}
             />
           ))


### PR DESCRIPTION
## Onda 1 — toolbar do Quadro de OS (paridade protótipo Cowork homologado)

Port de `oficina-page.jsx` (referência, traduzido pro stack Inertia/shadcn/tokens DS — não cópia cega).

### O que entra
1. **KPIs clicáveis como filtro** (canon D-05): clicar filtra os cards client-side (sem round-trip), anel ativo no KPI, demais esmaecem, chip *limpar filtro* na barra de busca; re-clique limpa. KPI "OS no quadro" segue só-leitura.
2. **Menu Visão** (botão sliders ao lado do toggle Quadro/Lista — `.ofc-adjust`):
   - **Foco**: Etapa (default) / Box / Mecânico — re-pivota as colunas client-side (cards agora carregam `box` + `mechanic_id` do BoardController). Drag desliga fora do foco Etapa (colunas pivotadas não são etapas FSM). Persistido em localStorage.
   - **Densidade**: Compacto (esconde sintoma/foto) / Padrão / Detalhe (foto maior, sintoma sem truncar, chip do box).
   - **Pressão: FORA desta onda** (decisão do escopo).
3. **Busca**: botão limpar (×), atalho `/`, contador reflete os cards visíveis ("N OS de M" quando KPI-filtro ativo).
4. **Atalhos de teclado** (canon D-07 — Larissa teclado-first): `N` nova OS · `/` foca busca · setas navegam cards (anel de foco + scrollIntoView) · `Enter` abre drawer · `Esc` fecha. Ignorados ao digitar em input/select/textarea; não atropela o KeyboardSensor do dnd-kit (`defaultPrevented` guard).
5. **Imprimir fila** (ghost, antes de Nova OS): `printOficinaFila.ts` porta o `printFila` do protótipo — folha A4 com as OS **visíveis** (busca+KPI+selects), atrasadas primeiro, total em carteira. Reusa o mecanismo canônico do `printServiceOrder.ts` (agora exporta `printHtmlDocument`). Obs: `proto-oficina-print.css` veio com token inválido (22 bytes) — CSS da folha escrito a partir da estrutura do `oficina-print.js`.
6. **Coluna Em execução** com ocupação `x/y boxes` no header (x = cards na coluna pré-filtro, y = boxes do `filterOptions` — canon do protótipo).

### Regras respeitadas
- `boardTone.ts` **intocado** · FSM/`STAGE_TRANSITIONS`/drag **intocados**
- Tokens DS (nenhuma cor crua nova) · strings PT-BR · `useMemo`/`useCallback` (lição PR #717)
- Charter Board.charter.md: Non-Goals preservados (sem criação inline, sem fiscal, sem vocabulário caçamba, drag terminal continua proibido)

### Validação
- `tsc --noEmit`: 0 erros nos arquivos tocados (erros restantes do repo são pré-existentes em main)
- `eslint` nos 6 arquivos: limpo (KPI filtrável virou `<button>` nativo)
- `npm run build:inertia`: ✓ built 15s
- `php -l` controller: ok

**Onda 2 (PR separado):** views Grade e Fila no toggle (referências `fila.jsx/css` já baixadas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)