### PR TITLE
feat(whatsapp): US-WA-304 drawer Canais e contas in-place (PR-5/10)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 5
+charter_version: 6
 permissao: whatsapp.access
 ---
 
@@ -260,13 +260,10 @@ Endpoint PATCH `atendimento.inbox.assign` + payload `availableAssignees`.
 Coluna `queue_override` em conversations + PATCH `atendimento.inbox.move_queue`
 + Popover na section Fila. Override vence heurística; null volta pra automática.
 
-### §5 Painel "Canais e contas" drawer
-Cowork tem drawer lateral com lista agrupada de canais (Baileys/Meta/Z-API
-+ contas com status ativo/em-breve). Hoje a tela linka direto pra
-`/atendimento/canais` (página completa). Drawer in-place economiza
-context switch.
-
-**US sugerida:** US-WA-XXX Channels drawer (~2-3h IA-pair).
+### §5 Painel "Canais e contas" drawer — ✅ ENTREGUE 2026-06-10 (US-WA-304)
+`ChannelsDrawer` (Sheet) agrupado por type + contas com status/health + link
+"Gerenciar" pra página completa. Zero backend novo (reusa `availableChannels`
++ `availableAccounts`).
 
 ### §6 Cutover Inbox legacy → Caixa Unificada V4 (P0 — pós-canary)
 Após Wagner aprovar canary 7d:
@@ -282,6 +279,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-304 Drawer Canais e contas** (PR-5/10): topnav "Canais" deixa de navegar pra página e abre `ChannelsDrawer` (Sheet in-place agrupado por type, contas com status ativo/em-breve + health, link Gerenciar pra `/atendimento/canais`). ZERO backend novo — reusa payloads `availableChannels`/`availableAccounts` (cobertos por R-WA-CAIXA-UNIF-001/002). Charter v6. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-305 Mover entre filas** (PR-4/10): coluna `queue_override` (migration idempotente, slug não-FK de propósito — fila deletada não quebra conversa) + `InboxController::moveQueue` (slug validado contra filas do business, 422 fail-loud) + Popover "mover" na section Fila com badge "manual" e volta pra automática. Charter v5. Pest R-WA-CAIXA-UNIF-009. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-301 Filas DB + painel** (PR-3/10): tabela `whatsapp_queues` (ADR 0267, per-schema antes da migration) + seed lazy idempotente do config + QueuesSheet CRUD (label/hue/SLA/dist/tags-gatilho, default protegida) + heurística tag→fila lê DB com fallback config. Topnav "Filas" deixa de ser disabled. Charter v4. Pest R-WA-CAIXA-UNIF-007/008. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-303 Composer completo** (PR-2/10): Templates via `TemplatePicker` legacy filtrado por provider do canal + payload `availableTemplates` (LOCAL/APPROVED) · Macros dropdown + autocomplete `/` inline reusando backend US-WA-048 (`macros.list` + `apply_macro`) · Variáveis `{{nome}}`/`{{telefone}}`/`{{operador}}` com botão `{}`, preview verde/vermelho e substituição no send. Charter v3. Pest R-WA-CAIXA-UNIF-006. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -42,6 +42,7 @@ import {
 } from '@/Components/ui/dropdown-menu';
 
 import ChannelChipsRow from './_components/ChannelChipsRow';
+import ChannelsDrawer from './_components/ChannelsDrawer';
 import QueuesSheet from './_components/QueuesSheet';
 import ConversationListV4 from './_components/ConversationListV4';
 import ConversationThreadV4 from './_components/ConversationThreadV4';
@@ -111,6 +112,8 @@ export default function CaixaUnificadaIndex({
 }: Props) {
   // US-WA-301 — painel Filas (Sheet in-place)
   const [filasOpen, setFilasOpen] = useState(false);
+  // US-WA-304 — drawer Canais e contas (Sheet in-place, charter §5)
+  const [canaisOpen, setCanaisOpen] = useState(false);
 
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -348,14 +351,17 @@ export default function CaixaUnificadaIndex({
           >
             Filas
           </button>
-          <a
-            href={route('atendimento.channels.index')}
+          {/* US-WA-304 — vira drawer in-place (Sheet); página completa fica no link
+              "Gerenciar" dentro do drawer */}
+          <button
+            type="button"
+            onClick={() => setCanaisOpen(true)}
             className="inline-flex items-center px-2.5 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
-            title="Gerenciar canais"
+            title="Canais e contas (drawer)"
             data-testid="caixa-unif-topnav-canais"
           >
             Canais
-          </a>
+          </button>
           <button
             type="button"
             className="inline-flex items-center px-2.5 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors disabled:opacity-45"
@@ -477,6 +483,15 @@ export default function CaixaUnificadaIndex({
           queues={queuesAdmin ?? []}
           availableTags={availableTags ?? []}
           canManage={canManageQueues ?? false}
+        />
+
+        {/* US-WA-304 — drawer Canais e contas (reusa payloads já carregados) */}
+        <ChannelsDrawer
+          open={canaisOpen}
+          onOpenChange={setCanaisOpen}
+          channels={availableChannels ?? []}
+          accounts={availableAccounts ?? []}
+          canManageChannels={canManageQueues ?? false}
         />
 
         {thread && (

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelsDrawer.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelsDrawer.tsx
@@ -1,0 +1,158 @@
+// ChannelsDrawer.tsx — drawer "Canais e contas" da Caixa Unificada V4
+// (US-WA-304 · charter §5).
+//
+// Substitui o context-switch pra /atendimento/canais por um Sheet in-place:
+// lista agrupada por TYPE de canal (glyph hue do catálogo) + contas com
+// status ativo/em-breve + link "Gerenciar canais" pra página completa.
+// Referência visual: prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx
+// (om-drawer "Canais e contas").
+//
+// ZERO backend novo — reusa payloads deferred `availableChannels` (catálogo
+// 7 types com count) e `availableAccounts` (instâncias com handle/status/
+// health) que a tela já carrega. Cobertura server-side: R-WA-CAIXA-UNIF-001/002.
+
+import { ExternalLink, Settings } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/Components/ui/sheet';
+import { Inline, Stack } from '@/Components/layout';
+import { cn } from '@/Lib/utils';
+import type { AccountItem, ChannelCatalogItem } from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  channels: ChannelCatalogItem[];
+  accounts: AccountItem[];
+  /** Permission whatsapp.settings.manage — mostra link "Gerenciar". */
+  canManageChannels: boolean;
+}
+
+const HEALTH_LABELS: Record<string, string> = {
+  healthy: 'saudável',
+  degraded: 'degradado',
+  down: 'fora do ar',
+  never_checked: 'sem verificação',
+};
+
+export default function ChannelsDrawer({ open, onOpenChange, channels, accounts, canManageChannels }: Props) {
+  const activeCount = accounts.filter(a => a.status === 'ativo').length;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Canais e contas</SheetTitle>
+          <SheetDescription>
+            {activeCount} {activeCount === 1 ? 'conta ativa' : 'contas ativas'}
+            {accounts.length - activeCount > 0 && ` · ${accounts.length - activeCount} em homologação`}
+          </SheetDescription>
+        </SheetHeader>
+
+        <Stack gap={4} className="mt-4">
+          {channels.map(ch => {
+            const accs = accounts.filter(a => a.channel_type === ch.id);
+            return (
+              <section key={ch.id} data-testid={`caixa-unif-drawer-chan-${ch.id}`}>
+                <Inline gap={2} align="center" className="mb-1.5">
+                  <span
+                    className="inline-grid place-items-center w-4 h-4 rounded-full text-white text-[9px] font-bold flex-shrink-0"
+                    style={{ background: `oklch(0.62 0.14 ${ch.hue})` }}
+                    aria-hidden
+                  >
+                    {ch.glyph}
+                  </span>
+                  <small className="text-[10px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
+                    {ch.label}
+                  </small>
+                  {ch.status === 'em_breve' && (
+                    <span className="inline-flex text-[9px] font-medium text-muted-foreground bg-muted border rounded-full px-1.5">
+                      em breve
+                    </span>
+                  )}
+                  {ch.count > 0 && (
+                    <small className="font-mono text-[10px] text-muted-foreground ml-auto">
+                      {ch.count} {ch.count === 1 ? 'conversa' : 'conversas'}
+                    </small>
+                  )}
+                </Inline>
+                {accs.length === 0 ? (
+                  <p className="text-[11px] text-muted-foreground italic px-1">
+                    Nenhuma conta conectada deste canal.
+                  </p>
+                ) : (
+                  <Stack gap={1}>
+                    {accs.map(acc => (
+                      <Inline
+                        key={acc.id}
+                        gap={2}
+                        align="center"
+                        justify="between"
+                        className={cn(
+                          'border rounded-md px-3 py-2',
+                          acc.status !== 'ativo' && 'opacity-65',
+                        )}
+                        data-testid={`caixa-unif-drawer-acc-${acc.id}`}
+                      >
+                        <span className="min-w-0">
+                          <b className="block text-[12px] font-semibold truncate">{acc.label}</b>
+                          <small className="block font-mono text-[10.5px] text-muted-foreground truncate">
+                            {acc.handle}
+                            {acc.status === 'ativo' && acc.channel_health !== 'healthy' && (
+                              <span title={`Health: ${acc.channel_health}`}>
+                                {' · '}{HEALTH_LABELS[acc.channel_health] ?? acc.channel_health}
+                              </span>
+                            )}
+                          </small>
+                        </span>
+                        <Inline gap={1} align="center" className="flex-shrink-0">
+                          {acc.status === 'ativo' ? (
+                            <span
+                              className="inline-flex text-[9.5px] font-semibold rounded-full px-2 py-px"
+                              style={{ background: 'oklch(0.93 0.06 145)', color: 'oklch(0.25 0.10 145)' }}
+                            >
+                              ativo
+                            </span>
+                          ) : (
+                            <span className="inline-flex text-[9.5px] font-medium text-muted-foreground bg-muted border rounded-full px-2 py-px">
+                              em breve
+                            </span>
+                          )}
+                          {canManageChannels && (
+                            <a
+                              href={route('atendimento.channels.show', acc.id)}
+                              className="p-1 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                              title={`Configurar ${acc.label}`}
+                              data-testid={`caixa-unif-drawer-acc-manage-${acc.id}`}
+                            >
+                              <Settings size={12} aria-hidden />
+                            </a>
+                          )}
+                        </Inline>
+                      </Inline>
+                    ))}
+                  </Stack>
+                )}
+              </section>
+            );
+          })}
+
+          {canManageChannels && (
+            <a
+              href={route('atendimento.channels.index')}
+              className="inline-flex items-center justify-center gap-1.5 border rounded-md px-3 py-2 text-[12px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              data-testid="caixa-unif-drawer-manage-all"
+            >
+              <ExternalLink size={13} aria-hidden />
+              Gerenciar canais (página completa)
+            </a>
+          )}
+        </Stack>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-5 de 10

**US-WA-304 — Drawer "Canais e contas"** (charter roadmap §5, P2)

- Topnav "Canais" deixa de navegar pra `/atendimento/canais` e abre **ChannelsDrawer** (Sheet in-place): lista agrupada por type (glyph hue do catálogo) + contas com status ativo/em-breve + health + link "Gerenciar canais" pra página completa
- **ZERO backend novo** — reusa payloads deferred `availableChannels`/`availableAccounts` que a tela já carrega (Tier 0 coberto por `R-WA-CAIXA-UNIF-001/002`)
- Referência visual: `om-drawer` do `inbox-page.jsx` V2

Charter → v6 (roadmap §5 ✅).

🤖 Generated with [Claude Code](https://claude.com/claude-code)