### PR TITLE
feat(whatsapp): US-WA-307 + Nova conversa — find-or-create + thread aberta (PR-6/10)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -1162,6 +1162,118 @@ class InboxController extends Controller
     }
 
     /**
+     * US-WA-307: POST `/atendimento/inbox/conversations` — inicia conversa
+     * outbound a partir do botão "+ Nova conversa" da Caixa Unificada V4.
+     *
+     * Find-or-create por (business, channel_id, customer_external_id) — número
+     * que já conversou reabre a thread existente (não duplica). Mensagem
+     * inicial opcional REUSA o pipeline completo do send() (ACL re-check,
+     * auto-prefix, dispatch driver) — zero duplicação de lógica de driver.
+     *
+     * Tier 0: canal precisa ser do business + ATIVO + user com ACL (US-WA-069).
+     * Contact via `contact_id` resolve phone/nome do CRM do MESMO business.
+     */
+    public function startConversation(\Illuminate\Http\Request $request): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $data = $request->validate([
+            'channel_id' => ['required', 'integer'],
+            'contact_id' => ['nullable', 'integer'],
+            'phone' => ['required_without:contact_id', 'nullable', 'string', 'max:30'],
+            'name' => ['nullable', 'string', 'max:120'],
+            'body' => ['nullable', 'string', 'max:4096'],
+        ]);
+
+        // Canal: do business + ativo + ACL (fail-loud)
+        $channel = Channel::query()
+            ->where('business_id', $businessId)
+            ->where('id', (int) $data['channel_id'])
+            ->first();
+        if (! $channel) {
+            abort(403, 'Canal não encontrado ou sem acesso.');
+        }
+        if ($channel->status !== 'active') {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'channel_id' => "Canal \"{$channel->label}\" não está ativo — conecte antes de iniciar conversas.",
+            ]);
+        }
+        if (! $this->canSeeAllChannels()) {
+            $hasAccess = ChannelUserAccess::query()
+                ->where('business_id', $businessId)
+                ->where('user_id', $userId)
+                ->where('channel_id', $channel->id)
+                ->whereNull('revoked_at')
+                ->exists();
+            if (! $hasAccess) {
+                abort(403, 'Sem acesso a este canal.');
+            }
+        }
+
+        // Contact CRM (mesmo business) resolve phone + nome
+        $contactId = isset($data['contact_id']) ? (int) $data['contact_id'] : null;
+        $phone = (string) ($data['phone'] ?? '');
+        $name = (string) ($data['name'] ?? '');
+        if ($contactId !== null) {
+            $contact = Contact::where('business_id', $businessId)->find($contactId);
+            if (! $contact) {
+                throw \Illuminate\Validation\ValidationException::withMessages([
+                    'contact_id' => 'Contato não encontrado neste business.',
+                ]);
+            }
+            $phone = $phone !== '' ? $phone : (string) ($contact->mobile ?? '');
+            $name = $name !== '' ? $name : (string) ($contact->name ?? '');
+        }
+
+        // Normaliza phone → formato canon customer_external_id ("+5511...")
+        $digits = preg_replace('/\D+/', '', $phone) ?? '';
+        if (strlen($digits) < 8) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'phone' => 'Telefone inválido — informe DDI+DDD+número (mínimo 8 dígitos).',
+            ]);
+        }
+        $externalId = '+' . $digits;
+
+        // Find-or-create — número que já conversou reabre a thread (não duplica)
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->where('channel_id', $channel->id)
+            ->where('customer_external_id', $externalId)
+            ->first();
+
+        if (! $conversation) {
+            $conversation = Conversation::query()->create([
+                'business_id' => $businessId,
+                'channel_id' => $channel->id,
+                'contact_id' => $contactId,
+                'customer_external_id' => $externalId,
+                'contact_name' => $name !== '' ? $name : $externalId,
+                'status' => 'open',
+                'last_message_at' => now(),
+            ]);
+        } elseif ($contactId !== null && $conversation->contact_id === null) {
+            // Reaberta a partir do CRM — aproveita pra vincular o Contact
+            $conversation->forceFill(['contact_id' => $contactId])->save();
+        }
+
+        // Mensagem inicial opcional — REUSA o pipeline send() inteiro
+        if (! empty($data['body']) && trim((string) $data['body']) !== '') {
+            $sendRequest = \Illuminate\Http\Request::create(
+                "/atendimento/inbox/{$conversation->id}/send",
+                'POST',
+                ['kind' => 'freeform', 'body' => trim((string) $data['body'])],
+            );
+            $sendRequest->setLaravelSession($request->session());
+            $this->send($sendRequest, $conversation->id);
+        }
+
+        return redirect()
+            ->route('atendimento.caixa-unificada.index', ['thread' => $conversation->id])
+            ->with('success', 'Conversa pronta.');
+    }
+
+    /**
      * US-WA-064: GET `/atendimento/inbox/contacts/search?q=...` — busca
      * Contacts UltimatePOS do business atual filtrando por nome/mobile/landline.
      *

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -188,6 +188,12 @@ Route::group([
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.move_queue');
 
+    // US-WA-307: + Nova conversa — find-or-create + mensagem inicial opcional
+    // (reusa pipeline send). Tier 0: canal ativo do business + ACL.
+    Route::post('/inbox/conversations', [InboxController::class, 'startConversation'])
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.start_conversation');
+
     // Wagner 2026-05-27 — Voice of Customer in-app capture (ADR UI-0016).
     // Captura feedback diretamente de mensagens do inbox WhatsApp.
     Route::post('/feedback/capture', [ClientFeedbackController::class, 'capture'])

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -656,3 +656,64 @@ it('R-WA-CAIXA-UNIF-009 — moveQueue: override vence heurística, null volta, s
     expect($props3['thread']['queue']['slug'])->toBe('financeiro')
         ->and($props3['thread']['queue_is_override'])->toBeFalse();
 });
+
+// ============================================================================
+// 8. US-WA-307 — + Nova conversa: find-or-create + guards Tier 0
+// ============================================================================
+
+function cuctPostRequest(string $uri, array $body = []): Request
+{
+    $request = Request::create($uri, 'POST', $body);
+    $request->setLaravelSession(app('session.store'));
+    return $request;
+}
+
+it('R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone', function () {
+    $chActive = cuctMakeChannel(1, 'caixa-unif-010-active-uuid');           // status=active
+    $chSetup = cuctMakeChannel(1, 'caixa-unif-010-setup-uuid', 'setup');    // não-ativo
+    $chNoAcl = cuctMakeChannel(1, 'caixa-unif-010-noacl-uuid');             // sem grant
+    cuctSetUserAndGrant(1, 10, [$chActive->id, $chSetup->id]);
+
+    $inbox = new \Modules\Whatsapp\Http\Controllers\Admin\InboxController();
+
+    // Cria nova conversa — phone normalizado pra +<digits>
+    $resp = $inbox->startConversation(cuctPostRequest('/atendimento/inbox/conversations', [
+        'channel_id' => $chActive->id,
+        'phone' => '+55 (48) 9999-0001',
+        'name' => 'Cliente Novo',
+    ]));
+    $conv = Conversation::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->where('customer_external_id', '+554899990001')
+        ->first();
+    expect($conv)->not->toBeNull()
+        ->and($conv->contact_name)->toBe('Cliente Novo')
+        ->and($conv->status)->toBe('open')
+        ->and($resp->getTargetUrl())->toContain('thread=' . $conv->id);
+
+    // Mesmo número de novo → REABRE (não duplica)
+    $inbox->startConversation(cuctPostRequest('/atendimento/inbox/conversations', [
+        'channel_id' => $chActive->id,
+        'phone' => '554899990001',
+    ]));
+    $count = Conversation::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', 1)
+        ->where('customer_external_id', '+554899990001')
+        ->count();
+    expect($count)->toBe(1);
+
+    // Canal não-ativo → 422
+    expect(fn () => $inbox->startConversation(cuctPostRequest('/atendimento/inbox/conversations', [
+        'channel_id' => $chSetup->id, 'phone' => '+5548999990002',
+    ])))->toThrow(\Illuminate\Validation\ValidationException::class);
+
+    // Canal sem ACL → 403 fail-loud (US-WA-069)
+    expect(fn () => $inbox->startConversation(cuctPostRequest('/atendimento/inbox/conversations', [
+        'channel_id' => $chNoAcl->id, 'phone' => '+5548999990003',
+    ])))->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+    // Telefone curto → 422
+    expect(fn () => $inbox->startConversation(cuctPostRequest('/atendimento/inbox/conversations', [
+        'channel_id' => $chActive->id, 'phone' => '123',
+    ])))->toThrow(\Illuminate\Validation\ValidationException::class);
+});

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 6
+charter_version: 7
 permissao: whatsapp.access
 ---
 
@@ -59,8 +59,13 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - **Dropdown de status** dentro do header da lista — 4 valores canônicos:
   Abertas / Pendentes / Aguardando / Resolvidas.
 - **Busca inline** com Enter pra aplicar, Esc pra limpar.
-- **Topnav direita** — Filas | Canais | Broadcast | + Nova conversa
-  (placeholders TODO US-WA-XXX exceto "Canais" que linka real).
+- **Topnav direita** — Filas (QueuesSheet US-WA-301) | Canais (ChannelsDrawer
+  US-WA-304) | Broadcast (placeholder — US-WA-306 no PR-7) | **+ Nova conversa**
+  (US-WA-307, 2026-06-10): dialog com conta ativa + telefone OU Contact CRM
+  (ContactPickerModal US-WA-064) + mensagem inicial opcional. POST
+  `atendimento.inbox.start_conversation` faz find-or-create (número que já
+  conversou REABRE thread) e redireciona com a thread aberta; mensagem inicial
+  reusa o pipeline send() completo (zero duplicação de driver).
 
 ### Banner "em homologação"
 - Canais com `Channel.status != 'active'` viram preview-only no backend
@@ -235,6 +240,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-007 — filas: seed lazy idempotente do config + payload lê DB + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-008 — CRUD filas: store/update/destroy + default protegida + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-009 — moveQueue: override vence heurística, null volta, slug inválido 422` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone` | mesmo arquivo |
 
 ---
 
@@ -279,6 +285,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-307 + Nova conversa** (PR-6/10): dialog conta ativa + telefone/Contact CRM + mensagem inicial opcional; `InboxController::startConversation` find-or-create Tier 0 (canal ativo do business + ACL US-WA-069; cross/inativo = 403/422) reusando pipeline send(). Charter v7. Pest R-WA-CAIXA-UNIF-010. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-304 Drawer Canais e contas** (PR-5/10): topnav "Canais" deixa de navegar pra página e abre `ChannelsDrawer` (Sheet in-place agrupado por type, contas com status ativo/em-breve + health, link Gerenciar pra `/atendimento/canais`). ZERO backend novo — reusa payloads `availableChannels`/`availableAccounts` (cobertos por R-WA-CAIXA-UNIF-001/002). Charter v6. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-305 Mover entre filas** (PR-4/10): coluna `queue_override` (migration idempotente, slug não-FK de propósito — fila deletada não quebra conversa) + `InboxController::moveQueue` (slug validado contra filas do business, 422 fail-loud) + Popover "mover" na section Fila com badge "manual" e volta pra automática. Charter v5. Pest R-WA-CAIXA-UNIF-009. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-301 Filas DB + painel** (PR-3/10): tabela `whatsapp_queues` (ADR 0267, per-schema antes da migration) + seed lazy idempotente do config + QueuesSheet CRUD (label/hue/SLA/dist/tags-gatilho, default protegida) + heurística tag→fila lê DB com fallback config. Topnav "Filas" deixa de ser disabled. Charter v4. Pest R-WA-CAIXA-UNIF-007/008. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -43,6 +43,7 @@ import {
 
 import ChannelChipsRow from './_components/ChannelChipsRow';
 import ChannelsDrawer from './_components/ChannelsDrawer';
+import NewConversationDialog from './_components/NewConversationDialog';
 import QueuesSheet from './_components/QueuesSheet';
 import ConversationListV4 from './_components/ConversationListV4';
 import ConversationThreadV4 from './_components/ConversationThreadV4';
@@ -114,6 +115,8 @@ export default function CaixaUnificadaIndex({
   const [filasOpen, setFilasOpen] = useState(false);
   // US-WA-304 — drawer Canais e contas (Sheet in-place, charter §5)
   const [canaisOpen, setCanaisOpen] = useState(false);
+  // US-WA-307 — dialog + Nova conversa
+  const [novaConvOpen, setNovaConvOpen] = useState(false);
 
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -371,11 +374,12 @@ export default function CaixaUnificadaIndex({
           >
             Broadcast
           </button>
+          {/* US-WA-307 — abre dialog (find-or-create + thread aberta) */}
           <button
             type="button"
-            className="inline-flex items-center px-3 py-1.5 text-[11.5px] font-semibold bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors disabled:opacity-45"
-            disabled
-            title="Iniciar nova conversa (em breve)"
+            onClick={() => setNovaConvOpen(true)}
+            className="inline-flex items-center px-3 py-1.5 text-[11.5px] font-semibold bg-primary text-primary-foreground rounded hover:bg-primary/90 transition-colors"
+            title="Iniciar nova conversa"
             data-testid="caixa-unif-topnav-nova"
           >
             + Nova conversa
@@ -492,6 +496,13 @@ export default function CaixaUnificadaIndex({
           channels={availableChannels ?? []}
           accounts={availableAccounts ?? []}
           canManageChannels={canManageQueues ?? false}
+        />
+
+        {/* US-WA-307 — + Nova conversa (find-or-create + abre thread) */}
+        <NewConversationDialog
+          open={novaConvOpen}
+          onOpenChange={setNovaConvOpen}
+          accounts={availableAccounts ?? []}
         />
 
         {thread && (

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/NewConversationDialog.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/NewConversationDialog.tsx
@@ -1,0 +1,207 @@
+// NewConversationDialog.tsx — "+ Nova conversa" da Caixa Unificada V4
+// (US-WA-307 · charter topnav).
+//
+// Dialog: conta ativa (select DS) + telefone OU Contact CRM (ContactPickerModal
+// reusado, US-WA-064) + mensagem inicial opcional. POST
+// atendimento.inbox.start_conversation faz find-or-create (número que já
+// conversou REABRE a thread, não duplica) e redireciona com ?thread= aberto.
+// Mensagem inicial reusa o pipeline send() inteiro no backend.
+
+import { useMemo, useState } from 'react';
+import { useForm } from '@inertiajs/react';
+import { MessageSquarePlus, Search, X } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Inline, Stack } from '@/Components/layout';
+import ContactPickerModal from '@/Pages/Whatsapp/_components/ContactPickerModal';
+import type { AccountItem } from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accounts: AccountItem[];
+}
+
+export default function NewConversationDialog({ open, onOpenChange, accounts }: Props) {
+  const activeAccounts = useMemo(() => accounts.filter(a => a.status === 'ativo'), [accounts]);
+  const [contactPickerOpen, setContactPickerOpen] = useState(false);
+  const [linkedContactId, setLinkedContactId] = useState<number | null>(null);
+
+  const form = useForm<{
+    channel_id: string;
+    contact_id: number | null;
+    phone: string;
+    name: string;
+    body: string;
+  }>({
+    channel_id: '',
+    contact_id: null,
+    phone: '',
+    name: '',
+    body: '',
+  });
+
+  function submit() {
+    if (form.processing) return;
+    form.transform(data => ({
+      ...data,
+      channel_id: Number(data.channel_id),
+      contact_id: linkedContactId,
+    }));
+    form.post(route('atendimento.inbox.start_conversation'), {
+      preserveScroll: true,
+      onSuccess: () => {
+        form.reset();
+        setLinkedContactId(null);
+        onOpenChange(false);
+      },
+    });
+  }
+
+  const canSubmit = form.data.channel_id !== ''
+    && (linkedContactId !== null || form.data.phone.replace(/\D/g, '').length >= 8)
+    && !form.processing;
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={(o) => { if (!o) { form.reset(); setLinkedContactId(null); } onOpenChange(o); }}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle className="inline-flex items-center gap-2">
+              <MessageSquarePlus size={18} aria-hidden />
+              Nova conversa
+            </DialogTitle>
+            <DialogDescription>
+              Número que já conversou reabre a thread existente — não duplica.
+            </DialogDescription>
+          </DialogHeader>
+
+          <Stack gap={3}>
+            <Stack gap={1}>
+              <Label className="text-[11px]">Conta de envio</Label>
+              <Select value={form.data.channel_id} onValueChange={v => form.setData('channel_id', v)}>
+                <SelectTrigger data-testid="caixa-unif-nova-conta">
+                  <SelectValue placeholder={activeAccounts.length === 0 ? 'Nenhuma conta ativa' : 'Selecione a conta'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {activeAccounts.map(a => (
+                    <SelectItem key={a.id} value={String(a.id)}>
+                      {a.label} · {a.handle}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {activeAccounts.length === 0 && (
+                <small className="text-[10.5px] text-muted-foreground">
+                  Conecte um canal em Canais antes de iniciar conversas.
+                </small>
+              )}
+            </Stack>
+
+            <Stack gap={1}>
+              <Inline gap={0} align="center" justify="between">
+                <Label htmlFor="nova-conv-phone" className="text-[11px]">Telefone (DDI+DDD+número)</Label>
+                <button
+                  type="button"
+                  onClick={() => setContactPickerOpen(true)}
+                  className="inline-flex items-center gap-1 text-[10.5px] text-muted-foreground hover:text-foreground transition-colors"
+                  data-testid="caixa-unif-nova-buscar-contato"
+                >
+                  <Search size={11} aria-hidden /> buscar no CRM
+                </button>
+              </Inline>
+              {linkedContactId !== null ? (
+                <Inline gap={2} align="center" className="border rounded-md px-3 py-2 bg-muted/30">
+                  <span className="text-[12px] flex-1 min-w-0 truncate">
+                    Contato CRM #{linkedContactId} vinculado — telefone vem do cadastro
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setLinkedContactId(null)}
+                    className="text-muted-foreground hover:text-destructive"
+                    title="Remover vínculo e digitar telefone"
+                    data-testid="caixa-unif-nova-unlink-contato"
+                  >
+                    <X size={13} aria-hidden />
+                  </button>
+                </Inline>
+              ) : (
+                <Input
+                  id="nova-conv-phone"
+                  value={form.data.phone}
+                  onChange={e => form.setData('phone', e.target.value)}
+                  placeholder="+55 48 99999-9999"
+                  inputMode="tel"
+                  data-testid="caixa-unif-nova-phone"
+                />
+              )}
+              {form.errors.phone && <small className="text-[10.5px] text-destructive">{form.errors.phone}</small>}
+              {form.errors.channel_id && <small className="text-[10.5px] text-destructive">{form.errors.channel_id}</small>}
+            </Stack>
+
+            {linkedContactId === null && (
+              <Stack gap={1}>
+                <Label htmlFor="nova-conv-name" className="text-[11px]">Nome (opcional)</Label>
+                <Input
+                  id="nova-conv-name"
+                  value={form.data.name}
+                  onChange={e => form.setData('name', e.target.value)}
+                  placeholder="Nome do contato"
+                  data-testid="caixa-unif-nova-name"
+                />
+              </Stack>
+            )}
+
+            <Stack gap={1}>
+              <Label htmlFor="nova-conv-body" className="text-[11px]">Mensagem inicial (opcional)</Label>
+              <Input
+                id="nova-conv-body"
+                value={form.data.body}
+                onChange={e => form.setData('body', e.target.value)}
+                placeholder="Ex.: Olá! Aqui é da Oimpresso…"
+                data-testid="caixa-unif-nova-body"
+              />
+              <small className="text-[10.5px] text-muted-foreground">
+                Sem mensagem, a conversa abre vazia e você usa o composer (templates, macros, variáveis).
+              </small>
+            </Stack>
+          </Stack>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => onOpenChange(false)}>Cancelar</Button>
+            <Button onClick={submit} disabled={!canSubmit} data-testid="caixa-unif-nova-submit">
+              {form.processing ? 'Abrindo…' : 'Iniciar conversa'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* US-WA-064 — picker de Contact CRM reusado (busca debounced) */}
+      <ContactPickerModal
+        open={contactPickerOpen}
+        onOpenChange={setContactPickerOpen}
+        searchRouteName="atendimento.inbox.contacts.search"
+        onSelect={(contactId) => {
+          setLinkedContactId(contactId);
+          setContactPickerOpen(false);
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-6 de 10

**US-WA-307 — "+ Nova conversa"** (topnav, P2)

- Botão deixa de ser disabled: **NewConversationDialog** com conta ativa (select DS) + telefone OU Contact CRM (`ContactPickerModal` US-WA-064 reusado) + mensagem inicial opcional
- **`InboxController::startConversation`** (POST `/atendimento/inbox/conversations`):
  - **find-or-create** por (business, channel, customer_external_id) — número que já conversou REABRE a thread (não duplica); vincula Contact se reaberta via CRM
  - Tier 0: canal do business + ATIVO + ACL US-WA-069 (403/422 fail-loud); phone normalizado `+<digits>`
  - Mensagem inicial **reusa o pipeline send() completo** (ACL re-check, auto-prefix, dispatch driver — zero duplicação)
  - Redirect pra `caixa-unificada?thread=<id>` (thread aberta)

### Pest
- `R-WA-CAIXA-UNIF-010` — cria + normaliza phone / reabre sem duplicar / canal inativo 422 / sem ACL 403 / phone curto 422

Charter → v7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)