### PR TITLE
feat(whatsapp): US-WA-306 broadcast FASE 1 — pre-flight LGPD + draft auditável (PR-7/10)

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_06_10_000003_create_whatsapp_broadcasts_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_06_10_000003_create_whatsapp_broadcasts_table.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-306 (ADR 0268) — campanha broadcast cross-canal (FASE 1: modelo +
+ * pre-flight + draft; disparo em massa é fase 2 com gate [W]).
+ *
+ * `status` só grava 'draft' nesta fase — transições dispatching/done/failed
+ * chegam com o Job rate-limited da fase 2 (anti M-AP-2: enum existe, motor não
+ * finge rodar).
+ *
+ * Inclui também a coluna de consentimento LGPD `whatsapp_opt_in_at` em
+ * `contacts` (NULL = sem opt-in = fora de qualquer broadcast).
+ *
+ * Idempotente: hasTable/hasColumn guards.
+ *
+ * @see memory/decisions/0268-whatsapp-broadcasts-campanha-scaffold.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('whatsapp_broadcasts')) {
+            Schema::create('whatsapp_broadcasts', function (Blueprint $table) {
+                $table->bigIncrements('id');
+                $table->unsignedInteger('business_id');
+                $table->unsignedBigInteger('channel_id');
+                $table->unsignedInteger('created_by_user_id');
+                $table->string('kind', 10)->default('freeform')
+                    ->comment('freeform|template');
+                $table->string('template_name', 64)->nullable();
+                $table->text('body')->nullable();
+                $table->string('status', 20)->default('draft')
+                    ->comment('draft|dispatching|done|failed — fase 1 so grava draft (ADR 0268)');
+                $table->json('audience_snapshot')
+                    ->comment('contagens do pre-flight congeladas no save (auditoria)');
+                $table->json('recipient_conversation_ids')
+                    ->comment('conversas elegiveis (opt-in LGPD) no momento do pre-flight');
+                $table->timestamp('dispatched_at')->nullable();
+                $table->timestamps();
+
+                $table->index(['business_id', 'status'], 'wb_biz_status_idx');
+            });
+        }
+
+        if (Schema::hasTable('contacts') && ! Schema::hasColumn('contacts', 'whatsapp_opt_in_at')) {
+            Schema::table('contacts', function (Blueprint $table) {
+                $table->timestamp('whatsapp_opt_in_at')->nullable()
+                    ->comment('LGPD: consentimento marketing WhatsApp; NULL = fora de broadcast (ADR 0268)');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('whatsapp_broadcasts');
+        if (Schema::hasTable('contacts') && Schema::hasColumn('contacts', 'whatsapp_opt_in_at')) {
+            Schema::table('contacts', function (Blueprint $table) {
+                $table->dropColumn('whatsapp_opt_in_at');
+            });
+        }
+    }
+};

--- a/Modules/Whatsapp/Entities/WhatsappBroadcast.php
+++ b/Modules/Whatsapp/Entities/WhatsappBroadcast.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * WhatsappBroadcast — campanha broadcast cross-canal (US-WA-306 · ADR 0268).
+ *
+ * FASE 1 (scaffold honesto): só `status=draft` é gravado — pre-flight calcula
+ * audiência (opt-in LGPD + janela 24h Meta) e congela snapshot auditável.
+ * FASE 2 (gate [W]): Job rate-limited transita draft→dispatching→done.
+ *
+ * Multi-tenant Tier 0 (ADR 0093) via HasBusinessScope.
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property int $channel_id
+ * @property int $created_by_user_id
+ * @property string $kind
+ * @property ?string $template_name
+ * @property ?string $body
+ * @property string $status
+ * @property array $audience_snapshot
+ * @property array $recipient_conversation_ids
+ * @property ?\Illuminate\Support\Carbon $dispatched_at
+ */
+class WhatsappBroadcast extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'whatsapp_broadcasts';
+
+    public const KINDS = ['freeform', 'template'];
+    public const STATUSES = ['draft', 'dispatching', 'done', 'failed'];
+
+    protected $fillable = [
+        'business_id', 'channel_id', 'created_by_user_id',
+        'kind', 'template_name', 'body', 'status',
+        'audience_snapshot', 'recipient_conversation_ids', 'dispatched_at',
+    ];
+
+    protected $casts = [
+        'audience_snapshot' => 'array',
+        'recipient_conversation_ids' => 'array',
+        'dispatched_at' => 'datetime',
+    ];
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/BroadcastController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/BroadcastController.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Validation\Rule;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\WhatsappBroadcast;
+
+/**
+ * BroadcastController — broadcast cross-canal FASE 1 (US-WA-306 · ADR 0268).
+ *
+ * Pre-flight REAL (audiência com opt-in LGPD + janela 24h Meta) + draft
+ * auditável. DISPARO É FASE 2 (Job rate-limited com gate [W]) — nenhum
+ * endpoint aqui toca driver (anti M-AP-2: sem fingir envio em massa).
+ *
+ * Permission: `whatsapp.send` (operacional) + ACL canal (US-WA-069).
+ * Tier 0 ADR 0093: where business_id explícito em toda query.
+ */
+class BroadcastController extends Controller
+{
+    /**
+     * POST /atendimento/broadcast/preflight — calcula audiência da campanha.
+     *
+     * Elegibilidade (sobre conversas EXISTENTES do canal — broadcast fase 1
+     * não prospecta números frios):
+     *   - conversa não-bloqueada do canal escolhido
+     *   - `with_opt_in`: Contact CRM vinculado COM `whatsapp_opt_in_at` (LGPD)
+     *     → SÓ estes entram em `recipient_conversation_ids`
+     *   - `in_window`: last_inbound_at ≥ now-24h (freeform permitido)
+     *   - `hsm_only`: fora da janela → exigirá template HSM APPROVED (fase 2)
+     */
+    public function preflight(Request $request): JsonResponse
+    {
+        [$businessId, , $channel] = $this->resolveChannelOrAbort($request);
+
+        $base = Conversation::query()
+            ->where('business_id', $businessId)
+            ->where('channel_id', $channel->id)
+            ->where('is_blocked', false);
+
+        $total = (clone $base)->count();
+
+        $optIn = (clone $base)
+            ->whereNotNull('contact_id')
+            ->whereExists(function ($q) use ($businessId) {
+                $q->selectRaw('1')
+                    ->from('contacts')
+                    ->whereColumn('contacts.id', 'conversations.contact_id')
+                    ->where('contacts.business_id', $businessId)
+                    ->whereNotNull('contacts.whatsapp_opt_in_at');
+            });
+
+        $withOptIn = (clone $optIn)->count();
+        $inWindow = (clone $optIn)->where('last_inbound_at', '>=', now()->subHours(24))->count();
+        $recipientIds = (clone $optIn)->pluck('id')->all();
+
+        return response()->json([
+            'total' => $total,
+            'with_opt_in' => $withOptIn,
+            'without_opt_in' => $total - $withOptIn,
+            'in_window' => $inWindow,
+            'hsm_only' => $withOptIn - $inWindow,
+            'recipient_conversation_ids' => $recipientIds,
+        ]);
+    }
+
+    /**
+     * POST /atendimento/broadcast — salva DRAFT auditável (fase 1).
+     *
+     * Snapshot da audiência é recalculado server-side no save (não confia no
+     * que o frontend mostrou) — draft congela quem estaria na lista.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        [$businessId, $userId, $channel] = $this->resolveChannelOrAbort($request);
+
+        $data = $request->validate([
+            'kind' => ['required', Rule::in(WhatsappBroadcast::KINDS)],
+            'template_name' => ['required_if:kind,template', 'nullable', 'string', 'max:64'],
+            'body' => ['required_if:kind,freeform', 'nullable', 'string', 'max:4096'],
+        ]);
+
+        // Recalcula audiência server-side (mesma lógica do preflight)
+        $preflight = $this->preflight($request)->getData(true);
+
+        if (($preflight['with_opt_in'] ?? 0) === 0) {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'audience' => 'Nenhum contato com opt-in LGPD neste canal — broadcast sem consentimento é proibido (ADR 0268).',
+            ]);
+        }
+
+        WhatsappBroadcast::query()->create([
+            'business_id' => $businessId,
+            'channel_id' => $channel->id,
+            'created_by_user_id' => $userId,
+            'kind' => $data['kind'],
+            'template_name' => $data['template_name'] ?? null,
+            'body' => $data['body'] ?? null,
+            'status' => 'draft',
+            'audience_snapshot' => collect($preflight)->except('recipient_conversation_ids')->all(),
+            'recipient_conversation_ids' => $preflight['recipient_conversation_ids'] ?? [],
+        ]);
+
+        return back()->with('success', 'Rascunho de broadcast salvo — disparo em massa é a fase 2 (ADR 0268).');
+    }
+
+    /**
+     * Canal: do business + ATIVO + ACL do user (fail-loud).
+     *
+     * @return array{0: int, 1: int, 2: Channel}
+     */
+    protected function resolveChannelOrAbort(Request $request): array
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $request->validate(['channel_id' => ['required', 'integer']]);
+        $channel = Channel::query()
+            ->where('business_id', $businessId)
+            ->where('id', (int) $request->input('channel_id'))
+            ->first();
+        if (! $channel) {
+            abort(403, 'Canal não encontrado ou sem acesso.');
+        }
+        if ($channel->status !== 'active') {
+            throw \Illuminate\Validation\ValidationException::withMessages([
+                'channel_id' => "Canal \"{$channel->label}\" não está ativo.",
+            ]);
+        }
+        $canSeeAll = (bool) (auth()->user()?->can('whatsapp.view-all-phones') ?? false);
+        if (! $canSeeAll) {
+            $hasAccess = ChannelUserAccess::query()
+                ->where('business_id', $businessId)
+                ->where('user_id', $userId)
+                ->where('channel_id', $channel->id)
+                ->whereNull('revoked_at')
+                ->exists();
+            if (! $hasAccess) {
+                abort(403, 'Sem acesso a este canal.');
+            }
+        }
+
+        return [$businessId, $userId, $channel];
+    }
+}

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Whatsapp\Http\Controllers\InstallController;
+use Modules\Whatsapp\Http\Controllers\Admin\BroadcastController;
 use Modules\Whatsapp\Http\Controllers\Admin\CaixaUnificadaController;
 use Modules\Whatsapp\Http\Controllers\Admin\ChannelsController;
 use Modules\Whatsapp\Http\Controllers\Admin\CsatController;
@@ -193,6 +194,15 @@ Route::group([
     Route::post('/inbox/conversations', [InboxController::class, 'startConversation'])
         ->middleware('can:whatsapp.send')
         ->name('atendimento.inbox.start_conversation');
+
+    // US-WA-306 (ADR 0268) — broadcast FASE 1: pre-flight real (opt-in LGPD +
+    // janela 24h) + draft auditável. Disparo em massa = fase 2 gate [W].
+    Route::post('/broadcast/preflight', [BroadcastController::class, 'preflight'])
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.broadcast.preflight');
+    Route::post('/broadcast', [BroadcastController::class, 'store'])
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.broadcast.store');
 
     // Wagner 2026-05-27 — Voice of Customer in-app capture (ADR UI-0016).
     // Captura feedback diretamente de mensagens do inbox WhatsApp.

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -17,6 +17,7 @@ contains:
   - "Admin/InboxController — UI omnichannel /atendimento/inbox lê schema novo (US-WA-067/069 ADR 0135)"
   - "Admin/CaixaUnificadaController — UI omnichannel V4 /atendimento/caixa-unificada redesign Cowork F3 MWART (PR-D 2026-05-15, coexiste Inbox legacy canary 7d)"
   - "Admin/QueuesController — CRUD filas de atendimento whatsapp_queues (US-WA-301 ADR 0267, painel QueuesSheet da Caixa Unificada V4)"
+  - "Admin/BroadcastController — broadcast fase 1: pre-flight audiencia (opt-in LGPD + janela 24h) + draft auditavel whatsapp_broadcasts (US-WA-306 ADR 0268; disparo = fase 2 gate W)"
   - "Admin/ClientFeedbackController — captura Voice of Customer canon a partir de bubble inbox (PR #1711 2026-05-27); ADR UI-0016 + ADR 0105 cliente-como-sinal"
   # API webhooks (US-WA-010/010b/002d)
   - "Api/MetaWebhookController — recebe events Meta Cloud (HMAC SHA-256 verify)"

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -32,9 +32,34 @@ uses(Tests\TestCase::class);
  * NUNCA usar biz=4 (ROTA LIVRE cliente real) em tests — ADR 0101.
  */
 beforeEach(function () {
-    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates', 'whatsapp_queues'] as $t) {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates', 'whatsapp_queues', 'whatsapp_broadcasts', 'contacts'] as $t) {
         Schema::dropIfExists($t);
     }
+
+    // US-WA-306 (ADR 0268) — broadcast fase 1 + contacts mínima (opt-in LGPD)
+    Schema::create('whatsapp_broadcasts', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('created_by_user_id');
+        $table->string('kind', 10)->default('freeform');
+        $table->string('template_name', 64)->nullable();
+        $table->text('body')->nullable();
+        $table->string('status', 20)->default('draft');
+        $table->json('audience_snapshot');
+        $table->json('recipient_conversation_ids');
+        $table->timestamp('dispatched_at')->nullable();
+        $table->timestamps();
+    });
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 120)->nullable();
+        $table->string('mobile', 30)->nullable();
+        $table->timestamp('whatsapp_opt_in_at')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
 
     // US-WA-301 (ADR 0267) — filas persistidas (espelho da migration 2026_06_10_000001)
     Schema::create('whatsapp_queues', function ($table) {
@@ -716,4 +741,61 @@ it('R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + gua
     expect(fn () => $inbox->startConversation(cuctPostRequest('/atendimento/inbox/conversations', [
         'channel_id' => $chActive->id, 'phone' => '123',
     ])))->toThrow(\Illuminate\Validation\ValidationException::class);
+});
+
+// ============================================================================
+// 9. US-WA-306 (ADR 0268) — broadcast fase 1: pre-flight LGPD/janela + draft
+// ============================================================================
+
+it('R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + draft auditável', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-011-uuid');
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    // 4 conversas: opt-in+janela | opt-in+fora-janela | SEM opt-in | bloqueada
+    $mk = function (int $contactId, ?string $optIn, int $inboundHoursAgo, bool $blocked = false) use ($ch) {
+        \Illuminate\Support\Facades\DB::table('contacts')->insert([
+            'id' => $contactId, 'business_id' => 1, 'name' => "C{$contactId}",
+            'mobile' => "+554899{$contactId}", 'whatsapp_opt_in_at' => $optIn,
+            'created_at' => now(), 'updated_at' => now(),
+        ]);
+        $conv = cuctMakeConv(1, $ch->id);
+        $conv->forceFill([
+            'contact_id' => $contactId,
+            'last_inbound_at' => now()->subHours($inboundHoursAgo),
+            'is_blocked' => $blocked,
+        ])->save();
+        return $conv;
+    };
+    $inWindow = $mk(101, now()->toDateTimeString(), 2);          // opt-in + janela aberta
+    $outWindow = $mk(102, now()->toDateTimeString(), 72);        // opt-in + fora (só HSM)
+    $mk(103, null, 1);                                           // SEM opt-in → fora da lista
+    $mk(104, now()->toDateTimeString(), 1, true);                // bloqueada → fora de tudo
+
+    $bcast = new \Modules\Whatsapp\Http\Controllers\Admin\BroadcastController();
+
+    $resp = $bcast->preflight(cuctPostRequest('/atendimento/broadcast/preflight', ['channel_id' => $ch->id]));
+    $pf = $resp->getData(true);
+    expect($pf['total'])->toBe(3)            // bloqueada fora
+        ->and($pf['with_opt_in'])->toBe(2)   // 101 + 102 (LGPD)
+        ->and($pf['without_opt_in'])->toBe(1)
+        ->and($pf['in_window'])->toBe(1)     // só 101
+        ->and($pf['hsm_only'])->toBe(1)      // 102
+        ->and($pf['recipient_conversation_ids'])->toContain($inWindow->id, $outWindow->id);
+
+    // Draft: snapshot recalculado server-side + status draft (fase 1 — sem disparo)
+    $bcast->store(cuctPostRequest('/atendimento/broadcast', [
+        'channel_id' => $ch->id, 'kind' => 'freeform', 'body' => 'Promoção da semana!',
+    ]));
+    $draft = \Modules\Whatsapp\Entities\WhatsappBroadcast::withoutGlobalScopes()
+        ->where('business_id', 1)->first();
+    expect($draft)->not->toBeNull()
+        ->and($draft->status)->toBe('draft')
+        ->and($draft->audience_snapshot['with_opt_in'])->toBe(2)
+        ->and($draft->recipient_conversation_ids)->toHaveCount(2)
+        ->and($draft->dispatched_at)->toBeNull(); // fase 1 NUNCA dispara
+
+    // Canal de outro tenant → 403 fail-loud (Tier 0)
+    $chAlien = cuctMakeChannel(99, 'caixa-unif-011-alien-uuid');
+    expect(fn () => $bcast->preflight(cuctPostRequest('/atendimento/broadcast/preflight', ['channel_id' => $chAlien->id])))
+        ->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
 });

--- a/memory/decisions/0268-whatsapp-broadcasts-campanha-scaffold.md
+++ b/memory/decisions/0268-whatsapp-broadcasts-campanha-scaffold.md
@@ -1,0 +1,101 @@
+---
+slug: 0268-whatsapp-broadcasts-campanha-scaffold
+number: 268
+title: "whatsapp_broadcasts — campanha broadcast cross-canal (modelo + pre-flight; disparo é fase 2) (US-WA-306)"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-10"
+module: whatsapp
+quarter: 2026-Q2
+tags: [whatsapp, atendimento, caixa-unificada, broadcast, lgpd, per-schema, multi-tenant, scaffold]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: ["0093-multi-tenant-isolation-tier-0", "0135-omnichannel-inbox-arquitetura", "0267-whatsapp-queues-tabela-filas-atendimento"]
+pii: false
+---
+
+# ADR 0268 — `whatsapp_broadcasts`: campanha broadcast (modelo + pre-flight; disparo fase 2)
+
+> ADR per-schema (padrão charter Caixa Unificada §1). Origem: brief [CC]
+> 2026-06-10, mandato [W] "aplicar todas" — US-WA-306 (charter §2). O próprio
+> brief prevê: "Se o escopo estourar, entregar scaffold honesto (modelo +
+> pre-flight sem disparo) e marcar WIP" — este ADR formaliza esse corte.
+
+## Status
+
+Proposto — 2026-06-10 · [CL] sob mandato [W] (brief PR-7/10).
+
+## Contexto
+
+Wagner quer disparar mensagem (HSM Meta ou freeform Baileys) pra N contatos
+com 1 click, respeitando janela 24h Meta + opt-in LGPD. Hoje não existe:
+1. Modelo de campanha (quem recebeu, quando, com qual template).
+2. Campo de opt-in marketing no Contact (LGPD Art. 7º — consentimento).
+3. Pipeline de disparo em massa com rate-limit (anti-ban Baileys/Meta).
+
+O pipeline de envio atual (`InboxController::send`) é request-scoped (sessão,
+ACL, driver inline) — disparo em massa por Job exige extrair o dispatch pra
+Service reusável. Esse refactor é a parte cara e arriscada (anti-ban, retry,
+idempotência) → **fase 2** com gate [W].
+
+## Decisão
+
+### Fase 1 (este PR — scaffold honesto)
+
+**Tabela `whatsapp_broadcasts`** (campanha):
+
+| Coluna | Tipo | Notas |
+|---|---|---|
+| `id` | bigIncrements | |
+| `business_id` | unsignedInteger | **Tier 0 ADR 0093** |
+| `channel_id` | unsignedBigInteger | conta de envio |
+| `created_by_user_id` | unsignedInteger | autor |
+| `kind` | string(10) | `freeform` \| `template` |
+| `template_name` | string(64) nullable | quando kind=template |
+| `body` | text nullable | quando kind=freeform |
+| `status` | string(20) default 'draft' | `draft` \| `dispatching` \| `done` \| `failed` — **só `draft` é gravado na fase 1** |
+| `audience_snapshot` | json | contagens do pre-flight (total/opt_in/in_window/hsm_only) congeladas no save |
+| `recipient_conversation_ids` | json | ids das conversas elegíveis no momento do pre-flight |
+| `dispatched_at` | timestamp nullable | fase 2 |
+| timestamps | | |
+
+**Coluna `whatsapp_opt_in_at`** (timestamp nullable) em `contacts` —
+consentimento de marketing LGPD. NULL = sem opt-in = **fora de qualquer
+broadcast**. Quem marca: atendente/cliente em fase própria (backfill e UI de
+consentimento = decisão [W]; nesta fase a coluna nasce vazia e o pre-flight
+mostra o tamanho real do problema).
+
+**Pre-flight real** (endpoint): pra conta escolhida, calcula sobre as
+conversas existentes do canal (não-bloqueadas, com Contact CRM vinculado):
+- `total` elegível bruto
+- `with_opt_in` (LGPD — só estes entram em lista de disparo)
+- `in_window` (last_inbound_at ≥ now-24h → freeform permitido)
+- `hsm_only` (fora da janela → só template HSM APPROVED)
+
+**Sem disparo**: botão "Disparar" nasce disabled com aviso explícito de fase 2
+(anti M-AP-2 — nada de fingir envio em massa que não roda).
+
+### Fase 2 (US futura — gate [W])
+
+Extração do dispatch do `InboxController::send` pra Service + Job em fila com
+rate-limit configurável + retry idempotente por destinatário + relatório de
+entrega. Só então `status` transita draft→dispatching→done.
+
+## Consequências
+
+- LGPD primeiro: lista de disparo NUNCA inclui contato sem `whatsapp_opt_in_at`.
+- Audience congelada no draft (auditável — quem estaria na lista naquele momento).
+- Broadcast vira dado, não ação — dá pra revisar com [W] antes de ligar o motor.
+
+## Alternativas consideradas
+
+1. **Disparo síncrono no request** — rejeitado: N envios num request = timeout
+   + ban risk + zero retry.
+2. **Sem opt-in (mandar pra todo mundo)** — rejeitado: LGPD Art. 7º; multa.
+3. **Opt-in em tabela própria** — rejeitado nesta fase: 1 timestamp no Contact
+   resolve e CRM já é a fonte de identidade (ADR 0197).

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **272** arquivos · **257** números únicos · máx **0267**
-- **ADRs ATIVOS (lifecycle ativo): 232** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 211 · proposto 35 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 232 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **273** arquivos · **258** números únicos · máx **0268**
+- **ADRs ATIVOS (lifecycle ativo): 233** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 211 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 233 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (272)
+## Todas as ADRs (273)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -304,3 +304,4 @@ _(íntegra)_
 | 0265 | aceito | ativo | errata | Oficina = reparo é o único domínio; erradicar resíduo de order_type=locacao; 'Ca |
 | 0266 | aceito | ativo | meta | Evals de comportamento dos agentes — golden set + replay cases + escada de auton |
 | 0267 | proposto | ativo | decision | whatsapp_queues — filas de atendimento persistidas em DB (US-WA-301) |
+| 0268 | proposto | ativo | decision | whatsapp_broadcasts — campanha broadcast cross-canal (modelo + pre-flight; dispa |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 7
+charter_version: 8
 permissao: whatsapp.access
 ---
 
@@ -166,8 +166,9 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 - ❌ **Wizard de conexão** — `/atendimento/canais/{id}` show + tabs.
 - ❌ **Roteamento automático de filas** (round-robin/sticky/members) —
   `dist`/`members` são persistidos (ADR 0267) mas o roteamento é US futura.
-- ❌ **Broadcast cross-canal** — placeholder; backlog (alta complexidade
-  janela 24h Meta + opt-in LGPD).
+- ❌ **Disparo em massa do broadcast** — fase 2 (ADR 0268): Job rate-limited
+  anti-ban + retry por destinatário, com gate [W]. A fase 1 (pre-flight LGPD +
+  rascunho auditável) está entregue; o botão "Disparar" fica disabled até lá.
 - ❌ **Mídia outbound/inbound** UI — preserva legacy `MediaPreviewCard`
   durante coexistência. PR seguinte unifica.
 
@@ -241,6 +242,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-008 — CRUD filas: store/update/destroy + default protegida + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-009 — moveQueue: override vence heurística, null volta, slug inválido 422` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + draft auditável` | mesmo arquivo |
 
 ---
 
@@ -250,12 +252,13 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 Tabela `whatsapp_queues` (ADR 0267) + QueuesSheet CRUD + seed lazy do config.
 Roteamento automático (dist/members) fica dormente até US futura.
 
-### §2 Broadcast cross-canal (P2)
-Disparar mensagem template (Meta HSM ou Baileys freeform) pra N contatos
-com 1 click. Respeitar janela 24h + opt-in LGPD. Pre-flight: contagem +
-preview + dry-run.
-
-**US sugerida:** US-WA-XXX Broadcast (~6-8h IA-pair).
+### §2 Broadcast cross-canal (P2) — 🟡 FASE 1 ENTREGUE 2026-06-10 (US-WA-306 · ADR 0268)
+Entregue: modelo `whatsapp_broadcasts` + opt-in LGPD (`contacts.whatsapp_opt_in_at`)
++ pre-flight real (total/opt-in/janela 24h/só-HSM) + rascunho auditável
+(snapshot congelado server-side) + BroadcastSheet.
+**Fase 2 (gate [W])**: extrair dispatch do send() pra Service + Job rate-limited
+anti-ban + retry por destinatário + relatório de entrega. Botão "Disparar"
+permanece disabled até lá (anti M-AP-2).
 
 ### §3 Assignee picker (P1) — ✅ ENTREGUE 2026-06-10 (US-WA-302)
 Dropdown no contexto da sidebar pra atribuir conv a operador específico.
@@ -285,6 +288,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-306 Broadcast FASE 1** (PR-7/10, scaffold honesto previsto no brief): ADR 0268 + `whatsapp_broadcasts` + `contacts.whatsapp_opt_in_at` (LGPD) + `BroadcastController` pre-flight real (opt-in/janela 24h/só-HSM) + draft auditável + `BroadcastSheet`. Disparo em massa = fase 2 com gate [W] (botão disabled, anti M-AP-2). Charter v8. Pest R-WA-CAIXA-UNIF-011. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-307 + Nova conversa** (PR-6/10): dialog conta ativa + telefone/Contact CRM + mensagem inicial opcional; `InboxController::startConversation` find-or-create Tier 0 (canal ativo do business + ACL US-WA-069; cross/inativo = 403/422) reusando pipeline send(). Charter v7. Pest R-WA-CAIXA-UNIF-010. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-304 Drawer Canais e contas** (PR-5/10): topnav "Canais" deixa de navegar pra página e abre `ChannelsDrawer` (Sheet in-place agrupado por type, contas com status ativo/em-breve + health, link Gerenciar pra `/atendimento/canais`). ZERO backend novo — reusa payloads `availableChannels`/`availableAccounts` (cobertos por R-WA-CAIXA-UNIF-001/002). Charter v6. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-305 Mover entre filas** (PR-4/10): coluna `queue_override` (migration idempotente, slug não-FK de propósito — fila deletada não quebra conversa) + `InboxController::moveQueue` (slug validado contra filas do business, 422 fail-loud) + Popover "mover" na section Fila com badge "manual" e volta pra automática. Charter v5. Pest R-WA-CAIXA-UNIF-009. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -41,6 +41,7 @@ import {
   DropdownMenuTrigger,
 } from '@/Components/ui/dropdown-menu';
 
+import BroadcastSheet from './_components/BroadcastSheet';
 import ChannelChipsRow from './_components/ChannelChipsRow';
 import ChannelsDrawer from './_components/ChannelsDrawer';
 import NewConversationDialog from './_components/NewConversationDialog';
@@ -117,6 +118,8 @@ export default function CaixaUnificadaIndex({
   const [canaisOpen, setCanaisOpen] = useState(false);
   // US-WA-307 — dialog + Nova conversa
   const [novaConvOpen, setNovaConvOpen] = useState(false);
+  // US-WA-306 — broadcast fase 1 (pre-flight + draft; disparo é fase 2 ADR 0268)
+  const [broadcastOpen, setBroadcastOpen] = useState(false);
 
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -365,11 +368,12 @@ export default function CaixaUnificadaIndex({
           >
             Canais
           </button>
+          {/* US-WA-306 — fase 1: pre-flight + rascunho (disparo = fase 2 ADR 0268) */}
           <button
             type="button"
-            className="inline-flex items-center px-2.5 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors disabled:opacity-45"
-            disabled
-            title="Broadcast cross-canal (em breve)"
+            onClick={() => setBroadcastOpen(true)}
+            className="inline-flex items-center px-2.5 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+            title="Broadcast cross-canal — audiência + rascunho (disparo na fase 2)"
             data-testid="caixa-unif-topnav-broadcast"
           >
             Broadcast
@@ -503,6 +507,14 @@ export default function CaixaUnificadaIndex({
           open={novaConvOpen}
           onOpenChange={setNovaConvOpen}
           accounts={availableAccounts ?? []}
+        />
+
+        {/* US-WA-306 — broadcast fase 1 (ADR 0268) */}
+        <BroadcastSheet
+          open={broadcastOpen}
+          onOpenChange={setBroadcastOpen}
+          accounts={availableAccounts ?? []}
+          templates={availableTemplates ?? []}
         />
 
         {thread && (

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/BroadcastSheet.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/BroadcastSheet.tsx
@@ -1,0 +1,256 @@
+// BroadcastSheet.tsx — broadcast cross-canal FASE 1 (US-WA-306 · ADR 0268).
+//
+// Pre-flight REAL: conta de envio → "Calcular audiência" chama
+// atendimento.broadcast.preflight e mostra contagens (total / com opt-in LGPD /
+// na janela 24h / só-HSM). "Salvar rascunho" persiste campanha auditável
+// (status=draft, snapshot congelado server-side).
+//
+// DISPARO É FASE 2 (Job rate-limited com gate [W]) — botão nasce disabled com
+// aviso explícito (anti M-AP-2: nada de fingir envio em massa que não roda).
+// Referência visual: om-drawer Broadcast do inbox-page.jsx (que era mock).
+
+import { useMemo, useState } from 'react';
+import { router } from '@inertiajs/react';
+import { AlertTriangle, Calculator, Save } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/Components/ui/sheet';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Inline, Stack } from '@/Components/layout';
+import type { ReadyTemplate } from '@/Pages/Whatsapp/_components/helpers';
+import type { AccountItem } from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  accounts: AccountItem[];
+  templates: ReadyTemplate[];
+}
+
+interface PreflightResult {
+  total: number;
+  with_opt_in: number;
+  without_opt_in: number;
+  in_window: number;
+  hsm_only: number;
+}
+
+const PROVIDER_BY_CHANNEL_TYPE: Record<string, string> = {
+  whatsapp_baileys: 'baileys',
+  whatsapp_meta: 'meta_cloud',
+  meta_cloud: 'meta_cloud',
+  whatsapp_zapi: 'zapi',
+};
+
+export default function BroadcastSheet({ open, onOpenChange, accounts, templates }: Props) {
+  const activeAccounts = useMemo(() => accounts.filter(a => a.status === 'ativo'), [accounts]);
+  const [channelId, setChannelId] = useState('');
+  const [kind, setKind] = useState<'freeform' | 'template'>('freeform');
+  const [templateName, setTemplateName] = useState('');
+  const [body, setBody] = useState('');
+  const [preflight, setPreflight] = useState<PreflightResult | null>(null);
+  const [loadingPreflight, setLoadingPreflight] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const selectedAccount = activeAccounts.find(a => String(a.id) === channelId);
+  const channelProvider = selectedAccount ? PROVIDER_BY_CHANNEL_TYPE[selectedAccount.channel_type] : undefined;
+  const channelTemplates = useMemo(
+    () => (channelProvider ? templates.filter(t => t.provider === channelProvider) : []),
+    [templates, channelProvider],
+  );
+
+  function runPreflight() {
+    if (!channelId || loadingPreflight) return;
+    setLoadingPreflight(true);
+    fetch(route('atendimento.broadcast.preflight'), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-CSRF-TOKEN': document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '',
+      },
+      body: JSON.stringify({ channel_id: Number(channelId) }),
+    })
+      .then(r => r.json())
+      .then((data: PreflightResult) => setPreflight(data))
+      .catch(() => setPreflight(null))
+      .finally(() => setLoadingPreflight(false));
+  }
+
+  function saveDraft() {
+    if (saving || !channelId) return;
+    setSaving(true);
+    router.post(
+      route('atendimento.broadcast.store'),
+      {
+        channel_id: Number(channelId),
+        kind,
+        template_name: kind === 'template' ? templateName : null,
+        body: kind === 'freeform' ? body : null,
+      },
+      {
+        preserveScroll: true,
+        preserveState: true,
+        onSuccess: () => onOpenChange(false),
+        onFinish: () => setSaving(false),
+      },
+    );
+  }
+
+  const canSave = channelId !== ''
+    && (kind === 'freeform' ? body.trim() !== '' : templateName !== '')
+    && preflight !== null
+    && preflight.with_opt_in > 0
+    && !saving;
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-full sm:max-w-md overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle>Broadcast cross-canal</SheetTitle>
+          <SheetDescription>
+            Fase 1: audiência (opt-in LGPD + janela 24h Meta) + rascunho auditável.
+            O disparo em massa rate-limited é a fase 2 (ADR 0268).
+          </SheetDescription>
+        </SheetHeader>
+
+        <Stack gap={3} className="mt-4">
+          <Stack gap={1}>
+            <Label className="text-[11px]">Conta de envio</Label>
+            <Select value={channelId} onValueChange={v => { setChannelId(v); setPreflight(null); setTemplateName(''); }}>
+              <SelectTrigger data-testid="caixa-unif-bcast-conta">
+                <SelectValue placeholder={activeAccounts.length === 0 ? 'Nenhuma conta ativa' : 'Selecione a conta'} />
+              </SelectTrigger>
+              <SelectContent>
+                {activeAccounts.map(a => (
+                  <SelectItem key={a.id} value={String(a.id)}>
+                    {a.label} · {a.handle}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </Stack>
+
+          <Stack gap={1}>
+            <Label className="text-[11px]">Tipo de mensagem</Label>
+            <Select value={kind} onValueChange={v => setKind(v as 'freeform' | 'template')}>
+              <SelectTrigger data-testid="caixa-unif-bcast-kind">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="freeform">Texto livre (só janela 24h aberta)</SelectItem>
+                <SelectItem value="template">Template HSM (fora da janela)</SelectItem>
+              </SelectContent>
+            </Select>
+          </Stack>
+
+          {kind === 'template' ? (
+            <Stack gap={1}>
+              <Label className="text-[11px]">Template do canal</Label>
+              <Select value={templateName} onValueChange={setTemplateName}>
+                <SelectTrigger data-testid="caixa-unif-bcast-template">
+                  <SelectValue placeholder={channelTemplates.length === 0 ? 'Nenhum template ready' : 'Selecione'} />
+                </SelectTrigger>
+                <SelectContent>
+                  {channelTemplates.map(t => (
+                    <SelectItem key={t.id} value={t.name}>{t.name} · {t.language}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Stack>
+          ) : (
+            <Stack gap={1}>
+              <Label htmlFor="bcast-body" className="text-[11px]">Mensagem</Label>
+              <Input
+                id="bcast-body"
+                value={body}
+                onChange={e => setBody(e.target.value)}
+                placeholder="Texto do broadcast…"
+                data-testid="caixa-unif-bcast-body"
+              />
+            </Stack>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={runPreflight}
+            disabled={!channelId || loadingPreflight}
+            className="gap-1.5"
+            data-testid="caixa-unif-bcast-preflight"
+          >
+            <Calculator size={14} aria-hidden />
+            {loadingPreflight ? 'Calculando…' : 'Calcular audiência (pre-flight)'}
+          </Button>
+
+          {preflight && (
+            <Stack gap={1} className="border rounded-md p-3 bg-muted/20" data-testid="caixa-unif-bcast-result">
+              <Inline gap={2} align="baseline" justify="between">
+                <small className="text-[11px] text-muted-foreground">Conversas no canal</small>
+                <b className="font-mono text-[12.5px]">{preflight.total}</b>
+              </Inline>
+              <Inline gap={2} align="baseline" justify="between">
+                <small className="text-[11px] text-muted-foreground">Com opt-in LGPD (entram na lista)</small>
+                <b className="font-mono text-[12.5px]">{preflight.with_opt_in}</b>
+              </Inline>
+              <Inline gap={2} align="baseline" justify="between">
+                <small className="text-[11px] text-muted-foreground">Sem opt-in (FORA — LGPD)</small>
+                <b className="font-mono text-[12.5px]">{preflight.without_opt_in}</b>
+              </Inline>
+              <Inline gap={2} align="baseline" justify="between">
+                <small className="text-[11px] text-muted-foreground">Janela 24h aberta (freeform ok)</small>
+                <b className="font-mono text-[12.5px]">{preflight.in_window}</b>
+              </Inline>
+              <Inline gap={2} align="baseline" justify="between">
+                <small className="text-[11px] text-muted-foreground">Fora da janela (só template HSM)</small>
+                <b className="font-mono text-[12.5px]">{preflight.hsm_only}</b>
+              </Inline>
+              {preflight.with_opt_in === 0 && (
+                <Inline gap={1} align="center" className="text-destructive mt-1">
+                  <AlertTriangle size={13} aria-hidden />
+                  <small className="text-[11px]">
+                    Nenhum contato com opt-in — broadcast sem consentimento é proibido.
+                  </small>
+                </Inline>
+              )}
+            </Stack>
+          )}
+
+          <Button
+            type="button"
+            onClick={saveDraft}
+            disabled={!canSave}
+            className="gap-1.5"
+            data-testid="caixa-unif-bcast-save"
+          >
+            <Save size={14} aria-hidden />
+            {saving ? 'Salvando…' : 'Salvar rascunho (auditável)'}
+          </Button>
+
+          <Button type="button" disabled variant="outline" title="Fase 2 — Job rate-limited com gate Wagner (ADR 0268)">
+            Disparar broadcast — fase 2 (em construção)
+          </Button>
+          <small className="text-[10.5px] text-muted-foreground">
+            O motor de disparo em massa (fila + rate-limit anti-ban + retry por
+            destinatário) entra na fase 2 com aprovação explícita — este painel já
+            deixa a campanha pronta e auditável.
+          </small>
+        </Stack>
+      </SheetContent>
+    </Sheet>
+  );
+}


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-7 de 10

**US-WA-306 — Broadcast cross-canal, FASE 1 (scaffold honesto previsto no brief)**

> Brief: "Se o escopo estourar, entregar scaffold honesto (modelo + pre-flight sem disparo) e marcar WIP". O disparo em massa exige extrair o dispatch do `send()` pra Service + Job rate-limited anti-ban — fase 2 com gate [W] ([ADR 0268](memory/decisions/0268-whatsapp-broadcasts-campanha-scaffold.md)).

### Entregue REAL nesta fase
- **ADR 0268** per-schema + migration `whatsapp_broadcasts` + `contacts.whatsapp_opt_in_at` (**LGPD: NULL = fora de qualquer broadcast**)
- **Pre-flight verdadeiro** (`BroadcastController::preflight`): total / com opt-in (só estes na lista) / janela 24h aberta (freeform ok) / fora (só HSM)
- **Draft auditável** (`store`): snapshot **recalculado server-side** + `recipient_conversation_ids` congelados; recusa salvar com 0 opt-in
- **BroadcastSheet**: conta + tipo (freeform/template do canal) + Calcular audiência + Salvar rascunho; **"Disparar" nasce DISABLED** com aviso de fase 2 (anti M-AP-2)

### Tier 0
- Canal do business + ativo + ACL (403/422 fail-loud)
- Pest `R-WA-CAIXA-UNIF-011` (contagens opt-in/janela/bloqueada + draft + canal alien 403)

Charter → v8 (§2 = 🟡 fase 1). SCOPE.md + índice ADR atualizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)