### PR TITLE
hotfix(whatsapp): caixa unificada — queuesAdmin degrade gracioso (incidente 'carregando canais 500')

### DIFF
--- a/.github/workflows/debug-caixa-logs.yml
+++ b/.github/workflows/debug-caixa-logs.yml
@@ -1,0 +1,42 @@
+name: Debug Caixa Unificada (one-shot logs)
+
+# Incidente 2026-06-10 "carregando canais erro 500" — lê estado real da prod:
+# commit deployado, existência das tabelas novas (whatsapp_queues/broadcasts,
+# colunas queue_override/whatsapp_opt_in_at) e últimas linhas de erro do
+# laravel.log. Pattern copiado de debug-fin-counts.yml (one-shot read-only).
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  debug:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Estado da prod (commit + tabelas + log)
+        run: |
+          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=20 \
+              ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} bash -s <<'REMOTE'
+          cd ${{ secrets.DEPLOY_PATH }} 2>/dev/null || cd ~/domains/oimpresso.com/public_html 2>/dev/null || cd ~/oimpresso.com
+          echo "== git deployado =="
+          git log -1 --oneline 2>/dev/null || echo "(sem git)"
+          echo "== migrations pendentes (top 15) =="
+          php artisan migrate:status 2>/dev/null | grep -i "pending\|whatsapp_queues\|broadcasts\|queue_override\|opt_in" | head -15 || true
+          echo "== tabelas novas =="
+          php artisan tinker --execute="echo (int) \Illuminate\Support\Facades\Schema::hasTable('whatsapp_queues'); echo '/'; echo (int) \Illuminate\Support\Facades\Schema::hasColumn('conversations','queue_override'); echo '/'; echo (int) \Illuminate\Support\Facades\Schema::hasTable('whatsapp_broadcasts');" 2>/dev/null || true
+          echo "== laravel.log: últimos ERROs =="
+          grep -E "production\.ERROR" storage/logs/laravel.log 2>/dev/null | tail -8 | cut -c1-400 || echo "(sem ERROR no log)"
+          REMOTE

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -265,27 +265,41 @@ class CaixaUnificadaController extends Controller
      */
     protected function buildQueuesAdminPayload(int $businessId): array
     {
-        $this->ensureDefaultQueues($businessId);
-        $defaultSlug = (string) config('whatsapp.default_queue', 'comercial');
+        // INCIDENTE 2026-06-10 ("carregando canais erro 500"): payload deferred
+        // SEM guard derruba o GRUPO Inertia::defer inteiro quando a tabela
+        // whatsapp_queues ainda não existe (deploy com rsync feito e migrate
+        // cancelado/pendente). Princípio duro 8 (ADR 0094): degrade gracioso —
+        // painel Filas mostra vazio, resto da tela vive.
+        try {
+            $this->ensureDefaultQueues($businessId);
+            $defaultSlug = (string) config('whatsapp.default_queue', 'comercial');
 
-        return WhatsappQueue::query()
-            ->where('business_id', $businessId)
-            ->orderBy('sort_order')
-            ->orderBy('label')
-            ->get()
-            ->map(fn (WhatsappQueue $q) => [
-                'id' => $q->id,
-                'slug' => $q->slug,
-                'label' => $q->label,
-                'hue' => $q->hue,
-                'sla_minutes' => $q->sla_minutes,
-                'sla' => $q->slaHuman(),
-                'dist' => $q->dist,
-                'trigger_tags' => (array) $q->trigger_tags,
-                'sort_order' => $q->sort_order,
-                'is_default' => $q->slug === $defaultSlug,
-            ])
-            ->all();
+            return WhatsappQueue::query()
+                ->where('business_id', $businessId)
+                ->orderBy('sort_order')
+                ->orderBy('label')
+                ->get()
+                ->map(fn (WhatsappQueue $q) => [
+                    'id' => $q->id,
+                    'slug' => $q->slug,
+                    'label' => $q->label,
+                    'hue' => $q->hue,
+                    'sla_minutes' => $q->sla_minutes,
+                    'sla' => $q->slaHuman(),
+                    'dist' => $q->dist,
+                    'trigger_tags' => (array) $q->trigger_tags,
+                    'sort_order' => $q->sort_order,
+                    'is_default' => $q->slug === $defaultSlug,
+                ])
+                ->all();
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\Log::warning('[caixa-unificada] queuesAdmin degrade gracioso', [
+                'business_id' => $businessId,
+                'error_class' => get_class($e),
+            ]);
+
+            return [];
+        }
     }
 
     /**


### PR DESCRIPTION
## 🚨 Incidente prod 2026-06-10 — "carregando canais erro 500" (Wagner)

**Hipótese raiz:** deploy parcial — rsync do código pós-PR-3 SEM `artisan migrate` (run de deploy 17:35Z **cancelled**). `buildQueuesAdminPayload` consulta `whatsapp_queues` sem guard → exceção derruba o **grupo `Inertia::defer` inteiro** (availableChannels junto) → spinner "Carregando canais…" + 500 no partial reload.

### Fix
- `buildQueuesAdminPayload`: try/catch → `[]` + warning log (princípio duro 8 ADR 0094 — painel Filas mostra vazio, resto da tela vive; `getQueuesConfig` já era guarded)
- `debug-caixa-logs.yml`: workflow one-shot read-only (commit deployado + migrate:status + hasTable + últimos ERRORs) pra diagnosticar prod sem SSH interativo

### Pós-merge
1. Disparar `deploy.yml` (com migrate) → alinha código+schema
2. Se persistir: `debug-caixa-logs.yml` pega o erro real

🤖 Generated with [Claude Code](https://claude.com/claude-code)