### PR TITLE
feat(whatsapp): pacote polish V2 — SLA pill, cheat-sheet, lightbox, mobile tabs, favoritos, transcript, apresentação (PR-8/10)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 8
+charter_version: 9
 permissao: whatsapp.access
 ---
 
@@ -150,6 +150,24 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 7. **Histórico** — placeholder (TODO US-WA-XXX: agregar Transactions).
 8. **Último contato** — relativeTimeBR do `last_message_at`.
 9. **Ações** — 3 botões (Emitir cobrança · Enviar arte · Ligar) — placeholders.
+
+### Polish V2 (PR-8, 2026-06-10 — do protótipo inbox-extras/out/cur)
+1. **SLA pill** — `slaState()` client-side (75% = âmbar, estourado = vermelho)
+   na lista e no header da thread; só conta quando o cliente falou por último.
+2. **⌘K palette** — TODO honesto: palette GLOBAL já existe (PMG-002 no
+   AppShellV2); estender com convs/contatos = US própria cross-módulo
+   (não duplicar palette — MANUAL #5 anti-duplicação).
+3. **Cheat-sheet `?`** — `InboxCheatSheet` com os atalhos REAIS (J/K///E/A/⌘⇧N/⌘K/?).
+4. **Lightbox in-app** — imagem da bubble abre `MediaFullscreenModal` reusado
+   (navegação entre todas as imagens da thread) em vez de `window.open`.
+5. **Mobile tabs <lg** — `InboxMobileTabs` Conversas/Thread/Contexto; abrir
+   conversa salta pra Thread; desktop 3-col intacto.
+6. **Favoritos** — estrela na conversa (`useInboxFavs`, localStorage per-user,
+   SEM DB — anti-hook preservado); favoritas ordenam no topo.
+7. **Transcript imprimível** — `InboxTranscriptDialog` print-friendly com
+   header Oimpresso; notas internas FORA por default (toggle consciente).
+8. **Modo apresentação** — `InboxPresenterMode` overlay limpo (sem IDs
+   internos nem notas), Esc fecha.
 
 ### Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL)
 - Todas queries via global scope `business_id` (Eloquent).
@@ -288,6 +306,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **Polish V2** (PR-8/10): SLA pill lista+thread (slaState 75%/estourado) · cheat-sheet `?` · lightbox MediaFullscreenModal reusado · mobile tabs <lg (InboxMobileTabs) · favoritos localStorage (useInboxFavs, sem DB) · transcript imprimível (notas fora por default) · modo apresentação (Esc). ⌘K = TODO honesto (palette global PMG-002 já existe; estender = US cross-módulo). 100% frontend — payloads cobertos por R-WA-CAIXA-UNIF-001/002. Charter v9. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-306 Broadcast FASE 1** (PR-7/10, scaffold honesto previsto no brief): ADR 0268 + `whatsapp_broadcasts` + `contacts.whatsapp_opt_in_at` (LGPD) + `BroadcastController` pre-flight real (opt-in/janela 24h/só-HSM) + draft auditável + `BroadcastSheet`. Disparo em massa = fase 2 com gate [W] (botão disabled, anti M-AP-2). Charter v8. Pest R-WA-CAIXA-UNIF-011. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-307 + Nova conversa** (PR-6/10): dialog conta ativa + telefone/Contact CRM + mensagem inicial opcional; `InboxController::startConversation` find-or-create Tier 0 (canal ativo do business + ACL US-WA-069; cross/inativo = 403/422) reusando pipeline send(). Charter v7. Pest R-WA-CAIXA-UNIF-010. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-304 Drawer Canais e contas** (PR-5/10): topnav "Canais" deixa de navegar pra página e abre `ChannelsDrawer` (Sheet in-place agrupado por type, contas com status ativo/em-breve + health, link Gerenciar pra `/atendimento/canais`). ZERO backend novo — reusa payloads `availableChannels`/`availableAccounts` (cobertos por R-WA-CAIXA-UNIF-001/002). Charter v6. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -43,6 +43,8 @@ import {
 
 import BroadcastSheet from './_components/BroadcastSheet';
 import ChannelChipsRow from './_components/ChannelChipsRow';
+import InboxCheatSheet from './_components/InboxCheatSheet';
+import InboxMobileTabs, { type MobileView } from './_components/InboxMobileTabs';
 import ChannelsDrawer from './_components/ChannelsDrawer';
 import NewConversationDialog from './_components/NewConversationDialog';
 import QueuesSheet from './_components/QueuesSheet';
@@ -120,6 +122,10 @@ export default function CaixaUnificadaIndex({
   const [novaConvOpen, setNovaConvOpen] = useState(false);
   // US-WA-306 — broadcast fase 1 (pre-flight + draft; disparo é fase 2 ADR 0268)
   const [broadcastOpen, setBroadcastOpen] = useState(false);
+  // Polish V2 §3 — cheat-sheet "?" de atalhos
+  const [cheatOpen, setCheatOpen] = useState(false);
+  // Polish V2 §5 — mobile tabs (<lg mostra 1 coluna por vez; desktop intacto)
+  const [mobileView, setMobileView] = useState<MobileView>('list');
 
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -171,6 +177,8 @@ export default function CaixaUnificadaIndex({
   }, [thread?.id]);
 
   function selectThread(id: number) {
+    // Polish V2 §5 — no mobile, abrir conversa salta pra tab Thread
+    setMobileView('thread');
     // Mesma estratégia perf do Inbox legacy: `conversations` NÃO precisa rebuscar
     // ao trocar thread — só thread+messages no `only:[]`.
     router.get(
@@ -264,6 +272,12 @@ export default function CaixaUnificadaIndex({
       if (e.key === 'a' || e.key === 'A') {
         e.preventDefault();
         setAwaitingHuman();
+        return;
+      }
+      // Polish V2 §3 — "?" abre/fecha o guia de atalhos
+      if (e.key === '?') {
+        e.preventDefault();
+        setCheatOpen(v => !v);
         return;
       }
     }
@@ -411,9 +425,18 @@ export default function CaixaUnificadaIndex({
         />
       </Deferred>
 
+      {/* Polish V2 §5 — tabs mobile (abaixo de lg; desktop 3-col intacto) */}
+      <InboxMobileTabs
+        view={mobileView}
+        onChange={setMobileView}
+        hasThread={thread !== null}
+        unread={stats?.unread ?? 0}
+      />
+
       {/* Shell 3-col */}
       <div className="flex-1 grid grid-cols-1 lg:grid-cols-[320px_1fr_300px] gap-0 min-h-0 overflow-hidden border rounded-md">
-        {/* Lista esquerda */}
+        {/* Lista esquerda — no mobile só aparece na tab Conversas */}
+        <div className={mobileView === 'list' ? 'min-h-0 h-full' : 'min-h-0 h-full hidden lg:block'}>
         <Deferred
           data={['conversations', 'stats']}
           fallback={(
@@ -456,9 +479,10 @@ export default function CaixaUnificadaIndex({
             activeTagIds={activeTagIds ?? []}
           />
         </Deferred>
+        </div>
 
-        {/* Thread central */}
-        <div className="min-w-0 min-h-0">
+        {/* Thread central — no mobile só aparece na tab Thread */}
+        <div className={mobileView === 'thread' ? 'min-w-0 min-h-0' : 'min-w-0 min-h-0 hidden lg:block'}>
           {thread && messages !== null ? (
             <ConversationThreadV4
               thread={thread}
@@ -518,6 +542,7 @@ export default function CaixaUnificadaIndex({
         />
 
         {thread && (
+          <div className={mobileView === 'context' ? 'min-h-0 h-full' : 'min-h-0 h-full hidden lg:block'}>
           <Deferred data="availableChannels" fallback={null}>
             <ContextSidebarV4
               thread={thread}
@@ -527,8 +552,12 @@ export default function CaixaUnificadaIndex({
               availableAssignees={availableAssignees ?? []}
             />
           </Deferred>
+          </div>
         )}
       </div>
+
+      {/* Polish V2 §3 — cheat-sheet de atalhos ("?") */}
+      <InboxCheatSheet open={cheatOpen} onOpenChange={setCheatOpen} />
     </div>
   );
 }

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -14,7 +14,7 @@
 
 import { useMemo, useState } from 'react';
 import { router } from '@inertiajs/react';
-import { Clock, Paperclip, Search, Tag, UserPlus, X } from 'lucide-react';
+import { Clock, Paperclip, Search, Star, Tag, UserPlus, X } from 'lucide-react';
 import {
   Popover,
   PopoverContent,
@@ -32,7 +32,9 @@ import {
   initials,
   avatarHue,
   relativeTimeBR,
+  slaState,
 } from './helpers';
+import { useInboxFavs } from './useInboxFavs';
 
 type InboundAging = '6h' | '12h' | '24h' | '48h' | '7d' | null;
 type OrderBy = 'last_message' | 'inbound';
@@ -76,6 +78,13 @@ export default function ConversationListV4({
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
   const tab = status as CaixaUnifTab;
+
+  // Polish V2 §6 — favoritos localStorage ordenam no topo (ordem original preservada dentro dos grupos)
+  const { isFav, toggleFav } = useInboxFavs();
+  const orderedConvs = useMemo(() => {
+    const data = conversations?.data ?? [];
+    return [...data.filter(c => isFav(c.id)), ...data.filter(c => !isFav(c.id))];
+  }, [conversations?.data, isFav]);
 
   const channelsById = useMemo(() => {
     const map = new Map<string, ChannelCatalogItem>();
@@ -390,10 +399,12 @@ export default function ConversationListV4({
           role="listbox"
           aria-label="Conversas"
         >
-          {conversations.data.map(conv => {
+          {orderedConvs.map(conv => {
             const ch = conv.channel_type ? channelsById.get(conv.channel_type) : undefined;
             const isSel = selectedId === conv.id;
             const isGhost = conv.preview_only;
+            const sla = slaState(conv);
+            const fav = isFav(conv.id);
             return (
               <li
                 key={conv.id}
@@ -461,11 +472,48 @@ export default function ConversationListV4({
                   </small>
                 </div>
 
-                {/* Lado direito — tempo + unread */}
+                {/* Lado direito — fav + tempo + SLA + unread */}
                 <div className="flex flex-col items-end gap-0.5 flex-shrink-0">
-                  <span className="text-[10px] text-muted-foreground font-mono">
-                    {relativeTimeBR(conv.last_message_at)}
+                  <span className="inline-flex items-center gap-1">
+                    {/* Polish V2 §6 — favorito (localStorage, ordena no topo) */}
+                    <button
+                      type="button"
+                      onClick={(e) => { e.stopPropagation(); toggleFav(conv.id); }}
+                      className={cn(
+                        'p-0.5 rounded transition-colors',
+                        !fav && 'text-muted-foreground/40 hover:text-muted-foreground',
+                      )}
+                      style={fav ? { color: 'oklch(0.75 0.15 80)' } : undefined}
+                      title={fav ? 'Remover dos favoritos' : 'Favoritar (fica no topo da lista)'}
+                      aria-pressed={fav}
+                      data-testid={`caixa-unif-fav-${conv.id}`}
+                    >
+                      <Star size={11} fill={fav ? 'currentColor' : 'none'} aria-hidden />
+                    </button>
+                    <span className="text-[10px] text-muted-foreground font-mono">
+                      {relativeTimeBR(conv.last_message_at)}
+                    </span>
                   </span>
+                  {/* Polish V2 §1 — pill SLA (âmbar ≥75%, vermelho estourado) */}
+                  {sla === 'breached' && (
+                    <span
+                      className="font-mono text-[9px] font-bold px-1.5 py-px rounded-full bg-destructive/10 text-destructive border border-destructive/30"
+                      title={`SLA ${conv.queue.sla} estourado — cliente aguardando resposta`}
+                      data-testid={`caixa-unif-sla-${conv.id}`}
+                    >
+                      SLA
+                    </span>
+                  )}
+                  {sla === 'warning' && (
+                    <span
+                      className="font-mono text-[9px] font-bold px-1.5 py-px rounded-full"
+                      style={{ background: 'oklch(0.95 0.06 80)', color: 'oklch(0.40 0.12 80)', border: '1px solid oklch(0.82 0.10 80)' }}
+                      title={`SLA ${conv.queue.sla} perto de estourar`}
+                      data-testid={`caixa-unif-sla-${conv.id}`}
+                    >
+                      SLA
+                    </span>
+                  )}
                   {conv.unread_count > 0 && (
                     <span
                       className="bg-primary text-primary-foreground font-mono text-[10px] font-bold px-1.5 py-px rounded-full"

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -11,7 +11,7 @@
 // Empty state quando thread=null (mantém UX Cockpit V2 do legacy Inbox).
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, CheckCheck, ClipboardCheck } from 'lucide-react';
+import { Check, CheckCheck, ClipboardCheck, FileDown, Presentation } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 import {
   type CaixaUnifMessage,
@@ -20,9 +20,13 @@ import {
   initials,
   avatarHue,
   dayGroupLabel,
+  slaState,
 } from './helpers';
 import ComposerV4 from './ComposerV4';
+import InboxPresenterMode from './InboxPresenterMode';
+import InboxTranscriptDialog from './InboxTranscriptDialog';
 import CaptureFeedbackSheet, { type CaptureFeedbackInput } from '@/Pages/Whatsapp/_components/CaptureFeedbackSheet';
+import MediaFullscreenModal from '@/Pages/Whatsapp/_components/MediaFullscreenModal';
 import type { ReadyTemplate } from '@/Pages/Whatsapp/_components/helpers';
 
 interface Props {
@@ -62,6 +66,28 @@ export default function ConversationThreadV4({
     () => channels.find(c => c.id === thread.channel_type),
     [channels, thread.channel_type],
   );
+
+  // Polish V2 §4 — lightbox in-app (MediaFullscreenModal reusado) em vez de window.open
+  const imageMessages = useMemo(
+    () => messages.filter(m => m.type === 'image' && m.media_url),
+    [messages],
+  );
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  // Polish V2 §7/§8 — transcript print-friendly + modo apresentação
+  const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [presenterOpen, setPresenterOpen] = useState(false);
+
+  // Polish V2 §1 — SLA no header (direção da última msg não-nota vem das messages)
+  const lastRealMsg = useMemo(
+    () => [...messages].reverse().find(m => !m.is_internal_note),
+    [messages],
+  );
+  const headerSla = slaState({
+    last_message_direction: lastRealMsg?.direction ?? null,
+    last_inbound_at: thread.last_inbound_at,
+    queue: thread.queue,
+  });
 
   // Auto-scroll para baixo no mount + nova msg
   useEffect(() => {
@@ -133,11 +159,53 @@ export default function ConversationThreadV4({
             )}
           </div>
         </div>
+        {/* Polish V2 §1 — pill SLA no header (cliente esperando além do alvo da fila) */}
+        {headerSla === 'breached' && (
+          <span
+            className="ml-auto font-mono text-[9.5px] font-bold px-2 py-px rounded-full bg-destructive/10 text-destructive border border-destructive/30 flex-shrink-0"
+            title={`SLA ${thread.queue.sla} da fila ${thread.queue.label} estourado`}
+            data-testid="caixa-unif-thread-sla"
+          >
+            SLA estourado
+          </span>
+        )}
+        {headerSla === 'warning' && (
+          <span
+            className="ml-auto font-mono text-[9.5px] font-bold px-2 py-px rounded-full flex-shrink-0"
+            style={{ background: 'oklch(0.95 0.06 80)', color: 'oklch(0.40 0.12 80)', border: '1px solid oklch(0.82 0.10 80)' }}
+            title={`SLA ${thread.queue.sla} da fila ${thread.queue.label} perto de estourar`}
+            data-testid="caixa-unif-thread-sla"
+          >
+            SLA
+          </span>
+        )}
+        {/* Polish V2 §7/§8 — transcript print + modo apresentação */}
+        <button
+          type="button"
+          onClick={() => setTranscriptOpen(true)}
+          className={cn(
+            'inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0',
+            headerSla === null && 'ml-auto',
+          )}
+          title="Transcript imprimível / PDF"
+          data-testid="caixa-unif-thread-transcript"
+        >
+          <FileDown size={12} aria-hidden />
+        </button>
+        <button
+          type="button"
+          onClick={() => setPresenterOpen(true)}
+          className="inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0"
+          title="Modo apresentação (overlay limpo, Esc sai)"
+          data-testid="caixa-unif-thread-presenter"
+        >
+          <Presentation size={12} aria-hidden />
+        </button>
         {!isPreview && !isBlocked && onResolve && (
           <button
             type="button"
             onClick={onResolve}
-            className="ml-auto inline-flex items-center gap-1 px-2.5 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors"
+            className="inline-flex items-center gap-1 px-2.5 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0"
             data-testid="caixa-unif-resolve-btn"
           >
             <Check size={12} aria-hidden /> Resolver
@@ -302,7 +370,8 @@ export default function ConversationThreadV4({
                       <img
                         src={m.media_thumbnail_url || m.media_url}
                         alt={m.media_filename || 'imagem'}
-                        onClick={() => window.open(m.media_url!, '_blank')}
+                        // Polish V2 §4 — lightbox in-app em vez de aba nova
+                        onClick={() => setLightboxIndex(imageMessages.findIndex(im => im.id === m.id))}
                         className="rounded-md max-w-full max-h-64 cursor-pointer object-cover mb-1"
                         loading="lazy"
                       />
@@ -367,6 +436,32 @@ export default function ConversationThreadV4({
         open={feedbackSheetOpen}
         onOpenChange={setFeedbackSheetOpen}
         input={feedbackInput}
+      />
+
+      {/* Polish V2 §4 — lightbox in-app (MediaFullscreenModal reusado US-WA-072) */}
+      {lightboxIndex !== null && imageMessages.length > 0 && (
+        <MediaFullscreenModal
+          urls={imageMessages.map(m => m.media_url!)}
+          filenames={imageMessages.map(m => m.media_filename ?? null)}
+          currentIndex={Math.max(0, lightboxIndex)}
+          onClose={() => setLightboxIndex(null)}
+        />
+      )}
+
+      {/* Polish V2 §7 — transcript imprimível */}
+      <InboxTranscriptDialog
+        open={transcriptOpen}
+        onOpenChange={setTranscriptOpen}
+        thread={thread}
+        messages={messages}
+      />
+
+      {/* Polish V2 §8 — modo apresentação */}
+      <InboxPresenterMode
+        open={presenterOpen}
+        onClose={() => setPresenterOpen(false)}
+        thread={thread}
+        messages={messages}
       />
 
       {/* Composer */}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxCheatSheet.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxCheatSheet.tsx
@@ -1,0 +1,49 @@
+// InboxCheatSheet — overlay "?" com os atalhos REAIS da tela (Polish V2 §3).
+//
+// Lista só o que existe de verdade (anti M-AP-2): J/K, /, E, A, ⌘⇧N, ⌘K
+// (palette global PMG-002), ? (este overlay). Esc fecha.
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import { Inline, Stack } from '@/Components/layout';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const SHORTCUTS: { keys: string; label: string }[] = [
+  { keys: 'J / K', label: 'Próxima / anterior conversa na lista' },
+  { keys: '/', label: 'Focar a busca de conversas' },
+  { keys: 'E', label: 'Resolver a conversa aberta' },
+  { keys: 'A', label: 'Marcar como aguardando humano' },
+  { keys: '⌘⇧N', label: 'Alternar Resposta / Nota interna no composer' },
+  { keys: '⌘K', label: 'Busca global (tasks/epics — palette do sistema)' },
+  { keys: '?', label: 'Abrir/fechar este guia de atalhos' },
+];
+
+export default function InboxCheatSheet({ open, onOpenChange }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-sm" data-testid="caixa-unif-cheatsheet">
+        <DialogHeader>
+          <DialogTitle>Atalhos de teclado</DialogTitle>
+          <DialogDescription>Funcionam fora de campos de texto.</DialogDescription>
+        </DialogHeader>
+        <Stack gap={1}>
+          {SHORTCUTS.map(s => (
+            <Inline key={s.keys} gap={3} align="baseline" justify="between" className="py-0.5">
+              <kbd className="font-mono text-[11px] bg-muted border rounded px-1.5 py-0.5 flex-shrink-0">{s.keys}</kbd>
+              <span className="text-[12px] text-muted-foreground text-right">{s.label}</span>
+            </Inline>
+          ))}
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxMobileTabs.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxMobileTabs.tsx
@@ -1,0 +1,69 @@
+// InboxMobileTabs — 3 tabs Conversas/Thread/Contexto abaixo de lg (Polish V2
+// §5 · inbox-extras.jsx). No desktop a shell 3-col fica intacta (lg:); no
+// mobile cada tab mostra UMA coluna em largura cheia.
+
+import { MessageSquare, PanelRight, List } from 'lucide-react';
+import { Grid } from '@/Components/layout';
+import { cn } from '@/Lib/utils';
+
+export type MobileView = 'list' | 'thread' | 'context';
+
+interface Props {
+  view: MobileView;
+  onChange: (view: MobileView) => void;
+  hasThread: boolean;
+  unread: number;
+}
+
+const TABS: { id: MobileView; label: string; icon: typeof List }[] = [
+  { id: 'list', label: 'Conversas', icon: List },
+  { id: 'thread', label: 'Thread', icon: MessageSquare },
+  { id: 'context', label: 'Contexto', icon: PanelRight },
+];
+
+export default function InboxMobileTabs({ view, onChange, hasThread, unread }: Props) {
+  return (
+    <Grid
+      cols={3}
+      gap={1}
+      className="lg:hidden border-b bg-card px-1 py-1"
+      role="tablist"
+      aria-label="Painéis da caixa unificada (mobile)"
+      data-testid="caixa-unif-mobile-tabs"
+    >
+      {TABS.map(t => {
+        const Icon = t.icon;
+        const disabled = t.id !== 'list' && !hasThread;
+        const active = view === t.id;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={active}
+            disabled={disabled}
+            onClick={() => onChange(t.id)}
+            data-testid={`caixa-unif-mobile-tab-${t.id}`}
+            className={cn(
+              'inline-flex items-center justify-center gap-1.5 h-8 rounded text-[11.5px] font-medium transition-colors',
+              active ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground hover:bg-muted',
+              disabled && 'opacity-40 cursor-not-allowed',
+            )}
+            title={disabled ? 'Selecione uma conversa primeiro' : undefined}
+          >
+            <Icon size={13} aria-hidden />
+            {t.label}
+            {t.id === 'list' && unread > 0 && (
+              <span className={cn(
+                'inline-flex items-center justify-center min-w-[15px] h-3.5 px-1 text-[9.5px] font-mono rounded-full',
+                active ? 'bg-primary-foreground/25 text-primary-foreground' : 'bg-primary text-primary-foreground',
+              )}>
+                {unread > 99 ? '99+' : unread}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </Grid>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxPresenterMode.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxPresenterMode.tsx
@@ -1,0 +1,77 @@
+// InboxPresenterMode — overlay limpo da conversa pra apresentar em reunião
+// (Polish V2 §8 · inbox-out.jsx). SEM IDs internos, sem notas internas, sem
+// status técnico — só o diálogo. Esc fecha.
+
+import { useEffect } from 'react';
+import { X } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import { Stack } from '@/Components/layout';
+import type { CaixaUnifMessage, CaixaUnifThread } from './helpers';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  thread: CaixaUnifThread;
+  messages: CaixaUnifMessage[];
+}
+
+export default function InboxPresenterMode({ open, onClose, thread, messages }: Props) {
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const visible = messages.filter(m => !m.is_internal_note);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-background overflow-y-auto"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Modo apresentação da conversa"
+      data-testid="caixa-unif-presenter"
+    >
+      <div className="max-w-2xl mx-auto px-6 py-8">
+        <Stack gap={1} className="mb-6">
+          <b className="text-[18px] font-semibold">{thread.contact_name || 'Conversa'}</b>
+          <small className="text-[12px] text-muted-foreground">
+            Modo apresentação — Esc pra sair · sem notas internas nem dados técnicos
+          </small>
+        </Stack>
+        <Stack gap={2}>
+          {visible.map(m => (
+            <div
+              key={m.id}
+              className={cn(
+                'max-w-[80%] px-4 py-2.5 rounded-lg text-[14px] leading-relaxed whitespace-pre-wrap break-words',
+                m.direction === 'inbound'
+                  ? 'self-start mr-auto bg-card border'
+                  : 'self-end ml-auto',
+              )}
+              style={m.direction === 'outbound'
+                ? { background: 'oklch(0.85 0.10 145)', color: 'oklch(0.18 0.10 145)' }
+                : undefined}
+            >
+              {m.body || (m.media_url ? '[mídia]' : '')}
+            </div>
+          ))}
+        </Stack>
+      </div>
+      <button
+        type="button"
+        onClick={onClose}
+        className="fixed top-4 right-4 inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-medium bg-card border rounded-full hover:bg-muted transition-colors"
+        title="Sair do modo apresentação (Esc)"
+        data-testid="caixa-unif-presenter-close"
+      >
+        <X size={13} aria-hidden /> Sair (Esc)
+      </button>
+    </div>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxTranscriptDialog.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxTranscriptDialog.tsx
@@ -1,0 +1,102 @@
+// InboxTranscriptDialog — transcript print-friendly da conversa (Polish V2 §7
+// · inbox-out.jsx). window.print() com CSS @media print isolando o conteúdo.
+//
+// Notas internas FICAM FORA por default (toggle consciente — transcript vai
+// pro cliente/arquivo; nota interna é da equipe). Header Oimpresso simples.
+
+import { useState } from 'react';
+import { Printer } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import { Button } from '@/Components/ui/button';
+import { Checkbox } from '@/Components/ui/checkbox';
+import { Inline, Stack } from '@/Components/layout';
+import type { CaixaUnifMessage, CaixaUnifThread } from './helpers';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  thread: CaixaUnifThread;
+  messages: CaixaUnifMessage[];
+}
+
+export default function InboxTranscriptDialog({ open, onOpenChange, thread, messages }: Props) {
+  const [includeNotes, setIncludeNotes] = useState(false);
+  const visible = messages.filter(m => includeNotes || !m.is_internal_note);
+
+  function print() {
+    window.print();
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-lg" data-testid="caixa-unif-transcript">
+        {/* Esconde o resto do app no print — só o transcript sai no papel */}
+        <style>{`@media print {
+          body * { visibility: hidden; }
+          [data-print-transcript], [data-print-transcript] * { visibility: visible; }
+          [data-print-transcript] { position: absolute; inset: 0; padding: 24px; }
+        }`}</style>
+        <DialogHeader>
+          <DialogTitle>Transcript da conversa</DialogTitle>
+          <DialogDescription>
+            Pronto pra imprimir/salvar como PDF (Ctrl+P usa o diálogo do navegador).
+          </DialogDescription>
+        </DialogHeader>
+
+        <Inline gap={2} align="center" justify="between">
+          <Inline gap={1} align="center">
+            <Checkbox
+              id="transcript-include-notes"
+              checked={includeNotes}
+              onCheckedChange={(v) => setIncludeNotes(v === true)}
+              data-testid="caixa-unif-transcript-notes-toggle"
+            />
+            <label
+              htmlFor="transcript-include-notes"
+              className="text-[11.5px] text-muted-foreground cursor-pointer"
+            >
+              Incluir notas internas (padrão: fora — transcript é cliente-facing)
+            </label>
+          </Inline>
+          <Button size="sm" onClick={print} className="gap-1.5" data-testid="caixa-unif-transcript-print">
+            <Printer size={13} aria-hidden /> Imprimir / PDF
+          </Button>
+        </Inline>
+
+        <div className="max-h-[55vh] overflow-y-auto border rounded-md p-4 bg-card" data-print-transcript>
+          <Stack gap={1} className="border-b pb-2 mb-3">
+            <b className="text-[14px] font-semibold">Oimpresso · Transcript de atendimento</b>
+            <small className="text-[11px] text-muted-foreground">
+              {thread.contact_name || thread.customer_external_id} · {thread.customer_external_id}
+              {thread.channel_label ? ` · ${thread.channel_label}` : ''}
+            </small>
+          </Stack>
+          <Stack gap={2}>
+            {visible.map(m => (
+              <Stack key={m.id} gap={0}>
+                <small className="text-[10px] font-mono text-muted-foreground">
+                  {new Date(m.created_at).toLocaleString('pt-BR')}
+                  {' · '}
+                  {m.is_internal_note
+                    ? `NOTA INTERNA${m.sender_user_name ? ` (${m.sender_user_name})` : ''}`
+                    : m.direction === 'inbound'
+                      ? (thread.contact_name || 'Cliente')
+                      : (m.sender_user_name || 'Atendimento')}
+                </small>
+                <span className="text-[12.5px] whitespace-pre-wrap break-words">
+                  {m.body || (m.media_url ? '[mídia]' : '')}
+                </span>
+              </Stack>
+            ))}
+          </Stack>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -301,7 +301,43 @@ export const CU_LS = {
   QUEUE: 'oimpresso.caixa-unif.queue',
   SEARCH: 'oimpresso.caixa-unif.search',
   SIDEBAR_COLLAPSED: 'oimpresso.caixa-unif.sidebar_collapsed',
+  /** Polish V2 §6 — favoritos per-user per-browser (sem DB, sem leakage cross-tenant) */
+  FAVORITES: 'oimpresso.caixa-unif.favorites',
 } as const;
+
+/**
+ * Polish V2 §1 — inverso de WhatsappQueue::slaHuman ("1h"/"4h"/"45min"/"1h30" → minutos).
+ */
+export function parseSlaMinutes(sla: string | null | undefined): number | null {
+  if (!sla) return null;
+  const m = sla.trim().match(/^(?:(\d+)h)?(?:(\d+)(?:min)?)?$/);
+  if (!m) return null;
+  const minutes = (Number(m[1] ?? 0)) * 60 + Number(m[2] ?? 0);
+  return minutes > 0 ? minutes : null;
+}
+
+export type SlaState = 'ok' | 'warning' | 'breached' | null;
+
+/**
+ * Polish V2 §1 — estado do SLA de 1ª resposta da conversa.
+ *
+ * Só conta quando o cliente falou por último (`last_message_direction ===
+ * 'inbound'`) — depois que o atendente respondeu o relógio para. `warning`
+ * a partir de 75% do SLA, `breached` ao estourar.
+ */
+export function slaState(conv: {
+  last_message_direction: 'inbound' | 'outbound' | null;
+  last_inbound_at: string | null;
+  queue: { sla: string | null };
+}): SlaState {
+  if (conv.last_message_direction !== 'inbound' || !conv.last_inbound_at) return null;
+  const slaMin = parseSlaMinutes(conv.queue.sla);
+  if (slaMin === null) return null;
+  const waitedMin = (Date.now() - new Date(conv.last_inbound_at).getTime()) / 60000;
+  if (waitedMin >= slaMin) return 'breached';
+  if (waitedMin >= slaMin * 0.75) return 'warning';
+  return 'ok';
+}
 
 export function cuLsGet(key: string, fallback = ''): string {
   if (typeof window === 'undefined') return fallback;

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/useInboxFavs.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/useInboxFavs.ts
@@ -1,0 +1,37 @@
+// useInboxFavs — favoritos da Caixa Unificada (Polish V2 §6 · inbox-extras.jsx).
+//
+// localStorage per-user per-browser (SEM DB — anti-hook do charter: filtros/
+// preferências não persistem em DB, sem leakage cross-tenant). Conversas
+// favoritas ordenam no topo da lista.
+
+import { useCallback, useState } from 'react';
+import { CU_LS, cuLsGet, cuLsSet } from './helpers';
+
+export function useInboxFavs(): {
+  favs: Set<number>;
+  isFav: (id: number) => boolean;
+  toggleFav: (id: number) => void;
+} {
+  const [favs, setFavs] = useState<Set<number>>(() => {
+    try {
+      const raw = cuLsGet(CU_LS.FAVORITES, '[]');
+      return new Set((JSON.parse(raw) as number[]).filter(n => typeof n === 'number'));
+    } catch {
+      return new Set();
+    }
+  });
+
+  const toggleFav = useCallback((id: number) => {
+    setFavs(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      cuLsSet(CU_LS.FAVORITES, JSON.stringify([...next]));
+      return next;
+    });
+  }, []);
+
+  const isFav = useCallback((id: number) => favs.has(id), [favs]);
+
+  return { favs, isFav, toggleFav };
+}


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-8 de 10

**Pacote polish V2** (7 dos 8 itens do protótipo `inbox-extras/out/cur`; 100% frontend — payloads cobertos por `R-WA-CAIXA-UNIF-001/002`):

1. **SLA pill** — `slaState()` client-side (só conta com cliente falando por último; âmbar ≥75%, vermelho estourado) na lista + header da thread
2. **⌘K** — TODO HONESTO: palette global PMG-002 já existe no AppShellV2; estender com convs/contatos = US própria cross-módulo (anti-duplicação MANUAL #5)
3. **Cheat-sheet `?`** — atalhos REAIS (J/K///E/A/⌘⇧N/⌘K/?)
4. **Lightbox** — `MediaFullscreenModal` reusado (navega entre imagens da thread) em vez de `window.open`
5. **Mobile tabs <lg** — `InboxMobileTabs` Conversas/Thread/Contexto (Grid primitive); abrir conversa salta pra Thread; desktop 3-col intacto
6. **Favoritos** — `useInboxFavs` localStorage per-user (SEM DB — anti-hook do charter preservado); estrela ordena no topo
7. **Transcript imprimível** — `@media print` isola conteúdo; notas internas FORA por default (Checkbox DS)
8. **Modo apresentação** — overlay limpo (sem IDs/notas), Esc fecha

Gates locais: layout-primitives ✅ zero delta · eslint baseline ✅ · tsc zero novo. Charter → v9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)