### PR TITLE
feat(whatsapp): PR-9 IA na thread — resumir, perguntar, sugerir resposta (PR-9/10)

### DIFF
--- a/Modules/Whatsapp/Ai/Agents/InboxAssistAgent.php
+++ b/Modules/Whatsapp/Ai/Agents/InboxAssistAgent.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Ai\Agents;
+
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+/**
+ * InboxAssistAgent — IA dentro da thread da Caixa Unificada V4 (PR-9 do brief
+ * [CC] 2026-06-10 · referência inbox-ai.jsx: SummarizeThread/AskInbox/SuggestReply).
+ *
+ * Usa laravel/ai (stack canônica ADR 0035) — MESMO pattern dos Agents da Jana
+ * (BriefingAgent/ChatCopilotoAgent). Validação pré-PR confirmou a infra:
+ * Modules/Jana/Services/Ai/LaravelAiSdkDriver + Agents Promptable.
+ *
+ * PII: o texto da conversa passa pelo PiiRedactor da Jana ANTES de chegar aqui
+ * (InboxAiController::convToText) — CPF/CNPJ/etc nunca vão pro provider.
+ */
+class InboxAssistAgent implements Agent
+{
+    use Promptable;
+
+    public function instructions(): Stringable|string
+    {
+        return <<<'PROMPT'
+        Você é o assistente de atendimento do oimpresso (ERP pra gráficas e PMEs brasileiras).
+        Trabalha DENTRO de uma conversa de WhatsApp entre um atendente e um cliente.
+        Responda sempre em português brasileiro, direto e profissional.
+        Baseie-se APENAS no transcript fornecido — nunca invente pedidos, valores ou prazos.
+        Se o transcript não tiver a informação, diga isso explicitamente.
+        Linhas marcadas [NOTA INTERNA] são da equipe — use como contexto, nunca exponha o conteúdo delas numa resposta sugerida pro cliente.
+        PROMPT;
+    }
+
+    public function promptSummarize(string $convText): string
+    {
+        return <<<PROMPT
+        Resuma a conversa abaixo pro atendente em no máximo 5 bullets:
+        contexto do cliente · o que ele quer · status atual · pendências · próximo passo sugerido.
+
+        Transcript:
+        {$convText}
+        PROMPT;
+    }
+
+    public function promptAsk(string $convText, string $question): string
+    {
+        return <<<PROMPT
+        Responda à pergunta do atendente usando APENAS o transcript abaixo.
+
+        Pergunta: {$question}
+
+        Transcript:
+        {$convText}
+        PROMPT;
+    }
+
+    public function promptSuggestReply(string $convText): string
+    {
+        return <<<PROMPT
+        Sugira a PRÓXIMA resposta do atendente pro cliente, com base no transcript abaixo.
+        Regras: português brasileiro, tom cordial e objetivo, 1-3 frases, sem inventar
+        prazo/valor que não esteja no transcript, sem expor notas internas.
+        Devolva SÓ o texto da resposta (sem aspas, sem prefixo).
+
+        Transcript:
+        {$convText}
+        PROMPT;
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxAiController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxAiController.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Admin;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Ai\Agents\InboxAssistAgent;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\Message;
+
+/**
+ * InboxAiController — IA na thread da Caixa Unificada V4 (PR-9 do brief [CC]).
+ *
+ * 3 endpoints finos sobre o InboxAssistAgent (laravel/ai, stack ADR 0035 —
+ * mesma infra validada dos Agents da Jana):
+ *   POST /atendimento/inbox/{id}/ai/summarize     → resumo 5 bullets
+ *   POST /atendimento/inbox/{id}/ai/ask           → pergunta sobre a conversa
+ *   POST /atendimento/inbox/{id}/ai/suggest-reply → sugestão de resposta
+ *
+ * Guardas (todas as rotas):
+ *   - Tier 0 ADR 0093: conversa do business atual + ACL canal (US-WA-069)
+ *   - LGPD: transcript passa pelo PiiRedactor da Jana ANTES do provider
+ *   - Custo: `config('copiloto.dry_run')` devolve fixture SEM tocar LLM
+ *     (mesma chave que gateia a Jana — dev/test nunca gastam token)
+ *   - Falha de provider → 503 com mensagem legível (nunca 500 cru)
+ */
+class InboxAiController extends Controller
+{
+    /** Últimas N mensagens no transcript — janela suficiente sem estourar contexto. */
+    protected const TRANSCRIPT_LIMIT = 60;
+
+    public function summarize(Request $request, int $id): JsonResponse
+    {
+        $conversation = $this->resolveConversationOrAbort($id);
+        $convText = $this->convToText($conversation);
+
+        if (config('copiloto.dry_run')) {
+            return response()->json(['text' => $this->fixtureSummarize($conversation)]);
+        }
+
+        return $this->runAgent(
+            fn (InboxAssistAgent $agent) => $agent->prompt($agent->promptSummarize($convText)),
+            'summarize',
+            $conversation,
+        );
+    }
+
+    public function ask(Request $request, int $id): JsonResponse
+    {
+        $data = $request->validate(['question' => ['required', 'string', 'max:500']]);
+        $conversation = $this->resolveConversationOrAbort($id);
+        $convText = $this->convToText($conversation);
+
+        if (config('copiloto.dry_run')) {
+            return response()->json(['text' => "[dry-run] Pergunta recebida: \"{$data['question']}\" — em produção a IA responde com base no transcript ({$this->messageCount($conversation)} mensagens)."]);
+        }
+
+        return $this->runAgent(
+            fn (InboxAssistAgent $agent) => $agent->prompt($agent->promptAsk($convText, $data['question'])),
+            'ask',
+            $conversation,
+        );
+    }
+
+    public function suggestReply(Request $request, int $id): JsonResponse
+    {
+        $conversation = $this->resolveConversationOrAbort($id);
+        $convText = $this->convToText($conversation);
+
+        if (config('copiloto.dry_run')) {
+            return response()->json(['text' => 'Olá! Recebemos sua mensagem e já estamos verificando — te retorno em instantes.']);
+        }
+
+        return $this->runAgent(
+            fn (InboxAssistAgent $agent) => $agent->prompt($agent->promptSuggestReply($convText)),
+            'suggest_reply',
+            $conversation,
+        );
+    }
+
+    /**
+     * Conversa do business atual + ACL canal (fail-loud) — Tier 0.
+     */
+    protected function resolveConversationOrAbort(int $id): Conversation
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = (int) (session('user.id') ?? auth()->id() ?? 0);
+
+        $conversation = Conversation::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($id);
+
+        $canSeeAll = (bool) (auth()->user()?->can('whatsapp.view-all-phones') ?? false);
+        $channelId = (int) ($conversation->channel_id ?? 0);
+        if (! $canSeeAll && $channelId !== 0) {
+            $hasAccess = ChannelUserAccess::query()
+                ->where('business_id', $businessId)
+                ->where('user_id', $userId)
+                ->where('channel_id', $channelId)
+                ->whereNull('revoked_at')
+                ->exists();
+            if (! $hasAccess) {
+                abort(403, 'Sem acesso ao canal desta conversa.');
+            }
+        }
+
+        return $conversation;
+    }
+
+    /**
+     * Transcript das últimas N mensagens — REDIGIDO (PiiRedactor da Jana) antes
+     * de qualquer provider. Notas internas entram marcadas (contexto da equipe;
+     * o Agent é instruído a nunca expô-las em resposta cliente-facing).
+     */
+    protected function convToText(Conversation $conversation): string
+    {
+        $messages = Message::query()
+            ->where('business_id', (int) $conversation->business_id)
+            ->where('conversation_id', $conversation->id)
+            ->orderByDesc('created_at')
+            ->limit(self::TRANSCRIPT_LIMIT)
+            ->get()
+            ->reverse();
+
+        $lines = $messages->map(function (Message $m) use ($conversation) {
+            $who = $m->is_internal_note
+                ? '[NOTA INTERNA]'
+                : ($m->direction === 'inbound' ? ($conversation->contact_name ?: 'Cliente') : 'Atendente');
+            $body = $m->body ?: ($m->media_url ? '[mídia]' : '');
+
+            return "{$who}: {$body}";
+        })->implode("\n");
+
+        // LGPD — CPF/CNPJ/PII nunca vão pro provider (reusa redactor canon da Jana)
+        try {
+            return app(\Modules\Jana\Services\Privacy\PiiRedactor::class)->redact($lines);
+        } catch (\Throwable) {
+            // Fallback regex CPF/CNPJ (mesmo do LaravelAiSdkDriver legacy path)
+            $lines = (string) preg_replace('/\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/', 'XXX.XXX.XXX-NN', $lines);
+
+            return (string) preg_replace('/\b\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}\b/', 'XX.XXX.XXX/XXXX-NN', $lines);
+        }
+    }
+
+    /**
+     * Executa o Agent com falha graciosa (provider fora → 503 legível).
+     */
+    protected function runAgent(\Closure $call, string $action, Conversation $conversation): JsonResponse
+    {
+        try {
+            $response = $call(new InboxAssistAgent());
+
+            Log::channel('copiloto-ai')->info("[inbox-ai] {$action}", [
+                'business_id' => (int) $conversation->business_id,
+                'conversation_id' => $conversation->id,
+            ]);
+
+            return response()->json(['text' => (string) $response]);
+        } catch (\Throwable $e) {
+            Log::channel('copiloto-ai')->warning("[inbox-ai] {$action} falhou", [
+                'business_id' => (int) $conversation->business_id,
+                'conversation_id' => $conversation->id,
+                'error_class' => get_class($e),
+            ]);
+
+            return response()->json([
+                'error' => 'IA indisponível agora — tente de novo em instantes.',
+            ], 503);
+        }
+    }
+
+    protected function fixtureSummarize(Conversation $conversation): string
+    {
+        $n = $this->messageCount($conversation);
+
+        return "[dry-run] Resumo da conversa com {$conversation->contact_name}: {$n} mensagens no transcript. Em produção a IA devolve 5 bullets (contexto · pedido · status · pendências · próximo passo).";
+    }
+
+    protected function messageCount(Conversation $conversation): int
+    {
+        return Message::query()
+            ->where('business_id', (int) $conversation->business_id)
+            ->where('conversation_id', $conversation->id)
+            ->count();
+    }
+}

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -7,6 +7,7 @@ use Modules\Whatsapp\Http\Controllers\Admin\CaixaUnificadaController;
 use Modules\Whatsapp\Http\Controllers\Admin\ChannelsController;
 use Modules\Whatsapp\Http\Controllers\Admin\CsatController;
 use Modules\Whatsapp\Http\Controllers\Admin\ClientFeedbackController;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxAiController;
 use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacrosController;
 use Modules\Whatsapp\Http\Controllers\Admin\MacroVariantsController;
@@ -203,6 +204,21 @@ Route::group([
     Route::post('/broadcast', [BroadcastController::class, 'store'])
         ->middleware('can:whatsapp.send')
         ->name('atendimento.broadcast.store');
+
+    // PR-9 brief [CC] — IA na thread (laravel/ai, mesma infra dos Agents Jana).
+    // dry_run da Jana gateia custo; PII redigida antes do provider (LGPD).
+    Route::post('/inbox/{id}/ai/summarize', [InboxAiController::class, 'summarize'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.ai.summarize');
+    Route::post('/inbox/{id}/ai/ask', [InboxAiController::class, 'ask'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.ai.ask');
+    Route::post('/inbox/{id}/ai/suggest-reply', [InboxAiController::class, 'suggestReply'])
+        ->whereNumber('id')
+        ->middleware('can:whatsapp.send')
+        ->name('atendimento.inbox.ai.suggest_reply');
 
     // Wagner 2026-05-27 — Voice of Customer in-app capture (ADR UI-0016).
     // Captura feedback diretamente de mensagens do inbox WhatsApp.

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -18,6 +18,7 @@ contains:
   - "Admin/CaixaUnificadaController — UI omnichannel V4 /atendimento/caixa-unificada redesign Cowork F3 MWART (PR-D 2026-05-15, coexiste Inbox legacy canary 7d)"
   - "Admin/QueuesController — CRUD filas de atendimento whatsapp_queues (US-WA-301 ADR 0267, painel QueuesSheet da Caixa Unificada V4)"
   - "Admin/BroadcastController — broadcast fase 1: pre-flight audiencia (opt-in LGPD + janela 24h) + draft auditavel whatsapp_broadcasts (US-WA-306 ADR 0268; disparo = fase 2 gate W)"
+  - "Admin/InboxAiController — IA na thread V4 (resumir/perguntar/sugerir resposta) via laravel/ai InboxAssistAgent; PII redigida (PiiRedactor Jana) + dry_run gateia custo (PR-9 brief CC 2026-06-10)"
   - "Admin/ClientFeedbackController — captura Voice of Customer canon a partir de bubble inbox (PR #1711 2026-05-27); ADR UI-0016 + ADR 0105 cliente-como-sinal"
   # API webhooks (US-WA-010/010b/002d)
   - "Api/MetaWebhookController — recebe events Meta Cloud (HMAC SHA-256 verify)"

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -816,7 +816,7 @@ it('R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL cana
     \Illuminate\Support\Facades\DB::table('messages')->insert([
         'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
         'provider' => 'whatsapp_baileys', 'type' => 'text',
-        'body' => 'Meu CPF é 123.456.789-09, quero orçamento de 500 cartões',
+        'body' => 'Quero orçamento de 500 cartões de visita pra minha loja',
         'status' => 'received', 'created_at' => now(),
     ]);
 

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -799,3 +799,49 @@ it('R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + dra
     expect(fn () => $bcast->preflight(cuctPostRequest('/atendimento/broadcast/preflight', ['channel_id' => $chAlien->id])))
         ->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
 });
+
+// ============================================================================
+// 10. PR-9 brief [CC] — IA na thread: dry_run gateia custo + Tier 0/ACL
+// ============================================================================
+
+it('R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL canal fail-loud', function () {
+    config(['copiloto.dry_run' => true]); // NUNCA toca provider em teste
+
+    $ch = cuctMakeChannel(1, 'caixa-unif-012-uuid');
+    $chNoAcl = cuctMakeChannel(1, 'caixa-unif-012-noacl-uuid');
+    $conv = cuctMakeConv(1, $ch->id);
+    $convNoAcl = cuctMakeConv(1, $chNoAcl->id);
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    \Illuminate\Support\Facades\DB::table('messages')->insert([
+        'business_id' => 1, 'conversation_id' => $conv->id, 'direction' => 'inbound',
+        'provider' => 'whatsapp_baileys', 'type' => 'text',
+        'body' => 'Meu CPF é 123.456.789-09, quero orçamento de 500 cartões',
+        'status' => 'received', 'created_at' => now(),
+    ]);
+
+    $ai = new \Modules\Whatsapp\Http\Controllers\Admin\InboxAiController();
+
+    // summarize dry-run → fixture (com contagem real de msgs), sem provider
+    $resp = $ai->summarize(cuctPostRequest("/atendimento/inbox/{$conv->id}/ai/summarize"), $conv->id);
+    expect($resp->getData(true)['text'])->toContain('[dry-run]')
+        ->and($resp->getData(true)['text'])->toContain('1 mensagens');
+
+    // ask dry-run ecoa a pergunta na fixture
+    $resp2 = $ai->ask(cuctPostRequest("/atendimento/inbox/{$conv->id}/ai/ask", ['question' => 'qual o pedido?']), $conv->id);
+    expect($resp2->getData(true)['text'])->toContain('qual o pedido?');
+
+    // suggest-reply dry-run devolve resposta plausível
+    $resp3 = $ai->suggestReply(cuctPostRequest("/atendimento/inbox/{$conv->id}/ai/suggest-reply"), $conv->id);
+    expect($resp3->getData(true)['text'])->not->toBe('');
+
+    // ACL: conversa de canal sem grant → 403 fail-loud (US-WA-069)
+    expect(fn () => $ai->summarize(cuctPostRequest("/atendimento/inbox/{$convNoAcl->id}/ai/summarize"), $convNoAcl->id))
+        ->toThrow(\Symfony\Component\HttpKernel\Exception\HttpException::class);
+
+    // Tier 0: conversa de outro tenant → 404
+    $chAlien = cuctMakeChannel(99, 'caixa-unif-012-alien-uuid');
+    $convAlien = cuctMakeConv(99, $chAlien->id);
+    expect(fn () => $ai->summarize(cuctPostRequest("/atendimento/inbox/{$convAlien->id}/ai/summarize"), $convAlien->id))
+        ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 9
+charter_version: 10
 permissao: whatsapp.access
 ---
 
@@ -151,6 +151,20 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 8. **Último contato** — relativeTimeBR do `last_message_at`.
 9. **Ações** — 3 botões (Emitir cobrança · Enviar arte · Ligar) — placeholders.
 
+### IA na thread (PR-9, 2026-06-10 — do protótipo inbox-ai.jsx)
+- **Validação pré-PR** (regra do brief): infra Jana EXISTE — laravel/ai SDK
+  (ADR 0035) + pattern Agents (`BriefingAgent`/`ChatCopilotoAgent`) → IA REAL,
+  não scaffold.
+- **3 endpoints finos** (`InboxAiController` + `InboxAssistAgent`):
+  `POST .../inbox/{id}/ai/summarize` (resumo 5 bullets) · `.../ai/ask`
+  (pergunta sobre o transcript) · `.../ai/suggest-reply` (preenche o composer;
+  humano SEMPRE revisa antes de enviar — nada vai pro cliente automático).
+- **LGPD**: transcript passa pelo `PiiRedactor` da Jana ANTES do provider;
+  notas internas entram marcadas e o Agent é instruído a nunca expô-las.
+- **Custo**: `config('copiloto.dry_run')` (mesma chave da Jana) devolve fixture
+  sem tocar LLM — dev/test nunca gastam token. Provider fora → 503 legível.
+- UI: header "Resumir"/"Perguntar" (`InboxAiDialog`) + composer "✦ Sugerir".
+
 ### Polish V2 (PR-8, 2026-06-10 — do protótipo inbox-extras/out/cur)
 1. **SLA pill** — `slaState()` client-side (75% = âmbar, estourado = vermelho)
    na lista e no header da thread; só conta quando o cliente falou por último.
@@ -261,6 +275,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-009 — moveQueue: override vence heurística, null volta, slug inválido 422` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + draft auditável` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL canal fail-loud` | mesmo arquivo |
 
 ---
 
@@ -306,6 +321,7 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-06-10 | Claude (mandato [W] "aplicar todas") | **IA na thread** (PR-9/10): validação pré-PR confirmou infra Jana (laravel/ai + Agents) → IA REAL. `InboxAssistAgent` + `InboxAiController` (summarize/ask/suggest-reply) com PII redigida (PiiRedactor), dry_run gateando custo, 503 gracioso. UI: header Resumir/Perguntar + composer ✦ Sugerir (humano revisa). Charter v10. Pest R-WA-CAIXA-UNIF-012. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **Polish V2** (PR-8/10): SLA pill lista+thread (slaState 75%/estourado) · cheat-sheet `?` · lightbox MediaFullscreenModal reusado · mobile tabs <lg (InboxMobileTabs) · favoritos localStorage (useInboxFavs, sem DB) · transcript imprimível (notas fora por default) · modo apresentação (Esc). ⌘K = TODO honesto (palette global PMG-002 já existe; estender = US cross-módulo). 100% frontend — payloads cobertos por R-WA-CAIXA-UNIF-001/002. Charter v9. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-306 Broadcast FASE 1** (PR-7/10, scaffold honesto previsto no brief): ADR 0268 + `whatsapp_broadcasts` + `contacts.whatsapp_opt_in_at` (LGPD) + `BroadcastController` pre-flight real (opt-in/janela 24h/só-HSM) + draft auditável + `BroadcastSheet`. Disparo em massa = fase 2 com gate [W] (botão disabled, anti M-AP-2). Charter v8. Pest R-WA-CAIXA-UNIF-011. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **US-WA-307 + Nova conversa** (PR-6/10): dialog conta ativa + telefone/Contact CRM + mensagem inicial opcional; `InboxController::startConversation` find-or-create Tier 0 (canal ativo do business + ACL US-WA-069; cross/inativo = 403/422) reusando pipeline send(). Charter v7. Pest R-WA-CAIXA-UNIF-010. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -23,7 +23,7 @@
 
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { useForm, router, usePage } from '@inertiajs/react';
-import { Braces, LayoutList, Loader2, Send, FileText, Paperclip, Slash, X } from 'lucide-react';
+import { Braces, LayoutList, Loader2, Send, FileText, Paperclip, Slash, Sparkles, X } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 import { Inline } from '@/Components/layout';
 import {
@@ -194,6 +194,30 @@ export default function ComposerV4({
       const v = varEntries.find(e => e.key === key.toLowerCase())?.value;
       return v ? v : raw; // sem valor → mantém literal (preview marca em vermelho)
     });
+  }
+
+  // ── PR-9: ✦ Sugerir resposta (IA server-side; humano SEMPRE revisa) ─────
+  const [suggesting, setSuggesting] = useState(false);
+  function suggestReply() {
+    if (suggesting || internalMode || !canType) return;
+    setSuggesting(true);
+    fetch(route('atendimento.inbox.ai.suggest_reply', conversationId), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-CSRF-TOKEN': document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '',
+      },
+    })
+      .then(async r => {
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.error ?? 'IA indisponível.');
+        form.setData('body', String(data.text ?? '').trim());
+        requestAnimationFrame(() => inputRef.current?.focus());
+      })
+      .catch((e: Error) => setMediaError(e.message))
+      .finally(() => setSuggesting(false));
   }
 
   function insertVar(key: string) {
@@ -574,6 +598,21 @@ export default function ComposerV4({
       }
       data-testid="caixa-unif-composer"
     >
+      {/* PR-9 — ✦ Sugerir resposta (IA preenche o input; humano revisa e envia) */}
+      {!internalMode && (
+        <button
+          type="button"
+          onClick={suggestReply}
+          disabled={!canType || suggesting}
+          title="IA sugere a próxima resposta — você revisa antes de enviar"
+          data-testid="caixa-unif-composer-suggest"
+          className="h-8 px-2.5 rounded-full border bg-card inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+        >
+          {suggesting ? <Loader2 size={11} className="animate-spin" aria-hidden /> : <Sparkles size={11} aria-hidden />}
+          Sugerir
+        </button>
+      )}
+
       {/* Toggle Resp / Nota — Cowork .om-mode-btn.on tokens OKLCH §589 */}
       <button
         type="button"

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -11,7 +11,7 @@
 // Empty state quando thread=null (mantém UX Cockpit V2 do legacy Inbox).
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, CheckCheck, ClipboardCheck, FileDown, Presentation } from 'lucide-react';
+import { Check, CheckCheck, ClipboardCheck, FileDown, Presentation, Sparkles } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 import {
   type CaixaUnifMessage,
@@ -23,6 +23,7 @@ import {
   slaState,
 } from './helpers';
 import ComposerV4 from './ComposerV4';
+import InboxAiDialog, { type InboxAiMode } from './InboxAiDialog';
 import InboxPresenterMode from './InboxPresenterMode';
 import InboxTranscriptDialog from './InboxTranscriptDialog';
 import CaptureFeedbackSheet, { type CaptureFeedbackInput } from '@/Pages/Whatsapp/_components/CaptureFeedbackSheet';
@@ -77,6 +78,9 @@ export default function ConversationThreadV4({
   // Polish V2 §7/§8 — transcript print-friendly + modo apresentação
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   const [presenterOpen, setPresenterOpen] = useState(false);
+
+  // PR-9 — IA na thread (Resumir / Perguntar)
+  const [aiMode, setAiMode] = useState<InboxAiMode | null>(null);
 
   // Polish V2 §1 — SLA no header (direção da última msg não-nota vem das messages)
   const lastRealMsg = useMemo(
@@ -179,14 +183,33 @@ export default function ConversationThreadV4({
             SLA
           </span>
         )}
-        {/* Polish V2 §7/§8 — transcript print + modo apresentação */}
+        {/* PR-9 — IA: Resumir / Perguntar (laravel/ai server-side, PII redigida) */}
         <button
           type="button"
-          onClick={() => setTranscriptOpen(true)}
+          onClick={() => setAiMode('summarize')}
           className={cn(
             'inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0',
             headerSla === null && 'ml-auto',
           )}
+          title="Resumir conversa com IA"
+          data-testid="caixa-unif-thread-ai-summarize"
+        >
+          <Sparkles size={12} aria-hidden /> Resumir
+        </button>
+        <button
+          type="button"
+          onClick={() => setAiMode('ask')}
+          className="inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0"
+          title="Perguntar sobre a conversa (IA responde só com o transcript)"
+          data-testid="caixa-unif-thread-ai-ask"
+        >
+          Perguntar
+        </button>
+        {/* Polish V2 §7/§8 — transcript print + modo apresentação */}
+        <button
+          type="button"
+          onClick={() => setTranscriptOpen(true)}
+          className="inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0"
           title="Transcript imprimível / PDF"
           data-testid="caixa-unif-thread-transcript"
         >
@@ -463,6 +486,16 @@ export default function ConversationThreadV4({
         thread={thread}
         messages={messages}
       />
+
+      {/* PR-9 — IA Resumir/Perguntar */}
+      {aiMode !== null && (
+        <InboxAiDialog
+          open={aiMode !== null}
+          onOpenChange={(o) => { if (!o) setAiMode(null); }}
+          mode={aiMode}
+          conversationId={thread.id}
+        />
+      )}
 
       {/* Composer */}
       <ComposerV4

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxAiDialog.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/InboxAiDialog.tsx
@@ -1,0 +1,118 @@
+// InboxAiDialog — "Resumir" e "Perguntar" da thread (PR-9 · inbox-ai.jsx).
+//
+// Chama os endpoints finos do InboxAiController (laravel/ai server-side,
+// PII redigida, dry_run gateia custo). Resultado é SEMPRE revisado pelo
+// humano — nada é enviado ao cliente automaticamente.
+
+import { useState } from 'react';
+import { Loader2, Sparkles } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Inline, Stack } from '@/Components/layout';
+
+export type InboxAiMode = 'summarize' | 'ask';
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: InboxAiMode;
+  conversationId: number;
+}
+
+function csrf(): string {
+  return document.querySelector<HTMLMetaElement>('meta[name="csrf-token"]')?.content ?? '';
+}
+
+export default function InboxAiDialog({ open, onOpenChange, mode, conversationId }: Props) {
+  const [question, setQuestion] = useState('');
+  const [result, setResult] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  function run() {
+    if (loading) return;
+    if (mode === 'ask' && !question.trim()) return;
+    setLoading(true);
+    setError(null);
+    setResult(null);
+    const routeName = mode === 'summarize' ? 'atendimento.inbox.ai.summarize' : 'atendimento.inbox.ai.ask';
+    fetch(route(routeName, conversationId), {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-CSRF-TOKEN': csrf() },
+      body: JSON.stringify(mode === 'ask' ? { question: question.trim() } : {}),
+    })
+      .then(async r => {
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.error ?? 'Falha na IA.');
+        setResult(data.text ?? '');
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => { if (!o) { setResult(null); setError(null); setQuestion(''); } onOpenChange(o); }}
+    >
+      <DialogContent className="sm:max-w-md" data-testid="caixa-unif-ai-dialog">
+        <DialogHeader>
+          <DialogTitle className="inline-flex items-center gap-2">
+            <Sparkles size={16} aria-hidden />
+            {mode === 'summarize' ? 'Resumir conversa' : 'Perguntar sobre a conversa'}
+          </DialogTitle>
+          <DialogDescription>
+            A IA responde só com o que está no transcript (dados sensíveis são
+            redigidos antes). Revise antes de usar com o cliente.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Stack gap={2}>
+          {mode === 'ask' && (
+            <Inline gap={2} align="center">
+              <Input
+                value={question}
+                onChange={e => setQuestion(e.target.value)}
+                onKeyDown={e => { if (e.key === 'Enter') run(); }}
+                placeholder="Ex.: o cliente já confirmou o endereço de entrega?"
+                data-testid="caixa-unif-ai-question"
+              />
+            </Inline>
+          )}
+
+          <Button
+            type="button"
+            onClick={run}
+            disabled={loading || (mode === 'ask' && !question.trim())}
+            className="gap-1.5"
+            data-testid="caixa-unif-ai-run"
+          >
+            {loading
+              ? (<><Loader2 size={14} className="animate-spin" aria-hidden /> Consultando…</>)
+              : (mode === 'summarize' ? 'Gerar resumo' : 'Perguntar')}
+          </Button>
+
+          {error && (
+            <p className="text-[11.5px] text-destructive" role="alert">{error}</p>
+          )}
+          {result !== null && (
+            <div
+              className="border rounded-md p-3 bg-muted/20 text-[12.5px] whitespace-pre-wrap break-words max-h-[45vh] overflow-y-auto"
+              data-testid="caixa-unif-ai-result"
+            >
+              {result}
+            </div>
+          )}
+        </Stack>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Caixa Unificada — brief [CC] 2026-06-10 · mandato [W] "aplicar todas" · PR-9 de 10

**Pacote IA na thread** (referência `inbox-ai.jsx`)

### Validação pré-PR (regra do brief: "primeiro valide o que a Jana expõe")
Infra **EXISTE**: laravel/ai SDK (ADR 0035) + pattern Agents (`BriefingAgent`/`ChatCopilotoAgent` etc.) → **IA REAL, não scaffold**.

### O que muda
- **`InboxAssistAgent`** (laravel/ai, instructions PT-BR de atendimento, anti-alucinação: só o transcript; notas internas marcadas e nunca expostas pro cliente)
- **`InboxAiController`** — 3 endpoints finos:
  - `POST .../inbox/{id}/ai/summarize` → resumo 5 bullets
  - `POST .../inbox/{id}/ai/ask` → pergunta sobre o transcript
  - `POST .../inbox/{id}/ai/suggest-reply` → preenche o composer (humano SEMPRE revisa)
- **LGPD**: transcript passa pelo `PiiRedactor` da Jana ANTES do provider (fallback regex CPF/CNPJ)
- **Custo**: `config('copiloto.dry_run')` (mesma chave da Jana) devolve fixture SEM tocar LLM; provider fora → 503 legível
- **Tier 0**: conversa do business + ACL canal US-WA-069 (403/404 fail-loud)
- UI: header "Resumir"/"Perguntar" (`InboxAiDialog`) + composer "✦ Sugerir"

### Pest
- `R-WA-CAIXA-UNIF-012` — dry_run fixtures (sem LLM) + ACL 403 + cross-tenant 404

Charter → v10. SCOPE.md atualizado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)