### PR TITLE
fix(deploy): OPcache-invalidate só touch (best-effort), remove dump-autoload flaky

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -288,22 +288,20 @@ jobs:
       - name: Permissions storage + bootstrap/cache
         run: /tmp/ssh_exec.sh "cd $RDIR && chmod -R 775 storage bootstrap/cache 2>&1 | tail -3 || true"
 
-      - name: Force OPcache invalidate (dump-autoload + touch)
-        # LSPHP/LiteSpeed segura bytecode entre deploys. dump-autoload muda mtime dos
-        # compilados; find -exec touch força re-stat de todos os PHPs. Sem --no-dev
-        # (incidente 2026-06-06: --no-dev removia provider Scribe dev do classmap → 500).
-        # `public` incluído (ADR 0269): garante que o próprio _ops_opcache_reset.php
-        # recompile antes do step de reset — senão o endpoint que vai resetar o OPcache
-        # poderia ele mesmo ser servido como bytecode velho (paradoxo de bootstrap).
-        # `-name '*.php'` mantém o touch barato em public/ (só os poucos .php; ignora
-        # os bundles .js/.css de build-inertia/build).
+      - name: Force OPcache invalidate (touch mtime — best-effort)
+        # LSPHP/LiteSpeed segura bytecode entre deploys. `find -exec touch` bump o mtime
+        # dos PHPs → LSPHP re-stata (validate_timestamps). `public` incluído pra recompilar
+        # o próprio _ops_opcache_reset.php antes do reset HTTP (senão o endpoint que vai
+        # resetar o OPcache poderia ser servido como bytecode velho — paradoxo de bootstrap).
+        # `-name '*.php'` mantém barato (ignora bundles .js/.css).
+        #
+        # NÃO roda `composer dump-autoload` aqui: o step "Composer install" já faz o
+        # dump-autoload canônico (-o --classmap-authoritative). Rodar de novo era redundante
+        # E flaky — em 2026-06-10 o `dump-autoload --optimize` standalone abortou com help/exit 1
+        # (platform-req), derrubando o deploy DEPOIS do publish. Best-effort (`|| true`): o
+        # reset real e confirmado é o step HTTP seguinte; o failsafe protege o site.
         run: |
-          /tmp/ssh_exec.sh "
-            set -o pipefail &&
-            cd $RDIR &&
-            /usr/local/bin/composer dump-autoload --optimize --ignore-platform-req=ext-opentelemetry 2>&1 | tail -3 &&
-            find app bootstrap config routes public -name '*.php' -exec touch {} + 2>&1 | tail -3
-          "
+          /tmp/ssh_exec.sh "cd $RDIR && find app bootstrap config routes public -name '*.php' -exec touch {} + 2>&1 | tail -3" || echo "::warning::touch best-effort falhou — seguindo (reset confirmado é via HTTP)"
 
       - name: Maintenance mode OFF
         run: /tmp/ssh_exec.sh "cd $RDIR && php artisan up"


### PR DESCRIPTION
## Contexto

2º hotfix do auto-deploy. Com o publish já corrigido ([#2523](https://github.com/wagnerra23/oimpresso.com/pull/2523)), o auto-deploy **publicou os bundles novos com sucesso** (hash mudou pra `app-EkPlsqOL.js`, site 200), mas ficou **vermelho** no step `Force OPcache invalidate`.

## Causa

Esse step rodava `composer dump-autoload --optimize` standalone, que abortou com help/exit 1 (platform-req) **depois** do publish. O `failsafe if:always()` segurou o site no ar (validou a rede de segurança 🎯), mas o deploy ficou red.

O `dump-autoload` ali era **redundante** — o step `Composer install` já roda `dump-autoload -o --classmap-authoritative`.

## Fix

Step vira **só `find ... touch` best-effort** (`|| true`): bump de mtime pro LSPHP re-statar (incl. `public/` pro `_ops_opcache_reset.php` recompilar). O reset real e confirmado é o step HTTP seguinte; o failsafe protege o site. Um hiccup de touch nunca mais derruba o deploy.

## Próxima validação

O próximo auto-deploy passa a alcançar o step `Reset OPcache via HTTP — OBRIGATÓRIO` pela 1ª vez (até agora foi pulado por falhas anteriores) — é o teste real do mecanismo de token file-fallback.

Refs: ADR 0269

🤖 Generated with [Claude Code](https://claude.com/claude-code)