### PR TITLE
fix(deploy): SSH robusto Hostinger — -4 IPv4 + warm-up + retries (causa raiz dos 255)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,9 +139,20 @@ jobs:
         run: |
           cat > /tmp/ssh_exec.sh <<'EOF'
           #!/bin/bash
-          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+          # Flags canônicos Hostinger (memory/reference/hostinger.md §SSH):
+          #  -4  IPv4 OBRIGATÓRIO — IPv6 falha e dá "Connection timed out" (causa raiz dos
+          #      255 em 2026-06-10). BatchMode=yes falha rápido em prompt inesperado.
+          #      ConnectionAttempts + ServerAlive pra rede flaky runner→Hostinger.
+          #  ControlMaster (multiplexing) NÃO é usado: falha "mux_client_request_session"
+          #  no Hostinger (catalogado). Uma conexão por comando é o caminho suportado.
+          ssh -4 \
+              -o BatchMode=yes \
               -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=20 \
+              -o ConnectTimeout=60 \
+              -o ConnectionAttempts=5 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=10 \
+              -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
               ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
               "$@"
           EOF
@@ -153,6 +164,14 @@ jobs:
             | grep -oE '/assets/(inertia|app)-[a-zA-Z0-9_-]+\.(js|css)' \
             | sort -u > /tmp/bundle_before.txt || true
           echo "BEFORE:" && cat /tmp/bundle_before.txt || true
+
+      - name: Warm-up do caminho SSH (curl 5x — Hostinger flaky, ver hostinger.md)
+        # "Sem warm-up, primeiro SSH quase sempre dá Connection timed out" (hostinger.md).
+        # 5 hits IPv4 acordam a rota runner→Hostinger antes do 1º comando SSH.
+        run: |
+          for i in 1 2 3 4 5; do
+            curl -4 -s -o /dev/null -w "$i:%{http_code} " https://oimpresso.com/login --max-time 15 || true
+          done; echo
 
       - name: Pré-deploy check — server state
         run: |

--- a/.github/workflows/force-clean-rebuild-trigger.yml
+++ b/.github/workflows/force-clean-rebuild-trigger.yml
@@ -34,19 +34,33 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: SSH helper
         run: |
           cat > /tmp/ssh_exec.sh <<'EOF'
           #!/bin/bash
-          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+          # Flags canônicos Hostinger (memory/reference/hostinger.md §SSH): -4 IPv4 OBRIGATÓRIO
+          # (IPv6 falha → "Connection timed out"), BatchMode, ConnectionAttempts + ServerAlive.
+          # ControlMaster NÃO usado (falha "mux_client_request_session" no Hostinger).
+          ssh -4 \
+              -o BatchMode=yes \
               -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=20 \
+              -o ConnectTimeout=60 \
+              -o ConnectionAttempts=5 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=10 \
+              -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
               ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
               "$@"
           EOF
           chmod +x /tmp/ssh_exec.sh
+
+      - name: Warm-up do caminho SSH (curl 5x — Hostinger flaky, ver hostinger.md)
+        run: |
+          for i in 1 2 3 4 5; do
+            curl -4 -s -o /dev/null -w "$i:%{http_code} " https://oimpresso.com/login --max-time 15 || true
+          done; echo
 
       - name: Pre-clean inventory
         run: |

--- a/.github/workflows/quick-sync.yml
+++ b/.github/workflows/quick-sync.yml
@@ -48,13 +48,27 @@ jobs:
         run: |
           cat > /tmp/ssh_exec.sh <<'EOF'
           #!/bin/bash
-          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+          # Flags canônicos Hostinger (memory/reference/hostinger.md §SSH): -4 IPv4 OBRIGATÓRIO
+          # (IPv6 falha → "Connection timed out"), BatchMode, ConnectionAttempts + ServerAlive.
+          # ControlMaster NÃO usado (falha "mux_client_request_session" no Hostinger).
+          ssh -4 \
+              -o BatchMode=yes \
               -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=20 \
+              -o ConnectTimeout=60 \
+              -o ConnectionAttempts=5 \
+              -o ServerAliveInterval=15 \
+              -o ServerAliveCountMax=10 \
+              -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
               ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
               "$@"
           EOF
           chmod +x /tmp/ssh_exec.sh
+
+      - name: Warm-up do caminho SSH (curl 5x — Hostinger flaky, ver hostinger.md)
+        run: |
+          for i in 1 2 3 4 5; do
+            curl -4 -s -o /dev/null -w "$i:%{http_code} " https://oimpresso.com/login --max-time 15 || true
+          done; echo
 
       - name: Git pull
         run: |

--- a/memory/reference/hostinger.md
+++ b/memory/reference/hostinger.md
@@ -81,9 +81,11 @@ ssh -4 [...flags...] u906587222@148.135.133.115 \
 ```
 Validado 2026-04-27: Sprint 2 quebrou /memcofre+/copiloto em 5min, rollback em ~30s.
 
-### Workflows GitHub Actions
+### Workflows GitHub Actions (atualizado 2026-06-10 — ADR 0269)
 
-`.github/workflows/deploy.yml` é manual (`workflow_dispatch`). `quick-sync.yml` está QUEBRADO desde 2026-04-26 (falha Setup SSH). Hostinger NÃO recebe deploys automáticos — sempre pull manual via SSH após merge.
+`.github/workflows/deploy.yml` **auto-deploya em push pra main** (paths-ignore docs) — build no runner + bundles via tar/ssh + OPcache reset confirmado + smoke de hash. `workflow_dispatch` mantido como fallback. `quick-sync.yml` virou **escape manual** (`workflow_dispatch`-only); `force-clean-rebuild-trigger.yml` segue como nuclear manual.
+
+> **Os helpers SSH desses workflows usam os flags canônicos desta página** (`-4` IPv4, `ConnectTimeout`, `ConnectionAttempts=5`, `ServerAlive`) + warm-up curl 5× antes do 1º SSH. Sem o `-4` o runner tentava IPv6 e dava `Connection timed out` em massa (incidente 2026-06-10). **ControlMaster (multiplexing) continua proibido** — falha `mux_client_request_session`; é 1 conexão por comando mesmo.
 
 ## hPanel acesso humano
 


### PR DESCRIPTION
## Causa raiz (não era multiplexing)

Os deploys de hoje à noite falharam em massa com `ssh: connect to host ***: Connection timed out` (exit 255). Wagner mandou ler `memory/reference/hostinger.md` — e o doc canônico já tinha a resposta:

- **`-4` (IPv4) é OBRIGATÓRIO** — "IPv6 falha" no Hostinger. O helper SSH dos workflows **não tinha** → o runner tentava IPv6 → timeout em massa.
- **Warm-up:** "Sem warm-up, primeiro SSH quase sempre dá Connection timed out" (5× curl /login antes do 1º SSH).
- Flags fracos: `ConnectTimeout=20` (curto), sem `ConnectionAttempts`, sem `ServerAlive`.
- **ControlMaster (multiplexing) NÃO funciona** no Hostinger (`mux_client_request_session`) — então a ideia inicial de "1 conexão por deploy" estava errada. É 1 conexão por comando mesmo.

## Fix (recipe canônico do hostinger.md em todos os 3 workflows)

`deploy.yml` + `quick-sync.yml` + `force-clean-rebuild-trigger.yml`:
- `ssh -4 -o BatchMode=yes -o ConnectTimeout=60 -o ConnectionAttempts=5 -o ServerAliveInterval=15 -o ServerAliveCountMax=10`
- step **Warm-up** (curl 5× IPv4 /login) antes do 1º SSH
- keyscan `|| true` também no force-clean (consistência)
- `hostinger.md` §Workflows atualizado (refletindo o auto-deploy ADR 0269 + os flags)

## Nota

O site está e esteve **200** o tempo todo — as falhas 255 foram **antes** do `maintenance ON`, então nunca tocaram o prod. Este PR torna o auto-deploy confiável de verdade. Vou observar o run pós-merge.

Refs: ADR 0269 · `memory/reference/hostinger.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)