### PR TITLE
fix(oficina): drawer da OS nao quebra (tela branca) com item de tipo fora do enum

### DIFF
--- a/Modules/OficinaAuto/Console/Commands/OficinaBoardDemoCommand.php
+++ b/Modules/OficinaAuto/Console/Commands/OficinaBoardDemoCommand.php
@@ -180,7 +180,7 @@ class OficinaBoardDemoCommand extends Command
             ServiceOrderItem::create([
                 'business_id'    => $biz,
                 'service_order_id' => $order->id,
-                'tipo'           => 'servico',
+                'tipo'           => 'mao_obra', // enum válido (peca|mao_obra|servico_terceiro)
                 'descricao'      => $spec['sintoma'],
                 'quantidade'     => 1,
                 'valor_unitario' => $spec['valor'],

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemRow.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemRow.tsx
@@ -35,15 +35,21 @@ interface Props {
   busy?: boolean;
 }
 
-const TIPO_LABEL: Record<ItemTipo, string> = {
+// Record<string> (não Record<ItemTipo>) + lookup com fallback: blinda contra um
+// `tipo` fora do enum vindo do backend/dado legado. Sem isso, um tipo não-mapeado
+// faz TIPO_ICON[tipo] = undefined → <Icon/> = React #130 = TELA BRANCA na OS
+// inteira (incidente 2026-06-10 — item com tipo='servico' fora do enum).
+const TIPO_LABEL: Record<string, string> = {
   peca: 'Peça',
   mao_obra: 'Mão de obra',
+  servico: 'Serviço',
   servico_terceiro: 'Serviço terceiro',
 };
 
-const TIPO_ICON: Record<ItemTipo, typeof Wrench> = {
+const TIPO_ICON: Record<string, typeof Wrench> = {
   peca: Package,
   mao_obra: Wrench,
+  servico: Wrench,
   servico_terceiro: UserCog,
 };
 
@@ -59,7 +65,8 @@ function formatBRL(value: number | string | null | undefined): string {
 }
 
 export default function ServiceOrderItemRow({ item, onEdit, onDelete, busy = false }: Props) {
-  const Icon = TIPO_ICON[item.tipo];
+  const Icon = TIPO_ICON[item.tipo] ?? Wrench;
+  const tipoLabel = TIPO_LABEL[item.tipo] ?? item.tipo;
   const qtd = toFloat(item.quantidade);
   const vu = toFloat(item.valor_unitario);
   const total = toFloat(item.valor_total);
@@ -75,7 +82,7 @@ export default function ServiceOrderItemRow({ item, onEdit, onDelete, busy = fal
         <Box className="min-w-0 flex-1">
           <div className="text-foreground font-medium truncate">{item.descricao}</div>
           <div className="text-muted-foreground text-[10.5px]">
-            {TIPO_LABEL[item.tipo]} ·{' '}
+            {tipoLabel} ·{' '}
             {qtd.toLocaleString('pt-BR', { maximumFractionDigits: 3 })} × {formatBRL(vu)}
           </div>
         </Box>


### PR DESCRIPTION
Bug: tela branca ao abrir OS com item de tipo fora do enum (React #130). ServiceOrderItemRow fazia TIPO_ICON[tipo]=undefined. Fix: Record<string> + fallback (Icon ?? Wrench, label ?? tipo) + 'servico' mapeado. Seeder demo: 'servico' -> 'mao_obra'. tsc/eslint/php-l limpos; repro confirmada via browser MCP.

Generated with Claude Code