### PR TITLE
ci(governance): governance-drift always-run no PR — required-readiness do ADR 0216 PR scan

### DIFF
--- a/.github/workflows/governance-drift.yml
+++ b/.github/workflows/governance-drift.yml
@@ -1,22 +1,16 @@
 name: Governance Drift Framework — ADR 0216
 
 # Generaliza secrets-governance.yml (ADR 0215) — orquestra TODOS DriftCheckers
-# via governance:audit. Canary 7d: roda em paralelo com secrets-governance.yml
-# legacy. PR cleanup remove o legacy depois.
+# via governance:audit. (secrets-governance.yml legacy foi consolidado aqui
+# na ADR 0271 onda 2 — canary ADR 0216 encerrado.)
 
 on:
+  # ADR 0271 onda 2 (follow-up B — required-readiness): pull_request SEM paths
+  # (always-run) pra promover "ADR 0216 PR scan" a required sem deadlock
+  # "Expected — waiting". O --diff-only passa trivial em diff fora de escopo;
+  # o custo fixo (composer+npm ~2-3min) foi aceito por Wagner 2026-06-11.
   pull_request:
     branches: [main]
-    paths:
-      - 'memory/**'
-      - 'config/**'
-      - 'Modules/**'
-      - 'app/**'
-      - 'composer.json'
-      - 'composer.lock'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.env.example'
   schedule:
     # Daily 06:35 BRT (09:35 UTC) — Camada 3 ADR 0216 health-check + auto-PR
     - cron: '35 9 * * *'


### PR DESCRIPTION
## ADR 0271 onda 2 — follow-up B (Variante B do handoff)

Remove o `paths:` do trigger `pull_request` do `governance-drift.yml` (always-run), pré-requisito pra promover **`ADR 0216 PR scan (governance:audit --diff-only)`** a required check sem o deadlock "Expected — waiting" (lição ADR 0261).

- `--diff-only` passa trivial quando o PR não toca escopo de drift — custo fixo = composer+npm (~2-3min/PR), aceito por Wagner 2026-06-11.
- `schedule` (daily 06:35 BRT + `secrets:audit --auto-pr`) e `workflow_dispatch` intactos.
- Header do workflow atualizado: canary ADR 0216 encerrado (legacy consolidado na onda 2, PR #2531).

**Pós-merge:** PATCH na branch protection adicionando o 14º required (comando da Variante B no handoff [2026-06-11-1145-gates-onda2-adr0271](memory/handoffs/2026-06-11-1145-gates-onda2-adr0271.md)).

Refs: ADR 0271 onda 2 · #2531

🤖 Generated with [Claude Code](https://claude.com/claude-code)