### PR TITLE
feat(oficina): Lista e Fila alinhadas ao canon do Board — KPIs clicáveis, filtros consolidados, meta-grid, timeline e sheets canon

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -87,6 +87,12 @@ class ServiceOrderController extends Controller
             'vehicle:' . implode(',', $vehicleCols),
         ]);
 
+        // Coluna VALOR da listagem com dado REAL (polish canon Board 2026-06-11):
+        // soma dos itens da OS (peças + mão-de-obra) via withSum — 1 subquery, sem N+1.
+        // O accessor valor_receber é sempre 0.0 (locação erradicada, ADR 0265); o valor
+        // de reparo vive em oficina_service_order_items.valor_total (US-OFICINA-027).
+        $base->withSum('items as items_total', 'valor_total');
+
         if ($hasContact) {
             $base->with('contact:id,name');
         }

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexItemsTotalTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexItemsTotalTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Polish canon Board 2026-06-11 — coluna VALOR da listagem com dado REAL.
+ *
+ * O accessor `valor_receber` é sempre 0.0 (locação erradicada, ADR 0265); o valor
+ * de reparo vive em `oficina_service_order_items.valor_total`. O index() passou a
+ * anexar `items_total` via `withSum('items as items_total', 'valor_total')` —
+ * 1 subquery agregada, sem N+1 na paginação.
+ *
+ * Valida a MESMA query do controller (validação direta — não roda HTTP middleware
+ * UltimatePOS, pattern ServiceOrderIndexStageFilterTest):
+ *   1. OS com itens → items_total = soma de valor_total
+ *   2. OS sem itens → items_total NULL (frontend formatBRL(null) → "—")
+ *   3. Multi-tenant Tier 0 — itens de OS de outro business não somam (FK por OS)
+ *
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php (método index)
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx (coluna VALOR)
+ */
+
+const BIZ_ITOTAL = 1;
+const PLATE_ITOTAL_PREFIX = 'ITOT';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('oficina_service_order_items')) {
+        $this->markTestSkipped('Rode migration 2026_05_17_000010 primeiro');
+    }
+});
+
+function itotal_criaOs(string $suffix, int $biz = BIZ_ITOTAL): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_ITOTAL_PREFIX . $suffix,
+        'vehicle_type' => 'caminhao',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => 'mecanica',
+        'status'      => 'aberta',
+        'entered_at'  => now(),
+    ]);
+}
+
+function itotal_cleanup(): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', 'like', PLATE_ITOTAL_PREFIX . '%')
+        ->pluck('id')
+        ->toArray();
+
+    if (empty($vehicles)) {
+        return;
+    }
+
+    $osIds = ServiceOrder::withoutGlobalScopes()
+        ->whereIn('vehicle_id', $vehicles)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($osIds)) {
+        ServiceOrderItem::withoutGlobalScopes()->whereIn('service_order_id', $osIds)->forceDelete();
+        ServiceOrder::withoutGlobalScopes()->whereIn('id', $osIds)->forceDelete();
+    }
+
+    Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+}
+
+it('1. withSum items_total soma valor_total dos itens da OS (mesma query do index)', function () {
+    session(['user.business_id' => BIZ_ITOTAL]);
+    $os = itotal_criaOs('A');
+
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_ITOTAL,
+        'service_order_id' => $os->id,
+        'tipo'             => 'peca',
+        'descricao'        => 'Disco de freio',
+        'quantidade'       => 2,
+        'valor_unitario'   => 300,
+    ]);
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_ITOTAL,
+        'service_order_id' => $os->id,
+        'tipo'             => 'mao_obra',
+        'descricao'        => 'Troca de discos',
+        'quantidade'       => 2,
+        'valor_unitario'   => 100,
+    ]);
+
+    $row = ServiceOrder::query()
+        ->withSum('items as items_total', 'valor_total')
+        ->find($os->id);
+
+    expect((float) $row->items_total)->toBe(800.0);
+})->afterEach(fn () => itotal_cleanup());
+
+it('2. OS sem itens → items_total NULL (frontend renderiza "—")', function () {
+    session(['user.business_id' => BIZ_ITOTAL]);
+    $os = itotal_criaOs('B');
+
+    $row = ServiceOrder::query()
+        ->withSum('items as items_total', 'valor_total')
+        ->find($os->id);
+
+    expect($row->items_total)->toBeNull();
+})->afterEach(fn () => itotal_cleanup());
+
+it('3. multi-tenant Tier 0 — global scope filtra a OS de outro business inteira', function () {
+    session(['user.business_id' => BIZ_ITOTAL]);
+
+    $osBiz1 = itotal_criaOs('C');
+    $osBiz99 = itotal_criaOs('D', 99);
+
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => 99,
+        'service_order_id' => $osBiz99->id,
+        'tipo'             => 'peca',
+        'descricao'        => 'Item de outro tenant',
+        'quantidade'       => 1,
+        'valor_unitario'   => 9999,
+    ]);
+
+    $rows = ServiceOrder::query()
+        ->withSum('items as items_total', 'valor_total')
+        ->whereIn('id', [$osBiz1->id, $osBiz99->id])
+        ->get();
+
+    // Global scope (biz=1): só a OS do tenant aparece; a OS biz=99 (e os R$ dela) não vazam.
+    expect($rows->pluck('id')->all())->toBe([$osBiz1->id]);
+})->afterEach(fn () => itotal_cleanup());

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
@@ -93,8 +93,9 @@ import DragConfirmDialog, {
 } from '@/Pages/OficinaAuto/ProducaoOficina/_components/DragConfirmDialog';
 import ServiceOrderRichSheet from '@/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet';
 import ServiceOrderKanbanColumn from './_components/board/ServiceOrderKanbanColumn';
+import BoardKpiCard from './_components/board/BoardKpiCard';
 import type { BoardDensity, ServiceOrderCardData } from './_components/board/ServiceOrderKanbanCard';
-import { kpiTone, toneForColor, gradeGlyph, type KpiTone } from './_components/board/boardTone';
+import { toneForColor, gradeGlyph } from './_components/board/boardTone';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -683,7 +684,7 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
         <div className="bg-white border-b border-border px-6 py-3">
           <div className={'grid grid-cols-2 @[700px]/board:grid-cols-3 @[1100px]/board:grid-cols-6 gap-2'}>
             {kpiCards.map(({ id, filterKey, ...kpi }) => (
-              <KpiCard
+              <BoardKpiCard
                 key={id}
                 {...kpi}
                 active={filterKey !== null && kpiFilter === filterKey}
@@ -932,57 +933,8 @@ export default function ServiceOrdersBoard({ columns, kpis, process_seeded, filt
 ServiceOrdersBoard.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;
 
 // ─── Subcomponents ───────────────────────────────────────────────────────────
-
-interface KpiCardProps {
-  label: string;
-  value: string;
-  /** sublinha descritiva (paridade Cowork — ex.: "faturamento previsto") */
-  sub?: string;
-  tone: KpiTone;
-  /** D-05 — KPI ativo como filtro (anel primary + aria-pressed) */
-  active?: boolean;
-  /** D-05 — outro KPI está filtrando (esmaece este) */
-  dimmed?: boolean;
-  /** presente = KPI filtrável (vira role=button); ausente = só leitura (ex.: valor) */
-  onClick?: () => void;
-}
-
-function KpiCard({ label, value, sub, tone, active = false, dimmed = false, onClick }: KpiCardProps) {
-  const t = kpiTone(tone);
-
-  const inner = (
-    <>
-      <span className={`text-[10px] font-semibold uppercase tracking-wider truncate ${t.label}`}>{label}</span>
-      <span className={`text-xl @[1100px]/board:text-2xl font-bold tabular-nums ${t.value}`}>{value}</span>
-      {sub ? <span className="text-[10px] text-muted-foreground truncate leading-tight">{sub}</span> : null}
-    </>
-  );
-
-  // KPI filtrável é <button> de verdade (a11y nativa: foco, Enter/Space, aria-pressed)
-  if (onClick !== undefined) {
-    return (
-      <button
-        type="button"
-        className={
-          `rounded-lg border px-3 py-2 flex flex-col gap-0.5 text-left w-full cursor-pointer select-none transition-all hover:shadow-sm ${t.wrapper}`
-          + (active ? ' ring-2 ring-primary ring-offset-1' : '')
-          + (dimmed ? ' opacity-50' : '')
-        }
-        aria-pressed={active}
-        title={active ? 'Clique pra limpar o filtro' : `Filtrar o quadro: ${label}`}
-        onClick={onClick}
-      >
-        {inner}
-      </button>
-    );
-  }
-
-  return (
-    <div className={`rounded-lg border px-3 py-2 flex flex-col gap-0.5 ${t.wrapper}`}>
-      {inner}
-    </div>
-  );
-}
+// KpiCard extraído pra ./_components/board/BoardKpiCard (2026-06-11) — a Index
+// passou a usar o MESMO canon de KPI clicável; um único componente pros dois.
 
 // ─── Grade (veículo × etapa · Onda 2) ────────────────────────────────────────
 // View de varredura client-side: cada linha é uma OS (placa + modelo + cliente),

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/service-orders
 component: resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
 owner: wagner
 status: live
-last_validated: "2026-06-09"
+last_validated: "2026-06-11"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada
@@ -15,7 +15,7 @@ related_adrs:
   - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
   - 0265-oficina-reparo-erradica-locacao
 tier: A
-charter_version: 3
+charter_version: 4
 ---
 
 # Page Charter — /oficina-auto/service-orders
@@ -33,8 +33,10 @@ Dashboard operacional pra atendente/gerente da oficina decidir próxima ação e
 ## Goals — Features (faz)
 
 - AppShellV2 + topnav padrão Cockpit V2 (ADR 0110)
-- `<PageHeader>` shared (h1 "Ordens de Serviço" + subtitle + ações Criar OS / Importer Firebird)
-- KpiGrid topo (reparo, ADR 0265): em diagnóstico, aguardando aprovação, em execução, atrasadas — **sem** "locações ativas"
+- `<PageHeader>` shared (h1 "Ordens de Serviço" + subtítulo descritivo, sem círculo decorativo de ícone — v4)
+- KPIs topo no canon do Board (`BoardKpiCard` — label uppercase + número tabular-nums + sublinha) e **clicáveis como filtro D-05** (clica filtra `?status=`, clica de novo limpa, chip "limpar filtro" na toolbar) — substituem as abas Todas/Em andamento/Concluídas mês/Atrasadas (v4)
+- Toolbar única canon `.ofc-view-toolbar`: busca com limpar (×) + contador "N OS", tipo (Mecânica/Manutenção), chips de estágio FSM, toggle **Quadro · Lista · Fila** (Quadro navega pro `/board` — simetria com o toggle do Board) (v4)
+- Coluna VALOR com dado real `items_total` (withSum dos itens da OS — `valor_receber` é accessor sempre-0 pós-ADR 0265); indicador de atraso único (pill "Atrasada", sem dot duplicado) (v4)
 - Listagem com filtros: status, order_type (manutencao/mecanica — **sem** locacao), vehicle.plate, contact, intervalo de datas
 - Badge status semântico (rose=atrasada, amber=orcamento aguardando, blue=em_servico, emerald=concluida)
 - Drawer detail (ServiceOrderSheet) ao clicar linha — FSM action panel + timeline append-only
@@ -81,3 +83,4 @@ Dashboard operacional pra atendente/gerente da oficina decidir próxima ação e
 
 - **2026-05-26** (v2) — Cockpit Pattern V2; KPI "locações ativas" + colunas locação mantidos.
 - **2026-06-09** (v3) — sweep ADR 0265 no front ([sessão](../../../../../memory/sessions/2026-06-09-sweep-os-front-adr0265.md) · [avaliação CC](../../../../../prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md)): KPI "Locações ativas" **morto**; colunas/pills/badges de locação → reparo (`OrderType = {manutencao, mecanica}`); `formatBRL(null)` → "—". `mecanica` deixou de cair no ramo locação.
+- **2026-06-11** (v4) — polish canon Board (pedido [W], mesmo canon Cowork oficina-page/oficina-fila): header sem círculo decorativo; KPIs no `BoardKpiCard` (extraído do Board) clicáveis D-05 substituindo as abas de status; toolbar única (busca+limpar+contador · tipo · estágio FSM · toggle Quadro/Lista/Fila); VALOR real (`items_total` via withSum); dot vermelho de atraso removido (pill única). FILA: caixa cinza → meta-grid canon (label 11px/valor 13px tabular-nums, defeito full-row), `ServiceOrderTimeline` no canon `.ofc-timeline` (fio+dot+quem·quando, sem pills com seta), stepper com labels truncadas (flex-1 min-w-0). DRAWER (`ServiceOrderSheet`): header eyebrow "OS #N · etapa" + badge tipo fora do título + h2 17px veículo + p 12.5px cliente, MiniKpi → meta compacta (Entrada/Valor BRL à direita), seções border-top fino (mesmo Section do RichSheet), Cancelar OS vira outline destructive.

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -6,17 +6,32 @@
 // null→"—" (antes vazava "R$ [redacted Tier 0]" literal na UI).
 // Espelha layout Vehicles Index (Wave 5-B).
 // RUNBOOK: memory/requisitos/OficinaAuto/RUNBOOK-index.md
+//
+// Polish canon Board [CC] 2026-06-11 (pedido [W] — alinhar Lista/Fila à língua
+// visual do Board aprovado, mesmo canon Cowork oficina-page/oficina-fila):
+//   1. Header sem círculo decorativo (PageHeader recebia ReactNode em prop string
+//      `icon` — renderizava caixa vazia): h1 + subtítulo descritivo, só Nova OS.
+//   2. KPIs no canon do Board (BoardKpiCard: label uppercase 10px + número grande
+//      tabular-nums + sublinha) e CLICÁVEIS como filtro D-05 (clica filtra ·
+//      clica de novo limpa · chip "limpar filtro" na toolbar).
+//   3. Abas Todas/Em andamento/Concluídas mês/Atrasadas REMOVIDAS (redundantes
+//      com os KPIs clicáveis). Toolbar única (canon .ofc-view-toolbar): busca com
+//      limpar (×) + contador, tipo, chips de estágio FSM e toggle de views.
+//   4. Coluna VALOR com dado REAL (items_total via withSum no Controller — o
+//      valor_receber é accessor sempre-0 pós-ADR 0265); indicador de atraso
+//      ÚNICO (pill "Atrasada" do StatusBadge; dot vermelho removido).
+//   5. Toggle Quadro · Lista · Fila — Quadro navega pro /board (simetria com o
+//      toggle do Board, que navega pra cá).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router } from '@inertiajs/react';
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
-import { Wrench, Plus, Search, LayoutGrid, List, PanelLeft } from 'lucide-react';
+import { Plus, Search, LayoutGrid, List as ListIcon, ListOrdered, X } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
-import KpiGrid from '@/Components/shared/KpiGrid';
-import KpiCard from '@/Components/shared/KpiCard';
+import BoardKpiCard from './_components/board/BoardKpiCard';
 import ServiceOrderStatusBadge from './_components/ServiceOrderStatusBadge';
 import ServiceOrderSheet from './_components/ServiceOrderSheet';
 import ServiceOrderFila from './_components/ServiceOrderFila';
@@ -64,7 +79,9 @@ interface ServiceOrder {
   vehicle?: VehicleRel | null;
   contact?: ContactRel | null;
   is_overdue?: boolean;
-  valor_receber?: number | string | null;
+  // Soma REAL dos itens da OS (withSum no index — peças + mão-de-obra). NULL
+  // quando a OS não tem item lançado. Substitui valor_receber (accessor sempre-0).
+  items_total?: number | string | null;
 }
 
 interface PaginatedOrders {
@@ -129,12 +146,18 @@ const EMPTY_KPIS: Kpis = {
 };
 
 // ──────── Helpers ────────
-const STATUS_PILLS: Array<{ key: string; label: string }> = [
-  { key: 'all', label: 'Todas' },
-  { key: 'manutencao_ativa', label: 'Em andamento' },
-  { key: 'concluida_mes', label: 'Concluídas mês' },
-  { key: 'atrasada', label: 'Atrasadas' },
+// D-05 — KPI clicável É o filtro de status (as abas Todas/Em andamento/Concluídas
+// mês/Atrasadas eram redundantes e foram removidas no polish canon Board 2026-06-11).
+// key = mesmo valor que o filtro ?status= do Controller (manutencao_ativa etc).
+const KPI_STATUS_FILTERS = [
+  { key: 'manutencao_ativa', label: 'Em andamento', sub: 'OS abertas em reparo', tone: 'indigo' as const },
+  { key: 'concluida_mes', label: 'Concluídas no mês', sub: 'finalizadas no mês corrente', tone: 'emerald' as const },
+  { key: 'atrasada', label: 'Atrasadas', sub: null, tone: 'rose' as const },
 ];
+
+const KPI_FILTER_LABEL: Record<string, string> = Object.fromEntries(
+  KPI_STATUS_FILTERS.map((k) => [k.key, k.label]),
+);
 
 const TYPE_PILLS: Array<{ key: string; label: string }> = [
   { key: 'all', label: 'Todos os tipos' },
@@ -254,30 +277,30 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
 
   const subtitle = `${kpis.manutencao_ativas} em andamento · ${kpis.concluidas_mes} concluídas no mês · ${kpis.atrasadas} atrasadas`;
 
+  // D-05 — filtro de status ativo (vem da querystring; KPI clicado = filtro aplicado)
+  const kpiStatusActive = filters.status && filters.status !== 'all' ? filters.status : null;
+  const kpiValueByKey: Record<string, number> = {
+    manutencao_ativa: kpis.manutencao_ativas,
+    concluida_mes: kpis.concluidas_mes,
+    atrasada: kpis.atrasadas,
+  };
+
   return (
     <AppShellV2>
       <Head title="Ordens de Serviço · Oficina Auto" />
       <div className="px-4 py-6 max-w-7xl mx-auto space-y-6">
+        {/* Header canon do Board: h1 + subtítulo descritivo, sem círculo decorativo.
+            "Quadro" saiu daqui — vive no toggle de views (simetria com o Board). */}
         <PageHeader
           title="Ordens de Serviço"
-          subtitle={subtitle}
-          icon={<Wrench className="size-5" />}
-          actions={
-            <div className="flex items-center gap-2">
-              {/* Quadro (Kanban) das OS de mecânica — fluxo real do carro ([W] 2026-06-02) */}
-              <Link href="/oficina-auto/ordens-servico/board">
-                <Button variant="outline">
-                  <LayoutGrid className="size-4 mr-1" />
-                  Quadro
-                </Button>
-              </Link>
-              <Link href="/oficina-auto/ordens-servico/create">
-                <Button>
-                  <Plus className="size-4 mr-1" />
-                  Nova OS
-                </Button>
-              </Link>
-            </div>
+          description={subtitle}
+          action={
+            <Link href="/oficina-auto/ordens-servico/create">
+              <Button>
+                <Plus className="size-4 mr-1" />
+                Nova OS
+              </Button>
+            </Link>
           }
         />
 
@@ -289,168 +312,189 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
           </div>
         )}
 
-        {/* KPIs — reparo (ADR 0265: KPI de locação morreu com o domínio) */}
-        <KpiGrid cols={3}>
-          <KpiCard
-            label="Em andamento"
-            value={kpis.manutencao_ativas}
-            tone="warning"
-            icon="wrench"
-          />
-          <KpiCard
-            label="Concluídas este mês"
-            value={kpis.concluidas_mes}
-            tone="success"
-            icon="check-circle-2"
-          />
-          <KpiCard
-            label="Atrasadas"
-            value={kpis.atrasadas}
-            tone="danger"
-            icon="alert-triangle"
-            description={kpis.atrasadas > 0 ? 'Cobrar imediatamente' : 'Tudo no prazo'}
-          />
-        </KpiGrid>
+        {/* KPIs canon do Board (BoardKpiCard) — CLICÁVEIS como filtro D-05:
+            clica filtra (?status=), clica de novo limpa; chip "limpar" na toolbar. */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+          {KPI_STATUS_FILTERS.map((kpi) => (
+            <BoardKpiCard
+              key={kpi.key}
+              label={kpi.label}
+              value={String(kpiValueByKey[kpi.key] ?? 0)}
+              sub={
+                kpi.key === 'atrasada'
+                  ? kpis.atrasadas > 0 ? 'cobrar imediatamente' : 'tudo no prazo'
+                  : kpi.sub ?? undefined
+              }
+              tone={kpi.tone}
+              active={kpiStatusActive === kpi.key}
+              dimmed={kpiStatusActive !== null && kpiStatusActive !== kpi.key}
+              onClick={() => applyFilter({ status: kpiStatusActive === kpi.key ? 'all' : kpi.key })}
+            />
+          ))}
+        </div>
 
-        {/* Toolbar: filter pills + tipo + search */}
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="inline-flex rounded-md border border-border overflow-hidden">
-            {STATUS_PILLS.map((pill) => {
-              const active = (filters.status || 'all') === pill.key;
-              return (
+        {/* Toolbar única (canon .ofc-view-toolbar do Board): [busca + limpar + chip
+            KPI + contador] | [tipo] | [toggle Quadro·Lista·Fila] — as abas de status
+            foram absorvidas pelos KPIs clicáveis. Chips de estágio FSM logo abaixo. */}
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <form onSubmit={handleSearchSubmit} className="flex flex-1 min-w-[240px] items-center gap-2">
+              <Search size={14} className="text-muted-foreground flex-shrink-0" />
+              <div className="relative flex-1 max-w-md">
+                <Input
+                  type="search"
+                  placeholder="Buscar OS, cliente ou placa…"
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  className="h-8 border-border pr-7"
+                  aria-label="Buscar OS, cliente ou placa"
+                />
+                {q !== '' && (
+                  <button
+                    type="button"
+                    className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                    onClick={() => setQ('')}
+                    aria-label="Limpar busca"
+                  >
+                    <X size={12} />
+                  </button>
+                )}
+              </div>
+
+              {/* D-05 — chip do KPI-filtro ativo (clicar limpa) */}
+              {kpiStatusActive && KPI_FILTER_LABEL[kpiStatusActive] && (
                 <button
-                  key={pill.key}
                   type="button"
-                  onClick={() => applyFilter({ status: pill.key })}
-                  className={cn(
-                    'px-3 py-1.5 text-sm transition-colors',
-                    active
-                      ? 'bg-muted text-foreground font-medium'
-                      : 'bg-background text-muted-foreground hover:bg-muted/50',
-                  )}
+                  className="inline-flex items-center gap-1 text-[11px] font-medium text-primary bg-primary/10 border border-primary/30 rounded-full px-2 py-0.5 hover:bg-primary/15 whitespace-nowrap"
+                  onClick={() => applyFilter({ status: 'all' })}
                 >
-                  {pill.label}
+                  <X size={10} /> limpar filtro: {KPI_FILTER_LABEL[kpiStatusActive]}
                 </button>
-              );
-            })}
+              )}
+
+              <span className="ml-auto pl-2 text-sm text-muted-foreground whitespace-nowrap" aria-live="polite">
+                <span className="font-medium text-foreground tabular-nums">{orders.total} OS</span>
+                {kpis.atrasadas > 0 && (
+                  <>
+                    <span className="mx-1.5">·</span>
+                    <span className="font-medium text-destructive tabular-nums">
+                      {kpis.atrasadas} atrasada{kpis.atrasadas === 1 ? '' : 's'}
+                    </span>
+                  </>
+                )}
+              </span>
+            </form>
+
+            {schemaFlags.has_order_type && (
+              <div className="inline-flex flex-shrink-0 rounded border border-border bg-white overflow-hidden" role="group" aria-label="Filtrar por tipo">
+                {TYPE_PILLS.map((pill, i) => {
+                  const active = (filters.type || 'all') === pill.key;
+                  return (
+                    <button
+                      key={pill.key}
+                      type="button"
+                      onClick={() => applyFilter({ type: pill.key })}
+                      aria-pressed={active}
+                      className={cn(
+                        'px-2.5 py-1 text-xs font-medium transition-colors',
+                        i > 0 && 'border-l border-border',
+                        active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50',
+                      )}
+                    >
+                      {pill.label}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Toggle de views (simetria com o Board): Quadro navega pro kanban;
+                Lista/Fila são in-page (?view=). */}
+            <div className="inline-flex flex-shrink-0 rounded border border-border bg-white overflow-hidden" role="group" aria-label="Visualização">
+              <Link
+                href="/oficina-auto/ordens-servico/board"
+                className="px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 text-foreground hover:bg-muted transition-colors"
+              >
+                <LayoutGrid size={12} /> Quadro
+              </Link>
+              <button
+                type="button"
+                onClick={() => changeView('lista')}
+                aria-pressed={view === 'lista'}
+                className={cn(
+                  'px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 transition-colors border-l border-border',
+                  view === 'lista' ? 'bg-primary text-white' : 'text-foreground hover:bg-muted',
+                )}
+              >
+                <ListIcon size={12} /> Lista
+              </button>
+              <button
+                type="button"
+                onClick={() => changeView('fila')}
+                aria-pressed={view === 'fila'}
+                className={cn(
+                  'px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 transition-colors border-l border-border',
+                  view === 'fila' ? 'bg-primary text-white' : 'text-foreground hover:bg-muted',
+                )}
+              >
+                <ListOrdered size={12} /> Fila
+              </button>
+            </div>
           </div>
 
-          {schemaFlags.has_order_type && (
-            <div className="inline-flex rounded-md border border-border overflow-hidden">
-              {TYPE_PILLS.map((pill) => {
-                const active = (filters.type || 'all') === pill.key;
+          {/* Gap #3 — chips de stage FSM estilo Linear (Wave 7-D). */}
+          {schemaFlags.has_current_stage && stages && stages.length > 0 && (
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground mr-1">
+                Estágio FSM:
+              </span>
+              <button
+                type="button"
+                onClick={() => applyFilter({ stage: 'all' })}
+                className={cn(
+                  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
+                  (filters.stage || 'all') === 'all'
+                    ? 'border-foreground bg-foreground text-background'
+                    : 'border-border text-muted-foreground hover:bg-muted/50',
+                )}
+              >
+                Todos
+              </button>
+              {stages.map((stage) => {
+                const active = filters.stage === stage.key;
+                const colors = STAGE_CHIP_COLOR_MAP[stage.color ?? 'gray'] ?? STAGE_CHIP_FALLBACK;
                 return (
                   <button
-                    key={pill.key}
+                    key={`${stage.process_key}-${stage.key}`}
                     type="button"
-                    onClick={() => applyFilter({ type: pill.key })}
+                    onClick={() => applyFilter({ stage: stage.key })}
+                    title={stage.is_terminal ? `${stage.name} (terminal)` : stage.name}
                     className={cn(
-                      'px-3 py-1.5 text-sm transition-colors',
-                      active
-                        ? 'bg-muted text-foreground font-medium'
-                        : 'bg-background text-muted-foreground hover:bg-muted/50',
+                      'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
+                      active ? colors.active : colors.idle,
+                      stage.is_terminal && !active && 'opacity-70',
                     )}
                   >
-                    {pill.label}
+                    <span>{stage.name}</span>
+                    <span
+                      className={cn(
+                        'inline-flex min-w-[18px] justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums',
+                        active ? 'bg-background/40' : 'bg-background',
+                      )}
+                    >
+                      {stage.count}
+                    </span>
                   </button>
                 );
               })}
             </div>
           )}
-
-          <form onSubmit={handleSearchSubmit} className="ml-auto flex gap-2">
-            <Input
-              placeholder="Buscar OS, cliente ou placa…"
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              className="w-64"
-            />
-            <Button type="submit" variant="outline" size="sm">
-              <Search className="size-4" />
-            </Button>
-          </form>
-
-          {/* Toggle de view in-page: Lista (tabela densa) ↔ Fila (master-detail) */}
-          <div className="inline-flex overflow-hidden rounded-md border border-border" role="group" aria-label="Modo de visualização">
-            <button
-              type="button"
-              onClick={() => changeView('lista')}
-              aria-pressed={view === 'lista'}
-              className={cn(
-                'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm transition-colors',
-                view === 'lista' ? 'bg-muted font-medium text-foreground' : 'bg-background text-muted-foreground hover:bg-muted/50',
-              )}
-            >
-              <List className="size-4" />
-              Lista
-            </button>
-            <button
-              type="button"
-              onClick={() => changeView('fila')}
-              aria-pressed={view === 'fila'}
-              className={cn(
-                'inline-flex items-center gap-1.5 border-l border-border px-3 py-1.5 text-sm transition-colors',
-                view === 'fila' ? 'bg-muted font-medium text-foreground' : 'bg-background text-muted-foreground hover:bg-muted/50',
-              )}
-            >
-              <PanelLeft className="size-4" />
-              Fila
-            </button>
-          </div>
         </div>
-
-        {/* Gap #3 — chips de stage FSM estilo Linear (Wave 7-D). */}
-        {schemaFlags.has_current_stage && stages && stages.length > 0 && (
-          <div className="flex flex-wrap items-center gap-1.5">
-            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground mr-1">
-              Estágio FSM:
-            </span>
-            <button
-              type="button"
-              onClick={() => applyFilter({ stage: 'all' })}
-              className={cn(
-                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
-                (filters.stage || 'all') === 'all'
-                  ? 'border-foreground bg-foreground text-background'
-                  : 'border-border text-muted-foreground hover:bg-muted/50',
-              )}
-            >
-              Todos
-            </button>
-            {stages.map((stage) => {
-              const active = filters.stage === stage.key;
-              const colors = STAGE_CHIP_COLOR_MAP[stage.color ?? 'gray'] ?? STAGE_CHIP_FALLBACK;
-              return (
-                <button
-                  key={`${stage.process_key}-${stage.key}`}
-                  type="button"
-                  onClick={() => applyFilter({ stage: stage.key })}
-                  title={stage.is_terminal ? `${stage.name} (terminal)` : stage.name}
-                  className={cn(
-                    'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
-                    active ? colors.active : colors.idle,
-                    stage.is_terminal && !active && 'opacity-70',
-                  )}
-                >
-                  <span>{stage.name}</span>
-                  <span
-                    className={cn(
-                      'inline-flex min-w-[18px] justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums',
-                      active ? 'bg-background/40' : 'bg-background',
-                    )}
-                  >
-                    {stage.count}
-                  </span>
-                </button>
-              );
-            })}
-          </div>
-        )}
 
         {/* Tabela / Empty state */}
         {orders.data.length === 0 ? (
           <EmptyState
-            icon={<Wrench className="size-12" />}
+            icon="wrench"
             title="Nenhuma OS encontrada"
             description={
               filters.status || filters.type || filters.stage || filters.q
@@ -507,13 +551,9 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                         )}
                         onClick={() => setOpenOsId(o.id)}
                       >
+                        {/* Indicador de atraso ÚNICO: pill "Atrasada" do StatusBadge
+                            (o dot vermelho duplicava o sinal — removido 2026-06-11). */}
                         <td className="px-3 py-2.5 font-mono font-semibold">
-                          {overdue && (
-                            <span
-                              className="inline-block w-2 h-2 rounded-full bg-rose-500 mr-1.5 align-middle"
-                              title="Atrasada"
-                            />
-                          )}
                           {o.number ?? `#${o.id}`}
                         </td>
                         <td className="px-3 py-2.5">
@@ -576,17 +616,14 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
                         >
                           {formatBRDate(prazo)}
                         </td>
+                        {/* VALOR real (items_total — soma dos itens da OS via withSum). */}
                         <td
                           className={cn(
                             'px-3 py-2.5 text-right tabular-nums',
-                            overdue
-                              ? 'text-rose-700 font-medium'
-                              : Number(o.valor_receber ?? 0) > 0
-                                ? 'text-amber-700'
-                                : 'text-muted-foreground',
+                            Number(o.items_total ?? 0) > 0 ? 'text-foreground font-medium' : 'text-muted-foreground',
                           )}
                         >
-                          {formatBRL(o.valor_receber)}
+                          {formatBRL(o.items_total)}
                         </td>
                         <td className="px-3 py-2.5">
                           <ServiceOrderStatusBadge

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFila.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFila.tsx
@@ -46,7 +46,9 @@ export interface FilaOrder {
   } | null;
   contact?: { id: number; name: string } | null;
   is_overdue?: boolean;
-  valor_receber?: number | string | null;
+  // Soma REAL dos itens da OS (withSum no index do Controller — peças + mão-de-obra).
+  // Substitui valor_receber (accessor sempre-0 pós-ADR 0265).
+  items_total?: number | string | null;
 }
 
 interface Props {
@@ -214,37 +216,27 @@ function OsDetailInline({
         {/* Pipeline FSM ao vivo (mesmo componente do drawer) */}
         <ServiceOrderStagePipeline serviceOrderId={o.id} enabled />
 
-        {/* Resumo da OS */}
-        <dl className="grid grid-cols-2 gap-x-6 gap-y-2 rounded-md border bg-muted/20 px-4 py-3 text-sm sm:grid-cols-3">
-          <div>
-            <dt className="text-xs text-muted-foreground">Tipo</dt>
-            <dd className="text-foreground">{typeLabel(o.order_type)}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">Veículo</dt>
-            <dd className="truncate font-mono text-foreground">{vehicleLabel(o)}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">Início</dt>
-            <dd className="tabular-nums text-foreground">{formatBRDate(inicio)}</dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">Prazo</dt>
-            <dd className={cn('tabular-nums', overdue ? 'font-medium text-destructive' : 'text-foreground')}>
-              {formatBRDate(prazo)}
-              {overdue && ' ⚠'}
-            </dd>
-          </div>
-          <div>
-            <dt className="text-xs text-muted-foreground">A receber</dt>
-            <dd className={cn('tabular-nums', Number(o.valor_receber ?? 0) > 0 ? 'text-warning' : 'text-foreground')}>
-              {formatBRL(o.valor_receber)}
-            </dd>
-          </div>
+        {/* Resumo da OS — meta-grid canon (.ofc-veh-card dl do protótipo): grid
+            auto/1fr, label muted 11px + valor 13px tabular-nums; defeito em linha
+            própria full (col-span-2). A caixa cinza virou meta compacta. */}
+        <dl className="grid grid-cols-[auto_1fr] items-baseline gap-x-4 gap-y-1.5 px-0.5">
+          <dt className="text-[11px] text-muted-foreground">Tipo</dt>
+          <dd className="text-[13px] text-foreground">{typeLabel(o.order_type)}</dd>
+          <dt className="text-[11px] text-muted-foreground">Veículo</dt>
+          <dd className="truncate font-mono text-[13px] text-foreground">{vehicleLabel(o)}</dd>
+          <dt className="text-[11px] text-muted-foreground">Início</dt>
+          <dd className="text-[13px] tabular-nums text-foreground">{formatBRDate(inicio)}</dd>
+          <dt className={cn('text-[11px]', overdue ? 'font-medium text-destructive' : 'text-muted-foreground')}>Prazo</dt>
+          <dd className={cn('text-[13px] tabular-nums', overdue ? 'font-semibold text-destructive' : 'text-foreground')}>
+            {formatBRDate(prazo)}
+            {overdue && ' ⚠'}
+          </dd>
+          <dt className="text-[11px] text-muted-foreground">Valor</dt>
+          <dd className="text-[13px] tabular-nums text-foreground">{formatBRL(o.items_total)}</dd>
           {defeito && (
-            <div className="col-span-2 sm:col-span-3">
-              <dt className="text-xs text-muted-foreground">Defeito</dt>
-              <dd className="text-foreground">{o.notes}</dd>
+            <div className="col-span-2 mt-1 border-t border-border/60 pt-2">
+              <dt className="text-[11px] text-muted-foreground">Defeito</dt>
+              <dd className="text-[13px] leading-relaxed text-foreground">{o.notes}</dd>
             </div>
           )}
         </dl>
@@ -297,8 +289,8 @@ function AppsRail({
             <dd className={cn('tabular-nums', overdue ? 'font-medium text-destructive' : 'text-foreground')}>{formatBRDate(prazo)}</dd>
           </div>
           <div className="flex justify-between gap-2">
-            <dt className="text-muted-foreground">A receber</dt>
-            <dd className="font-mono tabular-nums text-foreground">{formatBRL(o.valor_receber)}</dd>
+            <dt className="text-muted-foreground">Valor</dt>
+            <dd className="font-mono tabular-nums text-foreground">{formatBRL(o.items_total)}</dd>
           </div>
         </dl>
         <button

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
@@ -95,6 +95,16 @@ function getCsrfToken(): string {
   return meta?.getAttribute('content') ?? '';
 }
 
+// Ação DESTRUTIVA (Cancelar OS etc) ≠ ação crítica positiva (Concluir/Aprovar).
+// Destrutiva vira outline discreto vermelho — não um sólido gigante competindo
+// com a ação primária da etapa (polish canon Board 2026-06-11).
+function isDestructiveAction(action: FsmAction): boolean {
+  return /cancel/i.test(action.key) || action.target_stage?.key === 'cancelada';
+}
+
+const DESTRUCTIVE_OUTLINE_CLASS =
+  'border-destructive/40 text-destructive hover:bg-destructive/10 hover:text-destructive';
+
 /**
  * Empty state quando OS ainda não tem current_stage_id (legada / pré-FSM).
  * Mostra botão "Iniciar pipeline FSM" que chama o endpoint backend Wave 7-A.
@@ -339,11 +349,12 @@ export default function ServiceOrderFsmActionPanel({
                   .map((r) => r.label)
                   .join(' · ')
               : '';
+            const destructive = isDestructiveAction(action);
             return (
               <Button
                 key={action.key}
                 size="sm"
-                variant={action.is_critical ? 'destructive' : 'default'}
+                variant={destructive ? 'outline' : 'default'}
                 onClick={() => executeAction(action)}
                 disabled={executing || gateBlocked}
                 title={
@@ -353,7 +364,7 @@ export default function ServiceOrderFsmActionPanel({
                       ? `Move pra: ${action.target_stage.name}`
                       : 'Ação que não transita stage'
                 }
-                className="text-xs"
+                className={'text-xs' + (destructive ? ` ${DESTRUCTIVE_OUTLINE_CLASS}` : '')}
               >
                 {gateBlocked ? (
                   <Lock size={12} className="mr-1" />
@@ -428,7 +439,7 @@ export default function ServiceOrderFsmActionPanel({
                 Cancelar
               </Button>
               <Button
-                variant={confirmAction.is_critical ? 'destructive' : 'default'}
+                variant={isDestructiveAction(confirmAction) ? 'destructive' : 'default'}
                 size="sm"
                 onClick={confirmExecute}
                 disabled={executing}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
@@ -58,11 +58,16 @@ interface ServiceOrderDetail {
   id: number;
   number: string | null;
   status: string;
+  // Etapa FSM atual (key + name PT) pro eyebrow do drawer — null quando o processo
+  // não está seedado pro negócio (cai no fallback de status). Mesmo payload do RichSheet.
+  current_stage?: { key: string; name: string } | null;
   order_type: OrderType;
   // Campos de locação (delivery_address/expected_return_date/daily_rate/dias_locacao)
   // erradicados do payload do show() — ADR 0265.
   expected_completion: string | null;
-  valor_receber: number | string | null;
+  // Soma real dos itens da OS (peças + mão-de-obra) — mesmo campo do RichSheet.
+  // valor_receber (accessor sempre-0 pós-ADR 0265) saiu da UI do drawer.
+  items_total?: number | string;
   is_overdue?: boolean;
   entered_at: string | null;
   started_at: string | null;
@@ -113,6 +118,11 @@ const formatDateOnly = (iso: string | null | undefined) => {
   const [y, m, d] = datePart.split('-');
   if (!y || !m || !d) return iso;
   return `${d}/${m}/${y}`;
+};
+
+const capitalize = (s: string | null | undefined) => {
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 };
 
 export default function ServiceOrderSheet({
@@ -189,60 +199,56 @@ export default function ServiceOrderSheet({
 
         {!loading && data && (
           <>
-            {/* Header drawer — número OS + tipo badge + cliente */}
-            <SheetHeader className="px-6 pt-6 pb-4 border-b border-border space-y-2">
-              <div className="flex items-center gap-2 flex-wrap">
-                <span className="font-mono text-xs text-muted-foreground">
-                  {data.number ?? `#${data.id}`}
+            {/* Header drawer (canon .prod-drawer-head — MESMO vocabulário do
+                RichSheet): eyebrow 11px uppercase "OS #104 · <etapa>" + badge do
+                tipo ao lado (NÃO no título), h2 17px = veículo, p 12.5px = cliente. */}
+            <SheetHeader className="px-6 pt-6 pb-4 border-b border-border space-y-0">
+              <div className="flex items-center gap-2 flex-wrap text-[11px] font-medium uppercase tracking-[0.05em] text-muted-foreground">
+                <span>
+                  <span className="font-mono">OS {data.number ?? `#${data.id}`}</span>
+                  {' · '}
+                  {data.current_stage?.name ?? capitalize(data.status)}
+                  {data.is_overdue && (
+                    <span className="ml-1.5 font-semibold text-destructive">· Atrasada</span>
+                  )}
                 </span>
                 <OrderTypeBadge type={data.order_type} />
-                {data.is_overdue && (
-                  <span className="inline-flex items-center rounded-full border border-rose-200 bg-rose-50 px-2.5 py-0.5 text-[11px] font-medium text-rose-700 dark:border-rose-900/40 dark:bg-rose-950/40 dark:text-rose-300">
-                    <AlertTriangle size={10} className="mr-0.5" />
-                    Atrasada
-                  </span>
-                )}
               </div>
-              <SheetTitle className="text-xl font-semibold tracking-tight text-foreground">
-                {data.order_type === 'mecanica' ? 'Mecânica' : 'Manutenção'}{' '}
-                {data.number ?? `#${data.id}`}
+              <SheetTitle className="text-[17px] font-semibold leading-tight tracking-tight text-foreground mt-1 mb-0.5">
+                {data.vehicle?.vehicle_type ? capitalize(data.vehicle.vehicle_type) : 'Veículo'}
+                {data.vehicle?.plate ? (
+                  <span className="text-[13px] font-normal font-mono text-muted-foreground ml-1.5">
+                    · {data.vehicle.plate}
+                  </span>
+                ) : null}
               </SheetTitle>
-              <SheetDescription className="text-sm text-muted-foreground">
-                {data.contact ? (
-                  <span>{data.contact.name}</span>
-                ) : (
-                  <span>Cliente não informado</span>
-                )}
+              <SheetDescription className="text-[12.5px] text-muted-foreground">
+                {data.contact ? data.contact.name : 'Cliente não informado'}
               </SheetDescription>
             </SheetHeader>
 
-            {/* Conteúdo scroll — seções verticais (mesmo pattern SaleSheet) */}
-            <div className="flex-1 overflow-y-auto px-6 py-5 space-y-6">
+            {/* Conteúdo scroll — bloco-topo respira junto; seções seguem com
+                border-top fino (canon .ofc-drawer-section, MESMO do RichSheet). */}
+            <div className="flex-1 overflow-y-auto px-6 py-5">
+              <div className="space-y-4">
               {/* ADR 0192 — Integração Vendas × Oficina A1 KB-9.75.
-                  Card "Esta OS gerou venda #V-NNNN" renderiza acima dos KPIs
-                  quando ServiceOrderObserver (PR #1530) criou Transaction
-                  derivada na transição status='concluida'. Componente shared
-                  cross-módulo (vive em @/Components/shared/VendaDerivadaCard,
-                  reutilizado por Modules/Repair desde PR #1504 Onda 5). */}
+                  Card "Esta OS gerou venda #V-NNNN" renderiza no topo quando
+                  ServiceOrderObserver (PR #1530) criou Transaction derivada na
+                  transição status='concluida'. Componente shared cross-módulo. */}
               {data.venda_derivada && <VendaDerivadaCard venda={data.venda_derivada} />}
 
-              {/* KPIs mini horizontais — reparo (ADR 0265: Diárias/Diária eram locação) */}
-              <div className="grid grid-cols-2 gap-3">
-                <MiniKpi
-                  label="Entrada"
-                  value={formatDateOnly(data.started_at ?? data.entered_at)}
-                />
-                <MiniKpi
-                  label="A receber"
-                  value={formatBRL(data.valor_receber)}
-                  tone={
-                    data.is_overdue
-                      ? 'warning'
-                      : Number(data.valor_receber ?? 0) > 0
-                        ? 'warning'
-                        : 'success'
-                  }
-                />
+              {/* Entrada/Valor — linha de meta compacta (canon: label muted +
+                  valor tabular-nums à direita), não mais caixões MiniKpi. */}
+              <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[12px] px-0.5">
+                <dt className="text-muted-foreground">Entrada</dt>
+                <dd className="text-foreground tabular-nums text-right">
+                  {formatDateOnly(data.started_at ?? data.entered_at)}
+                </dd>
+                <dt className="text-muted-foreground">Valor</dt>
+                <dd className="tabular-nums font-semibold text-right text-success">
+                  {formatBRL(data.items_total ?? 0)}
+                </dd>
+              </dl>
               </div>
 
               {/* Detalhes — campos básicos OS */}
@@ -379,6 +385,9 @@ export default function ServiceOrderSheet({
 
 // ─── Subcomponents ───────────────────────────────────────────────────────────
 
+// Canon .ofc-drawer-section (MESMO Section do RichSheet — um único vocabulário
+// de sheet): seções separadas por border-top fino, h4 10.5px/600 uppercase
+// ls .04em muted; sem caixas empilhadas (MiniKpi removido 2026-06-11).
 function Section({
   title,
   icon: Icon,
@@ -389,62 +398,13 @@ function Section({
   children: React.ReactNode;
 }) {
   return (
-    <section>
-      <h3 className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground mb-2 flex items-center gap-1.5">
+    <section className="border-t border-border mt-2.5 pt-3.5 pb-1">
+      <h3 className="text-[10.5px] font-semibold uppercase tracking-[0.04em] text-muted-foreground mb-2.5 flex items-center gap-1.5">
         {Icon && <Icon size={11} />}
         {title}
       </h3>
       {children}
     </section>
-  );
-}
-
-function MiniKpi({
-  label,
-  value,
-  tone,
-}: {
-  label: string;
-  value: string;
-  tone?: 'success' | 'warning';
-}) {
-  return (
-    <div
-      className={
-        'rounded-md border p-2.5 ' +
-        (tone === 'warning'
-          ? 'border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/30'
-          : tone === 'success'
-            ? 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/40 dark:bg-emerald-950/30'
-            : 'border-border bg-muted/30')
-      }
-    >
-      <div
-        className={
-          'text-[10px] font-semibold uppercase tracking-wider ' +
-          (tone === 'warning'
-            ? 'text-amber-700 dark:text-amber-400'
-            : tone === 'success'
-              ? 'text-emerald-700 dark:text-emerald-400'
-              : 'text-muted-foreground')
-        }
-      >
-        {label}
-      </div>
-      <div
-        className={
-          'text-sm font-semibold tabular-nums mt-0.5 truncate ' +
-          (tone === 'warning'
-            ? 'text-amber-700 dark:text-amber-300'
-            : tone === 'success'
-              ? 'text-emerald-700 dark:text-emerald-300'
-              : 'text-foreground')
-        }
-        title={value}
-      >
-        {value}
-      </div>
-    </div>
   );
 }
 

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStagePipeline.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStagePipeline.tsx
@@ -140,12 +140,13 @@ export default function ServiceOrderStagePipeline({ serviceOrderId, enabled, ref
       <div className="relative flex items-center justify-between">
         {/* Linha de fundo cobrindo todo o range */}
         <div className="absolute top-3 left-3 right-3 h-0.5 bg-border" aria-hidden="true" />
-        {/* Linha de progresso até o stage atual */}
+        {/* Linha de progresso até o stage atual — colunas flex-1 centram o dot em
+            (i + 0.5)/n da largura (não mais justify-between em i/(n-1)). */}
         {currentIdx > 0 && (
           <div
             className="absolute top-3 left-3 h-0.5 bg-foreground/40 transition-all"
             style={{
-              width: `calc(${(Math.min(currentIdx, mainPath.length - 1) / Math.max(mainPath.length - 1, 1)) * 100}% - ${currentIdx === mainPath.length - 1 ? '0.75rem' : '0px'})`,
+              width: `${((Math.min(currentIdx, mainPath.length - 1) + 0.5) / Math.max(mainPath.length, 1)) * 100}%`,
             }}
             aria-hidden="true"
           />
@@ -158,7 +159,9 @@ export default function ServiceOrderStagePipeline({ serviceOrderId, enabled, ref
           const colors = STAGE_DOT_COLOR_MAP[stage.color ?? 'gray'] ?? FALLBACK_COLOR;
 
           return (
-            <div key={stage.key} className="relative z-10 flex flex-col items-center gap-1.5">
+            // flex-1 min-w-0 + label truncate: cada etapa ocupa fatia igual e o
+            // nome NUNCA invade a vizinha (nome completo no title/tooltip).
+            <div key={stage.key} className="relative z-10 flex flex-1 min-w-0 flex-col items-center gap-1.5 px-0.5">
               <div
                 className={cn(
                   'flex h-6 w-6 items-center justify-center rounded-full ring-4 transition-colors',
@@ -179,9 +182,10 @@ export default function ServiceOrderStagePipeline({ serviceOrderId, enabled, ref
               </div>
               <span
                 className={cn(
-                  'max-w-[80px] text-center text-[10px] leading-tight',
+                  'w-full truncate text-center text-[10px] leading-tight',
                   isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground',
                 )}
+                title={stage.name}
               >
                 {stage.name}
               </span>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderTimeline.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderTimeline.tsx
@@ -8,7 +8,7 @@
 //       memory/sessions/2026-05-20-arte-tela-fsm-workflow.md gap #1.
 
 import { useEffect, useState } from 'react';
-import { Clock, Loader2, User2, Zap, FileCheck2, ArrowRight, PlayCircle } from 'lucide-react';
+import { Loader2, Zap, FileCheck2, PlayCircle } from 'lucide-react';
 
 interface TimelineUser {
   id: number | null;
@@ -54,31 +54,6 @@ interface Props {
    */
   fallback?: React.ReactNode;
 }
-
-const STAGE_COLOR_MAP: Record<string, string> = {
-  gray: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
-  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
-  cyan: 'bg-cyan-100 text-cyan-700 dark:bg-cyan-900/40 dark:text-cyan-300',
-  amber: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  yellow: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
-  violet: 'bg-violet-100 text-violet-700 dark:bg-violet-900/40 dark:text-violet-300',
-  indigo: 'bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300',
-  emerald: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
-  green: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
-  red: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  rose: 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300',
-  slate: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
-};
-
-const stageBadge = (stage: TimelineStage | null) => {
-  if (!stage) return null;
-  const classes = STAGE_COLOR_MAP[stage.color ?? 'gray'] ?? STAGE_COLOR_MAP.gray;
-  return (
-    <span className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${classes}`}>
-      {stage.name}
-    </span>
-  );
-};
 
 const formatDate = (iso: string | null) => {
   if (!iso) return '—';
@@ -177,59 +152,57 @@ export default function ServiceOrderTimeline({ serviceOrderId, enabled, fallback
     );
   }
 
+  // Canon .ofc-timeline (protótipo Cowork oficina-page/oficina-fila): fio vertical
+  // + dot por evento + 3 linhas (quando · o quê · quem). As pills coloridas com
+  // seta saíram (polish canon Board 2026-06-11) — transição vira texto "De → Pra".
   return (
-    <ol className="relative space-y-3 border-l border-border pl-4">
+    <ol className="relative pl-4">
+      <span className="absolute left-1 top-1.5 bottom-1.5 w-px bg-border" aria-hidden="true" />
       {items.map((item) => {
         const motivo = (item.payload?.motivo as string | undefined) ?? null;
         const pipelineStarted = item.payload?.pipeline_started === true;
         return (
-          <li key={item.id} className="relative">
-            <span className="absolute -left-[21px] top-1 flex h-3 w-3 items-center justify-center rounded-full bg-background ring-2 ring-border">
-              <span className="h-1.5 w-1.5 rounded-full bg-foreground" />
-            </span>
-            <div className="space-y-1">
-              <div className="flex items-center justify-between gap-2 text-xs">
-                <span className="flex items-center gap-1 text-muted-foreground">
-                  <Clock size={12} /> {formatDate(item.executed_at)}
+          <li key={item.id} className="relative pl-2 pb-3 text-[11.5px] last:pb-0">
+            <span
+              className="absolute -left-[10px] top-[5px] h-[7px] w-[7px] rounded-full border-[1.5px] border-success bg-success"
+              aria-hidden="true"
+            />
+            <div className="text-[10.5px] tabular-nums text-muted-foreground">
+              {formatDate(item.executed_at)}
+            </div>
+            <div className="flex flex-wrap items-center gap-x-1.5 text-foreground">
+              {pipelineStarted && !item.action ? (
+                <span className="inline-flex items-center gap-1">
+                  <PlayCircle size={11} className="text-emerald-600 dark:text-emerald-400" />
+                  Pipeline iniciado
                 </span>
-                {item.user.name && (
-                  <span className="flex items-center gap-1 text-muted-foreground">
-                    <User2 size={12} /> {item.user.name}
-                  </span>
-                )}
-              </div>
-              <div className="flex flex-wrap items-center gap-1.5 text-sm">
-                {pipelineStarted && !item.action && (
-                  <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
-                    <PlayCircle size={12} className="text-emerald-600 dark:text-emerald-400" />
-                    Pipeline iniciado
-                  </span>
-                )}
-                {stageBadge(item.from_stage)}
-                {item.from_stage && item.to_stage && <ArrowRight size={12} className="text-muted-foreground" />}
-                {stageBadge(item.to_stage)}
-                {item.action && (
-                  <span className="text-xs text-muted-foreground">
-                    via <strong className="text-foreground">{item.action.label}</strong>
-                  </span>
-                )}
-                {item.action?.has_side_effect && (
-                  <span title="Side-effect disparado" className="inline-flex items-center text-amber-600 dark:text-amber-400">
-                    <Zap size={12} />
-                  </span>
-                )}
-                {item.action?.has_event && (
-                  <span title="Event disparado" className="inline-flex items-center text-blue-600 dark:text-blue-400">
-                    <FileCheck2 size={12} />
-                  </span>
-                )}
-              </div>
-              {motivo && (
-                <p className="text-xs italic text-muted-foreground">
-                  Motivo: {motivo}
-                </p>
+              ) : item.from_stage && item.to_stage ? (
+                <span>
+                  {item.from_stage.name} → <strong className="font-semibold">{item.to_stage.name}</strong>
+                </span>
+              ) : item.to_stage ? (
+                <strong className="font-semibold">{item.to_stage.name}</strong>
+              ) : null}
+              {item.action?.has_side_effect && (
+                <span title="Side-effect disparado" className="inline-flex items-center text-amber-600 dark:text-amber-400">
+                  <Zap size={11} />
+                </span>
+              )}
+              {item.action?.has_event && (
+                <span title="Event disparado" className="inline-flex items-center text-blue-600 dark:text-blue-400">
+                  <FileCheck2 size={11} />
+                </span>
               )}
             </div>
+            <div className="text-[10.5px] text-muted-foreground">
+              {item.user.name ?? '—'}
+              {item.action && <> · {item.action.label}</>}
+            </div>
+            {motivo && (
+              <p className="text-[10.5px] italic text-muted-foreground">
+                Motivo: {motivo}
+              </p>
+            )}
           </li>
         );
       })}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/BoardKpiCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/BoardKpiCard.tsx
@@ -1,0 +1,59 @@
+// KPI canon do Quadro de OS (paridade Cowork Onda 1.5) — card branco/tonal,
+// label uppercase 10px muted, número grande tabular-nums e SUBLINHA descritiva.
+// Clicável vira filtro D-05 (clica filtra · clica de novo limpa · aria-pressed).
+//
+// Extraído do Board.tsx em 2026-06-11 (polish Lista/Fila): a Index passou a usar
+// o MESMO vocabulário de KPI — um único componente, zero divergência visual.
+
+import { kpiTone, type KpiTone } from './boardTone';
+
+export interface BoardKpiCardProps {
+  label: string;
+  value: string;
+  /** sublinha descritiva (paridade Cowork — ex.: "faturamento previsto") */
+  sub?: string;
+  tone: KpiTone;
+  /** D-05 — KPI ativo como filtro (anel primary + aria-pressed) */
+  active?: boolean;
+  /** D-05 — outro KPI está filtrando (esmaece este) */
+  dimmed?: boolean;
+  /** presente = KPI filtrável (vira role=button); ausente = só leitura (ex.: valor) */
+  onClick?: () => void;
+}
+
+export default function BoardKpiCard({ label, value, sub, tone, active = false, dimmed = false, onClick }: BoardKpiCardProps) {
+  const t = kpiTone(tone);
+
+  const inner = (
+    <>
+      <span className={`text-[10px] font-semibold uppercase tracking-wider truncate ${t.label}`}>{label}</span>
+      <span className={`text-xl @[1100px]/board:text-2xl font-bold tabular-nums ${t.value}`}>{value}</span>
+      {sub ? <span className="text-[10px] text-muted-foreground truncate leading-tight">{sub}</span> : null}
+    </>
+  );
+
+  // KPI filtrável é <button> de verdade (a11y nativa: foco, Enter/Space, aria-pressed)
+  if (onClick !== undefined) {
+    return (
+      <button
+        type="button"
+        className={
+          `rounded-lg border px-3 py-2 flex flex-col gap-0.5 text-left w-full cursor-pointer select-none transition-all hover:shadow-sm ${t.wrapper}`
+          + (active ? ' ring-2 ring-primary ring-offset-1' : '')
+          + (dimmed ? ' opacity-50' : '')
+        }
+        aria-pressed={active}
+        title={active ? 'Clique pra limpar o filtro' : `Filtrar: ${label}`}
+        onClick={onClick}
+      >
+        {inner}
+      </button>
+    );
+  }
+
+  return (
+    <div className={`rounded-lg border px-3 py-2 flex flex-col gap-0.5 ${t.wrapper}`}>
+      {inner}
+    </div>
+  );
+}


### PR DESCRIPTION
## Module Grade

Módulo: **OficinaAuto** · polish UI canon Board (mesma sessão de canon do PR #2530 — referências `oficina-fila.jsx/.css` + `oficina-page.jsx/.css` Cowork).

## O que muda

### INDEX (Lista — `/oficina-auto/ordens-servico`)
1. **Header**: círculo decorativo vazio removido (a `Index` passava ReactNode na prop string `icon` do PageHeader → caixa `bg-primary/10` vazia). Padrão do Board: h1 + subtítulo descritivo; header só com **Nova OS**.
2. **KPIs canon do Board**: `BoardKpiCard` **extraído** de `Board.tsx` pra `_components/board/BoardKpiCard.tsx` (um único componente pros dois). Label uppercase 10px muted + número grande tabular-nums + sublinha. **Clicáveis como filtro D-05**: clica filtra (`?status=`), clica de novo limpa, chip "limpar filtro" na toolbar.
3. **Filtros consolidados**: fileira de abas Todas/Em andamento/Concluídas mês/Atrasadas **removida** (redundante com KPIs clicáveis). Toolbar única canon `.ofc-view-toolbar`: busca com limpar (×) + contador "N OS · N atrasadas" · tipo (Mecânica/Manutenção) · chips de estágio FSM · toggle.
4. **VALOR com dado real**: `withSum('items as items_total', 'valor_total')` no `index()` — o `valor_receber` é accessor **sempre-0** pós-ADR 0265 (a coluna mostrava R$ 0,00/— pra tudo). 1 subquery agregada, sem N+1. Indicador de atraso **único** (pill "Atrasada" do StatusBadge; dot vermelho removido). Datas já tabular-nums; mono mantido em Nº/veículo.
5. **Toggle Quadro · Lista · Fila** — Quadro navega pro `/board` (simetria com o toggle do Board, que navega pra cá).

### FILA (`?view=fila`)
6. Esqueleto master-detail **intocado**.
7. Caixa cinza do detalhe → **meta-grid canon** (grid auto/1fr, label muted 11px + valor 13px tabular-nums; defeito em linha própria full). "A receber" (sempre-0) → "Valor" real (`items_total`) — também no rail.
8. **Linha do tempo canon `.ofc-timeline`** (`ServiceOrderTimeline`, compartilhada com os drawers): fio vertical + dot por evento + 3 linhas (quando · o quê · quem); transição vira texto "De → **Pra**", sem pills coloridas com seta.
9. **Stepper**: etapas `flex-1 min-w-0` + label `truncate` com tooltip (sem sobreposição); linha de progresso recalculada pro centro da fatia.

### DRAWER da Lista (`ServiceOrderSheet` — MESMO vocabulário do RichSheet do PR #2530)
10. Eyebrow 11px uppercase "OS #104 · \<etapa\>" (consome `current_stage` que o `show()` já retorna) + **badge do tipo ao lado do eyebrow**, não no título; h2 17px = veículo (+ placa mono); p 12.5px = cliente.
11. ENTRADA/A RECEBER: caixões MiniKpi → **linha de meta compacta** (label muted + BRL tabular-nums à direita, `items_total` real); seções com **border-top fino + h4 10.5px uppercase** (Section canon do RichSheet) em vez de caixas.
12. **Cancelar OS** (ação destrutiva FSM) vira **outline destructive** discreto — não compete com a ação primária da etapa. Críticas positivas (Concluir/Aprovar) seguem sólidas. Funcionalidade FSM intocada.

## Decisão reportada (item 4 do pedido)
A fonte real do VALOR **existe** (`oficina_service_order_items.valor_total`, soma = mesmo `items_total` do drawer/Board) — coluna mantida com dado real, não removida. Onde a OS não tem item lançado: `NULL` → "—".

## Governança
- Tokens DS, primitivos mantidos; FSM intocado (só estilo de botão)
- `Index.charter.md` bump **v4** (trilha append-only)
- Teste Pest novo: `ServiceOrderIndexItemsTotalTest` (soma · NULL sem itens · Tier 0 multi-tenant)
- Typecheck: **-2 erros baseline** no Index (icon ReactNode→string); ESLint 0 errors (5 warnings pré-existentes de baseline); build vite OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)