### PR TITLE
fix(deploy): SSH robusto de verdade — warm-up na PORTA SSH + retry no comando (resolve 255 recorrente)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,16 +145,40 @@ jobs:
           #      ConnectionAttempts + ServerAlive pra rede flaky runner→Hostinger.
           #  ControlMaster (multiplexing) NÃO é usado: falha "mux_client_request_session"
           #  no Hostinger (catalogado). Uma conexão por comando é o caminho suportado.
-          ssh -4 \
-              -o BatchMode=yes \
-              -o StrictHostKeyChecking=accept-new \
-              -o ConnectTimeout=60 \
-              -o ConnectionAttempts=5 \
-              -o ServerAliveInterval=15 \
-              -o ServerAliveCountMax=10 \
-              -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
-              ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-              "$@"
+          #
+          # RETRY INTERNO (2026-06-11 — causa raiz recorrente "sempre quebra"): cada
+          # step chamava o ssh UMA vez; quando o TCP à porta SSH timava (Hostinger flaky),
+          # o 255 matava o deploy inteiro (run 27346860058: `php -v` timou 5min e morreu).
+          # Agora o wrapper retenta a CONEXÃO até 5x espaçando 15s — TODO step que usa
+          # ssh_exec.sh herda a resiliência de graça. Só retenta exit 255 (connect
+          # timeout/refused/reset); erro REAL do comando remoto (exit != 255) propaga na
+          # hora, sem mascarar. Timeouts menores por tentativa (30s×2) pra as 5 se
+          # espalharem no tempo e pegarem janelas em que a rota volta, em vez de 1
+          # tentativa-monolítica de 5min num único momento ruim.
+          ssh_attempt=1
+          ssh_max=5
+          while :; do
+            ssh -4 \
+                -o BatchMode=yes \
+                -o StrictHostKeyChecking=accept-new \
+                -o ConnectTimeout=30 \
+                -o ConnectionAttempts=2 \
+                -o ServerAliveInterval=15 \
+                -o ServerAliveCountMax=10 \
+                -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+                ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+                "$@"
+            ssh_rc=$?
+            # exit != 255 → comando remoto rodou (sucesso ou falha real); propaga.
+            [ "$ssh_rc" -ne 255 ] && exit "$ssh_rc"
+            if [ "$ssh_attempt" -ge "$ssh_max" ]; then
+              echo "ssh_exec: conexão falhou (exit 255) após ${ssh_max} tentativas" >&2
+              exit 255
+            fi
+            echo "ssh_exec: conexão falhou (255) — tentativa ${ssh_attempt}/${ssh_max}, aguardando 15s…" >&2
+            ssh_attempt=$((ssh_attempt + 1))
+            sleep 15
+          done
           EOF
           chmod +x /tmp/ssh_exec.sh
 
@@ -165,13 +189,29 @@ jobs:
             | sort -u > /tmp/bundle_before.txt || true
           echo "BEFORE:" && cat /tmp/bundle_before.txt || true
 
-      - name: Warm-up do caminho SSH (curl 5x — Hostinger flaky, ver hostinger.md)
-        # "Sem warm-up, primeiro SSH quase sempre dá Connection timed out" (hostinger.md).
-        # 5 hits IPv4 acordam a rota runner→Hostinger antes do 1º comando SSH.
+      - name: Warm-up do caminho SSH (porta SSH + curl — Hostinger flaky, ver hostinger.md)
+        # CORREÇÃO 2026-06-11: o warm-up ANTIGO só batia em https://.../login (porta 443)
+        # — NÃO esquentava a PORTA SSH, então o 1º connect SSH caía frio e dava
+        # "Connection timed out" (causa raiz dos 255). Agora o warm-up toca a porta SSH
+        # de verdade: (1) sonda TCP a porta SSH real até abrir (10× com gap, bounded por
+        # `timeout`); (2) curl 443 acorda CDN/rota; (3) um `ssh true` real (já com retry
+        # do helper) faz a 1ª conexão custosa acontecer AQUI, tolerante a falha — o
+        # Pré-deploy check logo abaixo é o gate que valida pra valer.
         run: |
-          for i in 1 2 3 4 5; do
+          echo "=== TCP probe na porta SSH (acorda a rota certa) ==="
+          for i in $(seq 1 10); do
+            if timeout 8 bash -c "echo > /dev/tcp/${{ secrets.SSH_HOST }}/${{ secrets.SSH_PORT }}" 2>/dev/null; then
+              echo "porta SSH respondeu (tentativa $i)"; break
+            fi
+            echo "porta SSH fechada/timeout (tentativa $i) — aguardando 10s…"; sleep 10
+          done
+          echo "=== curl 443 (acorda CDN/rota HTTP) ==="
+          for i in 1 2 3; do
             curl -4 -s -o /dev/null -w "$i:%{http_code} " https://oimpresso.com/login --max-time 15 || true
           done; echo
+          echo "=== ssh true (1ª conexão custosa acontece aqui, tolerante) ==="
+          /tmp/ssh_exec.sh "true" && echo "warm-up SSH OK" \
+            || echo "warm-up SSH ainda frio — o Pré-deploy check fará a validação real"
 
       - name: Pré-deploy check — server state
         run: |

--- a/memory/reference/hostinger.md
+++ b/memory/reference/hostinger.md
@@ -35,6 +35,10 @@ for i in 1 2 3 4 5; do
 done; echo
 ```
 
+> ⚠️ **O warm-up por curl bate na porta 443 (HTTP), NÃO na porta SSH (65002).** Quando a rota runner→Hostinger está fria *na porta SSH*, o `curl 443` retorna `200` mas o 1º `connect` SSH ainda dá `Connection timed out` → `exit 255` (incidente 2026-06-11, deploy run 27346860058: `php -v` timou 5 min e matou o deploy mesmo com warm-up curl). **Duas defesas obrigatórias** (já no `deploy.yml`):
+> 1. **Warm-up TCP na porta SSH de verdade** antes do 1º comando — sonda `bash -c "echo > /dev/tcp/$HOST/$PORT"` com `timeout` num loop, pra acordar a rota CERTA (não só a 443).
+> 2. **Retry no nível do comando SSH** (não confiar só no `ConnectionAttempts` interno do ssh): wrapper retenta a conexão até 5× espaçando ~15s, **só em `exit 255`** (connect timeout/refused/reset) — erro real do comando remoto (exit ≠ 255) propaga na hora. `ConnectTimeout=30 × ConnectionAttempts=2` por tentativa pra as 5 se espalharem no tempo e pegarem janelas boas, em vez de 1 tentativa-monolítica de 5 min num único momento ruim.
+
 ### SSH config robusto (não cortar nenhum flag)
 
 ```bash


### PR DESCRIPTION
## Problema — "sempre quebra"

Deploy pro Hostinger falha de forma recorrente no **Pré-deploy check — server state** com `ssh: connect to host *** port ***: Connection timed out` → `exit 255`. Run [27346860058](https://github.com/wagnerra23/oimpresso.com/actions/runs/27346860058): o 1º comando SSH (`php -v`) tentou por **5 min** (`ConnectTimeout=60 × ConnectionAttempts=5`) e morreu, bloqueando o deploy do PR #2533 (polish OficinaAuto).

## Causa raiz

1. **O warm-up esquentava a porta errada.** O warm-up batia em `https://oimpresso.com/login` (**porta 443**) — isso não acorda a **porta SSH** (65002). Com a rota runner→Hostinger fria *na porta SSH*, o curl 443 retornava `200` mas o 1º `connect` SSH ainda timava.
2. **Sem retry no nível do comando.** Cada step chamava `/tmp/ssh_exec.sh` **uma vez**; o `ConnectionAttempts=5` interno do ssh é 1 invocação monolítica de 5 min num único momento ruim. Um timeout = deploy morto. Re-disparar só empurrava o problema.

## Fix (duas defesas, no `deploy.yml`)

1. **Warm-up TCP na PORTA SSH de verdade** — sonda `bash -c "echo > /dev/tcp/$HOST/$PORT"` com `timeout 8` num loop de 10× com gap, acordando a rota certa; depois `ssh true` real (tolerante) faz a 1ª conexão custosa acontecer no warm-up, não no gate.
2. **Retry interno no `ssh_exec.sh`** — retenta a **conexão** até 5× espaçando 15s, **só em `exit 255`** (connect timeout/refused/reset). Erro real do comando remoto (exit ≠ 255) **propaga na hora**, sem mascarar (preserva os `set -o pipefail` dos steps de composer/migrate). `ConnectTimeout=30 × ConnectionAttempts=2` por tentativa pra as 5 se espalharem no tempo e pegarem janelas boas. **Todo step que usa `ssh_exec.sh` herda a resiliência** (pré-deploy, cleanup, backup, git pull, composer, migrate, publish, failsafe, tail).

Mantém os invariantes canônicos do Hostinger: `-4` IPv4, `BatchMode=yes`, `StrictHostKeyChecking=accept-new`, sem ControlMaster (multiplexing proibido).

## Doc
Causa raiz catalogada em `memory/reference/hostinger.md` §warm-up (curl 443 ≠ porta SSH).

## Verificação
O próprio merge deste PR (push → main) dispara um deploy usando **a versão corrigida** do workflow — é o teste de fogo. Se subir verde, resolve também o deploy pendente do #2533 (commit `03e50673` já está em main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)