### PR TITLE
fix(deploy): restaura ConnectTimeout em MINUTOS (canon hostinger.md) — meu fix anterior encurtou e piorou

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,46 +139,32 @@ jobs:
         run: |
           cat > /tmp/ssh_exec.sh <<'EOF'
           #!/bin/bash
-          # Flags canônicos Hostinger (memory/reference/hostinger.md §SSH):
-          #  -4  IPv4 OBRIGATÓRIO — IPv6 falha e dá "Connection timed out" (causa raiz dos
-          #      255 em 2026-06-10). BatchMode=yes falha rápido em prompt inesperado.
-          #      ConnectionAttempts + ServerAlive pra rede flaky runner→Hostinger.
-          #  ControlMaster (multiplexing) NÃO é usado: falha "mux_client_request_session"
-          #  no Hostinger (catalogado). Uma conexão por comando é o caminho suportado.
+          # Flags canônicos Hostinger (memory/reference/hostinger.md §"SSH config robusto").
+          #  -4  IPv4 OBRIGATÓRIO — IPv6 falha e dá "Connection timed out".
+          #  BatchMode=yes falha rápido em prompt inesperado.
+          #  ControlMaster (multiplexing) NÃO é usado: falha "mux_client_request_session".
+          #  Uma conexão por comando é o caminho suportado.
           #
-          # RETRY INTERNO (2026-06-11 — causa raiz recorrente "sempre quebra"): cada
-          # step chamava o ssh UMA vez; quando o TCP à porta SSH timava (Hostinger flaky),
-          # o 255 matava o deploy inteiro (run 27346860058: `php -v` timou 5min e morreu).
-          # Agora o wrapper retenta a CONEXÃO até 5x espaçando 15s — TODO step que usa
-          # ssh_exec.sh herda a resiliência de graça. Só retenta exit 255 (connect
-          # timeout/refused/reset); erro REAL do comando remoto (exit != 255) propaga na
-          # hora, sem mascarar. Timeouts menores por tentativa (30s×2) pra as 5 se
-          # espalharem no tempo e pegarem janelas em que a rota volta, em vez de 1
-          # tentativa-monolítica de 5min num único momento ruim.
-          ssh_attempt=1
-          ssh_max=5
-          while :; do
-            ssh -4 \
-                -o BatchMode=yes \
-                -o StrictHostKeyChecking=accept-new \
-                -o ConnectTimeout=30 \
-                -o ConnectionAttempts=2 \
-                -o ServerAliveInterval=15 \
-                -o ServerAliveCountMax=10 \
-                -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
-                ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
-                "$@"
-            ssh_rc=$?
-            # exit != 255 → comando remoto rodou (sucesso ou falha real); propaga.
-            [ "$ssh_rc" -ne 255 ] && exit "$ssh_rc"
-            if [ "$ssh_attempt" -ge "$ssh_max" ]; then
-              echo "ssh_exec: conexão falhou (exit 255) após ${ssh_max} tentativas" >&2
-              exit 255
-            fi
-            echo "ssh_exec: conexão falhou (255) — tentativa ${ssh_attempt}/${ssh_max}, aguardando 15s…" >&2
-            ssh_attempt=$((ssh_attempt + 1))
-            sleep 15
-          done
+          # ⚠️ ConnectTimeout ALTO É CANON (2026-06-11): o manual diz textual
+          # "ConnectTimeout=900 (Hostinger leva minutos pra handshake)". Em 2026-06-11
+          # eu (CC) ENCURTEI pra 30s achando que ajudaria — fez o oposto: o SSH desistia
+          # ANTES do handshake lento do Hostinger completar, causando o "sempre quebra"
+          # pós-fix. Restaurado pro espírito do manual (timeout em MINUTOS), só bounded
+          # a 180s×3 (≤9min/invocação) pra caber no job timeout de 30min. ServerAlive
+          # 3/200 (manual) mantém a conexão viva durante comandos remotos longos
+          # (composer/migrate) — router intermediário derruba conexão ociosa sem keepalive.
+          # SEM retry-loop externo agressivo (Wagner "cuidado com hostinger" — não
+          # martelar/arriscar ban): o próprio ConnectionAttempts=3 do ssh é a resiliência.
+          ssh -4 \
+              -o BatchMode=yes \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=180 \
+              -o ConnectionAttempts=3 \
+              -o ServerAliveInterval=3 \
+              -o ServerAliveCountMax=200 \
+              -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+              ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+              "$@"
           EOF
           chmod +x /tmp/ssh_exec.sh
 
@@ -189,29 +175,20 @@ jobs:
             | sort -u > /tmp/bundle_before.txt || true
           echo "BEFORE:" && cat /tmp/bundle_before.txt || true
 
-      - name: Warm-up do caminho SSH (porta SSH + curl — Hostinger flaky, ver hostinger.md)
-        # CORREÇÃO 2026-06-11: o warm-up ANTIGO só batia em https://.../login (porta 443)
-        # — NÃO esquentava a PORTA SSH, então o 1º connect SSH caía frio e dava
-        # "Connection timed out" (causa raiz dos 255). Agora o warm-up toca a porta SSH
-        # de verdade: (1) sonda TCP a porta SSH real até abrir (10× com gap, bounded por
-        # `timeout`); (2) curl 443 acorda CDN/rota; (3) um `ssh true` real (já com retry
-        # do helper) faz a 1ª conexão custosa acontecer AQUI, tolerante a falha — o
-        # Pré-deploy check logo abaixo é o gate que valida pra valer.
+      - name: Warm-up do caminho SSH (curl 5x + ssh true — Hostinger flaky, ver hostinger.md)
+        # Manual §"warm-up + retry": 5 hits curl IPv4 acordam a rota runner→Hostinger
+        # antes do 1º SSH. + 1 `ssh true` tolerante pra PAGAR o 1º connect lento
+        # (handshake "leva minutos" — manual) AQUI, fora do Pré-deploy check gated.
+        # O TCP probe `/dev/tcp` com `timeout 8` foi REMOVIDO (2026-06-11): com handshake
+        # de minutos, um probe de 8s sempre falha e só queima tempo/CI — quem espera o
+        # handshake lento é o ConnectTimeout=180 do ssh_exec.sh, não um probe curto.
         run: |
-          echo "=== TCP probe na porta SSH (acorda a rota certa) ==="
-          for i in $(seq 1 10); do
-            if timeout 8 bash -c "echo > /dev/tcp/${{ secrets.SSH_HOST }}/${{ secrets.SSH_PORT }}" 2>/dev/null; then
-              echo "porta SSH respondeu (tentativa $i)"; break
-            fi
-            echo "porta SSH fechada/timeout (tentativa $i) — aguardando 10s…"; sleep 10
-          done
-          echo "=== curl 443 (acorda CDN/rota HTTP) ==="
-          for i in 1 2 3; do
+          for i in 1 2 3 4 5; do
             curl -4 -s -o /dev/null -w "$i:%{http_code} " https://oimpresso.com/login --max-time 15 || true
           done; echo
-          echo "=== ssh true (1ª conexão custosa acontece aqui, tolerante) ==="
+          echo "=== ssh true (paga o 1º connect lento aqui, tolerante) ==="
           /tmp/ssh_exec.sh "true" && echo "warm-up SSH OK" \
-            || echo "warm-up SSH ainda frio — o Pré-deploy check fará a validação real"
+            || echo "warm-up SSH ainda frio — o Pré-deploy check valida pra valer"
 
       - name: Pré-deploy check — server state
         run: |

--- a/memory/reference/hostinger.md
+++ b/memory/reference/hostinger.md
@@ -35,9 +35,9 @@ for i in 1 2 3 4 5; do
 done; echo
 ```
 
-> ⚠️ **O warm-up por curl bate na porta 443 (HTTP), NÃO na porta SSH (65002).** Quando a rota runner→Hostinger está fria *na porta SSH*, o `curl 443` retorna `200` mas o 1º `connect` SSH ainda dá `Connection timed out` → `exit 255` (incidente 2026-06-11, deploy run 27346860058: `php -v` timou 5 min e matou o deploy mesmo com warm-up curl). **Duas defesas obrigatórias** (já no `deploy.yml`):
-> 1. **Warm-up TCP na porta SSH de verdade** antes do 1º comando — sonda `bash -c "echo > /dev/tcp/$HOST/$PORT"` com `timeout` num loop, pra acordar a rota CERTA (não só a 443).
-> 2. **Retry no nível do comando SSH** (não confiar só no `ConnectionAttempts` interno do ssh): wrapper retenta a conexão até 5× espaçando ~15s, **só em `exit 255`** (connect timeout/refused/reset) — erro real do comando remoto (exit ≠ 255) propaga na hora. `ConnectTimeout=30 × ConnectionAttempts=2` por tentativa pra as 5 se espalharem no tempo e pegarem janelas boas, em vez de 1 tentativa-monolítica de 5 min num único momento ruim.
+> ⚠️ **NÃO encurtar o `ConnectTimeout` (lição cara 2026-06-11).** O handshake do Hostinger *leva minutos* — `ConnectTimeout` tem que ser ALTO (manual: 900; no CI bounded a 180 pelo job timeout de 30min). Em 2026-06-11 o CC tentou "consertar" o deploy flaky **encurtando** pra `ConnectTimeout=30 × ConnectionAttempts=2` + warm-up por TCP-probe de 8s + retry-loop externo. Resultado: PIOROU ("sempre quebra") — o SSH desistia ANTES do handshake completar, e o probe de 8s sempre falhava. **Reverter pro canon**: `ConnectTimeout=180+` (minutos), `ConnectionAttempts=3-5`, `ServerAliveInterval=3`, `ServerAliveCountMax=200`, `-4`. Warm-up = **curl 443 ×5** (só acorda a rota) + 1 `ssh true` tolerante (paga o 1º connect lento). **Não** martelar com retry-loop agressivo (risco de ban / "cuidado com hostinger" — Wagner 2026-06-11).
+>
+> **Quando o deploy falha mesmo com os flags canônicos:** geralmente é **queda real da rota SSH do Hostinger** (a 443 pode continuar 200 enquanto a 65002 está inalcançável). Foi o caso 2026-06-11 ~12:30→13:30 (deploys 11:25/12:06/12:16 passaram; depois a 65002 caiu ~1h). Nenhum timeout sobrevive a outage de 1h dentro de job de 30min — **esperar a rota voltar e re-disparar UMA vez**, não ficar martelando.
 
 ### SSH config robusto (não cortar nenhum flag)
 


### PR DESCRIPTION
## Correção do meu próprio fix anterior (PR #2535)

Wagner apontou: *"está usando ipv4? cuidado com hostinger"* + *"leia o manual hostinger.md"*. Reli o manual e achei o erro.

### IPv4: sim, está forçado
`-4` no ssh + `curl -4` no warm-up. IPv4 nunca foi o problema.

### O erro: encurtei o ConnectTimeout (fui contra o manual)

O manual ([`memory/reference/hostinger.md`](memory/reference/hostinger.md) §SSH config robusto) diz **textual**:
> `ConnectTimeout=900` (Hostinger leva **minutos** pra handshake)

No PR #2535 eu **encurtei** pra `ConnectTimeout=30 × ConnectionAttempts=2` + TCP-probe de 8s + retry-loop externo, achando que ajudaria. Fez o **oposto**: o SSH desistia **antes do handshake lento do Hostinger completar** → "sempre quebra". O probe de 8s sempre falhava pela mesma razão.

| Flag | Manual (canon) | Meu #2535 (errado) | Agora |
|---|---:|---:|---:|
| `ConnectTimeout` | 900 | 30 ❌ | **180** (bounded ao job 30min) |
| `ConnectionAttempts` | 5 | 2 ❌ | **3** |
| `ServerAliveInterval` | 3 | 15 ❌ | **3** |
| `ServerAliveCountMax` | 200 | 10 ❌ | **200** |

### Mudanças
- **Restaura timeouts em minutos** (180s — alto o bastante pro handshake lento, bounded ao job de 30min; o manual usa 900 no uso interativo).
- **Warm-up volta ao canon**: `curl 443 ×5` (acorda a rota) + 1 `ssh true` tolerante (paga o 1º connect lento fora do gate). **TCP-probe de 8s removido** — inútil com handshake de minutos.
- **Sem retry-loop externo agressivo** — Wagner: *"cuidado com hostinger"* (não martelar, risco de ban). O `ConnectionAttempts=3` do próprio ssh é a resiliência.

### Nota honesta sobre o bloqueio de hoje
Os deploys de **11:25/12:06/12:16 passaram**; a partir de **~12:30 a porta SSH 65002 caiu** (a 443 seguia 200, a 65002 inalcançável) e ficou ~1h fora. **Nenhum timeout sobrevive a outage de 1h dentro de job de 30min** — o certo é esperar a rota do Hostinger voltar e re-disparar **uma vez**, não martelar. Catalogado no `hostinger.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)