### PR TITLE
feat(ui): BR inputs canonicos — NumericInputPtBR promovido + DocumentInput + PhoneInput

### DIFF
--- a/memory/requisitos/_DesignSystem/CHANGELOG.md
+++ b/memory/requisitos/_DesignSystem/CHANGELOG.md
@@ -6,6 +6,22 @@ next_review: "2026-09-06"
 
 # Changelog · Design System
 
+## [0.6.10] - 2026-06-11 · BR inputs canônicos em ui/ (NumericInputPtBR promovido + DocumentInput + PhoneInput)
+
+### Added
+
+- **`ui/document-input.tsx`** (`DocumentInput`): CPF/CNPJ com máscara progressiva + validação mod 11 UX-only (`valid: true|false|null` — null = incompleto, não acende erro). Compõe `Input` canon + `@/Lib/br-mask` + `br-validate`. `clampDigits` garante display === digits persistido. Backend `Rule\BR\CpfCnpj` segue a verdade (ADR 0093 Tier 0).
+- **`ui/phone-input.tsx`** (`PhoneInput`): telefone BR fixo/celular, pattern "9 separado" canon Cowork (aprovado Wagner sessão understand 2026-05-21). Emite `{ masked, digits }`.
+- **`tests/br-inputs.test.tsx`**: 11 testes — contratos de máscara/parse/valid + round-trip focus→edit→blur do numérico + axe runtime serious/critical=0 (idioma `a11y-primitives.test.tsx`).
+
+### Moved
+
+- **MOVE** `Pages/Sells/_components/NumericInputPtBR.tsx` → `Components/ui/numeric-input-ptbr.tsx` — promoção R-DS-001 (regra-de-2: PaymentRow + Sells/Create já consumiam). Named export adicionado; default preservado. Imports Sells atualizados.
+
+### Registry
+
+- `REGISTRY_DS_COMPONENTES.md` §Form controls: +3 linhas (NumericInputPtBR · DocumentInput · PhoneInput) — "se está aqui, não hand-rola".
+
 ## [0.6.9] - 2026-06-11 · MOVE componentes de domínio single-módulo pra Pages/<Mod>/_components
 
 Camada 4 (Módulo · UI-0013) sai da pasta global `Components/` quando só 1 módulo consome — alinha com convenção `_components/` já vigente (Sells, CaixaUnificada, ServiceOrders). `Components/` global fica reservada a: `ui/` (primitivos) · `shared/` (compostos cross-módulo) · `layout/` (ADR 0253) · `PageHeader/` (canon v3.8) · `cockpit/` (Shell) · `board/` (cross-módulo OficinaAuto+ProjectMgmt) · `Site/` (surface pública) · `NfeBrasil/` (domínio fiscal consumido por Sells).

--- a/prototipo-ui/REGISTRY_DS_COMPONENTES.md
+++ b/prototipo-ui/REGISTRY_DS_COMPONENTES.md
@@ -30,6 +30,9 @@
 | **Switch** | `@/Components/ui/switch` | ✅ | Radix | toggle hand-rolled / checkbox pra booleano de setting |
 | **Label** | `@/Components/ui/label` | ✅ | Radix | `<label className="text-xs …">` solto |
 | **Button** | `@/Components/ui/button` | ✅ | ✅ `variant="cowork-primary\|cowork-ghost"`, `size="cowork"` | `<button className="bg-… rounded-md px-…">` cru |
+| **NumericInputPtBR** (moeda/decimal) | `@/Components/ui/numeric-input-ptbr` | ✅ 2026-06-11 (promovido de Sells) | herda Input cowork | `<Input type="number" onChange={Number(...)}>` ← bug R$ Larissa 2026-05-27 (locale) |
+| **DocumentInput** (CPF/CNPJ) | `@/Components/ui/document-input` | ✅ 2026-06-11 | herda Input cowork | hand-wiring `maskCPF/maskCNPJ + validateCPF` repetido por tab (drawer Cliente Wave C-FE) |
+| **PhoneInput** (telefone BR) | `@/Components/ui/phone-input` | ✅ 2026-06-11 | herda Input cowork | hand-wiring `maskTel` + Input por tela |
 
 ## Overlays / navegação / feedback
 

--- a/resources/js/Components/ui/document-input.tsx
+++ b/resources/js/Components/ui/document-input.tsx
@@ -1,0 +1,79 @@
+// DocumentInput — CPF/CNPJ com máscara progressiva + validação mod 11 (UX-only).
+//
+// Compõe <Input> canon (variant cowork default · ADR UI-0015) + `@/Lib/br-mask`
+// + `@/Lib/br-validate`. Substitui o hand-wiring repetido nos 4 tabs do drawer
+// Cliente (IdentificacaoTab etc — Wave C-FE) e em qualquer form novo com documento.
+//
+// Validação client-side é UX-only (borda vermelha via aria-invalid). Backend
+// (Rule\BR\CpfCnpj + FormRequest) é a verdade canônica — ADR 0093 Tier 0 força
+// revalidação server-side em TODA mutação.
+//
+// Contrato de `valid` (espelha br-validate):
+//   true  = documento completo e mod 11 OK
+//   false = documento completo e ERRADO (só aqui acende aria-invalid)
+//   null  = incompleto (user ainda digitando — não acende erro)
+//
+// Uso:
+//   <DocumentInput value={cpfCnpj} onValueChange={({ masked, digits, valid }) => ...} />
+//   <DocumentInput tipo="cpf" value={cpf} onValueChange={...} />
+
+import { Input, type InputProps } from '@/Components/ui/input';
+import { maskCPF, maskCNPJ, maskCpfCnpjAuto, onlyDigits } from '@/Lib/br-mask';
+import { validateCPF, validateCNPJ } from '@/Lib/br-validate';
+
+type DocumentTipo = 'cpf' | 'cnpj' | 'auto';
+
+interface DocumentInputProps extends Omit<InputProps, 'value' | 'onChange' | 'type'> {
+  /** Valor controlado — aceita com ou sem máscara (deriva sempre dos dígitos). */
+  value: string;
+  /** Emite a cada tecla: masked (display) + digits (persistir) + valid (UX). */
+  onValueChange: (v: { masked: string; digits: string; valid: boolean | null }) => void;
+  /** `auto` (default) detecta CPF↔CNPJ pelo nº de dígitos (≤11 CPF, >11 CNPJ). */
+  tipo?: DocumentTipo;
+}
+
+function maskDocument(tipo: DocumentTipo, raw: string): string {
+  if (tipo === 'cpf') return maskCPF(raw);
+  if (tipo === 'cnpj') return maskCNPJ(raw);
+  return maskCpfCnpjAuto(raw);
+}
+
+// Trunca digits no limite do tipo — garante display (mask trunca) === digits
+// emitido pra persistir. Sem isso, colar 14 dígitos em tipo=cpf mascararia 11
+// mas emitiria 14 (drift display↔banco).
+function clampDigits(tipo: DocumentTipo, digits: string): string {
+  return digits.slice(0, tipo === 'cpf' ? 11 : 14);
+}
+
+function validateDocument(tipo: DocumentTipo, digits: string): boolean | null {
+  if (tipo === 'cpf') return validateCPF(digits);
+  if (tipo === 'cnpj') return validateCNPJ(digits);
+  return digits.length > 11 ? validateCNPJ(digits) : validateCPF(digits);
+}
+
+function DocumentInput({ value, onValueChange, tipo = 'auto', ...rest }: DocumentInputProps) {
+  const digits = clampDigits(tipo, onlyDigits(value));
+  const invalid = validateDocument(tipo, digits) === false;
+
+  return (
+    <Input
+      {...rest}
+      type="text"
+      inputMode="numeric"
+      autoComplete="off"
+      value={maskDocument(tipo, digits)}
+      aria-invalid={invalid || undefined}
+      onChange={(e) => {
+        const d = clampDigits(tipo, onlyDigits(e.target.value));
+        onValueChange({
+          masked: maskDocument(tipo, d),
+          digits: d,
+          valid: validateDocument(tipo, d),
+        });
+      }}
+    />
+  );
+}
+
+export { DocumentInput };
+export type { DocumentInputProps, DocumentTipo };

--- a/resources/js/Components/ui/numeric-input-ptbr.tsx
+++ b/resources/js/Components/ui/numeric-input-ptbr.tsx
@@ -1,4 +1,8 @@
-// NumericInputPtBR — input numérico pt-BR safe.
+// NumericInputPtBR — input numérico pt-BR safe (canon ui/ · BR inputs).
+//
+// PROMOVIDO de Pages/Sells/_components → ui/ em 2026-06-11 (R-DS-001 regra-de-2:
+// PaymentRow + Sells/Create já consumiam; vira superfície canônica junto com
+// document-input + phone-input). Registrado em REGISTRY_DS_COMPONENTES.md.
 //
 // Origem (Bug R$ [redacted Tier 0]k Larissa 2026-05-27):
 //   <Input type="number" value={p.unit_price} onChange={Number(e.target.value)}> permitia
@@ -85,4 +89,5 @@ const NumericInputPtBR = forwardRef<HTMLInputElement, Props>(function NumericInp
   );
 });
 
+export { NumericInputPtBR };
 export default NumericInputPtBR;

--- a/resources/js/Components/ui/phone-input.tsx
+++ b/resources/js/Components/ui/phone-input.tsx
@@ -1,0 +1,42 @@
+// PhoneInput — telefone BR com máscara progressiva fixo/celular.
+//
+// Compõe <Input> canon (variant cowork default · ADR UI-0015) + `maskTel` de
+// `@/Lib/br-mask` — pattern "9 separado" do protótipo Cowork, Wagner aprovou
+// sessão understand 2026-05-21:
+//   "11988887777" → "(11) 9 8888-7777"  (celular 11d)
+//   "1133334444"  → "(11) 3333-4444"    (fixo 10d)
+//
+// Substitui o hand-wiring de maskTel + Input repetido (ContatoTab do drawer
+// Cliente e forms novos com telefone). Persistir SEMPRE `digits` (sem máscara).
+//
+// Uso:
+//   <PhoneInput value={telefone} onValueChange={({ masked, digits }) => ...} />
+
+import { Input, type InputProps } from '@/Components/ui/input';
+import { maskTel, onlyDigits } from '@/Lib/br-mask';
+
+interface PhoneInputProps extends Omit<InputProps, 'value' | 'onChange' | 'type'> {
+  /** Valor controlado — aceita com ou sem máscara (deriva sempre dos dígitos). */
+  value: string;
+  /** Emite a cada tecla: masked (display) + digits (persistir). */
+  onValueChange: (v: { masked: string; digits: string }) => void;
+}
+
+function PhoneInput({ value, onValueChange, ...rest }: PhoneInputProps) {
+  return (
+    <Input
+      {...rest}
+      type="tel"
+      inputMode="tel"
+      autoComplete="tel-national"
+      value={maskTel(onlyDigits(value))}
+      onChange={(e) => {
+        const d = onlyDigits(e.target.value);
+        onValueChange({ masked: maskTel(d), digits: d });
+      }}
+    />
+  );
+}
+
+export { PhoneInput };
+export type { PhoneInputProps };

--- a/resources/js/Pages/Sells/Create.design-spec.json
+++ b/resources/js/Pages/Sells/Create.design-spec.json
@@ -1,7 +1,7 @@
 {
   "screen": "Sells/Create",
   "path": "resources/js/Pages/Sells/Create.tsx",
-  "measured_against_sha": "5c6c557f5",
+  "measured_against_sha": "56edc6f70",
   "generated_by": "scripts/design-spec-gen.mjs (DERIVADO — não editar à mão)",
   "shell": [
     "AppShellV2"
@@ -16,6 +16,7 @@
       "Checkbox",
       "Input",
       "Label",
+      "NumericInputPtBR",
       "Textarea"
     ],
     "shared": [
@@ -24,7 +25,6 @@
     ],
     "layout": [],
     "local": [
-      "NumericInputPtBR (./_components/NumericInputPtBR)",
       "PaymentRow (./_components/PaymentRow)",
       "QuickAddVehicleSheet (./_components/QuickAddVehicleSheet)",
       "dropdownEntries (./_components/dropdownEntries)",
@@ -44,8 +44,8 @@
     "native_input": 1
   },
   "totals": {
-    "canon_components": 11,
-    "local_components": 5,
+    "canon_components": 12,
+    "local_components": 4,
     "uses_layout_primitives": false,
     "structural_violations": 7
   }

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -35,7 +35,7 @@ import CustomerSearchAutocomplete, {
 } from './_components/CustomerSearchAutocomplete';
 import QuickAddVehicleSheet from './_components/QuickAddVehicleSheet';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
-import NumericInputPtBR from './_components/NumericInputPtBR';
+import NumericInputPtBR from '@/Components/ui/numeric-input-ptbr';
 import { dropdownEntries } from './_components/dropdownEntries';
 import {
   Select,

--- a/resources/js/Pages/Sells/_components/PaymentRow.tsx
+++ b/resources/js/Pages/Sells/_components/PaymentRow.tsx
@@ -25,7 +25,7 @@ import {
   SelectValue,
 } from '@/Components/ui/select';
 import { dropdownEntries } from './dropdownEntries';
-import NumericInputPtBR from './NumericInputPtBR';
+import NumericInputPtBR from '@/Components/ui/numeric-input-ptbr';
 
 export interface Payment {
   amount: number;

--- a/tests/br-inputs.test.tsx
+++ b/tests/br-inputs.test.tsx
@@ -1,0 +1,184 @@
+// BR inputs canon (ui/document-input · ui/phone-input · ui/numeric-input-ptbr) —
+// comportamento de máscara/parse + a11y runtime (axe, idioma de tests/a11y-primitives.test.tsx).
+//
+// POR QUE: estes componentes substituem hand-wiring de máscara repetido (drawer
+// Cliente Wave C-FE) e o NumericInputPtBR nasceu de bug real de produção
+// (R$ digitado virando outro valor por locale do navegador — 2026-05-27).
+// Este teste TRAVA os contratos: máscara progressiva, digits sem máscara pra
+// persistir, valid mod 11 (true/false/null), round-trip focus→edit→blur do numérico.
+//
+// Validação client é UX-only — backend Rule\BR\CpfCnpj continua a verdade (ADR 0093).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup, fireEvent, screen } from '@testing-library/react';
+import { useState } from 'react';
+import axe from 'axe-core';
+
+import { DocumentInput } from '@/Components/ui/document-input';
+import { PhoneInput } from '@/Components/ui/phone-input';
+import { NumericInputPtBR } from '@/Components/ui/numeric-input-ptbr';
+import { Label } from '@/Components/ui/label';
+
+afterEach(cleanup);
+
+// Harness controlado — espelha como uma tela real consome (useState + onValueChange).
+function DocumentHarness({ tipo }: { tipo?: 'cpf' | 'cnpj' | 'auto' }) {
+  const [doc, setDoc] = useState('');
+  const [last, setLast] = useState<{ digits: string; valid: boolean | null }>({ digits: '', valid: null });
+  return (
+    <div>
+      <Label htmlFor="doc">CPF/CNPJ</Label>
+      <DocumentInput id="doc" tipo={tipo} value={doc} onValueChange={(v) => { setDoc(v.digits); setLast(v); }} />
+      <output data-testid="digits">{last.digits}</output>
+      <output data-testid="valid">{String(last.valid)}</output>
+    </div>
+  );
+}
+
+function PhoneHarness() {
+  const [tel, setTel] = useState('');
+  const [digits, setDigits] = useState('');
+  return (
+    <div>
+      <Label htmlFor="tel">Telefone</Label>
+      <PhoneInput id="tel" value={tel} onValueChange={(v) => { setTel(v.digits); setDigits(v.digits); }} />
+      <output data-testid="digits">{digits}</output>
+    </div>
+  );
+}
+
+function NumericHarness() {
+  const [n, setN] = useState(0);
+  return (
+    <div>
+      <Label htmlFor="num">Valor</Label>
+      <NumericInputPtBR id="num" value={n} onChange={setN} />
+      <output data-testid="number">{n}</output>
+    </div>
+  );
+}
+
+describe('DocumentInput (CPF/CNPJ)', () => {
+  it('mascara CPF progressivo e valida mod 11 (CPF válido)', () => {
+    render(<DocumentHarness />);
+    const input = screen.getByLabelText('CPF/CNPJ') as HTMLInputElement;
+
+    // CPF válido conhecido: 529.982.247-25 (dígitos verificadores corretos).
+    fireEvent.change(input, { target: { value: '52998224725' } });
+    expect(input.value).toBe('529.982.247-25');
+    expect(screen.getByTestId('digits').textContent).toBe('52998224725');
+    expect(screen.getByTestId('valid').textContent).toBe('true');
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+
+  it('CPF completo ERRADO acende aria-invalid; incompleto NÃO (valid null)', () => {
+    render(<DocumentHarness />);
+    const input = screen.getByLabelText('CPF/CNPJ') as HTMLInputElement;
+
+    // Incompleto — sem erro enquanto digita.
+    fireEvent.change(input, { target: { value: '529982' } });
+    expect(screen.getByTestId('valid').textContent).toBe('null');
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+
+    // Completo e errado (sequência repetida é inválida por convenção).
+    fireEvent.change(input, { target: { value: '11111111111' } });
+    expect(screen.getByTestId('valid').textContent).toBe('false');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  it('tipo auto vira CNPJ acima de 11 dígitos (máscara 00.000.000/0000-00)', () => {
+    render(<DocumentHarness />);
+    const input = screen.getByLabelText('CPF/CNPJ') as HTMLInputElement;
+
+    // CNPJ válido conhecido: 11.222.333/0001-81.
+    fireEvent.change(input, { target: { value: '11222333000181' } });
+    expect(input.value).toBe('11.222.333/0001-81');
+    expect(screen.getByTestId('valid').textContent).toBe('true');
+  });
+
+  it('tipo=cpf trunca em 11 dígitos (não vira CNPJ)', () => {
+    render(<DocumentHarness tipo="cpf" />);
+    const input = screen.getByLabelText('CPF/CNPJ') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '52998224725999' } });
+    expect(screen.getByTestId('digits').textContent).toBe('52998224725');
+    expect(input.value).toBe('529.982.247-25');
+  });
+});
+
+describe('PhoneInput (telefone BR)', () => {
+  it('celular 11d usa pattern 9 separado (canon Cowork aprovado Wagner 2026-05-21)', () => {
+    render(<PhoneHarness />);
+    const input = screen.getByLabelText('Telefone') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '11988887777' } });
+    expect(input.value).toBe('(11) 9 8888-7777');
+    expect(screen.getByTestId('digits').textContent).toBe('11988887777');
+  });
+
+  it('fixo 10d formata (00) 0000-0000 e progressivo não quebra', () => {
+    render(<PhoneHarness />);
+    const input = screen.getByLabelText('Telefone') as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '11' } });
+    expect(input.value).toBe('(11');
+
+    fireEvent.change(input, { target: { value: '1133334444' } });
+    expect(input.value).toBe('(11) 3333-4444');
+  });
+});
+
+describe('NumericInputPtBR (promovido de Sells — contrato do bug R$ Larissa)', () => {
+  it('digitar com vírgula emite número canônico e blur reformata pt-BR', () => {
+    render(<NumericHarness />);
+    const input = screen.getByLabelText('Valor') as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '1234,5' } });
+    expect(screen.getByTestId('number').textContent).toBe('1234.5');
+
+    fireEvent.blur(input);
+    expect(input.value).toBe('1.234,50');
+  });
+
+  it('entrada inválida no blur volta pro último valor canônico (não NaN)', () => {
+    render(<NumericHarness />);
+    const input = screen.getByLabelText('Valor') as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: '25' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('25,00');
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: ',,,' } });
+    fireEvent.blur(input);
+    expect(input.value).toBe('25,00');
+    expect(screen.getByTestId('number').textContent).toBe('25');
+  });
+});
+
+describe('a11y runtime (axe — serious/critical = 0, idioma a11y-primitives)', () => {
+  async function expectNoSeriousViolations(container: HTMLElement) {
+    const results = await axe.run(container, {
+      resultTypes: ['violations'],
+    });
+    const relevant = results.violations.filter((v) => v.impact === 'serious' || v.impact === 'critical');
+    expect(relevant.map((v) => `${v.id}: ${v.help}`)).toEqual([]);
+  }
+
+  it('DocumentInput com Label associado passa axe', async () => {
+    const { container } = render(<DocumentHarness />);
+    await expectNoSeriousViolations(container);
+  });
+
+  it('PhoneInput com Label associado passa axe', async () => {
+    const { container } = render(<PhoneHarness />);
+    await expectNoSeriousViolations(container);
+  });
+
+  it('NumericInputPtBR com Label associado passa axe', async () => {
+    const { container } = render(<NumericHarness />);
+    await expectNoSeriousViolations(container);
+  });
+});

--- a/tests/br-inputs.test.tsx
+++ b/tests/br-inputs.test.tsx
@@ -63,9 +63,9 @@ describe('DocumentInput (CPF/CNPJ)', () => {
     render(<DocumentHarness />);
     const input = screen.getByLabelText('CPF/CNPJ') as HTMLInputElement;
 
-    // CPF válido conhecido: 529.982.247-25 (dígitos verificadores corretos).
+    // CPF de teste público com DV válido — não pessoa real // pii-allowlist
     fireEvent.change(input, { target: { value: '52998224725' } });
-    expect(input.value).toBe('529.982.247-25');
+    expect(input.value).toBe('529.982.247-25'); // pii-allowlist (mesmo número de teste acima)
     expect(screen.getByTestId('digits').textContent).toBe('52998224725');
     expect(screen.getByTestId('valid').textContent).toBe('true');
     expect(input.getAttribute('aria-invalid')).toBeNull();
@@ -86,13 +86,13 @@ describe('DocumentInput (CPF/CNPJ)', () => {
     expect(input.getAttribute('aria-invalid')).toBe('true');
   });
 
-  it('tipo auto vira CNPJ acima de 11 dígitos (máscara 00.000.000/0000-00)', () => {
+  it('tipo auto vira CNPJ acima de 11 dígitos (máscara NN.NNN.NNN/NNNN-NN)', () => {
     render(<DocumentHarness />);
     const input = screen.getByLabelText('CPF/CNPJ') as HTMLInputElement;
 
-    // CNPJ válido conhecido: 11.222.333/0001-81.
+    // CNPJ de teste público com DV válido — não empresa real // pii-allowlist
     fireEvent.change(input, { target: { value: '11222333000181' } });
-    expect(input.value).toBe('11.222.333/0001-81');
+    expect(input.value).toBe('11.222.333/0001-81'); // pii-allowlist (mesmo número de teste acima)
     expect(screen.getByTestId('valid').textContent).toBe('true');
   });
 
@@ -102,7 +102,7 @@ describe('DocumentInput (CPF/CNPJ)', () => {
 
     fireEvent.change(input, { target: { value: '52998224725999' } });
     expect(screen.getByTestId('digits').textContent).toBe('52998224725');
-    expect(input.value).toBe('529.982.247-25');
+    expect(input.value).toBe('529.982.247-25'); // pii-allowlist (número de teste público, DV válido)
   });
 });
 


### PR DESCRIPTION
## Intent (1 PR = 1 intent)

**BR inputs canônicos em `ui/`** — componentiza o que cada form hand-wirava com `@/Lib/br-mask` + `br-validate`. Parte 2/4 da onda de organização de componentes (pedido Wagner 2026-06-11).

## O que entra

| Componente | Origem | Substitui (anti-pattern) |
|---|---|---|
| `ui/numeric-input-ptbr.tsx` | **PROMOÇÃO** de `Pages/Sells/_components/` (R-DS-001 regra-de-2: PaymentRow + Create já consumiam) | `<Input type="number" onChange={Number(...)}>` — o bug R$ da Larissa 2026-05-27 (locale do browser) |
| `ui/document-input.tsx` (NOVO) | demanda real: 4 tabs do drawer Cliente hand-wiram maskCPF/CNPJ + validate | mask+validate repetido por tela |
| `ui/phone-input.tsx` (NOVO) | ContatoTab + forms novos | `maskTel` + Input hand-wired |

## Contratos travados por teste (11 novos, `tests/br-inputs.test.tsx`)

- Máscara progressiva (CPF `529.982.247-25`, CNPJ `11.222.333/0001-81`, celular `(11) 9 8888-7777` pattern 9-separado canon Cowork aprovado Wagner 2026-05-21)
- `valid: true|false|null` — null enquanto digita (não acende erro), `aria-invalid` só com documento completo e errado
- `clampDigits`: display === digits emitido (colar 14 dígitos em `tipo=cpf` trunca nos dois lados — pego por teste durante o desenvolvimento)
- Round-trip focus→edit→blur do numérico (digita `1234,5` → emite `1234.5` → blur formata `1.234,50`; entrada inválida volta pro canônico, nunca NaN)
- axe runtime serious/critical = 0 (idioma `a11y-primitives.test.tsx`)

## Validação client é UX-only

Backend (`Rule\BR\CpfCnpj` + FormRequest) segue a verdade canônica — ADR 0093 Tier 0 revalida toda mutação server-side.

## Docs

- `REGISTRY_DS_COMPONENTES.md` §Form controls +3 linhas ("se está aqui, não hand-rola") — ds-guard limpo
- CHANGELOG DS **0.6.10** (Added + Moved)

## Gates locais

vitest 13/13 ✅ · `lint:baseline:check` ✅ Δ-23 (zero violação nova nos arquivos do PR) · `reuse:gate` ✅ · `layout:check` ✅ · 332+/3− (≤300 de código: 145 são teste+docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
