### PR TITLE
feat(oficina): Lista com paridade TOTAL do protótipo Cowork — 6 KPIs + abas de box + tabela rica

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -72,10 +72,14 @@ class ServiceOrderController extends Controller
         $statusFilter = $request->string('status')->toString();
         $typeFilter   = $request->string('type')->toString();
         $stageFilter  = $request->string('stage')->toString();
+        $boxFilter    = $request->string('box')->toString();
         $q            = $request->string('q')->toString();
 
         // ──────── Base query (multi-tenant via global scope) ────────
-        $vehicleCols = ['id', 'plate', 'vehicle_type'];
+        // mileage_at_entry (km de entrada) entra pra coluna VEÍCULO da tabela rica
+        // (paridade Board — pedido [W] 2026-06-11). Guard de schema implícito (campo
+        // existe desde a migration de Vehicle; se ausente, o select ignora).
+        $vehicleCols = ['id', 'plate', 'vehicle_type', 'mileage_at_entry'];
         if ($hasVehicleNumber) {
             $vehicleCols[] = 'vehicle_number';
         }
@@ -86,6 +90,12 @@ class ServiceOrderController extends Controller
         $base = ServiceOrder::query()->with([
             'vehicle:' . implode(',', $vehicleCols),
         ]);
+
+        // Mecânico responsável (coluna MECÂNICO da tabela rica) — guard schema Wave 2.1.
+        $hasResourceSchema = Schema::hasColumn('service_orders', 'box_label');
+        if ($hasResourceSchema) {
+            $base->with('assignedUser:id,first_name,last_name,surname');
+        }
 
         // Coluna VALOR da listagem com dado REAL (polish canon Board 2026-06-11):
         // soma dos itens da OS (peças + mão-de-obra) via withSum — 1 subquery, sem N+1.
@@ -113,7 +123,7 @@ class ServiceOrderController extends Controller
                     break;
                 case 'atrasada':
                     // Atraso de REPARO (ADR 0265 — locação erradicada): OS não-terminal
-                    // com expected_completion vencida. Espelha buildServiceOrderKpisPayload.
+                    // com expected_completion vencida. Espelha buildListKpis (KPI Urgentes).
                     $qb->whereNotIn('status', ['concluida', 'cancelada'])
                         ->whereNotNull('expected_completion')
                         ->whereDate('expected_completion', '<', now()->toDateString());
@@ -145,6 +155,11 @@ class ServiceOrderController extends Controller
                 ->where('key', $stageFilter)
                 ->pluck('id');
             $qb->whereIn('current_stage_id', $stageIds);
+        });
+
+        // ──────── Filter box (abas de box/elevador — paridade Board [W] 2026-06-11) ────────
+        $base->when($boxFilter !== '' && $boxFilter !== 'all' && $hasResourceSchema, function ($qb) use ($boxFilter) {
+            $qb->where('box_label', $boxFilter);
         });
 
         // ──────── Search ────────
@@ -182,27 +197,35 @@ class ServiceOrderController extends Controller
         );
         $base->orderByDesc('id');
 
-        // Wave 26 D6 — Inertia::defer pro kpis payload (RUNBOOK-inertia-defer-pattern):
+        // Mapa stage_id → {key,name,color} do processo de mecânica (resolve a coluna
+        // ETAPA da tabela rica sem N+1). Paridade Board [W] 2026-06-11.
+        $stageMap = $hasCurrentStage ? $this->buildStageMap() : [];
+
+        // Paginação + transform: injeta etapa/mecânico/km/box em cada linha (tabela rica).
+        $orders = $base->paginate(25)->withQueryString();
+        $orders->through(fn ($o) => $this->shapeListRow($o, $stageMap));
+
+        // Wave 26 D6 — Inertia::defer pros payloads agregados (RUNBOOK-inertia-defer-pattern):
         // - orders eager (sempre tem; resposta partial reload `only:['orders']` espera direto)
-        // - kpis defer (4 COUNT queries — pula quando UI já tem cached/partial reload)
+        // - kpis/boxes defer (COUNT/DISTINCT — pula quando partial reload não pede)
         // - schemaFlags eager (booleanos baratos Schema::hasColumn cached)
-        // - filters eager (UI state)
-        // Rollback Wave L/W7 PR #963 estudado: defer só aplicado em payload que NÃO é target de partial reload + tem custo > 50ms.
         return Inertia::render('OficinaAuto/ServiceOrders/Index', [
-            'orders'  => $base->paginate(25)->withQueryString(),
+            'orders'  => $orders,
             'filters' => [
                 'status' => $statusFilter,
                 'type'   => $typeFilter,
                 'stage'  => $stageFilter,
+                'box'    => $boxFilter,
                 'q'      => $q,
             ],
-            'kpis' => Inertia::defer(fn () => $this->buildServiceOrderKpisPayload($hasOrderType)),
-            // Gap #3 estado-da-arte FSM screen — chips por stage estilo Linear.
-            // Defer porque é COUNT por stage (~8 stages × cacamba_* processos).
+            // 6 KPIs do protótipo Cowork (paridade Board): contagem por etapa do pipeline
+            // (Recepção/Diagnóstico/Aguardando peças/Em execução), Urgentes (atrasadas) e
+            // Valor em curso (soma items_total das OS não-terminais). Clicáveis como filtro.
+            'kpis' => Inertia::defer(fn () => $this->buildListKpis($hasCurrentStage, $hasResourceSchema)),
+            // Abas de box/elevador (paridade Board) — distinct sobre as OS do business.
+            'boxes' => Inertia::defer(fn () => $this->buildListBoxOptions($hasResourceSchema)),
+            // Gap #3 — chips por stage (mantido pra retrocompat de quem usa ?stage=).
             'stages' => Inertia::defer(fn () => $this->buildStagesPayload($hasCurrentStage)),
-            // schemaFlags: booleanos baratos (Schema::hasColumn cached) — mantém eager.
-            // Flags de locação (has_return_date/has_delivery_address/has_daily_rate)
-            // erradicadas (ADR 0265) — frontend não consome mais.
             'schemaFlags' => [
                 'has_order_type'      => $hasOrderType,
                 'has_number'          => $hasNumber,
@@ -211,8 +234,165 @@ class ServiceOrderController extends Controller
                 'has_current_stage'   => $hasCurrentStage,
                 'has_vehicle_number'  => $hasVehicleNumber,
                 'has_capacity_m3'     => $hasCapacityM3,
+                'has_resources'       => $hasResourceSchema,
             ],
         ]);
+    }
+
+    /**
+     * Mapa stage_id → {key,name,color} do processo oficina_mecanica_os do business.
+     * Resolve a coluna ETAPA da tabela rica (paridade Board) sem N+1.
+     *
+     * @return array<int, array{key:string, name:string, color:string|null}>
+     */
+    private function buildStageMap(): array
+    {
+        $businessId = (int) (session('user.business_id') ?? session('business.id') ?? 0);
+
+        return \App\Domain\Fsm\Models\SaleProcessStage::query()
+            ->whereHas('process', function ($p) use ($businessId) {
+                $p->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
+                    ->where('business_id', $businessId)
+                    ->where('key', 'oficina_mecanica_os');
+            })
+            ->get(['id', 'key', 'name', 'color'])
+            ->keyBy('id')
+            ->map(fn ($s) => ['key' => $s->key, 'name' => $s->name, 'color' => $s->color])
+            ->all();
+    }
+
+    /**
+     * Shape de 1 linha da tabela rica da Lista (paridade Board [W] 2026-06-11).
+     * Adiciona etapa (key/name/color), box, mecânico e km de entrada ao payload que
+     * o frontend já consumia (campos básicos + items_total). Reusa accessor is_overdue
+     * via expected_completion (ADR 0265 — reparo).
+     *
+     * @param  array<int, array{key:string, name:string, color:string|null}>  $stageMap
+     * @return array<string, mixed>
+     */
+    private function shapeListRow(ServiceOrder $order, array $stageMap): array
+    {
+        $stageId = $order->getAttribute('current_stage_id');
+        $stage = $stageId !== null ? ($stageMap[(int) $stageId] ?? null) : null;
+
+        $mechanic = $order->relationLoaded('assignedUser') ? $order->assignedUser : null;
+        $mechanicName = $mechanic
+            ? trim(($mechanic->first_name ?? '') . ' ' . ($mechanic->last_name ?? ($mechanic->surname ?? '')))
+            : null;
+
+        $expected = $order->expected_completion;
+        $isOverdue = $expected !== null
+            && ! in_array($order->status, ['concluida', 'cancelada', 'entregue'], true)
+            && $expected->isPast();
+
+        $boxLabel = $order->getAttribute('box_label');
+        $km = $order->vehicle?->getAttribute('mileage_at_entry');
+
+        return [
+            'id'         => (int) $order->id,
+            'number'     => $order->getAttribute('number'),
+            'status'     => $order->status,
+            'order_type' => $order->getAttribute('order_type'),
+            'expected_completion' => $expected?->toIso8601String(),
+            'entered_at' => $order->entered_at?->toIso8601String(),
+            'started_at' => $order->getAttribute('started_at')?->toIso8601String(),
+            'notes'      => $order->notes,
+            'vehicle'    => $order->vehicle ? [
+                'id'             => (int) $order->vehicle->id,
+                'plate'          => $order->vehicle->getAttribute('plate'),
+                'vehicle_type'   => $order->vehicle->getAttribute('vehicle_type'),
+                'vehicle_number' => $order->vehicle->getAttribute('vehicle_number'),
+                'capacity_m3'    => $order->vehicle->getAttribute('capacity_m3'),
+            ] : null,
+            'contact'    => $order->relationLoaded('contact') && $order->contact
+                ? ['id' => (int) $order->contact->id, 'name' => $order->contact->name]
+                : null,
+            'is_overdue' => $isOverdue,
+            'items_total' => $order->getAttribute('items_total') !== null ? (float) $order->getAttribute('items_total') : null,
+            // Campos ricos (paridade Board): etapa FSM, box, mecânico, km de entrada.
+            'stage'       => $stage,
+            'box'         => is_string($boxLabel) && $boxLabel !== '' ? $boxLabel : null,
+            'mechanic_name' => $mechanicName !== null && $mechanicName !== '' ? $mechanicName : null,
+            'km'          => $km !== null ? (int) $km : null,
+        ];
+    }
+
+    /**
+     * 6 KPIs do protótipo Cowork pra Lista/Fila (paridade Board). Contagem por etapa do
+     * pipeline (Recepção/Diagnóstico/Aguardando peças/Em execução) + Urgentes (atrasadas)
+     * + Valor em curso (soma items_total das OS não-terminais). Multi-tenant Tier 0 via
+     * global scope ServiceOrder.
+     *
+     * @return array<string, int|float>
+     */
+    private function buildListKpis(bool $hasCurrentStage, bool $hasResourceSchema): array
+    {
+        $stageMap = $hasCurrentStage ? $this->buildStageMap() : [];
+        // stage_id por key (recepcao/em_diagnostico/aguardando_pecas/em_execucao).
+        $idsByKey = [];
+        foreach ($stageMap as $id => $info) {
+            $idsByKey[$info['key']][] = $id;
+        }
+
+        $countStage = function (string $key) use ($idsByKey): int {
+            $ids = $idsByKey[$key] ?? [];
+            if (empty($ids)) {
+                return 0;
+            }
+            return ServiceOrder::query()->whereIn('current_stage_id', $ids)->count();
+        };
+
+        $atrasadas = ServiceOrder::query()
+            ->whereNotIn('status', ['concluida', 'cancelada', 'entregue'])
+            ->whereNotNull('expected_completion')
+            ->whereDate('expected_completion', '<', now()->toDateString())
+            ->count();
+
+        // Valor em curso = soma items_total das OS não-terminais (faturamento previsto).
+        $valorEmCurso = (float) ServiceOrder::query()
+            ->whereNotIn('status', ['concluida', 'cancelada', 'entregue'])
+            ->withSum('items as t', 'valor_total')
+            ->get(['id'])
+            ->sum('t');
+
+        $boxesTotal = 0;
+        if ($hasResourceSchema) {
+            $boxesTotal = ServiceOrder::query()
+                ->whereNotNull('box_label')->where('box_label', '!=', '')
+                ->distinct()->count('box_label');
+        }
+
+        return [
+            'recepcao'        => $countStage('recepcao'),
+            'em_diagnostico'  => $countStage('em_diagnostico'),
+            'aguardando_pecas' => $countStage('aguardando_pecas'),
+            'em_execucao'     => $countStage('em_execucao'),
+            'atrasadas'       => $atrasadas,
+            'valor_em_curso'  => round($valorEmCurso, 2),
+            'boxes_total'     => $boxesTotal,
+        ];
+    }
+
+    /**
+     * Abas de box/elevador (paridade Board) — distinct box_label + contagem por box.
+     * Multi-tenant Tier 0 via global scope ServiceOrder.
+     *
+     * @return list<array{label:string, count:int}>
+     */
+    private function buildListBoxOptions(bool $hasResourceSchema): array
+    {
+        if (! $hasResourceSchema) {
+            return [];
+        }
+
+        return ServiceOrder::query()
+            ->whereNotNull('box_label')->where('box_label', '!=', '')
+            ->selectRaw('box_label, COUNT(*) as total')
+            ->groupBy('box_label')
+            ->orderBy('box_label')
+            ->get()
+            ->map(fn ($r) => ['label' => (string) $r->box_label, 'count' => (int) $r->total])
+            ->all();
     }
 
     /**
@@ -663,50 +843,6 @@ class ServiceOrderController extends Controller
             ->all();
     }
 
-    /**
-     * KPIs Index — 4 COUNT queries separadas (não afetadas por filtros).
-     *
-     * Extraído pra helper + Inertia::defer no index() pra pular execução quando
-     * partial reload `only:['orders']` não pede kpis (RUNBOOK-inertia-defer-pattern).
-     */
-    private function buildServiceOrderKpisPayload(bool $hasOrderType): array
-    {
-        $kpiBase = fn () => ServiceOrder::query();
-
-        if ($hasOrderType) {
-            $manutencaoAtivas = $kpiBase()
-                ->where('order_type', 'manutencao')
-                ->whereNotIn('status', ['concluida', 'cancelada'])
-                ->count();
-        } else {
-            // Fallback pré-Wave 5-A: tudo ainda não tem tipo, agrupa em "manutenção"
-            $manutencaoAtivas = $kpiBase()
-                ->whereNotIn('status', ['concluida', 'cancelada'])
-                ->count();
-        }
-
-        $concluidasMes = $kpiBase()
-            ->where('status', 'concluida')
-            ->whereMonth('updated_at', now()->month)
-            ->whereYear('updated_at', now()->year)
-            ->count();
-
-        // Atraso de REPARO (ADR 0265 — locação erradicada): OS não-terminal com
-        // expected_completion vencida. Mesma regra do filtro ?status=atrasada.
-        $atrasadas = $kpiBase()
-            ->whereNotIn('status', ['concluida', 'cancelada'])
-            ->whereNotNull('expected_completion')
-            ->whereDate('expected_completion', '<', now()->toDateString())
-            ->count();
-
-        // Key 'locacoes_ativas' REMOVIDA do contrato (ADR 0265 — o frontend já não
-        // renderiza o card; dívida P5 do RUNBOOK-erradicacao-locacao quitada aqui).
-        return [
-            'manutencao_ativas' => $manutencaoAtivas,
-            'concluidas_mes'    => $concluidasMes,
-            'atrasadas'         => $atrasadas,
-        ];
-    }
 
     public function create(): Response
     {

--- a/Modules/OficinaAuto/Tests/Feature/Wave26OficinaAutoSaturationTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/Wave26OficinaAutoSaturationTest.php
@@ -143,9 +143,10 @@ describe('Wave 26 OficinaAuto POLISH 77→88', function () {
         expect(file_exists($ctrlPath))->toBeTrue();
         $src = file_get_contents($ctrlPath);
 
-        // Wave 26 D6: defer no kpis (4 COUNT queries) — pula em partial reload `only:['orders']`
+        // Wave 26 D6: defer no kpis (COUNT queries) — pula em partial reload `only:['orders']`.
+        // Paridade Board 2026-06-11: o builder virou buildListKpis (6 KPIs do protótipo).
         expect($src)->toContain("'kpis' => Inertia::defer(");
-        expect($src)->toContain('buildServiceOrderKpisPayload');
+        expect($src)->toContain('buildListKpis');
     });
 
     it('D6: ServiceOrderController index() documenta razão do rollback Wave L/W7', function () {

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
@@ -15,7 +15,7 @@ related_adrs:
   - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
   - 0265-oficina-reparo-erradica-locacao
 tier: A
-charter_version: 4
+charter_version: 5
 ---
 
 # Page Charter — /oficina-auto/service-orders
@@ -84,3 +84,4 @@ Dashboard operacional pra atendente/gerente da oficina decidir próxima ação e
 - **2026-05-26** (v2) — Cockpit Pattern V2; KPI "locações ativas" + colunas locação mantidos.
 - **2026-06-09** (v3) — sweep ADR 0265 no front ([sessão](../../../../../memory/sessions/2026-06-09-sweep-os-front-adr0265.md) · [avaliação CC](../../../../../prototipo-ui/AVALIACAO_OS_GIT_2026-06-09.md)): KPI "Locações ativas" **morto**; colunas/pills/badges de locação → reparo (`OrderType = {manutencao, mecanica}`); `formatBRL(null)` → "—". `mecanica` deixou de cair no ramo locação.
 - **2026-06-11** (v4) — polish canon Board (pedido [W], mesmo canon Cowork oficina-page/oficina-fila): header sem círculo decorativo; KPIs no `BoardKpiCard` (extraído do Board) clicáveis D-05 substituindo as abas de status; toolbar única (busca+limpar+contador · tipo · estágio FSM · toggle Quadro/Lista/Fila); VALOR real (`items_total` via withSum); dot vermelho de atraso removido (pill única). FILA: caixa cinza → meta-grid canon (label 11px/valor 13px tabular-nums, defeito full-row), `ServiceOrderTimeline` no canon `.ofc-timeline` (fio+dot+quem·quando, sem pills com seta), stepper com labels truncadas (flex-1 min-w-0). DRAWER (`ServiceOrderSheet`): header eyebrow "OS #N · etapa" + badge tipo fora do título + h2 17px veículo + p 12.5px cliente, MiniKpi → meta compacta (Entrada/Valor BRL à direita), seções border-top fino (mesmo Section do RichSheet), Cancelar OS vira outline destructive.
+- **2026-06-11** (v5) — **paridade TOTAL com o protótipo Cowork** (pedido [W] "resultado esperado" = nível do Board, após o v4 ficar aquém). LISTA reconstruída: **6 KPIs** (Recepção/Em diagnóstico/Aguardando peças/Em execução/Urgentes/**Valor em curso**) clicáveis (etapa via `?stage=`, urgentes via `?status=atrasada`, valor só-leitura); **abas de box/elevador** (`?box=` com contador); **tabela rica** (OS · PLACA Mercosul · VEÍCULO+km · CLIENTE · ETAPA dot+nome · BOX · MECÂNICO · PRAZO · VALOR). Header vira "Oficina Auto" + subtítulo "Recepção, diagnóstico, peças, execução e entrega de veículos". Backend `index()` enriquecido — `buildStageMap`/`shapeListRow`/`buildListKpis`/`buildListBoxOptions` (`buildServiceOrderKpisPayload` 3-KPI removido); etapa/box/mecânico/km com lastro real (`assignedUser`, `mileage_at_entry`, `current_stage_id`), "—" quando ausente (no-mock). FILA com detalhe rico inline = PR seguinte.

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -1,27 +1,21 @@
 // @memcofre tela=/oficina-auto/ordens-servico module=OficinaAuto
 // V0.6 dashboard de OS — Martinho LIVE prod biz=164 (sub-vertical 4 ADR 0194).
-// 2026-06-09 sweep ADR 0265 (avaliação [CC]): locação erradicada do front —
-// types/pills/colunas/copy agora são de REPARO (mecanica|manutencao). Colunas
-// de locação (Endereço/Diárias) removidas; "Caçamba"→"Veículo"; formatBRL
-// null→"—" (antes vazava "R$ [redacted Tier 0]" literal na UI).
-// Espelha layout Vehicles Index (Wave 5-B).
+// 2026-06-09 sweep ADR 0265: locação erradicada (types/copy de REPARO).
 // RUNBOOK: memory/requisitos/OficinaAuto/RUNBOOK-index.md
 //
-// Polish canon Board [CC] 2026-06-11 (pedido [W] — alinhar Lista/Fila à língua
-// visual do Board aprovado, mesmo canon Cowork oficina-page/oficina-fila):
-//   1. Header sem círculo decorativo (PageHeader recebia ReactNode em prop string
-//      `icon` — renderizava caixa vazia): h1 + subtítulo descritivo, só Nova OS.
-//   2. KPIs no canon do Board (BoardKpiCard: label uppercase 10px + número grande
-//      tabular-nums + sublinha) e CLICÁVEIS como filtro D-05 (clica filtra ·
-//      clica de novo limpa · chip "limpar filtro" na toolbar).
-//   3. Abas Todas/Em andamento/Concluídas mês/Atrasadas REMOVIDAS (redundantes
-//      com os KPIs clicáveis). Toolbar única (canon .ofc-view-toolbar): busca com
-//      limpar (×) + contador, tipo, chips de estágio FSM e toggle de views.
-//   4. Coluna VALOR com dado REAL (items_total via withSum no Controller — o
-//      valor_receber é accessor sempre-0 pós-ADR 0265); indicador de atraso
-//      ÚNICO (pill "Atrasada" do StatusBadge; dot vermelho removido).
-//   5. Toggle Quadro · Lista · Fila — Quadro navega pro /board (simetria com o
-//      toggle do Board, que navega pra cá).
+// Paridade TOTAL com o protótipo Cowork [CC] 2026-06-11 (pedido [W] "resultado
+// esperado" = nível do Board): a Lista deixou de ser uma tabela densa simples e
+// virou o canon Cowork da tela Oficina Auto —
+//   1. 6 KPIs (Recepção · Em diagnóstico · Aguardando peças · Em execução ·
+//      Urgentes · Valor em curso) no BoardKpiCard, CLICÁVEIS como filtro (etapa
+//      via ?stage=, urgentes via ?status=atrasada; "Valor em curso" só-leitura);
+//   2. abas de box/elevador (?box=) com contador, paridade .prod-equip-filters;
+//   3. toolbar única (busca + limpar + contador + tipo + toggle Quadro·Lista·Fila);
+//   4. TABELA RICA: OS · PLACA Mercosul · VEÍCULO+km · CLIENTE · ETAPA (dot+nome) ·
+//      BOX · MECÂNICO · PRAZO · VALOR (items_total real). Sem dado fake — etapa/box/
+//      mecânico/km vêm do backend (shapeListRow) com lastro real; "—" quando ausente.
+// Backend: ServiceOrderController::index() enriquecido (buildStageMap/shapeListRow/
+// buildListKpis/buildListBoxOptions). Fila segue na 2ª view (ServiceOrderFila).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, router } from '@inertiajs/react';
@@ -31,14 +25,14 @@ import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 import BoardKpiCard from './_components/board/BoardKpiCard';
-import ServiceOrderStatusBadge from './_components/ServiceOrderStatusBadge';
+import { toneForColor } from './_components/board/boardTone';
 import ServiceOrderSheet from './_components/ServiceOrderSheet';
 import ServiceOrderFila from './_components/ServiceOrderFila';
 import { cn } from '@/Lib/utils';
 
-// View in-page da listagem: tabela densa ou fila master-detail (handoff Cowork
-// 2026-06-03). Reflete em `?view=` (querystring, canon do charter — sem sessionStorage).
+// View in-page da listagem: tabela rica ou fila master-detail. Reflete em `?view=`.
 type ListView = 'lista' | 'fila';
 
 function initialView(): ListView {
@@ -63,25 +57,33 @@ interface ContactRel {
   name: string;
 }
 
+// Etapa FSM atual da OS (resolvida no backend via buildStageMap).
+interface StageRel {
+  key: string;
+  name: string;
+  color: string | null;
+}
+
 interface ServiceOrder {
   id: number;
   number?: string | null;
   status: string;
   order_type?: OrderType;
-  // Atraso de reparo (ADR 0265): só expected_completion. Campos de locação
-  // (delivery_address/expected_return_date/daily_rate/dias_locacao) erradicados.
   expected_completion?: string | null;
   entered_at?: string | null;
   started_at?: string | null;
   completed_at?: string | null;
-  // Sintoma/defeito relatado na entrada da OS — 1ª linha exibida na coluna "Defeito".
   notes?: string | null;
   vehicle?: VehicleRel | null;
   contact?: ContactRel | null;
   is_overdue?: boolean;
-  // Soma REAL dos itens da OS (withSum no index — peças + mão-de-obra). NULL
-  // quando a OS não tem item lançado. Substitui valor_receber (accessor sempre-0).
+  // Soma REAL dos itens da OS (withSum no index). NULL quando sem item lançado.
   items_total?: number | string | null;
+  // Campos ricos (paridade Board): etapa, box, mecânico, km de entrada.
+  stage?: StageRel | null;
+  box?: string | null;
+  mechanic_name?: string | null;
+  km?: number | null;
 }
 
 interface PaginatedOrders {
@@ -99,23 +101,24 @@ interface Filters {
   status: string;
   type: string;
   stage: string;
+  box: string;
   q: string;
 }
 
+// 6 KPIs do protótipo Cowork (paridade Board).
 interface Kpis {
-  manutencao_ativas: number;
-  concluidas_mes: number;
+  recepcao: number;
+  em_diagnostico: number;
+  aguardando_pecas: number;
+  em_execucao: number;
   atrasadas: number;
+  valor_em_curso: number;
+  boxes_total: number;
 }
 
-// Gap #3 estado-da-arte FSM screen — chips por stage estilo Linear (Wave 7-D).
-interface Stage {
-  key: string;
-  name: string;
-  color: string | null;
+interface BoxOption {
+  label: string;
   count: number;
-  is_terminal: boolean;
-  process_key: string;
 }
 
 interface SchemaFlags {
@@ -126,38 +129,52 @@ interface SchemaFlags {
   has_current_stage: boolean;
   has_vehicle_number: boolean;
   has_capacity_m3: boolean;
+  has_resources: boolean;
 }
 
 interface Props {
   orders: PaginatedOrders;
   filters: Filters;
-  // kpis vem via Inertia::defer (Wave 26 D6) — undefined no primeiro render.
-  // Default value no destructuring evita crash até segundo request chegar.
+  // kpis/boxes vêm via Inertia::defer — undefined no primeiro render (default evita crash).
   kpis?: Kpis;
-  // stages vem via Inertia::defer (Gap #3 Wave 7-D) — undefined antes do segundo request.
-  stages?: Stage[];
+  boxes?: BoxOption[];
   schemaFlags: SchemaFlags;
 }
 
 const EMPTY_KPIS: Kpis = {
-  manutencao_ativas: 0,
-  concluidas_mes: 0,
+  recepcao: 0,
+  em_diagnostico: 0,
+  aguardando_pecas: 0,
+  em_execucao: 0,
   atrasadas: 0,
+  valor_em_curso: 0,
+  boxes_total: 0,
 };
 
-// ──────── Helpers ────────
-// D-05 — KPI clicável É o filtro de status (as abas Todas/Em andamento/Concluídas
-// mês/Atrasadas eram redundantes e foram removidas no polish canon Board 2026-06-11).
-// key = mesmo valor que o filtro ?status= do Controller (manutencao_ativa etc).
-const KPI_STATUS_FILTERS = [
-  { key: 'manutencao_ativa', label: 'Em andamento', sub: 'OS abertas em reparo', tone: 'indigo' as const },
-  { key: 'concluida_mes', label: 'Concluídas no mês', sub: 'finalizadas no mês corrente', tone: 'emerald' as const },
-  { key: 'atrasada', label: 'Atrasadas', sub: null, tone: 'rose' as const },
+// ──────── KPIs (6 cards do protótipo) ────────
+// Cada KPI clicável aplica um filtro: os 4 de etapa via ?stage=<key>; "Urgentes"
+// via ?status=atrasada; "Valor em curso" é só-leitura (faturamento previsto).
+type KpiFilter = { stage: string } | { status: string } | null;
+
+interface KpiDef {
+  id: keyof Kpis;
+  label: string;
+  sub: string;
+  tone: 'default' | 'blue' | 'violet' | 'indigo' | 'rose' | 'emerald';
+  filter: KpiFilter;
+  money?: boolean;
+}
+
+const KPI_CARDS: KpiDef[] = [
+  { id: 'recepcao',         label: 'Recepção',         sub: 'aguardando triagem',     tone: 'default', filter: { stage: 'recepcao' } },
+  { id: 'em_diagnostico',   label: 'Em diagnóstico',   sub: 'em análise técnica',     tone: 'blue',    filter: { stage: 'em_diagnostico' } },
+  { id: 'aguardando_pecas', label: 'Aguardando peças', sub: 'peça a caminho',         tone: 'violet',  filter: { stage: 'aguardando_pecas' } },
+  { id: 'em_execucao',      label: 'Em execução',      sub: 'boxes ocupados agora',   tone: 'indigo',  filter: { stage: 'em_execucao' } },
+  { id: 'atrasadas',        label: 'Urgentes',         sub: 'prazo crítico',          tone: 'rose',    filter: { status: 'atrasada' } },
+  { id: 'valor_em_curso',   label: 'Valor em curso',   sub: 'faturamento previsto',   tone: 'emerald', filter: null, money: true },
 ];
 
-const KPI_FILTER_LABEL: Record<string, string> = Object.fromEntries(
-  KPI_STATUS_FILTERS.map((k) => [k.key, k.label]),
-);
+const STAGE_KEYS = ['recepcao', 'em_diagnostico', 'aguardando_pecas', 'em_execucao'] as const;
 
 const TYPE_PILLS: Array<{ key: string; label: string }> = [
   { key: 'all', label: 'Todos os tipos' },
@@ -167,7 +184,6 @@ const TYPE_PILLS: Array<{ key: string; label: string }> = [
 
 function formatBRDate(value?: string | null): string {
   if (!value) return '—';
-  // Aceita "YYYY-MM-DD" ou ISO datetime; evita problema de fuso interpretando como UTC.
   const datePart = value.length >= 10 ? value.slice(0, 10) : value;
   const [y, m, d] = datePart.split('-');
   if (!y || !m || !d) return value;
@@ -181,7 +197,11 @@ function formatBRL(value: number | string | null | undefined): string {
   return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 }
 
-// Atraso de REPARO (ADR 0265 — locação erradicada): só expected_completion.
+function formatBRLshort(value: number): string {
+  return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 });
+}
+
+// Atraso de REPARO (ADR 0265): só expected_completion.
 function isOverdueClient(o: ServiceOrder): boolean {
   if (typeof o.is_overdue === 'boolean') return o.is_overdue;
   if (['concluida', 'cancelada'].includes(o.status)) return false;
@@ -193,41 +213,16 @@ function isOverdueClient(o: ServiceOrder): boolean {
   return target < today;
 }
 
-// 1ª linha do sintoma/defeito relatado (coluna "Defeito" + linha secundária da Fila).
-function firstLine(notes?: string | null): string {
-  if (!notes) return '';
-  const line = notes.split(/\r?\n/)[0]?.trim() ?? '';
-  return line;
+function capitalize(s?: string | null): string {
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
 }
 
-// Gap #3 — paleta de cores Tailwind por stage.color (vinda do seeder OficinaAutoFsmSeeder).
-const STAGE_CHIP_FALLBACK = {
-  idle: 'border-gray-200 text-gray-700 hover:bg-gray-50',
-  active: 'border-gray-400 bg-gray-100 text-gray-900',
-};
-const STAGE_CHIP_COLOR_MAP: Record<string, { idle: string; active: string }> = {
-  gray:    { idle: 'border-gray-200 text-gray-700 hover:bg-gray-50',         active: 'border-gray-400 bg-gray-100 text-gray-900' },
-  blue:    { idle: 'border-blue-200 text-blue-700 hover:bg-blue-50',         active: 'border-blue-400 bg-blue-100 text-blue-900' },
-  cyan:    { idle: 'border-cyan-200 text-cyan-700 hover:bg-cyan-50',         active: 'border-cyan-400 bg-cyan-100 text-cyan-900' },
-  amber:   { idle: 'border-amber-200 text-amber-700 hover:bg-amber-50',      active: 'border-amber-400 bg-amber-100 text-amber-900' },
-  yellow:  { idle: 'border-yellow-200 text-yellow-700 hover:bg-yellow-50',   active: 'border-yellow-400 bg-yellow-100 text-yellow-900' },
-  violet:  { idle: 'border-violet-200 text-violet-700 hover:bg-violet-50',   active: 'border-violet-400 bg-violet-100 text-violet-900' },
-  indigo:  { idle: 'border-indigo-200 text-indigo-700 hover:bg-indigo-50',   active: 'border-indigo-400 bg-indigo-100 text-indigo-900' },
-  emerald: { idle: 'border-emerald-200 text-emerald-700 hover:bg-emerald-50', active: 'border-emerald-400 bg-emerald-100 text-emerald-900' },
-  green:   { idle: 'border-green-200 text-green-700 hover:bg-green-50',      active: 'border-green-400 bg-green-100 text-green-900' },
-  red:     { idle: 'border-red-200 text-red-700 hover:bg-red-50',            active: 'border-red-400 bg-red-100 text-red-900' },
-  rose:    { idle: 'border-rose-200 text-rose-700 hover:bg-rose-50',         active: 'border-rose-400 bg-rose-100 text-rose-900' },
-  slate:   { idle: 'border-slate-200 text-slate-700 hover:bg-slate-50',      active: 'border-slate-400 bg-slate-100 text-slate-900' },
-};
-
 // ──────── Component ────────
-export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS, stages, schemaFlags }: Props) {
+export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS, boxes, schemaFlags }: Props) {
   const [q, setQ] = useState(filters.q ?? '');
   const [view, setView] = useState<ListView>(initialView);
 
-  // Troca de view reflete em `?view=` sem roundtrip ao servidor (shareable; canon
-  // do charter = querystring, não sessionStorage). History API só altera a search
-  // string da mesma página, sem desincronizar o Inertia.
   const changeView = useCallback((next: ListView) => {
     setView(next);
     if (typeof window === 'undefined') return;
@@ -237,14 +232,13 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
     window.history.replaceState(window.history.state, '', url.toString());
   }, []);
 
-  // Drawer ServiceOrder state — clicar row abre OS no drawer (US-OFICINA-OS-DRAWER).
+  // Drawer ServiceOrder state — clicar row abre OS no drawer.
   const [openOsId, setOpenOsId] = useState<number | null>(null);
   const handleSheetOpenChange = useCallback((open: boolean) => {
     if (!open) setOpenOsId(null);
   }, []);
   const handleOrderChanged = useCallback(() => {
-    // Refresh listagem + contadores stages após transição FSM (status/stage/valor mudam)
-    router.reload({ only: ['orders', 'kpis', 'stages'], preserveScroll: true, preserveState: true });
+    router.reload({ only: ['orders', 'kpis', 'boxes'] });
   }, []);
 
   // Live search com debounce 300ms
@@ -261,38 +255,52 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q]);
 
-  function applyFilter(patch: Partial<Filters>) {
+  const applyFilter = useCallback((patch: Partial<Filters>) => {
     const next = { ...filters, ...patch, q };
     Object.keys(next).forEach((k) => {
       const v = (next as Record<string, string>)[k];
       if (!v || v === 'all' || v === '') delete (next as Record<string, string>)[k];
     });
     router.get('/oficina-auto/ordens-servico', next, { preserveState: true, preserveScroll: true });
-  }
+  }, [filters, q]);
 
   function handleSearchSubmit(e: FormEvent) {
     e.preventDefault();
     applyFilter({});
   }
 
-  const subtitle = `${kpis.manutencao_ativas} em andamento · ${kpis.concluidas_mes} concluídas no mês · ${kpis.atrasadas} atrasadas`;
+  const subtitle = 'Recepção, diagnóstico, peças, execução e entrega de veículos';
 
-  // D-05 — filtro de status ativo (vem da querystring; KPI clicado = filtro aplicado)
-  const kpiStatusActive = filters.status && filters.status !== 'all' ? filters.status : null;
-  const kpiValueByKey: Record<string, number> = {
-    manutencao_ativa: kpis.manutencao_ativas,
-    concluida_mes: kpis.concluidas_mes,
-    atrasada: kpis.atrasadas,
-  };
+  // KPI ativo (deriva da querystring): etapa ∈ stage keys → esse id; status=atrasada → 'atrasadas'.
+  const activeKpiId: keyof Kpis | null =
+    filters.stage && (STAGE_KEYS as readonly string[]).includes(filters.stage)
+      ? (filters.stage as keyof Kpis)
+      : filters.status === 'atrasada'
+        ? 'atrasadas'
+        : null;
+
+  const kpiClick = useCallback((kpi: KpiDef) => {
+    if (!kpi.filter) return;
+    if ('stage' in kpi.filter) {
+      const isActive = filters.stage === kpi.filter.stage;
+      applyFilter({ stage: isActive ? 'all' : kpi.filter.stage, status: 'all' });
+    } else {
+      const isActive = filters.status === kpi.filter.status;
+      applyFilter({ status: isActive ? 'all' : kpi.filter.status, stage: 'all' });
+    }
+  }, [filters.stage, filters.status, applyFilter]);
+
+  const activeKpiLabel = activeKpiId
+    ? KPI_CARDS.find((k) => k.id === activeKpiId)?.label ?? null
+    : null;
 
   return (
     <AppShellV2>
       <Head title="Ordens de Serviço · Oficina Auto" />
-      <div className="px-4 py-6 max-w-7xl mx-auto space-y-6">
-        {/* Header canon do Board: h1 + subtítulo descritivo, sem círculo decorativo.
-            "Quadro" saiu daqui — vive no toggle de views (simetria com o Board). */}
+      <div className="px-4 py-6 max-w-[1400px] mx-auto space-y-5">
+        {/* Header canon: título da tela + subtítulo descritivo (protótipo Cowork). */}
         <PageHeader
-          title="Ordens de Serviço"
+          title="Oficina Auto"
           description={subtitle}
           action={
             <Link href="/oficina-auto/ordens-servico/create">
@@ -304,7 +312,6 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
           }
         />
 
-        {/* Aviso pré-Wave 5-A (some quando schema migrar) */}
         {!schemaFlags.has_order_type && (
           <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
             Schema Wave 5-A pendente — distinção mecânica/manutenção só ativa após migração de
@@ -312,192 +319,177 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
           </div>
         )}
 
-        {/* KPIs canon do Board (BoardKpiCard) — CLICÁVEIS como filtro D-05:
-            clica filtra (?status=), clica de novo limpa; chip "limpar" na toolbar. */}
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-          {KPI_STATUS_FILTERS.map((kpi) => (
-            <BoardKpiCard
-              key={kpi.key}
-              label={kpi.label}
-              value={String(kpiValueByKey[kpi.key] ?? 0)}
-              sub={
-                kpi.key === 'atrasada'
-                  ? kpis.atrasadas > 0 ? 'cobrar imediatamente' : 'tudo no prazo'
-                  : kpi.sub ?? undefined
-              }
-              tone={kpi.tone}
-              active={kpiStatusActive === kpi.key}
-              dimmed={kpiStatusActive !== null && kpiStatusActive !== kpi.key}
-              onClick={() => applyFilter({ status: kpiStatusActive === kpi.key ? 'all' : kpi.key })}
-            />
-          ))}
+        {/* 6 KPIs canon do Board (BoardKpiCard) — clicáveis como filtro. */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-2">
+          {KPI_CARDS.map((kpi) => {
+            const active = activeKpiId === kpi.id;
+            const value = kpi.money ? formatBRLshort(kpis.valor_em_curso) : String(kpis[kpi.id] ?? 0);
+            return (
+              <BoardKpiCard
+                key={kpi.id}
+                label={kpi.label}
+                value={value}
+                sub={kpi.sub}
+                tone={kpi.tone}
+                active={active}
+                dimmed={activeKpiId !== null && !active && kpi.filter !== null}
+                onClick={kpi.filter ? () => kpiClick(kpi) : undefined}
+              />
+            );
+          })}
         </div>
 
-        {/* Toolbar única (canon .ofc-view-toolbar do Board): [busca + limpar + chip
-            KPI + contador] | [tipo] | [toggle Quadro·Lista·Fila] — as abas de status
-            foram absorvidas pelos KPIs clicáveis. Chips de estágio FSM logo abaixo. */}
-        <div className="space-y-2">
-          <div className="flex flex-wrap items-center gap-3">
-            <form onSubmit={handleSearchSubmit} className="flex flex-1 min-w-[240px] items-center gap-2">
-              <Search size={14} className="text-muted-foreground flex-shrink-0" />
-              <div className="relative flex-1 max-w-md">
-                <Input
-                  type="search"
-                  placeholder="Buscar OS, cliente ou placa…"
-                  value={q}
-                  onChange={(e) => setQ(e.target.value)}
-                  className="h-8 border-border pr-7"
-                  aria-label="Buscar OS, cliente ou placa"
-                />
-                {q !== '' && (
-                  <button
-                    type="button"
-                    className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
-                    onClick={() => setQ('')}
-                    aria-label="Limpar busca"
-                  >
-                    <X size={12} />
-                  </button>
-                )}
-              </div>
+        {/* Abas de box/elevador (paridade .prod-equip-filters) — filtro ?box=. */}
+        {schemaFlags.has_resources && boxes && boxes.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Filtrar por box">
+            <button
+              type="button"
+              onClick={() => applyFilter({ box: 'all' })}
+              aria-pressed={!filters.box || filters.box === 'all'}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-colors',
+                !filters.box || filters.box === 'all'
+                  ? 'bg-primary text-white border-primary'
+                  : 'bg-white text-foreground border-border hover:bg-muted',
+              )}
+            >
+              Todos os boxes
+              <span className={cn('tabular-nums rounded px-1', !filters.box || filters.box === 'all' ? 'bg-white/20' : 'bg-muted')}>
+                {orders.total}
+              </span>
+            </button>
+            {boxes.map((b) => {
+              const active = filters.box === b.label;
+              return (
+                <button
+                  key={b.label}
+                  type="button"
+                  onClick={() => applyFilter({ box: active ? 'all' : b.label })}
+                  aria-pressed={active}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium whitespace-nowrap transition-colors',
+                    active ? 'bg-primary text-white border-primary' : 'bg-white text-foreground border-border hover:bg-muted',
+                  )}
+                >
+                  {b.label}
+                  <span className={cn('tabular-nums rounded px-1', active ? 'bg-white/20' : 'bg-muted')}>{b.count}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
 
-              {/* D-05 — chip do KPI-filtro ativo (clicar limpa) */}
-              {kpiStatusActive && KPI_FILTER_LABEL[kpiStatusActive] && (
+        {/* Toolbar única: busca + limpar + chip KPI + contador · tipo · toggle de views. */}
+        <div className="flex flex-wrap items-center gap-3">
+          <form onSubmit={handleSearchSubmit} className="flex flex-1 min-w-[240px] items-center gap-2">
+            <Search size={14} className="text-muted-foreground flex-shrink-0" />
+            <div className="relative flex-1 max-w-md">
+              <Input
+                type="search"
+                placeholder="placa · veículo · cliente · #OS"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                className="h-8 border-border pr-7"
+                aria-label="Buscar OS, placa ou cliente"
+              />
+              {q !== '' && (
                 <button
                   type="button"
-                  className="inline-flex items-center gap-1 text-[11px] font-medium text-primary bg-primary/10 border border-primary/30 rounded-full px-2 py-0.5 hover:bg-primary/15 whitespace-nowrap"
-                  onClick={() => applyFilter({ status: 'all' })}
+                  className="absolute right-1.5 top-1/2 -translate-y-1/2 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-muted"
+                  onClick={() => setQ('')}
+                  aria-label="Limpar busca"
                 >
-                  <X size={10} /> limpar filtro: {KPI_FILTER_LABEL[kpiStatusActive]}
+                  <X size={12} />
                 </button>
               )}
+            </div>
 
-              <span className="ml-auto pl-2 text-sm text-muted-foreground whitespace-nowrap" aria-live="polite">
-                <span className="font-medium text-foreground tabular-nums">{orders.total} OS</span>
-                {kpis.atrasadas > 0 && (
-                  <>
-                    <span className="mx-1.5">·</span>
-                    <span className="font-medium text-destructive tabular-nums">
-                      {kpis.atrasadas} atrasada{kpis.atrasadas === 1 ? '' : 's'}
-                    </span>
-                  </>
-                )}
-              </span>
-            </form>
-
-            {schemaFlags.has_order_type && (
-              <div className="inline-flex flex-shrink-0 rounded border border-border bg-white overflow-hidden" role="group" aria-label="Filtrar por tipo">
-                {TYPE_PILLS.map((pill, i) => {
-                  const active = (filters.type || 'all') === pill.key;
-                  return (
-                    <button
-                      key={pill.key}
-                      type="button"
-                      onClick={() => applyFilter({ type: pill.key })}
-                      aria-pressed={active}
-                      className={cn(
-                        'px-2.5 py-1 text-xs font-medium transition-colors',
-                        i > 0 && 'border-l border-border',
-                        active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50',
-                      )}
-                    >
-                      {pill.label}
-                    </button>
-                  );
-                })}
-              </div>
+            {activeKpiLabel && (
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 text-[11px] font-medium text-primary bg-primary/10 border border-primary/30 rounded-full px-2 py-0.5 hover:bg-primary/15 whitespace-nowrap"
+                onClick={() => applyFilter({ stage: 'all', status: 'all' })}
+              >
+                <X size={10} /> limpar filtro: {activeKpiLabel}
+              </button>
             )}
 
-            {/* Toggle de views (simetria com o Board): Quadro navega pro kanban;
-                Lista/Fila são in-page (?view=). */}
-            <div className="inline-flex flex-shrink-0 rounded border border-border bg-white overflow-hidden" role="group" aria-label="Visualização">
-              <Link
-                href="/oficina-auto/ordens-servico/board"
-                className="px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 text-foreground hover:bg-muted transition-colors"
-              >
-                <LayoutGrid size={12} /> Quadro
-              </Link>
-              <button
-                type="button"
-                onClick={() => changeView('lista')}
-                aria-pressed={view === 'lista'}
-                className={cn(
-                  'px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 transition-colors border-l border-border',
-                  view === 'lista' ? 'bg-primary text-white' : 'text-foreground hover:bg-muted',
-                )}
-              >
-                <ListIcon size={12} /> Lista
-              </button>
-              <button
-                type="button"
-                onClick={() => changeView('fila')}
-                aria-pressed={view === 'fila'}
-                className={cn(
-                  'px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 transition-colors border-l border-border',
-                  view === 'fila' ? 'bg-primary text-white' : 'text-foreground hover:bg-muted',
-                )}
-              >
-                <ListOrdered size={12} /> Fila
-              </button>
-            </div>
-          </div>
+            <span className="ml-auto pl-2 text-sm text-muted-foreground whitespace-nowrap" aria-live="polite">
+              <span className="font-medium text-foreground tabular-nums">{orders.total} OS</span>
+              {kpis.atrasadas > 0 && (
+                <>
+                  <span className="mx-1.5">·</span>
+                  <span className="font-medium text-destructive tabular-nums">
+                    {kpis.atrasadas} atrasada{kpis.atrasadas === 1 ? '' : 's'}
+                  </span>
+                </>
+              )}
+            </span>
+          </form>
 
-          {/* Gap #3 — chips de stage FSM estilo Linear (Wave 7-D). */}
-          {schemaFlags.has_current_stage && stages && stages.length > 0 && (
-            <div className="flex flex-wrap items-center gap-1.5">
-              <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground mr-1">
-                Estágio FSM:
-              </span>
-              <button
-                type="button"
-                onClick={() => applyFilter({ stage: 'all' })}
-                className={cn(
-                  'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
-                  (filters.stage || 'all') === 'all'
-                    ? 'border-foreground bg-foreground text-background'
-                    : 'border-border text-muted-foreground hover:bg-muted/50',
-                )}
-              >
-                Todos
-              </button>
-              {stages.map((stage) => {
-                const active = filters.stage === stage.key;
-                const colors = STAGE_CHIP_COLOR_MAP[stage.color ?? 'gray'] ?? STAGE_CHIP_FALLBACK;
+          {schemaFlags.has_order_type && (
+            <div className="inline-flex flex-shrink-0 rounded border border-border bg-white overflow-hidden" role="group" aria-label="Filtrar por tipo">
+              {TYPE_PILLS.map((pill, i) => {
+                const active = (filters.type || 'all') === pill.key;
                 return (
                   <button
-                    key={`${stage.process_key}-${stage.key}`}
+                    key={pill.key}
                     type="button"
-                    onClick={() => applyFilter({ stage: stage.key })}
-                    title={stage.is_terminal ? `${stage.name} (terminal)` : stage.name}
+                    onClick={() => applyFilter({ type: pill.key })}
+                    aria-pressed={active}
                     className={cn(
-                      'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
-                      active ? colors.active : colors.idle,
-                      stage.is_terminal && !active && 'opacity-70',
+                      'px-2.5 py-1 text-xs font-medium transition-colors',
+                      i > 0 && 'border-l border-border',
+                      active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted/50',
                     )}
                   >
-                    <span>{stage.name}</span>
-                    <span
-                      className={cn(
-                        'inline-flex min-w-[18px] justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums',
-                        active ? 'bg-background/40' : 'bg-background',
-                      )}
-                    >
-                      {stage.count}
-                    </span>
+                    {pill.label}
                   </button>
                 );
               })}
             </div>
           )}
+
+          {/* Toggle de views (simetria com o Board): Quadro navega pro kanban; Lista/Fila in-page. */}
+          <div className="inline-flex flex-shrink-0 rounded border border-border bg-white overflow-hidden" role="group" aria-label="Visualização">
+            <Link
+              href="/oficina-auto/ordens-servico/board"
+              className="px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 text-foreground hover:bg-muted transition-colors"
+            >
+              <LayoutGrid size={12} /> Quadro
+            </Link>
+            <button
+              type="button"
+              onClick={() => changeView('lista')}
+              aria-pressed={view === 'lista'}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 transition-colors border-l border-border',
+                view === 'lista' ? 'bg-primary text-white' : 'text-foreground hover:bg-muted',
+              )}
+            >
+              <ListIcon size={12} /> Lista
+            </button>
+            <button
+              type="button"
+              onClick={() => changeView('fila')}
+              aria-pressed={view === 'fila'}
+              className={cn(
+                'px-2.5 py-1 text-xs font-medium inline-flex items-center gap-1 transition-colors border-l border-border',
+                view === 'fila' ? 'bg-primary text-white' : 'text-foreground hover:bg-muted',
+              )}
+            >
+              <ListOrdered size={12} /> Fila
+            </button>
+          </div>
         </div>
 
-        {/* Tabela / Empty state */}
+        {/* Tabela rica / Fila / Empty state */}
         {orders.data.length === 0 ? (
           <EmptyState
             icon="wrench"
             title="Nenhuma OS encontrada"
             description={
-              filters.status || filters.type || filters.stage || filters.q
+              filters.status || filters.type || filters.stage || filters.box || filters.q
                 ? 'Ajuste os filtros ou crie uma nova ordem de serviço.'
                 : 'Crie a primeira ordem de serviço para acompanhar o fluxo da oficina.'
             }
@@ -522,115 +514,87 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
           <div className="rounded-lg border bg-card overflow-hidden">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
-                <thead className="border-b bg-muted/50 text-xs uppercase text-muted-foreground">
+                <thead className="border-b bg-muted/50 text-[11px] uppercase tracking-wide text-muted-foreground">
                   <tr>
-                    <th className="px-3 py-2 text-left">Nº OS</th>
-                    <th className="px-3 py-2 text-left">Tipo</th>
-                    <th className="px-3 py-2 text-left">Veículo</th>
-                    <th className="px-3 py-2 text-left">Cliente</th>
-                    <th className="px-3 py-2 text-left">Defeito</th>
-                    <th className="px-3 py-2 text-left">Entrada</th>
-                    <th className="px-3 py-2 text-left">Previsão</th>
-                    <th className="px-3 py-2 text-right">Valor</th>
-                    <th className="px-3 py-2 text-left">Status</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">OS</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Placa</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Veículo</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Cliente</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Etapa</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Box</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Mecânico</th>
+                    <th className="px-3 py-2.5 text-left font-semibold">Prazo</th>
+                    <th className="px-3 py-2.5 text-right font-semibold">Valor</th>
                   </tr>
                 </thead>
                 <tbody>
                   {orders.data.map((o) => {
                     const overdue = isOverdueClient(o);
-                    const startedAt = o.started_at ?? o.entered_at;
-                    const prazo = o.expected_completion;
-                    const defeito = firstLine(o.notes);
-
+                    const tone = toneForColor(o.stage?.color);
                     return (
                       <tr
                         key={o.id}
                         className={cn(
                           'border-b last:border-0 transition-colors cursor-pointer',
-                          overdue ? 'bg-rose-50/50 hover:bg-rose-50' : 'hover:bg-muted/30',
+                          overdue ? 'bg-rose-50/40 hover:bg-rose-50' : 'hover:bg-muted/30',
                         )}
                         onClick={() => setOpenOsId(o.id)}
                       >
-                        {/* Indicador de atraso ÚNICO: pill "Atrasada" do StatusBadge
-                            (o dot vermelho duplicava o sinal — removido 2026-06-11). */}
-                        <td className="px-3 py-2.5 font-mono font-semibold">
+                        <td className="px-3 py-2.5 font-mono font-semibold whitespace-nowrap">
                           {o.number ?? `#${o.id}`}
                         </td>
-                        <td className="px-3 py-2.5">
-                          {o.order_type === 'mecanica' ? (
-                            <span className="inline-block px-2 py-0.5 text-xs rounded bg-violet-50 text-violet-700 border border-violet-200">
-                              Mecânica
-                            </span>
-                          ) : o.order_type === 'manutencao' ? (
-                            <span className="inline-block px-2 py-0.5 text-xs rounded bg-amber-50 text-amber-700 border border-amber-200">
-                              Manutenção
-                            </span>
+                        <td className="px-3 py-2">
+                          {o.vehicle?.plate ? (
+                            <MercosulPlate plate={o.vehicle.plate} size="sm" />
                           ) : (
-                            <span className="text-xs text-muted-foreground">—</span>
+                            <span className="text-xs text-muted-foreground italic">sem placa</span>
                           )}
                         </td>
-                        <td className="px-3 py-2.5 font-mono text-xs">
-                          {o.vehicle ? (
-                            <>
-                              <span className="font-semibold">
-                                {o.vehicle.vehicle_number ?? o.vehicle.plate}
-                              </span>
-                              {o.vehicle.vehicle_number && (
-                                <span className="text-muted-foreground ml-1">
-                                  · {o.vehicle.plate}
-                                </span>
-                              )}
-                              {o.vehicle.capacity_m3 && (
-                                <div className="text-[11px] text-muted-foreground font-sans">
-                                  {o.vehicle.capacity_m3}m³
-                                </div>
-                              )}
-                            </>
-                          ) : (
-                            '—'
+                        <td className="px-3 py-2.5">
+                          <span className="font-medium text-foreground">
+                            {capitalize(o.vehicle?.vehicle_type) || '—'}
+                          </span>
+                          {o.km != null && (
+                            <span className="ml-1.5 text-[11px] text-muted-foreground tabular-nums">
+                              {o.km.toLocaleString('pt-BR')} km
+                            </span>
                           )}
                         </td>
                         <td className="px-3 py-2.5">
                           {o.contact?.name ?? <span className="text-muted-foreground">—</span>}
                         </td>
-                        <td className="px-3 py-2.5">
-                          {defeito ? (
-                            <span
-                              className="block max-w-[28ch] truncate text-xs text-muted-foreground"
-                              title={defeito}
-                            >
-                              {defeito}
+                        <td className="px-3 py-2.5 whitespace-nowrap">
+                          {o.stage ? (
+                            <span className="inline-flex items-center gap-1.5 text-xs">
+                              <span className={cn('inline-block h-2 w-2 rounded-full', tone.dot)} />
+                              {o.stage.name}
                             </span>
                           ) : (
-                            <span className="text-muted-foreground">—</span>
+                            <span className="text-xs text-muted-foreground">—</span>
                           )}
                         </td>
-                        <td className="px-3 py-2.5 text-xs tabular-nums text-muted-foreground">
-                          {formatBRDate(startedAt)}
+                        <td className="px-3 py-2.5 text-xs">
+                          {o.box ?? <span className="text-muted-foreground">—</span>}
+                        </td>
+                        <td className="px-3 py-2.5 text-xs">
+                          {o.mechanic_name ?? <span className="text-muted-foreground">—</span>}
                         </td>
                         <td
                           className={cn(
-                            'px-3 py-2.5 text-xs tabular-nums',
+                            'px-3 py-2.5 text-xs tabular-nums whitespace-nowrap',
                             overdue ? 'text-rose-700 font-medium' : 'text-muted-foreground',
                           )}
                         >
-                          {formatBRDate(prazo)}
+                          {formatBRDate(o.expected_completion)}
+                          {overdue && ' ⚠'}
                         </td>
-                        {/* VALOR real (items_total — soma dos itens da OS via withSum). */}
                         <td
                           className={cn(
-                            'px-3 py-2.5 text-right tabular-nums',
+                            'px-3 py-2.5 text-right tabular-nums whitespace-nowrap',
                             Number(o.items_total ?? 0) > 0 ? 'text-foreground font-medium' : 'text-muted-foreground',
                           )}
                         >
                           {formatBRL(o.items_total)}
-                        </td>
-                        <td className="px-3 py-2.5">
-                          <ServiceOrderStatusBadge
-                            status={o.status}
-                            orderType={o.order_type}
-                            isOverdue={overdue}
-                          />
                         </td>
                       </tr>
                     );
@@ -639,7 +603,6 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
               </table>
             </div>
 
-            {/* Paginação */}
             {orders.last_page > 1 && (
               <div className="flex items-center justify-between gap-2 px-3 py-3 border-t bg-muted/20 text-xs">
                 <div className="text-muted-foreground">
@@ -670,7 +633,7 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
         )}
       </div>
 
-      {/* Drawer ServiceOrder — abre ao clicar em qualquer linha da listagem */}
+      {/* Drawer ServiceOrder — abre ao clicar em qualquer linha. */}
       <ServiceOrderSheet
         serviceOrderId={openOsId}
         open={openOsId !== null}
@@ -687,5 +650,6 @@ function currentFiltersExceptQ(filters: Filters): Record<string, string> {
   if (filters.status && filters.status !== 'all') out.status = filters.status;
   if (filters.type && filters.type !== 'all') out.type = filters.type;
   if (filters.stage && filters.stage !== 'all') out.stage = filters.stage;
+  if (filters.box && filters.box !== 'all') out.box = filters.box;
   return out;
 }


### PR DESCRIPTION
## Contexto

[W] mostrou o protótipo Cowork como **resultado esperado** — o polish anterior ([#2533](https://github.com/wagnerra23/oimpresso.com/pull/2533): 3 KPIs + tabela simples) ficou **aquém**. Esta onda eleva a **Lista** (`/oficina-auto/ordens-servico` view=lista) à paridade total com o protótipo (= nível do Board). Confirmado por [W] via AskUserQuestion: "paridade total", mantendo `/ordens-servico` e `/board` como páginas separadas.

## Antes → Depois

| | #2533 (aquém) | Este PR (paridade) |
|---|---|---|
| KPIs | 3 (Em andamento/Concluídas/Atrasadas) | **6** (Recepção·Em diagnóstico·Aguardando peças·Em execução·Urgentes·**Valor em curso**) |
| Abas de box | — | **Todos os boxes / Box N / Elevador N** com contador |
| Tabela | Nº/Tipo/Veículo/Cliente/Defeito/Entrada/Previsão/Valor/Status | **OS · PLACA Mercosul · VEÍCULO+km · CLIENTE · ETAPA (dot+nome) · BOX · MECÂNICO · PRAZO · VALOR** |
| Header | "Ordens de Serviço" | "Oficina Auto" + "Recepção, diagnóstico, peças, execução e entrega" |

## Frontend (`Index.tsx` reescrita)
- 6 **BoardKpiCard** clicáveis: os 4 de etapa filtram `?stage=`, Urgentes `?status=atrasada`, **Valor em curso** só-leitura (faturamento previsto). Chip "limpar filtro".
- **Abas de box** (`?box=`) com contador, paridade `.prod-equip-filters`.
- Toolbar única (busca `placa·veículo·cliente·#OS` + limpar + contador + tipo + toggle Quadro·Lista·Fila).
- **Tabela rica** com `MercosulPlate`, etapa-dot (`toneForColor`), km, box, mecânico, prazo, valor real.

## Backend (`ServiceOrderController::index()`)
- `buildStageMap` (stage_id→{key,name,color} do `oficina_mecanica_os`, sem N+1)
- `shapeListRow` (injeta etapa/box/mecânico/km por linha via `paginator->through()`)
- `buildListKpis` (6 KPIs · defer) + `buildListBoxOptions` (abas · defer)
- eager `assignedUser` + `vehicle.mileage_at_entry`; filtro `?box=`
- `buildServiceOrderKpisPayload` (3-KPI) **removido** (dead code); teste D6 saturation aponta pra `buildListKpis`

## Governança
- **Sem dado fake** (gate no-mock): etapa/box/mecânico/km com lastro real (`assignedUser`, `mileage_at_entry`, `current_stage_id`); "—" quando ausente.
- **Multi-tenant Tier 0** preservado (global scope `ServiceOrder`).
- Charter `Index.charter.md` bump **v5** (trilha append-only).
- Typecheck limpo · ESLint 0 errors · build vite OK.

**Próximo PR:** Fila com detalhe rico inline (DVI/fotos/peças/checklist) + rail CRM — fecha a paridade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)