### PR TITLE
docs(handoff): frontmatter conforme schema (slug+tldr) — fix-forward gate Handoff #2543

### DIFF
--- a/memory/handoffs/2026-06-11-1205-arvore-componentes-canonica-3-prs.md
+++ b/memory/handoffs/2026-06-11-1205-arvore-componentes-canonica-3-prs.md
@@ -1,7 +1,12 @@
 ---
 date: "2026-06-11"
-hour_brt: "12:05"
-topic: "Árvore de componentes canônica — auditoria 57/100 → 3 PRs mergeados + enforcement"
+time: "12:05"
+slug: "arvore-componentes-canonica-3-prs"
+tldr: "Auditoria componentes 57/100 → 3 PRs mergeados (#2539 moves domínio · #2540 BR inputs ui/ · #2542 components-tree-guard) + ADR proposal arvore-componentes-canonica aguarda Wagner. ListPage PT-01-as-code adiado consciente (F4 em curso)."
+decided_by: [Wagner]
+cycle: null
+prs: ["2539", "2540", "2542", "2543"]
+next_steps: ["Wagner aprova/edita memory/decisions/proposals/2026-06-11-arvore-componentes-canonica.md", "ListPage via ADR própria + piloto + gate visual (roadmap §3 da proposal)"]
 duration: "~3h"
 authors: [Wagner (aprovador), Claude Code]
 ---


### PR DESCRIPTION
Gate 'Handoff (memory/handoffs/*.md)' falhou no #2543: schema exige date/slug/tldr e o frontmatter tinha date/hour_brt/topic. Fix só de frontmatter — narrativa intacta (append-only preservado em espírito; conformidade evita memory-health vermelho diário).

🤖 Generated with [Claude Code](https://claude.com/claude-code)