### PR TITLE
docs(mwart): /mwart-override é registro humano, não comando de CI (resto superseded por ADR 0271)

### DIFF
--- a/.claude/skills/mwart-process/SKILL.md
+++ b/.claude/skills/mwart-process/SKILL.md
@@ -120,9 +120,11 @@ Camadas 2 e 3 são US-MWART-001 e US-MWART-002 (próximo PR após este ADR merge
 
 ## Override (exceções autorizadas)
 
-Wagner pode autorizar exceção via comentário em PR: `/mwart-override <razão>`. Exceção fica registrada em ADR per-tela `memory/decisions/<NNNN>-mwart-excecao-<mod>-<tela>.md` (lifecycle `historical` — auditoria).
+Wagner pode autorizar exceção **de processo** via comentário em PR: `/mwart-override <razão>`. Exceção fica registrada em ADR per-tela `memory/decisions/<NNNN>-mwart-excecao-<mod>-<tela>.md` (lifecycle `historical` — auditoria).
 
-Sem `/mwart-override`, gates não cedem. Iniciante (`[L]`), esposa (`[E]`), Maíra, Felipe — todos passam pelo mesmo caminho. Wagner também (não pode skipar pra si).
+⚠️ **O comentário não mexe em check de CI.** Nenhum workflow processa `issue_comment` — `/mwart-override` é registro humano, não comando de máquina (caso real PR #2544, 2026-06-11: Wagner comentou override e o check `visual-regression` seguiu vermelho). Pra deixar `visual-regression` verde o único caminho é atualizar a baseline: `./vendor/bin/pest tests/Browser/ --update-snapshots` + commit dos screenshots (ADR 0271 — sem gate-teatro).
+
+Sem `/mwart-override`, gates de processo não cedem. Iniciante (`[L]`), esposa (`[E]`), Maíra, Felipe — todos passam pelo mesmo caminho. Wagner também (não pode skipar pra si).
 
 ## Refs
 


### PR DESCRIPTION
## O que

Mata a promessa morta do bot de `visual-regression`: o comentário em PRs com regressão visual dizia que comentar `/mwart-override <razão>` liberava o gate — mas **nenhum workflow tem trigger `issue_comment`** que processe esse comando. O texto era a única ocorrência de `mwart-override` em `.github/`.

**Caso real:** PR #2544 — Wagner aprovou o visual via override em 2026-06-11 e o check continuou vermelho.

## Decisão (opção b — subtração honesta)

Entre (a) criar handler `issue_comment` que valide permissão + marque o check verde, e (b) remover a promessa e documentar o caminho real — escolhida a **(b)**:

- É a mesma classe "papel promete o que a máquina não faz" que a ADR 0271 caçou (ex: correção de `proibicoes.md` §MWART) — e a direção vigente é **subtrair** gates/automação (64→58→alvo 33), não somar workflow novo com superfície de manipulação de check sem ratificação.
- Se Wagner quiser o override de verdade (opção a), vira decisão explícita em ADR própria.

## Mudanças (16 linhas)

1. **`.github/workflows/visual-regression.yml`** — seção "### Override" removida do comentário do bot; texto agora deixa explícito que atualizar a baseline é o **único** caminho que deixa o check verde:
   ```bash
   ./vendor/bin/pest tests/Browser/ --update-snapshots
   git add tests/Browser/Screenshots/ && git commit
   ```
   Comentário YAML registra o porquê + caso real.

2. **`.claude/skills/mwart-process/SKILL.md`** — seção "Override" clarificada: `/mwart-override` é **registro humano de exceção de processo** (ADR per-tela `historical`), não comando de CI; o check `visual-regression` só fica verde via baseline atualizada.

## Refs

- ADR 0271 — revisão gates CI / subtração de teatro
- ADR 0108 — regressão visual Pest Browser Tier 2
- Caso real: PR #2544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
