### PR TITLE
test(browser): âncora Oficina/OS 'Ordens' → 'Oficina Auto' pós workspace unificado

### DIFF
--- a/tests/Browser/CoreScreens/AuthBridgeSmokeTest.php
+++ b/tests/Browser/CoreScreens/AuthBridgeSmokeTest.php
@@ -62,7 +62,10 @@ $screens = [
     'Fiscal/Cockpit'       => ['/fiscal',                      'fiscal.cockpit.access',       'Notas Fiscais'],
     'Fiscal/NF-e'          => ['/fiscal/nfe',                  'fiscal.nfe.access',           'NF-e'],
     'Fiscal/NFS-e'         => ['/fiscal/nfse',                 'fiscal.nfse.access',          'NFS-e'],
-    'Oficina/OS'           => ['/oficina-auto/ordens-servico', 'oficinaauto.orders.view',     'Ordens'],
+    // Workspace unificado (#2544): âncora = H1 "Oficina Auto", que renderiza mesmo sem o
+    // processo FSM oficina_mecanica_os seedado (VisregTenantSeeder não traz o processo —
+    // o corpo cai no empty-state, mas o header monta sempre).
+    'Oficina/OS'           => ['/oficina-auto/ordens-servico', 'oficinaauto.orders.view',     'Oficina Auto'],
 ];
 
 foreach ($screens as $nome => [$rota, $permissao, $ancora]) {

--- a/tests/Browser/CoreScreens/SmokeTest.php
+++ b/tests/Browser/CoreScreens/SmokeTest.php
@@ -55,7 +55,8 @@ $screens = [
     'Fiscal/NF-e'          => ['/fiscal/nfe',                 'fiscal.nfe.access',           'NF-e'],          // CU-4
     'Fiscal/NFS-e'         => ['/fiscal/nfse',                'fiscal.nfse.access',          'NFS-e'],         // CU-4
     'Financeiro/Unificado' => ['/financeiro/unificado',      'financeiro.unificado.access', 'Financeiro'],   // CU-5
-    'Oficina/OS'           => ['/oficina-auto/ordens-servico', 'oficinaauto.orders.view',   'Ordens'],       // CU-6
+    // Âncora = H1 do workspace unificado (#2544) — renderiza mesmo sem o FSM seedado.
+    'Oficina/OS'           => ['/oficina-auto/ordens-servico', 'oficinaauto.orders.view',   'Oficina Auto'],  // CU-6
     // — cobertura herdada (handoff Cowork 2026-06-02 §B) —
     'Compras'              => ['/compras',                    'compras.view',                'Compras'],
 ];


### PR DESCRIPTION
## Problema

O smoke autenticado **Oficina/OS** (`tests/Browser/CoreScreens/AuthBridgeSmokeTest.php`) está **falhando em main desde 2026-06-11** e derruba o check `visual-regression` de todo PR que toca Pages/Components (observado em #2546 e #2548):

> Expected to see text [Ordens] on the page initially with the url [.../_visreg-login/1?to=%2Foficina-auto%2Fordens-servico], but it was not found or not visible.

Causa: o #2544 (`72a68c4b2`) unificou a tela de OS em 1 workspace com 4 views in-page — o texto "Ordens" não aparece mais visível no estado inicial.

## Fix

Atualiza a **âncora de texto** da tela Oficina/OS de `'Ordens'` → `'Oficina Auto'`:

- É o **H1 do workspace unificado** (`Board.tsx:683`), renderizado **incondicionalmente** no header — inclusive no empty-state sem o processo FSM `oficina_mecanica_os` seedado (o `VisregTenantSeeder` não traz o processo, então no gate o corpo cai no empty-state mas o header monta sempre). Zero dependência de dados além do seeder do gate.
- `assertSee` + `assertNoConsoleLogs` **mantidos** — nada de asserção removida.
- Mesma correção aplicada no irmão `SmokeTest.php` (CU-6), que tinha a mesma âncora defasada na mesma tabela de telas-núcleo (mesma quebra latente).

Único outro consumidor da rota (`ConformanceProbesTest.php`) já lida com o empty-state — sem mudança. `CoreScreensIntegrityTest.php` (Tier 1) já tinha sido atualizado pelo #2544.

Refs: ADR 0108

🤖 Generated with [Claude Code](https://claude.com/claude-code)