### PR TITLE
refactor(oficina): remove shim MercosulPlate — fonte unica shared/ (ADR 0251 cumprida)

### DIFF
--- a/memory/requisitos/_DesignSystem/CHANGELOG.md
+++ b/memory/requisitos/_DesignSystem/CHANGELOG.md
@@ -6,6 +6,10 @@ next_review: "2026-09-06"
 
 # Changelog · Design System
 
+## [0.6.14] - 2026-06-11 · DELETE shim MercosulPlate (ADR 0251 cumprida — fonte única shared/)
+
+- **DELETE** `Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx` (re-export shim de compat) — 3 consumidores (ServiceOrderRichSheet · Board · ServiceOrderKanbanCard) apontados direto pra `@/Components/shared/MercosulPlate`. Deleção amparada por ADR 0251 (shim era transitório) + ADR 0272 §roadmap (remoção pós-#2544). Última duplicata mecânica da auditoria 2026-06-11 fechada.
+
 ## [0.6.13] - 2026-06-11 · renames de colisão de nome + catraca reuse apertada 25→21
 
 Auditoria de duplicatas ("tem arquivos duplicados ainda?"): `Fiscal/_components/ModuleTopNav` (44 linhas) e `kb/_components/CommandPalette` (162 linhas) NÃO são cópias dos homônimos shared/global — são implementações próprias dividindo o nome. O erro é a colisão (confunde reuso e polui o sinal do reuse-index), não o conteúdo.

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate.tsx
@@ -1,6 +1,0 @@
-// MercosulPlate — PROMOVIDO pra @/Components/shared/MercosulPlate (ADR 0251).
-//
-// Este arquivo agora é só um re-export pra não quebrar os imports existentes do
-// OficinaAuto (ServiceOrderRichSheet, ServiceOrderKanbanCard).
-// Fonte canônica única lá — Sells (venda com veículo) usa a MESMA plaquinha.
-export { default } from '@/Components/shared/MercosulPlate';

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -47,7 +47,7 @@ import {
   SheetTitle,
 } from '@/Components/ui/sheet';
 import { Button } from '@/Components/ui/button';
-import MercosulPlate from './MercosulPlate';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 import ServiceOrderFsmActionPanel from '../../ServiceOrders/_components/ServiceOrderFsmActionPanel';
 import ServiceOrderTimeline from '../../ServiceOrders/_components/ServiceOrderTimeline';
 import ServiceOrderStageGate from '../../ServiceOrders/_components/ServiceOrderStageGate';

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx
@@ -86,7 +86,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/Components/ui/popover
 import { Segmented } from '@/Components/ui/segmented';
 import { Inline } from '@/Components/layout';
 import { printOficinaFila, type FilaPrintRow } from '@/Lib/printOficinaFila';
-import MercosulPlate from '@/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 import KanbanDndProvider from '@/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider';
 import DragConfirmDialog, {
   type PendingTransition,

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/board/ServiceOrderKanbanCard.tsx
@@ -18,7 +18,7 @@ import { useDraggable } from '@dnd-kit/core';
 import { CSS } from '@dnd-kit/utilities';
 import { ClipboardCheck, AlertTriangle, Clock, Wrench, Camera, Warehouse, ArrowRight, History } from 'lucide-react';
 import { Inline } from '@/Components/layout';
-import MercosulPlate from '@/Pages/OficinaAuto/ProducaoOficina/_components/MercosulPlate';
+import MercosulPlate from '@/Components/shared/MercosulPlate';
 
 // Densidade do card (menu Visão — Onda 1 paridade Cowork): compacto esconde
 // sintoma+foto (triagem rápida de fila grande); detalhe respira (foto maior,


### PR DESCRIPTION
Última duplicata mecânica da auditoria de hoje. O shim era re-export transitório ('pra não quebrar imports existentes' — ADR 0251); a ADR 0272 §roadmap liberou a remoção pós-#2544 (mergeado). 3 consumidores apontados direto pro canon. Gates todos verdes, zero visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)