### PR TITLE
test(e2e): re-ancora specs G-3 no Quadro de OS canônico (workspace #2551)

### DIFF
--- a/e2e/oficina-os-funcional-fluxo.spec.ts
+++ b/e2e/oficina-os-funcional-fluxo.spec.ts
@@ -67,17 +67,20 @@ test.describe.serial('UC-11 · OS funcional fim-a-fim (caminho da Larissa)', () 
     // só apareceu no drawer, 3 passos depois).
     await expect(page).toHaveURL(/\/oficina-auto\/ordens-servico\/\d+$/, { timeout: 15_000 });
 
-    // ── 3. Achar o card no kanban e abrir o documento vivo (drawer) ────────────
+    // ── 3. Achar o card no quadro e abrir o documento vivo (drawer) ────────────
+    // /producao-oficina virou redirect permanente pro Quadro de OS canônico
+    // (ServiceOrders/Board.tsx — workspace unificado #2551); o goto prova o redirect.
     await page.goto('/oficina-auto/producao-oficina');
     await page.waitForLoadState('networkidle');
-    const busca = page.getByPlaceholder(/Buscar OS, ve[ií]culo ou cliente/i);
+    const busca = page.getByPlaceholder(/Buscar OS, placa ou cliente/i);
     await expect(busca).toBeVisible();
     await busca.fill(PLACA);
 
     const recepcao = page.getByLabel('Coluna Recepção');
     await expect(recepcao).toBeVisible();
+    // Busca do Board é server-side (debounce + router.get) — timeout cobre o round-trip.
     const card = recepcao.getByRole('button').filter({ hasText: new RegExp(PLACA, 'i') }).first();
-    await expect(card, `card da OS recém-criada (${PLACA}) deve aparecer em Recepção`).toBeVisible();
+    await expect(card, `card da OS recém-criada (${PLACA}) deve aparecer em Recepção`).toBeVisible({ timeout: 15_000 });
     await card.click();
 
     // Drawer rico aberto — seções canônicas do charter visíveis.

--- a/e2e/oficina-uc06-gate-etapa.spec.ts
+++ b/e2e/oficina-uc06-gate-etapa.spec.ts
@@ -1,18 +1,20 @@
 import { test, expect, type Page } from '@playwright/test';
 
-// E2E de comportamento — Produção / Kanban da Oficina (ADR 0264 G-3).
-// Fonte do contrato: resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md
-//   UC-01 (ver o pátio: 5 colunas de reparo) · UC-02 (6 KPIs) · UC-03 (busca) ·
-//   UC-06 (avançar de etapa sem furar a regra — gate de etapa).
+// E2E de comportamento — Quadro de OS da Oficina (ADR 0264 G-3).
+// Tela canônica: resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx — o workspace
+// unificado (#2551) substituiu o kanban antigo de ProducaoOficina; a rota
+// /oficina-auto/producao-oficina sobrevive como REDIRECT permanente (menu antigo,
+// bookmarks, links em WhatsApp) e o goto daqui PROVA que ela segue viva.
+// Contrato de origem: resources/js/Pages/OficinaAuto/ProducaoOficina/Index.casos.md
+// (re-ancoragem do casos.md pro Board fica na Onda Q2 do mandato ONDAS-QUALIDADE).
+//   UC-01 (ver o pátio: 5 colunas de reparo) · UC-02 (KPIs) · UC-03 (busca) ·
+//   UC-06 (avançar de etapa sem furar a regra — gate de etapa opina no drop).
 //
-// Locators RESILIENTES — aria-label/role/text que já EXISTEM no componente (CacambaKanbanColumn
-// expõe aria-label="Coluna {label}" + texto preditivo do gate). NUNCA classe CSS (L-24).
+// Locators RESILIENTES — aria-label/role/text que já EXISTEM no componente
+// (ServiceOrderKanbanColumn expõe aria-label="Coluna {label}"). NUNCA classe CSS (L-24).
 // ZERO edição na tela viva (charter-protected): o teste lê o contrato visível, não muda nada.
-//
-// ⚠️ Primeiro run verde PENDENTE de validação no stack do app (sem PHP/serve no desktop).
-// O workflow e2e-gate.yml é NÃO-required até verde-estável (ADR 0261).
 
-const ROUTE = '/oficina-auto/producao-oficina';
+const ROUTE = '/oficina-auto/producao-oficina'; // redirect → Quadro de OS canônico
 const COLUNAS = ['Recepção', 'Diagnóstico', 'Aguardando peças', 'Em execução', 'Pronto p/ retirar'];
 
 test.beforeEach(async ({ page }) => {
@@ -35,7 +37,8 @@ test('UC-02 · os números do dia — os 6 KPIs renderizam', async ({ page }) =>
 });
 
 test('UC-03 · achar uma OS na hora — a busca filtra', async ({ page }) => {
-  const busca = page.getByPlaceholder(/Buscar OS, ve[ií]culo ou cliente/i);
+  // Placeholder do Board canônico (workspace #2551): "Buscar OS, placa ou cliente…  ( / )".
+  const busca = page.getByPlaceholder(/Buscar OS, placa ou cliente/i);
   await expect(busca).toBeVisible();
   await busca.fill('zzz-placa-inexistente-xyz');
   // não quebra a tela; as colunas continuam presentes (resultado pode ficar vazio).
@@ -43,28 +46,43 @@ test('UC-03 · achar uma OS na hora — a busca filtra', async ({ page }) => {
 });
 
 // UC-06 · avançar de etapa sem furar a regra (D-01 gate).
-// O gate dá um VEREDITO VISÍVEL durante o arrasto: "Solte p/ avançar" (libera) vs
-// "Abre os detalhes (não avança aqui)" (barra). dnd-kit usa pointer events, então
-// arrastamos com mouse.move/down/up. Se não houver card (DB sem seed), o teste registra
-// skip explícito (não falso-verde) — o seed de biz=1 é responsabilidade do CI.
-test('UC-06 · gate de etapa mostra veredito ao arrastar (libera vs barra)', async ({ page }) => {
+// No Board o veredito PREDITIVO durante o arrasto saiu (kanbanDrag.ts: "consumidores
+// que não usam o feedback (ex.: ServiceOrders/Board) ignoram o context"); o GATE opina
+// no DROP (Board.tsx handleDragMove): transição não-listada/backward = toast "Transição
+// não permitida (from → to)" · OS fora do pipeline = toast "OS sem pipeline iniciado" ·
+// transição crítica = DragConfirmDialog. Provamos o lado que NUNCA avança: drop num
+// alvo INVÁLIDO tem que produzir veredito visível — o gate opina, o card não anda.
+test('UC-06 · gate de etapa opina no drop inválido (não avança)', async ({ page }) => {
   const recepcao = page.getByLabel('Coluna Recepção');
   await expect(recepcao).toBeVisible();
 
-  const card = recepcao.getByRole('button').first();
-  const temCard = await card.count();
-  test.skip(temCard === 0, 'Sem card em Recepção (DB sem seed biz=1) — gate não exercitável aqui.');
+  // Card em qualquer coluna serve: de Recepção, "Pronto p/ retirar" é salto não-listado;
+  // de qualquer outra, voltar pra Recepção é backward (nunca listado). OS sem pipeline
+  // cai no outro toast — ambos são veredito do gate.
+  const cardRecepcao = recepcao.getByRole('button').first();
+  let card = cardRecepcao;
+  let alvoInvalido = page.getByLabel('Coluna Pronto p/ retirar');
+  if ((await cardRecepcao.count()) === 0) {
+    const cardQualquer = page
+      .locator('[aria-roledescription="Card arrastável entre etapas"], [aria-roledescription="OS sem pipeline — clique pra iniciar"]')
+      .first();
+    test.skip((await cardQualquer.count()) === 0, 'Sem card no quadro (DB sem seed biz=1) — gate não exercitável aqui.');
+    card = cardQualquer;
+    alvoInvalido = page.getByLabel('Coluna Recepção');
+  }
 
-  // Arrasto pointer-based até uma coluna inválida → espera o veredito de barra visível.
-  const alvoInvalido = page.getByLabel('Coluna Pronto p/ retirar');
   await dragPointer(page, card, alvoInvalido);
+  await page.mouse.up(); // o veredito do Board sai no DROP (handleDragMove), não durante o arrasto
 
-  // O componente mostra um destes vereditos (aria-live) — provamos que o GATE opina.
-  const veredito = page.getByText(/Solte p\/ avançar|Solte p\/ confirmar avanço|Abre os detalhes \(não avança aqui\)/);
-  await expect(veredito.first()).toBeVisible();
+  await expect(
+    page.getByText(/Transição não permitida|OS sem pipeline iniciado/i).first(),
+    'gate deve dar veredito visível no drop inválido',
+  ).toBeVisible({ timeout: 10_000 });
 });
 
 // Helper de arrasto compatível com dnd-kit (pointer events, não HTML5 drag).
+// NÃO solta o botão — quem decide se o veredito é durante (preditivo) ou no drop
+// (Board) é o teste, via page.mouse.up().
 async function dragPointer(page: Page, source: ReturnType<Page['locator']>, target: ReturnType<Page['locator']>) {
   const s = await source.boundingBox();
   const t = await target.boundingBox();
@@ -74,5 +92,5 @@ async function dragPointer(page: Page, source: ReturnType<Page['locator']>, targ
   // movimentos incrementais — dnd-kit precisa de delta pra ativar o sensor.
   await page.mouse.move(s.x + s.width / 2 + 8, s.y + s.height / 2 + 8, { steps: 4 });
   await page.mouse.move(t.x + t.width / 2, t.y + t.height / 2, { steps: 10 });
-  await page.waitForTimeout(150); // deixa o overlay/veredito pintar
+  await page.waitForTimeout(150); // deixa o overlay pintar antes do drop
 }


### PR DESCRIPTION
## Onda Q1 (mandato ONDAS-QUALIDADE) — conserto de causa antes do flip

Dispatch de re-validação em `main` ([27364711144](https://github.com/wagnerra23/oimpresso.com/actions/runs/27364711144)) FALHOU 3/5 UCs: o **workspace unificado da Oficina (#2551)** trocou a tela — `/producao-oficina` virou redirect permanente pro Quadro de OS (`ServiceOrders/Board.tsx`). Os specs ancoravam na tela morta. Regra do mandato: *flaky/vermelho → consertar a CAUSA antes de flipar, nunca retry-até-passar* (ADR 0261).

### Consertos (specs re-ancorados na tela canônica)
- **UC-03 + UC-11**: placeholder da busca `Buscar OS, veículo ou cliente` → `Buscar OS, placa ou cliente` (Board, server-side — timeout cobre o round-trip)
- **UC-06**: o veredito **preditivo** durante o arrasto não existe no Board (`kanbanDrag.ts`: Board ignora o context). O gate agora opina **no DROP** (`handleDragMove`): re-ancorado em drop inválido → toast `Transição não permitida`/`OS sem pipeline iniciado` + `mouse.up()` no helper
- **UC-01/UC-02**: passavam (colunas/KPIs idênticos no Board) — intactos

O E2E fez exatamente o trabalho dele: pegou a tela mudando embaixo do contrato. Re-ancoragem do `Index.casos.md` pro Board fica na **Onda Q2**.

### Validação
Dispatch do e2e-gate NESTA branch (run será linkado em comentário) antes do merge; depois 2× verdes em `main` → flip #2560.

Refs: ADR 0264 G-3 · ADR 0261 · ONDAS-QUALIDADE Q1

🤖 Generated with [Claude Code](https://claude.com/claude-code)