### PR TITLE
ci(governance): secret scan gitleaks no umbrella — advisory, diff-only, required-ready

### DIFF
--- a/.github/workflows/governance-gate-umbrella.yml
+++ b/.github/workflows/governance-gate-umbrella.yml
@@ -39,3 +39,23 @@ jobs:
         run: node scripts/governance/memory-health.mjs
       - name: Meta-teste dos scripts de governança (controle-negativo)
         run: npm run test:adr-governance
+
+  # Segredo NOVO em QUALQUER arquivo do diff (API key, token, senha) — fecha o gap
+  # entre o memory-health (só memory/) e o secrets:audit (só scheduled, não barra PR).
+  # Job SEPARADO de propósito: check context próprio ("Secret scan ...") nasce
+  # ADVISORY (método faseado ADR 0271 — promover a required via gh api após ~2
+  # semanas sem falso-positivo). Always-run sem paths = required-ready desde já.
+  # gitleaks-action escaneia só os COMMITS do PR (linhas adicionadas) — segredos
+  # históricos já catalogados (incidente memory/claude) NÃO flagam a menos que o PR
+  # os toque. Falso-positivo (fixture fake etc) → allowlist em .gitleaks.toml na raiz.
+  # Licença: GITLEAKS_LICENSE só é exigida em repo de ORG — wagnerra23 é user account.
+  secret-scan:
+    name: Secret scan (gitleaks · só linhas novas do PR)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Gap que fecha

Hoje **nada barra um PR que adiciona segredo em arquivo de código**: o `memory-health` (enforce) só cobre `memory/`, e o `secrets:audit --auto-pr` é scheduled (Camada 3) — detecta DEPOIS do merge. Este PR adiciona **gitleaks** como job novo no umbrella de governança (zero workflow file novo — preserva a consolidação 64→53 da onda 2).

## Desenho (método faseado ADR 0271)

- **Job separado** = check context próprio (`Secret scan (gitleaks · só linhas novas do PR)`) → nasce **ADVISORY** (reporta, não bloqueia). O umbrella required existente não muda de nome nem de comportamento.
- **Diff-only**: gitleaks-action escaneia só os commits do PR (linhas adicionadas) — os segredos históricos já catalogados (incidente memory/claude, rotação pendente) **não** flagam a menos que o PR os toque (o que é desejável).
- **Always-run sem paths** = required-ready desde o nascimento, sem deadlock.
- Falso-positivo (fixture fake, exemplo em doc) → allowlist em `.gitleaks.toml` na raiz (criar quando o primeiro caso aparecer).
- Licença: `GITLEAKS_LICENSE` só é exigida em repo de **organização** — `wagnerra23` é user account, gratuito.

## Promoção a required (Wagner — após ~2 semanas sem falso-positivo, ≥2026-06-25)

```bash
gh api repos/wagnerra23/oimpresso.com/branches/main/protection/required_status_checks/contexts   -X POST -f "contexts[]=Secret scan (gitleaks · só linhas novas do PR)"
```

(POST em `/contexts` ADICIONA sem reescrever a lista dos 15 atuais. Rollback: mesmo endpoint com `-X DELETE`.)

Refs: ADR 0271, ADR 0256

🤖 Generated with [Claude Code](https://claude.com/claude-code)