### PR TITLE
ci(casos-gate): ratchet só-desce do baseline de cobertura (Onda Q2 item 2)

### DIFF
--- a/.github/workflows/casos-gate.yml
+++ b/.github/workflows/casos-gate.yml
@@ -44,6 +44,21 @@ jobs:
       - name: Casos ratchet (falha em violação NOVA de trio/rastreabilidade)
         run: node scripts/casos-coverage-guard.mjs
 
+      # Onda Q2 (mandato ONDAS-QUALIDADE 2026-06-11) — ratchet SÓ-DESCE do arquivo de
+      # baseline: o ratchet acima pega violação nova no REPO, mas não impedia o próprio
+      # baseline commitado de CRESCER via `--write-baseline` (fotografar dívida nova).
+      # Crescimento consciente (refactor move tela com dívida legada) = label
+      # `casos-baseline-grow-approved` no PR (decisão visível, não default).
+      - name: Baseline só-desce (cobertura de casos nunca regride)
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'casos-baseline-grow-approved')
+        run: |
+          git fetch --no-tags origin main
+          if git show origin/main:scripts/casos-coverage-baseline.json > /tmp/casos-baseline-main.json 2>/dev/null; then
+            node scripts/casos-coverage-guard.mjs --check-baseline-shrink /tmp/casos-baseline-main.json
+          else
+            echo "baseline ausente no main (bootstrap) — skip"
+          fi
+
       - name: Diagnóstico em caso de falha
         if: failure()
         run: |

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "casos:check": "node scripts/casos-coverage-guard.mjs",
     "casos:report": "node scripts/casos-coverage-guard.mjs --report",
     "casos:baseline:write": "node scripts/casos-coverage-guard.mjs --write-baseline",
+    "casos:baseline:shrink-check": "node scripts/casos-coverage-guard.mjs --check-baseline-shrink",
     "casos:results": "node scripts/casos-results-collect.mjs",
     "dominio:check": "node scripts/domain-dict-guard.mjs",
     "dominio:report": "node scripts/domain-dict-guard.mjs --report",

--- a/scripts/casos-coverage-guard.mjs
+++ b/scripts/casos-coverage-guard.mjs
@@ -39,6 +39,7 @@
 // MODOS (idioma dos guards existentes):
 //   node scripts/casos-coverage-guard.mjs                  # valida vs baseline (exit 1 se piorou)
 //   node scripts/casos-coverage-guard.mjs --write-baseline  # (re)grava baseline (uso consciente)
+//   node scripts/casos-coverage-guard.mjs --check-baseline-shrink <ref.json>  # só-desce: baseline commitado não pode crescer vs referência (Onda Q2)
 //   node scripts/casos-coverage-guard.mjs --report          # imprime o relatório de dívida (humano)
 //   node scripts/casos-coverage-guard.mjs --json            # saída JSON pra CI
 //
@@ -56,6 +57,12 @@ const MANIFEST_PATH = resolve(ROOT, 'scripts/casos-test-results.json'); // G-7: 
 const TEST_DIRS = ['Modules', 'tests', 'app', 'e2e']; // onde um UC-id pode ser referenciado por teste
 
 const MODE_WRITE = process.argv.includes('--write-baseline');
+// --check-baseline-shrink <old-baseline.json> — Onda Q2 (ratchet só-desce): o ARQUIVO
+// de baseline commitado só pode ENCOLHER vs a referência (main). Crescimento consciente
+// (refactor que move tela com dívida) = label `casos-baseline-grow-approved` no PR
+// (o workflow pula este check). Git-free: o CI extrai a referência via `git show`.
+const SHRINK_IDX = process.argv.indexOf('--check-baseline-shrink');
+const SHRINK_REF_PATH = SHRINK_IDX >= 0 ? process.argv[SHRINK_IDX + 1] || null : null;
 const MODE_REPORT = process.argv.includes('--report');
 const MODE_JSON = process.argv.includes('--json');
 
@@ -355,6 +362,36 @@ function loadBaseline() {
 // Main
 // ---------------------------------------------------------------------------
 function main() {
+  // Modo só-desce compara baseline ATUAL (commitado no PR) vs baseline de REFERÊNCIA
+  // (main) — não varre o repo. Roda ANTES de computeViolations (barato, sem I/O de Pages).
+  if (SHRINK_IDX >= 0) {
+    if (!SHRINK_REF_PATH || !existsSync(SHRINK_REF_PATH)) {
+      console.log('ℹ️ Baseline de referência ausente (bootstrap) — só-desce sem efeito. OK.');
+      process.exit(0);
+    }
+    const cur = loadBaseline();
+    if (!cur) {
+      console.error(`❌ Baseline atual ausente (${norm(BASELINE_PATH)}). Rode: npm run casos:baseline:write`);
+      process.exit(1);
+    }
+    const refSet = new Set(JSON.parse(readFileSync(SHRINK_REF_PATH, 'utf8')).violations || []);
+    const grew = (cur.violations || []).filter((v) => !refSet.has(v));
+    if (grew.length) {
+      console.error(`\n❌ Baseline CRESCEU: ${grew.length} entrada(s) nova(s) vs referência (só-desce, Onda Q2):\n`);
+      for (const v of grew.slice(0, 30)) console.error('  🆕 ' + v);
+      if (grew.length > 30) console.error(`  … +${grew.length - 30}`);
+      console.error(
+        '\nO baseline de cobertura de casos é catraca: ENCOLHER é sempre OK, crescer não.' +
+          '\nFeche o trio/teste da tela em vez de fotografar a dívida nova.' +
+          '\nMudança consciente (refactor move tela com dívida legada): label `casos-baseline-grow-approved` no PR.',
+      );
+      process.exit(1);
+    }
+    const shrunk = refSet.size - (cur.violations || []).length;
+    console.log(`✅ Baseline só-desce OK (${shrunk > 0 ? `caiu −${shrunk}` : 'estável'} vs referência).`);
+    process.exit(0);
+  }
+
   const { violations, stats } = computeViolations();
 
   if (MODE_JSON) {

--- a/tests/casosGuard.spec.ts
+++ b/tests/casosGuard.spec.ts
@@ -276,3 +276,47 @@ describe('casos:check — G-7 status derivado do verde (físico)', () => {
     expect(out).toMatch(/status:lies:resources\/js\/Pages\/R\/Index\.casos\.md#UC-02/);
   });
 });
+
+// ── Onda Q2 — ratchet SÓ-DESCE do arquivo de baseline (--check-baseline-shrink) ────────
+// O ratchet padrão pega violação nova no repo; este modo impede o BASELINE COMMITADO de
+// crescer vs a referência (main). Método ADR 0258: visto FALHAR (cresceu) e PASSAR (encolheu).
+describe('casos:check — só-desce do baseline (Onda Q2, físico)', () => {
+  const baselineWith = (rel: string, violations: string[]) =>
+    write(rel, JSON.stringify({ _meta: { gate: 'fixture' }, violations }, null, 2));
+
+  it('SENSIBILIDADE: baseline com entrada NOVA vs referência → exit 1 citando a entrada', () => {
+    baselineWith('ref/baseline-main.json', ['trio:missing-casos:resources/js/Pages/A/Index.tsx']);
+    baselineWith('scripts/casos-coverage-baseline.json', [
+      'trio:missing-casos:resources/js/Pages/A/Index.tsx',
+      'trio:missing-casos:resources/js/Pages/B/Index.tsx', // dívida NOVA fotografada
+    ]);
+    const out = runExpectFail('--check-baseline-shrink ref/baseline-main.json');
+    expect(out).toMatch(/Baseline CRESCEU/);
+    expect(out).toMatch(/trio:missing-casos:resources\/js\/Pages\/B\/Index\.tsx/);
+    expect(out).toMatch(/casos-baseline-grow-approved/); // caminho consciente documentado
+  });
+
+  it('ESPECIFICIDADE: baseline ENCOLHEU vs referência → passa reportando a queda', () => {
+    baselineWith('ref/baseline-main.json', [
+      'trio:missing-casos:resources/js/Pages/A/Index.tsx',
+      'trio:missing-casos:resources/js/Pages/B/Index.tsx',
+    ]);
+    baselineWith('scripts/casos-coverage-baseline.json', [
+      'trio:missing-casos:resources/js/Pages/A/Index.tsx',
+    ]);
+    const out = run('--check-baseline-shrink ref/baseline-main.json');
+    expect(out).toMatch(/só-desce OK/);
+    expect(out).toMatch(/caiu −1/);
+  });
+
+  it('ESPECIFICIDADE: baseline idêntico → estável, passa', () => {
+    baselineWith('ref/baseline-main.json', ['x:1']);
+    baselineWith('scripts/casos-coverage-baseline.json', ['x:1']);
+    expect(run('--check-baseline-shrink ref/baseline-main.json')).toMatch(/estável/);
+  });
+
+  it('GRACIOSO: referência ausente (bootstrap) → exit 0 sem efeito', () => {
+    baselineWith('scripts/casos-coverage-baseline.json', ['x:1']);
+    expect(run('--check-baseline-shrink ref/nao-existe.json')).toMatch(/bootstrap/);
+  });
+});


### PR DESCRIPTION
## Onda Q2 item 2 — baseline de casos vira catraca de verdade

O `casos-gate` (required) pega violação nova no repo, mas o **arquivo** `casos-coverage-baseline.json` podia crescer silenciosamente via `--write-baseline`. Agora:

- Novo modo `--check-baseline-shrink <ref.json>` no guard (git-free; o CI extrai a referência do main via `git show`)
- Step novo no `casos-gate.yml`: entrada nova no baseline commitado = 🔴
- Escape consciente: label `casos-baseline-grow-approved` no PR
- npm alias `casos:baseline:shrink-check`

### Prova 2 lados (ADR 0258 — meta-teste físico no CI via casos-meta-gate)
- 🔴 SENSIBILIDADE: baseline com entrada nova vs ref → exit 1 citando a entrada + o label de escape
- 🟢 ESPECIFICIDADE: baseline encolhido/estável → passa reportando a queda
- bootstrap (ref ausente) → gracioso exit 0

vitest local: **23/23** (19 existentes + 4 novos).

Refs: ONDAS-QUALIDADE Q2 · ADR 0264 · ADR 0258 · ADR 0261

🤖 Generated with [Claude Code](https://claude.com/claude-code)