### PR TITLE
ci(casos-results): merge per-UC entre rodadas — runner parcial não apaga prova alheia (Onda Q2)

### DIFF
--- a/scripts/casos-results-collect.mjs
+++ b/scripts/casos-results-collect.mjs
@@ -27,8 +27,9 @@
 // checagem (rápida) evita o deadlock que o ADR 0261 proíbe.
 //
 // USO:
-//   node scripts/casos-results-collect.mjs                 # lê test-results/, grava manifesto
+//   node scripts/casos-results-collect.mjs                 # lê test-results/, MERGE per-UC no manifesto
 //   node scripts/casos-results-collect.mjs --results <dir> # diretório de results alternativo
+//   node scripts/casos-results-collect.mjs --no-merge      # sobrescreve o manifesto inteiro (reset consciente)
 //   node scripts/casos-results-collect.mjs --seed-empty    # cria manifesto vazio (bootstrap F1)
 //
 // Refs: ADR 0264 (G-5/G-7) · ADR 0261 (enforcement faseado, não-deadlock) · ADR 0256 (catraca).
@@ -41,6 +42,10 @@ const MANIFEST_PATH = resolve(ROOT, 'scripts/casos-test-results.json');
 
 const argv = process.argv.slice(2);
 const SEED_EMPTY = argv.includes('--seed-empty');
+// --no-merge: sobrescreve o manifesto inteiro (reset consciente). Default é MERGE
+// per-UC (Onda Q2): runners diferentes (Playwright e2e-gate · Pest financeiro-pest)
+// produzem vereditos em workflows separados — overwrite total apagaria a prova do outro.
+const NO_MERGE = argv.includes('--no-merge');
 const resultsIdx = argv.indexOf('--results');
 const RESULTS_DIR = resolve(ROOT, resultsIdx >= 0 ? argv[resultsIdx + 1] : 'test-results');
 
@@ -154,9 +159,29 @@ function main() {
     process.exit(0); // não-fatal: rodada vazia não é erro, só não atualiza.
   }
 
+  // MERGE per-UC (Onda Q2): o manifesto guarda o ÚLTIMO veredito conhecido POR UC
+  // (ran_at carrega o frescor; o G-7 stale-results pega tela-mudou-depois-do-teste).
+  // UC ausente da rodada atual preserva o veredito anterior — runner parcial
+  // (ex.: só o Pest do Financeiro) não apaga a prova do outro (Playwright e2e).
+  let preserved = 0;
+  if (!NO_MERGE && existsSync(MANIFEST_PATH)) {
+    try {
+      const prev = JSON.parse(readFileSync(MANIFEST_PATH, 'utf8'))?.ucs || {};
+      for (const [uc, entry] of Object.entries(prev)) {
+        if (!(uc in ucs)) {
+          ucs[uc] = entry;
+          preserved += 1;
+        }
+      }
+    } catch {
+      // manifesto anterior ilegível → segue só com a rodada atual (igual --no-merge)
+    }
+  }
+
   const stats = writeManifest(ucs, sources);
   console.log(
     `✅ Manifesto gravado: ${stats.ucs} UCs (${stats.pass} pass · ${stats.fail} fail · ${stats.skip} skip) ` +
+      (preserved ? `— ${preserved} preservado(s) de rodadas anteriores (merge per-UC; reset: --no-merge) ` : '') +
       `de ${sources.length} relatório(s) → ${norm(MANIFEST_PATH)}`,
   );
   process.exit(0);

--- a/tests/casosResultsCollect.spec.ts
+++ b/tests/casosResultsCollect.spec.ts
@@ -94,4 +94,30 @@ describe('casos:results — coletor de test-results → manifesto por-UC (físic
     const m = readManifest();
     expect(Object.keys(m.ucs)).toEqual(['UC-01']);
   });
+
+  // ── Onda Q2 — MERGE per-UC entre RODADAS (runners em workflows separados) ──────────
+  it('MERGE entre rodadas: UC ausente do XML atual PRESERVA veredito anterior', () => {
+    write(MANIFEST, JSON.stringify({ ucs: { 'UC-01': { verdict: 'pass', ran_at: '2026-06-01', tests: 1 } } }));
+    junit('pest.xml', suite(tcPass('UC-F01 título gerado')));
+    const out = run();
+    const m = readManifest();
+    expect(m.ucs['UC-F01'].verdict).toBe('pass'); // rodada atual entra
+    expect(m.ucs['UC-01'].verdict).toBe('pass'); // anterior preservado (runner parcial não apaga prova alheia)
+    expect(m.ucs['UC-01'].ran_at).toBe('2026-06-01');
+    expect(out).toMatch(/1 preservado/);
+  });
+
+  it('MERGE entre rodadas: UC presente no XML atual SOBRESCREVE o veredito antigo (fail novo vence pass velho)', () => {
+    write(MANIFEST, JSON.stringify({ ucs: { 'UC-01': { verdict: 'pass', ran_at: '2026-06-01', tests: 1 } } }));
+    junit('e2e.xml', suite(tcFail('UC-01 regrediu')));
+    run();
+    expect(readManifest().ucs['UC-01'].verdict).toBe('fail');
+  });
+
+  it('--no-merge: reset consciente sobrescreve o manifesto inteiro', () => {
+    write(MANIFEST, JSON.stringify({ ucs: { 'UC-01': { verdict: 'pass', ran_at: '2026-06-01', tests: 1 } } }));
+    junit('pest.xml', suite(tcPass('UC-F01 título gerado')));
+    run('--no-merge');
+    expect(Object.keys(readManifest().ucs)).toEqual(['UC-F01']); // UC-01 saiu
+  });
 });


### PR DESCRIPTION
## Onda Q2 — infraestrutura pro espelho Financeiro no manifesto G-7

O coletor `casos:results` sobrescrevia o manifesto inteiro a cada rodada. Com vereditos vindo de **workflows separados** (Playwright no e2e-gate · Pest no financeiro-pest), coletar um apagaria a prova do outro.

- Default agora é **merge per-UC**: rodada atual sobrescreve por UC; UC ausente preserva o veredito anterior (`ran_at` carrega o frescor; o G-7 `stale-results` pega tela-mudou-depois-do-teste)
- Reset consciente: `--no-merge`

### Prova 2 lados (meta-teste físico, roda no casos-meta-gate)
- preserva UC ausente da rodada (`1 preservado` no output)
- sobrescreve UC presente (fail novo vence pass velho)
- `--no-merge` reseta o manifesto inteiro

vitest: **10/10**.

Próximo PR da onda: UC-F01..03 no RetencaoLoopE2ETest + allowlist financeiro-pest + JUnit artifact + Financeiro/Unificado casos.md.

Refs: ONDAS-QUALIDADE Q2 · ADR 0264 G-7 · ADR 0258

🤖 Generated with [Claude Code](https://claude.com/claude-code)