### PR TITLE
test(casos): espelho Financeiro (UC-F01..03) + Sells/Index (UC-S10) — manifesto 13 UCs (Onda Q2)

### DIFF
--- a/.github/workflows/financeiro-pest.yml
+++ b/.github/workflows/financeiro-pest.yml
@@ -24,6 +24,7 @@ on:
     branches: [main]
     paths:
       - 'Modules/Financeiro/**'
+      - 'tests/Feature/TravaSegunda/**'
       - 'database/schema/mysql-schema.sql'
       - '.github/workflows/financeiro-pest.yml'
 
@@ -60,6 +61,7 @@ jobs:
           filters: |
             fin:
               - 'Modules/Financeiro/**'
+              - 'tests/Feature/TravaSegunda/**'
               - 'database/schema/mysql-schema.sql'
               - '.github/workflows/financeiro-pest.yml'
 
@@ -162,6 +164,15 @@ jobs:
               ]);
               echo 'conta criada biz='.\$bizId.PHP_EOL;
             }
+            // Onda Q2 — RetencaoLoopE2ETest (UC-F01..03) exige location + contact (type != lead).
+            if (\$bizId && ! DB::table('business_locations')->where('business_id',\$bizId)->exists()) {
+              DB::table('business_locations')->insert(['business_id'=>\$bizId,'name'=>'Matriz CI','country'=>'BR','state'=>'SP','city'=>'SP','zip_code'=>'0','created_at'=>now(),'updated_at'=>now()]);
+              echo 'location criada'.PHP_EOL;
+            }
+            if (\$bizId && ! DB::table('contacts')->where('business_id',\$bizId)->where('type','!=','lead')->exists()) {
+              DB::table('contacts')->insert(['business_id'=>\$bizId,'type'=>'customer','name'=>'Cliente CI','contact_id'=>'CO0001','created_by'=>1,'is_default'=>1,'created_at'=>now(),'updated_at'=>now()]);
+              echo 'contact criado'.PHP_EOL;
+            }
           "
 
       - name: Stub Vite manifest (Inertia root view sem build do front)
@@ -195,7 +206,10 @@ jobs:
           DB_USERNAME: root
           DB_PASSWORD: root
         run: |
+          mkdir -p test-results
           vendor/bin/pest --no-coverage --colors=always \
+            --log-junit test-results/pest-financeiro-junit.xml \
+            tests/Feature/TravaSegunda/RetencaoLoopE2ETest.php \
             Modules/Financeiro/Tests/Feature/UnificadoCanceladoArquivadosKpiTest.php \
             Modules/Financeiro/Tests/Feature/Advisor/Onda31AdvisorPortalTest.php \
             Modules/Financeiro/Tests/Feature/AccountsLegacyMapMultiTenantTest.php \
@@ -214,3 +228,14 @@ jobs:
             Modules/Financeiro/Tests/Feature/UnificadoCommentsAuditTest.php \
             Modules/Financeiro/Tests/Feature/UnificadoConferirTest.php \
             Modules/Financeiro/Tests/Feature/UnificadoUpdateTest.php
+
+      # Onda Q2 (G-7 / Salto #2): o JUnit do Pest alimenta o manifesto por-UC
+      # (casos:results MERGE per-UC — vereditos UC-F01..03 do RetencaoLoopE2ETest).
+      # Roda mesmo em falha: a falha É o veredito que o G-7 registra.
+      - name: Upload JUnit (veredito por-UC — casos:results)
+        if: ${{ !cancelled() && steps.changes.outputs.fin == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: pest-financeiro-junit
+          path: test-results/pest-financeiro-junit.xml
+          retention-days: 14

--- a/e2e/sells-index.spec.ts
+++ b/e2e/sells-index.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+
+// E2E de comportamento — LISTA DE VENDAS (Onda Q2, ADR 0264 G-3).
+// Contrato: resources/js/Pages/Sells/Index.casos.md
+//   UC-S10 · a lista de vendas abre com as pílulas de status (visão de cobrança).
+// Locators RESILIENTES — role/text (L-24).
+
+test('UC-S10 · lista de vendas renderiza com pílulas de status', async ({ page }) => {
+  await page.goto('/sells');
+  await page.waitForLoadState('networkidle');
+
+  await expect(page.getByRole('heading', { name: 'Vendas' })).toBeVisible({ timeout: 15_000 });
+  // Pílulas de classificação por payment_status (Todas é a default).
+  await expect(page.getByText('Todas', { exact: true }).first()).toBeVisible();
+});

--- a/resources/js/Pages/Financeiro/Unificado/Index.casos.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.casos.md
@@ -1,0 +1,56 @@
+---
+casos: Financeiro Unificado · /financeiro/unificado
+irmaos: Index.charter.md (lei)
+tecnica: Caso de uso = narrativa do cliente + critério de aceite verificável (Dado/Quando/Então)
+por_que: comportamento é durável — não muda no refactor; é teste E explicação de uso E material de treino.
+owner: wagner
+last_run: "2026-06-11"
+---
+
+# Casos de Uso & Aceite — Financeiro Unificado
+
+> Tela P0 do fio **venda → faturamento → caixa** (mandato ONDAS-QUALIDADE Q2). Os UCs
+> abaixo espelham o ENCADEAMENTO que sustenta esta tela: a venda gera o título a receber,
+> o recebimento baixa o título e registra entrada no caixa — provado ponta-a-ponta contra
+> DB real (canon: não-mocka-DB) por `tests/Feature/TravaSegunda/RetencaoLoopE2ETest.php`,
+> que roda no CI (`financeiro-pest.yml`, check required) e alimenta o manifesto G-7 via
+> JUnit. `Status: ✅` só com veredito `pass` no manifesto.
+>
+> **Status:** ✅ passa (com prova no manifesto) · 🧪 em teste/prova parcial · ⬜ não verificado · ❌ quebrou.
+
+---
+
+## UC-F01 · Venda a prazo gera título a receber (CU-3→CU-5)
+- **Persona:** Kamila (financeiro) — confiança de que NENHUMA venda a prazo fica sem cobrança.
+- **Aceite:** Dado venda final a prazo 30 dias · Então nasce `fin_titulos` tipo `receber`, status `aberto`, valor total = valor da venda, vencimento +30d da data da venda.
+- **Teste:** `RetencaoLoopE2ETest` ("UC-F01 · CU-3→CU-5") — Observer da venda, DB MySQL real.
+- **Status: ✅**
+
+## UC-F02 · Recebimento baixa o título e entra no caixa (CU-5)
+- **Persona:** Kamila — o "recebi" do balcão tem que virar baixa + caixa sem digitação dupla.
+- **Aceite:** Dado título aberto · Quando o pagamento total entra (`TransactionPayment`) · Então o título quita (`valor_aberto = 0`), nasce a `fin_titulo_baixas` ligada ao pagamento e o `fin_caixa_movimentos` registra `entrada` ligada à baixa.
+- **Teste:** `RetencaoLoopE2ETest` ("UC-F02 · CU-5") — TransactionPaymentObserver no DB real.
+- **Status: ✅**
+
+## UC-F03 · Wire fiscal da venda existe (CU-4)
+- **Persona:** Larissa — o botão "Emitir NF-e" da venda não pode apontar pro vazio.
+- **Aceite:** Dado a rota da tela de venda · Então os endpoints fiscais que ela dispara (NF-e emitir) existem e respondem (a emissão SEFAZ em si é coberta com stub pelas suítes NfeBrasil/NFSe — não reduplicado aqui).
+- **Teste:** `RetencaoLoopE2ETest` ("UC-F03 · CU-4").
+- **Status: ✅**
+
+---
+
+## Backlog de casos (sem id — entram quando tiverem teste que os defenda)
+
+> Regra G-2: UC declarado sem teste citando o id = órfão. Itens SEM token de UC até existir teste real.
+
+- **[BACKLOG] Lentes (caixa/competência/fiscal) refinam os KPIs** — coberto por `UnificadoLentesGuardTest` (Pest GUARD); vira UC com id quando os GUARDs ganharem UC-id no título.
+- **[BACKLOG] Baixa manual pela tela (dialog)** — coberto por `UnificadoBaixaDialogGuardTest`; idem.
+- **[BACKLOG] Conciliação bancária (extrato ↔ título)** — fluxo Pluggy/Inter; espelhar quando o harness tiver extrato fixture.
+
+## Como rodar a suíte
+1. **Pest (MySQL real):** lane `financeiro-pest.yml` (check required `PHP / Pest (Financeiro · MySQL)`) — JUnit vira manifesto via `npm run casos:results` (merge per-UC).
+2. **Cadência:** rodar ao fim de toda mexida no Financeiro. UC ❌ = regressão → lição + conserto.
+
+## Trilha do tempo
+- 2026-06-11 · [CL] criado na Onda Q2 (mandato ONDAS-QUALIDADE): UC-F01..03 espelham o RetencaoLoopE2ETest (CU-3→CU-5) no manifesto G-7; RetencaoLoop entrou na allowlist do financeiro-pest + JUnit artifact.

--- a/resources/js/Pages/Sells/Index.casos.md
+++ b/resources/js/Pages/Sells/Index.casos.md
@@ -1,0 +1,39 @@
+---
+casos: Lista de vendas · /sells
+irmaos: Index.charter.md (lei)
+tecnica: Caso de uso = narrativa do cliente + critério de aceite verificável (Dado/Quando/Então)
+por_que: comportamento é durável — não muda no refactor; é teste E explicação de uso E material de treino.
+owner: wagner
+last_run: "2026-06-11"
+---
+
+# Casos de Uso & Aceite — Lista de vendas
+
+> Tela P0 (mandato ONDAS-QUALIDADE Q2). `Status: ✅` só com veredito `pass` no manifesto G-7.
+>
+> **Status:** ✅ passa (com prova no manifesto) · 🧪 em teste/prova parcial · ⬜ não verificado · ❌ quebrou.
+
+---
+
+## UC-S10 · Abrir a lista e enxergar a cobrança num relance
+- **Persona:** Larissa / Kamila — "quem está devendo?" sem montar relatório.
+- **Aceite:** Dado a tela carregada · Então o título **Vendas** renderiza e as pílulas de status por pagamento aparecem (default **Todas**; pagas/a-receber derivadas de `payment_status`).
+- **Teste:** `e2e/sells-index.spec.ts` (Playwright, harness G-3 e2e-gate).
+- **Status: ✅**
+
+---
+
+## Backlog de casos (sem id — entram quando tiverem teste que os defenda)
+
+> Regra G-2: UC declarado sem teste citando o id = órfão. Itens SEM token de UC até existir teste real.
+
+- **[BACKLOG] Filtrar pela pílula muda as linhas** — clicar "A receber" mostra só vendas `due/partial`; exige venda semeada com status variados no harness.
+- **[BACKLOG] Drawer da venda (documento vivo)** — clicar na linha abre o drawer com FSM/pagamentos; espelhar âncoras pós-DS v6.
+- **[BACKLOG] Imprimir resumo do caixa de hoje** — botão no header; exige stub de print (mesmo padrão UC-11 Oficina).
+
+## Como rodar a suíte
+1. **E2E:** `npm run e2e:check` no harness do CI (e2e-gate) — vereditos viram manifesto via `npm run casos:results` (merge per-UC).
+2. **Cadência:** rodar ao fim de toda mexida em Sells/Index. UC ❌ = regressão → lição + conserto.
+
+## Trilha do tempo
+- 2026-06-11 · [CL] criado na Onda Q2 (mandato ONDAS-QUALIDADE) com UC-S10 + spec `sells-index.spec.ts`.

--- a/scripts/casos-coverage-baseline.json
+++ b/scripts/casos-coverage-baseline.json
@@ -1,13 +1,13 @@
 {
   "_meta": {
-    "generated_at": "2026-06-11T18:12:32.912Z",
+    "generated_at": "2026-06-11T18:29:12.949Z",
     "gate": "casos:check (ADR 0264 G-1 trio + G-2 rastreabilidade + G-5 metadata + G-6 frescor + G-7 status derivado)",
     "stats": {
       "pages": 275,
-      "casos_files": 2,
-      "ucs_declared": 9,
+      "casos_files": 4,
+      "ucs_declared": 14,
       "missing_charter": 144,
-      "missing_casos": 273,
+      "missing_casos": 271,
       "orphan_ucs": 0,
       "metadata_issues": 0,
       "stale_cases": 0,
@@ -139,7 +139,6 @@
     "trio:missing-casos:resources/js/Pages/Financeiro/PlanoContas/Index.tsx",
     "trio:missing-casos:resources/js/Pages/Financeiro/ProvaViva.tsx",
     "trio:missing-casos:resources/js/Pages/Financeiro/Relatorios/Index.tsx",
-    "trio:missing-casos:resources/js/Pages/Financeiro/Unificado/Index.tsx",
     "trio:missing-casos:resources/js/Pages/Financeiro/Unificado/Novo.tsx",
     "trio:missing-casos:resources/js/Pages/Fiscal/_lib/linkify.tsx",
     "trio:missing-casos:resources/js/Pages/Fiscal/Cockpit.tsx",
@@ -267,7 +266,6 @@
     "trio:missing-casos:resources/js/Pages/Sells/Create.tsx",
     "trio:missing-casos:resources/js/Pages/Sells/Drafts.tsx",
     "trio:missing-casos:resources/js/Pages/Sells/Edit.tsx",
-    "trio:missing-casos:resources/js/Pages/Sells/Index.tsx",
     "trio:missing-casos:resources/js/Pages/Sells/Quotations.tsx",
     "trio:missing-casos:resources/js/Pages/Sells/Show.tsx",
     "trio:missing-casos:resources/js/Pages/Sells/Subscriptions.tsx",

--- a/scripts/casos-test-results.json
+++ b/scripts/casos-test-results.json
@@ -1,13 +1,13 @@
 {
   "_meta": {
-    "generated_at": "2026-06-11T18:10:58.839Z",
+    "generated_at": "2026-06-11T18:28:57.253Z",
     "gate": "casos status derivado (ADR 0264 G-7 — Status por UC vem do veredito real do teste)",
     "sources": [
-      "test-results/playwright-junit.xml"
+      "test-results/pest-financeiro-junit.xml"
     ],
     "stats": {
-      "ucs": 9,
-      "pass": 9,
+      "ucs": 13,
+      "pass": 13,
       "fail": 0,
       "skip": 0
     },
@@ -19,6 +19,21 @@
     ]
   },
   "ucs": {
+    "UC-F02": {
+      "verdict": "pass",
+      "ran_at": null,
+      "tests": 1
+    },
+    "UC-F03": {
+      "verdict": "pass",
+      "ran_at": null,
+      "tests": 1
+    },
+    "UC-F01": {
+      "verdict": "pass",
+      "ran_at": null,
+      "tests": 1
+    },
     "UC-11": {
       "verdict": "pass",
       "ran_at": "2026-06-11",
@@ -60,6 +75,11 @@
       "tests": 1
     },
     "UC-09": {
+      "verdict": "pass",
+      "ran_at": "2026-06-11",
+      "tests": 1
+    },
+    "UC-S10": {
       "verdict": "pass",
       "ran_at": "2026-06-11",
       "tests": 1

--- a/tests/Feature/TravaSegunda/RetencaoLoopE2ETest.php
+++ b/tests/Feature/TravaSegunda/RetencaoLoopE2ETest.php
@@ -76,7 +76,7 @@ function tsMakeSell(int $businessId, int $locationId, int $contactId, int $userI
     return Transaction::create(array_merge($defaults, $overrides));
 }
 
-it('CU-3→CU-5: venda a prazo gera título a receber com vencimento +30d (valor correto)', function () {
+it('UC-F01 · CU-3→CU-5: venda a prazo gera título a receber com vencimento +30d (valor correto)', function () {
     $hoje = Carbon::now();
     $tx = tsMakeSell(
         $this->business->id,
@@ -109,7 +109,7 @@ it('CU-3→CU-5: venda a prazo gera título a receber com vencimento +30d (valor
     expect($diffDias)->toBe(30, 'título vence 30 dias após a venda (CU-5)');
 });
 
-it('CU-5: recebimento baixa o título (vende→fatura→recebe completo)', function () {
+it('UC-F02 · CU-5: recebimento baixa o título (vende→fatura→recebe completo)', function () {
     $conta = \Modules\Financeiro\Models\ContaBancaria::query()
         ->withoutGlobalScope(BusinessScopeImpl::class)
         ->where('business_id', $this->business->id)
@@ -161,7 +161,7 @@ it('CU-5: recebimento baixa o título (vende→fatura→recebe completo)', funct
     expect($mov->tipo)->toBe('entrada');
 });
 
-it('CU-4: os endpoints fiscais que a tela de venda dispara existem (wire-up Onda 2)', function () {
+it('UC-F03 · CU-4: os endpoints fiscais que a tela de venda dispara existem (wire-up Onda 2)', function () {
     // O botão "Emitir NF-e" (VdNfeEmitModal) chama POST /nfe-brasil/transactions/{tx}/emitir.
     expect(Route::has('nfe-brasil.transactions.emitir') || collect(Route::getRoutes())->contains(
         fn ($r) => $r->uri() === 'nfe-brasil/transactions/{tx}/emitir' && in_array('POST', $r->methods(), true),


### PR DESCRIPTION
## Onda Q2 item 3 — o fio venda→faturamento→caixa entra no manifesto G-7

### Descoberta da onda
`RetencaoLoopE2ETest` (a prova backend do encadeamento CU-3→CU-5) **não rodava em lugar nenhum do CI** — fora da allowlist do financeiro-pest e skipando em sqlite no ci.yml. Agora roda na lane MySQL required.

### O que muda
- `RetencaoLoopE2ETest` ganha UC-F01/F02/F03 nos títulos → entra na **allowlist** do `financeiro-pest.yml` + seed ganha location+contact (pré-requisitos) + `--log-junit` + artifact `pest-financeiro-junit`
- `Financeiro/Unificado/Index.casos.md` (UC-F01..03 ✅ com prova) + `Sells/Index.casos.md` (UC-S10) + `e2e/sells-index.spec.ts`
- **Manifesto: 13 UCs, 13 pass** — merge per-UC dos 2 runners (e2e [27368509966](https://github.com/wagnerra23/oimpresso.com/actions/runs/27368509966) + Pest [27368511483](https://github.com/wagnerra23/oimpresso.com/actions/runs/27368511483)); primeira prova REAL do #2567 (`10 preservado(s)`)
- **Baseline 417 → 415 (−2)** — só-desce ✅

Refs: ONDAS-QUALIDADE Q2 · ADR 0264 G-2/G-7 · ADR 0258

🤖 Generated with [Claude Code](https://claude.com/claude-code)