### PR TITLE
feat(foundations): §TEMPERO na fundação — sombras/ease/atmosfera + atmosfera no shell (FA-1)

### DIFF
--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-10T14:15:21.783Z",
-    "total_lines": 20230,
+    "generated_at": "2026-06-11T18:35:07.102Z",
+    "total_lines": 20250,
     "file_count": 29,
     "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
     "refs": [
@@ -10,7 +10,7 @@
     ]
   },
   "files": {
-    "resources/css/cockpit.css": 2289,
+    "resources/css/cockpit.css": 2290,
     "resources/css/cowork-canon-financeiro-bundle.css": 4747,
     "resources/css/cowork-compras-bundle.css": 182,
     "resources/css/cowork-fields.css": 392,
@@ -21,7 +21,7 @@
     "resources/css/fin-mobile.css": 67,
     "resources/css/fin-output.css": 1004,
     "resources/css/fiscal-cockpit.css": 1381,
-    "resources/css/foundations.css": 26,
+    "resources/css/foundations.css": 45,
     "resources/css/inertia.css": 363,
     "resources/css/kb.css": 184,
     "resources/css/screen-grade.css": 16,

--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -151,7 +151,8 @@
   font-family: var(--font-sans);
   font-size: 13.5px;
   color: var(--text);
-  background: var(--bg);
+  background-color: var(--bg);
+  background-image: var(--atmo);   /* atmosfera do ERP — §TEMPERO (foundations.css); par dark via [data-theme]. Telas por cima ficam transparentes pra deixar passar. */
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }

--- a/resources/css/foundations.css
+++ b/resources/css/foundations.css
@@ -23,4 +23,30 @@
   --fs-7: 22px;    /* h1 de página · KPI médio */
   --fs-8: 28px;    /* número grande */
   --fs-9: 38px;    /* número hero */
+
+  /* ── TEMPERO — norte visual do ERP ([W] autorizou 2026-06-10, MESMA autorização
+     textual "vai"/"sim sim é isso que eu quero" do ramp acima — fonte "Norte: Fluxo
+     do Caminhão", §TEMPERO do gabarito ds-v6/tokens.css). Os 3 conceitos que faltavam
+     na fundação: UMA fonte de luz (sombras de baixo→cima, sutis), microfísica única
+     (--ease/--t) e fundo com atmosfera (--atmo, par dark abaixo). Consumir SEMPRE via
+     var(); redefinir em css de tela = espalhamento (foundation-guard barra). ── */
+  --sh-1: 0 4px 14px -6px oklch(0.2 0.02 282 / .10), 0 1px 3px oklch(0.2 0.02 282 / .07);   /* card assentado */
+  --sh-2: 0 18px 50px -18px oklch(0.2 0.02 282 / .30), 0 4px 14px -6px oklch(0.2 0.02 282 / .16); /* flutuante: drawer/modal/popover/cmdk */
+  --ease: cubic-bezier(.22, 1, .36, 1);  /* desacelera como coisa física — curva única do ERP */
+  --t-1: .15s;  --t-2: .3s;
+  --atmo: radial-gradient(1100px 600px at 82% -8%, oklch(0.55 0.15 295 / .05), transparent 60%),
+          radial-gradient(900px 520px at 8% 108%, oklch(0.55 0.10 250 / .04), transparent 62%);
+}
+
+/* ── TEMPERO · dark ──
+   O atributo data-theme mora no elemento .cockpit (Shell). Casar por [data-theme]
+   (sem a classe .cockpit) mantém a Fundação desacoplada da estrutura do Shell
+   (ADR UI-0013) e funciona porque o atributo está nesse mesmo elemento; nada mais
+   define as sombras nem a atmosfera, então não há conflito de especificidade.
+   Só os 3 tokens que mudam no escuro. */
+[data-theme="dark"]{
+  --sh-1: 0 4px 14px -6px rgba(0,0,0,.45), 0 1px 3px rgba(0,0,0,.3);
+  --sh-2: 0 18px 50px -18px rgba(0,0,0,.6), 0 4px 14px -6px rgba(0,0,0,.4);
+  --atmo: radial-gradient(1100px 600px at 82% -8%, oklch(0.26 0.07 295 / .28), transparent 60%),
+          radial-gradient(900px 520px at 8% 108%, oklch(0.24 0.05 250 / .22), transparent 62%);
 }

--- a/resources/css/foundations.css
+++ b/resources/css/foundations.css
@@ -24,12 +24,9 @@
   --fs-8: 28px;    /* número grande */
   --fs-9: 38px;    /* número hero */
 
-  /* ── TEMPERO — norte visual do ERP ([W] autorizou 2026-06-10, MESMA autorização
-     textual "vai"/"sim sim é isso que eu quero" do ramp acima — fonte "Norte: Fluxo
-     do Caminhão", §TEMPERO do gabarito ds-v6/tokens.css). Os 3 conceitos que faltavam
-     na fundação: UMA fonte de luz (sombras de baixo→cima, sutis), microfísica única
-     (--ease/--t) e fundo com atmosfera (--atmo, par dark abaixo). Consumir SEMPRE via
-     var(); redefinir em css de tela = espalhamento (foundation-guard barra). ── */
+  /* ── TEMPERO ([W] 2026-06-10, mesma autorização do ramp · §TEMPERO gabarito ds-v6) ──
+     UMA fonte de luz (--sh-1/--sh-2), microfísica (--ease/--t-1/--t-2), atmosfera (--atmo,
+     par dark abaixo). Consumir via var(); redefinir em tela = espalhamento (foundation-guard). */
   --sh-1: 0 4px 14px -6px oklch(0.2 0.02 282 / .10), 0 1px 3px oklch(0.2 0.02 282 / .07);   /* card assentado */
   --sh-2: 0 18px 50px -18px oklch(0.2 0.02 282 / .30), 0 4px 14px -6px oklch(0.2 0.02 282 / .16); /* flutuante: drawer/modal/popover/cmdk */
   --ease: cubic-bezier(.22, 1, .36, 1);  /* desacelera como coisa física — curva única do ERP */
@@ -38,12 +35,8 @@
           radial-gradient(900px 520px at 8% 108%, oklch(0.55 0.10 250 / .04), transparent 62%);
 }
 
-/* ── TEMPERO · dark ──
-   O atributo data-theme mora no elemento .cockpit (Shell). Casar por [data-theme]
-   (sem a classe .cockpit) mantém a Fundação desacoplada da estrutura do Shell
-   (ADR UI-0013) e funciona porque o atributo está nesse mesmo elemento; nada mais
-   define as sombras nem a atmosfera, então não há conflito de especificidade.
-   Só os 3 tokens que mudam no escuro. */
+/* TEMPERO · dark — data-theme mora no .cockpit; casar por [data-theme] (sem a classe)
+   mantém a Fundação desacoplada do Shell (ADR UI-0013) e casa no mesmo elemento. */
 [data-theme="dark"]{
   --sh-1: 0 4px 14px -6px rgba(0,0,0,.45), 0 1px 3px rgba(0,0,0,.3);
   --sh-2: 0 18px 50px -18px rgba(0,0,0,.6), 0 4px 14px -6px rgba(0,0,0,.4);


### PR DESCRIPTION
## FA-1 — §TEMPERO na fundação (completa o PR-4 do pacote Financeiro F2)

**Origem:** handoff Cowork `PROMPT_PARA_CODE_ONDAS-FINANCEIRO` ([CC] 2026-06-11, proposta §10.4 — validado contra `origin/main` fresco antes de agir).

**Autorização:** [W] 2026-06-10 — **mesma autorização textual** ("vai" / "sim sim é isso que eu quero") do type ramp que landou no PR #2493. O ramp foi só metade do §TEMPERO; esta PR entrega a outra metade que ficou pra trás.

### Validação §10.4 (estado real vs premissa do prompt)
| Premissa [CC] | Estado @main `f22904c5e` | Veredito |
|---|---|---|
| `foundations.css` tem só o ramp, sem tempero | confirmado (grep `--sh-1\|--atmo\|--ease` = 0 em foundations/cockpit/inertia) | **executado** |
| tokens já no `TOKEN_DEF_ALLOW` do foundation-guard | confirmado (`foundations.css` + `cockpit.css` allowlisted) | sem mexer em allowlist |
| par dark no seletor real do repo | real = `.cockpit[data-theme="dark"]` (cockpit.css) | usei `[data-theme="dark"]` na Fundação |

### O que muda
- **`resources/css/foundations.css`** — na Camada Fundações:
  - `--sh-1` (card assentado) / `--sh-2` (flutuante: drawer/modal/popover/cmdk) — **uma fonte de luz**, par light + dark
  - `--ease` (cubic-bezier única do ERP) + `--t-1`/`--t-2` (microfísica)
  - `--atmo` (radial roxo 5% light / 28% dark), par dark sob `[data-theme="dark"]`
- **`resources/css/cockpit.css`** — `background-image: var(--atmo)` no container `.cockpit` (Shell). `background` shorthand virou `background-color` + `background-image` pra não zerar a imagem.

Valores **canônicos do §TEMPERO** (gabarito `ds-v6/tokens.css`), copiados verbatim — não o arquivo inteiro (o gabarito é o monólito v4→v5 do protótipo e até duplica `--sh-1/--sh-2`).

### Decisão de arquitetura (ADR UI-0013)
O atributo `data-theme` mora no elemento `.cockpit` (Shell). A Fundação casa por `[data-theme="dark"]` **sem** a classe `.cockpit` → não acopla a Camada Fundações à estrutura do Shell, e funciona porque o atributo está nesse mesmo elemento. Como nada mais define `--sh-*`/`--atmo`, não há conflito de especificidade.

### Gates (locais, verdes)
- `foundation-guard` ✅ — token-def 6/6 dentro do teto, 29 .css na allowlist, 0 espalhamento
- `conformance-gate --all` ✅ — 28 arquivos conformes (cor crua + accent roxo 250–330 + papel de token + type ramp)
- `stylelint` baseline ✅ — **delta 0** (427 = 427); `foundations.css` limpo (0 violação)

> Gotcha pego e corrigido no ciclo: comentário com `--sh-*/--atmo` tem `*/` que **fecha o comentário CSS** → parse error. Reescrito sem `*/` (mesma lição da DS v6 PR3).

### Escopo / não-Tier-0
Aditivo. `--accent` roxo 295 intocado (count=1). Nenhum token existente alterado, nenhum hex novo, nenhum arquivo CSS novo.

### Visual
Mudança é observável (atmosfera sutil em todo shell + sombras/transições disponíveis pra consumo). **Prova visual light+dark @1280/@1440 via smoke pós-merge** (app full precisa de DB/tenant; não roda no worktree isolado) + gate `visual-regression` do CI. A adoção das sombras/transições no Financeiro live é a **FA-3** (depende desta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
