### PR TITLE
ci(dominio-guard): suporte a domínios CORE — migrations_paths + tables_scope + code_paths (Onda Q3)

### DIFF
--- a/scripts/domain-dict-guard.mjs
+++ b/scripts/domain-dict-guard.mjs
@@ -175,9 +175,15 @@ function currentEnums(moduleName, dict = null) {
   const dirs = dict?.migrations_paths?.length
     ? dict.migrations_paths.map((p) => resolve(ROOT, p))
     : [join(MODULES_DIR, moduleName, 'Database', 'Migrations')];
+  // Ordena pelo BASENAME (timestamp da migration) com comparação por codepoint —
+  // cross-dir o last-write-wins tem que ser CRONOLÓGICO (não path-alfabético) e
+  // determinístico entre Windows/CI (localeCompare é locale-dependente). Caso real:
+  // nfse_emissoes criada no NFSe (2026_05_01) e RE-criada no NfeBrasil (2026_05_11) —
+  // o estado atual é o do NfeBrasil.
+  const base = (p) => p.split(/[\\/]/).pop();
   const files = dirs
     .flatMap((d) => walk(d, (full, name) => name.endsWith('.php')))
-    .sort((a, b) => a.localeCompare(b));
+    .sort((a, b) => (base(a) < base(b) ? -1 : base(a) > base(b) ? 1 : 0));
   const scope = dict?.tables_scope?.length ? new Set(dict.tables_scope) : null;
   const state = {};
   for (const file of files) {

--- a/scripts/domain-dict-guard.mjs
+++ b/scripts/domain-dict-guard.mjs
@@ -64,7 +64,7 @@
 //
 // Refs: ADR 0264 (G-4 + Salto #3 cobertura de código) · ADR 0265 (erradica locação) · ADR 0261 (enforcement faseado) · ADR 0256 (catraca).
 
-import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
 import { resolve, join, relative } from 'node:path';
 
 const ROOT = process.cwd();
@@ -111,6 +111,13 @@ function loadDicts() {
       enums: parsed.enums,
       forbidden_ui_terms: parsed.forbidden_ui_terms || [],
       forbidden_ui_paths: parsed.forbidden_ui_paths || [],
+      // Onda Q3 — domínios CORE (vendas/estoque vivem em database/migrations + app/,
+      // não em Modules/<X>): paths explícitos substituem os defaults por-módulo.
+      // tables_scope restringe o undeclared-column check às tabelas que o domínio
+      // REIVINDICA (sem ele, um dict core seria cobrado por users.marital_status etc).
+      migrations_paths: Array.isArray(parsed.migrations_paths) ? parsed.migrations_paths : null,
+      code_paths: Array.isArray(parsed.code_paths) ? parsed.code_paths : null,
+      tables_scope: Array.isArray(parsed.tables_scope) ? parsed.tables_scope : null,
       file: `memory/dominio/${e.name}`,
     };
   }
@@ -158,13 +165,20 @@ function extractEnumDefs(upRegion) {
   return defs.sort((a, b) => a.index - b.index);
 }
 
-// Para um módulo: percorre migrations sorted, last-write-wins por tab.col.
+// Para um domínio: percorre migrations sorted, last-write-wins por tab.col.
+// Default: Modules/<module>/Database/Migrations. Domínio CORE (Onda Q3) declara
+// `migrations_paths` (ex.: ["database/migrations"]) e opcionalmente `tables_scope`
+// (só as tabelas reivindicadas entram no estado → undeclared-column não cobra
+// tabela alheia num diretório compartilhado).
 // Retorna map: "tab.col" -> [valores atuais].
-function currentEnums(moduleName) {
-  const dir = join(MODULES_DIR, moduleName, 'Database', 'Migrations');
-  const files = walk(dir, (full, name) => name.endsWith('.php')).sort((a, b) =>
-    a.localeCompare(b),
-  );
+function currentEnums(moduleName, dict = null) {
+  const dirs = dict?.migrations_paths?.length
+    ? dict.migrations_paths.map((p) => resolve(ROOT, p))
+    : [join(MODULES_DIR, moduleName, 'Database', 'Migrations')];
+  const files = dirs
+    .flatMap((d) => walk(d, (full, name) => name.endsWith('.php')))
+    .sort((a, b) => a.localeCompare(b));
+  const scope = dict?.tables_scope?.length ? new Set(dict.tables_scope) : null;
   const state = {};
   for (const file of files) {
     const content = readFileSync(file, 'utf8');
@@ -173,6 +187,7 @@ function currentEnums(moduleName) {
     // pra o ALTER...ENUM voltar a ser uma sequência contígua antes do regex.
     const glued = upRegion.replace(/['"]\s*\.\s*['"]/g, '');
     for (const def of extractEnumDefs(glued)) {
+      if (scope && !scope.has(def.table)) continue; // tabela não-reivindicada (Onda Q3)
       state[`${def.table}.${def.col}`] = def.values; // last write wins
     }
   }
@@ -214,8 +229,24 @@ function buildColIndex(enums) {
   return idx;
 }
 
-// Arquivos de CÓDIGO de aplicação do módulo (exclui data-setup e testes — ver header).
-function moduleCodeFiles(moduleName) {
+// Arquivos de CÓDIGO de aplicação do domínio (exclui data-setup e testes — ver header).
+// Default: Modules/<module>. Domínio CORE declara `code_paths` ESTREITOS (colunas
+// genéricas tipo `status`/`tipo` super-casam — escopo largo em app/ = ruído).
+function moduleCodeFiles(moduleName, dict = null) {
+  if (dict?.code_paths) {
+    const wanted = (full, name) => {
+      if (!name.endsWith('.php') && !name.endsWith('.tsx') && !name.endsWith('.ts')) return false;
+      const rel = norm(full);
+      return !/\/(Database|Tests|tests)\//.test(rel);
+    };
+    return dict.code_paths.flatMap((p) => {
+      const full = resolve(ROOT, p);
+      if (!existsSync(full)) return [];
+      // path pode ser um ARQUIVO único (controller específico) ou diretório.
+      if (statSync(full).isFile()) return wanted(full, full.split(/[\\/]/).pop()) ? [full] : [];
+      return walk(full, wanted);
+    });
+  }
   const dir = join(MODULES_DIR, moduleName);
   return walk(dir, (full, name) => {
     if (!name.endsWith('.php')) return false;
@@ -271,11 +302,11 @@ const lineOf = (content, index) => content.slice(0, index).split('\n').length;
 
 // Viola se a coluna é GOVERNADA pelo dicionário e o valor NÃO é canônico.
 // Retorna { keys:Set, occ:{ key -> [{file,line}] } }.
-function codeValueViolations(moduleName, colIndex) {
+function codeValueViolations(moduleName, colIndex, dict = null) {
   const keys = new Set();
   const occ = {};
   if (!Object.keys(colIndex).length) return { keys, occ };
-  for (const file of moduleCodeFiles(moduleName)) {
+  for (const file of moduleCodeFiles(moduleName, dict)) {
     const content = readFileSync(file, 'utf8');
     for (const { col, value, index } of codeValueRefs(content)) {
       const allowed = colIndex[col];
@@ -359,7 +390,7 @@ function computeViolations() {
 
   // Módulos COM dicionário → comparação valor-a-valor.
   for (const [mod, dict] of Object.entries(dicts)) {
-    const actual = currentEnums(mod);
+    const actual = currentEnums(mod, dict);
     const declaredCols = new Set(Object.keys(dict.enums));
     const actualCols = new Set(Object.keys(actual));
 
@@ -378,7 +409,7 @@ function computeViolations() {
     }
 
     // SALTO #3 — valores de domínio hardcoded no código de aplicação.
-    const { keys, occ } = codeValueViolations(mod, buildColIndex(dict.enums));
+    const { keys, occ } = codeValueViolations(mod, buildColIndex(dict.enums), dict);
     for (const key of keys) { violations.push(key); occurrences[key] = occ[key]; stats.code_divergences++; }
 
     // SALTO #4 — termos PROIBIDOS user-facing (trava de regressão ADR 0265).

--- a/tests/dominioGuard.spec.ts
+++ b/tests/dominioGuard.spec.ts
@@ -413,4 +413,27 @@ describe('dominio:check — domínios core (Onda Q3, físico)', () => {
     });
     expect(run('--json')).toMatch(/"ok": true/);
   });
+
+  it('CRONOLOGIA cross-dir: last-write-wins pelo TIMESTAMP da migration, não pelo path', () => {
+    // Caso real nfse_emissoes: módulo A cria (05_01), módulo B RE-cria depois (05_11).
+    // O estado atual é o de B, mesmo que o path de A ordene depois alfabeticamente.
+    write(
+      'pacotes/zfirst/migrations/2026_05_01_000000_create_t.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('t', function ($t) { $t->enum('status', ['velho']); });
+      } };`,
+    );
+    write(
+      'pacotes/afterz/migrations/2026_05_11_000000_create_t.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('t', function ($t) { $t->enum('status', ['novo']); });
+      } };`,
+    );
+    dict('FiscalX', { 't.status': ['novo'] }, {
+      migrations_paths: ['pacotes/zfirst/migrations', 'pacotes/afterz/migrations'],
+      tables_scope: ['t'],
+    });
+    // 'novo' (timestamp 05_11) vence 'velho' (05_01) → dict bate com o estado atual.
+    expect(run('--json')).toMatch(/"ok": true/);
+  });
 });

--- a/tests/dominioGuard.spec.ts
+++ b/tests/dominioGuard.spec.ts
@@ -327,3 +327,90 @@ describe('dominio:check — termos proibidos user-facing (Salto #4, físico)', (
     expect(out).not.toMatch(/forbidden-ui-term/);
   });
 });
+
+// ── Onda Q3 — domínios CORE (migrations_paths + tables_scope + code_paths) ─────────────
+// Vendas/estoque vivem em database/migrations (não Modules/<X>). O dict declara os paths
+// e REIVINDICA tabelas; undeclared-column não cobra tabela alheia do diretório compartilhado.
+describe('dominio:check — domínios core (Onda Q3, físico)', () => {
+  const coreMigration = (file: string, php: string) => write(`database/migrations/${file}`, php);
+
+  it('SENSIBILIDADE: enum core divergente do dicionário (via migrations_paths) → undeclared-value', () => {
+    coreMigration(
+      '2026_01_01_000000_create_transactions.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('transactions', function ($t) { $t->enum('payment_status', ['paid', 'due', 'partial', 'fantasma']); });
+      } };`,
+    );
+    dict('VendasCore', { 'transactions.payment_status': ['paid', 'due', 'partial'] }, {
+      migrations_paths: ['database/migrations'],
+      tables_scope: ['transactions'],
+    });
+    const out = runJsonExpectFail();
+    expect(out).toMatch(/dominio:undeclared-value:VendasCore:transactions\.payment_status:fantasma/);
+  });
+
+  it('ESPECIFICIDADE: tables_scope NÃO cobra tabela alheia do diretório compartilhado', () => {
+    coreMigration(
+      '2026_01_01_000000_create_core.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('transactions', function ($t) { $t->enum('payment_status', ['paid', 'due']); });
+        Schema::create('users', function ($t) { $t->enum('marital_status', ['married', 'unmarried']); });
+      } };`,
+    );
+    dict('VendasCore', { 'transactions.payment_status': ['paid', 'due'] }, {
+      migrations_paths: ['database/migrations'],
+      tables_scope: ['transactions'],
+    });
+    const out = run('--json');
+    expect(out).toMatch(/"ok": true/);
+    expect(out).not.toMatch(/users\.marital_status/); // fora do scope reivindicado
+  });
+
+  it('SENSIBILIDADE: sem tables_scope, coluna enum não-declarada no diretório É cobrada (semântica original)', () => {
+    coreMigration(
+      '2026_01_01_000000_create_core.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('transactions', function ($t) { $t->enum('payment_status', ['paid']); });
+        Schema::create('users', function ($t) { $t->enum('marital_status', ['married']); });
+      } };`,
+    );
+    dict('VendasCore', { 'transactions.payment_status': ['paid'] }, {
+      migrations_paths: ['database/migrations'],
+    });
+    const out = runJsonExpectFail();
+    expect(out).toMatch(/dominio:undeclared-column:VendasCore:users\.marital_status/);
+  });
+
+  it('SALTO #3 core: code_paths aceita ARQUIVO único e pega valor não-canônico', () => {
+    coreMigration(
+      '2026_01_01_000000_create_transactions.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('transactions', function ($t) { $t->enum('payment_status', ['paid', 'due']); });
+      } };`,
+    );
+    write('app/Http/Controllers/SellController.php', `<?php class SellController { function f($q) { return $q->where('payment_status', 'estornado'); } }`);
+    dict('VendasCore', { 'transactions.payment_status': ['paid', 'due'] }, {
+      migrations_paths: ['database/migrations'],
+      tables_scope: ['transactions'],
+      code_paths: ['app/Http/Controllers/SellController.php'],
+    });
+    const out = runJsonExpectFail();
+    expect(out).toMatch(/dominio:undeclared-code-value:VendasCore:payment_status:estornado/);
+  });
+
+  it('ESPECIFICIDADE core: valor canônico no code_path único passa limpo', () => {
+    coreMigration(
+      '2026_01_01_000000_create_transactions.php',
+      `<?php return new class { public function up(): void {
+        Schema::create('transactions', function ($t) { $t->enum('payment_status', ['paid', 'due']); });
+      } };`,
+    );
+    write('app/Http/Controllers/SellController.php', `<?php class SellController { function f($q) { return $q->where('payment_status', 'due'); } }`);
+    dict('VendasCore', { 'transactions.payment_status': ['paid', 'due'] }, {
+      migrations_paths: ['database/migrations'],
+      tables_scope: ['transactions'],
+      code_paths: ['app/Http/Controllers/SellController.php'],
+    });
+    expect(run('--json')).toMatch(/"ok": true/);
+  });
+});


### PR DESCRIPTION
## Onda Q3 PR-1 — o guard de domínio alcança o core UltimatePOS

Os 5 dicionários do mandato (vendas/financeiro/fiscal-faturamento/estoque/compras) cobrem domínios que vivem em `database/migrations` + `app/` — fora do alcance atual (`Modules/<X>` hardcoded). O bloco json do dicionário ganha 3 campos **opcionais** (defaults preservam 100% a semântica atual):

- `migrations_paths` — diretórios de migrations do domínio (ex.: `["database/migrations"]`)
- `tables_scope` — tabelas REIVINDICADAS: `undeclared-column` não cobra `users.marital_status` num diretório compartilhado; sem scope = semântica original integral
- `code_paths` — arquivos/diretórios ESTREITOS pro Salto #3 (colunas genéricas `status`/`tipo` super-casam em `app/` largo)

### Prova 2 lados (meta-teste físico, dominio-meta-gate)
- 🔴 enum core divergente via `migrations_paths` → `undeclared-value`
- 🟢 `tables_scope` não cobra tabela alheia · 🔴 SEM scope cobra (original preservada)
- 🔴 Salto #3 com `code_paths` de arquivo único pega valor não-canônico · 🟢 canônico passa

vitest **26/26** · repo real: 0 violações novas (oficina-auto.md intacto).

PR-2 da onda: os 5 dicionários grounded nos enums reais (panorama core já extraído).

Refs: ONDAS-QUALIDADE Q3 · ADR 0264 G-4 · ADR 0258

🤖 Generated with [Claude Code](https://claude.com/claude-code)