### PR TITLE
docs(dominio): 5 dicionários de domínio + vocab varchar no guard (Onda Q3)

### DIFF
--- a/memory/dominio/compras.md
+++ b/memory/dominio/compras.md
@@ -1,0 +1,49 @@
+---
+dominio: Compras (core UltimatePOS) — pedido, recebimento, devolução ao fornecedor
+fonte_unica: este arquivo é a fonte canônica do vocabulário de COMPRAS (ADR 0264 G-4, Onda Q3)
+gate: dominio:check (scripts/domain-dict-guard.mjs) — enum ⇔ bloco `json` abaixo
+owner: wagner
+related_adrs: [0264-governanca-executavel-trio-dominio-e2e]
+---
+
+# Dicionário de domínio — Compras (core)
+
+> **Fonte única do vocabulário de compras** (Onda Q3). Compras roda na MESMA espinha
+> `transactions` de vendas — este dicionário fixa a SEMÂNTICA do lado-compra; a declaração
+> machine-checked dos enums compartilhados é do [vendas.md](vendas.md) (dono da espinha),
+> não redeclarada aqui (duas declarações da mesma coluna = drift garantido).
+
+## Conceitos-chave (PT-BR canônico) — conforme o que o schema REALMENTE tem
+
+- **Compra** = `transactions` com `type=purchase`. Ciclo: `ordered` (**pedido emitido**) →
+  `pending` (aguardando) → `received` (**recebida** — só aqui entra estoque).
+- **Recebimento** = flip pra `status=received`; é o recebimento que MOVIMENTA estoque
+  (`purchase_lines` → `qty_available`), nunca o pedido.
+- **Devolução ao fornecedor** = `type=purchase_return` (espinha) — canônico "devolução",
+  nunca "estorno" (estorno é de pagamento, financeiro.md).
+- **Fornecedor** = `contacts` com `primary_role=supplier` (cadastro compartilhado — enums
+  declarados em vendas.md).
+- **Pagamento da compra** = título `tipo=pagar` com `origem=compra` (financeiro.md) — a
+  compra a prazo gera obrigação igual a venda gera direito.
+- **Custo** entra por `purchase_lines.purchase_price*` (decimal, sem enum) e alimenta o
+  método de custeio (`business.accounting_method` fifo/lifo/avco — tabela de config, sem
+  dono de domínio claimado; ver estoque.md).
+- **Sinônimos proibidos**: "entrada de nota" pra recebimento de compra (canônico:
+  recebimento; "nota" é documento fiscal — fiscal-faturamento.md); "ordem de compra" (o
+  schema chama `ordered`/pedido; "OS/ordem" é vocabulário da Oficina).
+
+## Enums canônicos (machine-checked por `dominio:check`)
+
+> Compras não possui enum EXCLUSIVO no schema atual (purchase_lines não tem enum; a espinha
+> é declarada em vendas.md). O bloco existe pro gate validar a INTENÇÃO (zero divergência)
+> e pro dicionário contar como fonte-única no censo — declaração vazia é honesta, não burlа.
+
+```json
+{
+  "module": "ComprasCore",
+  "migrations_paths": ["database/migrations"],
+  "tables_scope": ["purchase_lines"],
+  "code_paths": ["app/Http/Controllers/PurchaseController.php", "app/Http/Controllers/PurchaseReturnController.php"],
+  "enums": {}
+}
+```

--- a/memory/dominio/estoque.md
+++ b/memory/dominio/estoque.md
@@ -1,0 +1,65 @@
+---
+dominio: Estoque (core UltimatePOS) — produto, movimento, reserva, inventário
+fonte_unica: este arquivo é a fonte canônica do vocabulário de ESTOQUE (ADR 0264 G-4, Onda Q3)
+gate: dominio:check (scripts/domain-dict-guard.mjs) — enum core ⇔ bloco `json` abaixo
+owner: wagner
+related_adrs: [0264-governanca-executavel-trio-dominio-e2e]
+---
+
+# Dicionário de domínio — Estoque (core)
+
+> **Fonte única do vocabulário de estoque** (Onda Q3 — existe ANTES das telas de estoque que
+> [W] vai construir). Grounded no schema REAL (`database/migrations`).
+
+## Conceitos-chave (PT-BR canônico) — conforme o que o schema REALMENTE tem
+
+- **Movimento de estoque** NÃO é tabela própria: vive na espinha `transactions.type`
+  (`stock_adjustment` = ajuste/inventário · `opening_stock` = saldo inicial ·
+  `sell_transfer`/`purchase_transfer` = transferência entre locais). A declaração desses
+  valores é do [vendas.md](vendas.md) (dono da espinha) — aqui só a semântica.
+- **Saldo por local** = `variation_location_details.qty_available` (decimal, sem enum) —
+  termo canônico "saldo disponível", nunca "estoque atual" solto sem local.
+- **Reserva** = `stock_reservations.status ∈ {active, consumed, released, expired}` —
+  reserva CONSOME ao virar venda (`consumed`), LIBERA ao cancelar (`released`).
+- **Baixa de estoque** = efeito da venda final sobre `qty_available` (via sell lines);
+  produto `enable_stock=0` NÃO movimenta estoque (serviço/sob-demanda).
+- **Inventário** = ajuste (`stock_adjustment`) com `adjustment_type ∈ {normal, abnormal}`.
+- **Produto** = `products.type ∈ {single, variable, modifier}` — `variable` tem variações
+  reais (P/M/G); `single` tem a variação DUMMY interna (idioma UltimatePOS); `modifier` é
+  complemento (herança restaurante, vestigial pra nós).
+- **Sinônimos proibidos**: "kit" pra `combo` (combo não existe no enum atual — não inventar);
+  "depósito" pra `business_location` (canônico: "local"/"loja").
+
+## Enums canônicos (machine-checked por `dominio:check`)
+
+> `business.*` (accounting_method fifo/lifo/avco etc.) é tabela de CONFIGURAÇÃO mista —
+> fica de fora do claim até ter dono de domínio claro (não esconder: é decisão registrada).
+
+```json
+{
+  "module": "EstoqueCore",
+  "migrations_paths": ["database/migrations"],
+  "tables_scope": ["products", "stock_reservations", "warranties"],
+  "code_paths": [],
+  "enums": {
+    "products.type": ["single", "variable", "modifier"],
+    "products.barcode_type": ["C39", "C128"],
+    "products.tax_type": ["inclusive", "exclusive"],
+    "products.expiry_period_type": ["days", "months"],
+    "stock_reservations.status": ["active", "consumed", "released", "expired"],
+    "warranties.duration_type": ["days", "months", "years"]
+  }
+}
+```
+
+### Vestigial (visível, não escondido)
+
+- `products.type=modifier` — herança UltimatePOS restaurante (complementos de prato).
+  Gráfica/oficina não usa; manter até decisão [W] de erradicação.
+
+### Por que `code_paths: []` (Salto #3 adiado pro estoque)
+
+`ProductUtil.php` mistura `products.type` (single/variable) e `transactions.type`
+(sell/purchase/production_*) — o matching do guard é por NOME CURTO de coluna, então o
+índice do estoque colidia com a espinha de vendas (14 falsos-positivos no run local).
+Salto #3 do estoque entra quando o guard ganhar matching por tabela.

--- a/memory/dominio/financeiro.md
+++ b/memory/dominio/financeiro.md
@@ -1,0 +1,68 @@
+---
+dominio: Financeiro — títulos, baixas, caixa, conciliação (Modules/Financeiro + contas core)
+fonte_unica: este arquivo é a fonte canônica do vocabulário FINANCEIRO (ADR 0264 G-4, Onda Q3)
+gate: dominio:check (scripts/domain-dict-guard.mjs) — enum ⇔ bloco `json` abaixo
+owner: wagner
+related_adrs: [0264-governanca-executavel-trio-dominio-e2e, 0175-conta-bancaria-opcional]
+---
+
+# Dicionário de domínio — Financeiro
+
+> **Fonte única do vocabulário financeiro** (Onda Q3). Grounded nas migrations REAIS de
+> `Modules/Financeiro` + tabelas de conta do core. O fio canônico (provado por
+> `RetencaoLoopE2ETest`, UC-F01..03): **venda → título a receber → baixa → caixa**.
+
+## Conceitos-chave (PT-BR canônico)
+
+- **Título** = `fin_titulos` (`tipo ∈ {receber, pagar}`) — TODA obrigação tem título; venda a
+  prazo GERA título (`origem=venda`) via Observer, nunca por digitação manual duplicada.
+- **Baixa** = `fin_titulo_baixas` — o "recebi/paguei". Baixa total quita
+  (`status=quitado`, `valor_aberto=0`); parcial deixa `status=parcial`.
+- **Caixa** = `fin_caixa_movimentos` (`tipo ∈ {entrada, saida, ajuste, transferencia}`) —
+  a baixa REGISTRA o movimento (`origem_tipo=titulo_baixa`); caixa não se edita direto.
+- **Conciliação** = casar `fin_extrato_lancamentos`/`fin_bank_statement_lines`
+  (`pendente → sugerido → conciliado`, ou `ignorado`) com títulos/baixas.
+- **Estorno** é de PAGAMENTO/baixa (financeiro); **devolução** é de mercadoria (vendas.md).
+- **Sinônimos proibidos**: "conta a receber/pagar" como TABELA (canônico: título; "contas a
+  receber" só como NOME DE TELA/visão); "duplicata" (não existe no schema); "quitação
+  parcial" (canônico: baixa parcial).
+
+## Enums canônicos (machine-checked por `dominio:check`)
+
+```json
+{
+  "module": "Financeiro",
+  "migrations_paths": ["Modules/Financeiro/Database/Migrations", "database/migrations"],
+  "tables_scope": ["fin_bank_statement_lines", "fin_boleto_remessas", "fin_caixa_movimentos", "fin_categorias", "fin_extrato_lancamentos", "fin_planos_conta", "fin_titulo_baixas", "fin_titulos", "accounts", "account_transactions"],
+  "code_paths": ["Modules/Financeiro/Http", "Modules/Financeiro/Services", "Modules/Financeiro/Models", "Modules/Financeiro/Observers", "Modules/Financeiro/Jobs"],
+  "vocab": {
+    "fin_cobrancas.tipo": ["boleto", "pix_cob", "pix_cobv", "pix_recv", "card"]
+  },
+  "enums": {
+    "fin_titulos.tipo": ["receber", "pagar"],
+    "fin_titulos.status": ["aberto", "parcial", "quitado", "cancelado"],
+    "fin_titulos.origem": ["manual", "venda", "compra", "despesa", "recurring", "folha", "caixa"],
+    "fin_titulos.forma_pagamento": ["dinheiro", "pix", "boleto", "cartao_credito", "cartao_debito", "transferencia", "cheque", "compensacao", "outro"],
+    "fin_titulos.aprovacao_status": ["pendente", "aprovado", "rejeitado"],
+    "fin_titulo_baixas.meio_pagamento": ["dinheiro", "pix", "boleto", "cartao_credito", "cartao_debito", "transferencia", "cheque", "compensacao", "outro"],
+    "fin_caixa_movimentos.tipo": ["entrada", "saida", "ajuste", "transferencia"],
+    "fin_categorias.tipo": ["receita", "despesa", "ambos"],
+    "fin_planos_conta.tipo": ["ativo", "passivo", "patrimonio", "receita", "despesa", "custo"],
+    "fin_planos_conta.natureza": ["debito", "credito"],
+    "fin_extrato_lancamentos.origem": ["api", "ofx", "manual"],
+    "fin_extrato_lancamentos.status": ["pendente", "sugerido", "conciliado", "ignorado"],
+    "fin_bank_statement_lines.tipo": ["credit", "debit", "fee", "transfer", "unknown"],
+    "fin_bank_statement_lines.status": ["pendente", "sugerido", "conciliado", "ignorado"],
+    "fin_boleto_remessas.status": ["gerado_mock", "gerado", "enviado", "registrado", "pago", "vencido", "cancelado"],
+    "accounts.account_type": ["saving_current", "capital"],
+    "account_transactions.type": ["debit", "credit"],
+    "account_transactions.sub_type": ["opening_balance", "fund_transfer", "deposit"]
+  }
+}
+```
+
+### Nota de fronteira
+
+`transactions.payment_status` (paid/due/partial) é da espinha de VENDAS ([vendas.md](vendas.md));
+o Financeiro deriva o estado do TÍTULO a partir dele via Observer — drift entre os dois é bug
+(classe auditada pelo `financeiro-bridge-auditor`).

--- a/memory/dominio/fiscal-faturamento.md
+++ b/memory/dominio/fiscal-faturamento.md
@@ -1,0 +1,82 @@
+---
+dominio: Fiscal & Faturamento — NF-e/NFC-e/NFS-e, documentos da transação, impostos
+fonte_unica: este arquivo é a fonte canônica do vocabulário FISCAL (ADR 0264 G-4, Onda Q3)
+gate: dominio:check (scripts/domain-dict-guard.mjs) — enum ⇔ bloco `json` abaixo
+owner: wagner
+related_adrs: [0264-governanca-executavel-trio-dominio-e2e]
+---
+
+# Dicionário de domínio — Fiscal & Faturamento
+
+> **Fonte única do vocabulário fiscal** (Onda Q3 — [W] vai construir faturamento AGORA; o
+> dicionário existe ANTES das telas). Grounded nas migrations de `Modules/NfeBrasil` +
+> `Modules/NFSe` + core.
+
+## Princípio canônico — faturamento ≠ "nota"
+
+**Faturar = emitir o documento fiscal + gerar o título.** "Nota" sozinha é linguagem de
+balcão, não conceito do sistema: o que existe é **emissão** (`nfe_emissoes`/`nfse_emissoes`),
+**documento da transação** (`transaction_documents`) e **título** (financeiro.md). Tela ou
+agente que tratar "faturar" como só-imprimir-nota viola este dicionário.
+
+## Conceitos-chave (PT-BR canônico)
+
+- **Modelos**: `55` = NF-e · `65` = NFC-e · `67` = NFCom (em `nfe_emissoes.modelo`);
+  NFS-e (serviço, prefeitura) vive em `nfse_emissoes`. MDF-e/CT-e só como `doc_type`
+  de `transaction_documents` (wire futuro).
+- **Ciclo da emissão NF-e**: `pendente → enviando → autorizada` (felicidade) ·
+  `rejeitada/denegada/erro_envio` (falha) · `cancelada/inutilizada` (pós-autorização).
+  "Cancelar" exige evento fiscal — nunca DELETE.
+- **Manifestação do destinatário** (DF-e recebidos): `pendente → ciencia → confirmada`
+  (ou `desconhecida/nao_realizada`).
+- **Regime tributário** = `nfe_business_configs.regime ∈ {mei, simples, lucro_presumido,
+  lucro_real}` — DAS ≈6% deriva do regime caixa (tela Impostos, Financeiro).
+- **Split fiscal Vendas×Oficina** (oficina-auto.md): item `peca` → NF-e; `mao_obra`/
+  `servico_terceiro` → NFS-e.
+- **Sinônimos proibidos**: "nota de serviço" pra NFS-e em código/label (canônico: NFS-e);
+  "cupom" pra NFC-e (canônico: NFC-e); "faturar" significando só imprimir.
+
+## ⚠️ Conflito de vocabulário CATALOGADO — `nfse_emissoes.status`
+
+A tabela foi criada pelo `Modules/NFSe` (2026_05_01, vocab `rascunho/processando/emitida/
+cancelada/erro`) e **RE-criada** pelo `Modules/NfeBrasil` (2026_05_11, vocab `pending/sent/
+authorized/rejected/cancelled`) — dois módulos, dois vocabulários, a MESMA tabela (ambos têm
+model `NfseEmissao`). O estado cronológico atual (last-write-wins) é o do **NfeBrasil** —
+declarado abaixo. Consolidar os módulos (deprecar um) é decisão [W] pendente; até lá este
+dicionário trava o vocabulário VIVO e o guard acusa quem reintroduzir o antigo.
+
+## Enums canônicos (machine-checked por `dominio:check`)
+
+```json
+{
+  "module": "FiscalFaturamento",
+  "migrations_paths": ["Modules/NfeBrasil/Database/Migrations", "Modules/NFSe/Database/Migrations", "database/migrations"],
+  "tables_scope": ["nfe_business_configs", "nfe_dfe_eventos", "nfe_dfe_recebidos", "nfe_emissoes", "nfe_eventos", "nfe_inutilizacoes", "nfse_emissoes", "nfse_eventos_cancelamento", "nfse_provider_configs", "transaction_documents", "tax_rates", "invoice_schemes", "invoice_layouts"],
+  "code_paths": ["Modules/NfeBrasil/Http", "Modules/NfeBrasil/Services", "Modules/NFSe/Http", "Modules/NFSe/Services"],
+  "enums": {
+    "nfe_emissoes.modelo": ["55", "65", "67"],
+    "nfe_emissoes.status": ["pendente", "enviando", "autorizada", "rejeitada", "cancelada", "denegada", "inutilizada", "erro_envio"],
+    "nfe_eventos.status": ["pendente", "enviado", "autorizado", "rejeitado"],
+    "nfe_inutilizacoes.modelo": ["55", "65"],
+    "nfe_inutilizacoes.status": ["pendente", "enviado", "autorizado", "rejeitado"],
+    "nfe_dfe_eventos.status": ["pendente", "enviado", "autorizado", "rejeitado"],
+    "nfe_dfe_recebidos.status_manifestacao": ["pendente", "ciencia", "confirmada", "desconhecida", "nao_realizada"],
+    "nfe_business_configs.regime": ["mei", "simples", "lucro_presumido", "lucro_real"],
+    "nfse_emissoes.status": ["pending", "sent", "authorized", "rejected", "cancelled"],
+    "nfse_eventos_cancelamento.status": ["pendente", "enviado", "autorizado", "rejeitado"],
+    "nfse_provider_configs.ambiente": ["homologacao", "producao"],
+    "transaction_documents.doc_type": ["nfe55", "nfce65", "nfse56", "nfcom62", "mdfe58", "cte57", "boleto_asaas", "boleto_inter"],
+    "transaction_documents.status": ["pending", "authorized", "rejected", "cancelled"],
+    "tax_rates.calculation_type": ["fixed", "percentage"],
+    "tax_rates.rounding_type": ["up", "down", "normal"],
+    "invoice_schemes.scheme_type": ["blank", "year"],
+    "invoice_layouts.design": ["classic", "elegant"]
+  }
+}
+```
+
+### Nota de governança
+
+`NfeBrasil` e `NFSe` continuam listados no débito `module-no-dict` do baseline (o guard
+chaveia por nome de pasta `Modules/`); este dicionário LÓGICO cobre os dois — o débito zera
+quando a consolidação dos módulos for decidida.

--- a/memory/dominio/vendas.md
+++ b/memory/dominio/vendas.md
@@ -1,0 +1,89 @@
+---
+dominio: Vendas (core UltimatePOS) — balcão, a prazo, devolução; espinha de transações
+fonte_unica: este arquivo é a fonte canônica do vocabulário de VENDAS (ADR 0264 G-4, Onda Q3)
+gate: dominio:check (scripts/domain-dict-guard.mjs) — enum core ⇔ bloco `json` abaixo
+owner: wagner
+related_adrs: [0264-governanca-executavel-trio-dominio-e2e, 0265-oficina-reparo-erradica-locacao]
+---
+
+# Dicionário de domínio — Vendas (core)
+
+> **Fonte única do vocabulário de vendas** (Onda Q3 do mandato ONDAS-QUALIDADE — a defesa
+> anti-alucinação tem que existir ANTES das telas de estoque/faturamento que [W] vai construir).
+> Grounded no schema REAL (`database/migrations`, last-write-wins). Editar aqui é decisão de
+> domínio — não se acrescenta valor de enum sem registrar a semântica.
+
+## Conceitos-chave (PT-BR canônico)
+
+- **Venda balcão** = `transactions` com `type=sell`, `status=final`. Sem pagamento integral →
+  `payment_status=due|partial` (**venda a prazo / fiado** — permitido por decisão [W] 2026-05-27;
+  o backend deriva o status do pagamento, NUNCA a UI inventa estado).
+- **A espinha é compartilhada**: a tabela `transactions` carrega TODOS os movimentos do ERP
+  (`sell`, `purchase`, `expense`, ajustes e transferências de estoque, devoluções, saldos de
+  abertura). Este dicionário é o DONO da declaração; compras.md e estoque.md REFERENCIAM
+  estes valores, não os redeclaram.
+- **Origem da venda** = `transactions.source ∈ {balcao, oficina, online}` — oficina deriva venda
+  (Vendas×Oficina), nunca o contrário.
+- **Devolução** = `sell_return` (venda) / `purchase_return` (compra) — termo canônico "devolução",
+  nunca "estorno" (estorno é de PAGAMENTO, domínio financeiro).
+- **Cliente** = `contacts` (cadastro compartilhado cliente/fornecedor/funcionário via
+  `primary_role`). Walk-In Customer é o cliente-default do balcão (`is_default`).
+- **Sinônimos proibidos**: "pedido de venda" pra `status=final` (pedido é `ordered`); "orçamento"
+  pra venda final (orçamento/quotation é `draft`); "nota" pra venda (nota é documento FISCAL —
+  ver fiscal-faturamento.md).
+
+## Enums canônicos (machine-checked por `dominio:check`)
+
+```json
+{
+  "module": "VendasCore",
+  "migrations_paths": ["database/migrations"],
+  "tables_scope": ["transactions", "transaction_sell_lines", "transaction_payments", "cash_registers", "cash_register_transactions", "types_of_services", "sale_processes", "contacts"],
+  "code_paths": ["app/Http/Controllers/SellController.php", "app/Http/Controllers/SellPosController.php"],
+  "vocab": {
+    "transactions.type": ["purchase", "sell", "expense", "stock_adjustment", "sell_transfer", "purchase_transfer", "opening_stock", "sell_return", "opening_balance", "purchase_return", "production_purchase", "production_sell", "purchase_order"],
+    "transactions.status": ["received", "pending", "ordered", "draft", "final"],
+    "transactions.source": ["balcao", "oficina", "online"]
+  },
+  "enums": {
+    "transactions.payment_status": ["paid", "due", "partial"],
+    "transactions.discount_type": ["fixed", "percentage"],
+    "transactions.pay_term_type": ["days", "months"],
+    "transactions.recur_interval_type": ["days", "months", "years"],
+    "transactions.adjustment_type": ["normal", "abnormal"],
+    "transactions.packing_charge_type": ["fixed", "percent"],
+    "transactions.res_order_status": ["received", "cooked", "served"],
+    "transaction_sell_lines.line_discount_type": ["fixed", "percentage"],
+    "transaction_payments.method": ["cash", "card", "cheque", "bank_transfer", "custom_pay_1", "custom_pay_2", "custom_pay_3", "other"],
+    "transaction_payments.card_type": ["visa", "master"],
+    "cash_registers.status": ["close", "open"],
+    "cash_register_transactions.pay_method": ["cash", "card", "cheque", "bank_transfer", "custom_pay_1", "custom_pay_2", "custom_pay_3", "other"],
+    "cash_register_transactions.transaction_type": ["initial", "sell", "transfer", "refund"],
+    "cash_register_transactions.type": ["debit", "credit"],
+    "types_of_services.packing_charge_type": ["fixed", "percent"],
+    "sale_processes.default_for_contact_type": ["cf", "pf", "pj", "any"],
+    "contacts.tipo": ["PF", "PJ"],
+    "contacts.pay_term_type": ["days", "months"],
+    "contacts.pgto_padrao": ["pix", "boleto", "cartao", "dinheiro", "transferencia"],
+    "contacts.canal_preferido": ["whatsapp", "email", "telefone", "presencial"],
+    "contacts.segmento": ["varejo", "atacado", "agencia", "corporativo", "evento", "governo"],
+    "contacts.tabela_preco_padrao": ["padrao", "varejo", "atacado", "parceiro"],
+    "contacts.primary_role": ["customer", "supplier", "employee", "representative"],
+    "contacts.legacy_source": ["outro"]
+  }
+}
+```
+
+### Vestigial (declarado pra ficar VISÍVEL, não escondido)
+
+- `transactions.res_order_status` (`received/cooked/served`) — herança do UltimatePOS
+  restaurante (cozinha). Nenhuma gráfica/oficina usa; candidato a erradicação futura
+  (mesma classe do `locacao` da Oficina, ADR 0265). Declarado porque o schema o carrega.
+- `transaction_payments.card_type` (`visa/master`) — incompleto pro Brasil (sem elo/hiper);
+  o fluxo real registra `method=card` e ignora a bandeira. Não inventar bandeira nova sem
+  migration + decisão [W].
+
+## Cobertura de código (Salto #3)
+
+`code_paths` ESTREITOS de propósito (SellController + SellPosController): colunas genéricas
+(`status`/`type`) super-casam em `app/` largo. Ampliar caminho-a-caminho conforme telas novas.

--- a/scripts/domain-dict-baseline.json
+++ b/scripts/domain-dict-baseline.json
@@ -1,14 +1,14 @@
 {
   "_meta": {
-    "generated_at": "2026-06-10T17:00:56.474Z",
+    "generated_at": "2026-06-11T18:49:57.492Z",
     "gate": "dominio:check (ADR 0264 G-4 — dicionário de domínio ⇔ enum de migration + código, Salto #3)",
     "stats": {
-      "modules_with_dict": 1,
+      "modules_with_dict": 6,
       "modules_with_enums": 21,
       "divergences": 0,
-      "code_divergences": 0,
+      "code_divergences": 26,
       "forbidden_ui_terms": 76,
-      "modules_no_dict": 20
+      "modules_no_dict": 19
     },
     "nota": "Divergências ATUAIS fotografadas (débito): enum⇔dicionário E valores de domínio hardcoded no código (Salto #3). Gate falha só em divergência NOVA (ratchet). order_type=locacao zera quando a erradicação (ADR 0265) remover o valor do enum E das ramificações de código.",
     "refs": [
@@ -100,7 +100,6 @@
     "dominio:module-no-dict:ComunicacaoVisual",
     "dominio:module-no-dict:Crm",
     "dominio:module-no-dict:Essentials",
-    "dominio:module-no-dict:Financeiro",
     "dominio:module-no-dict:Governance",
     "dominio:module-no-dict:Jana",
     "dominio:module-no-dict:NfeBrasil",
@@ -114,6 +113,32 @@
     "dominio:module-no-dict:TeamMcp",
     "dominio:module-no-dict:Vestuario",
     "dominio:module-no-dict:Whatsapp",
-    "dominio:module-no-dict:Woocommerce"
+    "dominio:module-no-dict:Woocommerce",
+    "dominio:undeclared-code-value:Financeiro:origem:assinatura",
+    "dominio:undeclared-code-value:Financeiro:origem:boleto",
+    "dominio:undeclared-code-value:Financeiro:origem:repair",
+    "dominio:undeclared-code-value:Financeiro:origem:sells",
+    "dominio:undeclared-code-value:Financeiro:status:close",
+    "dominio:undeclared-code-value:Financeiro:status:ok",
+    "dominio:undeclared-code-value:Financeiro:type:expense",
+    "dominio:undeclared-code-value:Financeiro:type:sell",
+    "dominio:undeclared-code-value:FiscalFaturamento:ambiente:1",
+    "dominio:undeclared-code-value:FiscalFaturamento:ambiente:2",
+    "dominio:undeclared-code-value:FiscalFaturamento:status:emitida",
+    "dominio:undeclared-code-value:FiscalFaturamento:status:processando",
+    "dominio:undeclared-code-value:VendasCore:status:completed",
+    "dominio:undeclared-code-value:VendasCore:status:emitida",
+    "dominio:undeclared-code-value:VendasCore:status:erro",
+    "dominio:undeclared-code-value:VendasCore:status:paga",
+    "dominio:undeclared-code-value:VendasCore:status:partial",
+    "dominio:undeclared-code-value:VendasCore:tipo:boleto",
+    "dominio:undeclared-code-value:VendasCore:tipo:card",
+    "dominio:undeclared-code-value:VendasCore:tipo:pix_cob",
+    "dominio:undeclared-code-value:VendasCore:tipo:pix_cobv",
+    "dominio:undeclared-code-value:VendasCore:type:both",
+    "dominio:undeclared-code-value:VendasCore:type:combo",
+    "dominio:undeclared-code-value:VendasCore:type:customer",
+    "dominio:undeclared-code-value:VendasCore:type:modifier",
+    "dominio:undeclared-code-value:VendasCore:type:sales_order"
   ]
 }

--- a/scripts/domain-dict-guard.mjs
+++ b/scripts/domain-dict-guard.mjs
@@ -11,6 +11,9 @@
 //
 //   Fonte única por módulo: memory/dominio/<modulo>.md, bloco ```json com { module, enums }.
 //   enums = { "tabela.coluna": [valores canônicos], ... }.
+//   Onda Q3 (domínios core): + migrations_paths (dirs custom) · tables_scope (tabelas
+//   reivindicadas) · code_paths (Salto #3 estreito) · vocab (vocabulário de coluna
+//   VARCHAR sem constraint física — só col-index do Salto #3, sem comparação enum⇔schema).
 //
 // O guard deriva o ESTADO ATUAL de cada enum percorrendo as migrations do módulo
 // (last-write-wins por tabela.coluna, só a região up()) e compara com o dicionário.
@@ -118,6 +121,12 @@ function loadDicts() {
       migrations_paths: Array.isArray(parsed.migrations_paths) ? parsed.migrations_paths : null,
       code_paths: Array.isArray(parsed.code_paths) ? parsed.code_paths : null,
       tables_scope: Array.isArray(parsed.tables_scope) ? parsed.tables_scope : null,
+      // `vocab` (Onda Q3): vocabulário de coluna SEM constraint física (varchar) — o BD
+      // não constrange, o dicionário é a ÚNICA lei. Entra no col-index do Salto #3
+      // (código fora do vocab = violação) mas NÃO na comparação enum⇔schema (não há
+      // enum pra comparar). Caso real: transactions.type virou varchar(191) na física
+      // (módulos adicionam tipos como production_purchase sem ALTER).
+      vocab: parsed.vocab && typeof parsed.vocab === 'object' ? parsed.vocab : {},
       file: `memory/dominio/${e.name}`,
     };
   }
@@ -397,7 +406,10 @@ function computeViolations() {
   // Módulos COM dicionário → comparação valor-a-valor.
   for (const [mod, dict] of Object.entries(dicts)) {
     const actual = currentEnums(mod, dict);
-    const declaredCols = new Set(Object.keys(dict.enums));
+    // vocab conta como DECLARADA pro undeclared-column (migrations legadas podem registrar
+    // enum antigo de coluna que hoje é varchar — ex transactions.type) mas fica FORA da
+    // comparação valor-a-valor (não há constraint física pra comparar).
+    const declaredCols = new Set([...Object.keys(dict.enums), ...Object.keys(dict.vocab)]);
     const actualCols = new Set(Object.keys(actual));
 
     // Coluna enum no schema do módulo, fora do dicionário.
@@ -415,7 +427,8 @@ function computeViolations() {
     }
 
     // SALTO #3 — valores de domínio hardcoded no código de aplicação.
-    const { keys, occ } = codeValueViolations(mod, buildColIndex(dict.enums), dict);
+    // col-index = enums (constraint física) ∪ vocab (vocabulário de varchar — Onda Q3).
+    const { keys, occ } = codeValueViolations(mod, buildColIndex({ ...dict.enums, ...dict.vocab }), dict);
     for (const key of keys) { violations.push(key); occurrences[key] = occ[key]; stats.code_divergences++; }
 
     // SALTO #4 — termos PROIBIDOS user-facing (trava de regressão ADR 0265).

--- a/tests/dominioGuard.spec.ts
+++ b/tests/dominioGuard.spec.ts
@@ -332,6 +332,7 @@ describe('dominio:check — termos proibidos user-facing (Salto #4, físico)', (
 // Vendas/estoque vivem em database/migrations (não Modules/<X>). O dict declara os paths
 // e REIVINDICA tabelas; undeclared-column não cobra tabela alheia do diretório compartilhado.
 describe('dominio:check — domínios core (Onda Q3, físico)', () => {
+  const coreMig2 = (file: string, php: string) => write(`database/migrations/${file}`, php);
   const coreMigration = (file: string, php: string) => write(`database/migrations/${file}`, php);
 
   it('SENSIBILIDADE: enum core divergente do dicionário (via migrations_paths) → undeclared-value', () => {
@@ -436,4 +437,33 @@ describe('dominio:check — domínios core (Onda Q3, físico)', () => {
     // 'novo' (timestamp 05_11) vence 'velho' (05_01) → dict bate com o estado atual.
     expect(run('--json')).toMatch(/"ok": true/);
   });
+
+  it("VOCAB (varchar sem constraint): coluna no vocab nao e cobrada como undeclared-column nem comparada valor-a-valor", () => {
+    // migrations legadas registram enum antigo; fisica virou varchar (caso transactions.type)
+    coreMig2('2026_01_01_000000_create_t.php', `<?php return new class { public function up(): void {
+      Schema::create('t', function ($t) { $t->enum('tipo', ['a', 'b']); });
+    } };`);
+    dict('CoreV', { }, {
+      migrations_paths: ['database/migrations'],
+      tables_scope: ['t'],
+      vocab: { 't.tipo': ['a', 'b', 'c_do_modulo'] },
+    });
+    expect(run('--json')).toMatch(/"ok": true/); // sem undeclared-column nem stale-dict-value
+  });
+
+  it('VOCAB alimenta o Salto #3: valor fora do vocabulario no codigo = violacao; dentro passa', () => {
+    coreMig2('2026_01_01_000000_create_t.php', `<?php return new class { public function up(): void {
+      Schema::create('t', function ($t) { $t->string('tipo'); });
+    } };`);
+    write('app/X.php', `<?php class X { function f($q) { return $q->where('tipo', 'fantasma'); } }`);
+    dict('CoreV', { }, {
+      migrations_paths: ['database/migrations'],
+      tables_scope: ['t'],
+      code_paths: ['app/X.php'],
+      vocab: { 't.tipo': ['a', 'b'] },
+    });
+    const out = runJsonExpectFail();
+    expect(out).toMatch(/dominio:undeclared-code-value:CoreV:tipo:fantasma/);
+  });
 });
+


### PR DESCRIPTION
## Onda Q3 — a defesa anti-alucinação existe ANTES das telas de estoque/faturamento

5 dicionários novos em `memory/dominio/` (padrão oficina-auto.md), **grounded no schema real** (extração last-write-wins de 378 migrations core + módulos + squash): `vendas.md` · `estoque.md` · `financeiro.md` · `fiscal-faturamento.md` · `compras.md`. O `dominio-gate` (required) cobra os 5 desde já — **0 divergência de enum nos 6 dicts**.

### Guard: conceito novo `vocab` (commit 1)
Achado do Passo 0: `transactions.type/status/source` são **varchar(191)** no schema real — o BD não constrange nada (módulos adicionam `production_purchase`/`purchase_order` sem ALTER). `vocab` = vocabulário de coluna sem constraint física: entra no col-index do Salto #3, fora da comparação enum⇔schema. Meta-testes **29/29**.

### Descobertas catalogadas (26 débitos de código fotografados, ratchet trava novos)
1. **Drift classe-locação REAL**: `StoreTransactionRequest` valida `origem in:manual,sells,repair,assinatura,boleto` — mas o enum `fin_titulos.origem` é `{manual,venda,compra,despesa,recurring,folha,caixa}`; MySQL non-strict coage valor inválido pra `''`. Decisão [W] pendente.
2. **Conflito de vocabulário `nfse_emissoes.status`**: NFSe criou a tabela (05/01, `rascunho/processando/emitida`), NfeBrasil RE-criou (05/11, `pending/sent/authorized`) — dois models `NfseEmissao`, código do NFSe ainda ramifica no vocab antigo. Catalogado; consolidação = decisão [W].
3. Colisões de coluna-curta documentadas (tpAmb numérico × `ambiente`; `ProductUtil` mistura `products.type` × `transactions.type` → estoque `code_paths: []` até matching por tabela).

### Prova 2 lados (mandato Q3)
- gate verde nos 5 ✅ (`0 enum · débito estável`)
- violação sintética pega + termo legítimo passa: meta-testes físicos no dominio-meta-gate

Refs: ONDAS-QUALIDADE Q3 · ADR 0264 G-4 · ADR 0265 · ADR 0258

🤖 Generated with [Claude Code](https://claude.com/claude-code)