### PR TITLE
style(financeiro): tempero aplicado — sombras de elevação + transições → tokens (FA-3)

### DIFF
--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-11T18:35:07.102Z",
-    "total_lines": 20250,
+    "generated_at": "2026-06-11T18:54:27.368Z",
+    "total_lines": 20255,
     "file_count": 29,
     "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
     "refs": [
@@ -11,7 +11,7 @@
   },
   "files": {
     "resources/css/cockpit.css": 2290,
-    "resources/css/cowork-canon-financeiro-bundle.css": 4747,
+    "resources/css/cowork-canon-financeiro-bundle.css": 4752,
     "resources/css/cowork-compras-bundle.css": 182,
     "resources/css/cowork-fields.css": 392,
     "resources/css/cowork-payment-gateway-bundle.css": 257,

--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -86,7 +86,7 @@
   height: 100vh;
   width: 100vw;
   overflow: hidden;
-  transition: grid-template-columns .18s ease-out;
+  transition: grid-template-columns var(--t-1) var(--ease);
 }
 .fin-cowork .app.app--sb-rail { --sb-w: 56px; }
 .fin-cowork .app.app--sb-hidden { --sb-w: 0px; }
@@ -179,7 +179,7 @@
   background: oklch(0.20 0 0);
   border: 1px solid var(--sb-border);
   border-radius: var(--radius);
-  box-shadow: var(--shadow-pop);
+  box-shadow: var(--sh-2);
   padding: 6px;
   z-index: 50;
   font-size: var(--fs-3);
@@ -418,7 +418,7 @@
   background: oklch(0.22 0 0);
   border: 1px solid var(--sb-border);
   border-radius: var(--radius);
-  box-shadow: var(--shadow-pop);
+  box-shadow: var(--sh-2);
   padding: 6px;
   z-index: 60;
   font-size: var(--fs-3);
@@ -1274,7 +1274,7 @@
   min-height: 0;
   min-width: 0;
   overflow: hidden;
-  transition: width .15s;
+  transition: width var(--t-1) var(--ease);
 }
 
 .fin-cowork .linked-h .icon-btn {
@@ -1315,7 +1315,7 @@
 .fin-cowork .lblock-h .spacer { flex: 1 1 auto; }
 .fin-cowork .lblock-chev {
   color: var(--text-mute);
-  transition: transform .15s;
+  transition: transform var(--t-1) var(--ease);
   transform: rotate(0deg);
 }
 .fin-cowork .lblock-chev.open { transform: rotate(90deg); }
@@ -1587,7 +1587,7 @@
   vertical-align: middle;
   color: var(--text);
 }
-.fin-cowork .os-row { cursor: default; transition: background .08s; }
+.fin-cowork .os-row { cursor: default; transition: background var(--t-1) var(--ease); }
 .fin-cowork .os-row:hover { background: var(--bg-2); }
 .fin-cowork .os-row.selected { background: var(--accent-soft); }
 .fin-cowork .os-row.selected td { background: var(--accent-soft); }
@@ -2062,7 +2062,7 @@
   display:inline-flex; align-items:center; gap:6px;
   padding:8px 12px; border:none; background:transparent; cursor:pointer;
   font-size:var(--fs-2); color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:500;
-  border-bottom:2px solid transparent; transition:all .12s;
+  border-bottom:2px solid transparent; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .os-tab:hover { color:var(--text); }
 .fin-cowork .os-tab.active { color:var(--accent); border-bottom-color:var(--accent); }
@@ -2088,7 +2088,7 @@
 }
 .fin-cowork .os-table td { padding:10px 12px; border-bottom:1px solid oklch(0.96 0.01 250); font-size:var(--fs-3); vertical-align:top; }
 .fin-cowork .os-table tbody tr:last-child td { border-bottom:none; }
-.fin-cowork .os-row { cursor:pointer; transition:background .1s; }
+.fin-cowork .os-row { cursor:pointer; transition: background var(--t-1) var(--ease); }
 .fin-cowork .os-row:hover { background:oklch(0.98 0.01 var(--accent-h, 220)); }
 .fin-cowork .os-row.urgent { box-shadow:inset 3px 0 0 oklch(0.60 0.16 25); }
 
@@ -2239,7 +2239,7 @@
   cursor: pointer;
   z-index: 30;
   opacity: 0;
-  transition: opacity .12s, color .12s, background .12s, transform .12s;
+  transition: opacity var(--t-1) var(--ease), color var(--t-1) var(--ease), background var(--t-1) var(--ease), transform var(--t-1) var(--ease);
   padding: 0;
 }
 .fin-cowork .sb:hover .sb-collapse-handle, .fin-cowork .sb-collapse-handle:focus-visible, .fin-cowork .sb-collapse-handle:hover {
@@ -2289,7 +2289,7 @@
   cursor: pointer;
   position: relative;
   padding: 0;
-  transition: background .1s, color .1s;
+  transition: background var(--t-1) var(--ease), color var(--t-1) var(--ease);
 }
 .fin-cowork .sb-rail-btn:hover {
   background: var(--sb-hover);
@@ -2367,9 +2367,9 @@
   border-radius: 6px;
   pointer-events: none;
   opacity: 0;
-  transition: opacity .12s .12s, transform .12s .12s;
+  transition: opacity var(--t-1) var(--ease) .12s, transform var(--t-1) var(--ease) .12s;
   z-index: 60;
-  box-shadow: 0 4px 14px oklch(0 0 0 / 0.22);
+  box-shadow: var(--sh-2);
 }
 .fin-cowork .sb--rail [data-tip]:hover::after {
   opacity: 1;
@@ -2386,7 +2386,7 @@
   font-weight: 600;
   letter-spacing: 0.01em;
   text-transform: uppercase;
-  box-shadow: 0 6px 18px oklch(0 0 0 / 0.18);
+  box-shadow: var(--sh-2);
 }
 /* Esconde tooltip enquanto o flyout do grupo está aberto */
 .fin-cowork .sb--rail .sb-rail-btn.open[data-tip]::after {
@@ -2398,7 +2398,7 @@
   background: var(--sb-bg);
   border: 1px solid var(--sb-border);
   border-radius: 10px;
-  box-shadow: 0 12px 32px oklch(0 0 0 / 0.28);
+  box-shadow: var(--sh-2);
   padding: 6px;
   min-width: 220px;
   max-width: 260px;
@@ -2474,7 +2474,7 @@
   border-radius: 6px; padding: 6px 10px;
   color: var(--text-mute); cursor: pointer;
   font: inherit; font-size: var(--fs-3);
-  transition: border-color .12s;
+  transition: border-color var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-cmdk:hover { border-color: var(--text-mute); }
 .fin-cowork .vendas-aplus .vd-cmdk span { flex: 1; text-align: left; }
@@ -2493,7 +2493,7 @@
   padding: 4px 12px; font-size: var(--fs-2); font-weight: 600;
   color: var(--text-mute); border-radius: 4px;
   letter-spacing: 0.02em; cursor: pointer; font-family: inherit;
-  transition: all .15s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-vista button.on {
   background: var(--surface); color: var(--vd-green);
@@ -2514,7 +2514,7 @@
   position: absolute; top: calc(100% + 4px); right: 0;
   min-width: 240px; background: var(--surface);
   border: 1px solid var(--border); border-radius: 8px;
-  box-shadow: 0 8px 24px -8px rgba(0,0,0,.18), 0 0 0 1px rgba(0,0,0,.02);
+  box-shadow: var(--sh-2);
   padding: 4px; z-index: 30;
 }
 .fin-cowork .vendas-aplus .vd-views-item {
@@ -2647,7 +2647,7 @@
 }
 .fin-cowork .vendas-aplus .vd-stp-dot {
   width: 7px; height: 7px; border-radius: 50%;
-  background: var(--border); transition: all .15s;
+  background: var(--border); transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-stp-dot.done { background: var(--vd-green); }
 .fin-cowork .vendas-aplus .vd-stp-dot.current {
@@ -2682,7 +2682,7 @@
   padding: 5px 9px; border-radius: 5px;
   font-size: var(--fs-1); font-family: var(--font-mono); font-weight: 500;
   white-space: nowrap; pointer-events: none;
-  opacity: 0; transition: all .12s;
+  opacity: 0; transition: all var(--t-1) var(--ease);
   z-index: 20;
   box-shadow: 0 4px 12px rgba(0,0,0,.20);
 }
@@ -2697,11 +2697,11 @@
   transform: translateX(-50%) translateY(120px);
   background: var(--text); color: oklch(0.97 0.005 90);
   border-radius: 10px;
-  box-shadow: 0 12px 32px -8px rgba(0,0,0,.30);
+  box-shadow: var(--sh-2);
   padding: 10px 14px;
   display: flex; align-items: center; gap: 6px;
   z-index: 30; opacity: 0;
-  transition: all .22s ease-out;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-bulk.on {
   opacity: 1; transform: translateX(-50%) translateY(0);
@@ -2735,15 +2735,15 @@
   display: grid; place-items: start center;
   padding-top: 12vh;
   opacity: 0; pointer-events: none;
-  transition: opacity .14s;
+  transition: opacity var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-pal-bd.on { opacity: 1; pointer-events: auto; }
 .fin-cowork .vendas-aplus .vd-pal {
   width: 560px; max-width: 92vw;
   background: var(--surface); border-radius: 12px;
-  box-shadow: 0 24px 64px -12px rgba(0,0,0,.40);
+  box-shadow: var(--sh-2);
   overflow: hidden;
-  transform: scale(0.96); transition: transform .14s;
+  transform: scale(0.96); transition: transform var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-pal-bd.on .vd-pal { transform: scale(1); }
 .fin-cowork .vendas-aplus .vd-pal-in {
@@ -3013,7 +3013,7 @@
 .fin-cowork .vendas-aplus .vd-tree-arr {
   width: 12px; flex-shrink: 0; text-align: center;
   font-size: var(--fs-1); color: var(--text-mute);
-  transition: transform 0.12s;
+  transition: transform var(--t-1) var(--ease);
   cursor: pointer;
 }
 .fin-cowork .vendas-aplus .vd-tree-arr.open { transform: rotate(90deg); }
@@ -3036,7 +3036,7 @@
 .fin-cowork .vd-cheat {
   background: var(--surface);
   border-radius: 12px;
-  box-shadow: 0 24px 60px rgba(0,0,0,0.18);
+  box-shadow: var(--sh-2);
   width: 100%; max-width: 760px;
   max-height: 86vh; overflow: auto;
   display: flex; flex-direction: column;
@@ -3226,7 +3226,7 @@
   border: none; padding: 6px 12px;
   border-radius: 5px; font-size: var(--fs-2); font-weight: 600;
   cursor: pointer; flex-shrink: 0;
-  transition: background .1s;
+  transition: background var(--t-1) var(--ease);
 }
 .fin-cowork .vd-ai-cta:hover { background: oklch(0.46 0.20 295); }
 .fin-cowork .vd-ai-retry {
@@ -3333,7 +3333,7 @@
   border-radius: 8px;
   cursor: pointer;
   font-family: inherit;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-pal-ai-cta:hover {
   border-style: solid;
@@ -3420,7 +3420,7 @@
   display: flex; flex-direction: column;
   background: white; border: 1px solid var(--border);
   border-radius: 8px; overflow: hidden;
-  transition: border-color .12s;
+  transition: border-color var(--t-1) var(--ease);
 }
 .fin-cowork .vd-drawer-aplus .vd-item-cur.has-comments {
   border-color: oklch(0.82 0.10 240);
@@ -3460,7 +3460,7 @@
   position: relative;
   display: grid; place-items: center;
   color: var(--text-mute);
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vd-drawer-aplus .vd-item-c-comm:hover {
   border-color: oklch(0.55 0.13 240);
@@ -3612,7 +3612,7 @@
   font-family: var(--font-mono); font-size: var(--fs-1); font-weight: 600;
   padding: 1px 6px; border-radius: 4px;
   text-decoration: none; line-height: 1.5;
-  transition: opacity .12s;
+  transition: opacity var(--t-1) var(--ease);
 }
 .fin-cowork .vd-link:hover { opacity: 0.75; }
 .fin-cowork .vd-link-venda { background: var(--vd-green-soft); color: var(--vd-green); }
@@ -3760,7 +3760,7 @@
   position: absolute; top: calc(100% + 4px); right: 0;
   min-width: 240px; background: var(--surface);
   border: 1px solid var(--border); border-radius: 6px;
-  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+  box-shadow: var(--sh-2);
   padding: 6px; z-index: 30;
 }
 .fin-cowork .vendas-aplus .vd-visoes-grp {
@@ -3826,7 +3826,7 @@
   width: 30px; height: 26px;
   border-radius: 4px;
   color: var(--text-mute); cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   display: inline-grid; place-items: center;
 }
 .fin-cowork .fin-toolbar .fin-density button:hover { color: var(--text); background: oklch(0 0 0 / 0.04); }
@@ -3843,7 +3843,7 @@
   /* font: inherit — chip virou <button> no #1982; sem isso o UA stylesheet
      aplica fonte/line-height próprios do button e desalinha vs resto da toolbar. */
   font: inherit; font-size: var(--fs-2); font-weight: 500; color: var(--text-dim);
-  cursor: pointer; user-select: none; transition: all .12s;
+  cursor: pointer; user-select: none; transition: all var(--t-1) var(--ease);
   position: relative;
 }
 .fin-cowork .fin-toolbar .fin-filter-cb:hover {
@@ -3857,7 +3857,7 @@
   border: 1.5px solid var(--text-mute);
   border-radius: 3px;
   display: inline-grid; place-items: center;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   flex-shrink: 0;
 }
 .fin-cowork .fin-toolbar .fin-filter-cb.on {
@@ -3911,7 +3911,7 @@
   background: white;
   font-family: inherit; font-size: var(--fs-3); font-weight: 600;
   color: oklch(0.42 0.13 60);
-  cursor: pointer; transition: all .12s;
+  cursor: pointer; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-edit-btn:hover { background: oklch(0.96 0.06 60); }
 .fin-cowork .fin-edit-btn.has-edits {
@@ -3962,7 +3962,7 @@
   font-family: inherit; font-size: var(--fs-3);
   color: var(--text);
   outline: none;
-  transition: border-color .12s;
+  transition: border-color var(--t-1) var(--ease);
 }
 .fin-cowork .fin-edit-grid input[type="number"] { font-family: var(--font-mono); }
 .fin-cowork .fin-edit-grid input:focus, .fin-cowork .fin-edit-grid select:focus { border-color: oklch(0.62 0.13 60); box-shadow: 0 0 0 2px oklch(0.94 0.06 60); }
@@ -4065,7 +4065,7 @@
   background: white;
   font-family: inherit; font-size: var(--fs-2); font-weight: 500;
   color: var(--text-dim); cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   white-space: nowrap;
 }
 .fin-cowork .fin-foot-icon-btn:hover { background: var(--bg-2); color: var(--text); border-color: var(--text-mute); }
@@ -4077,7 +4077,7 @@
   border-radius: 6px;
   background: oklch(0.55 0.13 145); color: white;
   font-family: inherit; font-size: var(--fs-2); font-weight: 600;
-  cursor: pointer; transition: background .12s;
+  cursor: pointer; transition: background var(--t-1) var(--ease);
   white-space: nowrap;
 }
 .fin-cowork .fin-foot-mark-btn:hover { background: oklch(0.48 0.13 145); }
@@ -4127,7 +4127,7 @@
   font-size: var(--fs-3); font-weight: 500;
   color: var(--text-mute); cursor: pointer;
   border-bottom: 2px solid transparent;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   display: inline-flex; align-items: center; gap: 6px;
   position: relative;
 }
@@ -4205,7 +4205,7 @@
   border: 1.5px solid oklch(0.78 0.10 145); background: oklch(0.97 0.04 145);
   font-family: inherit; font-size: var(--fs-3); font-weight: 600;
   color: oklch(0.32 0.13 145);
-  cursor: pointer; transition: all .12s;
+  cursor: pointer; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-conferido-toggle:hover { background: oklch(0.94 0.06 145); }
 .fin-cowork .fin-conferido-toggle.on {
@@ -4390,7 +4390,7 @@
   border-radius: 14px;
   width: 100%; max-width: 760px;
   max-height: 88vh; overflow: auto;
-  box-shadow: 0 24px 80px rgba(0,0,0,0.18);
+  box-shadow: var(--sh-2);
   display: flex; flex-direction: column;
   animation: finDigestUp 0.22s ease-out;
 }
@@ -4478,7 +4478,7 @@
   border: 1px dashed var(--border); background: var(--surface);
   /* font: inherit — toggle virou <button> no #1982 (vd .fin-filter-cb). */
   font: inherit; font-size: var(--fs-2); font-weight: 500; color: var(--text-dim);
-  cursor: pointer; user-select: none; transition: all .12s;
+  cursor: pointer; user-select: none; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-toolbar .fin-filter-toggle:hover {
   border-color: var(--text-mute); color: var(--text);
@@ -4493,7 +4493,7 @@
   border: 1px solid var(--border); background: var(--surface);
   font-size: var(--fs-2); font-weight: 500; color: var(--text-dim);
   font-family: inherit; line-height: 1.4;
-  cursor: pointer; transition: all .12s;
+  cursor: pointer; transition: all var(--t-1) var(--ease);
   appearance: none; -webkit-appearance: none; -moz-appearance: none;
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%2378716c' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   background-repeat: no-repeat;
@@ -4551,13 +4551,13 @@
   padding: 4px 9px 4px 6px; border-radius: 5px;
   font-family: inherit; font-size: var(--fs-2); font-weight: 500;
   color: var(--vd-green, oklch(0.50 0.14 155)); cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vd-subpage .vd-bcrumb-back:hover {
   background: var(--vd-green-soft, oklch(0.94 0.05 155));
   border-color: var(--vd-green-soft, oklch(0.94 0.05 155));
 }
-.fin-cowork .vd-subpage .vd-bcrumb-back svg { flex-shrink: 0; transition: transform .12s; }
+.fin-cowork .vd-subpage .vd-bcrumb-back svg { flex-shrink: 0; transition: transform var(--t-1) var(--ease); }
 .fin-cowork .vd-subpage .vd-bcrumb-back:hover svg { transform: translateX(-2px); }
 .fin-cowork .vd-subpage .vd-bcrumb-sep {
   color: var(--text-mute); opacity: 0.5;
@@ -4605,7 +4605,7 @@
   padding: 5px 9px; border-radius: 5px;
   font-family: inherit; font-size: var(--fs-2); font-weight: 500;
   color: var(--text-dim); cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-toolbar-act:hover {
   background: var(--bg-2); color: var(--text);
@@ -4625,7 +4625,7 @@
   padding: 4px 10px; border-radius: 4px;
   font-family: inherit; font-size: var(--fs-2); font-weight: 500;
   color: var(--text-dim); cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-toolbar .vd-vista button:hover { color: var(--text); }
 .fin-cowork .vendas-aplus .vd-toolbar .vd-vista button.on {
@@ -4639,7 +4639,7 @@
   padding: 5px 9px; border-radius: 5px;
   font-family: inherit; font-size: var(--fs-2); font-weight: 500;
   color: var(--text-dim); cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-toolbar .vd-views-btn::after {
   content: '▾'; font-size: var(--fs-1); color: var(--text-mute); margin-left: 4px;
@@ -4668,7 +4668,7 @@
   display: inline-flex; gap: 2px;
   margin-left: 6px;
   opacity: 0; transform: translateX(-4px);
-  transition: opacity .12s, transform .12s;
+  transition: opacity var(--t-1) var(--ease), transform var(--t-1) var(--ease);
   vertical-align: middle;
 }
 .fin-cowork .vendas-aplus .os-row:hover .vd-row-actions, .fin-cowork .vendas-aplus .os-row.row-focused .vd-row-actions {
@@ -4680,7 +4680,7 @@
   border-radius: 4px; cursor: pointer;
   display: inline-grid; place-items: center;
   color: var(--text-mute);
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .vendas-aplus .vd-row-act:hover {
   border-color: var(--vd-green); color: var(--vd-green);
@@ -4745,3 +4745,8 @@
   --vd-green: oklch(0.52 0.14 60);
   --vd-green-soft: oklch(0.95 0.06 60);
 }
+
+/* Medida de linha (§TEMPERO FA-3): título com quebra equilibrada. text-wrap:balance só
+   reflui heading multi-linha — nunca alarga nem quebra layout. Prosa ≤60ch (pretty +
+   max-inline-size) fica por tela: precisa de QA visual por elemento, deferida. */
+.fin-cowork h1, .fin-cowork h2, .fin-cowork h3 { text-wrap: balance; }

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -65,7 +65,7 @@
   font-size: var(--fs-2);
   font-weight: 500;
   cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   white-space: nowrap;
 }
 .fin-cowork .fin-curadoria .fin-btn:hover { background: var(--fin-bg-soft); border-color: oklch(0.85 0.005 240); }
@@ -260,7 +260,7 @@
   font-weight: 500;
   color: var(--fin-text-mute);
   cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   user-select: none;
   --cb-hue: 240;
 }
@@ -422,7 +422,7 @@
   background: white;
   border: 1px solid var(--fin-line);
   border-radius: 6px;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.05);
+  box-shadow: var(--sh-1);
   font-size: var(--fs-3);
   color: var(--fin-text-mute);
   display: flex;
@@ -605,7 +605,7 @@
   background: oklch(1 0 0);
   color: oklch(0.40 0.01 80);
   font-size: var(--fs-2); font-weight: 500; font-family: inherit; line-height: 1.4;
-  box-sizing: border-box; cursor: pointer; transition: border-color .12s;
+  box-sizing: border-box; cursor: pointer; transition: border-color var(--t-1) var(--ease);
 }
 .fin-curadoria .fin-toolbar .fin-filter-group input[type="date"]:hover,
 .fin-curadoria .fin-toolbar input.fin-date-input:hover {
@@ -632,7 +632,7 @@
   background-color: oklch(1 0 0);
   color: oklch(0.40 0.01 80);
   font-size: var(--fs-2); font-weight: 500; font-family: inherit; line-height: 1.4;
-  box-sizing: border-box; cursor: pointer; transition: border-color .12s;
+  box-sizing: border-box; cursor: pointer; transition: border-color var(--t-1) var(--ease);
   background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='gray' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
   background-repeat: no-repeat;
   background-position: right 9px center;
@@ -646,7 +646,7 @@
   width: 24px; height: 26px; padding: 0;
   border-radius: 5px; border: 1px solid transparent; background: transparent;
   color: var(--text-mute); font-size: var(--fs-5); line-height: 1;
-  cursor: pointer; transition: all .12s;
+  cursor: pointer; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-toolbar .fin-date-clear:hover {
   background: var(--surface); border-color: var(--border); color: var(--text);

--- a/resources/css/fin-curadoria.css
+++ b/resources/css/fin-curadoria.css
@@ -31,7 +31,7 @@
   font-weight: 600;
   color: oklch(0.32 0.13 145);
   cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-curadoria .fin-conferido-toggle:hover { background: oklch(0.94 0.06 145); }
 .fin-cowork .fin-curadoria .fin-conferido-toggle.on {

--- a/resources/css/fin-output.css
+++ b/resources/css/fin-output.css
@@ -24,7 +24,7 @@
   font-size: var(--fs-1);
   font-weight: 600;
   cursor: pointer;
-  transition: background .12s;
+  transition: background var(--t-1) var(--ease);
   vertical-align: baseline;
   margin: 0 1px;
 }
@@ -70,7 +70,7 @@
   max-height: 88vh;
   background: white;
   border-radius: 12px;
-  box-shadow: 0 24px 64px oklch(0.20 0.005 240 / 0.25);
+  box-shadow: var(--sh-2);
   z-index: 101;
   display: flex;
   flex-direction: column;
@@ -115,7 +115,7 @@
   position: absolute;
   inset: 0 auto 0 0;
   background: linear-gradient(90deg, oklch(0.45 0.18 145), oklch(0.55 0.13 240));
-  transition: width .28s ease;
+  transition: width var(--t-2) var(--ease);
 }
 .fin-cowork .fin-curadoria .fin-checklist-body {
   flex: 1;
@@ -149,7 +149,7 @@
   background: white;
   border: 1px solid var(--fin-line);
   border-radius: 6px;
-  transition: background .12s;
+  transition: background var(--t-1) var(--ease);
 }
 .fin-cowork .fin-curadoria .fin-checklist-step.done {
   background: oklch(0.97 0.03 145);
@@ -220,7 +220,7 @@
   font-size: var(--fs-2);
   font-weight: 600;
   cursor: pointer;
-  transition: background .12s;
+  transition: background var(--t-1) var(--ease);
 }
 .fin-cowork .fin-curadoria .fin-fechamento-trigger:hover { background: var(--fin-bg-soft); }
 .fin-cowork .fin-curadoria .fin-fechamento-trigger .fin-fechamento-badge {
@@ -250,7 +250,7 @@
   transform: translate(-50%, -50%);
   width: min(680px, 92vw); max-height: 88vh;
   background: white; border-radius: 12px;
-  box-shadow: 0 24px 64px oklch(0.20 0.005 240 / 0.25);
+  box-shadow: var(--sh-2);
   z-index: 101; display: flex; flex-direction: column; overflow: hidden;
 }
 .fin-cowork .fin-curadoria .fin-trouble-h {
@@ -273,13 +273,13 @@
   background: white;
   border: 1px solid oklch(0.92 0.04 var(--tr-hue));
   border-radius: 8px; padding: 14px 16px; cursor: pointer;
-  transition: all .15s; display: flex; flex-direction: column; gap: 6px;
+  transition: all var(--t-1) var(--ease); display: flex; flex-direction: column; gap: 6px;
 }
 .fin-cowork .fin-curadoria .fin-trouble-card:hover {
   background: oklch(0.98 0.02 var(--tr-hue));
   border-color: oklch(0.78 0.10 var(--tr-hue));
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px oklch(0.55 0.13 var(--tr-hue) / 0.10);
+  box-shadow: var(--sh-1);
 }
 .fin-cowork .fin-curadoria .fin-trouble-card-equip {
   font-size: var(--fs-1); font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
@@ -313,7 +313,7 @@
 .fin-cowork .fin-curadoria .fin-trouble-answer {
   appearance: none; background: white; border: 2px solid var(--fin-line);
   border-radius: 6px; padding: 8px 32px;
-  font-family: inherit; font-size: var(--fs-3); font-weight: 600; cursor: pointer; transition: all .12s;
+  font-family: inherit; font-size: var(--fs-3); font-weight: 600; cursor: pointer; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-curadoria .fin-trouble-answer.yes { border-color: oklch(0.55 0.18 145); color: oklch(0.32 0.13 145); }
 .fin-cowork .fin-curadoria .fin-trouble-answer.yes:hover { background: oklch(0.96 0.05 145); }
@@ -459,7 +459,7 @@
   display: flex; align-items: center; justify-content: space-between;
   padding: 10px 20px;
   background: oklch(0.99 0 0); border-bottom: 1px solid oklch(0.90 0.005 80);
-  box-shadow: 0 1px 4px oklch(0 0 0 / 0.05);
+  box-shadow: var(--sh-1);
 }
 .fin-cowork .fin-transcript-bar-l { display: flex; align-items: baseline; gap: 8px; color: oklch(0.30 0.01 80); }
 .fin-cowork .fin-transcript-bar-l strong { font-size: var(--fs-4); }
@@ -468,7 +468,7 @@
 .fin-cowork .fin-transcript-btn {
   padding: 6px 14px; border-radius: 6px; font-size: var(--fs-3); font-weight: 500;
   background: white; color: oklch(0.30 0.01 80); border: 1px solid oklch(0.85 0.005 80);
-  cursor: pointer; transition: all 0.12s;
+  cursor: pointer; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-transcript-btn:hover { background: oklch(0.97 0.005 80); border-color: oklch(0.75 0.005 80); }
 .fin-cowork .fin-transcript-btn.primary { background: oklch(0.30 0.06 240); color: white; border-color: oklch(0.30 0.06 240); }
@@ -479,7 +479,7 @@
   max-width: 760px;
   margin: 24px auto;
   padding: 40px 48px;
-  box-shadow: 0 4px 18px oklch(0 0 0 / 0.08);
+  box-shadow: var(--sh-1);
   font-family: ui-serif, Georgia, 'Times New Roman', serif;
   color: oklch(0.18 0 0);
   font-size: var(--fs-3);
@@ -576,7 +576,7 @@
   max-height: min(85vh, 800px);
   background: white;
   border-radius: 14px;
-  box-shadow: 0 20px 60px oklch(0 0 0 / 0.30);
+  box-shadow: var(--sh-2);
   display: flex; flex-direction: column;
   overflow: hidden;
   font-family: ui-sans-serif, system-ui, sans-serif;
@@ -605,7 +605,7 @@
   border: none; background: transparent; cursor: pointer;
   color: oklch(0.45 0 0); font-size: var(--fs-6); line-height: 1;
   display: grid; place-items: center;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-resume-x:hover { background: oklch(0.95 0 0); color: oklch(0.20 0 0); }
 .fin-cowork .fin-resume-body {
@@ -655,7 +655,7 @@
   font-size: var(--fs-3); font-weight: 500;
   background: white; color: oklch(0.30 0 0);
   border: 1px solid oklch(0.85 0 0);
-  cursor: pointer; transition: all .12s;
+  cursor: pointer; transition: all var(--t-1) var(--ease);
 }
 .fin-cowork .fin-resume-btn:hover { background: oklch(0.97 0 0); }
 .fin-cowork .fin-resume-btn.primary {
@@ -694,7 +694,7 @@
   font-weight: 500;
   color: oklch(0.50 0.01 80);
   cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -951,7 +951,7 @@
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  transition: filter .12s;
+  transition: filter var(--t-1) var(--ease);
 }
 .fin-cowork .fin-ageing-bar .seg:hover { filter: brightness(0.95); }
 /* s1 = 0-30d  verde fresh */
@@ -986,7 +986,7 @@
   font-size: var(--fs-3);
   font-weight: 500;
   cursor: pointer;
-  transition: all .12s;
+  transition: all var(--t-1) var(--ease);
   white-space: nowrap;
 }
 .fin-cowork .fin-subnav-tab:hover {


### PR DESCRIPTION
## FA-3 — Tempero aplicado no Financeiro live (sombras + transições → tokens)

**Origem:** handoff Cowork `PROMPT_PARA_CODE_ONDAS-FINANCEIRO` ([CC] 2026-06-11, §10.4). **Depende de FA-1** (#2569): `--sh-1/--sh-2/--ease/--t-1/--t-2` em `foundations.css`.

### Sombras de elevação → token (18 curadas)
- **floating → `var(--sh-2)`**: dialogs (`.fin-checklist-dialog`/`.fin-trouble-dialog`/`.fin-resume-dialog`), menus (`.vd-views-menu`/`.vd-visoes-menu`/`.sb-dd`/`.user-menu`), command palette (`.vd-pal`), flyout (`.sb-rail-flyout`), digest (`.fin-digest`), bulk bar (`.vd-bulk`), cheatsheet (`.vd-cheat`), tooltips (`[data-tip]::after`)
- **card assentado → `var(--sh-1)`**: `.fin-transcript-page`/`.fin-transcript-bar`, `.fin-footer-tips`, `.fin-trouble-card:hover`

### ⚠️ Achado §10.4 (memória Cowork ≠ git) — por que não foram 53
O prompt mediu "53 box-shadow" (bundle 44 · fin-output 8 · fin-cowork 1). Revalidando @main: a **maioria não é elevação** —
- **anel de foco/seleção** `0 0 0 Npx var(--accent-soft)` (×~20) → converter pra `var(--sh-1)` viraria o anel roxo de foco numa **sombra cinza** = **regressão de acessibilidade**
- **barra inset de acento** `inset 3px 0 0 ...` (urgência/etapa) e **hairline** `0 1px 0 var(--border)` (borda de thead) → não são sombras de elevação

Tokenizei **só as 18 sombras de elevação reais**; **20 anéis/insets preservados** intactos. As 2 dark-overrides `.os-drawer`/`.os-modal` são **CSS morto** (`display:none` no escopo `.fin-cowork`, sem par light) — não tocadas (limpeza cabe à FA-4).

### Transições → token (58)
`transition: <prop> <dur> [<ease>]` → `<prop> var(--t-K) var(--ease)`. Duração pro degrau mais próximo (midpoint .225s → `t-1` .15s / `t-2` .3s), easing unificado na **curva única do ERP**, **delay preservado** (ex.: tooltips `... var(--ease) .12s`).

### Medida de linha
`text-wrap: balance` nos títulos (`.fin-cowork h1/h2/h3`) — só reflui heading multi-linha, nunca quebra layout. Prosa `≤60ch` (`pretty` + `max-inline-size`) **deferida** (precisa decisão de `max-width` por elemento + QA visual).

### Gates (locais, verdes)
- `conformance --all` ✅ · `foundation-guard` ✅ · `stylelint` baseline delta 0 · `css-size` rebaseline **+5** (consciente, só a regra de título-balance; diff toca só o bundle)

### Visual
Mudança de elevação/timing nos overlays é observável; revisão @1280/@1440 light+dark via `visual-regression` CI + smoke pós-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
