### PR TITLE
fix(financeiro): resync-from-core — corrige fin_titulos inflados (incidente num_uf, ROTA LIVRE biz=4)

### DIFF
--- a/Modules/Financeiro/Console/Commands/ResyncFromCoreCommand.php
+++ b/Modules/Financeiro/Console/Commands/ResyncFromCoreCommand.php
@@ -1,0 +1,292 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Modules\Financeiro\Models\Concerns\BusinessScopeImpl;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+use Modules\Financeiro\Services\TituloAutoService;
+
+/**
+ * Re-sincroniza fin_titulos inflados com o `transactions.final_total` JÁ
+ * CORRIGIDO do core (UltimatePOS) — resíduo do incidente `num_uf`.
+ *
+ * CONTEXTO (incidente ROTA LIVRE biz=4, maio/2026):
+ *  - Bug histórico do parser pt-BR `num_uf` (fix #2279) gravava
+ *    `transactions.final_total` 10×/100×/1000× inflado quando o valor entrava
+ *    formatado en-US ("80.00" → 8000) — pior ainda com desconto.
+ *  - O `TituloAutoService` (bridge) COPIA `final_total` cru pro
+ *    `fin_titulos.valor_total`. Logo, toda venda inflada virou título inflado.
+ *  - O incidente #2280 corrigiu o CORE (`sells:final-total-audit --apply`) via
+ *    `UPDATE` direto — que NÃO dispara Observer. Resultado: o core ficou certo,
+ *    mas o ESPELHO `fin_titulos` ficou congelado no valor podre. Larissa vê
+ *    "a receber R$ 50,8M" enquanto o core diz ~R$ 396k.
+ *
+ * O QUE FAZ: pra cada título venda/compra cujo `valor_total` diverge (acima de
+ * --ratio) do `final_total` corrigido do core, re-espelha o core:
+ *   1. Estorna (APPEND-ONLY, nunca delete — TECH-0002) as baixas-lixo do título
+ *      (valor_baixa > core * ratio — impossível matematicamente).
+ *   2. Seta `valor_total = core final_total` (+ metadata.valor_total_antigo).
+ *   3. Recalcula valor_aberto + status via TituloAutoService::recalcularTitulo
+ *      (preserva 'cancelado').
+ *   4. Grava trilha em activity_log (paridade com sells:final-total-audit).
+ *
+ * DEPENDÊNCIA DE ORDEM: rode `php artisan sells:final-total-audit --business=N`
+ * ANTES — ele conserta o CORE. Este comando só ESPELHA o core já corrigido.
+ * Se o core ainda estiver podre, valor_total == final_total (ambos lixo) e o
+ * título nem aparece como candidato (não há divergência) — é problema do core.
+ *
+ * SEGURO: DRY-RUN por padrão (apenas lista impacto). `--apply` exige `--business`.
+ * Idempotente: re-rodar não re-estorna (baixa já estornada é ignorada) nem
+ * re-mexe (valor_total já == core deixa de ser candidato). Reversível via
+ * `metadata.resync_from_core` + `metadata.valor_total_antigo`.
+ *
+ * Uso:
+ *   php artisan financeiro:resync-from-core --business=4            # DRY-RUN
+ *   php artisan financeiro:resync-from-core --business=4 --detail
+ *   php artisan financeiro:resync-from-core --business=4 --apply
+ *
+ * Refs: #2279 (fix num_uf), #2280 (correção core 16 vendas), ADR 0093 (Tier 0),
+ * RUNBOOK-bridge-sells-titulos-backfill.md, agent financeiro-bridge-auditor.
+ */
+class ResyncFromCoreCommand extends Command
+{
+    protected $signature = 'financeiro:resync-from-core
+        {--business= : ID do business (obrigatório — Tier 0 IRREVOGÁVEL ADR 0093)}
+        {--ratio=1.5 : valor_total / core final_total acima do qual considera inflado (default 1.5)}
+        {--since= : Data mínima YYYY-MM-DD (emissao do título) (opcional)}
+        {--limit= : Máximo de títulos por rodada (opcional)}
+        {--apply : Aplica a correção (default DRY-RUN seguro)}
+        {--detail : Lista cada título processado}';
+
+    protected $description = 'Re-sincroniza fin_titulos inflados (incidente num_uf) com o final_total corrigido do core. DRY-RUN por padrão.';
+
+    public function handle(TituloAutoService $service): int
+    {
+        $businessId = (int) $this->option('business');
+        if ($businessId <= 0) {
+            $this->error('--business=ID obrigatório (Tier 0 IRREVOGÁVEL — ADR 0093)');
+
+            return self::FAILURE;
+        }
+
+        $ratio = (float) ($this->option('ratio') ?: 1.5);
+        if ($ratio < 1.0) {
+            $this->error('--ratio deve ser >= 1.0 (razão valor_total / core).');
+
+            return self::FAILURE;
+        }
+
+        $since = $this->option('since');
+        if ($since !== null && ! preg_match('/^\d{4}-\d{2}-\d{2}$/', (string) $since)) {
+            $this->error('--since deve ser YYYY-MM-DD (ex: 2026-05-01)');
+
+            return self::FAILURE;
+        }
+
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+        $apply = (bool) $this->option('apply');
+        $detail = (bool) $this->option('detail');
+
+        $this->info(($apply ? '' : '[DRY-RUN] ')."Resync fin_titulos ← core (business={$businessId}, ratio={$ratio}x)");
+        $this->line('  Lembrete: rode `sells:final-total-audit --business='.$businessId.'` ANTES (conserta o core).');
+
+        // Candidatos: título venda/compra cujo valor_total diverge (inflado) do
+        // final_total corrigido do core. JOIN por origem_id + business_id (Tier 0).
+        $query = DB::table('fin_titulos as ft')
+            ->join('transactions as t', function ($join) {
+                $join->on('t.id', '=', 'ft.origem_id')
+                    ->on('t.business_id', '=', 'ft.business_id');
+            })
+            ->where('ft.business_id', $businessId)
+            ->whereIn('ft.origem', ['venda', 'compra'])
+            ->whereNull('ft.parcela_numero')
+            ->whereNull('ft.deleted_at')
+            ->where('t.final_total', '>', 0)
+            ->whereRaw('ft.valor_total > t.final_total * ?', [$ratio])
+            ->select(
+                'ft.id',
+                'ft.numero',
+                'ft.origem',
+                'ft.status',
+                'ft.valor_total',
+                'ft.valor_aberto',
+                't.final_total as core_total',
+            );
+
+        if ($since) {
+            $query->where('ft.emissao', '>=', $since);
+        }
+
+        $query->orderBy('ft.id', 'asc');
+
+        if ($limit) {
+            $query->limit($limit);
+        }
+
+        $candidatos = $query->get();
+        $total = $candidatos->count();
+
+        if ($total === 0) {
+            $this->info('Nada a re-sincronizar — nenhum título inflado vs core.');
+
+            return self::SUCCESS;
+        }
+
+        $this->warn(sprintf('%d título(s) inflado(s) detectado(s):', $total));
+
+        $somaAntiga = 0.0;
+        $somaNova = 0.0;
+        $tableRows = [];
+
+        foreach ($candidatos as $c) {
+            $coreTotal = (float) $c->core_total;
+            $valorTotal = (float) $c->valor_total;
+            $garbage = $this->baixasLixo($businessId, (int) $c->id, $coreTotal, $ratio);
+            $somaGarbage = (float) $garbage->sum('valor_baixa');
+
+            $somaAntiga += $valorTotal;
+            $somaNova += $coreTotal;
+
+            if ($detail || ! $apply) {
+                $tableRows[] = [
+                    'id' => $c->id,
+                    'numero' => $c->numero,
+                    'origem' => $c->origem,
+                    'status' => $c->status,
+                    'valor_atual' => number_format($valorTotal, 2, ',', '.'),
+                    'core' => number_format($coreTotal, 2, ',', '.'),
+                    'baixas_lixo' => $garbage->count().' (R$ '.number_format($somaGarbage, 2, ',', '.').')',
+                ];
+            }
+        }
+
+        if (! $apply) {
+            $this->table(
+                ['id', 'numero', 'origem', 'status', 'valor_atual', 'core', 'baixas_lixo'],
+                $tableRows,
+            );
+            $this->info('[DRY-RUN] valor_total somado: R$ '.number_format($somaAntiga, 2, ',', '.').' → R$ '.number_format($somaNova, 2, ',', '.'));
+            $this->info('[DRY-RUN] Re-rode com --apply pra corrigir.');
+
+            return self::SUCCESS;
+        }
+
+        $corrigidos = 0;
+        $baixasEstornadas = 0;
+
+        foreach ($candidatos as $c) {
+            $coreTotal = (float) $c->core_total;
+
+            DB::transaction(function () use ($service, $businessId, $c, $coreTotal, $ratio, &$corrigidos, &$baixasEstornadas, $detail) {
+                /** @var Titulo|null $titulo */
+                $titulo = Titulo::query()
+                    ->withoutGlobalScope(BusinessScopeImpl::class)
+                    ->where('business_id', $businessId)
+                    ->where('id', (int) $c->id)
+                    ->lockForUpdate()
+                    ->first();
+
+                if (! $titulo) {
+                    return;
+                }
+
+                $valorAntigo = (float) $titulo->valor_total;
+
+                // 1) Estorna baixas-lixo (append-only — TECH-0002, nunca delete).
+                $garbage = $this->baixasLixo($businessId, (int) $titulo->id, $coreTotal, $ratio);
+                foreach ($garbage as $b) {
+                    TituloBaixa::query()
+                        ->withoutGlobalScope(BusinessScopeImpl::class)
+                        ->create([
+                            'business_id' => $businessId,
+                            'titulo_id' => (int) $titulo->id,
+                            'conta_bancaria_id' => $b->conta_bancaria_id,
+                            'valor_baixa' => -1 * (float) $b->valor_baixa,
+                            'data_baixa' => now()->toDateString(),
+                            'meio_pagamento' => $b->meio_pagamento,
+                            'idempotency_key' => 'resync_estorno_'.$b->id,
+                            'estorno_de_id' => (int) $b->id,
+                            'observacoes' => 'Estorno resync: baixa-lixo do incidente num_uf (#2279/#2280)',
+                            'created_by' => 1,
+                        ]);
+                    $baixasEstornadas++;
+                }
+
+                // 2) valor_total = core (+ trilha pra rollback).
+                $metadata = $titulo->metadata ?? [];
+                $metadata['resync_from_core'] = now()->toIso8601String();
+                $metadata['valor_total_antigo'] = $valorAntigo;
+                $titulo->metadata = $metadata;
+                $titulo->valor_total = $coreTotal;
+                $titulo->save();
+
+                // 3) Recalcula valor_aberto + status (canônico; preserva cancelado).
+                $service->recalcularTitulo($titulo);
+
+                // 4) Trilha activity_log (paridade com sells:final-total-audit).
+                DB::table('activity_log')->insert([
+                    'log_name' => 'financeiro-resync-from-core',
+                    'description' => 'valor_total re-sincronizado com final_total corrigido do core (incidente num_uf #2279/#2280)',
+                    'subject_type' => Titulo::class,
+                    'subject_id' => (int) $titulo->id,
+                    'causer_type' => null,
+                    'causer_id' => null,
+                    'properties' => json_encode([
+                        'business_id' => $businessId,
+                        'attributes' => ['valor_total' => $coreTotal],
+                        'old' => ['valor_total' => $valorAntigo],
+                    ], JSON_UNESCAPED_UNICODE),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+
+                $corrigidos++;
+
+                if ($detail) {
+                    $this->line(sprintf(
+                        '  ✓ %s (#%d) R$ %s → R$ %s',
+                        $c->numero,
+                        $c->id,
+                        number_format($valorAntigo, 2, ',', '.'),
+                        number_format($coreTotal, 2, ',', '.'),
+                    ));
+                }
+            });
+        }
+
+        $this->info("✓ Resync concluído em business={$businessId}");
+        $this->info("  Títulos corrigidos: {$corrigidos}");
+        $this->info("  Baixas-lixo estornadas: {$baixasEstornadas}");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Baixas-lixo de um título: ativas (não-estorno), ainda não estornadas, com
+     * valor_baixa impossível (> core * ratio). Idempotente — exclui as que já
+     * têm estorno apontando (re-run não re-estorna).
+     *
+     * @return \Illuminate\Support\Collection<int, object>
+     */
+    private function baixasLixo(int $businessId, int $tituloId, float $coreTotal, float $ratio): \Illuminate\Support\Collection
+    {
+        return DB::table('fin_titulo_baixas as b')
+            ->where('b.business_id', $businessId)
+            ->where('b.titulo_id', $tituloId)
+            ->whereNull('b.estorno_de_id')
+            ->whereRaw('b.valor_baixa > ?', [$coreTotal * $ratio])
+            ->whereNotExists(function ($q) use ($businessId) {
+                $q->select(DB::raw('1'))
+                    ->from('fin_titulo_baixas as e')
+                    ->whereColumn('e.estorno_de_id', 'b.id')
+                    ->where('e.business_id', $businessId);
+            })
+            ->select('b.id', 'b.valor_baixa', 'b.conta_bancaria_id', 'b.meio_pagamento')
+            ->get();
+    }
+}

--- a/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
+++ b/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
@@ -115,6 +115,11 @@ class FinanceiroServiceProvider extends ServiceProvider
                 // tipo expense (core UltimatePOS) → fin_titulos AP (Financeiro).
                 // Idempotente via UNIQUE(business_id, origem, origem_id, parcela_numero).
                 \Modules\Financeiro\Console\Commands\BridgeExpenseToTitulosCommand::class,
+                // Incidente num_uf #2279/#2280 — re-sincroniza fin_titulos inflados
+                // com o final_total JÁ CORRIGIDO do core. O fix do core (#2280) foi
+                // UPDATE direto (não dispara Observer), deixando o espelho fin_titulos
+                // congelado no valor-lixo. DRY-RUN default, --business Tier 0, append-only.
+                \Modules\Financeiro\Console\Commands\ResyncFromCoreCommand::class,
                 // Fase 2 ADR 0236 — backfill OFX (fin_bank_statement_lines) →
                 // fin_extrato_lancamentos (canônica). Idempotente, --business
                 // obrigatório (Tier 0), --dry default-seguro. Unifica external_id.

--- a/Modules/Financeiro/Tests/Feature/ResyncFromCoreCommandTest.php
+++ b/Modules/Financeiro/Tests/Feature/ResyncFromCoreCommandTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use Illuminate\Support\Facades\DB;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Guard do ResyncFromCoreCommand — re-sincroniza fin_titulos inflados
+ * (resíduo do incidente num_uf #2279/#2280) com o final_total corrigido do core.
+ *
+ * Invariantes:
+ *  1. --business obrigatório (Tier 0 IRREVOGÁVEL ADR 0093)
+ *  2. DRY-RUN (default, sem --apply) não escreve nada
+ *  3. --apply: valor_total ← core final_total + estorna baixa-lixo (append-only)
+ *     + recalcula valor_aberto/status
+ *  4. Idempotente — 2ª run não re-estorna nem re-mexe
+ *  5. Não toca título de outro business (Tier 0 multi-tenant)
+ *
+ * Padrão skip gracioso (convenção Financeiro) quando DB greenfield.
+ */
+function resyncBootstrap(): Business
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco.');
+    }
+
+    return $business;
+}
+
+/**
+ * Cria uma venda core correta (final_total) + um fin_titulo INFLADO espelhando
+ * o valor-lixo histórico + uma baixa-lixo. Retorna [txId, tituloId, baixaId].
+ *
+ * @return array{0:int,1:int,2:int}
+ */
+function seedTituloInflado(int $businessId, int $userId, float $coreTotal, float $garbageTotal): array
+{
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => $businessId,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'due',
+        'final_total' => $coreTotal,
+        'total_remaining_amount' => $coreTotal,
+        'transaction_date' => '2026-06-01 10:00:00',
+        'created_by' => $userId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $tituloId = DB::table('fin_titulos')->insertGetId([
+        'business_id' => $businessId,
+        'numero' => 'R-RESYNCTEST'.$txId,
+        'tipo' => 'receber',
+        'status' => 'aberto',
+        'cliente_descricao' => 'Teste resync · #V-'.$txId,
+        'valor_total' => $garbageTotal,
+        'valor_aberto' => $garbageTotal,
+        'moeda' => 'BRL',
+        'emissao' => '2026-06-01',
+        'vencimento' => '2026-06-30',
+        'competencia_mes' => '2026-06',
+        'origem' => 'venda',
+        'origem_id' => $txId,
+        'parcela_numero' => null,
+        'created_by' => $userId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $baixaId = DB::table('fin_titulo_baixas')->insertGetId([
+        'business_id' => $businessId,
+        'titulo_id' => $tituloId,
+        'conta_bancaria_id' => null,
+        'valor_baixa' => $garbageTotal - 5,
+        'juros' => 0,
+        'multa' => 0,
+        'desconto' => 0,
+        'data_baixa' => '2026-06-01',
+        'meio_pagamento' => 'pix',
+        'idempotency_key' => 'resynctest_'.$txId,
+        'created_by' => $userId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    return [$txId, $tituloId, $baixaId];
+}
+
+function cleanupResync(int $businessId, int $txId, int $tituloId): void
+{
+    DB::table('fin_titulo_baixas')->where('titulo_id', $tituloId)->delete();
+    DB::table('activity_log')
+        ->where('log_name', 'financeiro-resync-from-core')
+        ->where('subject_id', $tituloId)
+        ->delete();
+    DB::table('fin_titulos')->where('id', $tituloId)->delete();
+    DB::table('transactions')->where('id', $txId)->delete();
+}
+
+it('bloqueia execução sem --business (Tier 0)', function () {
+    $exit = $this->artisan('financeiro:resync-from-core')->run();
+
+    expect($exit)->toBe(1); // FAILURE
+});
+
+it('dry-run (default) não escreve nada', function () {
+    $business = resyncBootstrap();
+    $userId = DB::table('users')->where('business_id', $business->id)->value('id');
+    if (! $userId) {
+        $this->markTestSkipped('Sem user no business.');
+    }
+
+    [$txId, $tituloId] = seedTituloInflado((int) $business->id, (int) $userId, 220.90, 209004535.00);
+
+    $this->artisan("financeiro:resync-from-core --business={$business->id}")
+        ->assertExitCode(0);
+
+    $titulo = DB::table('fin_titulos')->where('id', $tituloId)->first();
+    expect((float) $titulo->valor_total)->toBe(209004535.00); // intacto
+
+    $baixasCount = DB::table('fin_titulo_baixas')->where('titulo_id', $tituloId)->count();
+    expect($baixasCount)->toBe(1); // nenhum estorno criado
+
+    cleanupResync((int) $business->id, $txId, $tituloId);
+});
+
+it('--apply corrige valor_total ao core + estorna baixa-lixo + recalcula', function () {
+    $business = resyncBootstrap();
+    $userId = DB::table('users')->where('business_id', $business->id)->value('id');
+    if (! $userId) {
+        $this->markTestSkipped('Sem user.');
+    }
+
+    [$txId, $tituloId] = seedTituloInflado((int) $business->id, (int) $userId, 220.90, 209004535.00);
+
+    $this->artisan("financeiro:resync-from-core --business={$business->id} --apply")
+        ->assertExitCode(0);
+
+    $titulo = DB::table('fin_titulos')->where('id', $tituloId)->first();
+    expect((float) $titulo->valor_total)->toBe(220.90);
+    expect((float) $titulo->valor_aberto)->toBe(220.90); // baixa-lixo estornada → aberto cheio
+    expect($titulo->status)->toBe('aberto');
+
+    // Estorno append-only criado (negativo) — baixas líquidas somam ~0.
+    $netBaixas = (float) DB::table('fin_titulo_baixas')->where('titulo_id', $tituloId)->sum('valor_baixa');
+    expect(round($netBaixas, 2))->toBe(0.0);
+
+    $estornoExiste = DB::table('fin_titulo_baixas')
+        ->where('titulo_id', $tituloId)
+        ->whereNotNull('estorno_de_id')
+        ->exists();
+    expect($estornoExiste)->toBeTrue();
+
+    cleanupResync((int) $business->id, $txId, $tituloId);
+});
+
+it('é idempotente — 2ª run não re-estorna nem re-mexe', function () {
+    $business = resyncBootstrap();
+    $userId = DB::table('users')->where('business_id', $business->id)->value('id');
+    if (! $userId) {
+        $this->markTestSkipped('Sem user.');
+    }
+
+    [$txId, $tituloId] = seedTituloInflado((int) $business->id, (int) $userId, 100.00, 100000.00);
+
+    $this->artisan("financeiro:resync-from-core --business={$business->id} --apply")->assertExitCode(0);
+    $count1 = DB::table('fin_titulo_baixas')->where('titulo_id', $tituloId)->count();
+
+    $this->artisan("financeiro:resync-from-core --business={$business->id} --apply")->assertExitCode(0);
+    $count2 = DB::table('fin_titulo_baixas')->where('titulo_id', $tituloId)->count();
+
+    expect($count2)->toBe($count1); // nenhum estorno novo na 2ª run
+
+    $titulo = DB::table('fin_titulos')->where('id', $tituloId)->first();
+    expect((float) $titulo->valor_total)->toBe(100.00);
+
+    cleanupResync((int) $business->id, $txId, $tituloId);
+});
+
+it('não toca título de outro business (Tier 0 multi-tenant)', function () {
+    $business = resyncBootstrap();
+    $other = Business::where('id', '!=', $business->id)->first();
+    if (! $other) {
+        $this->markTestSkipped('Precisa 2+ businesses no banco.');
+    }
+    $userId = DB::table('users')->where('business_id', $other->id)->value('id');
+    if (! $userId) {
+        $this->markTestSkipped('Sem user no outro business.');
+    }
+
+    [$txId, $tituloId] = seedTituloInflado((int) $other->id, (int) $userId, 220.90, 209004535.00);
+
+    // Roda pro business DIFERENTE
+    $this->artisan("financeiro:resync-from-core --business={$business->id} --apply")
+        ->assertExitCode(0);
+
+    $titulo = DB::table('fin_titulos')->where('id', $tituloId)->first();
+    expect((float) $titulo->valor_total)->toBe(209004535.00); // intacto (outro tenant)
+
+    cleanupResync((int) $other->id, $txId, $tituloId);
+});


### PR DESCRIPTION
## Problema

A **Visão Unificada** da ROTA LIVRE (biz=4, Larissa) mostra **a receber R$ 50,8M** enquanto a operação real (core UltimatePOS) é **~R$ 396k**. Wagner reportou: "o financeiro está muito errado mesmo".

### Causa-raiz (com prova)

1. Bug histórico do parser pt-BR `num_uf` (fix **#2279**) gravava `transactions.final_total` 10×/100×/1000× inflado quando o valor entrava formatado en-US ("80.00" → 8000) — pior com desconto.
2. O `TituloAutoService` (bridge) **copia `final_total` cru** pro `fin_titulos.valor_total`. Logo, toda venda inflada virou título inflado.
3. O incidente **#2280** corrigiu o **CORE** via `UPDATE` direto (`sells:final-total-audit --apply`) — que **não dispara Observer**. O core ficou certo, mas o **espelho `fin_titulos` ficou congelado no valor-lixo**.

Auditoria em prod (biz=4, read-only): **17 títulos inflados concentram R$ 367,9M (98,6% da base)**; os outros 18.117 batem **centavo-a-centavo** com o core.

## Fix

Comando `financeiro:resync-from-core` que re-espelha o core **já corrigido** nos títulos divergentes:
1. Estorna baixas-lixo (**append-only** — TECH-0002, nunca delete).
2. Seta `valor_total = final_total` do core (+ `metadata.valor_total_antigo` pra rollback).
3. Recalcula `valor_aberto`/`status` via `TituloAutoService::recalcularTitulo` (preserva `cancelado`).
4. Grava `activity_log` (paridade com `sells:final-total-audit`).

## Segurança

- **DRY-RUN por padrão** — apenas lista impacto; `--apply` exige `--business`.
- **Tier 0 IRREVOGÁVEL (ADR 0093)** — `business_id` explícito em toda query + teste multi-tenant.
- **Idempotente** (re-run não re-estorna) + **reversível** (`metadata`).
- **Dependência de ordem:** rodar `sells:final-total-audit --business=N` ANTES (conserta o core). Este comando só espelha o core já corrigido.

## Testes

Pest — 5 invariantes: bloqueio sem `--business`, dry-run não-escreve, `--apply` corrige+estorna+recalcula, idempotência, multi-tenant.

## Uso (próximo passo, gated por Wagner)

```
php artisan financeiro:resync-from-core --business=4            # DRY-RUN (mostra os 17)
php artisan sells:final-total-audit --business=4                # confirma core limpo
php artisan financeiro:resync-from-core --business=4 --apply    # aplica
```

Refs: #2279 #2280 · ADR 0093 · RUNBOOK-bridge-sells-titulos-backfill · agent financeiro-bridge-auditor

🤖 Generated with [Claude Code](https://claude.com/claude-code)