### PR TITLE
ci(meta-gates): o processo se autocobra — registry de gates + frescor + licao_sem_assercao (Onda Q5)

### DIFF
--- a/.github/workflows/governance-gate-umbrella.yml
+++ b/.github/workflows/governance-gate-umbrella.yml
@@ -39,6 +39,8 @@ jobs:
         run: node scripts/governance/memory-health.mjs
       - name: Meta-teste dos scripts de governança (controle-negativo)
         run: npm run test:adr-governance
+      - name: Meta-teste dos checks G/H/I do memory-health (Onda Q5 — controle-negativo)
+        run: npm run test:memory-health
 
   # Segredo NOVO em QUALQUER arquivo do diff (API key, token, senha) — fecha o gap
   # entre o memory-health (só memory/) e o secrets:audit (só scheduled, não barra PR).

--- a/.github/workflows/memory-health.yml
+++ b/.github/workflows/memory-health.yml
@@ -13,6 +13,10 @@ on:
       - 'memory/**'
       - 'scripts/governance/memory-health.mjs'
       - 'scripts/governance/.memory-health-baseline.json'
+      # Onda Q5 — Check G (registry canônico de gates): workflow novo/alterado
+      # tem que passar pelo censo; o umbrella (always-run) também cobre.
+      - '.github/workflows/**'
+      - 'scripts/governance/gates-registry.json'
   schedule:
     # Daily 06h30 BRT (09h30 UTC) — batimento cardíaco da memória (após health-check dados).
     - cron: '30 9 * * *'

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts",
     "test:adr-governance": "vitest run tests/governanceAdrScripts.spec.ts",
+    "test:memory-health": "vitest run tests/memoryHealth.spec.ts",
     "test:casos-guard": "vitest run tests/casosGuard.spec.ts",
     "test:casos-results": "vitest run tests/casosResultsCollect.spec.ts",
     "test:dominio-guard": "vitest run tests/dominioGuard.spec.ts"

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -1,0 +1,230 @@
+{
+  "_meta": {
+    "gate": "memory-health Check G (Onda Q5 — registry canonico de gates, ADR 0256)",
+    "nota": "TODO workflow em .github/workflows DEVE estar registrado aqui (nome + classe + proposito). Workflow novo fora do registry = FAIL no memory-health (umbrella, todo PR). Tirar workflow = remover a entrada junto (entrada orfa = warn).",
+    "classes": {
+      "gate": "bloqueia/valida PR",
+      "meta": "testa os proprios gates",
+      "automacao": "cron/scheduled/dispatch utilitario",
+      "deploy": "entrega"
+    }
+  },
+  "workflows": {
+    "a11y-axe-gate.yml": {
+      "nome": "A11y axe runtime (jsdom · componentes canon)",
+      "classe": "gate"
+    },
+    "a11y-gate.yml": {
+      "nome": "A11y ratchet (acessibilidade = categoria protegida)",
+      "classe": "gate"
+    },
+    "adr-index-gate.yml": {
+      "nome": "ADR Index Gate — ADR 0258",
+      "classe": "gate"
+    },
+    "adr-lint.yml": {
+      "nome": "ADR frontmatter lint",
+      "classe": "gate"
+    },
+    "casos-gate.yml": {
+      "nome": "Casos-coverage ratchet (trio-de-tela + caso↔teste)",
+      "classe": "gate"
+    },
+    "casos-meta-gate.yml": {
+      "nome": "Casos-guard meta-teste (vitest)",
+      "classe": "meta"
+    },
+    "ci.yml": {
+      "nome": "CI",
+      "classe": "gate"
+    },
+    "components-tree-guard.yml": {
+      "nome": "Components tree guard (árvore canônica de Components/)",
+      "classe": "gate"
+    },
+    "composer-lock-sync.yml": {
+      "nome": "Composer lock sync",
+      "classe": "automacao"
+    },
+    "conformance-gate.yml": {
+      "nome": "Conformance Gate — cor-crua DS (Camada 1 · anti-regressão de contrato)",
+      "classe": "gate"
+    },
+    "cowork-inbox.yml": {
+      "nome": "cowork-inbox",
+      "classe": "automacao"
+    },
+    "create-test-business.yml": {
+      "nome": "Create Test Business (biz 99 · one-shot)",
+      "classe": "automacao"
+    },
+    "css-size-gate.yml": {
+      "nome": "CSS size ratchet (congelar sprawl · MANUAL-CSS-JS#1)",
+      "classe": "gate"
+    },
+    "deploy.yml": {
+      "nome": "Deploy to Hostinger",
+      "classe": "deploy"
+    },
+    "design-identity-gate.yml": {
+      "nome": "Design Identity Gate (soft)",
+      "classe": "gate"
+    },
+    "design-index-gate.yml": {
+      "nome": "Design index single-source gate",
+      "classe": "gate"
+    },
+    "design-return-gate.yml": {
+      "nome": "Design return gate (§10.2 pós-merge)",
+      "classe": "automacao"
+    },
+    "design-spec-gate.yml": {
+      "nome": "Design-spec por-tela (contrato estrutural determinístico)",
+      "classe": "gate"
+    },
+    "dominio-gate.yml": {
+      "nome": "Dominio-dict ratchet (coerência de domínio)",
+      "classe": "gate"
+    },
+    "dominio-meta-gate.yml": {
+      "nome": "Dominio-guard meta-teste (vitest)",
+      "classe": "meta"
+    },
+    "e2e-gate.yml": {
+      "nome": "E2E Playwright (UCs críticos) — G-3",
+      "classe": "gate"
+    },
+    "eslint-gate.yml": {
+      "nome": "ESLint 9 (ADR 0209)",
+      "classe": "gate"
+    },
+    "financeiro-pest.yml": {
+      "nome": "Financeiro · Pest (MySQL)",
+      "classe": "gate"
+    },
+    "force-clean-rebuild-trigger.yml": {
+      "nome": "Force Clean Rebuild (one-shot)",
+      "classe": "automacao"
+    },
+    "governance-drift.yml": {
+      "nome": "Governance Drift Framework — ADR 0216",
+      "classe": "gate"
+    },
+    "governance-gate-umbrella.yml": {
+      "nome": "Governance Gate (umbrella)",
+      "classe": "gate"
+    },
+    "governance-gate.yml": {
+      "nome": "Governance Gate (pre-merge)",
+      "classe": "gate"
+    },
+    "infra-contract-required.yml": {
+      "nome": "Infra Contract Required",
+      "classe": "gate"
+    },
+    "jana-ragas-canary.yml": {
+      "nome": "Jana RAGAS Canary (daily 06:00 UTC)",
+      "classe": "automacao"
+    },
+    "jana-ragas-gate.yml": {
+      "nome": "Jana RAGAS Eval Gate",
+      "classe": "gate"
+    },
+    "jscpd-gate.yml": {
+      "nome": "jscpd ratchet (anti-duplicação de bloco copy-paste)",
+      "classe": "gate"
+    },
+    "layout-primitives-guard.yml": {
+      "nome": "Layout primitives guard (flex/grid solto)",
+      "classe": "gate"
+    },
+    "memory-health.yml": {
+      "nome": "Memory Health — ADR 0256",
+      "classe": "gate"
+    },
+    "memory-schema-gate-extended.yml": {
+      "nome": "Memory schema gate EXTENDED (D6 #4)",
+      "classe": "gate"
+    },
+    "memory-schema-gate.yml": {
+      "nome": "Memory schema gate (ONDA 5 S1)",
+      "classe": "gate"
+    },
+    "module-grades-gate.yml": {
+      "nome": "Module Grades Gate (anti-regressão)",
+      "classe": "gate"
+    },
+    "modules-pest.yml": {
+      "nome": "Modules Pest",
+      "classe": "gate"
+    },
+    "multi-tenant-gate.yml": {
+      "nome": "Multi-tenant gate",
+      "classe": "gate"
+    },
+    "mutation-gate.yml": {
+      "nome": "Mutation Gate (advisory)",
+      "classe": "gate"
+    },
+    "no-mock-gate.yml": {
+      "nome": "No-mock-in-prod ratchet (stub/mock em controller)",
+      "classe": "gate"
+    },
+    "pageheader-gate.yml": {
+      "nome": "PageHeader migration guard (F4 · congela header antigo)",
+      "classe": "gate"
+    },
+    "phpstan-baseline-regen.yml": {
+      "nome": "PHPStan baseline regen (manual)",
+      "classe": "automacao"
+    },
+    "phpstan-gate.yml": {
+      "nome": "PHPStan / Larastan (ADR 0208)",
+      "classe": "gate"
+    },
+    "quick-sync.yml": {
+      "nome": "Quick Sync (manual escape — auto-deploy agora é deploy.yml)",
+      "classe": "deploy"
+    },
+    "repair-shared-vocab.yml": {
+      "nome": "Repair shared vocabulary guard",
+      "classe": "gate"
+    },
+    "reuse-gate.yml": {
+      "nome": "Reuse duplicates ratchet (anti-duplicação de símbolo)",
+      "classe": "gate"
+    },
+    "run-financeiro-demo-seeder.yml": {
+      "nome": "Run FinanceiroDemoSeeder (one-shot)",
+      "classe": "automacao"
+    },
+    "scope-guard.yml": {
+      "nome": "Scope Guard (anti-drift)",
+      "classe": "gate"
+    },
+    "scorer-sync-gate.yml": {
+      "nome": "Scorer sync (regex score-mechanized.mjs ↔ UiDeterministicScorer.php)",
+      "classe": "gate"
+    },
+    "screen-coverage-gate.yml": {
+      "nome": "Screen Coverage Gate (catraca de cobertura)",
+      "classe": "gate"
+    },
+    "stylelint-gate.yml": {
+      "nome": "Stylelint CSS anti-drift (G5 · ADR 0209)",
+      "classe": "gate"
+    },
+    "ui-architecture-gate.yml": {
+      "nome": "UI architecture gate",
+      "classe": "gate"
+    },
+    "ui-lint.yml": {
+      "nome": "UI Lint (Constituição UI v2)",
+      "classe": "gate"
+    },
+    "visual-regression.yml": {
+      "nome": "Visual Regression (Pest 4 Browser)",
+      "classe": "gate"
+    }
+  }
+}

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -227,6 +227,80 @@ function checkAntiResurrection() {
   }
 }
 
+// ── Check G: registry canônico de gates (Onda Q5 — o processo se autocobra) ─
+// "Regra que ninguém cobra morre" — gate novo entrava em .github/workflows sem
+// censo nenhum. TODO workflow DEVE estar em scripts/governance/gates-registry.json
+// (nome + classe + propósito). Workflow fora do registry = 🔴 (pega gate novo
+// mecanicamente); entrada órfã (workflow apagado) = 🟡.
+function checkGatesRegistry() {
+  const REGISTRY = 'scripts/governance/gates-registry.json';
+  const wfDir = '.github/workflows';
+  if (!exists(wfDir)) return;
+  if (!exists(REGISTRY)) {
+    fails.push({ check: 'G', kind: 'registry-ausente',
+      msg: `${REGISTRY} não existe — o censo de gates é obrigatório (Onda Q5). Recriar a partir do main.` });
+    return;
+  }
+  let reg;
+  try { reg = JSON.parse(read(REGISTRY)).workflows || {}; } catch {
+    fails.push({ check: 'G', kind: 'registry-ilegivel', msg: `${REGISTRY} não parseia como JSON.` });
+    return;
+  }
+  const files = readdirSync(join(ROOT, wfDir)).filter((f) => f.endsWith('.yml') || f.endsWith('.yaml'));
+  const fora = files.filter((f) => !(f in reg));
+  if (fora.length) {
+    fails.push({ check: 'G', kind: 'workflow-fora-do-registry', count: fora.length,
+      msg: `workflow(s) NOVO(s) sem registro no censo de gates (${REGISTRY}): ${fora.join(', ')} — registre nome+classe+propósito no MESMO PR.` });
+  }
+  const orfas = Object.keys(reg).filter((f) => !files.includes(f));
+  if (orfas.length) {
+    warns.push({ check: 'G', kind: 'registry-entrada-orfa', count: orfas.length,
+      msg: `entrada(s) do registry sem workflow correspondente: ${orfas.join(', ')} — remova do censo.` });
+  }
+}
+
+// ── Check H: frescor de doc-cache "✓lido @main <data>" (Onda Q5) ────────────
+// Censos/tabelas derivadas carregam carimbo de leitura contra o main. Carimbo
+// >14 dias = a "verdade cacheada" provavelmente driftou → 🟡 revalidar.
+function checkLidoFreshness() {
+  const LIMIT_DAYS = 14;
+  const stamps = [];
+  for (const dir of ['memory', 'prototipo-ui']) {
+    for (const f of listFiles(dir, (p) => p.endsWith('.md'))) {
+      let content; try { content = read(f); } catch { continue; }
+      for (const m of content.matchAll(/✓\s*lido\s*@?main[^\d]{0,20}(\d{4}-\d{2}-\d{2})/gi)) {
+        stamps.push({ file: f, date: m[1] });
+      }
+    }
+  }
+  const today = new Date();
+  const old = stamps.filter((s) => (today - new Date(s.date)) / 86400000 > LIMIT_DAYS);
+  if (old.length) {
+    const sample = old.slice(0, 5).map((s) => `${s.file} (${s.date})`).join(' · ');
+    warns.push({ check: 'H', kind: 'doc-cache-stale', count: old.length,
+      msg: `carimbo(s) "✓lido @main" com mais de ${LIMIT_DAYS} dias: ${sample}${old.length > 5 ? ` … +${old.length - 5}` : ''} — revalidar contra o main e re-carimbar.` });
+  }
+}
+
+// ── Check I: lição sem asserção (Onda Q5) ───────────────────────────────────
+// Lição em memory/LICOES_CC.md que não aponta gate/G#/IT# nem se declara
+// `não-mecanizável:` é lição que vai morrer no tempo (DESIGN.md §16.2 provou).
+function checkLicaoSemAssercao() {
+  const FILE = 'memory/LICOES_CC.md';
+  if (!exists(FILE)) return;
+  const content = read(FILE);
+  const blocks = content.split(/^## (?=L-\d)/m).slice(1);
+  const sem = [];
+  for (const b of blocks) {
+    const id = (b.match(/^L-\d+[a-z]?/) || ['?'])[0];
+    if (!/\bG-?\d|\bIT-?\d|gate|guard|ratchet|catraca|não-mecanizável\s*:|nao-mecanizavel\s*:/i.test(b)) sem.push(id);
+  }
+  if (sem.length) {
+    warns.push({ check: 'I', kind: 'licao-sem-assercao', count: sem.length,
+      msg: `lição(ões) sem gate/G#/IT# nem marcador \`não-mecanizável:\`: ${sem.slice(0, 8).join(', ')}${sem.length > 8 ? ` … +${sem.length - 8}` : ''} — toda lição aponta o check que a mecaniza OU se declara não-mecanizável.` });
+  }
+}
+
 // ── run ─────────────────────────────────────────────────────────────────────
 checkAdrCollisions();
 checkScorecardFantasma();
@@ -234,6 +308,9 @@ checkSecretsInMemory();
 checkStaleCanon();
 checkAdrEnumDrift();
 checkAntiResurrection();
+checkGatesRegistry();
+checkLidoFreshness();
+checkLicaoSemAssercao();
 
 if (UPDATE_BASELINE) {
   writeFileSync(join(ROOT, BASELINE_FILE), JSON.stringify({ checkC: checkCByFile }, null, 2) + '\n');

--- a/tests/memoryHealth.spec.ts
+++ b/tests/memoryHealth.spec.ts
@@ -1,0 +1,115 @@
+// Camada META — teste FÍSICO (caixa-preta) dos checks G/H/I do memory-health (Onda Q5).
+//
+// Método ADR 0258: todo check é visto FALHAR (sensibilidade) e PASSAR (especificidade)
+// num fixture físico antes de valer. Roda o .mjs real (subprocess) num dir temporário.
+//
+// Cobre: scripts/governance/memory-health.mjs (Check G registry de gates · Check H
+// frescor "✓lido @main" · Check I lição sem asserção).
+// Refs: ADR 0256 · ADR 0258 · padrão casosGuard.spec.ts / dominioGuard.spec.ts.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+
+const REPO = process.cwd();
+const HEALTH = resolve(REPO, 'scripts/governance/memory-health.mjs');
+
+let tmp: string;
+
+const write = (rel: string, content: string) => {
+  const full = join(tmp, rel);
+  mkdirSync(dirname(full), { recursive: true });
+  writeFileSync(full, content);
+};
+
+const registry = (workflows: Record<string, unknown>) =>
+  write('scripts/governance/gates-registry.json', JSON.stringify({ workflows }, null, 2));
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), 'memhealth-'));
+  mkdirSync(join(tmp, 'memory'), { recursive: true });
+});
+afterEach(() => rmSync(tmp, { recursive: true, force: true }));
+
+const run = (args = '--json') =>
+  execSync(`node "${HEALTH}" ${args}`, { cwd: tmp, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+const runExpectFail = (args = '--json'): string => {
+  try {
+    run(args);
+    throw new Error('esperava exit 1, mas passou');
+  } catch (e: any) {
+    if (e?.message === 'esperava exit 1, mas passou') throw e;
+    return (e.stdout || '') + (e.stderr || '');
+  }
+};
+
+describe('memory-health — Check G: registry canônico de gates (Onda Q5, físico)', () => {
+  it('SENSIBILIDADE: workflow NOVO fora do registry → 🔴 fail citando o arquivo', () => {
+    write('.github/workflows/gate-novo.yml', 'name: x\non: pull_request\n');
+    registry({}); // censo vazio — gate-novo.yml não registrado
+    const out = runExpectFail();
+    expect(out).toMatch(/workflow-fora-do-registry/);
+    expect(out).toMatch(/gate-novo\.yml/);
+  });
+
+  it('ESPECIFICIDADE: workflow registrado no censo → sem fail G', () => {
+    write('.github/workflows/gate-novo.yml', 'name: x\non: pull_request\n');
+    registry({ 'gate-novo.yml': { nome: 'x', classe: 'gate' } });
+    const out = run();
+    expect(out).not.toMatch(/workflow-fora-do-registry/);
+  });
+
+  it('SENSIBILIDADE: registry ausente com workflows presentes → 🔴 registry-ausente', () => {
+    write('.github/workflows/gate-novo.yml', 'name: x\n');
+    const out = runExpectFail();
+    expect(out).toMatch(/registry-ausente/);
+  });
+
+  it('🟡 entrada órfã (workflow apagado, censo não atualizado) → warn, não fail', () => {
+    mkdirSync(join(tmp, '.github/workflows'), { recursive: true });
+    registry({ 'apagado.yml': { nome: 'morto', classe: 'gate' } });
+    const out = run();
+    expect(out).toMatch(/registry-entrada-orfa/);
+    expect(out).toMatch(/"ok": true/); // warn não bloqueia
+  });
+});
+
+describe('memory-health — Check H: frescor "✓lido @main" (Onda Q5, físico)', () => {
+  it('SENSIBILIDADE: carimbo com >14 dias → 🟡 doc-cache-stale', () => {
+    write('memory/censo-gates.md', '# censo\n\n✓lido @main 2026-01-01\n');
+    const out = run();
+    expect(out).toMatch(/doc-cache-stale/);
+    expect(out).toMatch(/censo-gates\.md/);
+  });
+
+  it('ESPECIFICIDADE: carimbo fresco (hoje) → sem warn H', () => {
+    const hoje = new Date().toISOString().slice(0, 10);
+    write('memory/censo-gates.md', `# censo\n\n✓lido @main ${hoje}\n`);
+    const out = run();
+    expect(out).not.toMatch(/doc-cache-stale/);
+  });
+});
+
+describe('memory-health — Check I: lição sem asserção (Onda Q5, físico)', () => {
+  it('SENSIBILIDADE: lição sem gate/G#/IT# nem `não-mecanizável:` → 🟡 citando o id', () => {
+    write('memory/LICOES_CC.md', '# lições\n\n## L-99 — esqueci de tudo\n- **Erro:** x\n- **Regra:** prestar atenção.\n');
+    const out = run();
+    expect(out).toMatch(/licao-sem-assercao/);
+    expect(out).toMatch(/L-99/);
+  });
+
+  it('ESPECIFICIDADE: lição apontando gate (G-7) passa limpa', () => {
+    write('memory/LICOES_CC.md', '# lições\n\n## L-98 — status mentia\n- **Regra:** veredito vem do manifesto G-7.\n');
+    const out = run();
+    expect(out).not.toMatch(/licao-sem-assercao/);
+  });
+
+  it('ESPECIFICIDADE: lição declarada `não-mecanizável:` passa limpa', () => {
+    write('memory/LICOES_CC.md', '# lições\n\n## L-97 — tom de conversa\n- não-mecanizável: julgamento humano.\n');
+    const out = run();
+    expect(out).not.toMatch(/licao-sem-assercao/);
+  });
+});


### PR DESCRIPTION
## Onda Q5 — sobrevivência no tempo ("regra que ninguém cobra morre")

Passo 0 auditado: governance-drift (ADR 0216, DriftCheckers + daily) e memory-health (ADR 0256, checks A-F) já são substantivos; casos-meta-gate e dominio-meta-gate já provam os guards. O que FALTAVA — 3 checks novos no `memory-health` (roda em **todo PR** via umbrella + daily 06h30):

- **Check G (🔴 fail-class)** — censo canônico [`scripts/governance/gates-registry.json`](scripts/governance/gates-registry.json): **54 workflows registrados** (nome+classe). Workflow NOVO fora do registry = vermelho mecânico (pega gate novo); entrada órfã = 🟡.
- **Check H (🟡)** — carimbo `✓lido @main <data>` com >14 dias = amarelo (censos/tabelas derivadas têm prazo de validade).
- **Check I (🟡)** — lição em `memory/LICOES_CC.md` sem gate/G#/IT# nem `não-mecanizável:` = amarelo (14 atuais sinalizadas — é dívida visível, não bloqueio).

### Prova 2 lados (controle-negativo de CADA meta-check — mandato Q5)
`tests/memoryHealth.spec.ts` — **9 meta-testes físicos** (G: fora-do-registry 🔴 / registrado 🟢 / registry-ausente 🔴 / órfã 🟡 · H: stale 🟡 / fresco 🟢 · I: sem-asserção 🟡 / cita G-7 🟢 / não-mecanizável 🟢). Wired no umbrella (`test:memory-health`). Repo real: `ok: true` (0 fails, 3 warns informativos).

Refs: ONDAS-QUALIDADE Q5 · ADR 0256 · ADR 0258 · ADR 0216

🤖 Generated with [Claude Code](https://claude.com/claude-code)