### PR TITLE
ci(financeiro): workflow_dispatch pra rodar resync-from-core na prod (incidente num_uf biz=4)

### DIFF
--- a/.github/workflows/run-financeiro-resync.yml
+++ b/.github/workflows/run-financeiro-resync.yml
@@ -1,0 +1,100 @@
+name: Run financeiro:resync-from-core (one-shot)
+
+# Workflow_dispatch dedicado pra rodar `financeiro:resync-from-core` no Hostinger
+# prod. Corrige o resíduo do incidente num_uf (#2279/#2280): fin_titulos inflados
+# que o fix do core (UPDATE direto, sem Observer) deixou desincronizados. Roda o
+# comando REAL testado (PR #2576) — append-only, idempotente, activity_log,
+# reversível (metadata.valor_total_antigo). Não há SQL ad-hoc aqui.
+#
+# DRY-RUN sempre roda (preview no log). `apply=true` exige escolha explícita no
+# dispatch. Tier 0: business_id obrigatório, sem default.
+#
+# Wagner 2026-06-11: corrigir A RECEBER R$ 50,8M → ~R$ 421k em biz=4 (ROTA LIVRE).
+# Dependência de ordem: o core já foi corrigido em #2280 (sells:final-total-audit).
+
+on:
+  workflow_dispatch:
+    inputs:
+      business_id:
+        description: 'business_id alvo (Tier 0 — obrigatório, sem default)'
+        required: true
+        type: string
+      apply:
+        description: 'aplicar de verdade (true) ou só dry-run (false)'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  resync:
+    name: resync biz=${{ inputs.business_id }} apply=${{ inputs.apply }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: SSH helper
+        run: |
+          cat > /tmp/ssh_exec.sh <<'EOF'
+          #!/bin/bash
+          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=20 \
+              ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+              "$@"
+          EOF
+          chmod +x /tmp/ssh_exec.sh
+
+      - name: Pre-run check (comando deployado na prod?)
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan --version &&
+            php artisan list 2>&1 | grep -i 'resync-from-core' &&
+            ls -la Modules/Financeiro/Console/Commands/ResyncFromCoreCommand.php
+          "
+
+      - name: A RECEBER antes
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan tinker --execute=\"echo 'A receber ANTES biz=${{ inputs.business_id }}: ' . \Modules\Financeiro\Models\Titulo::withoutGlobalScopes()->where('business_id', ${{ inputs.business_id }})->where('tipo','receber')->whereIn('status',['aberto','parcial'])->sum('valor_aberto');\"
+          "
+
+      - name: DRY-RUN (sempre — preview)
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan financeiro:resync-from-core --business=${{ inputs.business_id }} --detail 2>&1 | tail -60
+          "
+
+      - name: APPLY (só se apply=true)
+        if: ${{ inputs.apply == 'true' }}
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan financeiro:resync-from-core --business=${{ inputs.business_id }} --apply --detail 2>&1 | tail -60
+          "
+
+      - name: A RECEBER depois (só se apply=true)
+        if: ${{ inputs.apply == 'true' }}
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan tinker --execute=\"echo 'A receber DEPOIS biz=${{ inputs.business_id }}: ' . \Modules\Financeiro\Models\Titulo::withoutGlobalScopes()->where('business_id', ${{ inputs.business_id }})->where('tipo','receber')->whereIn('status',['aberto','parcial'])->sum('valor_aberto');\"
+          "
+
+      - name: Done
+        run: echo "resync-from-core biz=${{ inputs.business_id }} apply=${{ inputs.apply }} concluido. Verificar /financeiro/unificado em prod."

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -198,6 +198,10 @@
       "nome": "Run FinanceiroDemoSeeder (one-shot)",
       "classe": "automacao"
     },
+    "run-financeiro-resync.yml": {
+      "nome": "Run financeiro:resync-from-core (one-shot · incidente num_uf)",
+      "classe": "automacao"
+    },
     "scope-guard.yml": {
       "nome": "Scope Guard (anti-drift)",
       "classe": "gate"


### PR DESCRIPTION
Workflow_dispatch que roda o comando **real testado** `financeiro:resync-from-core` (PR #2576) no Hostinger prod via SSH — **sem SQL ad-hoc**, escreve `activity_log`, append-only, idempotente, reversível.

- **DRY-RUN sempre** roda (preview dos 17 títulos no log).
- **`apply=true`** exige escolha explícita no dispatch.
- Mostra **A RECEBER antes/depois**.
- Pre-check garante que o comando está deployado antes de aplicar.
- Tier 0: `business_id` obrigatório, sem default.

Modelado em `run-financeiro-demo-seeder.yml` (mesmo canal SSH dos incidentes anteriores, ex #2280).

Uso: Actions → "Run financeiro:resync-from-core" → business_id=4, apply=false (preview) → depois apply=true.

Refs: #2576 #2279 #2280 · ADR 0093

🤖 Generated with [Claude Code](https://claude.com/claude-code)