### PR TITLE
test(q4): PROVA SINTÉTICA — NÃO MERGEAR — pixel-diff deve acusar h1 vermelho

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -1048,7 +1048,7 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
             tabs ao lado de Filtros avançados — Wagner 2026-05-21). */}
         <header className="os-head vd-head-clean">
           <div className="os-head-l">
-            <h1>Vendas</h1>
+            <h1 style={{ color: 'red' }}>Vendas</h1>
             {/* PR 1666 — header subtitle métrica live (paridade prototipo Cowork).
                 Substitui string estática por agregados do payload atual.
                 Fallback elegante quando rows ainda não carregaram. */}


### PR DESCRIPTION
## ⚠️ PR de prova — será FECHADO sem merge

Prova de **SENSIBILIDADE** do gate de pixel (Onda Q4, mandato regra 3): `h1` da lista de Vendas pintado de vermelho — mudança **só visual** (texto intacto → e2e textual UC-S10 segue verde; quem acusa é o pixel-diff núcleo-6).

**Esperado:** step `Pixel-diff núcleo-6 (ADVISORY)` com veredito 🟡 `PIXEL-DIFF ADVISORY FALHOU` + artifact `pixel-diff-views` mostrando o diff no header.
**Especificidade** já provada: run [27371559873](https://github.com/wagnerra23/oimpresso.com/actions/runs/27371559873) verde contra as baselines commitadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)