### PR TITLE
ci(fv-f1): coleta JUnit da suite — upload always() + sumario JSON por arquivo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main, 6.7-react]
   pull_request:
+  # FV-F1 (plano SDD 2026-06-12 semana 0): dispatch manual pra provar a coleta
+  # JUnit sem depender de PR (artefato pest-ci-junit >0 bytes).
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -92,7 +95,30 @@ jobs:
         # OpenAI; ex "mentira do Sonnet", parecer PR #2270). Modules/Jana nao
         # esta no modules-pest.yml, entao ancoramos a
         # catraca aqui pra ela rodar de fato em todo PR.
-        run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage
+        # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
+        run: |
+          mkdir -p test-results
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage --log-junit test-results/junit.xml
+
+      # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
+      # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML
+      # antes do upload. Agora: sumário JSON por arquivo de teste com n_testcases
+      # checado contra o declarado no <testsuite> raiz (exit!=0 se XML ausente,
+      # 0 bytes ou incoerente) + upload com if: always() e if-no-files-found: error.
+      - name: Sumario JUnit por arquivo (junit-summary.mjs)
+        if: always()
+        run: node scripts/tests/junit-summary.mjs test-results/junit.xml --out test-results/junit-summary.json
+
+      - name: Upload JUnit + sumario (sempre — a falha E o dado)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pest-ci-junit
+          path: |
+            test-results/junit.xml
+            test-results/junit-summary.json
+          retention-days: 14
+          if-no-files-found: error
 
   frontend:
     name: Frontend / Vite build

--- a/scripts/tests/junit-summary.mjs
+++ b/scripts/tests/junit-summary.mjs
@@ -49,6 +49,10 @@ const norm = (p) => {
   if (!p) return null;
   let s = unesc(p).replace(/\\/g, '/');
   if (s.startsWith(cwdPrefix)) s = s.slice(cwdPrefix.length);
+  // Pest emite file="Path.php::it nome do teste" no <testcase> — corta o sufixo
+  // pra agregacao ser de fato POR ARQUIVO (validado no run 27415097837).
+  const sep = s.indexOf('::');
+  if (sep !== -1) s = s.slice(0, sep);
   return s;
 };
 

--- a/scripts/tests/junit-summary.mjs
+++ b/scripts/tests/junit-summary.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * junit-summary.mjs — sumário JSON por arquivo de teste a partir de JUnit XML (PHPUnit/Pest).
+ *
+ * Uso: node scripts/tests/junit-summary.mjs <junit.xml> [--out <summary.json>]
+ *
+ * Contrato (FV-F1 — plano SDD 2026-06-12, semana 0):
+ *   - XML ausente ou 0 bytes                       → exit 1 (tripwire do "artefato 0 bytes")
+ *   - 0 <testcase> ou contado != declarado no raiz → exit 2 (coleta incoerente)
+ *   - ok                                           → JSON em stdout (+ --out) e exit 0
+ *
+ * Zero deps (node >=18). NÃO inclui mensagens de falha no output — só contagens
+ * e paths de arquivo de teste (repo é PÚBLICO; anti-PII por construção).
+ */
+import { readFileSync, writeFileSync, existsSync, statSync, appendFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function fail(code, msg) {
+  console.error(`junit-summary: ${msg}`);
+  process.exit(code);
+}
+
+const args = process.argv.slice(2);
+const xmlPath = args[0];
+const outIdx = args.indexOf('--out');
+const outPath = outIdx !== -1 ? args[outIdx + 1] : null;
+
+if (!xmlPath) fail(1, 'uso: node scripts/tests/junit-summary.mjs <junit.xml> [--out <summary.json>]');
+if (!existsSync(xmlPath)) fail(1, `XML nao existe: ${xmlPath} (pest rodou com --log-junit apontando pra ca?)`);
+if (statSync(xmlPath).size === 0) fail(1, `XML tem 0 bytes: ${xmlPath} (processo morto antes do flush — o bug FV-F1 original)`);
+
+const raw = readFileSync(xmlPath, 'utf8');
+// PHPUnit escapa texto de failure/error (sem CDATA), mas removemos CDATA/comentarios
+// por seguranca antes do walker de tags.
+const xml = raw
+  .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+  .replace(/<!--[\s\S]*?-->/g, '')
+  .replace(/<\?[\s\S]*?\?>/g, '');
+
+const attr = (s, name) => {
+  const m = s.match(new RegExp(`\\b${name}="([^"]*)"`));
+  return m ? m[1] : null;
+};
+const unesc = (s) =>
+  s.replace(/&quot;/g, '"').replace(/&apos;/g, "'").replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
+
+const cwdPrefix = resolve(process.cwd()).replace(/\\/g, '/') + '/';
+const norm = (p) => {
+  if (!p) return null;
+  let s = unesc(p).replace(/\\/g, '/');
+  if (s.startsWith(cwdPrefix)) s = s.slice(cwdPrefix.length);
+  return s;
+};
+
+const tagRe = /<(\/?)([\w.:-]+)((?:"[^"]*"|'[^']*'|[^>"'])*?)(\/?)>/g;
+const files = new Map();
+const totals = { passed: 0, failed: 0, errors: 0, skipped: 0 };
+const suiteFileStack = [];
+let suiteDepth = 0;
+let declared = 0;
+let counted = 0;
+let current = null;
+let curStatus = null;
+
+function commitTestcase() {
+  if (!current) return;
+  counted++;
+  const entry =
+    files.get(current.file) ??
+    { file: current.file, tests: 0, passed: 0, failed: 0, errors: 0, skipped: 0, time: 0 };
+  entry.tests++;
+  entry[curStatus]++;
+  totals[curStatus]++;
+  entry.time += current.time;
+  files.set(current.file, entry);
+  current = null;
+  curStatus = null;
+}
+
+for (const m of xml.matchAll(tagRe)) {
+  const [, close, name, rawAttrs, selfClose] = m;
+  if (name === 'testsuite') {
+    if (close) {
+      suiteDepth--;
+      suiteFileStack.pop();
+    } else if (!selfClose) {
+      // soma so os <testsuite> de nivel raiz (filhos diretos de <testsuites>):
+      // e o total agregado que o PHPUnit declara — base do check de coerencia.
+      if (suiteDepth === 0) declared += parseInt(attr(rawAttrs, 'tests') ?? '0', 10) || 0;
+      suiteDepth++;
+      suiteFileStack.push(norm(attr(rawAttrs, 'file')));
+    }
+    continue;
+  }
+  if (name === 'testcase') {
+    if (!close) {
+      current = {
+        file: norm(attr(rawAttrs, 'file')) || [...suiteFileStack].reverse().find(Boolean) || '(sem arquivo)',
+        time: parseFloat(attr(rawAttrs, 'time') ?? '0') || 0,
+      };
+      curStatus = 'passed';
+      if (selfClose) commitTestcase();
+    } else {
+      commitTestcase();
+    }
+    continue;
+  }
+  if (current && !close) {
+    if (name === 'failure') curStatus = 'failed';
+    else if (name === 'error') curStatus = 'errors';
+    else if (name === 'skipped') curStatus = 'skipped';
+  }
+}
+
+const result = {
+  schema: 'junit-summary/v1',
+  generated_at: new Date().toISOString(),
+  source: xmlPath.replace(/\\/g, '/'),
+  n_testcases: counted,
+  n_testcases_declared: declared,
+  coherent: counted > 0 && counted === declared,
+  totals,
+  files: [...files.values()]
+    .sort((a, b) => a.file.localeCompare(b.file))
+    .map((f) => ({ ...f, time: Math.round(f.time * 1000) / 1000 })),
+};
+
+if (outPath) writeFileSync(outPath, JSON.stringify(result, null, 2) + '\n');
+console.log(JSON.stringify(result, null, 2));
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const lines = [
+    `### JUnit summary — ${counted} testcases (${result.coherent ? 'coerente' : 'INCOERENTE'})`,
+    '',
+    '| arquivo de teste | tests | pass | fail | err | skip |',
+    '|---|---:|---:|---:|---:|---:|',
+    ...result.files.map((f) => `| ${f.file} | ${f.tests} | ${f.passed} | ${f.failed} | ${f.errors} | ${f.skipped} |`),
+  ];
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n');
+}
+
+if (counted === 0) fail(2, 'XML existe mas tem 0 <testcase> — coleta quebrada (sintoma do artefato 0 bytes)');
+if (counted !== declared) fail(2, `incoerencia: contados ${counted} != declarados ${declared} no(s) <testsuite> raiz`);


### PR DESCRIPTION
## Frente FV — passo F1 (Semana 0 do plano SDD)

Plano-mãe: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` (§4 Semana 0, frente FV: "F1 fix artefato JUnit"). Porquê: `memory/sessions/2026-06-12-audit-sdd-pesquisa-reclassificacao.md` (achado 2: "nenhum run full-repo jamais foi salvo — artefato 0 bytes").

### Anti-stale (re-derivado de origin/main em 2026-06-12)
O plano dizia "--log-junit JÁ existe em algum workflow" — confere só pra `financeiro-pest.yml:211`. O run Pest do `ci.yml` (linha 95) **não tinha** `--log-junit` nem artefato nenhum. Este PR corrige a coleta no `ci.yml` (o workflow da suite que roda em TODO PR), sem mudar o subset de testes.

### O que muda
- **`--log-junit test-results/junit.xml`** no run Pest existente — subset de testes byte-a-byte INTACTO (só `mkdir` + flag de log).
- **`scripts/tests/junit-summary.mjs`** (novo, zero deps): sumário JSON por arquivo de teste (`tests/passed/failed/errors/skipped/time`) + check de coerência `n_testcases` contado vs declarado no `<testsuite>` raiz. Exit 1 se XML ausente/0 bytes (o bug original), exit 2 se incoerente. Não emite mensagens de falha — só contagens e paths (repo público, anti-PII).
- **Upload `pest-ci-junit`** com `if: always()` + `if-no-files-found: error` — a falha É o dado; artefato vazio agora QUEBRA o job em vez de subir 0 bytes silencioso.
- **`workflow_dispatch`** habilitado no CI pra provar a coleta sob demanda.

### DoD — como um workflow_dispatch produz artefato >0 bytes com n_testcases coerente
1. `gh workflow run CI --ref <branch>` (ou o próprio run de `pull_request` deste PR).
2. Pest roda o subset atual e o PHPUnit 12.5 escreve `test-results/junit.xml` ao final do run (inclusive com testes vermelhos — só processo morto perde o flush, e esse caso agora dá exit 1 no sumário).
3. `junit-summary.mjs` valida tamanho >0 e `n_testcases == tests=` do `<testsuite>` raiz; grava `junit-summary.json` e tabela no step summary.
4. Upload sobe XML + JSON sempre; se nada existir, `if-no-files-found: error` deixa o job vermelho (fim do 0-byte silencioso).

Selftest local (4 casos, output no PR thread da sessão): good→exit 0 coherent:true (5/5), 0 bytes→exit 1, ausente→exit 1, declarado 99 vs contado 5→exit 2.

Gates: `ci.yml` já registrado em `scripts/governance/gates-registry.json` (entrada "CI"); nenhum workflow novo criado. Mudança nasce sem alterar required-ness de nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)