### PR TITLE
feat(governance): hook red-first em modo WARN - advisory de nascenca (SDD FV-T0)

### DIFF
--- a/.claude/hooks/warn-red-first.ps1
+++ b/.claude/hooks/warn-red-first.ps1
@@ -1,0 +1,101 @@
+# warn-red-first.ps1 - PreToolUse (advisory - red-first WARN / SDD Semana 0 passo FV-T0)
+# Avisa quando Edit/Write toca arquivo de PRODUCAO (app/**, Modules/**/{Services,Entities,Http}/**)
+# sem nenhum teste (*Test.php) tocado/criado na sessao recente (uncommitted via git status
+# OU commitado na janela recente via git log). Ensina: escreva o teste que FALHA primeiro
+# (red), depois o codigo que o faz passar (green), depois refatore.
+#
+# Origem: plano-mae memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md
+#         (Semana 0, frente FV, passo T0) + audit 2026-06-12 P1 item 5 (red-first hook).
+# Padrao: segue nudge-test-contract-anchor.ps1 (advisory, fail-open, ASCII puro PS 5.1).
+#
+# ADVISORY DE NASCENCA: exit 0 SEMPRE, nunca bloqueia nesta fase (gates novos nascem advisory).
+#
+# CRITERIO DE PROMOCAO A BLOQUEADOR (escrito ANTES da medicao, anti promotion-fatigue):
+#   - Taxa de falso-positivo <10% medida em 14 dias de uso real.
+#     Falso-positivo = warn disparado em edicao que NAO precisava de teste novo
+#     (ex.: rename mecanico, fix de typo em string, codemod, hotfix com teste ja verde).
+#   - Promocao = PR + ADR propria + calendario de promocoes (max 1 promocao/semana,
+#     plano-mae secao 3 correcao 6). NUNCA flip silencioso.
+#   - Fase WARN deliberadamente LENIENTE: QUALQUER *Test.php tocado na sessao conta
+#     (nao exige nome correspondente). Estreitar pra correspondencia por nome e
+#     decisao da fase de promocao, com dados dos 14 dias.
+#
+# Env overrides (teste/tuning):
+#   OIMPRESSO_REDFIRST_MODE         = warn (default) | off
+#   OIMPRESSO_REDFIRST_REPO_ROOT    = raiz do repo git (default: 2 niveis acima deste script)
+#   OIMPRESSO_REDFIRST_WINDOW_HOURS = janela "sessao recente" pra commits (default 4)
+
+$ErrorActionPreference = 'SilentlyContinue'
+try {
+    if ($env:OIMPRESSO_REDFIRST_MODE -eq 'off') { exit 0 }
+
+    $raw = [Console]::In.ReadToEnd()
+    if (-not $raw) { exit 0 }
+    $payload = $raw | ConvertFrom-Json
+    $path = [string]$payload.tool_input.file_path
+    if (-not $path) { exit 0 }
+
+    # Normaliza separadores
+    $norm = $path -replace '\\', '/'
+
+    # Raiz do repo (override pra teste isolado em repo temporario)
+    $repoRoot = $env:OIMPRESSO_REDFIRST_REPO_ROOT
+    if (-not $repoRoot) {
+        $hooksDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+        $repoRoot = Split-Path (Split-Path $hooksDir -Parent) -Parent
+    }
+    $rootNorm = ($repoRoot -replace '\\', '/').TrimEnd('/')
+
+    # Caminho relativo a raiz (se absoluto dentro do repo)
+    $rel = $norm
+    if ($rel.StartsWith($rootNorm + '/', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $rel = $rel.Substring($rootNorm.Length + 1)
+    }
+
+    # Exclusoes: teste e markdown NUNCA disparam
+    if ($rel -match '(?i)Test\.php$') { exit 0 }
+    if ($rel -match '(?i)\.md$') { exit 0 }
+
+    # So arquivo de PRODUCAO: app/** ou Modules/<Mod>/(Services|Entities|Http)/** (.php)
+    $isProd = ($rel -match '(?i)^app/.+\.php$') -or
+              ($rel -match '(?i)^Modules/[^/]+/(Services|Entities|Http)/.+\.php$')
+    if (-not $isProd) { exit 0 }
+
+    # Janela da sessao recente (commits)
+    $hours = 4
+    if ($env:OIMPRESSO_REDFIRST_WINDOW_HOURS -match '^\d+$') {
+        $hours = [int]$env:OIMPRESSO_REDFIRST_WINDOW_HOURS
+    }
+
+    # 1) Teste tocado e ainda nao commitado (git status: modified/added/untracked)
+    # -uall: sem ele, dir untracked novo aparece como "?? tests/" e o *Test.php dentro some
+    $touched = @()
+    $statusOut = & git -C $repoRoot status --porcelain -uall 2>$null
+    if ($statusOut) {
+        $touched += @($statusOut | Where-Object { $_ -match '(?i)Test\.php$' })
+    }
+
+    # 2) Teste commitado dentro da janela recente
+    if ($touched.Count -eq 0) {
+        $logOut = & git -C $repoRoot log --since="$hours hours ago" --name-only --pretty=format: 2>$null
+        if ($logOut) {
+            $touched += @($logOut | Where-Object { $_ -match '(?i)Test\.php$' })
+        }
+    }
+
+    # Red-first cumprido nesta fase: algum teste foi tocado na sessao recente
+    if ($touched.Count -gt 0) { exit 0 }
+
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($rel)
+
+    Write-Host ""
+    Write-Host "[RED-FIRST - advisory / SDD FV-T0]"
+    Write-Host "  Voce vai editar codigo de PRODUCAO ($rel) sem nenhum teste tocado nesta sessao."
+    Write-Host "  Escreva o teste que FALHA primeiro: crie/ajuste ${base}Test.php, rode, veja"
+    Write-Host "  VERMELHO, e so entao escreva o codigo que o faz passar (red -> green -> refactor)."
+    Write-Host "  Teste escrito DEPOIS do codigo tende a copiar o comportamento atual (tautologico)."
+    Write-Host "  Aviso advisory - exit 0, nao bloqueia nada nesta fase."
+    Write-Host "  Ref: plano SDD memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md (FV-T0)."
+    Write-Host ""
+    exit 0
+} catch { exit 0 }

--- a/.claude/hooks/warn-red-first.test.ps1
+++ b/.claude/hooks/warn-red-first.test.ps1
@@ -1,0 +1,150 @@
+# Smoke test -- warn-red-first.ps1 (SDD FV-T0)
+# Roda: powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/warn-red-first.test.ps1
+#
+# Usa repos git TEMPORARIOS como fixture (OIMPRESSO_REDFIRST_REPO_ROOT) pra que o
+# estado do repo real nao contamine o resultado (deterministico em qualquer maquina).
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path $MyInvocation.MyCommand.Path -Parent
+$hook = Join-Path $here 'warn-red-first.ps1'
+
+$failures = 0
+$total = 0
+
+function New-FixtureRepo {
+    param([switch]$WithUncommittedTest, [switch]$WithCommittedTest)
+
+    $dir = Join-Path $env:TEMP ("redfirst-fixture-" + [Guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    # NAO usar 2>$null em git nativo aqui: PS 5.1 + ErrorActionPreference Stop converte
+    # stderr redirecionado em NativeCommandError fatal. Config local neutraliza CRLF global.
+    & git -C $dir init -q
+    & git -C $dir config user.email "test@local"
+    & git -C $dir config user.name "fixture"
+    & git -C $dir config core.autocrlf false
+    & git -C $dir config core.safecrlf false
+    & git -C $dir config commit.gpgsign false
+
+    # Commit base SEM teste (so um arquivo de producao + readme)
+    New-Item -ItemType Directory -Path (Join-Path $dir 'app/Services') -Force | Out-Null
+    Set-Content -Path (Join-Path $dir 'app/Services/Foo.php') -Value '<?php class Foo {}' -Encoding Ascii
+    Set-Content -Path (Join-Path $dir 'README.txt') -Value 'fixture' -Encoding Ascii
+    & git -C $dir add -A
+    & git -C $dir commit -q -m "base sem teste"
+
+    if ($WithCommittedTest) {
+        New-Item -ItemType Directory -Path (Join-Path $dir 'tests/Unit') -Force | Out-Null
+        Set-Content -Path (Join-Path $dir 'tests/Unit/FooTest.php') -Value '<?php class FooTest {}' -Encoding Ascii
+        & git -C $dir add -A
+        & git -C $dir commit -q -m "teste recem commitado"
+    }
+
+    if ($WithUncommittedTest) {
+        New-Item -ItemType Directory -Path (Join-Path $dir 'tests/Unit') -Force | Out-Null
+        Set-Content -Path (Join-Path $dir 'tests/Unit/BarTest.php') -Value '<?php class BarTest {}' -Encoding Ascii
+        # fica untracked (aparece no git status --porcelain)
+    }
+
+    return $dir
+}
+
+function Test-Hook {
+    param([string]$Name, [string]$FilePath, [string]$RepoRoot, [bool]$ExpectWarn, [string]$Mode = 'warn')
+
+    $script:total++
+    $env:OIMPRESSO_REDFIRST_MODE = $Mode
+    $env:OIMPRESSO_REDFIRST_REPO_ROOT = $RepoRoot
+
+    $payload = @{ tool_name = 'Edit'; tool_input = @{ file_path = $FilePath } } | ConvertTo-Json -Compress -Depth 10
+    $output = $payload | & powershell -NoProfile -ExecutionPolicy Bypass -File $hook | Out-String
+    $exitCode = $LASTEXITCODE
+
+    $warned = $output -match '\[RED-FIRST'
+    $okExit = ($exitCode -eq 0)
+    $okWarn = ($warned -eq $ExpectWarn)
+
+    if ($okExit -and $okWarn) {
+        Write-Host "  OK  $Name (warn=$warned exit=$exitCode)"
+    } else {
+        Write-Host "  FAIL $Name -- expected warn=$ExpectWarn got warn=$warned exit=$exitCode" -ForegroundColor Red
+        $script:failures++
+    }
+}
+
+Write-Host "=== warn-red-first smoke (FV-T0) ==="
+
+# Fixtures
+$repoSemTeste = New-FixtureRepo
+$repoTesteUncommitted = New-FixtureRepo -WithUncommittedTest
+$repoTesteCommitado = New-FixtureRepo -WithCommittedTest
+
+# T1: producao app/** sem teste tocado -> WARN (exit 0)
+Test-Hook -Name 'T1 app-sem-teste WARN' `
+    -FilePath "$repoSemTeste/app/Services/Foo.php" -RepoRoot $repoSemTeste -ExpectWarn $true
+
+# T2: producao Modules/**/Services sem teste tocado -> WARN
+Test-Hook -Name 'T2 Modules-Services-sem-teste WARN' `
+    -FilePath "$repoSemTeste/Modules/Financeiro/Services/ContaService.php" -RepoRoot $repoSemTeste -ExpectWarn $true
+
+# T3: producao Modules/**/Http sem teste tocado -> WARN
+Test-Hook -Name 'T3 Modules-Http-sem-teste WARN' `
+    -FilePath "$repoSemTeste/Modules/Nfe/Http/Controllers/NotaController.php" -RepoRoot $repoSemTeste -ExpectWarn $true
+
+# T4: arquivo *Test.php (mesmo em path de producao) -> silencio
+Test-Hook -Name 'T4 Test.php-excluido silencio' `
+    -FilePath "$repoSemTeste/Modules/Nfe/Http/NotaTest.php" -RepoRoot $repoSemTeste -ExpectWarn $false
+
+# T5: arquivo .md em path de producao -> silencio
+Test-Hook -Name 'T5 markdown-excluido silencio' `
+    -FilePath "$repoSemTeste/app/Services/README.md" -RepoRoot $repoSemTeste -ExpectWarn $false
+
+# T6: fora de producao (resources/js) -> silencio
+Test-Hook -Name 'T6 fora-de-producao silencio' `
+    -FilePath "$repoSemTeste/resources/js/Pages/Foo/Index.tsx" -RepoRoot $repoSemTeste -ExpectWarn $false
+
+# T7: Modules fora de Services|Entities|Http (ex.: Database) -> silencio
+Test-Hook -Name 'T7 Modules-Database silencio' `
+    -FilePath "$repoSemTeste/Modules/Nfe/Database/Migrations/2026_01_01_foo.php" -RepoRoot $repoSemTeste -ExpectWarn $false
+
+# T8: teste UNCOMMITTED na sessao (git status) -> silencio (red-first cumprido)
+Test-Hook -Name 'T8 teste-uncommitted silencio' `
+    -FilePath "$repoTesteUncommitted/app/Services/Foo.php" -RepoRoot $repoTesteUncommitted -ExpectWarn $false
+
+# T9: teste COMMITADO na janela recente (git log) -> silencio
+Test-Hook -Name 'T9 teste-commitado-recente silencio' `
+    -FilePath "$repoTesteCommitado/app/Services/Foo.php" -RepoRoot $repoTesteCommitado -ExpectWarn $false
+
+# T10: modo off -> silencio mesmo sem teste
+Test-Hook -Name 'T10 modo-off silencio' `
+    -FilePath "$repoSemTeste/app/Services/Foo.php" -RepoRoot $repoSemTeste -ExpectWarn $false -Mode 'off'
+
+# T11: payload sem file_path -> silencio, exit 0 (fail-open)
+$script:total++
+$env:OIMPRESSO_REDFIRST_MODE = 'warn'
+$env:OIMPRESSO_REDFIRST_REPO_ROOT = $repoSemTeste
+$out11 = '{"tool_name":"Edit","tool_input":{}}' | & powershell -NoProfile -ExecutionPolicy Bypass -File $hook | Out-String
+if ($LASTEXITCODE -eq 0 -and $out11 -notmatch '\[RED-FIRST') {
+    Write-Host "  OK  T11 payload-sem-path fail-open"
+} else {
+    Write-Host "  FAIL T11 payload-sem-path -- exit=$LASTEXITCODE output=$out11" -ForegroundColor Red
+    $failures++
+}
+
+# T12: stdin vazio -> exit 0 (fail-open)
+$script:total++
+$out12 = '' | & powershell -NoProfile -ExecutionPolicy Bypass -File $hook | Out-String
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "  OK  T12 stdin-vazio fail-open"
+} else {
+    Write-Host "  FAIL T12 stdin-vazio -- exit=$LASTEXITCODE" -ForegroundColor Red
+    $failures++
+}
+
+# Cleanup fixtures + env
+Remove-Item -Recurse -Force $repoSemTeste, $repoTesteUncommitted, $repoTesteCommitado -ErrorAction SilentlyContinue
+$env:OIMPRESSO_REDFIRST_MODE = $null
+$env:OIMPRESSO_REDFIRST_REPO_ROOT = $null
+
+Write-Host ""
+Write-Host "Total: $total | Failures: $failures"
+if ($failures -gt 0) { exit 1 } else { exit 0 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -97,6 +97,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/nudge-test-contract-anchor.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/warn-red-first.ps1"
           }
         ]
       },


### PR DESCRIPTION
## Frente FV-T0 — Semana 0 da reestruturacao SDD

Plano-mae: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` — Semana 0, frente **FV**, passo **T0** ("red-first hook" — lacuna 1 dos criticos adversariais, secao 3; origem: audit `memory/sessions/2026-06-12-audit-sdd-pesquisa-reclassificacao.md` P1 item 5).

## O que faz

Hook PreToolUse `warn-red-first.ps1` em `Edit/Write/MultiEdit`:

- **Escopo**: arquivo de PRODUCAO — `app/**` e `Modules/**/{Services,Entities,Http}/**` (`.php`), excluindo `*Test.php` e `.md`.
- **Comportamento**: WARN quando nenhum `*Test.php` foi tocado/criado na sessao recente (uncommitted via `git status --porcelain -uall` OU commitado na janela de 4h via `git log --since`). Mensagem ensina: **escreva o teste que FALHA primeiro** (red -> green -> refactor).
- **ADVISORY DE NASCENCA**: `exit 0` SEMPRE — nunca bloqueia nesta fase (regra "gates novos nascem advisory").
- **Criterio de promocao a bloqueador** escrito no header do hook: taxa de falso-positivo <10% medida em 14 dias de uso real + PR + ADR propria + calendario de promocoes (max 1/semana, plano-mae secao 3 correcao 6).
- Segue o padrao exato do `nudge-test-contract-anchor.ps1` (advisory, fail-open try/catch, ASCII puro PS 5.1, `$raw` nao `$input`).
- Env overrides: `OIMPRESSO_REDFIRST_MODE` (warn|off), `OIMPRESSO_REDFIRST_REPO_ROOT`, `OIMPRESSO_REDFIRST_WINDOW_HOURS`.

## DoD — evidencia

`warn-red-first.test.ps1` — 12 casos com **repos git temporarios como fixture** (deterministico em qualquer maquina, estado do repo real nao contamina):

```
=== warn-red-first smoke (FV-T0) ===
  OK  T1 app-sem-teste WARN (warn=True exit=0)
  OK  T2 Modules-Services-sem-teste WARN (warn=True exit=0)
  OK  T3 Modules-Http-sem-teste WARN (warn=True exit=0)
  OK  T4 Test.php-excluido silencio (warn=False exit=0)
  OK  T5 markdown-excluido silencio (warn=False exit=0)
  OK  T6 fora-de-producao silencio (warn=False exit=0)
  OK  T7 Modules-Database silencio (warn=False exit=0)
  OK  T8 teste-uncommitted silencio (warn=False exit=0)
  OK  T9 teste-commitado-recente silencio (warn=False exit=0)
  OK  T10 modo-off silencio (warn=False exit=0)
  OK  T11 payload-sem-path fail-open
  OK  T12 stdin-vazio fail-open

Total: 12 | Failures: 0
```

Smoke end-to-end no repo real (cwd raiz, path relativo como no settings.json): warn emitido + `exit=0`. Latencia ~554ms (inclui startup do PowerShell). settings.json validado como JSON + hooks 0 bytes nao-ASCII (PS 5.1 safe).

## Notas

- Sem workflow CI novo → sem entry em `gates-registry.json`.
- 255 linhas, 1 intent, 3 arquivos (2 novos + 1 entry no settings.json).
- NAO mergear sem revisao Wagner (draft de proposito).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
