### PR TITLE
ci(sdd): foundation-ratchet FV-Q1 — catracas so-diminui da fundacao de testes (advisory)

### DIFF
--- a/.github/workflows/foundation-ratchet.yml
+++ b/.github/workflows/foundation-ratchet.yml
@@ -1,0 +1,38 @@
+name: Foundation Ratchet (advisory)
+
+# Catracas "só diminui" da fundação de testes — SDD Semana 0 · frente FV-Q1
+# (memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md §4).
+# 3 contadores congelados de medição REAL (scripts/tests/baselines/):
+#   n_quarantine · n_refresh_database · n_business_first — subir qualquer um = vermelho.
+# Convenção: marcador `@group legacy-quarantine` exige `quarantine-reason:` a ≤3 linhas.
+#
+# ADVISORY de nascença (gates novos nunca nascem required — método faseado ADR 0271):
+# não está no branch protection, nunca bloqueia merge. Promoção a required SÓ via
+# calendário de promoções do plano (§4 semanas 4-6, depois de R1). Always-run sem
+# paths = required-ready + contadores no job summary em TODO PR. Node puro, sem MySQL.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: foundation-ratchet-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ratchet:
+    name: Foundation ratchet (advisory · quarentena/RefreshDatabase/Business::first)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Selftest — fixtures boa/ruim provam que a catraca morde
+        run: node scripts/tests/foundation-ratchet.test.mjs
+      - name: Catraca vs baseline (+ contadores no job summary)
+        run: node scripts/tests/foundation-ratchet.mjs

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -106,6 +106,10 @@
       "nome": "Force Clean Rebuild (one-shot)",
       "classe": "automacao"
     },
+    "foundation-ratchet.yml": {
+      "nome": "Foundation ratchet (advisory · catracas só-diminui da fundação de testes — SDD FV-Q1)",
+      "classe": "gate"
+    },
     "governance-drift.yml": {
       "nome": "Governance Drift Framework — ADR 0216",
       "classe": "gate"

--- a/scripts/tests/baselines/foundation-ratchet-baseline.json
+++ b/scripts/tests/baselines/foundation-ratchet-baseline.json
@@ -1,0 +1,8 @@
+{
+  "generated_by": "scripts/tests/foundation-ratchet.mjs --write",
+  "counters": {
+    "n_quarantine": 0,
+    "n_refresh_database": 69,
+    "n_business_first": 96
+  }
+}

--- a/scripts/tests/fixtures/foundation-ratchet/bad/baseline.json
+++ b/scripts/tests/fixtures/foundation-ratchet/bad/baseline.json
@@ -1,0 +1,8 @@
+{
+  "nota": "baseline da fixture ruim — tudo 0 pra provar que SUBIR qualquer contador avermelha",
+  "counters": {
+    "n_quarantine": 0,
+    "n_refresh_database": 0,
+    "n_business_first": 0
+  }
+}

--- a/scripts/tests/fixtures/foundation-ratchet/bad/tests/Feature/QuarentenaSemRazaoTest.php
+++ b/scripts/tests/fixtures/foundation-ratchet/bad/tests/Feature/QuarentenaSemRazaoTest.php
@@ -1,0 +1,21 @@
+<?php
+
+// FIXTURE (ruim) do foundation-ratchet selftest — quarentena sem motivo escrito
+// e contadores acima do baseline (tudo 0). O gate TEM que ficar vermelho aqui.
+
+namespace FoundationRatchetFixtures\Bad;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group legacy-quarantine
+ */
+class QuarentenaSemRazaoTest
+{
+    use RefreshDatabase;
+
+    public function test_exemplo(): void
+    {
+        $business = \App\Business::first();
+    }
+}

--- a/scripts/tests/fixtures/foundation-ratchet/good/baseline.json
+++ b/scripts/tests/fixtures/foundation-ratchet/good/baseline.json
@@ -1,0 +1,8 @@
+{
+  "nota": "baseline da fixture boa — bate com a medição (1 quarentena com razão · 1 RefreshDatabase · 1 Business::first)",
+  "counters": {
+    "n_quarantine": 1,
+    "n_refresh_database": 1,
+    "n_business_first": 1
+  }
+}

--- a/scripts/tests/fixtures/foundation-ratchet/good/tests/Feature/ExemploQuarentenadoTest.php
+++ b/scripts/tests/fixtures/foundation-ratchet/good/tests/Feature/ExemploQuarentenadoTest.php
@@ -1,0 +1,22 @@
+<?php
+
+// FIXTURE (boa) do foundation-ratchet selftest — quarentena COM razão; contadores == baseline.
+// NÃO é teste real: vive fora dos roots escaneados (tests/ · Modules/*/Tests/) de propósito.
+
+namespace FoundationRatchetFixtures\Good;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group legacy-quarantine
+ * quarantine-reason: depende de seed global ausente no MySQL do CI — burn-down FV-B1.
+ */
+class ExemploQuarentenadoTest
+{
+    use RefreshDatabase;
+
+    public function test_exemplo(): void
+    {
+        $business = \App\Business::first();
+    }
+}

--- a/scripts/tests/foundation-ratchet.mjs
+++ b/scripts/tests/foundation-ratchet.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// scripts/tests/foundation-ratchet.mjs — catracas "só diminui" da fundação de testes (SDD Semana 0 · FV-Q1).
+//
+// POR QUE (memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md §4):
+// a full-suite nunca rodou verde em DB real. Antes da nightly diagnóstica medir, congelamos
+// 3 contadores REAIS (medidos no repo, não no plano — regra anti-stale) pra nenhum PR piorar:
+//   n_quarantine        — marcadores `legacy-quarantine` (burn-down: subir = regressão)
+//   n_refresh_database  — ARQUIVOS de teste com RefreshDatabase (alvo: DatabaseTransactions)
+//   n_business_first    — ocorrências de Business::first() cru em teste (alvo: trait WithSeededTenant)
+//
+// CONVENÇÃO QUARENTENA (hard-fail, independe de baseline): todo marcador exige
+// `quarantine-reason: <motivo>` a ≤3 linhas. Quarentena sem razão escrita é proibida.
+//
+// Determinístico, Node puro, sem MySQL, segundos. Espelha os ratchets do projeto (a11y/reuse/no-mock).
+// SUBIR baseline = SÓ `--write --force` (diff visível no PR — ex.: quarentena em massa Q3 planejada).
+//
+// USO:
+//   node scripts/tests/foundation-ratchet.mjs            # gate vs baseline (+ job summary se em CI)
+//   node scripts/tests/foundation-ratchet.mjs --json     # contadores em JSON
+//   node scripts/tests/foundation-ratchet.mjs --write    # (re)grava baseline — só pra DESCER
+//   ... --root <dir> --baseline <file>                   # fixtures/selftest (mesmo code path)
+
+import { appendFileSync, existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+
+const args = process.argv.slice(2);
+const opt = (n) => { const i = args.indexOf(n); return i >= 0 ? args[i + 1] : null; };
+const ROOT = opt('--root') || process.cwd();
+const BASELINE = opt('--baseline') || join(ROOT, 'scripts/tests/baselines/foundation-ratchet-baseline.json');
+
+const MARKER = /@group\s+legacy-quarantine\b|#\[Group\(['"]legacy-quarantine['"]\)\]|->group\(['"]legacy-quarantine['"]/;
+const REASON = /quarantine-reason:\s*\S/;
+
+// Roots canônicos: tests/ + Modules/<X>/Tests/. Comparação case-insensitive + readdir
+// (cada dir REAL visitado 1×) — imune ao alias NTFS Tests/tests que duplicaria contagem.
+function testRoots(root) {
+  const roots = [];
+  if (existsSync(join(root, 'tests'))) roots.push(join(root, 'tests'));
+  const mods = join(root, 'Modules');
+  if (!existsSync(mods)) return roots;
+  for (const m of readdirSync(mods, { withFileTypes: true })) {
+    if (!m.isDirectory()) continue;
+    for (const e of readdirSync(join(mods, m.name), { withFileTypes: true }))
+      if (e.isDirectory() && e.name.toLowerCase() === 'tests') roots.push(join(mods, m.name, e.name));
+  }
+  return roots;
+}
+function* phpFiles(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    if (e.isDirectory()) yield* phpFiles(join(dir, e.name));
+    else if (e.name.endsWith('.php')) yield join(dir, e.name);
+  }
+}
+
+function measure(root) {
+  const counters = { n_quarantine: 0, n_refresh_database: 0, n_business_first: 0 };
+  const semRazao = [];
+  for (const tr of testRoots(root)) for (const f of phpFiles(tr)) {
+    const src = readFileSync(f, 'utf8');
+    if (/\bRefreshDatabase\b/.test(src)) counters.n_refresh_database++;
+    counters.n_business_first += (src.match(/\bBusiness::first\s*\(/g) || []).length;
+    if (!MARKER.test(src)) continue;
+    const lines = src.split('\n');
+    lines.forEach((line, i) => {
+      if (!MARKER.test(line)) return;
+      counters.n_quarantine++;
+      if (!REASON.test(lines.slice(Math.max(0, i - 3), i + 4).join('\n')))
+        semRazao.push(`${relative(root, f).replace(/\\/g, '/')}:${i + 1}`);
+    });
+  }
+  return { counters, semRazao };
+}
+
+const { counters, semRazao } = measure(ROOT);
+
+if (args.includes('--json')) {
+  console.log(JSON.stringify({ counters, quarantine_sem_razao: semRazao }, null, 2));
+  process.exit(0);
+}
+
+if (args.includes('--write')) {
+  let prev = null;
+  try { prev = JSON.parse(readFileSync(BASELINE, 'utf8')).counters; } catch { /* 1ª medição */ }
+  const sobe = prev ? Object.keys(counters).filter((k) => counters[k] > prev[k]) : [];
+  if (sobe.length && !args.includes('--force')) {
+    console.error(`✗ --write recusado: ${sobe.join(', ')} SUBIRIA. Catraca só desce. Subida planejada (ex.: quarentena em massa Q3) = --write --force, visível no diff do PR.`);
+    process.exit(1);
+  }
+  mkdirSync(dirname(BASELINE), { recursive: true });
+  writeFileSync(BASELINE, JSON.stringify({ generated_by: 'scripts/tests/foundation-ratchet.mjs --write', counters }, null, 2) + '\n');
+  console.log(`✓ baseline gravado: ${JSON.stringify(counters)}${sobe.length ? ' (FORÇADO pra cima — justifique no PR)' : ''}`);
+  process.exit(0);
+}
+
+// gate (default)
+let baseline;
+try { baseline = JSON.parse(readFileSync(BASELINE, 'utf8')).counters; }
+catch { console.error(`✗ baseline ausente/ilegível (${BASELINE}). Rode: node scripts/tests/foundation-ratchet.mjs --write`); process.exit(2); }
+
+const rows = Object.keys(baseline).map((k) => {
+  const cur = counters[k] ?? 0; const base = baseline[k];
+  return { k, base, cur, status: cur > base ? 'SUBIU' : cur < base ? 'desceu' : 'ok' };
+});
+const pioras = rows.filter((r) => r.status === 'SUBIU');
+const fail = pioras.length > 0 || semRazao.length > 0;
+
+if (process.env.GITHUB_STEP_SUMMARY) {
+  const md = ['## Foundation ratchet (advisory · FV-Q1)', '', '| contador | baseline | atual | Δ |', '|---|---:|---:|---|',
+    ...rows.map((r) => `| ${r.k} | ${r.base} | ${r.cur} | ${r.cur > r.base ? `🔴 +${r.cur - r.base}` : r.cur < r.base ? `🟢 −${r.base - r.cur}` : '—'} |`),
+    semRazao.length ? `\n🔴 **quarentena sem \`quarantine-reason:\`** (${semRazao.length}): ${semRazao.join(' · ')}` : ''].join('\n');
+  appendFileSync(process.env.GITHUB_STEP_SUMMARY, md + '\n');
+}
+
+for (const r of rows) console.log(`  ${r.status === 'SUBIU' ? '✗' : '✓'} ${r.k}: ${r.cur} (baseline ${r.base})`);
+if (semRazao.length) console.error(`✗ marcador legacy-quarantine SEM quarantine-reason: a ≤3 linhas:\n  ${semRazao.join('\n  ')}`);
+if (fail) {
+  if (pioras.length) console.error(`✗ catraca FALHOU — fundação piorou: ${pioras.map((r) => `${r.k} ${r.base}→${r.cur}`).join(', ')}. Não adicione RefreshDatabase/Business::first() cru em teste novo (use DatabaseTransactions / trait de tenant seedado).`);
+  process.exit(1);
+}
+const ganho = rows.filter((r) => r.status === 'desceu');
+console.log(`✓ foundation ratchet OK${ganho.length ? ` — ↓ ${ganho.map((r) => r.k).join(', ')}: rode --write pra travar o ganho` : ''}.`);

--- a/scripts/tests/foundation-ratchet.test.mjs
+++ b/scripts/tests/foundation-ratchet.test.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// TESTE DE REGRESSÃO — prova que a catraca da fundação MORDE (plano SDD §2: "quem vigia os vigias").
+// Fixtures boa/ruim exercitam o MESMO code path do gate real (--root/--baseline). Sem rede, sem MySQL.
+// Rodar: node scripts/tests/foundation-ratchet.test.mjs — exit 0 = todos passam, exit 1 = regressão.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, 'foundation-ratchet.mjs');
+const FIX = join(__dirname, 'fixtures', 'foundation-ratchet');
+
+let fails = 0;
+const check = (name, cond) => { console.log(`${cond ? '[OK]' : '[FAIL]'} ${name}`); if (!cond) fails++; };
+const exec = (a, env = {}) => spawnSync('node', [SCRIPT, ...a], { encoding: 'utf8', env: { ...process.env, GITHUB_STEP_SUMMARY: '', ...env } });
+const run = (root, extra = [], env = {}) => exec(['--root', join(FIX, root), '--baseline', join(FIX, root, 'baseline.json'), ...extra], env);
+
+// 1. Fixture BOA: quarentena com razão, contadores == baseline → verde.
+check('boa → exit 0', run('good').status === 0);
+
+// 2. Fixture RUIM: 3 contadores acima do baseline + quarentena sem razão → vermelho acusando certo.
+const bad = run('bad');
+const out = (bad.stdout || '') + (bad.stderr || '');
+check('ruim → exit 1', bad.status === 1);
+check('ruim → acusa n_refresh_database 0→1', /n_refresh_database 0→1/.test(out));
+check('ruim → acusa n_business_first 0→1', /n_business_first 0→1/.test(out));
+check('ruim → acusa quarentena SEM quarantine-reason', /SEM quarantine-reason/.test(out));
+
+// 3. --json parseável e fiel à medição da fixture boa.
+const j = JSON.parse(run('good', ['--json']).stdout);
+check('--json: boa mede 1/1/1', j.counters.n_quarantine === 1 && j.counters.n_refresh_database === 1 && j.counters.n_business_first === 1);
+
+// 4. Catraca de ESCRITA: --write recusa SUBIR sem --force (baseline intacto); --force grava.
+const tmp = mkdtempSync(join(tmpdir(), 'fr-'));
+const tmpBl = join(tmp, 'baseline.json');
+const zeros = { counters: { n_quarantine: 0, n_refresh_database: 0, n_business_first: 0 } };
+writeFileSync(tmpBl, JSON.stringify(zeros));
+const refuse = exec(['--root', join(FIX, 'good'), '--baseline', tmpBl, '--write']);
+check('--write que sobe → recusado (exit 1)', refuse.status === 1 && /recusado/.test(refuse.stderr));
+check('--write recusado → baseline intacto', JSON.parse(readFileSync(tmpBl, 'utf8')).counters.n_quarantine === 0);
+const forced = exec(['--root', join(FIX, 'good'), '--baseline', tmpBl, '--write', '--force']);
+check('--write --force → grava (exit 0)', forced.status === 0 && JSON.parse(readFileSync(tmpBl, 'utf8')).counters.n_quarantine === 1);
+
+// 5. MELHORA (contador < baseline) → verde + convite pra travar o ganho via --write.
+writeFileSync(tmpBl, JSON.stringify({ counters: { n_quarantine: 2, n_refresh_database: 2, n_business_first: 2 } }));
+const melhora = exec(['--root', join(FIX, 'good'), '--baseline', tmpBl]);
+check('melhora → exit 0 + convite --write', melhora.status === 0 && /--write pra travar/.test(melhora.stdout));
+
+// 6. Job summary: contadores aparecem em tabela quando GITHUB_STEP_SUMMARY existe.
+const sum = join(tmp, 'summary.md');
+writeFileSync(sum, '');
+run('bad', [], { GITHUB_STEP_SUMMARY: sum });
+const md = readFileSync(sum, 'utf8');
+check('summary → tabela com contadores + sem-razão', /n_quarantine/.test(md) && /quarantine-reason/.test(md));
+
+console.log('');
+if (fails === 0) { console.log('[PASS] catraca MORDE — subir = vermelho, sem razão = vermelho, --write só desce. (10/10)'); process.exit(0); }
+console.log(`[FAIL] ${fails} caso(s) — a catraca NÃO está garantida. NÃO mergear.`);
+process.exit(1);


### PR DESCRIPTION
## O quê

Frente **FV-Q1** da **Semana 0** do plano-mãe da reestruturação SDD ([memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md](../blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) §4 — "FV: ... Q1 catracas quarentena"): mecanismo de quarentena + catracas "só diminui" da fundação de testes.

- **`scripts/tests/foundation-ratchet.mjs`** — ratchet determinístico (Node puro, sem MySQL, **0.15s**) com 3 contadores que **só diminuem**:
  - `n_quarantine` — marcadores `legacy-quarantine` (PHPDoc `@group`, atributo `#[Group(...)]` ou Pest `->group(...)`)
  - `n_refresh_database` — arquivos de teste com `RefreshDatabase` (alvo da conversão: `DatabaseTransactions`)
  - `n_business_first` — ocorrências de `Business::first()` cru em teste (alvo: trait de tenant seedado)
- **Convenção de quarentena**: todo marcador exige `quarantine-reason: <motivo>` a ≤3 linhas — quarentena sem razão escrita = hard-fail, independe de baseline.
- **Catraca de escrita**: `--write` só DESCE baseline; subida planejada (quarentena em massa Q3) exige `--write --force`, visível no diff do PR.
- **`.github/workflows/foundation-ratchet.yml`** — **ADVISORY de nascença** (método faseado ADR 0271, NÃO entra no branch protection; promoção só via calendário de promoções do plano §4 semanas 4-6, depois de R1). Always-run sem paths = required-ready + contadores em tabela no job summary de **todo PR**.
- Registrado em `scripts/governance/gates-registry.json` (regra memory-health Check G).

## Baselines REAIS (regra anti-stale — re-derivados de origin/main, não do plano)

| contador | plano dizia | medição real congelada |
|---|---|---|
| n_quarantine | — (convenção nova) | **0** |
| n_refresh_database | — | **69 arquivos** |
| n_business_first | "78 arquivos" | **96 ocorrências** |

Cross-check duplo: walk readdir do script (imune ao alias NTFS `Tests/tests` que inflava o rg pra 157) × `git ls-files + grep` = **96 = 96** exato; RefreshDatabase 69 vs 68 (delta = `tests/Pest.php`, top-level que o pathspec `tests/**/*.php` não pega — script correto).

## Prova (DoD)

Selftest `scripts/tests/foundation-ratchet.test.mjs` (padrão hooks `.test` do repo) — fixtures boa/ruim no **mesmo code path** do gate real:

```
[OK] boa → exit 0
[OK] ruim → exit 1
[OK] ruim → acusa n_refresh_database 0→1
[OK] ruim → acusa n_business_first 0→1
[OK] ruim → acusa quarentena SEM quarantine-reason
[OK] --json: boa mede 1/1/1
[OK] --write que sobe → recusado (exit 1)
[OK] --write recusado → baseline intacto
[OK] --write --force → grava (exit 0)
[OK] melhora → exit 0 + convite --write
[OK] summary → tabela com contadores + sem-razão
[PASS] catraca MORDE — subir = vermelho, sem razão = vermelho, --write só desce. (10/10)
```

Gate real no repo: `✓ 0/69/96 (baseline 0/69/96)` em 0.15s. `memory-health.mjs`: 0 🔴 (Check G ok). Diff: **292 linhas** (≤300), 1 intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)