### PR TITLE
ci(financeiro-pest): extrai composite action pest-mysql-setup + seed biz=2 (FV-F2)

### DIFF
--- a/.github/actions/pest-mysql-setup/action.yml
+++ b/.github/actions/pest-mysql-setup/action.yml
@@ -1,0 +1,164 @@
+# Composite action — setup canônico pra rodar Pest contra MySQL REAL.
+# Extraída de financeiro-pest.yml (FV-F2, plano SDD 2026-06-12) pra reuso
+# pelas lanes de burn-down por módulo (FV B1/B2/...) sem copy-paste.
+#
+# ⚠️ LIMITAÇÃO GitHub Actions: composite action NÃO pode declarar `services:`
+# (service containers são job-level). O JOB CONSUMIDOR DEVE declarar o service
+# mysql:8.0 com MYSQL_ROOT_PASSWORD/MYSQL_DATABASE compatíveis com os inputs
+# (ver .github/workflows/financeiro-pest.yml — bloco `services.mysql`).
+# Esta action cobre o resto: PHP + deps + .env + migrate + seed multi-tenant.
+#
+# Usa o SCHEMA BASELINE (database/schema/mysql-schema.sql, gerado via schema:dump
+# da prod 2026-06-04 com as 820 migrations registradas). `migrate` carrega o
+# schema final num passo só + roda só as migrations novas → sem o problema de
+# fresh-install (FK ordering / type-mismatch) que as migrations legacy têm.
+
+name: 'Pest MySQL Setup'
+description: >-
+  PHP 8.4 + Composer + .env MySQL + migrate (schema baseline) + seed mínimo
+  multi-tenant: biz=1 (fixture completa) E biz=2 (Tier 0 cross-tenant).
+  Requer service container MySQL declarado no job consumidor.
+
+inputs:
+  php-version:
+    description: 'Versão do PHP'
+    required: false
+    default: '8.4'
+  db-host:
+    description: 'Host do MySQL (service container)'
+    required: false
+    default: '127.0.0.1'
+  db-port:
+    description: 'Porta do MySQL'
+    required: false
+    default: '3306'
+  db-database:
+    description: 'Database de teste'
+    required: false
+    default: 'oimpresso_test'
+  db-username:
+    description: 'Usuário do MySQL'
+    required: false
+    default: 'root'
+  db-password:
+    description: 'Senha do MySQL (a do service container CI, não-secreta)'
+    required: false
+    default: 'root'
+
+runs:
+  using: composite
+  steps:
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: bcmath, ctype, dom, fileinfo, intl, json, mbstring, openssl, pdo, pdo_mysql, tokenizer, xml, zip, gd, opentelemetry
+        tools: composer:v2
+        coverage: none
+
+    - name: Cache Composer
+      uses: actions/cache@v4
+      with:
+        path: ~/.composer/cache
+        key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+        restore-keys: composer-${{ runner.os }}-
+
+    - name: Prepare dirs
+      shell: bash
+      run: mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+
+    - name: Install PHP deps
+      shell: bash
+      run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+    - name: Wait for MySQL
+      shell: bash
+      run: |
+        for i in $(seq 1 30); do
+          if mysqladmin ping -h${{ inputs.db-host }} -u${{ inputs.db-username }} -p${{ inputs.db-password }} --silent; then echo "MySQL up"; break; fi
+          echo "waiting mysql ($i)"; sleep 2
+        done
+
+    - name: Create .env (MySQL)
+      shell: bash
+      run: |
+        # ${{ inputs.* }} é substituído pelo runner ANTES do bash — heredoc quoted ok.
+        cat > .env <<'EOF'
+        APP_NAME=oimpresso-fin
+        APP_ENV=testing
+        APP_KEY=
+        APP_DEBUG=true
+        APP_URL=http://localhost
+        LOG_CHANNEL=stderr
+        DB_CONNECTION=mysql
+        DB_HOST=${{ inputs.db-host }}
+        DB_PORT=${{ inputs.db-port }}
+        DB_DATABASE=${{ inputs.db-database }}
+        DB_USERNAME=${{ inputs.db-username }}
+        DB_PASSWORD=${{ inputs.db-password }}
+        CACHE_DRIVER=array
+        QUEUE_CONNECTION=sync
+        SESSION_DRIVER=array
+        MAIL_MAILER=array
+        BCRYPT_ROUNDS=4
+        TELESCOPE_ENABLED=false
+        SCOUT_DRIVER=null
+        MCP_TOOLS_EXPOSED=false
+        EOF
+        php artisan key:generate --force
+        php artisan package:discover --ansi
+
+    - name: Migrate (carrega schema baseline + migrations novas)
+      # Com database/schema/mysql-schema.sql presente, o Laravel carrega o
+      # schema final + a tabela migrations (820 linhas) num passo, depois roda
+      # só as migrations posteriores ao dump. Sem replay fresh-install.
+      shell: bash
+      run: php artisan migrate --force
+
+    - name: Seed mínimo (biz=1 fixture completa + biz=2 Tier 0 cross-tenant)
+      # DummyBusinessSeeder é stale (insere colunas removidas do schema real, ex
+      # contacts.first_name). Em vez dele, semeamos o MÍNIMO que os testes precisam
+      # (Business::first() + um user + uma conta), com as colunas NOT NULL atuais do
+      # schema baseline, resolvendo o FK circular business.owner_id ↔ users.business_id.
+      #
+      # biz=2 (FV-F2 — Tier 0 cross-tenant): segundo tenant MÍNIMO (business + user,
+      # SEM conta/location/contact) pros testes de isolamento multi-tenant terem um
+      # segundo business real. Business::first() continua devolvendo biz=1.
+      shell: bash
+      run: |
+        php artisan db:seed --class="Database\\Seeders\\CurrenciesTableSeeder" --force || true
+        php artisan db:seed --class="Database\\Seeders\\PermissionsTableSeeder" --force || true
+        php artisan tinker --execute="
+          use Illuminate\\Support\\Facades\\DB;
+          \$curId = optional(DB::table('currencies')->first())->id ?? 1;
+          if (! DB::table('business')->where('id', 1)->exists()) {
+            \$uid = DB::table('users')->insertGetId(['first_name'=>'CI','username'=>'ci_admin','password'=>bcrypt('ci'),'created_at'=>now(),'updated_at'=>now()]);
+            \$bid = DB::table('business')->insertGetId(['name'=>'CI Biz','currency_id'=>\$curId,'owner_id'=>\$uid,'stop_selling_before'=>0,'weighing_scale_setting'=>'','certificado'=>'','officeimpresso_numerodemaquinas'=>0,'created_at'=>now(),'updated_at'=>now()]);
+            DB::table('users')->where('id', \$uid)->update(['business_id'=>\$bid]);
+            echo 'seed biz='.\$bid.' user='.\$uid.PHP_EOL;
+          }
+          if (! DB::table('business')->where('id', 2)->exists()) {
+            \$uid2 = DB::table('users')->insertGetId(['first_name'=>'CI Biz2','username'=>'ci_admin_b2','password'=>bcrypt('ci'),'created_at'=>now(),'updated_at'=>now()]);
+            DB::table('business')->insert(['id'=>2,'name'=>'CI Biz 2','currency_id'=>\$curId,'owner_id'=>\$uid2,'stop_selling_before'=>0,'weighing_scale_setting'=>'','certificado'=>'','officeimpresso_numerodemaquinas'=>0,'created_at'=>now(),'updated_at'=>now()]);
+            DB::table('users')->where('id', \$uid2)->update(['business_id'=>2]);
+            echo 'seed biz2=2 user='.\$uid2.PHP_EOL;
+          }
+          DB::statement('SET FOREIGN_KEY_CHECKS=0'); // conta usa account_id fake (sem row em accounts)
+          \$bizId = optional(DB::table('business')->first())->id;
+          if (\$bizId && ! \Modules\Financeiro\Models\ContaBancaria::query()->where('business_id',\$bizId)->exists()) {
+            \Modules\Financeiro\Models\ContaBancaria::create([
+              'business_id'=>\$bizId,'account_id'=>999001,'agencia'=>'0001','carteira'=>'0',
+              'beneficiario_documento'=>'00000000000000','beneficiario_razao_social'=>'CI Test','saldo_cached'=>0,
+            ]);
+            echo 'conta criada biz='.\$bizId.PHP_EOL;
+          }
+          // Onda Q2 — RetencaoLoopE2ETest (UC-F01..03) exige location + contact (type != lead).
+          if (\$bizId && ! DB::table('business_locations')->where('business_id',\$bizId)->exists()) {
+            DB::table('business_locations')->insert(['business_id'=>\$bizId,'name'=>'Matriz CI','country'=>'BR','state'=>'SP','city'=>'SP','zip_code'=>'0','created_at'=>now(),'updated_at'=>now()]);
+            echo 'location criada'.PHP_EOL;
+          }
+          if (\$bizId && ! DB::table('contacts')->where('business_id',\$bizId)->where('type','!=','lead')->exists()) {
+            DB::table('contacts')->insert(['business_id'=>\$bizId,'type'=>'customer','name'=>'Cliente CI','contact_id'=>'CO0001','created_by'=>1,'is_default'=>1,'created_at'=>now(),'updated_at'=>now()]);
+            echo 'contact criado'.PHP_EOL;
+          }
+        "

--- a/.github/workflows/financeiro-pest.yml
+++ b/.github/workflows/financeiro-pest.yml
@@ -1,7 +1,8 @@
 name: Financeiro · Pest (MySQL)
 
 # Lane dedicado pra rodar a suíte Pest do Modules/Financeiro contra MySQL REAL
-# + seed mínimo (biz=1). Existe porque ci.yml e modules-pest.yml rodam SQLite
+# + seed mínimo (biz=1 + biz=2 — via .github/actions/pest-mysql-setup, FV-F2).
+# Existe porque ci.yml e modules-pest.yml rodam SQLite
 # :memory: SEM migrate — e os testes Feature do Financeiro dependem de schema
 # completo + business semeado (Business::first()), então lá eles dariam skip
 # (falsa cobertura). Aqui executam de verdade. (US-FIN-052)
@@ -27,6 +28,7 @@ on:
       - 'tests/Feature/TravaSegunda/**'
       - 'database/schema/mysql-schema.sql'
       - '.github/workflows/financeiro-pest.yml'
+      - '.github/actions/pest-mysql-setup/**'
 
 concurrency:
   group: financeiro-pest-${{ github.ref }}
@@ -64,116 +66,20 @@ jobs:
               - 'tests/Feature/TravaSegunda/**'
               - 'database/schema/mysql-schema.sql'
               - '.github/workflows/financeiro-pest.yml'
+              - '.github/actions/pest-mysql-setup/**'
 
       - name: Skip-as-pass (nada do Financeiro mudou)
         if: steps.changes.outputs.fin == 'false'
         run: echo "✅ Sem mudanças no Modules/Financeiro — skip-as-pass (required-ready, ADR 0271 onda 2)."
 
-      - name: Setup PHP 8.4
+      # FV-F2 (plano SDD 2026-06-12): setup extraído pra composite action reusável
+      # pelas lanes de burn-down por módulo. PHP + Composer + .env + migrate
+      # (schema baseline) + seed mínimo (biz=1 fixture completa + biz=2 Tier 0
+      # cross-tenant). O service container MySQL permanece DECLARADO ACIMA no job
+      # (composite action não pode declarar services — limitação GitHub Actions).
+      - name: Setup Pest MySQL (PHP + deps + .env + migrate + seed biz=1/biz=2)
         if: steps.changes.outputs.fin == 'true'
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '8.4'
-          extensions: bcmath, ctype, dom, fileinfo, intl, json, mbstring, openssl, pdo, pdo_mysql, tokenizer, xml, zip, gd, opentelemetry
-          tools: composer:v2
-          coverage: none
-
-      - name: Cache Composer
-        if: steps.changes.outputs.fin == 'true'
-        uses: actions/cache@v4
-        with:
-          path: ~/.composer/cache
-          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
-          restore-keys: composer-${{ runner.os }}-
-
-      - name: Prepare dirs
-        if: steps.changes.outputs.fin == 'true'
-        run: mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
-
-      - name: Install PHP deps
-        if: steps.changes.outputs.fin == 'true'
-        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
-
-      - name: Wait for MySQL
-        if: steps.changes.outputs.fin == 'true'
-        run: |
-          for i in $(seq 1 30); do
-            if mysqladmin ping -h127.0.0.1 -uroot -proot --silent; then echo "MySQL up"; break; fi
-            echo "waiting mysql ($i)"; sleep 2
-          done
-
-      - name: Create .env (MySQL)
-        if: steps.changes.outputs.fin == 'true'
-        run: |
-          cat > .env <<'EOF'
-          APP_NAME=oimpresso-fin
-          APP_ENV=testing
-          APP_KEY=
-          APP_DEBUG=true
-          APP_URL=http://localhost
-          LOG_CHANNEL=stderr
-          DB_CONNECTION=mysql
-          DB_HOST=127.0.0.1
-          DB_PORT=3306
-          DB_DATABASE=oimpresso_test
-          DB_USERNAME=root
-          DB_PASSWORD=root
-          CACHE_DRIVER=array
-          QUEUE_CONNECTION=sync
-          SESSION_DRIVER=array
-          MAIL_MAILER=array
-          BCRYPT_ROUNDS=4
-          TELESCOPE_ENABLED=false
-          SCOUT_DRIVER=null
-          MCP_TOOLS_EXPOSED=false
-          EOF
-          php artisan key:generate --force
-          php artisan package:discover --ansi
-
-      - name: Migrate (carrega schema baseline + migrations novas)
-        if: steps.changes.outputs.fin == 'true'
-        # Com database/schema/mysql-schema.sql presente, o Laravel carrega o
-        # schema final + a tabela migrations (820 linhas) num passo, depois roda
-        # só as migrations posteriores ao dump. Sem replay fresh-install.
-        run: php artisan migrate --force
-
-      - name: Seed mínimo (biz=1 + user + conta bancária)
-        if: steps.changes.outputs.fin == 'true'
-        # DummyBusinessSeeder é stale (insere colunas removidas do schema real, ex
-        # contacts.first_name). Em vez dele, semeamos o MÍNIMO que os testes precisam
-        # (Business::first() + um user + uma conta), com as colunas NOT NULL atuais do
-        # schema baseline, resolvendo o FK circular business.owner_id ↔ users.business_id.
-        run: |
-          php artisan db:seed --class="Database\\Seeders\\CurrenciesTableSeeder" --force || true
-          php artisan db:seed --class="Database\\Seeders\\PermissionsTableSeeder" --force || true
-          php artisan tinker --execute="
-            use Illuminate\\Support\\Facades\\DB;
-            \$curId = optional(DB::table('currencies')->first())->id ?? 1;
-            if (! DB::table('business')->where('id', 1)->exists()) {
-              \$uid = DB::table('users')->insertGetId(['first_name'=>'CI','username'=>'ci_admin','password'=>bcrypt('ci'),'created_at'=>now(),'updated_at'=>now()]);
-              \$bid = DB::table('business')->insertGetId(['name'=>'CI Biz','currency_id'=>\$curId,'owner_id'=>\$uid,'stop_selling_before'=>0,'weighing_scale_setting'=>'','certificado'=>'','officeimpresso_numerodemaquinas'=>0,'created_at'=>now(),'updated_at'=>now()]);
-              DB::table('users')->where('id', \$uid)->update(['business_id'=>\$bid]);
-              echo 'seed biz='.\$bid.' user='.\$uid.PHP_EOL;
-            }
-            DB::statement('SET FOREIGN_KEY_CHECKS=0'); // conta usa account_id fake (sem row em accounts)
-            \$bizId = optional(DB::table('business')->first())->id;
-            if (\$bizId && ! \Modules\Financeiro\Models\ContaBancaria::query()->where('business_id',\$bizId)->exists()) {
-              \Modules\Financeiro\Models\ContaBancaria::create([
-                'business_id'=>\$bizId,'account_id'=>999001,'agencia'=>'0001','carteira'=>'0',
-                'beneficiario_documento'=>'00000000000000','beneficiario_razao_social'=>'CI Test','saldo_cached'=>0,
-              ]);
-              echo 'conta criada biz='.\$bizId.PHP_EOL;
-            }
-            // Onda Q2 — RetencaoLoopE2ETest (UC-F01..03) exige location + contact (type != lead).
-            if (\$bizId && ! DB::table('business_locations')->where('business_id',\$bizId)->exists()) {
-              DB::table('business_locations')->insert(['business_id'=>\$bizId,'name'=>'Matriz CI','country'=>'BR','state'=>'SP','city'=>'SP','zip_code'=>'0','created_at'=>now(),'updated_at'=>now()]);
-              echo 'location criada'.PHP_EOL;
-            }
-            if (\$bizId && ! DB::table('contacts')->where('business_id',\$bizId)->where('type','!=','lead')->exists()) {
-              DB::table('contacts')->insert(['business_id'=>\$bizId,'type'=>'customer','name'=>'Cliente CI','contact_id'=>'CO0001','created_by'=>1,'is_default'=>1,'created_at'=>now(),'updated_at'=>now()]);
-              echo 'contact criado'.PHP_EOL;
-            }
-          "
+        uses: ./.github/actions/pest-mysql-setup
 
       - name: Stub Vite manifest (Inertia root view sem build do front)
         if: steps.changes.outputs.fin == 'true'


### PR DESCRIPTION
## Frente FV-F2 — Semana 0 da reestruturação SDD

Plano-mãe: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` — §4 Semana 0, frente **FV**, passo **F2 composite action pest-mysql** (audit: `memory/sessions/2026-06-12-audit-sdd-pesquisa-reclassificacao.md`).

## O que faz

Refactor **puro** da lane `financeiro-pest.yml`: extrai o setup (PHP 8.4 + Composer cache + deps + .env MySQL + migrate via schema baseline + seed mínimo) pra composite action reusável `.github/actions/pest-mysql-setup` — as futuras lanes de burn-down por módulo (FV B1/B2/B3) consomem a mesma action sem copy-paste.

- **Seed cria biz=1 E biz=2** (mandato Tier 0 cross-tenant da frente): biz=1 = fixture completa intocada (user + conta + location + contact; `Business::first()` continua devolvendo biz=1); biz=2 = tenant mínimo (business + user). Verificado contra os 19 arquivos da allowlist: nenhum veredito muda — `AccountsLegacyMapMultiTenantTest` (único que consulta segundo business) continua skip no checkpoint seguinte (`firstAccountFor` → sem row em `accounts`, o seed usa `account_id` fake 999001).
- **Limitação GitHub Actions (re-derivada vs plano):** composite action NÃO declara `services:` (job-level only) — o service container mysql:8.0 permanece no job consumidor, documentado no header da action.
- Paths-filter + push paths ganham `.github/actions/pest-mysql-setup/**` (fidelidade de trigger: mudança no setup exercitava a lane quando era inline; continua exercitando extraída).
- Nome do workflow/job **inalterados** (contexto de gate preservado). gates-registry: sem mudança (workflow existente, sem workflow novo).

## DoD — prova

Dry-run local (yaml parse + schema composite + diff de equivalência + lints):

```
[1] YAML parse OK: financeiro-pest.yml + action.yml
[2] Composite schema OK: using=composite, all run steps have shell:bash
[3] Workflow OK: consumes local action 1x (gated by skip-as-pass),
    MySQL service kept at job level, gate/job names unchanged
[4] Equivalence diff (sequência ordenada de steps old origin/main vs new
    workflow+action com defaults expandidos): único delta = bloco seed biz=2
    + superset do paths-filter
[5] PASS — refactor is behavior-identical modulo the mandated biz=2 seed block
bash -n: OK nos 6 run steps da action
php -l [tinker seed snippet]: No syntax errors detected
```

**A prova final é o próprio gate existente neste PR**: `PHP / Pest (Financeiro · MySQL)` roda no CI consumindo a action (este PR toca `.github/workflows/financeiro-pest.yml`, então o paths-filter dispara o caminho pesado, não o skip-as-pass) — verde = comportamento idêntico confirmado em execução real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)