### PR TITLE
feat(governance): sdd-scorecard agregador GT-G2 — scorecard v1 (3 vivas + 7 not_yet_measured)

### DIFF
--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -1,0 +1,112 @@
+{
+  "_meta": {
+    "scorecard": "SDD — sistema spec-anchored + verificação agêntica (plano 2026-06-12 §2)",
+    "generator": "scripts/governance/sdd-scorecard.mjs",
+    "plan": "memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md",
+    "determinismo": "sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio",
+    "composta": "v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured",
+    "anchor_coverage_regra": "numerador = campos `**Implementado em:**` sem placeholder (TODO/_[path]_/_pendente_/a criar/_xx_) com ≥1 path existente no disco; denominador = headings `US-XXX-NNN` nos 57 SPECs",
+    "ratchet": {
+      "armed": false,
+      "como_armar": "SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — armar SÓ via calendário de promoções do ADR do scorecard (GT-G1)"
+    }
+  },
+  "metrics": {
+    "anchor_coverage": {
+      "status": "measured",
+      "value": 2.8,
+      "unit": "%",
+      "direction": "up",
+      "target": 100,
+      "source": "grep estrito memory/requisitos/*/SPEC.md (este script)",
+      "detail": {
+        "specs_total": 57,
+        "specs_with_field": 15,
+        "us_total": 780,
+        "fields_total": 84,
+        "fields_placeholder": 50,
+        "fields_filled": 34,
+        "fields_anchored_strict": 22
+      }
+    },
+    "full_suite_pass_rate": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "up",
+      "target": "100% não-quarentenado",
+      "source": "nightly MySQL diagnóstica (FV-F3) — nenhum run full-repo MySQL jamais foi salvo",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    },
+    "n_quarantine": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "target": 0,
+      "source": "grep @group legacy-quarantine — grupo só passa a existir na quarentena FV-Q3",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    },
+    "coverage_pct": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "up",
+      "target": "só sobe (catraca C2)",
+      "source": "pcov instrumentado em CI (P0-2) — hoje coverage: none",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    },
+    "ghost_count": {
+      "status": "measured",
+      "value": 27,
+      "unit": "nomes distintos",
+      "direction": "down",
+      "target": 0,
+      "source": "scripts/governance/knowledge-drift.mjs --json (Modules/<X> citado e inexistente no disco; nomes: rodar a fonte direto)",
+      "detail": {
+        "citing_modules": 39
+      }
+    },
+    "front_door_coverage": {
+      "status": "measured",
+      "value": 63.9,
+      "unit": "%",
+      "direction": "up",
+      "target": 100,
+      "source": "scripts/governance/knowledge-drift.mjs --json (BRIEFING.md presente por módulo)",
+      "detail": {
+        "with_door": 39,
+        "modules": 61
+      }
+    },
+    "recall_eval_violations": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "target": 0,
+      "source": "golden set recall (KL-C2) — depende do alias map das 13 colisões ADR",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    },
+    "ragas_real_uptime": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "up",
+      "target": "≥95%",
+      "source": "RAGAS canário modo REAL diário (KL-D1/D4) — hoje compara mock com mock",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    },
+    "drift_alarms": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "target": "advisory perene",
+      "source": "protection-drift + watchdog de staleness (GT-G4)",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    },
+    "backfill_error_rate": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "target": "<2%",
+      "source": "ledger do protocolo refutador G5 — só existe após 1º lote IA refutado",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+    }
+  }
+}

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+// sdd-scorecard.mjs — agregador do scorecard SDD (GT-G2, Semana 0 do plano
+// memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md §2).
+//
+// POR QUE EXISTE: a reestruturação SDD só é "medida, testada, garantida" se houver
+// UM lugar com as 10 métricas e a regra anti-stale — baseline capturado na 1ª
+// medição REAL da fonte, nunca copiado do plano. Este script agrega o que JÁ é
+// medível hoje e declara o resto `not_yet_measured` (mentir "0" seria pior).
+//
+// FONTES VIVAS (hoje):
+//   - knowledge-drift.mjs --json  → ghost_count + front_door_coverage
+//   - grep dos SPECs              → anchor_coverage ESTRITO (campo preenchido
+//                                   sem placeholder E ≥1 path existente no disco)
+// As outras 7 métricas nascem `not_yet_measured` com a fonte futura declarada.
+//
+// DETERMINÍSTICO: zero timestamps/sha no arquivo — re-run sem mudança = diff vazio.
+// Uso (na raiz do repo):
+//   node scripts/governance/sdd-scorecard.mjs            # mede + escreve governance/sdd-scorecard.json
+//   node scripts/governance/sdd-scorecard.mjs --json     # mede + imprime no stdout (não escreve)
+//   node scripts/governance/sdd-scorecard.mjs --ratchet  # compara com o commitado; DESARMADO (exit 0)
+//                                                        # armar: SDD_RATCHET_ARM=1 (só após ADR do scorecard)
+// Node puro (fs + execSync). Sem deps, sem DB, sem PHP. Idioma: clone de knowledge-drift.mjs.
+
+import { readdirSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const OUT = join(ROOT, 'governance', 'sdd-scorecard.json');
+const MODE_JSON = process.argv.includes('--json');
+const MODE_RATCHET = process.argv.includes('--ratchet');
+const ARMED = process.env.SDD_RATCHET_ARM === '1';
+
+// ── fonte 1: knowledge-drift --json ─────────────────────────────────────────
+function measureKnowledgeDrift() {
+  const raw = execSync(`"${process.execPath}" scripts/governance/knowledge-drift.mjs --json`, {
+    cwd: ROOT, maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+  const rows = JSON.parse(raw);
+  const names = new Set();
+  let citing = 0;
+  for (const r of rows) if (r.ghosts.length) { citing++; for (const g of r.ghosts) names.add(g); }
+  const withDoor = rows.filter((r) => r.door !== 'NÃO').length;
+  return { ghost_count: names.size, ghost_citing_modules: citing, door_num: withDoor, door_den: rows.length };
+}
+
+// ── fonte 2: grep estrito dos SPECs ─────────────────────────────────────────
+const PLACEHOLDER_RE = /TODO|_\[path\]_|_pendente_|a criar|_xx_/i;
+const ANCHOR_PATH_RE = /(?:resources\/js|Modules|app|routes|tests|scripts|database|config|prototipo-ui)\/[A-Za-z0-9_\-./]+/g;
+const US_HEADING_RE = /^#{2,4}\s+.*US-[A-Z][A-Za-z0-9]*-\d/gm;
+const FIELD_RE = /\*\*Implementado em:\*\*[^\n]*/g;
+
+function measureAnchors() {
+  const REQ = join(ROOT, 'memory', 'requisitos');
+  const specs = readdirSync(REQ, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(REQ, e.name, 'SPEC.md')))
+    .map((e) => join(REQ, e.name, 'SPEC.md'))
+    .sort();
+  let usTotal = 0, fields = 0, placeholder = 0, filled = 0, anchored = 0, specsWithField = 0;
+  for (const f of specs) {
+    const txt = readFileSync(f, 'utf8');
+    usTotal += (txt.match(US_HEADING_RE) || []).length;
+    const fl = txt.match(FIELD_RE) || [];
+    if (fl.length) specsWithField++;
+    for (const field of fl) {
+      fields++;
+      if (PLACEHOLDER_RE.test(field)) { placeholder++; continue; }
+      filled++;
+      const paths = field.match(ANCHOR_PATH_RE) || [];
+      if (paths.some((p) => existsSync(join(ROOT, p.replace(/[.,;:]+$/, ''))))) anchored++;
+    }
+  }
+  return { specs_total: specs.length, specs_with_field: specsWithField, us_total: usTotal,
+    fields_total: fields, fields_placeholder: placeholder, fields_filled: filled,
+    fields_anchored_strict: anchored };
+}
+
+// ── montagem do scorecard (ordem fixa = output determinístico) ──────────────
+function pct(num, den) { return den ? Math.round((1000 * num) / den) / 10 : null; }
+const notYet = (direction, target, source) => ({
+  status: 'not_yet_measured', value: null, direction, target, source,
+  baseline_rule: '1ª medição real da fonte, nunca do plano (anti-stale)',
+});
+
+function buildScorecard() {
+  const kd = measureKnowledgeDrift();
+  const an = measureAnchors();
+  return {
+    _meta: {
+      scorecard: 'SDD — sistema spec-anchored + verificação agêntica (plano 2026-06-12 §2)',
+      generator: 'scripts/governance/sdd-scorecard.mjs',
+      plan: 'memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md',
+      determinismo: 'sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio',
+      composta: 'v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured',
+      anchor_coverage_regra: 'numerador = campos `**Implementado em:**` sem placeholder (TODO/_[path]_/_pendente_/a criar/_xx_) com ≥1 path existente no disco; denominador = headings `US-XXX-NNN` nos 57 SPECs',
+      ratchet: { armed: false, como_armar: 'SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — armar SÓ via calendário de promoções do ADR do scorecard (GT-G1)' },
+    },
+    metrics: {
+      anchor_coverage: {
+        status: 'measured', value: pct(an.fields_anchored_strict, an.us_total), unit: '%',
+        direction: 'up', target: 100,
+        source: 'grep estrito memory/requisitos/*/SPEC.md (este script)',
+        detail: an,
+      },
+      full_suite_pass_rate: notYet('up', '100% não-quarentenado',
+        'nightly MySQL diagnóstica (FV-F3) — nenhum run full-repo MySQL jamais foi salvo'),
+      n_quarantine: notYet('down', 0,
+        'grep @group legacy-quarantine — grupo só passa a existir na quarentena FV-Q3'),
+      coverage_pct: notYet('up', 'só sobe (catraca C2)',
+        'pcov instrumentado em CI (P0-2) — hoje coverage: none'),
+      ghost_count: {
+        status: 'measured', value: kd.ghost_count, unit: 'nomes distintos',
+        direction: 'down', target: 0,
+        source: 'scripts/governance/knowledge-drift.mjs --json (Modules/<X> citado e inexistente no disco; nomes: rodar a fonte direto)',
+        detail: { citing_modules: kd.ghost_citing_modules },
+      },
+      front_door_coverage: {
+        status: 'measured', value: pct(kd.door_num, kd.door_den), unit: '%',
+        direction: 'up', target: 100,
+        source: 'scripts/governance/knowledge-drift.mjs --json (BRIEFING.md presente por módulo)',
+        detail: { with_door: kd.door_num, modules: kd.door_den },
+      },
+      recall_eval_violations: notYet('down', 0,
+        'golden set recall (KL-C2) — depende do alias map das 13 colisões ADR'),
+      ragas_real_uptime: notYet('up', '≥95%',
+        'RAGAS canário modo REAL diário (KL-D1/D4) — hoje compara mock com mock'),
+      drift_alarms: notYet('down', 'advisory perene',
+        'protection-drift + watchdog de staleness (GT-G4)'),
+      backfill_error_rate: notYet('down', '<2%',
+        'ledger do protocolo refutador G5 — só existe após 1º lote IA refutado'),
+    },
+  };
+}
+
+// ── ratchet (preparado, DESARMADO) ──────────────────────────────────────────
+function ratchet(current) {
+  if (!existsSync(OUT)) { console.log('  --ratchet: sem baseline commitado em governance/sdd-scorecard.json — nada a comparar.'); return 0; }
+  const base = JSON.parse(readFileSync(OUT, 'utf8'));
+  const violations = [];
+  for (const [name, m] of Object.entries(current.metrics)) {
+    const b = base.metrics?.[name];
+    if (!b || b.status !== 'measured' || m.status !== 'measured') continue;
+    if (m.direction === 'down' && m.value > b.value) violations.push(`${name}: ${b.value} → ${m.value} (só pode DESCER)`);
+    if (m.direction === 'up' && m.value < b.value) violations.push(`${name}: ${b.value} → ${m.value} (só pode SUBIR)`);
+  }
+  if (!violations.length) { console.log('  --ratchet: nenhuma regressão vs baseline commitado. ✓'); return 0; }
+  for (const v of violations) console.log(`  🔴 RATCHET: ${v}`);
+  if (!ARMED) { console.log('  (desarmado — exit 0; armar via SDD_RATCHET_ARM=1 quando o ADR do scorecard aprovar a promoção)'); return 0; }
+  return 1;
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+const scorecard = buildScorecard();
+const body = JSON.stringify(scorecard, null, 2) + '\n';
+
+if (MODE_JSON) { process.stdout.write(body); process.exit(0); }
+if (MODE_RATCHET) process.exit(ratchet(scorecard));
+
+writeFileSync(OUT, body, 'utf8');
+const measured = Object.entries(scorecard.metrics).filter(([, m]) => m.status === 'measured');
+const pending = Object.keys(scorecard.metrics).length - measured.length;
+console.log(`\n  SDD SCORECARD → governance/sdd-scorecard.json\n`);
+for (const [name, m] of measured) console.log(`  ✓ ${name.padEnd(22)} ${String(m.value).padStart(6)} ${m.unit}  (meta: ${m.target}, ${m.direction === 'up' ? 'sobe' : 'desce'})`);
+console.log(`  … ${pending} métricas not_yet_measured (fonte futura declarada no JSON — baseline na 1ª medição real)\n`);


### PR DESCRIPTION
## Frente GT-G2 — Semana 0 da reestruturação SDD

Plano-mãe: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` — **§2 (MEDIDA — scorecard único)** + **§4 Semana 0, frente GT, passo "agregador G2"**. Audit que originou: `memory/sessions/2026-06-12-audit-sdd-pesquisa-reclassificacao.md`.

### O que entra
- `scripts/governance/sdd-scorecard.mjs` (164 linhas) — node puro sem deps, clone do idioma `knowledge-drift.mjs`. Lê SÓ as fontes que JÁ existem:
  - `knowledge-drift.mjs --json` → `ghost_count` + `front_door_coverage`
  - grep estrito dos 57 SPECs → `anchor_coverage` (campo `**Implementado em:**` sem placeholder **E** ≥1 path existente no disco / headings US)
  - As outras 7 métricas nascem `not_yet_measured` com a fonte futura declarada — **baseline na 1ª medição real da fonte, nunca do plano** (regra anti-stale).
- `governance/sdd-scorecard.json` — **1ª medição commitada (scorecard v1)**.

### Scorecard v1 real (números re-derivados de origin/main, não copiados do plano)
| Métrica | Valor | Meta | Detalhe |
|---|---:|---:|---|
| anchor_coverage | **2.8%** | 100% | 22 anchored estrito / 780 US headings · 57 SPECs, 15 com campo, 84 campos (50 placeholder, 34 preenchidos) |
| ghost_count | **27** nomes | 0 | 39 módulos citantes (plano batia: 27/39) |
| front_door_coverage | **63.9%** | 100% | 39/61 módulos com BRIEFING.md (plano dizia 62% — stale) |
| demais 7 | `not_yet_measured` | — | full_suite_pass_rate, n_quarantine, coverage_pct, recall_eval_violations, ragas_real_uptime, drift_alarms, backfill_error_rate |

### DoD provado (output real, não narração)
1. **Determinismo** — rodou 2×, `git diff governance/sdd-scorecard.json` após re-run = **0 arquivos** (sem timestamps/sha no corpo; `_meta` separado e estático).
2. **Ratchet preparado mas DESARMADO** — baseline adulterado de propósito: detecta ambas direções (`anchor_coverage 50 → 2.8 só pode SUBIR`, `ghost_count 20 → 27 só pode DESCER`); desarmado = exit 0 com aviso; `SDD_RATCHET_ARM=1` = exit 1. Armar só via calendário de promoções do ADR do scorecard (GT-G1).
3. **Composta NÃO calculada** enquanto houver `not_yet_measured` (v1 ≠ v2 — regimes não comparáveis, declarado no `_meta`).

### Fora de escopo (consciente)
- Workflow CI (gate nasceria advisory em PR futuro) → por isso `gates-registry.json` **intocado**.
- ADR do scorecard com calendário de promoções = frente GT-G1 (paralela).

🤖 Generated with [Claude Code](https://claude.com/claude-code)