### PR TITLE
docs(charters): backfill mecanico frontmatter page/component — 29 charters (SDD Semana 0 · CH-1)

### DIFF
--- a/resources/js/Pages/Admin/GovernanceV4.charter.md
+++ b/resources/js/Pages/Admin/GovernanceV4.charter.md
@@ -1,9 +1,10 @@
 ---
-page: Admin/GovernanceV4
+page: /admin/governance/v4
+component: resources/js/Pages/Admin/GovernanceV4.tsx
 controller: Modules\Admin\Http\Controllers\GovernanceV4DashboardController@indexV2
 route: admin.governance.v4
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Wagner / governance command center (1440px desktop)
 persona_secundaria: time MCP futuro (Felipe/Maiara — read-only ONDA 7+)
 charter_version: 1.0

--- a/resources/js/Pages/Admin/ScreenReview.charter.md
+++ b/resources/js/Pages/Admin/ScreenReview.charter.md
@@ -1,9 +1,10 @@
 ---
-page: Admin/ScreenReview
+page: /admin/screen-review
+component: resources/js/Pages/Admin/ScreenReview.tsx
 controller: Modules\Admin\Http\Controllers\ScreenReviewController@index
 route: admin.screen-review
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Wagner / governance + PDCA loop visual telas (1440px desktop)
 persona_secundaria: Claude Code (lê reviews pra próximo round F1.5)
 charter_version: 1.0

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.charter.md
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.charter.md
@@ -1,5 +1,7 @@
 ---
-page_id: admin.screen-review.dashboard
+page: /admin/screen-review/dashboard
+component: resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+page_id: admin-screen-review-dashboard
 route: /admin/screen-review/dashboard
 status: live
 owner: wagner

--- a/resources/js/Pages/Auditoria/Index.charter.md
+++ b/resources/js/Pages/Auditoria/Index.charter.md
@@ -1,3 +1,9 @@
+---
+page: /auditoria
+component: resources/js/Pages/Auditoria/Index.tsx
+status: draft
+---
+
 # Charter — Pages/Auditoria/Index.tsx
 
 > Charter F1.5 obrigatório (ADR 0107 + ADR 0114). Atualizado Wave 25 (2026-05-16) — adiciona Export flow + Bulk action panel + edge cases catalogados.

--- a/resources/js/Pages/ComunicacaoVisual/Index.charter.md
+++ b/resources/js/Pages/ComunicacaoVisual/Index.charter.md
@@ -1,3 +1,9 @@
+---
+page: /comunicacao-visual
+component: resources/js/Pages/ComunicacaoVisual/Index.tsx
+status: draft
+---
+
 # Charter — Pages/ComunicacaoVisual/Index.tsx
 
 > Charter MWART F1.5 (ADR 0107 visual-comparison gate) — Comunicação Visual landing.

--- a/resources/js/Pages/Financeiro/Dre/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Dre/Index.charter.md
@@ -1,13 +1,14 @@
 ---
 slug: financeiro-dre-index
-page: resources/js/Pages/Financeiro/Dre/Index.tsx
+page: /financeiro/dre
+component: resources/js/Pages/Financeiro/Dre/Index.tsx
 status: live
 module: Financeiro
 persona: ["wagner", "eliana"]
 stories: [US-FIN-014a]
 visual_comparison: memory/requisitos/Financeiro/dre-visual-comparison.md
 canon_source: public/cowork-preview/erp-shell/financeiro-telas-extras.jsx (TelaDRE linha 361-483)
-related_adrs: [ui/0114, 0093, 0104, 0107, 0109]
+related_adrs: [0114-prototipo-ui-cowork-loop-formalizado, 0093-multi-tenant-isolation-tier-0, 0104-processo-mwart-canonico-unico-caminho, 0107-emendation-0104-visual-comparison-gate-f3, 0109-claude-design-plugin-integrado-processo-mwart]
 created_at: 2026-05-20
 ---
 

--- a/resources/js/Pages/Fiscal/Cockpit.charter.md
+++ b/resources/js/Pages/Fiscal/Cockpit.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal
+component: resources/js/Pages/Fiscal/Cockpit.tsx
 page_id: fiscal-cockpit
 url: /fiscal
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0094, 0101, 0104, 0114]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0101-tests-business-id-1-nunca-cliente, 0104-processo-mwart-canonico-unico-caminho, 0114-prototipo-ui-cowork-loop-formalizado]
 prototypes:
   - "prototipo-ui/.../fiscal-page.jsx §8 FiscalCockpit"
 ---

--- a/resources/js/Pages/Fiscal/Config.charter.md
+++ b/resources/js/Pages/Fiscal/Config.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal/config
+component: resources/js/Pages/Fiscal/Config.tsx
 page_id: fiscal-config
 url: /fiscal/config
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0101-tests-business-id-1-nunca-cliente, 0104-processo-mwart-canonico-unico-caminho]
 prototypes:
   - "prototipo-ui/.../fiscal-data.jsx CONFIG"
 ---

--- a/resources/js/Pages/Fiscal/Dfe.charter.md
+++ b/resources/js/Pages/Fiscal/Dfe.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal/dfe
+component: resources/js/Pages/Fiscal/Dfe.tsx
 page_id: fiscal-dfe
 url: /fiscal/dfe
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0094, 0101, 0104, 0116]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0101-tests-business-id-1-nunca-cliente, 0104-processo-mwart-canonico-unico-caminho, 0116-pivot-gold-manifestacao-destinatario-emenda-0115]
 prototypes:
   - "prototipo-ui/.../fiscal-data.jsx DFE_PENDENTE/DFE_HISTORICO"
 ---

--- a/resources/js/Pages/Fiscal/Eventos.charter.md
+++ b/resources/js/Pages/Fiscal/Eventos.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal/eventos
+component: resources/js/Pages/Fiscal/Eventos.tsx
 page_id: fiscal-eventos
 url: /fiscal/eventos
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0101-tests-business-id-1-nunca-cliente, 0104-processo-mwart-canonico-unico-caminho]
 prototypes:
   - "prototipo-ui/.../fiscal-page.jsx §11 FiscalEventosPage"
 ---

--- a/resources/js/Pages/Fiscal/Nfe.charter.md
+++ b/resources/js/Pages/Fiscal/Nfe.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal/nfe
+component: resources/js/Pages/Fiscal/Nfe.tsx
 page_id: fiscal-nfe
 url: /fiscal/nfe
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0104, 0114, 0143]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0104-processo-mwart-canonico-unico-caminho, 0114-prototipo-ui-cowork-loop-formalizado, 0143-fsm-pipeline-live-prod-marco-2026-05-12]
 prototypes:
   - prototipo-ui/Oimpresso ERP - Chat.html (fiscal-page.jsx §9 FiscalNFePage)
   - prototipo-ui/fiscal-page.css

--- a/resources/js/Pages/Fiscal/Nfse.charter.md
+++ b/resources/js/Pages/Fiscal/Nfse.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal/nfse
+component: resources/js/Pages/Fiscal/Nfse.tsx
 page_id: fiscal-nfse
 url: /fiscal/nfse
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0101-tests-business-id-1-nunca-cliente, 0104-processo-mwart-canonico-unico-caminho]
 prototypes:
   - "prototipo-ui/.../fiscal-page.jsx §10 FiscalNFSePage"
 ---

--- a/resources/js/Pages/Fiscal/Sped.charter.md
+++ b/resources/js/Pages/Fiscal/Sped.charter.md
@@ -1,11 +1,13 @@
 ---
+page: /fiscal/sped
+component: resources/js/Pages/Fiscal/Sped.tsx
 page_id: fiscal-sped
 url: /fiscal/sped
 module: Fiscal
 status: draft
 created: 2026-05-20
 owner: wagner
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0101-tests-business-id-1-nunca-cliente, 0104-processo-mwart-canonico-unico-caminho]
 prototypes:
   - "prototipo-ui/.../fiscal-data.jsx SPED_PERIODOS/LIVROS"
 ---

--- a/resources/js/Pages/Jana/Painel.charter.md
+++ b/resources/js/Pages/Jana/Painel.charter.md
@@ -1,4 +1,6 @@
 ---
+page: /jana/painel
+component: resources/js/Pages/Jana/Painel.tsx
 status: live
 versao: 1.0
 adrs: [0035, 0039, 0093, 0114]

--- a/resources/js/Pages/Manufacturing/Index.charter.md
+++ b/resources/js/Pages/Manufacturing/Index.charter.md
@@ -1,7 +1,9 @@
 ---
-page_id: manufacturing/index
+page: /manufacturing/v2/production
+component: resources/js/Pages/Manufacturing/Index.tsx
+page_id: manufacturing-index
 status: draft
-owner: Wagner
+owner: wagner
 created: 2026-05-16
 wave: J
 ---

--- a/resources/js/Pages/Purchase/Create.charter.md
+++ b/resources/js/Pages/Purchase/Create.charter.md
@@ -1,10 +1,12 @@
 ---
-page: resources/js/Pages/Purchase/Create.tsx
+page: /purchases/create
+component: resources/js/Pages/Purchase/Create.tsx
 tela: purchase/create
 tipo: FORM (CREATE)
 modulo: Purchase
 runbook: memory/requisitos/Inventory/RUNBOOK-purchase-create.md
-status: F3 implementado (aguarda smoke Wagner)
+status: draft
+status_note: "F3 implementado (aguarda smoke Wagner)"
 adr_refs: [0104, 0093, 0114, 0149]
 mwart_pattern_reuse:
   blueprint_cowork: prototipo-ui/prototipos/compras/visual-source.html

--- a/resources/js/Pages/Purchase/Edit.charter.md
+++ b/resources/js/Pages/Purchase/Edit.charter.md
@@ -1,10 +1,12 @@
 ---
-page: resources/js/Pages/Purchase/Edit.tsx
+page: /purchases/{id}/edit
+component: resources/js/Pages/Purchase/Edit.tsx
 tela: purchase/edit
 tipo: FORM (EDIT)
 modulo: Purchase
 runbook: memory/requisitos/Inventory/RUNBOOK-purchase-edit.md
-status: F3 implementado
+status: draft
+status_note: "F3 implementado"
 adr_refs: [0104, 0093, 0114, 0149]
 mwart_pattern_reuse:
   blueprint_cowork: prototipo-ui/prototipos/compras/visual-source.html

--- a/resources/js/Pages/StockAdjustment/Create.charter.md
+++ b/resources/js/Pages/StockAdjustment/Create.charter.md
@@ -1,10 +1,12 @@
 ---
-page: resources/js/Pages/StockAdjustment/Create.tsx
+page: /stock-adjustments/create
+component: resources/js/Pages/StockAdjustment/Create.tsx
 tela: stock_adjustment/create
 tipo: FORM CREATE
 modulo: Inventory / StockAdjustment
 runbook: memory/requisitos/Inventory/RUNBOOK-stock-adjustment-create.md
-status: F3 implementado
+status: draft
+status_note: "F3 implementado"
 adr_refs: [0104, 0093, 0114, 0149]
 mwart_pattern_reuse:
   blueprint_cowork: prototipo-ui/prototipos/inventario-migracao/F1.html

--- a/resources/js/Pages/StockAdjustment/Index.charter.md
+++ b/resources/js/Pages/StockAdjustment/Index.charter.md
@@ -1,10 +1,12 @@
 ---
-page: resources/js/Pages/StockAdjustment/Index.tsx
+page: /stock-adjustments
+component: resources/js/Pages/StockAdjustment/Index.tsx
 tela: stock_adjustment/index
 tipo: LIST
 modulo: Inventory / StockAdjustment
 runbook: memory/requisitos/Inventory/RUNBOOK-stock-adjustment-index.md
-status: F3 implementado
+status: draft
+status_note: "F3 implementado"
 adr_refs: [0104, 0093, 0114, 0149]
 mwart_pattern_reuse:
   blueprint_cowork: prototipo-ui/prototipos/inventario-migracao/visual-source.html

--- a/resources/js/Pages/StockTransfer/Create.charter.md
+++ b/resources/js/Pages/StockTransfer/Create.charter.md
@@ -1,10 +1,12 @@
 ---
-page: resources/js/Pages/StockTransfer/Create.tsx
+page: /stock-transfers/create
+component: resources/js/Pages/StockTransfer/Create.tsx
 tela: stock_transfers/create
 tipo: FORM CREATE
 modulo: Inventory / StockTransfer
 runbook: memory/requisitos/Inventory/RUNBOOK-stock-transfer-create.md
-status: F3 implementado
+status: draft
+status_note: "F3 implementado"
 adr_refs: [0104, 0093, 0114, 0149]
 mwart_pattern_reuse:
   blueprint_cowork: prototipo-ui/prototipos/inventario-migracao/visual-source.html

--- a/resources/js/Pages/StockTransfer/Index.charter.md
+++ b/resources/js/Pages/StockTransfer/Index.charter.md
@@ -1,10 +1,12 @@
 ---
-page: resources/js/Pages/StockTransfer/Index.tsx
+page: /stock-transfers
+component: resources/js/Pages/StockTransfer/Index.tsx
 tela: stock_transfers/index
 tipo: LIST
 modulo: Inventory / StockTransfer
 runbook: memory/requisitos/Inventory/RUNBOOK-stock-transfer-index.md
-status: F3 implementado
+status: draft
+status_note: "F3 implementado"
 adr_refs: [0104, 0093, 0114, 0149]
 mwart_pattern_reuse:
   blueprint_cowork: prototipo-ui/prototipos/inventario-migracao/visual-source.html

--- a/resources/js/Pages/TransactionPayment/Edit.charter.md
+++ b/resources/js/Pages/TransactionPayment/Edit.charter.md
@@ -1,3 +1,9 @@
+---
+page: /payments/v2/{id}/edit
+component: resources/js/Pages/TransactionPayment/Edit.tsx
+status: draft
+---
+
 # Charter — `TransactionPayment/Edit.tsx`
 
 > Rota Inertia: `/payments/v2/{id}/edit` · Controller: `TransactionPaymentController::editInertia` · Submit reusa `update($id)` legacy.

--- a/resources/js/Pages/TransactionPayment/Index.charter.md
+++ b/resources/js/Pages/TransactionPayment/Index.charter.md
@@ -1,3 +1,9 @@
+---
+page: /payments/v2
+component: resources/js/Pages/TransactionPayment/Index.tsx
+status: draft
+---
+
 # Charter — `TransactionPayment/Index.tsx`
 
 > Rota Inertia: `/payments/v2` · Controller: `TransactionPaymentController::indexInertia` · Wave Blade T1 Migration B (2026-05-17).

--- a/resources/js/Pages/TransactionPayment/Show.charter.md
+++ b/resources/js/Pages/TransactionPayment/Show.charter.md
@@ -1,3 +1,9 @@
+---
+page: /payments/v2/{id}
+component: resources/js/Pages/TransactionPayment/Show.tsx
+status: draft
+---
+
 # Charter — `TransactionPayment/Show.tsx`
 
 > Rota Inertia: `/payments/v2/{id}` · Controller: `TransactionPaymentController::showInertia` · Equivalente `viewPayment()` modal Blade.

--- a/resources/js/Pages/governance/ModuleGrades/Index.charter.md
+++ b/resources/js/Pages/governance/ModuleGrades/Index.charter.md
@@ -1,8 +1,9 @@
 ---
-page: governance/ModuleGrades/Index
+page: /governance/module-grades
+component: resources/js/Pages/governance/ModuleGrades/Index.tsx
 route: /governance/module-grades
 status: live
-owner: [W]
+owner: wagner
 adrs: [0153, 0154, 0155]
 runbook: memory/requisitos/Governance/RUNBOOK-module-grades.md
 ---

--- a/resources/js/Pages/governance/ModuleGrades/Show.charter.md
+++ b/resources/js/Pages/governance/ModuleGrades/Show.charter.md
@@ -1,8 +1,9 @@
 ---
-page: governance/ModuleGrades/Show
+page: /governance/module-grades/{name}
+component: resources/js/Pages/governance/ModuleGrades/Show.tsx
 route: /governance/module-grades/{name}
 status: live
-owner: [W]
+owner: wagner
 adrs: [0153, 0154, 0155, 0167]
 runbook: memory/requisitos/Governance/RUNBOOK-module-grades.md
 ---

--- a/resources/js/Pages/kb/Graph.charter.md
+++ b/resources/js/Pages/kb/Graph.charter.md
@@ -1,15 +1,16 @@
 ---
-page: kb/Graph
+page: /kb/graph
+component: resources/js/Pages/kb/Graph.tsx
 controller: Modules\KB\Http\Controllers\KbGraphController@index (TODO Agent A — ONDA 5 backend)
 route: kb.graph
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Wagner / governança (1440px desktop)
 persona_secundaria: Larissa / operacional gráfica (1280px balcão, ONDA 6+)
 charter_version: 1.0
 charter_at: 2026-05-15
 related_adrs:
-  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central # proposta
   - 0094-constituicao-v2-7-camadas-8-principios
   - 0093-multi-tenant-isolation-tier-0
   - 0104-processo-mwart-canonico-unico-caminho

--- a/resources/js/Pages/kb/Index.charter.md
+++ b/resources/js/Pages/kb/Index.charter.md
@@ -1,15 +1,16 @@
 ---
-page: kb/Index
+page: /kb
+component: resources/js/Pages/kb/Index.tsx
 controller: Modules\KB\Http\Controllers\KbController@index
 route: kb.index
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Wagner / governança (1440px desktop)
 persona_secundaria: Larissa / operacional gráfica (1280px balcão, ONDA 6+)
 charter_version: 1.0
 charter_at: 2026-05-15
 related_adrs:
-  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central # proposta
   - 0039-ui-chat-cockpit-padrao
   - 0104-processo-mwart-canonico-unico-caminho
   - 0114-prototipo-ui-cowork-loop-formalizado

--- a/resources/js/Pages/kb/Index.v2.charter.md
+++ b/resources/js/Pages/kb/Index.v2.charter.md
@@ -1,15 +1,16 @@
 ---
-page: kb/Index.v2
+page: /kb/v2
+component: resources/js/Pages/kb/Index.v2.tsx
 controller: Modules\KB\Http\Controllers\KbController@indexV2
 route: kb.v2
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Wagner / governança (1440px desktop)
 persona_secundaria: Larissa / operacional gráfica (1280px balcão, ONDA 6+)
 charter_version: 1.0
 charter_at: 2026-05-16
 related_adrs:
-  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central # proposta
   - 0039-ui-chat-cockpit-padrao
   - 0104-processo-mwart-canonico-unico-caminho
   - 0107-emendation-0104-visual-comparison-gate-f3


### PR DESCRIPTION
## Frente CH-1 — backfill mecânico de frontmatter nos charters incompletos

**Plano-mãe:** [`memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md`](../blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) — §3 lacuna 5 ("Charters sem frontmatter: backfill mecânico ANTES do batch SA-A5") + §4 Semana 0, frente **Charters**. Motivação: [audit SDD 2026-06-12](../blob/main/memory/sessions/2026-06-12-audit-sdd-pesquisa-reclassificacao.md) (charters como fonte de inferência do join US↔tela).

**Re-derivação anti-stale:** o plano dizia "~32 sem `component:`/`page:`" — medição real em origin/main confirmou **32 incompletos** (5 sem frontmatter · 27 sem `component:` · 10 sem `page:`). O prompt da frente dizia "`page:` = caminho do .tsx" — o **schema real** (`scripts/memory-schemas/charter.schema.json`) inverte: `page:` = URL (`^/`), `component:` = path `.tsx`. Seguido o schema.

### Preenchidos (29)

`component:` = `.tsx` ao lado (existsSync verificado). `page:` = URL re-derivada das rotas reais (todas com `Inertia::render` **1-hit** + rota confirmada):

| Charter | page: | Proveniência da URL |
|---|---|---|
| Auditoria/Index ⊕ | `/auditoria` | `Modules/Auditoria/Routes/web.php` `Route::get('/')` prefix auditoria |
| ComunicacaoVisual/Index ⊕ | `/comunicacao-visual` | `Modules/ComunicacaoVisual/Routes/web.php:17-28` closure |
| TransactionPayment/Index ⊕ | `/payments/v2` | `routes/web.php:569` |
| TransactionPayment/Edit ⊕ | `/payments/v2/{id}/edit` | `routes/web.php:570` |
| TransactionPayment/Show ⊕ | `/payments/v2/{id}` | `routes/web.php:571` |
| Admin/GovernanceV4 | `/admin/governance/v4` | corpo do charter L79 + render 1-hit |
| Admin/ScreenReview | `/admin/screen-review` | corpo L77 + render 1-hit |
| Admin/ScreenReviewDashboard | `/admin/screen-review/dashboard` | fm `route:` + `Modules/Admin/Routes/web.php:95` |
| governance/ModuleGrades/Index | `/governance/module-grades` | fm `route:` |
| governance/ModuleGrades/Show | `/governance/module-grades/{name}` | fm `route:` |
| kb/Index | `/kb` | `Modules/KB/Http/routes.php:36` prefix kb |
| kb/Index.v2 | `/kb/v2` | `routes.php:42-44` named `kb.v2` (= fm `route:`) |
| kb/Graph | `/kb/graph` | `routes.php:51` |
| Financeiro/Dre/Index | `/financeiro/dre` | `Modules/Financeiro/Routes/web.php:151` prefix financeiro |
| Fiscal/Cockpit | `/fiscal` | fm `url:` + Routes prefix fiscal `Route::get('/')` |
| Fiscal/{Config,Dfe,Eventos,Nfe,Nfse,Sped} | `/fiscal/<sub>` | fm `url:` + Routes confirmam (6 telas) |
| Jana/Painel | `/jana/painel` | fm `rota:` |
| Manufacturing/Index | `/manufacturing/v2/production` | `Modules/Manufacturing/Routes/web.php:24-25` → `indexV2` |
| Purchase/Create · Purchase/Edit | `/purchases/create` · `/purchases/{id}/edit` | `Route::resource('purchases')` `routes/web.php:446` |
| StockAdjustment/{Index,Create} | `/stock-adjustments[ /create]` | `Route::resource` `routes/web.php:580` |
| StockTransfer/{Index,Create} | `/stock-transfers[ /create]` | `Route::resource` `routes/web.php:597` |

⊕ = sem frontmatter antes; ganhou bloco mínimo `page/component/status: draft` (draft porque só Wagner promove a `live` — skill charter-write).

### Pulados (3 + us:)

| Item | Razão |
|---|---|
| `kb/Node.charter.md` | Conceito drawer SEM `.tsx` dedicado — schema exige `component` `.tsx`; preencher = inventar âncora falsa |
| `kb/Paths.charter.md` | idem (dialog concept) |
| `kb/Troubleshooter.charter.md` | idem (dialog concept) |
| `us:` em TODOS os 29 | Nenhuma citação inequívoca: US-AUDIT-007 é range-pointer pro SPEC ("US-AUDIT-007..010"), US-FIN-025 é non-goal ("Mobile fica US-FIN-025"), US-RB-044 é negação ("NÃO altera US-RB-044"). Jana/Painel e Dre já carregam `us:`/`stories:` |

### Normalizações obrigatórias no frontmatter pré-existente dos arquivos tocados

O `memory-schema-gate` valida o frontmatter INTEIRO de arquivo modificado no PR (strict ON) — tocar = sair 100% válido. Achados pré-existentes corrigidos (frontmatter-only, corpo intocado):

1. **YAML inválido** `owner: [W] Wagner` (5 arquivos — crashava gray-matter, gate vermelho) + `owner: [W]`/`Wagner` (3) → `owner: wagner` (enum do schema).
2. **Octal trap**: `related_adrs: [0093, 0104, 0143…]` — YAML 1.1 parseia `0143` como inteiro **99** (corrupção silenciosa de âncora!) e `0093` como string fora do pattern → convertidos pra slugs canônicos verificados em `memory/decisions/` (8 arquivos). Colisão `0101` (2 ADRs com mesmo número) resolvida pelo próprio corpo dos charters Fiscal: "**Pest biz=1** (ADR 0101)" = `0101-tests-business-id-1-nunca-cliente`. `ui/0114` (Dre) = core `0114-prototipo-ui-cowork-loop-formalizado` (namespace UI só vai até 0018).
3. **Sufixo** `… (proposta)` em `related_adrs` (kb ×3) → vira comentário YAML `# proposta` (preserva a anotação, passa o pattern).
4. **`page_id`** com `.`/`/` → kebab (`admin-screen-review-dashboard`, `manufacturing-index`). Route names Laravel NÃO foram tocados.
5. **`status:` fora do enum** ("F3 implementado…", 6 arquivos Purchase/Stock*) → `status: draft` + `status_note:` preservando o texto original.

### DoD — evidência

Réplica local exata do step AJV do `memory-schema-gate.yml` (gray-matter + ajv/2020 allErrors contra `charter.schema.json`, escopo = diff vs origin/main):

```
29 charters no diff · 0 problemas   (29/29 PASS)
```

Inventário re-rodado pós-backfill: `sem frontmatter: 0 · sem component: 3 (os 3 kb pulados) · sem page: 0`. Cobertura `component:` 104→**133**/136, `page:` válida 121→**133**/136. Scripts determinísticos idempotentes (2ª execução: 29× "já completo", 0 mudanças) — mantidos fora do repo pra respeitar ≤300 linhas; tabela de proveniência acima é a fonte de auditoria (refutador G5).

### Decisões pendentes pro Wagner (needs_wagner)

- Confirmar mapeamento `status: "F3 implementado…"` → `draft`+`status_note` (6 charters) — alternativa seria `live`, mas só Wagner promove.
- Os 5 charters ⊕ nasceram `status: draft` — telas já em produção podem merecer `live` (decisão Wagner).
- Destino dos 3 charters kb concept sem `.tsx` (formalizar como conceito? schema com `component` opcional pra conceitos?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
