### PR TITLE
ci(tests): full-suite Pest MySQL nightly no CT 100 — script + RUNBOOK (FV-F3)

### DIFF
--- a/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
+++ b/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
@@ -28,7 +28,7 @@ related_adrs:
 `/opt/oimpresso-fullsuite/ct100-fullsuite.sh` (cópia de [`scripts/tests/ct100-fullsuite.sh`](../../../scripts/tests/ct100-fullsuite.sh) — o versionado é a fonte; atualizar a cópia após merge, passo no frontmatter):
 
 1. `git fetch/reset` do clone público em `/opt/oimpresso-fullsuite/code` (origin/main);
-2. `composer install` usando o PHP da imagem `oimpresso/mcp:latest` + `composer.phar` local (imagem não tem composer/git/node; entrypoint octane sempre sobrescrito com `--entrypoint php`);
+2. `composer install` na imagem `composer:2` (a `oimpresso/mcp` não tem composer/git e `myfatoorah/*` é source-only; `--no-scripts` + `--ignore-platform-reqs` — só baixa deps, o runtime é o mcp, cujo entrypoint octane é sempre sobrescrito com `--entrypoint php`);
 3. **recria** a DB dedicada `oimpresso_fullsuite_test` no container `mysql-workers` (usuário `fullsuite` com GRANT **só** nesse schema — Tier 0 por construção);
 4. `.env` testing idêntico ao canon CI (`.github/actions/pest-mysql-setup`) + `migrate` via schema baseline (`database/schema/mysql-schema.sql`) + seed mínimo biz=1/biz=2;
 5. `vendor/bin/pest --log-junit` (suite inteira, timeout 4h, lock anti-overlap);
@@ -40,7 +40,7 @@ related_adrs:
 /opt/oimpresso-fullsuite/
 ├── ct100-fullsuite.sh      # cópia do versionado
 ├── .env.local              # creds DB de TESTE — NUNCA no repo (chmod 600)
-├── composer.phar           # baixado no 1º run
+├── .composer-cache/        # cache composer entre runs
 ├── code/                   # clone público, reset a cada run
 ├── cron.log                # stdout do cron
 └── runs/<YYYYMMDD-HHMMSS>/ # run.log + junit.xml + summary.json + sha.txt

--- a/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
+++ b/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
@@ -1,0 +1,82 @@
+---
+title: "Full-suite Pest MySQL nightly no CT 100 (FV-F3 — diagnostica, nunca required)"
+module: "Infra"
+owner: "W"
+status: "ativo"
+last_validated: "2026-06-12"
+preconditions:
+  - "Acesso SSH root@100.99.207.66 (Tailscale, BatchMode)"
+  - "Container mysql-workers up na rede docker-host_default"
+  - "Imagem oimpresso/mcp:latest presente (PHP 8.4 + pdo_mysql)"
+  - "/opt/oimpresso-fullsuite/.env.local com creds da DB de TESTE (chmod 600)"
+steps:
+  - "Re-rodar manual: nohup /opt/oimpresso-fullsuite/ct100-fullsuite.sh &"
+  - "Acompanhar: tail -f /opt/oimpresso-fullsuite/runs/latest/run.log"
+  - "Coletar summary: cat /opt/oimpresso-fullsuite/runs/latest/summary.json"
+  - "Atualizar script: scp scripts/tests/ct100-fullsuite.sh root@100.99.207.66:/opt/oimpresso-fullsuite/"
+related_adrs:
+  - "0062-separacao-runtime-hostinger-ct100"
+  - "0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes"
+---
+
+# RUNBOOK — full-suite Pest MySQL nightly no CT 100
+
+> **FV-F3 do plano SDD** ([sessão 2026-06-12](../../sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md)): nenhum run full-repo MySQL jamais foi salvo — esta nightly produz o **1º número real** que alimenta `full_suite_pass_rate` no scorecard (ADR 0275). É **diagnóstica: NUNCA vira required**; quem promove é a catraca Q1 depois do funil de quarentena.
+
+## O que roda
+
+`/opt/oimpresso-fullsuite/ct100-fullsuite.sh` (cópia de [`scripts/tests/ct100-fullsuite.sh`](../../../scripts/tests/ct100-fullsuite.sh) — o versionado é a fonte; atualizar a cópia após merge, passo no frontmatter):
+
+1. `git fetch/reset` do clone público em `/opt/oimpresso-fullsuite/code` (origin/main);
+2. `composer install` usando o PHP da imagem `oimpresso/mcp:latest` + `composer.phar` local (imagem não tem composer/git/node; entrypoint octane sempre sobrescrito com `--entrypoint php`);
+3. **recria** a DB dedicada `oimpresso_fullsuite_test` no container `mysql-workers` (usuário `fullsuite` com GRANT **só** nesse schema — Tier 0 por construção);
+4. `.env` testing idêntico ao canon CI (`.github/actions/pest-mysql-setup`) + `migrate` via schema baseline (`database/schema/mysql-schema.sql`) + seed mínimo biz=1/biz=2;
+5. `vendor/bin/pest --log-junit` (suite inteira, timeout 4h, lock anti-overlap);
+6. summary via [`scripts/tests/junit-summary.mjs`](../../../scripts/tests/junit-summary.mjs) (FV-F1 — tripwire de artefato 0 bytes) + retenção dos últimos 14 runs.
+
+## Onde ficam os artefatos
+
+```
+/opt/oimpresso-fullsuite/
+├── ct100-fullsuite.sh      # cópia do versionado
+├── .env.local              # creds DB de TESTE — NUNCA no repo (chmod 600)
+├── composer.phar           # baixado no 1º run
+├── code/                   # clone público, reset a cada run
+├── cron.log                # stdout do cron
+└── runs/<YYYYMMDD-HHMMSS>/ # run.log + junit.xml + summary.json + sha.txt
+    └── latest -> símlink pro run mais recente
+```
+
+## Cron (02:00 BRT — host já é America/Sao_Paulo)
+
+```
+0 2 * * * /opt/oimpresso-fullsuite/ct100-fullsuite.sh >> /opt/oimpresso-fullsuite/cron.log 2>&1
+```
+
+Instalado no crontab do root do CT 100. Conferir: `ssh root@100.99.207.66 crontab -l`.
+
+## Como coletar o resultado (consumo pelo scorecard)
+
+```bash
+ssh -o BatchMode=yes root@100.99.207.66 cat /opt/oimpresso-fullsuite/runs/latest/summary.json
+```
+
+`summary.json` traz contagens por arquivo de teste (sem mensagens de falha — repo é público, anti-PII por construção). `sha.txt` diz contra qual commit de main o run rodou. Se `summary.json` não existir, o run morreu antes do flush — ver `run.log` do mesmo diretório.
+
+## Guard-rails anti-prod (ADR 0062)
+
+- Script **aborta** se `DB_DATABASE` não terminar em `_test`;
+- usuário MySQL `fullsuite` tem GRANT apenas em `oimpresso_fullsuite_test.*` — mesmo um teste mal-comportado não alcança `oimpresso_workers` nem qualquer outra base;
+- nada em `/opt` existente foi tocado; containers existentes intactos (suite roda em containers descartáveis `--rm`);
+- Hostinger fora do circuito por completo.
+
+## Troubleshooting
+
+| Sintoma | Ação |
+|---|---|
+| "outro run em andamento" | lock ativo (`/opt/oimpresso-fullsuite/.lock`); se órfão: `docker rm -f oimpresso-fullsuite-run` e re-rodar |
+| junit.xml 0 bytes / ausente | run morto antes do flush (OOM/timeout) — ver fim do `run.log`; subir `FULLSUITE_TIMEOUT` ou rodar chunked (abaixo) |
+| migrate falha | schema baseline mudou em main — rodar de novo (DB é recriada do zero a cada run) |
+| disco | retenção automática mantém 14 runs; clone+vendor ~2,5 GB |
+
+**Modo chunked** (fallback se a suite inteira estourar memória): rodar por diretório com um junit por chunk, ex. `--log-junit /artifacts/junit-unit.xml tests/Unit`, depois `Modules/<X>/Tests` um a um, e somar os summaries.

--- a/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
+++ b/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
@@ -31,7 +31,7 @@ related_adrs:
 2. `composer install` na imagem `composer:2` (a `oimpresso/mcp` não tem composer/git e `myfatoorah/*` é source-only; `--no-scripts` + `--ignore-platform-reqs` — só baixa deps, o runtime é o mcp, cujo entrypoint octane é sempre sobrescrito com `--entrypoint php`);
 3. **recria** a DB dedicada `oimpresso_fullsuite_test` no container `mysql-workers` (usuário `fullsuite` com GRANT **só** nesse schema — Tier 0 por construção);
 4. `.env` testing idêntico ao canon CI (`.github/actions/pest-mysql-setup`) + `migrate` via schema baseline (`database/schema/mysql-schema.sql`) + seed mínimo biz=1/biz=2;
-5. `vendor/bin/pest --log-junit` (suite inteira, timeout 4h, lock anti-overlap);
+5. `vendor/bin/pest --log-junit` (suite inteira, timeout 4h, lock anti-overlap). Arquivo que mata o **loader** da suite (`uses(TestCase)` file-level em pasta já vinculada no `tests/Pest.php` — 4 casos conhecidos em `tests/Feature` em 2026-06-12) é posto de lado **só no clone descartável**, registrado em `loader-blockers.txt` (dado pro triage Q2) e o run re-tenta — consertar os arquivos é das lanes de burn-down;
 6. summary via [`scripts/tests/junit-summary.mjs`](../../../scripts/tests/junit-summary.mjs) (FV-F1 — tripwire de artefato 0 bytes) + retenção dos últimos 14 runs.
 
 ## Onde ficam os artefatos

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# ct100-fullsuite.sh — nightly full-suite Pest contra MySQL REAL no CT 100.
+# FV-F3 (plano SDD 2026-06-12) — corrida DIAGNOSTICA: 1o numero real da suite
+# inteira; NUNCA vira required. Artefatos: junit.xml + summary.json + run.log.
+#
+# Instalado em: /opt/oimpresso-fullsuite/ct100-fullsuite.sh (COPIA deste arquivo
+# versionado — atualizar la apos merge; ver RUNBOOK-ct100-fullsuite.md).
+# Cron root: 0 2 * * * (host TZ America/Sao_Paulo => 02:00 BRT).
+#
+# Guard-rails (ADR 0062 — CT 100 isolado, NUNCA prod):
+#   - DB de teste DEDICADA (recriada a cada run) no container mysql-workers;
+#   - usuario MySQL proprio com GRANT SOMENTE no schema *_test;
+#   - aborta se DB_DATABASE nao terminar em _test;
+#   - creds vivem APENAS em /opt/oimpresso-fullsuite/.env.local (chmod 600).
+set -euo pipefail
+export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+
+BASE="${FULLSUITE_BASE:-/opt/oimpresso-fullsuite}"
+CODE="$BASE/code"
+RUNS="$BASE/runs"
+IMAGE="${FULLSUITE_IMAGE:-oimpresso/mcp:latest}"     # PHP 8.4 ZTS + pdo_mysql
+NET="${FULLSUITE_NET:-docker-host_default}"          # rede onde mysql-workers resolve por DNS
+MYSQL_CONTAINER="${FULLSUITE_MYSQL_CONTAINER:-mysql-workers}"
+REPO_URL="${FULLSUITE_REPO:-https://github.com/wagnerra23/oimpresso.com.git}"
+TIMEOUT_S="${FULLSUITE_TIMEOUT:-14400}"              # hard-kill 4h
+KEEP_RUNS="${FULLSUITE_KEEP_RUNS:-14}"
+ENV_LOCAL="$BASE/.env.local"
+
+# lock — cron + run manual nunca sobrepoem
+exec 9>"$BASE/.lock"
+flock -n 9 || { echo "ct100-fullsuite: outro run em andamento (lock $BASE/.lock) — saindo"; exit 0; }
+
+[ -f "$ENV_LOCAL" ] || { echo "FATAL: $ENV_LOCAL ausente (DB_HOST/DB_PORT/DB_DATABASE/DB_USERNAME/DB_PASSWORD)"; exit 1; }
+# shellcheck disable=SC1090
+source "$ENV_LOCAL"
+
+case "$DB_DATABASE" in
+  *_test) ;;
+  *) echo "FATAL: DB_DATABASE '$DB_DATABASE' nao termina em _test — protecao anti-prod (ADR 0062)"; exit 1 ;;
+esac
+
+TS="$(date +%Y%m%d-%H%M%S)"
+RUN_DIR="$RUNS/$TS"
+mkdir -p "$RUN_DIR"
+exec > >(tee -a "$RUN_DIR/run.log") 2>&1
+echo "=== ct100-fullsuite $TS (db=$DB_DATABASE host=$DB_HOST image=$IMAGE) ==="
+
+# container PHP descartavel (entrypoint da imagem e octane — sempre sobrescrever)
+dphp() {
+  docker run --rm --network "$NET" \
+    -v "$CODE":/workspace -v "$RUN_DIR":/artifacts \
+    -v "$BASE/composer.phar":/composer.phar:ro \
+    -v "$BASE/.composer-cache":/composer-cache \
+    -e COMPOSER_CACHE_DIR=/composer-cache -e COMPOSER_ALLOW_SUPERUSER=1 \
+    -w /workspace --entrypoint php "$IMAGE" "$@"
+}
+
+echo "--- [1/7] sync codigo (origin/main)"
+if [ ! -d "$CODE/.git" ]; then
+  git clone --depth 1 "$REPO_URL" "$CODE"
+else
+  git -C "$CODE" fetch --depth 1 origin main
+  git -C "$CODE" reset --hard FETCH_HEAD
+  git -C "$CODE" clean -fd --quiet || true
+fi
+SHA="$(git -C "$CODE" rev-parse --short HEAD)"
+echo "$SHA" > "$RUN_DIR/sha.txt"
+echo "HEAD: $SHA"
+
+echo "--- [2/7] composer install (php da imagem + composer.phar local)"
+mkdir -p "$BASE/.composer-cache"
+[ -f "$BASE/composer.phar" ] || curl -fsSL https://getcomposer.org/download/latest-2.x/composer.phar -o "$BASE/composer.phar"
+mkdir -p "$CODE/storage/framework/cache" "$CODE/storage/framework/sessions" \
+         "$CODE/storage/framework/views" "$CODE/storage/logs" "$CODE/bootstrap/cache"
+dphp /composer.phar install --no-interaction --prefer-dist --no-progress --no-scripts
+
+echo "--- [3/7] recria DB de teste dedicada ($DB_DATABASE)"
+docker exec -i "$MYSQL_CONTAINER" sh -c 'MYSQL_PWD=$(cat /run/secrets/mysql_root) exec mysql -uroot' <<SQL
+DROP DATABASE IF EXISTS \`$DB_DATABASE\`;
+CREATE DATABASE \`$DB_DATABASE\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS '$DB_USERNAME'@'%' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON \`$DB_DATABASE\`.* TO '$DB_USERNAME'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+echo "--- [4/7] .env testing + key + discover"
+cat > "$CODE/.env" <<EOF
+APP_NAME=oimpresso-fullsuite
+APP_ENV=testing
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+LOG_CHANNEL=stderr
+DB_CONNECTION=mysql
+DB_HOST=$DB_HOST
+DB_PORT=$DB_PORT
+DB_DATABASE=$DB_DATABASE
+DB_USERNAME=$DB_USERNAME
+DB_PASSWORD=$DB_PASSWORD
+CACHE_DRIVER=array
+QUEUE_CONNECTION=sync
+SESSION_DRIVER=array
+MAIL_MAILER=array
+BCRYPT_ROUNDS=4
+TELESCOPE_ENABLED=false
+SCOUT_DRIVER=null
+MCP_TOOLS_EXPOSED=false
+EOF
+dphp artisan key:generate --force
+dphp artisan package:discover --ansi
+
+echo "--- [5/7] migrate (schema baseline) + seed minimo multi-tenant"
+dphp artisan migrate --force
+# seed identico ao canon CI (.github/actions/pest-mysql-setup): biz=1 fixture + biz=2 Tier 0
+cat > "$CODE/storage/fullsuite-seed.php" <<'PHPEOF'
+<?php
+use Illuminate\Support\Facades\DB;
+$curId = optional(DB::table('currencies')->first())->id ?? 1;
+if (! DB::table('business')->where('id', 1)->exists()) {
+    $uid = DB::table('users')->insertGetId(['first_name'=>'CI','username'=>'ci_admin','password'=>bcrypt('ci'),'created_at'=>now(),'updated_at'=>now()]);
+    $bid = DB::table('business')->insertGetId(['name'=>'CI Biz','currency_id'=>$curId,'owner_id'=>$uid,'stop_selling_before'=>0,'weighing_scale_setting'=>'','certificado'=>'','officeimpresso_numerodemaquinas'=>0,'created_at'=>now(),'updated_at'=>now()]);
+    DB::table('users')->where('id', $uid)->update(['business_id'=>$bid]);
+    echo 'seed biz='.$bid.' user='.$uid.PHP_EOL;
+}
+if (! DB::table('business')->where('id', 2)->exists()) {
+    $uid2 = DB::table('users')->insertGetId(['first_name'=>'CI Biz2','username'=>'ci_admin_b2','password'=>bcrypt('ci'),'created_at'=>now(),'updated_at'=>now()]);
+    DB::table('business')->insert(['id'=>2,'name'=>'CI Biz 2','currency_id'=>$curId,'owner_id'=>$uid2,'stop_selling_before'=>0,'weighing_scale_setting'=>'','certificado'=>'','officeimpresso_numerodemaquinas'=>0,'created_at'=>now(),'updated_at'=>now()]);
+    DB::table('users')->where('id', $uid2)->update(['business_id'=>2]);
+    echo 'seed biz2=2 user='.$uid2.PHP_EOL;
+}
+DB::statement('SET FOREIGN_KEY_CHECKS=0');
+$bizId = optional(DB::table('business')->first())->id;
+if ($bizId && ! \Modules\Financeiro\Models\ContaBancaria::query()->where('business_id', $bizId)->exists()) {
+    \Modules\Financeiro\Models\ContaBancaria::create([
+        'business_id'=>$bizId,'account_id'=>999001,'agencia'=>'0001','carteira'=>'0',
+        'beneficiario_documento'=>'00000000000000','beneficiario_razao_social'=>'CI Test','saldo_cached'=>0,
+    ]);
+    echo 'conta criada biz='.$bizId.PHP_EOL;
+}
+if ($bizId && ! DB::table('business_locations')->where('business_id', $bizId)->exists()) {
+    DB::table('business_locations')->insert(['business_id'=>$bizId,'name'=>'Matriz CI','country'=>'BR','state'=>'SP','city'=>'SP','zip_code'=>'0','created_at'=>now(),'updated_at'=>now()]);
+    echo 'location criada'.PHP_EOL;
+}
+if ($bizId && ! DB::table('contacts')->where('business_id', $bizId)->where('type', '!=', 'lead')->exists()) {
+    DB::table('contacts')->insert(['business_id'=>$bizId,'type'=>'customer','name'=>'Cliente CI','contact_id'=>'CO0001','created_by'=>1,'is_default'=>1,'created_at'=>now(),'updated_at'=>now()]);
+    echo 'contact criado'.PHP_EOL;
+}
+PHPEOF
+dphp artisan db:seed --class="Database\\Seeders\\CurrenciesTableSeeder" --force || true
+dphp artisan db:seed --class="Database\\Seeders\\PermissionsTableSeeder" --force || true
+dphp artisan tinker --execute="require base_path('storage/fullsuite-seed.php');"
+
+echo "--- [6/7] pest full-suite (diagnostico — fail e DADO, nao erro; timeout ${TIMEOUT_S}s)"
+docker rm -f oimpresso-fullsuite-run >/dev/null 2>&1 || true
+PEST_EXIT=0
+timeout -s TERM "$TIMEOUT_S" docker run --rm --name oimpresso-fullsuite-run \
+  --network "$NET" -v "$CODE":/workspace -v "$RUN_DIR":/artifacts \
+  -w /workspace --entrypoint php "$IMAGE" -d memory_limit=2G \
+  vendor/bin/pest --log-junit /artifacts/junit.xml --colors=never || PEST_EXIT=$?
+docker rm -f oimpresso-fullsuite-run >/dev/null 2>&1 || true
+echo "pest exit code: $PEST_EXIT"
+
+echo "--- [7/7] summary (junit-summary.mjs FV-F1 — tripwire artefato 0 bytes) + retencao"
+node "$CODE/scripts/tests/junit-summary.mjs" "$RUN_DIR/junit.xml" --out "$RUN_DIR/summary.json" \
+  || echo "junit-summary exit $? — XML ausente/incoerente (run morreu antes do flush?)"
+ln -sfn "$RUN_DIR" "$RUNS/latest"
+find "$RUNS" -maxdepth 1 -mindepth 1 -type d | sort | head -n "-$KEEP_RUNS" | xargs -r rm -rf
+echo "=== done $TS sha=$SHA pest_exit=$PEST_EXIT artefatos=$RUN_DIR ==="

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -49,9 +49,6 @@ echo "=== ct100-fullsuite $TS (db=$DB_DATABASE host=$DB_HOST image=$IMAGE) ==="
 dphp() {
   docker run --rm --network "$NET" \
     -v "$CODE":/workspace -v "$RUN_DIR":/artifacts \
-    -v "$BASE/composer.phar":/composer.phar:ro \
-    -v "$BASE/.composer-cache":/composer-cache \
-    -e COMPOSER_CACHE_DIR=/composer-cache -e COMPOSER_ALLOW_SUPERUSER=1 \
     -w /workspace --entrypoint php "$IMAGE" "$@"
 }
 
@@ -67,12 +64,15 @@ SHA="$(git -C "$CODE" rev-parse --short HEAD)"
 echo "$SHA" > "$RUN_DIR/sha.txt"
 echo "HEAD: $SHA"
 
-echo "--- [2/7] composer install (php da imagem + composer.phar local)"
-mkdir -p "$BASE/.composer-cache"
-[ -f "$BASE/composer.phar" ] || curl -fsSL https://getcomposer.org/download/latest-2.x/composer.phar -o "$BASE/composer.phar"
-mkdir -p "$CODE/storage/framework/cache" "$CODE/storage/framework/sessions" \
+echo "--- [2/7] composer install (imagem composer:2 — myfatoorah/* e source-only, exige git)"
+# A imagem oimpresso/mcp nao tem composer nem git; composer:2 tem ambos. So
+# baixa deps (--no-scripts): nenhum codigo do app roda; runtime real e o mcp.
+mkdir -p "$BASE/.composer-cache" \
+         "$CODE/storage/framework/cache" "$CODE/storage/framework/sessions" \
          "$CODE/storage/framework/views" "$CODE/storage/logs" "$CODE/bootstrap/cache"
-dphp /composer.phar install --no-interaction --prefer-dist --no-progress --no-scripts
+docker run --rm --network "$NET" -v "$CODE":/app -w /app \
+  -v "$BASE/.composer-cache":/tmp/composer-cache -e COMPOSER_CACHE_DIR=/tmp/composer-cache \
+  composer:2 composer install --no-interaction --prefer-dist --no-progress --no-scripts --ignore-platform-reqs
 
 echo "--- [3/7] recria DB de teste dedicada ($DB_DATABASE)"
 docker exec -i "$MYSQL_CONTAINER" sh -c 'MYSQL_PWD=$(cat /run/secrets/mysql_root) exec mysql -uroot' <<SQL

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -158,13 +158,29 @@ dphp artisan tinker --execute="require base_path('storage/fullsuite-seed.php');"
 
 echo "--- [6/7] pest full-suite (diagnostico — fail e DADO, nao erro; timeout ${TIMEOUT_S}s)"
 docker rm -f oimpresso-fullsuite-run >/dev/null 2>&1 || true
+# Arquivo com uses(TestCase) file-level dentro de pasta ja vinculada no
+# tests/Pest.php ->in('Feature') MATA o loader da suite inteira (exit 255)
+# antes de executar 1 teste — 4 casos conhecidos em tests/Feature (2026-06-12).
+# Diagnostico nao pode morrer com isso: poe o arquivo de lado SO NO CLONE
+# descartavel, REGISTRA em loader-blockers.txt (vira dado pro triage Q2) e
+# re-tenta. Consertar os arquivos e das lanes de burn-down, nao desta.
 PEST_EXIT=0
-timeout -s TERM "$TIMEOUT_S" docker run --rm --name oimpresso-fullsuite-run \
-  --network "$NET" -v "$CODE":/workspace -v "$RUN_DIR":/artifacts \
-  -w /workspace --entrypoint php "$IMAGE" -d memory_limit=2G \
-  vendor/bin/pest --log-junit /artifacts/junit.xml --colors=never || PEST_EXIT=$?
+for attempt in $(seq 1 12); do
+  PEST_EXIT=0
+  timeout -s TERM "$TIMEOUT_S" docker run --rm --name oimpresso-fullsuite-run \
+    --network "$NET" -v "$CODE":/workspace -v "$RUN_DIR":/artifacts \
+    -w /workspace --entrypoint php "$IMAGE" -d memory_limit=2G \
+    vendor/bin/pest --log-junit /artifacts/junit.xml --colors=never \
+    2>&1 | tee "$RUN_DIR/pest-out.txt" || PEST_EXIT=$?
+  BLOCKER=$(grep -oP 'can not be used\. The folder \[/workspace/\K[^]]+' "$RUN_DIR/pest-out.txt" | head -1 || true)
+  [ -z "$BLOCKER" ] && break
+  echo "LOADER-BLOCKER ($attempt): $BLOCKER — movido pro lado no clone, registrado"
+  echo "$BLOCKER" >> "$RUN_DIR/loader-blockers.txt"
+  mkdir -p "$CODE/.loader-quarantine/$(dirname "$BLOCKER")"
+  mv "$CODE/$BLOCKER" "$CODE/.loader-quarantine/$BLOCKER"
+done
 docker rm -f oimpresso-fullsuite-run >/dev/null 2>&1 || true
-echo "pest exit code: $PEST_EXIT"
+echo "pest exit code: $PEST_EXIT (loader-blockers: $(wc -l < "$RUN_DIR/loader-blockers.txt" 2>/dev/null || echo 0))"
 
 echo "--- [7/7] summary (junit-summary.mjs FV-F1 — tripwire artefato 0 bytes) + retencao"
 node "$CODE/scripts/tests/junit-summary.mjs" "$RUN_DIR/junit.xml" --out "$RUN_DIR/summary.json" \

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -110,6 +110,12 @@ dphp artisan key:generate --force
 dphp artisan package:discover --ansi
 
 echo "--- [5/7] migrate (schema baseline) + seed minimo multi-tenant"
+# A imagem mcp nao tem o CLI mysql que `artisan migrate` invoca pra carregar o
+# schema dump ("Loading stored database schemas" → sh: mysql: not found).
+# Preload manual do baseline (820 migrations ja registradas no dump) usando o
+# client do proprio container mysql; o migrate entao so roda migrations novas.
+docker exec -i "$MYSQL_CONTAINER" sh -c "MYSQL_PWD=\$(cat /run/secrets/mysql_root) exec mysql -uroot $DB_DATABASE" \
+  < "$CODE/database/schema/mysql-schema.sql"
 dphp artisan migrate --force
 # seed identico ao canon CI (.github/actions/pest-mysql-setup): biz=1 fixture + biz=2 Tier 0
 cat > "$CODE/storage/fullsuite-seed.php" <<'PHPEOF'


### PR DESCRIPTION
## O que

Frente **FV-F3-CT100** da FASE 1 da reestruturação SDD ([plano 2026-06-12](memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) · semanas 1-2): nightly **diagnóstica** full-suite Pest contra MySQL real no CT 100 — produz o 1º número real de `full_suite_pass_rate` pro scorecard (ADR 0275). O plano §0 mediu: nenhum run full-repo MySQL jamais foi salvo (artefato 0 bytes).

- `scripts/tests/ct100-fullsuite.sh` (novo, 190 linhas) — fonte versionada; cópia instalada em `/opt/oimpresso-fullsuite/` no CT 100 via scp (passo no RUNBOOK).
- `memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md` (novo, 82 linhas) — re-rodar, artefatos, coleta do summary, troubleshooting, modo chunked. Frontmatter validado local contra `runbook.schema.json` (AJV, mesmo código do gate).

## Como roda

1. clone público em `/opt/oimpresso-fullsuite/code` (reset pra origin/main a cada run);
2. composer install na imagem `composer:2` (a `oimpresso/mcp` não tem composer/git e `myfatoorah/*` é source-only; `--no-scripts --ignore-platform-reqs` — só baixa deps);
3. **DB de teste dedicada** `oimpresso_fullsuite_test` recriada por run no `mysql-workers`; usuário `fullsuite` com GRANT **só** nesse schema; script **aborta** se `DB_DATABASE` não terminar em `_test` (ADR 0062 — NUNCA prod);
4. preload do schema baseline via client do próprio mysql-workers (a mcp não tem o CLI `mysql` que o `artisan migrate` shella) + migrate + seed mínimo biz=1/biz=2 (réplica do canon `.github/actions/pest-mysql-setup`, FV-F2);
5. `vendor/bin/pest --log-junit` (timeout 4h, lock anti-overlap). **Loader-blockers** (`uses(TestCase)` file-level em pasta já vinculada no `tests/Pest.php` — mata a suite inteira com exit 255 antes de executar 1 teste) são postos de lado SÓ no clone descartável, registrados em `loader-blockers.txt` e o run re-tenta;
6. summary via `scripts/tests/junit-summary.mjs` (FV-F1, tripwire 0 bytes) + retenção 14 runs.

## Descobertas do 1º run real (run `20260612-101615`, sha 50db892)

- **4 loader-blockers** invisíveis no CI (ci.yml roda subset path-scoped): `tests/Feature/Domain/Fsm/ConsumirEstoqueAuditTest.php` + `tests/Feature/Sells/{SaleJourneyGatingTest,SellsCreateVehicleGatingTest,VeiculoNaVendaSchemaTest}.php` — consertar é das lanes de burn-down FV-B*, não desta;
- amostra `tests/Unit` contra MySQL real: **16 failed, 96 passed (2491 assertions)** — primeiro número real da história da full-suite;
- suite completa em execução no momento da abertura deste PR (resultado no `runs/latest/summary.json` quando terminar).

## Estado no CT 100 (já executado)

- Cron root instalado: `0 2 * * * /opt/oimpresso-fullsuite/ct100-fullsuite.sh >> /opt/oimpresso-fullsuite/cron.log 2>&1` (host TZ America/Sao_Paulo = 02:00 BRT);
- 1º run full em andamento (nohup); artefatos em `/opt/oimpresso-fullsuite/runs/latest/`;
- creds da DB de teste só em `/opt/oimpresso-fullsuite/.env.local` (chmod 600, geradas no servidor — zero credencial neste repo);
- nada existente em /opt tocado; containers existentes intactos (suite roda em containers `--rm`); Hostinger fora do circuito.

## Gates

- Nightly é diagnóstica e roda FORA do GitHub Actions → **nenhum workflow novo**, sem entry em `gates-registry.json`. Promoção a required é da catraca Q1 (calendário ADR 0275), não desta lane — esta nightly **NUNCA vira required**.

Refs: ADR 0062 · ADR 0275 · plano SDD 2026-06-12 FASE-1 FV-F3

🤖 Generated with [Claude Code](https://claude.com/claude-code)