### PR TITLE
ci(governance): anchor-lint ADR 0273 + anchor-drift advisory diff-aware (SDD SA-A2/A3)

### DIFF
--- a/.github/workflows/anchor-drift.yml
+++ b/.github/workflows/anchor-drift.yml
@@ -1,0 +1,60 @@
+name: Anchor Drift (advisory)
+
+# Lint do anchor spec↔código — SA-A3 do plano SDD (memory/sessions/2026-06-12-
+# plano-reestruturacao-sdd-ondas-paralelas.md, frente SA) · gramática ADR 0273.
+#
+# ADVISORY (fase F1 do ratchet, ADR 0273 §4): nasce fora dos required (regra do
+# projeto: gate novo nunca nasce required). O lint roda em modo REPORT (exit 0
+# sempre) — vermelho aqui só se o script quebrar (precedente mutation-gate: sem
+# mascara de erro; advisory porque NAO e required, nao porque se esconde).
+# Promoção F2 (diff-only required) / F3 (full-tree) via calendario de promocoes
+# do ADR 0275 — nunca neste arquivo direto.
+#
+# DIFF-AWARE nos PRs: linta só os SPECs tocados (args posicionais do lint).
+# CRON semanal: full-tree (anchor morre quando CÓDIGO move sem o SPEC mudar —
+# só o full-tree periódico pega esse drift).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'memory/requisitos/**/SPEC.md'
+      - 'scripts/governance/anchor-lint.mjs'
+      - '.github/workflows/anchor-drift.yml'
+  schedule:
+    - cron: '0 6 * * 1' # segunda 06:00 UTC — full-tree semanal
+  workflow_dispatch:
+
+concurrency:
+  group: anchor-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  anchor-lint:
+    name: anchor-lint ADR 0273 (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # diff contra base do PR
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: anchor-lint (diff-aware no PR · full-tree no cron/dispatch)
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            CHANGED=$(git diff --name-only --diff-filter=d "origin/${{ github.base_ref }}...HEAD" -- 'memory/requisitos/*/SPEC.md')
+            if [ -n "$CHANGED" ]; then
+              echo "SPECs tocados no PR:"; echo "$CHANGED"
+              # shellcheck disable=SC2086
+              node scripts/governance/anchor-lint.mjs $CHANGED
+            else
+              echo "Nenhum SPEC tocado (PR mudou lint/workflow) — full-tree:"
+              node scripts/governance/anchor-lint.mjs
+            fi
+          else
+            node scripts/governance/anchor-lint.mjs
+          fi

--- a/scripts/governance/anchor-lint.mjs
+++ b/scripts/governance/anchor-lint.mjs
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+// anchor-lint.mjs — parser da gramática anchor spec↔código (ADR 0273 · passo SA-A2
+// do plano memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md).
+//
+// POR QUE EXISTE: "a spec mente" (auditoria SDD 2026-06-12). O campo
+// `**Implementado em:**` não tinha formato máquina-parseável — sem lint, anchor
+// falso/morto/placeholder era indistinguível de anchor verdadeiro. Este script
+// implementa EXATAMENTE a gramática do ADR 0273 §1 (sentinelas `_pendente_` e
+// `_parcial_` como estados de 1ª classe) e classifica cada US dos SPECs:
+//
+//   sem_campo     US sem linha `**Implementado em:**`
+//   placeholder   legado: _[TODO…]_ · _[path]_ · (a criar…) · pseudo-path _xx_
+//   pendente      `_pendente_` — tela não construída é estado LEGÍTIMO (coberta)
+//   parcial       `_parcial_` + ≥1 path, todos existentes (coberta, pendência rastreável)
+//   anchored_ok   preenchido com ≥1 segmento-path e TODOS os paths existem no disco
+//   anchored_dead preenchido mas path inexistente OU sem nenhum path verificável
+//                 (anchor quebrado = mentira detectável — ADR 0273 §2)
+//
+// anchor_coverage = (anchored_ok + pendente + parcial) / US_total  — por módulo e global.
+//
+// Uso (na raiz do repo):
+//   node scripts/governance/anchor-lint.mjs                 # full-tree, tabela humana
+//   node scripts/governance/anchor-lint.mjs --json          # JSON determinístico (sem timestamp/sha)
+//   node scripts/governance/anchor-lint.mjs <SPEC.md ...>   # diff-aware: só os SPECs passados
+//   node scripts/governance/anchor-lint.mjs --check         # exit 1 se dead>0 ou violação v1 —
+//                                                           # RESERVADO pra fase F2 (ADR 0273 §4);
+//                                                           # F1 ADVISORY usa modos acima (exit 0 sempre)
+// Node puro (fs). Sem deps, sem DB, sem PHP. Idioma: clone de knowledge-drift.mjs.
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { join, dirname, resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const REQ = join(ROOT, 'memory', 'requisitos');
+const JSON_OUT = process.argv.includes('--json');
+const CHECK = process.argv.includes('--check');
+
+// ── regexes canônicas (ADR 0273 §1 — referência única; NÃO afrouxar sem novo ADR) ──
+const GRAMMAR_RE = /^\*\*Implementado em:\*\* (?:_pendente_(?: — .+)?|(?:_parcial_ · )?(?:`[^`]+`)(?: · `[^`]+`)* · verificado@[0-9a-f]{7} \(\d{4}-\d{2}-\d{2}\)(?: — .+)?)$/;
+// detecção LENIENTE de campo (legados usam `> ` blockquote — Vestuario — e espaçamento vário)
+const FIELD_RE = /^(?:>\s*)?\*\*Implementado em:\*\*\s*(.*)$/;
+const US_HEAD_RE = /^(#{2,4})\s+.*\bUS-[A-Z][A-Za-z0-9]*-\d/;
+const US_ID_RE = /US-[A-Z][A-Za-z0-9]*-\d+(?:\.\.\d+)?/;
+const HEAD_RE = /^(#{1,6})\s/;
+// taxonomia de placeholder legado (ADR 0273 "Contexto") — pendente/parcial têm precedência
+const PLACEHOLDER_RE = /TODO|_\[path\]_|\ba criar\b|_xx_/i;
+const MDLINK_RE = /\[`([^`]+)`\]\(([^)]+)\)/g; // [`seg`](alvo) — alvo relativo ao SPEC
+const ANCHOR_FORMAT_V1_RE = /^anchor_format:\s*["']?v1["']?\s*$/m;
+
+function frontmatter(txt) {
+  if (!txt.startsWith('---')) return '';
+  const end = txt.indexOf('\n---', 3);
+  return end === -1 ? '' : txt.slice(0, end);
+}
+
+// extrai segmentos-path verificáveis do resto do campo; devolve {paths:[{seg,abs}],…}
+function extractPaths(rest, specDir) {
+  const paths = [];
+  let remaining = rest;
+  for (const m of rest.matchAll(MDLINK_RE)) {
+    const target = m[2].split('#')[0];
+    if (/^https?:/.test(target)) continue;
+    if (m[1].includes('/') || target.includes('/')) {
+      paths.push({ seg: m[1], abs: resolve(specDir, target) });
+      remaining = remaining.replace(m[0], ' ');
+    }
+  }
+  for (const m of remaining.matchAll(/`([^`]+)`/g)) {
+    const seg = m[1].replace(/[.,;:]+$/, '');
+    // segmento-path = contém '/' E é relativo à raiz do repo (ADR 0273 §1);
+    // `/rota` (URL) e `~/...` (home) não são verificáveis → tratados como símbolo
+    if (seg.includes('/') && !seg.startsWith('/') && !seg.startsWith('~')) paths.push({ seg, abs: resolve(ROOT, seg) });
+  }
+  return paths;
+}
+
+function classify(rest, specDir) {
+  if (rest.startsWith('_pendente_')) return { state: 'pendente', dead: [] };
+  const parcial = rest.startsWith('_parcial_');
+  if (!parcial && PLACEHOLDER_RE.test(rest)) return { state: 'placeholder', dead: [] };
+  const paths = extractPaths(rest, specDir);
+  const dead = paths.filter((p) => !existsSync(p.abs)).map((p) => p.seg);
+  if (!paths.length) return { state: 'anchored_dead', dead: ['(nenhum segmento-path — preenchido/parcial exige ≥1 path, ADR 0273 §1)'] };
+  if (dead.length) return { state: 'anchored_dead', dead };
+  return { state: parcial ? 'parcial' : 'anchored_ok', dead: [] };
+}
+
+function lintSpec(file) {
+  const txt = readFileSync(file, 'utf8');
+  const specDir = dirname(file);
+  const isV1 = ANCHOR_FORMAT_V1_RE.test(frontmatter(txt));
+  const lines = txt.split('\n');
+  const usList = []; // {id, line, level, fields:[{line, raw, rest}]}
+  const orphans = [];
+  let cur = null;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trimEnd();
+    const head = line.match(HEAD_RE);
+    if (head) {
+      if (US_HEAD_RE.test(line)) {
+        cur = { id: (line.match(US_ID_RE) || ['US-?'])[0], line: i + 1, level: head[1].length, fields: [] };
+        usList.push(cur);
+      } else if (cur && head[1].length <= cur.level) cur = null;
+      continue;
+    }
+    const f = line.match(FIELD_RE);
+    if (f) (cur ? cur.fields : orphans).push({ line: i + 1, raw: line, rest: f[1] });
+  }
+  const counts = { sem_campo: 0, placeholder: 0, pendente: 0, parcial: 0, anchored_ok: 0, anchored_dead: 0 };
+  const deadList = [], v1Violations = [];
+  let fieldsTotal = 0, fieldsPlaceholder = 0, grammarOk = 0;
+  const everyField = [...usList.flatMap((u) => u.fields), ...orphans];
+  for (const f of everyField) {
+    fieldsTotal++;
+    if (GRAMMAR_RE.test(f.raw)) grammarOk++;
+    else if (isV1) v1Violations.push({ line: f.line, raw: f.raw.slice(0, 120) });
+    const c = classify(f.rest, specDir);
+    if (c.state === 'placeholder') fieldsPlaceholder++;
+    f.state = c.state; f.dead = c.dead;
+  }
+  for (const u of usList) {
+    if (!u.fields.length) { counts.sem_campo++; continue; }
+    const c = u.fields[0]; // 1 linha por US (gramática); extras contam em fields_total
+    counts[c.state]++;
+    if (c.state === 'anchored_dead') deadList.push({ us: u.id, line: c.line, missing: c.dead });
+  }
+  const usTotal = usList.length;
+  const covered = counts.anchored_ok + counts.pendente + counts.parcial;
+  return {
+    us_total: usTotal, counts, coverage_pct: usTotal ? Math.round((1000 * covered) / usTotal) / 10 : null,
+    fields_total: fieldsTotal, fields_placeholder: fieldsPlaceholder, fields_grammar_ok: grammarOk,
+    orphan_fields: orphans.length, anchor_format_v1: isV1, dead: deadList, v1_violations: v1Violations,
+  };
+}
+
+// ── seleção de SPECs: full-tree ou diff-aware (args posicionais) ─────────────
+const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+let specs;
+if (args.length) {
+  specs = args.map((a) => resolve(ROOT, a)).filter((p) => /memory[\\/]requisitos[\\/][^\\/]+[\\/]SPEC\.md$/.test(p) && existsSync(p)).sort();
+} else {
+  specs = readdirSync(REQ, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(REQ, e.name, 'SPEC.md')))
+    .map((e) => join(REQ, e.name, 'SPEC.md')).sort();
+}
+
+const modules = specs.map((f) => ({ module: dirname(f).split(/[\\/]/).pop(), ...lintSpec(f) }));
+const sum = (k) => modules.reduce((a, m) => a + m[k], 0);
+const states = ['sem_campo', 'placeholder', 'pendente', 'parcial', 'anchored_ok', 'anchored_dead'];
+const byState = Object.fromEntries(states.map((s) => [s, modules.reduce((a, m) => a + m.counts[s], 0)]));
+const usTotal = sum('us_total');
+const covered = byState.anchored_ok + byState.pendente + byState.parcial;
+const coverage = usTotal ? Math.round((1000 * covered) / usTotal) / 10 : null;
+
+for (const m of modules) m.flag = m.us_total === 0 ? '🟡' : (m.counts.anchored_dead > 0 || m.v1_violations.length || m.coverage_pct === 0) ? '🔴' : m.coverage_pct === 100 ? '🟢' : '🟡';
+
+const report = {
+  _meta: {
+    lint: 'anchor spec↔código — gramática ADR 0273 §1 (sentinelas _pendente_/_parcial_ de 1ª classe)',
+    generator: 'scripts/governance/anchor-lint.mjs',
+    coverage_regra: 'anchor_coverage = (anchored_ok + pendente + parcial) / us_total — _pendente_ é coberto (tela não construída ≠ dívida de anchor); anchored_ok exige TODOS os paths existentes (§2)',
+    determinismo: 'sem timestamps/sha no output — re-run sem mudança no repo = diff vazio',
+    fase: 'F1 ADVISORY (ADR 0273 §4) — exit 0 sempre nos modos default/--json; --check (exit 1) reservado pra F2',
+    scope: args.length ? 'diff-aware (args)' : 'full-tree',
+  },
+  summary: {
+    specs_total: modules.length, us_total: usTotal, anchor_coverage_pct: coverage, by_state: byState,
+    fields_total: sum('fields_total'), fields_placeholder: sum('fields_placeholder'),
+    fields_grammar_ok: sum('fields_grammar_ok'), orphan_fields: sum('orphan_fields'),
+    v1_files: modules.filter((m) => m.anchor_format_v1).length, v1_violations: sum('v1_violations'),
+  },
+  modules,
+};
+
+if (JSON_OUT) { process.stdout.write(JSON.stringify(report, null, 2) + '\n'); process.exit(0); }
+
+console.log(`\n  ANCHOR LINT — spec↔código (ADR 0273) · ${modules.length} SPECs · escopo: ${report._meta.scope}\n`);
+console.log(`  ${'MÓDULO'.padEnd(20)} ${'US'.padStart(4)} ${'s/campo'.padStart(7)} ${'phold'.padStart(5)} ${'pend'.padStart(4)} ${'parc'.padStart(4)} ${'ok'.padStart(4)} ${'dead'.padStart(4)} ${'cov%'.padStart(6)}`);
+console.log('  ' + '─'.repeat(70));
+for (const m of modules) {
+  const c = m.counts;
+  console.log(`  ${m.flag} ${m.module.padEnd(18)} ${String(m.us_total).padStart(4)} ${String(c.sem_campo).padStart(7)} ${String(c.placeholder).padStart(5)} ${String(c.pendente).padStart(4)} ${String(c.parcial).padStart(4)} ${String(c.anchored_ok).padStart(4)} ${String(c.anchored_dead).padStart(4)} ${String(m.coverage_pct ?? '—').padStart(6)}`);
+  for (const d of m.dead) console.log(`       💀 ${d.us} (L${d.line}): ${d.missing.join(' · ')}`);
+  for (const v of m.v1_violations) console.log(`       ✗ v1 L${v.line}: não casa gramática ADR 0273 §1 → ${v.raw}`);
+}
+console.log('  ' + '─'.repeat(70));
+console.log(`\n  ANCHOR COVERAGE GLOBAL: ${coverage}%  (= (${byState.anchored_ok} ok + ${byState.pendente} pend + ${byState.parcial} parc) / ${usTotal} US)`);
+console.log(`  Campos: ${report.summary.fields_total} total · ${report.summary.fields_placeholder} placeholder · ${report.summary.fields_grammar_ok} já na gramática v1 · ${report.summary.orphan_fields} órfãos (fora de bloco US)`);
+console.log(`  Estados por US: sem_campo ${byState.sem_campo} · placeholder ${byState.placeholder} · pendente ${byState.pendente} · parcial ${byState.parcial} · anchored_ok ${byState.anchored_ok} · anchored_dead ${byState.anchored_dead}`);
+console.log(`\n  💀 anchored_dead = anchor quebrado (mentira detectável). Corrigir via backfill SA-A4/A5 — nunca inventar path.\n`);
+
+if (CHECK && (byState.anchored_dead > 0 || report.summary.v1_violations > 0)) process.exit(1);
+process.exit(0);

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -18,6 +18,10 @@
       "nome": "A11y ratchet (acessibilidade = categoria protegida)",
       "classe": "gate"
     },
+    "anchor-drift.yml": {
+      "nome": "Anchor Drift — lint spec↔código ADR 0273 (diff-aware no PR + cron semanal full-tree · ADVISORY F1 — SA-A2/A3)",
+      "classe": "gate"
+    },
     "adr-index-gate.yml": {
       "nome": "ADR Index Gate — ADR 0258",
       "classe": "gate"


### PR DESCRIPTION
## Frente SA-A2+A3 — FASE 1 da reestruturação SDD

Plano-mãe: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` (Semana 0, frente SA) · Gramática: ADR 0273 (aceita) · Ratchet/promoções: ADR 0271 + ADR 0275.

### O que entra (257 linhas, 1 intent)
- **`scripts/governance/anchor-lint.mjs`** — parser determinístico (node puro, zero deps, idioma clone de `knowledge-drift.mjs`) da gramática canônica do campo `**Implementado em:**` (ADR 0273 §1), incluindo as sentinelas `_pendente_` e `_parcial_` como estados de 1ª classe. Classifica cada US: `sem_campo | placeholder | pendente | parcial | anchored_ok | anchored_dead` e emite `anchor_coverage = (ok+pendente+parcial)/US_total` por módulo e global. Tabela 🔴🟡🟢 + `--json` determinístico + modo diff-aware (args posicionais) + `--check` (exit 1) RESERVADO pra F2.
- **`.github/workflows/anchor-drift.yml`** — ADVISORY F1 (gate novo nasce advisory): lint em modo report (exit 0 sempre — vermelho só se o script quebrar, precedente mutation-gate); diff-aware nos PRs que tocam `memory/requisitos/**/SPEC.md` + cron semanal full-tree + dispatch.
- **`scripts/governance/gates-registry.json`** — entry `anchor-drift.yml` (Check G do memory-health).

### Medição REAL (re-derivada em origin/main@50db89208 — regra anti-stale)
```
57 SPECs · 781 US headings · 84 campos **Implementado em:**
50 placeholder · 14 anchored_ok · 15 anchored_dead · 0 pendente/parcial (sentinela é nova)
ANCHOR COVERAGE GLOBAL: 1.8%  (= (14 ok + 0 pend + 0 parc) / 781 US)
5 campos órfãos (fora de bloco US — ProjectMgmt, seções R-PMG)
```
Determinismo provado: 2 runs `--json` consecutivos = **diff vazio**.
Fixture de gramática (não commitada): 9 casos cobrindo pendente±justificativa, parcial, preenchido válido, path morto, placeholder, sem campo, violação v1 sem `verificado@`, símbolo `X@metodo` ignorado — todos classificados conforme ADR; `--check` exit 1, modo report exit 0.

Drift REAL já caçado pelo lint: SPEC da Jana ancora `Modules/Jana/Providers/OimpressoMcpServer.php` — não existe no disco (provider real é `JanaServiceProvider.php`); `resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx` idem.

### Notas
- Coverage 1.8% ≠ ~4% do scorecard: aqui `anchored_ok` exige **todos** os paths existentes (ADR 0273 §2 'se todos os paths existem'); `sdd-scorecard.mjs` usa ≥1 path (grep interim). Follow-up GT: scorecard consumir `anchor-lint --json` como fonte.
- Placeholder = 50 (plano estimava ~49) — re-derivado do repo, taxonomia ADR (`TODO` · `_[path]_` · `a criar` · `_xx_`).
- Segmentos `/rota` (URL) e `~/...` (home) não são paths repo-relativos (§1) → tratados como símbolo, não derrubam o anchor.
- NÃO mexe em SPECs (backfill = SA-A4/A5/A6) nem promove gate (F2/F3 via calendário ADR 0275).

🤖 Generated with [Claude Code](https://claude.com/claude-code)