### PR TITLE
ci(ragas): destrava modo real canary/gate — sai do mock-teatro sem ligar nada (SDD F1 KL-D1)

### DIFF
--- a/.github/workflows/jana-ragas-canary.yml
+++ b/.github/workflows/jana-ragas-canary.yml
@@ -20,9 +20,18 @@ name: Jana RAGAS Canary (daily 06:00 UTC)
 #   3. Calcula delta percentual por métrica
 #   4. Falha se ANY métrica regrediu > REGRESSION_THRESHOLD_PCT
 #
-# Custo prod estimado (mock default):
-#   - Daily 06:00 UTC × mock = $0/dia
-#   - Real mode (workflow_dispatch): ~$0.06/run × 30 dias = ~$1.80/mês (aceitável)
+# Custo prod (re-derivado 2026-06-12: golden set 51 perguntas × 2 judge calls × $0.0004):
+#   - Sem secret OPENAI_API_KEY no repo: TODO run cai em mock = $0 (warning claro no summary)
+#   - Com secret: cron diário roda REAL ~$0.04/run × 30 dias = ~$1.22/mês (≤$1.80 conservador)
+#
+# SDD F1 KL-D1 (2026-06-12) — saída do mock-teatro:
+#   Antes, RAGAS_FORCE_MOCK=true era hardcoded no .env e JanaRagasCiCommand faz
+#   `$forceMock = $mode === 'mock' || env('RAGAS_FORCE_MOCK')` — dispatch com mode=real
+#   rodava MOCK silenciosamente. Agora o step `mode` resolve o modo EFETIVO:
+#   real só quando solicitado (input dispatch OU cron) E secret OPENAI_API_KEY existe.
+#   Sem secret → fallback mock + warning (nunca quebra). Cron SOLICITA real — vira real
+#   automaticamente quando Wagner adicionar o secret (1 clique, Settings → Secrets).
+#   Summary mostra em destaque qual modo RODOU (anti-teatro).
 #
 # Workflow_dispatch input `update_baseline: true` regrava baseline com run atual
 # (Wagner usa pra estabelecer baseline inicial + recalibrar após improvements aprovados).
@@ -69,6 +78,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # KL-D1 anti-teatro — resolve o modo EFETIVO antes de tudo:
+      #   workflow_dispatch → input `mode` (default mock)
+      #   schedule (cron)   → SOLICITA real; sem secret OPENAI_API_KEY cai em mock
+      #                       (= continua mock até Wagner adicionar o secret, 1 clique)
+      # real sem secret NUNCA roda (judge devolveria 0.0 em tudo) → fallback mock + warning.
+      - name: Resolve modo efetivo (mock|real)
+        id: mode
+        env:
+          REQUESTED_MODE: ${{ github.event_name == 'schedule' && 'real' || github.event.inputs.mode || 'mock' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
+        run: |
+          effective="${REQUESTED_MODE}"
+          fallback=""
+          if [ "${effective}" = "real" ] && [ "${HAS_OPENAI_KEY}" != "true" ]; then
+            effective="mock"
+            fallback="modo real solicitado, mas secret OPENAI_API_KEY ausente no repo — fallback pra MOCK (Settings → Secrets pra ligar; ~\$1.22/mês)"
+            echo "::warning::RAGAS canary: ${fallback}"
+          fi
+          {
+            echo "requested=${REQUESTED_MODE}"
+            echo "effective=${effective}"
+            echo "fallback=${fallback}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Modo solicitado: ${REQUESTED_MODE} | efetivo: ${effective}"
+
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
@@ -99,8 +133,14 @@ jobs:
       - name: Prepare Laravel storage dirs
         run: mkdir -p storage/framework/cache/data storage/framework/sessions storage/framework/views storage/logs storage/app/ragas bootstrap/cache
 
-      - name: Create .env (mock-safe default)
+      # RAGAS_FORCE_MOCK condicional ao modo efetivo (KL-D1) — hardcoded true era o
+      # que tornava dispatch mode=real um teatro (JanaRagasCiCommand OR-eia com env).
+      - name: Create .env (RAGAS_FORCE_MOCK condicional ao modo efetivo)
+        env:
+          EFFECTIVE_MODE: ${{ steps.mode.outputs.effective }}
         run: |
+          force_mock=true
+          if [ "${EFFECTIVE_MODE}" = "real" ]; then force_mock=false; fi
           printf '%s\n' \
             'APP_NAME=oimpresso-jana-canary' \
             'APP_ENV=testing' \
@@ -118,14 +158,14 @@ jobs:
             'SCOUT_DRIVER=null' \
             'MCP_TOOLS_EXPOSED=false' \
             'RAGAS_ENABLED=true' \
-            'RAGAS_FORCE_MOCK=true' > .env
+            "RAGAS_FORCE_MOCK=${force_mock}" > .env
           php artisan key:generate
           php artisan package:discover --ansi
 
       - name: Run canary (PHP eval + Python diff vs baseline)
         id: canary
         env:
-          RAGAS_MODE: ${{ github.event.inputs.mode || 'mock' }}
+          RAGAS_MODE: ${{ steps.mode.outputs.effective }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           REGRESSION_THRESHOLD_PCT: ${{ github.event.inputs.regression_threshold_pct || '5.0' }}
         run: |
@@ -140,6 +180,9 @@ jobs:
 
       - name: Render GITHUB_STEP_SUMMARY
         if: always()
+        env:
+          REQUESTED_MODE: ${{ steps.mode.outputs.requested }}
+          MODE_FALLBACK: ${{ steps.mode.outputs.fallback }}
         run: |
           python3 - <<'PY'
           import json, os, pathlib
@@ -150,10 +193,26 @@ jobs:
           r = json.loads(out.read_text())
           gate = 'PASS' if r.get('gate_status') == 'pass' else 'FAIL'
           icon = ':white_check_mark:' if gate == 'PASS' else ':x:'
+          # Anti-teatro (KL-D1): banner usa o modo que RODOU de fato (report PHP),
+          # não o que o workflow pediu — impossível confundir mock com real.
+          ran_mode = r.get('mode', 'unknown')
+          requested = os.environ.get('REQUESTED_MODE', '?')
+          fallback = os.environ.get('MODE_FALLBACK', '')
+          if ran_mode == 'real':
+              banner = f"# :money_with_wings: MODO: REAL — LLM judge consumido (custo ${r.get('cost_usd', 0)})"
+          else:
+              banner = f"# :performing_arts: MODO: MOCK — scores fixos, zero LLM (NÃO é avaliação real)"
           lines = [
+              banner,
+              "",
+              f"Solicitado: `{requested}` · Rodou: `{ran_mode}`",
+          ]
+          if fallback:
+              lines += ["", f"> :warning: {fallback}"]
+          lines += [
+              "",
               f"## {icon} Jana RAGAS Canary — {gate}",
               "",
-              f"- Modo: `{r.get('mode')}` (custo `${r.get('cost_usd', 0)}`)",
               f"- Threshold regressão: `{r.get('regression_threshold_pct')}%`",
               f"- Perguntas avaliadas: `{r.get('n_questions')}` (baseline: `{r.get('baseline_n_questions', 'N/A')}`)",
               "",
@@ -188,10 +247,13 @@ jobs:
 
       - name: Update baseline (workflow_dispatch only)
         if: github.event_name == 'workflow_dispatch' && github.event.inputs.update_baseline == 'true' && steps.canary.outcome == 'success'
+        env:
+          # Sem isto, re-run em modo real judgaria 0.0 e gravaria baseline zerada
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           # Sobrescreve baseline com scores deste run (Wagner aprovou via dispatch flag)
           python3 scripts/jana-ragas-runner.py \
-            --mode="${{ github.event.inputs.mode || 'mock' }}" \
+            --mode="${{ steps.mode.outputs.effective }}" \
             --baseline=governance/jana-ragas-baseline.json \
             --threshold-pct="${{ github.event.inputs.regression_threshold_pct || '5.0' }}" \
             --output=canary-result.json \

--- a/.github/workflows/jana-ragas-gate.yml
+++ b/.github/workflows/jana-ragas-gate.yml
@@ -9,7 +9,16 @@ name: Jana RAGAS Eval Gate
 #   - Este é PR paths-triggered + cron BLOQUEANTE (exit 1 abaixo threshold)
 #
 # Comando: `php artisan jana:ragas-ci-eval --json`
-# Modo: mock default (zero LLM cost CI). Real mode via secret RAGAS_MODE=real ($0.06/run).
+# Modo: mock default (zero LLM cost CI). Real mode via secret RAGAS_MODE=real (~$0.04/run,
+# re-derivado 2026-06-12: golden set 51 perguntas × 2 judge calls × $0.0004).
+#
+# SDD F1 KL-D1 (2026-06-12) — saída do mock-teatro:
+#   RAGAS_FORCE_MOCK no .env era hardcoded true; como JanaRagasCiCommand OR-eia
+#   `--mode` com env('RAGAS_FORCE_MOCK'), pedir real rodava MOCK silenciosamente.
+#   Agora step `mode` resolve modo EFETIVO (real exige secret OPENAI_API_KEY; sem
+#   secret → fallback mock + warning, nunca quebra) e o summary mostra em destaque
+#   qual modo RODOU (anti-teatro). PR/cron continuam mock até Wagner setar
+#   secret RAGAS_MODE=real (opt-in explícito — flip de PR gate não é automático).
 #
 # Thresholds W28 (calibrados pra Vellum 50-100 target W27):
 #   - faithfulness   ≥ 0.80
@@ -55,6 +64,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # KL-D1 anti-teatro — resolve modo EFETIVO. Real exige secret OPENAI_API_KEY;
+      # sem secret cai em mock com warning (nunca quebra). Diferente do canary, aqui
+      # o real NÃO flipa automático com o secret: exige RAGAS_MODE=real (opt-in),
+      # porque este gate BLOQUEIA merge em modo real — flip silencioso seria surpresa.
+      - name: Resolve modo efetivo (mock|real)
+        id: mode
+        env:
+          REQUESTED_MODE: ${{ github.event.inputs.mode || secrets.RAGAS_MODE || 'mock' }}
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' }}
+        run: |
+          effective="${REQUESTED_MODE}"
+          fallback=""
+          if [ "${effective}" = "real" ] && [ "${HAS_OPENAI_KEY}" != "true" ]; then
+            effective="mock"
+            fallback="modo real solicitado, mas secret OPENAI_API_KEY ausente no repo — fallback pra MOCK advisory (Settings → Secrets pra ligar)"
+            echo "::warning::RAGAS gate: ${fallback}"
+          fi
+          {
+            echo "requested=${REQUESTED_MODE}"
+            echo "effective=${effective}"
+            echo "fallback=${fallback}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Modo solicitado: ${REQUESTED_MODE} | efetivo: ${effective}"
+
       - name: Setup PHP 8.4
         uses: shivammathur/setup-php@v2
         with:
@@ -78,8 +111,14 @@ jobs:
         # que precisa de realpath(storage/framework/views). Sem dir, throw "Please provide a valid cache path".
         run: mkdir -p storage/framework/cache/data storage/framework/sessions storage/framework/views storage/logs storage/app/ragas bootstrap/cache
 
-      - name: Create .env (mock-safe)
+      # RAGAS_FORCE_MOCK condicional ao modo efetivo (KL-D1) — hardcoded true era o
+      # que tornava o modo real um teatro (JanaRagasCiCommand OR-eia com env).
+      - name: Create .env (RAGAS_FORCE_MOCK condicional ao modo efetivo)
+        env:
+          EFFECTIVE_MODE: ${{ steps.mode.outputs.effective }}
         run: |
+          force_mock=true
+          if [ "${EFFECTIVE_MODE}" = "real" ]; then force_mock=false; fi
           printf '%s\n' \
             'APP_NAME=oimpresso-jana-ragas-ci' \
             'APP_ENV=testing' \
@@ -97,15 +136,15 @@ jobs:
             'SCOUT_DRIVER=null' \
             'MCP_TOOLS_EXPOSED=false' \
             'RAGAS_ENABLED=true' \
-            'RAGAS_FORCE_MOCK=true' > .env
+            "RAGAS_FORCE_MOCK=${force_mock}" > .env
           php artisan key:generate
           php artisan package:discover --ansi
 
       - name: Run RAGAS CI eval (mock default — zero $)
         id: ragas
         env:
-          # Default mock — pra real mode crie secret RAGAS_MODE=real + OPENAI_API_KEY
-          RAGAS_MODE: ${{ github.event.inputs.mode || secrets.RAGAS_MODE || 'mock' }}
+          # Modo efetivo resolvido no step `mode` (real só com secret OPENAI_API_KEY presente)
+          RAGAS_MODE: ${{ steps.mode.outputs.effective }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           RAGAS_THRESHOLD_FAITHFULNESS: '0.80'
           RAGAS_THRESHOLD_RELEVANCY: '0.75'
@@ -124,6 +163,54 @@ jobs:
           name: jana-ragas-ci-result-${{ github.run_id }}
           path: ragas-result.json
           retention-days: 30
+
+      # KL-D1 anti-teatro: summary destaca o modo que RODOU (campo `mode` do report
+      # PHP = ground truth), não o que foi pedido — impossível confundir mock com real.
+      # python3 vem pré-instalado no ubuntu-latest (sem setup-python neste workflow).
+      - name: Render GITHUB_STEP_SUMMARY (modo em destaque)
+        if: always()
+        env:
+          REQUESTED_MODE: ${{ steps.mode.outputs.requested }}
+          MODE_FALLBACK: ${{ steps.mode.outputs.fallback }}
+        run: |
+          python3 - <<'PY'
+          import json, os, pathlib
+          out = pathlib.Path('ragas-result.json')
+          requested = os.environ.get('REQUESTED_MODE', '?')
+          fallback = os.environ.get('MODE_FALLBACK', '')
+          lines = []
+          if not out.exists():
+              lines = ['# :x: Jana RAGAS Gate — eval falhou antes de gerar ragas-result.json']
+          else:
+              r = json.loads(out.read_text())
+              ran_mode = r.get('mode', 'unknown')
+              if ran_mode == 'real':
+                  banner = f"# :money_with_wings: MODO: REAL — LLM judge consumido (custo ${r.get('cost_usd', 0)}) — gate BLOQUEANTE"
+              else:
+                  banner = "# :performing_arts: MODO: MOCK — scores fixos, zero LLM (advisory, NÃO é avaliação real)"
+              gate = 'PASS' if r.get('gate_status') == 'pass' else 'FAIL'
+              icon = ':white_check_mark:' if gate == 'PASS' else ':x:'
+              lines = [
+                  banner,
+                  "",
+                  f"Solicitado: `{requested}` · Rodou: `{ran_mode}`",
+              ]
+              if fallback:
+                  lines += ["", f"> :warning: {fallback}"]
+              lines += [
+                  "",
+                  f"## {icon} Gate — {gate}",
+                  "",
+                  f"- faithfulness_avg: `{r.get('faithfulness_avg', 0):.4f}` (threshold 0.80)",
+                  f"- relevancy_avg: `{r.get('relevancy_avg', 0):.4f}` (threshold 0.75)",
+                  f"- Perguntas: `{r.get('n_passed', 0)}/{r.get('n_questions', 0)}` acima do threshold",
+              ]
+          summary = os.environ.get('GITHUB_STEP_SUMMARY')
+          if summary:
+              with open(summary, 'a', encoding='utf-8') as f:
+                  f.write('\n'.join(lines) + '\n')
+          print('\n'.join(lines))
+          PY
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
@@ -156,11 +243,14 @@ jobs:
 
       - name: Fail if gate did not pass (só modo REAL — mock é advisory)
         env:
-          RAGAS_MODE: ${{ github.event.inputs.mode || secrets.RAGAS_MODE || 'mock' }}
+          # KL-D1: usa modo EFETIVO — antes recomputava a expressão e podia tratar como
+          # "real" um run que de fato rodou mock (real pedido sem secret = teatro duplo).
+          RAGAS_MODE: ${{ steps.mode.outputs.effective }}
         run: |
           gate=$(php -r "echo json_decode(file_get_contents('ragas-result.json'), true)['gate_status'];")
-          # Auditoria 2026-06-11 (ADR 0271): em modo mock os scores são FIXOS (0.85/0.78) —
-          # "bloquear" sobre score mockado é gate de teatro (sempre verde, avalia nada).
+          # Auditoria 2026-06-11 (ADR 0271): em modo mock os scores são FIXOS
+          # (0.85/0.82 — JanaRagasCiCommand::enableMock) — "bloquear" sobre score mockado
+          # é gate de teatro (sempre verde, avalia nada).
           # Mock = advisory (notice). Bloqueio só quando há evidência real (RAGAS_MODE=real).
           if [ "$RAGAS_MODE" != "real" ]; then
             echo "::notice::Jana RAGAS rodou em MOCK (scores fixos, zero LLM) — advisory, não bloqueia. Pra gate real: RAGAS_MODE=real."


### PR DESCRIPTION
## Frente KL-D1 — FASE 1 reestruturação SDD

Plano: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` (§4 semanas 2-4, trilha D: "D1 destrava RAGAS real (secret = Wagner)") · ADR 0271 (gates estado real — mock advisory).

## Problema (mock-teatro)

`RAGAS_FORCE_MOCK=true` era **hardcoded** no `.env` gerado pelos 2 workflows, e `JanaRagasCiCommand` faz `$forceMock = $mode === 'mock' || env('RAGAS_FORCE_MOCK')` — ou seja, **dispatch com `mode=real` rodava MOCK silenciosamente** (scores fixos 0.85/0.82). Pior: o step bloqueante do gate recomputava o modo *pedido*, então um "real" pedido sem secret passaria como se fosse avaliação real. E real sem `OPENAI_API_KEY` faz `callJudge` devolver 0.0 em tudo (garbage).

## O que muda

1. **Step novo `Resolve modo efetivo (mock|real)`** nos 2 workflows: real só quando solicitado **E** secret `OPENAI_API_KEY` existe; sem secret → fallback mock + `::warning` (nunca quebra).
2. **`RAGAS_FORCE_MOCK` no `.env` agora condicional** ao modo efetivo (era a raiz do teatro).
3. **canary:** cron SOLICITA real — vira real automático quando Wagner adicionar o secret (1 clique). Hoje (sem secret) continua mock, com warning claro.
4. **gate:** real continua **opt-in** via secret `RAGAS_MODE=real` (gate bloqueia merge em real — flip automático seria surpresa).
5. **Summary anti-teatro:** banner em destaque com o modo que **RODOU** (campo `mode` do report PHP = ground truth) + linha `Solicitado: X · Rodou: Y` — impossível confundir mock com real. Gate ganhou step summary novo (antes só PR comment).
6. Update-baseline ganha `OPENAI_API_KEY` no env (re-run real sem a key gravaria baseline zerada).

Custo re-derivado do código (não copiado do plano): golden set **51 perguntas** × 2 judge calls × `$0.0004` (`JanaRagasCiCommand::COST_PER_JUDGE_CALL_USD`) = **~$0.04/run → ~$1.22/mês** no cron diário (≤ $1.80 conservador do plano).

**Nada liga hoje** — sem o secret, todo run cai em mock com warning. Gates continuam com o mesmo caráter (canary informativo, gate mock advisory per ADR 0271).

## DoD

- [x] YAML dry-parse OK (PyYAML `safe_load`, 13 steps canary / 12 steps gate)
- [x] Step de resolução dry-run em bash (3 cenários: cron sem secret → mock+warning; cron com secret → real; dispatch default → mock)
- [x] Summary simulado com o snippet REAL extraído do YAML, 4 cenários (canary mock-fallback / canary real / gate mock advisory / gate real fail) — trechos abaixo

<details><summary>Summary simulado — canary, cron HOJE (sem secret): solicitou real, RODOU MOCK</summary>

```markdown
# :performing_arts: MODO: MOCK — scores fixos, zero LLM (NÃO é avaliação real)

Solicitado: `real` · Rodou: `mock`

> :warning: modo real solicitado, mas secret OPENAI_API_KEY ausente no repo — fallback pra MOCK (Settings → Secrets pra ligar; ~$1.22/mês)

## :white_check_mark: Jana RAGAS Canary — PASS

- Threshold regressão: `5.0%`
- Perguntas avaliadas: `51` (baseline: `0`)
```
</details>

<details><summary>Summary simulado — canary, cron com secret: RODOU REAL</summary>

```markdown
# :money_with_wings: MODO: REAL — LLM judge consumido (custo $0.0408)

Solicitado: `real` · Rodou: `real`

## :white_check_mark: Jana RAGAS Canary — PASS

- Threshold regressão: `5.0%`
- Perguntas avaliadas: `51` (baseline: `51`)

| Métrica | Atual | Baseline | Delta % | Status |
|---|---|---|---|---|
| faithfulness | 0.8123 | 0.8047 | +0.94% | :white_check_mark: |
| answer_relevancy | 0.7691 | 0.7755 | -0.83% | :white_check_mark: |
```
</details>

## needs_wagner

Adicionar secret `OPENAI_API_KEY` no repo (Settings → Secrets and variables → Actions) quando quiser ligar o canary real — ~$1.22/mês. (Gate de PR em real é um segundo clique separado: secret `RAGAS_MODE=real`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)