### PR TITLE
ci(governance): meta-catraca do scorecard SDD — workflow advisory + baseline versionado (GT-G3)

### DIFF
--- a/.github/workflows/sdd-scorecard.yml
+++ b/.github/workflows/sdd-scorecard.yml
@@ -1,0 +1,89 @@
+name: SDD Scorecard (advisory)
+
+# Meta-catraca do scorecard SDD — GT-G3 do plano (memory/sessions/2026-06-12-
+# plano-reestruturacao-sdd-ondas-paralelas.md §2 GARANTIDA + §4 Semanas 1-2)
+# + ADR 0275 (regra de armamento §3, calendário de promoções §5 linha G3).
+#
+# 3 sinais sobre governance/sdd-scorecard.json + governance/sdd-scorecard-baseline.json:
+#   1. determinismo — 2 runs do agregador = output idêntico (diff vazio)
+#   2. staleness    — scorecard commitado ≠ medição atual (rodar e commitar)
+#   3. ratchet      — métrica ARMADA (armed:true no baseline) regrediu vs baseline
+#                     → piorar exige editar o baseline em diff visível no PR
+#
+# ADVISORY DE NASCENÇA (ADR 0261/0271/0275 — gate novo nunca nasce required):
+# os 3 sinais rodam com continue-on-error, então o WORKFLOW fica sempre verde
+# nesta fase; vermelho aparece como annotation no step + job summary. Promoção
+# a required SÓ via calendário do ADR 0275 §5 (linha G3: 7 execuções diárias
+# verdes + 0 falso-positivo em 14 dias) — no flip, remover os continue-on-error
+# é parte do PR de promoção (com required-checks-baseline.json, GT-G4).
+#
+# Cron diário 06:50 BRT (09:50 UTC) — pós-nightly: alimenta a sequência de
+# medições válidas que arma métricas (ADR 0275 §3).
+
+on:
+  pull_request:
+    branches: [main]
+    paths: # diff-aware: fontes vivas do scorecard
+      - 'memory/requisitos/**'        # SPECs (anchor_coverage) + BRIEFINGs/docs (ghost_count, front_door)
+      - 'Modules/*/module.json'       # criar/deletar módulo muda ghost_count/front_door_coverage
+      - 'scripts/governance/sdd-scorecard.mjs'
+      - 'scripts/governance/knowledge-drift.mjs'
+      - 'governance/sdd-scorecard.json'
+      - 'governance/sdd-scorecard-baseline.json'
+      - '.github/workflows/sdd-scorecard.yml'
+  schedule:
+    - cron: '50 9 * * *' # 06:50 BRT diário (pós-nightly)
+  workflow_dispatch:
+
+concurrency:
+  group: sdd-scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scorecard:
+    name: SDD scorecard meta-catraca (advisory · determinismo + staleness + ratchet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Medir — agregador escreve governance/sdd-scorecard.json
+        run: |
+          node scripts/governance/sdd-scorecard.mjs | tee /tmp/scorecard.txt
+          { echo '## SDD Scorecard (medição desta run)'; echo '```'; cat /tmp/scorecard.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Determinismo — 2ª run = diff vazio
+        continue-on-error: true
+        run: |
+          node scripts/governance/sdd-scorecard.mjs --json > /tmp/run2.json
+          if diff governance/sdd-scorecard.json /tmp/run2.json; then
+            echo "determinismo OK — 2 runs idênticas (diff vazio)"
+          else
+            echo "::warning::agregador NÃO determinístico — 2 runs divergem (viola contrato do sdd-scorecard.mjs)"
+            exit 1
+          fi
+
+      - name: Staleness — scorecard commitado bate com a medição atual?
+        continue-on-error: true
+        run: |
+          if git diff --exit-code governance/sdd-scorecard.json; then
+            echo "scorecard commitado em dia com a medição atual"
+          else
+            echo "::warning::governance/sdd-scorecard.json commitado está DEFASADO — rode 'node scripts/governance/sdd-scorecard.mjs' e commite o resultado"
+            exit 1
+          fi
+
+      - name: Ratchet — métrica ARMADA regrediu vs baseline? (ADR 0275 §3)
+        continue-on-error: true
+        run: |
+          set +e
+          node scripts/governance/sdd-scorecard.mjs --ratchet > /tmp/ratchet.txt 2>&1
+          rc=$?
+          cat /tmp/ratchet.txt
+          { echo '### Ratchet vs governance/sdd-scorecard-baseline.json'; echo '```'; cat /tmp/ratchet.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          exit $rc

--- a/governance/sdd-scorecard-baseline.json
+++ b/governance/sdd-scorecard-baseline.json
@@ -1,0 +1,102 @@
+{
+  "_meta": {
+    "baseline": "SDD scorecard baseline v1 — meta-catraca GT-G3 (plano 2026-06-12 §2 GARANTIDA + §4 Semanas 1-2)",
+    "adr": "memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md",
+    "capturado_de": "medição REAL de scripts/governance/sdd-scorecard.mjs em origin/main 50db89208 (2026-06-12) — nunca copiado de plano/ADR (regra anti-stale)",
+    "regra_armamento": "ADR 0275 §3 — métrica só ARMA (armed:true ⇒ --ratchet exit 1 na regressão) após 3 medições válidas consecutivas da fonte real (sem erro, não-mock, valor não-nulo); fonte parada >48h desarma até nova sequência de 3",
+    "regra_piora": "piorar value, desarmar métrica ou absorver regressão = SÓ via PR editando este arquivo (diff visível) citando ADR 0275 — exceção nunca é invisível",
+    "consumidores": [
+      ".github/workflows/sdd-scorecard.yml (advisory — continue-on-error nesta fase)",
+      "scripts/governance/sdd-scorecard.mjs --ratchet"
+    ]
+  },
+  "metrics": {
+    "anchor_coverage": {
+      "status": "measured",
+      "value": 2.8,
+      "unit": "%",
+      "direction": "up",
+      "armed": false,
+      "valid_measurements": 2,
+      "fonte": "grep estrito memory/requisitos/*/SPEC.md (sdd-scorecard.mjs — fonte nasceu no PR #2597)",
+      "nota_armamento": "2 medições válidas (PR #2597 e este PR, ambas 2.8% = 22 anchors estritos / 781 US) — arma na 3ª medição do workflow sdd-scorecard.yml, via PR editando este arquivo com link da run"
+    },
+    "full_suite_pass_rate": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "up",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "nightly MySQL diagnóstica (FV-F3) — baseline na 1ª medição real"
+    },
+    "n_quarantine": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "grep @group legacy-quarantine — grupo só passa a existir na quarentena FV-Q3"
+    },
+    "coverage_pct": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "up",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "pcov instrumentado em CI (P0-2) — hoje coverage: none"
+    },
+    "ghost_count": {
+      "status": "measured",
+      "value": 27,
+      "unit": "nomes distintos",
+      "direction": "down",
+      "armed": true,
+      "valid_measurements": 3,
+      "fonte": "scripts/governance/knowledge-drift.mjs --json",
+      "nota_armamento": "3 medições válidas consecutivas da fonte: reconhecimento ADR 0275 (27 nomes / 39 citantes) + run do PR #2597 (27) + run deste PR (27)"
+    },
+    "front_door_coverage": {
+      "status": "measured",
+      "value": 63.9,
+      "unit": "%",
+      "direction": "up",
+      "armed": true,
+      "valid_measurements": 3,
+      "fonte": "scripts/governance/knowledge-drift.mjs --json (BRIEFING.md presente por módulo)",
+      "nota_armamento": "3 medições válidas consecutivas da fonte: reconhecimento ADR 0275 (64% = 39/61) + run do PR #2597 (63.9) + run deste PR (63.9 = 39/61)"
+    },
+    "recall_eval_violations": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "golden set recall (KL-C2) — depende do alias map das 13 colisões ADR"
+    },
+    "ragas_real_uptime": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "up",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "RAGAS canário modo REAL diário (KL-D1/D4) — hoje compara mock com mock"
+    },
+    "drift_alarms": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "protection-drift + watchdog de staleness (GT-G4)",
+      "nota_armamento": "NUNCA arma — alarme advisory perene, nunca required (ADR 0275 métrica 9)"
+    },
+    "backfill_error_rate": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "armed": false,
+      "valid_measurements": 0,
+      "fonte": "ledger do protocolo refutador G5 (governance/sdd-verification-ledger.json) — só existe após 1º lote IA refutado"
+    }
+  }
+}

--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -7,8 +7,8 @@
     "composta": "v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured",
     "anchor_coverage_regra": "numerador = campos `**Implementado em:**` sem placeholder (TODO/_[path]_/_pendente_/a criar/_xx_) com ≥1 path existente no disco; denominador = headings `US-XXX-NNN` nos 57 SPECs",
     "ratchet": {
-      "armed": false,
-      "como_armar": "SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — armar SÓ via calendário de promoções do ADR do scorecard (GT-G1)"
+      "baseline": "governance/sdd-scorecard-baseline.json — armed POR MÉTRICA (ADR 0275 §3: arma após 3 medições válidas consecutivas da fonte real; armar/desarmar/piorar = PR editando o baseline, diff visível)",
+      "simulacao": "SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — trata todas as medidas como armadas (selftest local)"
     }
   },
   "metrics": {
@@ -22,7 +22,7 @@
       "detail": {
         "specs_total": 57,
         "specs_with_field": 15,
-        "us_total": 780,
+        "us_total": 781,
         "fields_total": 84,
         "fields_placeholder": 50,
         "fields_filled": 34,

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -222,6 +222,10 @@
       "nome": "Screen Coverage Gate (catraca de cobertura)",
       "classe": "gate"
     },
+    "sdd-scorecard.yml": {
+      "nome": "SDD Scorecard meta-catraca (advisory · determinismo + staleness + ratchet vs baseline — GT-G3, ADR 0275)",
+      "classe": "meta"
+    },
     "stylelint-gate.yml": {
       "nome": "Stylelint CSS anti-drift (G5 · ADR 0209)",
       "classe": "gate"

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -17,8 +17,11 @@
 // Uso (na raiz do repo):
 //   node scripts/governance/sdd-scorecard.mjs            # mede + escreve governance/sdd-scorecard.json
 //   node scripts/governance/sdd-scorecard.mjs --json     # mede + imprime no stdout (não escreve)
-//   node scripts/governance/sdd-scorecard.mjs --ratchet  # compara com o commitado; DESARMADO (exit 0)
-//                                                        # armar: SDD_RATCHET_ARM=1 (só após ADR do scorecard)
+//   node scripts/governance/sdd-scorecard.mjs --ratchet  # compara com governance/sdd-scorecard-baseline.json (GT-G3):
+//                                                        # métrica ARMADA (armed:true no baseline) que regrediu = exit 1;
+//                                                        # desarmada que regrediu = warn (exit 0). ADR 0275 §3: métrica só
+//                                                        # arma após 3 medições válidas consecutivas da fonte real.
+//                                                        # SDD_RATCHET_ARM=1 trata todas como armadas (simulação/selftest).
 // Node puro (fs + execSync). Sem deps, sem DB, sem PHP. Idioma: clone de knowledge-drift.mjs.
 
 import { readdirSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
@@ -27,6 +30,7 @@ import { join } from 'node:path';
 
 const ROOT = process.cwd();
 const OUT = join(ROOT, 'governance', 'sdd-scorecard.json');
+const BASELINE = join(ROOT, 'governance', 'sdd-scorecard-baseline.json');
 const MODE_JSON = process.argv.includes('--json');
 const MODE_RATCHET = process.argv.includes('--ratchet');
 const ARMED = process.env.SDD_RATCHET_ARM === '1';
@@ -93,7 +97,10 @@ function buildScorecard() {
       determinismo: 'sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio',
       composta: 'v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured',
       anchor_coverage_regra: 'numerador = campos `**Implementado em:**` sem placeholder (TODO/_[path]_/_pendente_/a criar/_xx_) com ≥1 path existente no disco; denominador = headings `US-XXX-NNN` nos 57 SPECs',
-      ratchet: { armed: false, como_armar: 'SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — armar SÓ via calendário de promoções do ADR do scorecard (GT-G1)' },
+      ratchet: {
+        baseline: 'governance/sdd-scorecard-baseline.json — armed POR MÉTRICA (ADR 0275 §3: arma após 3 medições válidas consecutivas da fonte real; armar/desarmar/piorar = PR editando o baseline, diff visível)',
+        simulacao: 'SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — trata todas as medidas como armadas (selftest local)',
+      },
     },
     metrics: {
       anchor_coverage: {
@@ -132,20 +139,29 @@ function buildScorecard() {
   };
 }
 
-// ── ratchet (preparado, DESARMADO) ──────────────────────────────────────────
+// ── ratchet vs baseline VERSIONADO (GT-G3 meta-catraca) ─────────────────────
+// Compara a medição ATUAL com governance/sdd-scorecard-baseline.json — arquivo
+// commitado: piorar exige editar o baseline em diff VISÍVEL no PR (plano §2
+// GARANTIDA). Armed é POR MÉTRICA no baseline (ADR 0275 §3 — só arma após 3
+// medições válidas consecutivas da fonte real): armada que regrediu = exit 1;
+// desarmada que regrediu = warn (reporta, não pune).
 function ratchet(current) {
-  if (!existsSync(OUT)) { console.log('  --ratchet: sem baseline commitado em governance/sdd-scorecard.json — nada a comparar.'); return 0; }
-  const base = JSON.parse(readFileSync(OUT, 'utf8'));
-  const violations = [];
+  if (!existsSync(BASELINE)) { console.log('  --ratchet: sem baseline em governance/sdd-scorecard-baseline.json — nada a comparar.'); return 0; }
+  const base = JSON.parse(readFileSync(BASELINE, 'utf8'));
+  const red = [], warn = [];
   for (const [name, m] of Object.entries(current.metrics)) {
     const b = base.metrics?.[name];
-    if (!b || b.status !== 'measured' || m.status !== 'measured') continue;
-    if (m.direction === 'down' && m.value > b.value) violations.push(`${name}: ${b.value} → ${m.value} (só pode DESCER)`);
-    if (m.direction === 'up' && m.value < b.value) violations.push(`${name}: ${b.value} → ${m.value} (só pode SUBIR)`);
+    if (!b || typeof b.value !== 'number' || m.status !== 'measured') continue;
+    const worse = m.direction === 'down' ? m.value > b.value : m.value < b.value;
+    if (!worse) continue;
+    const msg = `${name}: baseline ${b.value} → ${m.value} (${m.direction === 'down' ? 'só pode DESCER' : 'só pode SUBIR'})`;
+    if (b.armed === true || ARMED) red.push(msg); else warn.push(msg);
   }
-  if (!violations.length) { console.log('  --ratchet: nenhuma regressão vs baseline commitado. ✓'); return 0; }
-  for (const v of violations) console.log(`  🔴 RATCHET: ${v}`);
-  if (!ARMED) { console.log('  (desarmado — exit 0; armar via SDD_RATCHET_ARM=1 quando o ADR do scorecard aprovar a promoção)'); return 0; }
+  if (!red.length && !warn.length) { console.log('  --ratchet: nenhuma regressão vs governance/sdd-scorecard-baseline.json. ✓'); return 0; }
+  for (const v of warn) console.log(`  ⚠️ RATCHET (desarmada — reporta, não pune · ADR 0275 §3): ${v}`);
+  for (const v of red) console.log(`  🔴 RATCHET (ARMADA): ${v}`);
+  if (!red.length) return 0;
+  console.log('  Piora intencional? Edite governance/sdd-scorecard-baseline.json no MESMO PR (diff visível) citando ADR 0275.');
   return 1;
 }
 


### PR DESCRIPTION
## Frente GT-G3 — meta-catraca do scorecard (Semanas 1-2 do plano SDD)

Plano: `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` §2 GARANTIDA ("baselines em arquivo versionado — piorar = PR vermelho, exceção só visível em diff") + §4 Semanas 1-2 ("GT: G3 meta-catraca (advisory)").
ADR: [0275](memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md) — §3 regra de armamento (3 medições válidas) + §5 calendário (linha G3: 7 execuções diárias verdes + 0 FP em 14d pro flip futuro).

### O que entra

| Arquivo | O quê |
|---|---|
| `.github/workflows/sdd-scorecard.yml` (novo) | ADVISORY: PR diff-aware (paths das fontes) + cron diário 06:50 BRT (09:50 UTC, pós-nightly) + dispatch. 3 sinais com `continue-on-error` — **workflow sempre verde nesta fase**; vermelho aparece como annotation/step + job summary |
| `governance/sdd-scorecard-baseline.json` (novo) | Baseline v1 da medição **REAL** em `origin/main 50db89208` (não copiado do plano): `anchor_coverage` 2.8% (desarmada — fonte com 2 medições), `ghost_count` 27 (**ARMADA** — 3 medições válidas), `front_door_coverage` 63.9% (**ARMADA** — 3 medições), 7 `not_yet_measured` desarmadas |
| `scripts/governance/sdd-scorecard.mjs` | `--ratchet` agora compara com o baseline versionado e respeita `armed` POR MÉTRICA (ADR 0275 §3); armada regredindo = exit 1, desarmada = warn. `SDD_RATCHET_ARM=1` vira modo simulação/selftest |
| `scripts/governance/gates-registry.json` | Entry `sdd-scorecard.yml` (classe `meta`) — exigência memory-health Check G |
| `governance/sdd-scorecard.json` | Re-medição (us_total 780→781, main moveu) + `_meta.ratchet` novo |

### DoD (output real, local)

Regressão simulada — fixture temp citando `Modules/GhostSimulacaoGtG3`:
```
🔴 RATCHET (ARMADA): ghost_count: baseline 27 → 28 (só pode DESCER)
  Piora intencional? Edite governance/sdd-scorecard-baseline.json no MESMO PR (diff visível) citando ADR 0275.
exit=1
```
Árvore limpa (PR normal):
```
--ratchet: nenhuma regressão vs governance/sdd-scorecard-baseline.json. ✓
exit=0
```
Determinismo: `2 runs --json idênticas (diff vazio)` · memory-health: `0 🔴 fail` · YAML validado.

### Decisões a validar (Wagner)

- `ghost_count` + `front_door_coverage` nascem **armadas** no baseline (fonte `knowledge-drift.mjs` com 3 medições válidas documentadas: reconhecimento ADR 0275 + run PR #2597 + run deste PR). Como o workflow é continue-on-error, armada ≠ bloqueia merge — só pinta o step de vermelho. Se preferir nascer 100% desarmado, é 1 linha no baseline.
- Promoção a required (remover continue-on-error) SÓ via calendário ADR 0275 §5, depois de 7 execuções diárias verdes + 0 FP em 14d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)