### PR TITLE
fix(jana): KL-C1 - conserta duplo-OFF do peso_real (config nao-null + vocabulario lifecycle alinhado, flag OFF)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -714,21 +714,47 @@ return [
         // Valor DIRETO (sem env) — Larastan barra env() fora de config/ raiz,
         // mesmo padrão que a Área A adotou pro resto deste bloco.
         //
-        // NOTA de namespace: este arquivo é merged como `copiloto.*`
-        // (JanaServiceProvider::registerConfig). O driver lê via
-        // config('copiloto.peso_real.retrieval_enabled') — chave que HOJE resolve
-        // pra null em runtime real (não há mergeConfigFrom 'copiloto.peso_real'),
-        // ou seja: OFF por default em prod, garantido. Para LIGAR em homolog,
-        // Wagner registra o merge `copiloto.peso_real` OU seta via config() runtime.
-        // Os testes exercitam ON via config([...]) em runtime (independe do merge).
+        // NOTA de namespace (CORRIGIDA — KL-C1 2026-06-12, fim do "duplo-OFF"):
+        // este arquivo é merged como `copiloto.*` via JanaServiceProvider::
+        // registerConfig → mergeConfigFrom(config.php, 'copiloto'). A chave
+        // config('copiloto.peso_real.retrieval_enabled') resolve NÃO-NULL (= false)
+        // tanto em boot normal quanto sob `config:cache` (verificado via tinker
+        // 2026-06-12). O kill-switch é ESTA chave, funcional nos dois sentidos:
+        // pra ligar em homolog Wagner muda este valor (ou via config() runtime) —
+        // nenhum merge extra é necessário. O guard do driver lê com default
+        // explícito false (resiliente a config/copiloto.php publicado stale).
         'retrieval_enabled' => false,
 
         // (a) DECISÃO/ADR — multiplicador por lifecycle (não decai por tempo).
+        //
+        // KL-C1 (plano SDD 2026-06-12): vocabulário ALINHADO ao que o dado real
+        // carrega — antes a tabela só tinha o vocabulário ADR 0232 (accepted-
+        // historical/sunsetting), que NADA produz, e todo doc real caía no
+        // fallback 0.1 (aceito == superseded → viola ADR 0270 D-4 "o morto não
+        // volta no top-K com o mesmo peso do vigente"). Fontes do vocabulário:
+        //   - metadata['status'] EN normalizado (SeedAdrsCommand::normalizeStatus):
+        //     accepted | proposed | historical | superseded — mesmo vocabulário do
+        //     time_decay.status_multipliers (Wagner aprovou 2026-05-13).
+        //   - frontmatter canônico (scripts/memory-schemas/adr.schema.json, FONTE
+        //     ÚNICA): status proposto|aceito|...; lifecycle ativo|arquivado|
+        //     substituido|historical (applyPesoReal prefere metadata['lifecycle']).
+        // Pesos: vigente = 1.0 · historical = 0.5 · superseded/substituido/
+        // arquivado = 0.3. Desconhecido → fallback conservador 0.1 (não infla).
         'lifecycle_mult' => [
+            // vigente — peso cheio
             'accepted'            => 1.0,
+            'aceito'              => 1.0,
+            'ativo'               => 1.0,
+            'proposed'            => 1.0,
+            'proposto'            => 1.0,
+            // morto — decai por lifecycle (nunca por idade)
+            'historical'          => 0.5,
+            'superseded'          => 0.3,
+            'substituido'         => 0.3,
+            'arquivado'           => 0.3,
+            // legacy ADR 0232 (back-compat com fatos antigos)
             'accepted-historical' => 0.8,
             'sunsetting'          => 0.4,
-            'superseded'          => 0.1,
             'deprecated'          => 0.1,
         ],
 

--- a/Modules/Jana/Services/Memoria/MeilisearchDriver.php
+++ b/Modules/Jana/Services/Memoria/MeilisearchDriver.php
@@ -199,10 +199,12 @@ class MeilisearchDriver implements MemoriaContrato
         //   - MEMÓRIA (session/handoff/fato): mantém o decay já aplicado em 3.5
         //
         // SEGURANÇA MÁXIMA: passo guardado por feature-flag OFF por default
-        // (config('copiloto.peso_real.retrieval_enabled')). Com a flag OFF o pipeline
-        // é BYTE-IDÊNTICO ao legado — $candidatos flui intacto pro reranker.
-        // Wagner liga conscientemente em homolog após validação.
-        if (config('copiloto.peso_real.retrieval_enabled')) {
+        // (config('copiloto.peso_real.retrieval_enabled') — resolve não-null via
+        // mergeConfigFrom 'copiloto'; default explícito false cobre runtime com
+        // config publicada stale). Com a flag OFF o pipeline é BYTE-IDÊNTICO ao
+        // legado — $candidatos flui intacto pro reranker. Wagner liga
+        // conscientemente em homolog após validação (kill-switch KL-C1).
+        if ((bool) config('copiloto.peso_real.retrieval_enabled', false)) {
             $candidatos = $this->applyPesoReal($candidatos, $merged);
         }
 

--- a/Modules/Jana/Services/Peso/PesoRealService.php
+++ b/Modules/Jana/Services/Peso/PesoRealService.php
@@ -20,8 +20,9 @@ namespace Modules\Jana\Services\Peso;
  *     scope — esta classe só recebe números já resolvidos.
  *   - Determinístico: mesma entrada → mesma saída. Testável sem fixtures de DB.
  *
- * Área A da Etapa 5 do IAOS — PROPOSTA, NÃO plugada (não toca MeilisearchDriver,
- * retrieval, settings nem prod). Ver ADR 0232 (status: proposto).
+ * Área A da Etapa 5 do IAOS — plugada no MeilisearchDriver::applyPesoReal SOB
+ * feature-flag `copiloto.peso_real.retrieval_enabled` (kill-switch, OFF por
+ * default: prod intocada). Ver ADR 0232 + ADR 0270 D-4 (decaimento no recall).
  *
  * Estado-da-arte que sustenta as fórmulas:
  *   - Iniciativas: WSJF / Cost of Delay (SAFe / Reinertsen) — value÷effort com
@@ -38,12 +39,28 @@ class PesoRealService
     /**
      * Defaults de fallback hardcoded — usados quando config('copiloto.peso_real.*')
      * está ausente. Garante que o service NUNCA quebra por config faltando.
+     *
+     * KL-C1 (2026-06-12): espelho da tabela `copiloto.peso_real.lifecycle_mult`,
+     * alinhada ao vocabulário REAL — status EN normalizado (accepted/proposed/
+     * historical/superseded) + frontmatter canônico PT (aceito/proposto; lifecycle
+     * ativo/arquivado/substituido/historical). Antes, só o vocabulário ADR 0232
+     * existia e todo doc real caía no fallback 0.1 (ADR 0270 D-4 violada).
      */
     private const FALLBACK_LIFECYCLE_MULT = [
+        // vigente — peso cheio
         'accepted'            => 1.0,
+        'aceito'              => 1.0,
+        'ativo'               => 1.0,
+        'proposed'            => 1.0,
+        'proposto'            => 1.0,
+        // morto — decai por lifecycle (nunca por idade)
+        'historical'          => 0.5,
+        'superseded'          => 0.3,
+        'substituido'         => 0.3,
+        'arquivado'           => 0.3,
+        // legacy ADR 0232 (back-compat com fatos antigos)
         'accepted-historical' => 0.8,
         'sunsetting'          => 0.4,
-        'superseded'          => 0.1,
         'deprecated'          => 0.1,
     ];
 
@@ -77,7 +94,9 @@ class PesoRealService
      * lifecycle não-mapeado não infla ranking.
      *
      * @param int    $relevanciaMeta 0-100 (clampado).
-     * @param string $lifecycle      accepted | accepted-historical | sunsetting | superseded | deprecated
+     * @param string $lifecycle      vigente (accepted|aceito|ativo|proposed|proposto) |
+     *                               historical | superseded|substituido|arquivado |
+     *                               legacy ADR 0232 (accepted-historical|sunsetting|deprecated)
      */
     public function pesoDecisao(int $relevanciaMeta, string $lifecycle): float
     {

--- a/Modules/Jana/Tests/Feature/Memoria/PesoRealRetrievalTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/PesoRealRetrievalTest.php
@@ -107,15 +107,43 @@ it('flag OFF (default) NÃO reordena — saída idêntica ao applyTimeDecay (nã
     expect(array_column($resultado, 'id'))->toBe([1, 2]); // ordem do applyTimeDecay preservada
 });
 
-it('config default de retrieval_enabled é false (segurança máxima)', function () {
-    // Não sobrescreve config — lê o valor real do config.php carregado.
-    // Como o arquivo é merged sob `copiloto`, a chave `jana.*` resolve null em
-    // runtime real → falsy → OFF. Ambos os caminhos garantem OFF por default.
-    $copiloto = config('copiloto.peso_real.retrieval_enabled');
-    $jana     = config('copiloto.peso_real.retrieval_enabled');
+it('KL-C1 — config resolve NÃO-NULL: retrieval_enabled === false e lifecycle_mult populado (fim do duplo-OFF)', function () {
+    // Não sobrescreve config — lê o valor REAL merged (JanaServiceProvider::
+    // registerConfig → mergeConfigFrom 'copiloto'). O "duplo-OFF" era: flag false
+    // no arquivo + chave resolvendo null em runtime (kill-switch não-funcional).
+    // Agora a chave resolve false ESTRITO (não null) — a flag é a única porta.
+    expect(config('copiloto.peso_real.retrieval_enabled'))->toBeFalse()
+        ->and(config('copiloto.peso_real.lifecycle_mult'))->toBeArray()
+        // Vocabulário canônico alinhado (status EN normalizado + frontmatter PT):
+        ->and(config('copiloto.peso_real.lifecycle_mult.aceito'))->toBe(1.0)
+        ->and(config('copiloto.peso_real.lifecycle_mult.ativo'))->toBe(1.0)
+        ->and(config('copiloto.peso_real.lifecycle_mult.proposed'))->toBe(1.0)
+        ->and(config('copiloto.peso_real.lifecycle_mult.historical'))->toBe(0.5)
+        ->and(config('copiloto.peso_real.lifecycle_mult.superseded'))->toBe(0.3);
+});
 
-    expect((bool) $copiloto)->toBeFalse();
-    expect((bool) $jana)->toBeFalse();
+it('KL-C1 — flag AUSENTE (null, ex.: config publicada stale) continua OFF: kill-switch resiliente', function () {
+    // Simula o runtime degradado que motivou o "duplo-OFF": copiloto.peso_real
+    // inteiro resolvendo null. O guard do driver lê com default explícito false
+    // → applyPesoReal NUNCA roda → pipeline byte-idêntico ao legado.
+    config(['copiloto.peso_real' => null]);
+
+    $driver = new MeilisearchDriver();
+
+    $merged = collect([
+        pesoMakeFato(1, 'ADR superseded', ['doc_type' => 'adr', 'status' => 'superseded'], ageDays: 30),
+        pesoMakeFato(2, 'ADR aceito',     ['doc_type' => 'adr', 'status' => 'accepted'],   ageDays: 30),
+    ]);
+
+    $candidatos = pesoInvokeTimeDecay($driver, $merged);
+
+    // Mesma expressão do guard em buscarInterno (default explícito false).
+    $resultado = (bool) config('copiloto.peso_real.retrieval_enabled', false)
+        ? pesoInvokePesoReal($driver, $candidatos, $merged)
+        : $candidatos;
+
+    expect(config('copiloto.peso_real.retrieval_enabled'))->toBeNull() // cenário degradado reproduzido
+        ->and($resultado)->toBe($candidatos);                          // OFF: saída idêntica
 });
 
 // ── 2. flag ON — Peso Real reordena decisões por lifecycle (sem decay) ─────
@@ -133,7 +161,7 @@ it('flag ON — ADR accepted reordena ACIMA de ADR superseded (decisão evergree
 
     // Input em ordem "errada": superseded primeiro (id 1), accepted depois (id 2).
     // Mesmo age → o time-decay sozinho não inverteria forte; o Peso Real (decisão)
-    // usa lifecycle_mult (accepted=1.0 vs superseded=0.1) e deve trazer o accepted
+    // usa lifecycle_mult (accepted=1.0 vs superseded=0.3) e deve trazer o accepted
     // pro topo independente da idade.
     $merged = collect([
         pesoMakeFato(1, 'ADR superseded', ['doc_type' => 'adr', 'status' => 'superseded'], ageDays: 5),
@@ -148,9 +176,56 @@ it('flag ON — ADR accepted reordena ACIMA de ADR superseded (decisão evergree
     expect($reordenado[0]['id'])->toBe(2);
     expect($reordenado[1]['id'])->toBe(1);
 
-    // peso(accepted) = 70 × 1.0 = 70 ; peso(superseded) = 70 × 0.1 = 7
+    // peso(accepted) = 70 × 1.0 = 70 ; peso(superseded) = 70 × 0.3 = 21 (KL-C1)
     expect($reordenado[0]['score'])->toEqualWithDelta(70.0, 0.01);
-    expect($reordenado[1]['score'])->toEqualWithDelta(7.0, 0.01);
+    expect($reordenado[1]['score'])->toEqualWithDelta(21.0, 0.01);
+});
+
+it('flag ON — vocabulário real do seeder (proposed/historical/superseded) ordena 1.0 > 0.5 > 0.3', function () {
+    // KL-C1: metadata['status'] real vem EN-normalizado do SeedAdrsCommand
+    // (accepted|proposed|historical|superseded). ANTES, proposed e historical
+    // não existiam na lifecycle_mult → caíam no fallback 0.1 = peso de morto.
+    config(['copiloto.peso_real.retrieval_enabled' => true]);
+    config(['copiloto.time_decay.enabled' => true]);
+
+    $driver = new MeilisearchDriver();
+
+    $merged = collect([
+        pesoMakeFato(1, 'ADR superseded', ['doc_type' => 'adr', 'status' => 'superseded'], ageDays: 1),
+        pesoMakeFato(2, 'ADR historical', ['doc_type' => 'adr', 'status' => 'historical'], ageDays: 1),
+        pesoMakeFato(3, 'ADR proposed',   ['doc_type' => 'adr', 'status' => 'proposed'],   ageDays: 1),
+    ]);
+
+    $candidatos = pesoInvokeTimeDecay($driver, $merged);
+    $reordenado = pesoInvokePesoReal($driver, $candidatos, $merged);
+
+    expect(array_column($reordenado, 'id'))->toBe([3, 2, 1]);
+    // pesos: proposed 70×1.0=70 · historical 70×0.5=35 · superseded 70×0.3=21
+    expect($reordenado[0]['score'])->toEqualWithDelta(70.0, 0.01);
+    expect($reordenado[1]['score'])->toEqualWithDelta(35.0, 0.01);
+    expect($reordenado[2]['score'])->toEqualWithDelta(21.0, 0.01);
+});
+
+it('flag ON — lifecycle canônico do frontmatter (ativo/substituido) é preferido e não cai no fallback', function () {
+    // applyPesoReal prefere metadata['lifecycle'] sobre metadata['status'].
+    // Vocabulário canônico (scripts/memory-schemas/adr.schema.json):
+    // ativo|arquivado|substituido|historical. ADR 0270 D-4: vigente > morto.
+    config(['copiloto.peso_real.retrieval_enabled' => true]);
+    config(['copiloto.time_decay.enabled' => true]);
+
+    $driver = new MeilisearchDriver();
+
+    $merged = collect([
+        pesoMakeFato(1, 'ADR substituido', ['doc_type' => 'adr', 'lifecycle' => 'substituido', 'status' => 'superseded'], ageDays: 1),
+        pesoMakeFato(2, 'ADR ativo',       ['doc_type' => 'adr', 'lifecycle' => 'ativo',       'status' => 'aceito'],     ageDays: 1),
+    ]);
+
+    $candidatos = pesoInvokeTimeDecay($driver, $merged);
+    $reordenado = pesoInvokePesoReal($driver, $candidatos, $merged);
+
+    expect(array_column($reordenado, 'id'))->toBe([2, 1]);
+    expect($reordenado[0]['score'])->toEqualWithDelta(70.0, 0.01); // ativo 70×1.0
+    expect($reordenado[1]['score'])->toEqualWithDelta(21.0, 0.01); // substituido 70×0.3
 });
 
 it('flag ON — respeita relevancia_meta do metadata quando a Área B já populou', function () {

--- a/Modules/Jana/Tests/Feature/Peso/PesoRealServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Peso/PesoRealServiceTest.php
@@ -29,8 +29,29 @@ it('(a) decisão accepted ranka acima de superseded com relevância igual', func
     $superseded = $this->svc->pesoDecisao(80, 'superseded');
 
     expect($accepted)->toBe(80.0)            // 80 × 1.0
-        ->and($superseded)->toBe(8.0)        // 80 × 0.1
+        ->and($superseded)->toBe(24.0)       // 80 × 0.3 (KL-C1 — alinhado ao time_decay aprovado 2026-05-13)
         ->and($accepted)->toBeGreaterThan($superseded);
+});
+
+it('(a2) KL-C1 — vocabulário canônico real não cai mais no fallback 0.1', function () {
+    // status EN normalizado (SeedAdrsCommand::normalizeStatus) + frontmatter
+    // canônico (adr.schema.json): vigente=1.0 > historical=0.5 > superseded=0.3.
+    // ANTES deste fix, aceito/proposto/ativo/historical caíam TODOS em 0.1 —
+    // vigente pesava igual a morto (violava ADR 0270 D-4).
+    expect($this->svc->pesoDecisao(80, 'aceito'))->toBe(80.0)        // 80 × 1.0
+        ->and($this->svc->pesoDecisao(80, 'ativo'))->toBe(80.0)      // lifecycle vigente
+        ->and($this->svc->pesoDecisao(80, 'proposed'))->toBe(80.0)
+        ->and($this->svc->pesoDecisao(80, 'proposto'))->toBe(80.0)
+        ->and($this->svc->pesoDecisao(80, 'historical'))->toBe(40.0)  // 80 × 0.5
+        ->and($this->svc->pesoDecisao(80, 'substituido'))->toBe(24.0) // 80 × 0.3
+        ->and($this->svc->pesoDecisao(80, 'arquivado'))->toBe(24.0);  // 80 × 0.3
+
+    // Ordem D-4: vigente > historical > superseded — o morto não volta com o
+    // mesmo peso do vigente.
+    expect($this->svc->pesoDecisao(80, 'aceito'))
+        ->toBeGreaterThan($this->svc->pesoDecisao(80, 'historical'))
+        ->and($this->svc->pesoDecisao(80, 'historical'))
+        ->toBeGreaterThan($this->svc->pesoDecisao(80, 'superseded'));
 });
 
 it('(b) decisão NÃO muda com o tempo — peso é função só de relevância × lifecycle', function () {
@@ -179,7 +200,8 @@ it('(i) config ausente usa fallback hardcoded sem quebrar', function () {
     $svc = new PesoRealService();
 
     expect($svc->pesoDecisao(80, 'accepted'))->toBe(80.0)           // lifecycle fallback
-        ->and($svc->pesoDecisao(80, 'superseded'))->toBe(8.0)
+        ->and($svc->pesoDecisao(80, 'aceito'))->toBe(80.0)          // vocabulário canônico no fallback hardcoded também
+        ->and($svc->pesoDecisao(80, 'superseded'))->toBe(24.0)      // 80 × 0.3 (KL-C1)
         ->and($svc->pesoMemoria(90, diasDesde: 3650, critica: true))->toBe(45.0) // piso fallback 0.5
         ->and($svc->sinalCliente('paga_reporta'))->toBe(1.0)        // sinal fallback
         ->and($svc->timeCriticality('compliance'))->toBe(1.5);      // time_crit fallback


### PR DESCRIPTION
## Frente KL-C1 — FASE 1 reestruturação SDD (trilha C decay)

**Plano-mãe:** [memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) — Semanas 2-4, trilha C: "C1 fix config peso_real (flag OFF)".
**ADR:** [0270 D-4 decaimento](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0270-ciclo-de-vida-da-informacao-porta-unica-destilacao-decaimento.md) — "o morto não volta no top-K com o mesmo peso do vigente".

## O duplo-OFF (re-derivado do código real, não copiado do plano)

1. **Flag OFF** — `retrieval_enabled => false` (intencional, kill-switch).
2. **Config "resolvendo null"** — a nota de namespace do `config.php` afirmava que `config('copiloto.peso_real.retrieval_enabled')` resolve null em runtime real e que Wagner precisaria "registrar o merge" pra ligar. **Re-derivação via tinker 2026-06-12: a chave resolve `false` (não-null) em boot normal E sob `config:cache`** (o `mergeConfigFrom 'copiloto'` do `JanaServiceProvider::registerConfig` cobre o bloco). A nota stale foi corrigida e o guard do driver agora lê com default explícito `false` — kill-switch funcional nos dois sentidos e resiliente a `config/copiloto.php` publicado stale.
3. **Vocabulário lifecycle desalinhado (o defeito real)** — `lifecycle_mult` só tinha o vocabulário ADR 0232 (`accepted-historical`/`sunsetting`), que NADA produz. O dado real carrega:
   - `metadata['status']` EN normalizado pelo `SeedAdrsCommand::normalizeStatus`: `accepted|proposed|historical|superseded`
   - frontmatter canônico (`scripts/memory-schemas/adr.schema.json`): status `proposto|aceito`; lifecycle `ativo|arquivado|substituido|historical`

   Com flag ON, `proposed`/`historical`/`aceito`/`ativo` caíam TODOS no fallback 0.1 → vigente pesava igual a morto (ADR 0270 D-4 violada).

## Fix (FLAG MESTRE PERMANECE OFF — prod intocada)

- `lifecycle_mult` alinhado: **vigente (accepted/aceito/ativo/proposed/proposto) = 1.0 · historical = 0.5 · superseded/substituido/arquivado = 0.3** (alinha os `status_multipliers` do time_decay que Wagner aprovou 2026-05-13; ADR 0270 não fixa valores numéricos). Chaves legacy ADR 0232 mantidas (back-compat). Desconhecido → 0.1 conservador (não infla ranking).
- `PesoRealService::FALLBACK_LIFECYCLE_MULT` espelhado + docblocks stale corrigidos.
- Guard do `MeilisearchDriver`: `(bool) config('copiloto.peso_real.retrieval_enabled', false)`.

## Prova (Pest)

- **Flag OFF = byte-idêntico**: teste de não-regressão existente + NOVO teste com `copiloto.peso_real = null` (cenário degradado) → pipeline idêntico.
- **Config resolve não-null**: NOVO teste lê o valor real merged → `toBeFalse()` estrito (não null) + lifecycle_mult populado.
- **Flag ON (runtime de teste)**: vocabulário real do seeder ordena 1.0 > 0.5 > 0.3; lifecycle canônico do frontmatter (`ativo`/`substituido`) não cai mais no fallback.

```
Tests:    52 passed (162 assertions)  — Peso/ + PesoRealRetrievalTest + TimeDecayTest
Full Modules/Jana: 806 passed / 72 failed / 31 skipped — HEAD limpo: 802 / 72 / 31
(72 fails pré-existentes de env local, idênticos; +4 passed = os testes novos)
PHPStan: [OK] No errors (3 sources tocados)
```

## Tier 0

- Nenhuma query cross-tenant nova — `applyPesoReal` segue operando em material já scoped (teste de assinatura sem `businessId` mantido).
- Flag OFF garante prod intocada; ligar é decisão consciente de Wagner em homolog (C4 do plano, com eval before/after no CT 100).

Diff: 174+/30− (≤300, 1 intent). NÃO mergear — draft pra revisão Wagner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
