### PR TITLE
ci(governance): protection-drift — baseline de required checks + watchdog de staleness (GT-G4)

### DIFF
--- a/.github/workflows/protection-drift.yml
+++ b/.github/workflows/protection-drift.yml
@@ -1,0 +1,67 @@
+name: Protection Drift (advisory)
+
+# Drift de branch protection + watchdog de staleness — GT-G4 do plano
+# (memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md §2
+# GARANTIDA) + ADR 0275 §5 (demoção exige PR + ADR) e §3 (fonte parada >48h).
+#
+# Fecha o único buraco real do sistema de gates: a DEMOÇÃO INVISÍVEL — admin
+# remove um required check em 1 clique e nenhum diff aparece. Diário, compara
+# o estado VIVO (gh api) com governance/required-checks-baseline.json:
+#   - required que SUMIU do vivo → 🔴 (demoção só via PR editando o baseline + ADR)
+#   - required NOVO no vivo      → 🟡 aviso (entrar é permitido; sugerir PR de baseline)
+#   - enforcement enfraquecido   → 🔴 (everyone → non_admins = admin bypass)
+#   - watchdog: métrica measured do sdd-scorecard-baseline com fonte sem run
+#     verde >48h → 🔴 (canário parado é regressão silenciosa)
+#
+# ADVISORY DE NASCENÇA (ADR 0261/0271/0275 — gate novo nunca nasce required):
+# o step roda com continue-on-error, vermelho vira annotation + job summary.
+# OBS: drift_alarms é alarme advisory PERENE (ADR 0275 métrica 9) — este
+# workflow NUNCA entra no calendário de promoções a required.
+#
+# Diff-aware no PR: roda quando o PR toca o baseline (caminho sancionado de
+# demoção/promoção) — se o PR adiciona context ainda não-vivo, o 🔴 esperado
+# sinaliza "flipar a protection junto do merge" (ADR 0275 §5 item 4).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'governance/required-checks-baseline.json'
+      - 'governance/sdd-scorecard-baseline.json' # watchdog lê as métricas measured daqui
+      - 'scripts/governance/protection-drift.mjs'
+      - '.github/workflows/protection-drift.yml'
+  schedule:
+    - cron: '10 10 * * *' # 07:10 BRT diário (pós sdd-scorecard 09:50 UTC)
+  workflow_dispatch:
+
+concurrency:
+  group: protection-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read # watchdog lê last run verde dos workflows-fonte
+
+jobs:
+  drift:
+    name: Protection drift + watchdog staleness (advisory)
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Drift required checks (vivo vs baseline) + watchdog staleness
+        continue-on-error: true
+        run: |
+          set +e
+          node scripts/governance/protection-drift.mjs | tee /tmp/drift.txt
+          rc=$?
+          { echo '## Protection Drift + Watchdog (GT-G4 · advisory)'; echo '```'; cat /tmp/drift.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          if [ $rc -ne 0 ]; then
+            echo "::warning::protection-drift detectou 🔴 — required demovido/enforcement fraco/fonte stale. Ver job summary (advisory perene, ADR 0275 métrica 9)."
+          fi
+          exit $rc

--- a/governance/required-checks-baseline.json
+++ b/governance/required-checks-baseline.json
@@ -1,0 +1,43 @@
+{
+  "_meta": {
+    "baseline": "Required checks de main CONGELADOS — GT-G4 (plano 2026-06-12 §2 GARANTIDA)",
+    "adr": "memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md",
+    "regra": "required que SUMIR do vivo = 🔴 drift (demoção SÓ via PR editando este arquivo + ADR — ADR 0275 §5); required NOVO no vivo = 🟡 aviso (entrar é permitido, abrir PR incorporando); promoção a required atualiza este arquivo no MESMO PR do flip",
+    "capturado_em": "2026-06-12",
+    "capturado_de_sha": "4804dde2c",
+    "fonte": "gh api repos/<repo>/branches/main (.protection) + repos/<repo>/rules/branches/main — rota admin não usada (404 pra não-admin)",
+    "limitacao": "o resumo público da protection clássica não expõe o flag strict (só rulesets expõem) — strict clássico é verificado no flip R1 pelo humano (ADR 0275 §5)",
+    "consumidores": [
+      "scripts/governance/protection-drift.mjs",
+      ".github/workflows/protection-drift.yml"
+    ]
+  },
+  "branch": "main",
+  "enforcement_level": "everyone",
+  "classic_protection": {
+    "contexts": [
+      "ADR 0216 PR scan (governance:audit --diff-only)",
+      "ADR frontmatter",
+      "Append-only canon (ADRs, handoffs, Constituição)",
+      "Casos-coverage · ratchet (trio + rastreabilidade)",
+      "Conformance · cor-crua ratchet vs baseline",
+      "Dominio-dict · ratchet (enum ⇔ dicionário)",
+      "E2E Playwright · UCs críticos",
+      "Frontend / Vite build",
+      "No hardcode business_id (Tier 0)",
+      "No-mock-in-prod · ratchet",
+      "PHP / Pest (Financeiro · MySQL)",
+      "PHP / Pest (Unit)",
+      "PHPStan / Larastan · ratchet vs baseline",
+      "PII scan (CPF/CNPJ literal)",
+      "UI Lint · ratchet vs baseline",
+      "visual-regression"
+    ]
+  },
+  "rulesets": {
+    "strict_required_status_checks_policy": false,
+    "contexts": [
+      "Governance Gate (índice + memory-health + meta-teste)"
+    ]
+  }
+}

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -198,6 +198,10 @@
       "nome": "PHPStan / Larastan (ADR 0208)",
       "classe": "gate"
     },
+    "protection-drift.yml": {
+      "nome": "Protection Drift — baseline de required checks + watchdog de staleness (advisory PERENE · cron diário 10:10 UTC — GT-G4, ADR 0275 §5/§3)",
+      "classe": "meta"
+    },
     "quick-sync.yml": {
       "nome": "Quick Sync (manual escape — auto-deploy agora é deploy.yml)",
       "classe": "deploy"

--- a/scripts/governance/protection-drift.mjs
+++ b/scripts/governance/protection-drift.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+// protection-drift.mjs — drift de branch protection + watchdog de staleness (GT-G4,
+// plano memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md §2
+// GARANTIDA + ADR 0275 §5 calendário/demoção e §3 armamento/staleness).
+//
+// POR QUE EXISTE: o único buraco real do sistema de gates é a DEMOÇÃO INVISÍVEL —
+// admin remove um required check em 1 clique e nenhum diff aparece em lugar nenhum.
+// Este script congela a lista real em governance/required-checks-baseline.json:
+//   - required que SUMIU do vivo → 🔴 exit 1 (demoção só via PR editando o baseline + ADR)
+//   - required NOVO no vivo      → 🟡 aviso (entrar é permitido; sugerir PR de baseline)
+//   - enforcement enfraquecido   → 🔴 (everyone → non_admins = admin bypass liberado)
+// + WATCHDOG: métrica `measured` do governance/sdd-scorecard-baseline.json cuja fonte
+//   (workflow) está sem run verde >48h → 🔴 (canário parado é regressão silenciosa).
+//
+// FONTES VIVAS (públicas; funcionam com GITHUB_TOKEN contents:read — a rota admin
+// /branches/main/protection NÃO é usada porque exige admin e 404a pra agente):
+//   gh api repos/<repo>/branches/main        → .protection (contexts clássicos + enforcement_level)
+//   gh api repos/<repo>/rules/branches/main  → required_status_checks vindos de rulesets
+//   gh api repos/<repo>/actions/workflows/<wf>/runs?status=success&per_page=1
+//
+// DETERMINÍSTICO: --json sem idade computada — timestamps são literais da API;
+// 2 runs seguidas sem mudança no mundo = diff vazio.
+//
+// Uso (na raiz do repo, GH_TOKEN ou gh auth ativos):
+//   node scripts/governance/protection-drift.mjs                    # tabela 🔴🟡🟢; exit 1 se 🔴
+//   node scripts/governance/protection-drift.mjs --json             # JSON determinístico no stdout
+//   node scripts/governance/protection-drift.mjs --capture          # (re)escreve o baseline do vivo — ato deliberado, commit + PR
+//   node scripts/governance/protection-drift.mjs --fixture <f.json> # estado vivo vem de arquivo (simulação/selftest GT-G6)
+// Node puro (fs + execSync). Idioma: clone de sdd-scorecard.mjs.
+
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const REPO = 'wagnerra23/oimpresso.com';
+const BASELINE = join(ROOT, 'governance', 'required-checks-baseline.json');
+const SCORECARD_BASELINE = join(ROOT, 'governance', 'sdd-scorecard-baseline.json');
+const STALE_HOURS = 48;
+const MODE_JSON = process.argv.includes('--json');
+const MODE_CAPTURE = process.argv.includes('--capture');
+const fxIdx = process.argv.indexOf('--fixture');
+const FIXTURE = fxIdx > -1 ? process.argv[fxIdx + 1] : null;
+
+// métrica measured do scorecard → workflow que mantém a fonte viva (watchdog ADR 0275 §3).
+// Métrica nova `measured` sem entry aqui = 🟡 aviso (adicionar o mapeamento).
+const WATCHDOG_SOURCES = {
+  anchor_coverage: 'sdd-scorecard.yml',
+  ghost_count: 'sdd-scorecard.yml',
+  front_door_coverage: 'sdd-scorecard.yml',
+};
+
+function gh(path) {
+  return JSON.parse(execSync(`gh api "${path}"`, { maxBuffer: 8 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] }).toString());
+}
+
+function fetchLive() {
+  if (FIXTURE) return JSON.parse(readFileSync(FIXTURE, 'utf8'));
+  const branch = gh(`repos/${REPO}/branches/main`);
+  const rules = gh(`repos/${REPO}/rules/branches/main`).filter((r) => r.type === 'required_status_checks');
+  const live = {
+    enforcement_level: branch.protection?.required_status_checks?.enforcement_level ?? null,
+    classic_contexts: (branch.protection?.required_status_checks?.contexts ?? []).slice().sort(),
+    ruleset_contexts: rules.flatMap((r) => (r.parameters?.required_status_checks ?? []).map((c) => c.context)).sort(),
+    ruleset_strict: rules.some((r) => r.parameters?.strict_required_status_checks_policy === true),
+    workflow_runs: {},
+  };
+  for (const wf of [...new Set(Object.values(WATCHDOG_SOURCES))].sort()) {
+    const runs = gh(`repos/${REPO}/actions/workflows/${wf}/runs?status=success&per_page=1`);
+    live.workflow_runs[wf] = runs.workflow_runs?.[0]?.run_started_at ?? null;
+  }
+  return live;
+}
+
+function capture(live) {
+  const sha = execSync('git rev-parse --short HEAD', { cwd: ROOT }).toString().trim();
+  const body = {
+    _meta: {
+      baseline: 'Required checks de main CONGELADOS — GT-G4 (plano 2026-06-12 §2 GARANTIDA)',
+      adr: 'memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md',
+      regra: 'required que SUMIR do vivo = 🔴 drift (demoção SÓ via PR editando este arquivo + ADR — ADR 0275 §5); required NOVO no vivo = 🟡 aviso (entrar é permitido, abrir PR incorporando); promoção a required atualiza este arquivo no MESMO PR do flip',
+      capturado_em: new Date().toISOString().slice(0, 10),
+      capturado_de_sha: sha,
+      fonte: 'gh api repos/<repo>/branches/main (.protection) + repos/<repo>/rules/branches/main — rota admin não usada (404 pra não-admin)',
+      limitacao: 'o resumo público da protection clássica não expõe o flag strict (só rulesets expõem) — strict clássico é verificado no flip R1 pelo humano (ADR 0275 §5)',
+      consumidores: ['scripts/governance/protection-drift.mjs', '.github/workflows/protection-drift.yml'],
+    },
+    branch: 'main',
+    enforcement_level: live.enforcement_level,
+    classic_protection: { contexts: live.classic_contexts },
+    rulesets: { strict_required_status_checks_policy: live.ruleset_strict, contexts: live.ruleset_contexts },
+  };
+  writeFileSync(BASELINE, JSON.stringify(body, null, 2) + '\n', 'utf8');
+  console.log(`  --capture: baseline escrito em governance/required-checks-baseline.json (${live.classic_contexts.length} classic + ${live.ruleset_contexts.length} ruleset @ ${sha}) — commite via PR.`);
+}
+
+function compareProtection(live, base) {
+  const red = [], warn = [];
+  const baseAll = new Set([...(base.classic_protection?.contexts ?? []), ...(base.rulesets?.contexts ?? [])]);
+  const liveAll = new Set([...(live.classic_contexts ?? []), ...(live.ruleset_contexts ?? [])]);
+  const missing = [...baseAll].filter((c) => !liveAll.has(c)).sort();
+  const extra = [...liveAll].filter((c) => !baseAll.has(c)).sort();
+  for (const c of missing) red.push(`required SUMIU do vivo: "${c}" — demoção exige PR editando governance/required-checks-baseline.json + ADR (ADR 0275 §5)`);
+  for (const c of extra) warn.push(`required NOVO no vivo (fora do baseline): "${c}" — entrar é permitido; abrir PR incorporando ao baseline`);
+  if (base.enforcement_level === 'everyone' && live.enforcement_level !== 'everyone')
+    red.push(`enforcement_level enfraqueceu: baseline "everyone" → vivo "${live.enforcement_level}" (admin bypass liberado)`);
+  if (Boolean(base.rulesets?.strict_required_status_checks_policy) !== Boolean(live.ruleset_strict))
+    warn.push(`strict_required_status_checks_policy (rulesets) mudou: baseline ${Boolean(base.rulesets?.strict_required_status_checks_policy)} → vivo ${Boolean(live.ruleset_strict)} — refletir via PR de baseline`);
+  return { missing, extra, red, warn };
+}
+
+function watchdog(live) {
+  const red = [], warn = [], rows = [];
+  if (FIXTURE && !('workflow_runs' in live)) return { rows, red, warn, skipped: 'fixture sem workflow_runs' };
+  if (!existsSync(SCORECARD_BASELINE)) return { rows, red, warn: ['governance/sdd-scorecard-baseline.json ausente — watchdog sem métricas'], skipped: null };
+  const sb = JSON.parse(readFileSync(SCORECARD_BASELINE, 'utf8'));
+  const now = Date.now();
+  for (const [name, m] of Object.entries(sb.metrics ?? {})) {
+    if (m.status !== 'measured') continue;
+    const wf = WATCHDOG_SOURCES[name];
+    if (!wf) { warn.push(`${name}: measured sem workflow mapeado no watchdog — adicionar em WATCHDOG_SOURCES (protection-drift.mjs)`); continue; }
+    const last = live.workflow_runs?.[wf] ?? null;
+    const stale = !last || now - Date.parse(last) > STALE_HOURS * 3600 * 1000;
+    rows.push({ metric: name, workflow: wf, last_success: last, stale });
+    if (stale) red.push(`${name}: fonte ${wf} sem run verde há >${STALE_HOURS}h (último sucesso: ${last ?? 'NUNCA'}) — canário parado é regressão silenciosa (ADR 0275 §3: métrica desarma até nova sequência de 3)`);
+  }
+  return { rows, red, warn, skipped: null };
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+const live = fetchLive();
+if (MODE_CAPTURE) { capture(live); process.exit(0); }
+if (!existsSync(BASELINE)) {
+  console.error('  🔴 sem baseline — rode `node scripts/governance/protection-drift.mjs --capture` e commite governance/required-checks-baseline.json via PR.');
+  process.exit(1);
+}
+const base = JSON.parse(readFileSync(BASELINE, 'utf8'));
+const drift = compareProtection(live, base);
+const wd = watchdog(live);
+const reds = [...drift.red, ...wd.red];
+const warns = [...drift.warn, ...wd.warn];
+const verdict = reds.length ? 'red' : warns.length ? 'yellow' : 'green';
+
+if (MODE_JSON) {
+  process.stdout.write(JSON.stringify({ live, drift: { missing: drift.missing, extra: drift.extra }, watchdog: { rows: wd.rows, skipped: wd.skipped ?? null }, reds, warns, verdict }, null, 2) + '\n');
+  process.exit(reds.length ? 1 : 0);
+}
+
+console.log('\n  PROTECTION DRIFT — main vivo vs governance/required-checks-baseline.json\n');
+const baseTotal = (base.classic_protection?.contexts ?? []).length + (base.rulesets?.contexts ?? []).length;
+const liveTotal = (live.classic_contexts ?? []).length + (live.ruleset_contexts ?? []).length;
+console.log(`  baseline: ${baseTotal} required (${(base.classic_protection?.contexts ?? []).length} classic + ${(base.rulesets?.contexts ?? []).length} ruleset) · vivo: ${liveTotal} · enforcement: ${live.enforcement_level}`);
+if (!drift.missing.length && !drift.red.length) console.log('  🟢 nenhum required demovido');
+console.log('\n  WATCHDOG STALENESS — fontes das métricas measured (sdd-scorecard-baseline)');
+if (wd.skipped) console.log(`  ⏭️  pulado: ${wd.skipped}`);
+for (const r of wd.rows) console.log(`  ${r.stale ? '🔴' : '🟢'} ${r.metric.padEnd(22)} ← ${r.workflow} (último verde: ${r.last_success ?? 'NUNCA'})`);
+if (warns.length || reds.length) console.log('');
+for (const w of warns) console.log(`  🟡 ${w}`);
+for (const r of reds) console.log(`  🔴 ${r}`);
+console.log(`\n  veredito: ${verdict === 'red' ? '🔴 DRIFT' : verdict === 'yellow' ? '🟡 avisos' : '🟢 ok'}\n`);
+process.exit(reds.length ? 1 : 0);


### PR DESCRIPTION
## O que é

Frente **GT-G4** da FASE 2 da reestruturação SDD (**US-GOV-017 fase 2** · [plano-mãe §2 GARANTIDA](memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) · [ADR 0275 §5/§3](memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md)).

Fecha o único buraco real do sistema de gates: **demoção invisível** — admin remove um required check em 1 clique e nenhum diff aparece em lugar nenhum.

## Entregas (275 linhas, 1 intent)

| Arquivo | Papel |
|---|---|
| `governance/required-checks-baseline.json` | Lista REAL congelada via gh api @ `4804dde2c`: **16 contexts clássicos + 1 ruleset** ("Governance Gate") = os **17** que as regras citavam — o plano contava 16 porque a rota admin não enxerga rulesets. `enforcement_level: everyone`. |
| `scripts/governance/protection-drift.mjs` | Vivo (gh api **público** — `branches/main` + `rules/branches/main`; a rota admin `/branches/main/protection` 404a pra não-admin) vs baseline: required que **SUMIU = exit 1** (demoção só via PR editando o baseline + ADR); **NOVO = aviso** (entrar é permitido, sugere PR); **enforcement enfraquecido = exit 1**. **Watchdog de staleness**: métrica `measured` do `sdd-scorecard-baseline.json` cuja fonte (workflow) está sem run verde **>48h = exit 1** (ADR 0275 §3). Modos `--json` (determinístico), `--capture`, `--fixture` (selftest GT-G6). |
| `.github/workflows/protection-drift.yml` | **ADVISORY de nascença** (`continue-on-error` — ADR 0261/0271) · cron diário **10:10 UTC** + diff-aware em PR que toca o baseline + `workflow_dispatch`. Alarme advisory **PERENE** — nunca vira required (ADR 0275 métrica 9). |
| `scripts/governance/gates-registry.json` | Entry do workflow novo (classe `meta`). |

## DoD — evidência de execução local

**1. Run real (gh api vivo) — verde 17/17:**
```
  PROTECTION DRIFT — main vivo vs governance/required-checks-baseline.json
  baseline: 17 required (16 classic + 1 ruleset) · vivo: 17 · enforcement: everyone
  🟢 nenhum required demovido
  WATCHDOG STALENESS — fontes das métricas measured (sdd-scorecard-baseline)
  🟢 anchor_coverage        ← sdd-scorecard.yml (último verde: 2026-06-12T14:58:01Z)
  🟢 ghost_count            ← sdd-scorecard.yml (último verde: 2026-06-12T14:58:01Z)
  🟢 front_door_coverage    ← sdd-scorecard.yml (último verde: 2026-06-12T14:58:01Z)
  veredito: 🟢 ok
final-exit=0
```

**2. Simulação de demoção via fixture (visual-regression removido) — exit 1:**
```
  🔴 required SUMIU do vivo: "visual-regression" — demoção exige PR editando governance/required-checks-baseline.json + ADR (ADR 0275 §5)
  veredito: 🔴 DRIFT
fixture-exit=1
```

**3. Fixture mista (enforcement `non_admins` + required novo + fonte stale 2026-06-01) — exit 1:**
```
  🟡 required NOVO no vivo (fora do baseline): "Gate Novo Hipotetico" — entrar é permitido; abrir PR incorporando ao baseline
  🔴 enforcement_level enfraqueceu: baseline "everyone" → vivo "non_admins" (admin bypass liberado)
  🔴 anchor_coverage: fonte sdd-scorecard.yml sem run verde há >48h (último sucesso: 2026-06-01T00:00:00Z) — canário parado é regressão silenciosa (ADR 0275 §3: métrica desarma até nova sequência de 3)
mix-exit=1
```

**4. Determinismo:** `DETERMINISMO OK: diff vazio (run1 exit=0, run2 exit=0)` — 2 runs `--json` idênticas.

**5. memory-health local:** `0 🔴 fail · 3 🟡 warn` (warns pré-existentes em main, não relacionados).

## Decisões de implementação

- **Watchdog mora no protection-drift.mjs** (não no scorecard): staleness é alarme de OPERAÇÃO da fonte, não medição — e o GT-G3 (sdd-scorecard.yml) já checa staleness do *arquivo* scorecard; aqui checamos se o *workflow-fonte* continua rodando. Map `WATCHDOG_SOURCES` métrica→workflow; métrica `measured` sem map = 🟡 aviso.
- **Endpoints públicos** em vez da rota admin: agente/CI com `GITHUB_TOKEN` read-only consegue ler (probe anônimo validado). Limitação documentada no baseline: o resumo público não expõe `strict` da protection clássica (rulesets expõem) — verificado no flip R1 pelo humano.
- **`--capture`** regenera o baseline do vivo — mas só vale commitado via PR (diff visível), nunca silencioso.

## Não faz

- ❌ Não mergeia (draft — Wagner decide)
- ❌ Não toca sdd-scorecard.mjs (área GT-G2/G3) — `drift_alarms` continua `not_yet_measured` até o scorecard consumir este script
- ❌ Não promove nada a required (advisory perene por design)

Refs: US-GOV-017 SDD-F2 GT-G4 · plano-mãe 2026-06-12 §2 · ADR 0275

🤖 Generated with [Claude Code](https://claude.com/claude-code)