### PR TITLE
test(fundacao): Business::first() cru → seededTenant() em 20 testes da raiz (FV-B4 PR-b)

### DIFF
--- a/tests/Feature/Auditoria/ContactPiiLogsActivityTest.php
+++ b/tests/Feature/Auditoria/ContactPiiLogsActivityTest.php
@@ -74,7 +74,7 @@ it('cenario 2: update tax_number_1 NAO gera entry (campo NAO logado pra PII LGPD
         ->count();
 
     // tax_number_1 NAO esta no logOnly por design — PII nao auditada
-    $this->contact->tax_number_1 = '123.456.789-00'; // formato CPF deliberado pro test
+    $this->contact->tax_number_1 = '123.456.789-00'; // formato CPF deliberado pro test # pii-allowlist
     $this->contact->save();
 
     $countAfter = Activity::query()
@@ -88,7 +88,7 @@ it('cenario 2: update tax_number_1 NAO gera entry (campo NAO logado pra PII LGPD
 it('cenario 3: PII regex assert — properties JSON NUNCA contem CPF/CNPJ mesmo em update completo', function () {
     // Update mistura campo logado + campo PII — properties so deve ter campo logado
     $this->contact->name = 'Cliente Teste Audit-003';
-    $this->contact->tax_number_1 = '12.345.678/0001-99'; // CNPJ formato deliberado
+    $this->contact->tax_number_1 = '12.345.678/0001-99'; // CNPJ formato deliberado # pii-allowlist
     $this->contact->mobile = '(11) 99999-8888';
     $this->contact->save();
 

--- a/tests/Feature/Auditoria/ContactPiiLogsActivityTest.php
+++ b/tests/Feature/Auditoria/ContactPiiLogsActivityTest.php
@@ -23,12 +23,9 @@ uses(DatabaseTransactions::class);
 
 beforeEach(function () {
     try {
-        $this->business = \App\Business::first();
+        $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         $this->markTestSkipped('Schema UltimatePOS ausente — rode local com DB_CONNECTION=mysql (dev) ou aguarde CI integration job.');
-    }
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
     }
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();

--- a/tests/Feature/Auditoria/ProductStockLogsActivityTest.php
+++ b/tests/Feature/Auditoria/ProductStockLogsActivityTest.php
@@ -26,12 +26,9 @@ uses(DatabaseTransactions::class);
 
 beforeEach(function () {
     try {
-        $this->business = \App\Business::first();
+        $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         $this->markTestSkipped('Schema UltimatePOS ausente — rode local com DB_CONNECTION=mysql (dev) ou aguarde CI integration job.');
-    }
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
     }
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();

--- a/tests/Feature/Auditoria/RevertServiceTest.php
+++ b/tests/Feature/Auditoria/RevertServiceTest.php
@@ -34,10 +34,7 @@ beforeEach(function () {
         $this->markTestSkipped('Coluna causer_kind nao existe.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {

--- a/tests/Feature/Auditoria/SellLinePaymentLogsActivityTest.php
+++ b/tests/Feature/Auditoria/SellLinePaymentLogsActivityTest.php
@@ -20,12 +20,9 @@ uses(DatabaseTransactions::class);
 
 beforeEach(function () {
     try {
-        $this->business = \App\Business::first();
+        $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         $this->markTestSkipped('Schema UltimatePOS ausente — rode local com DB_CONNECTION=mysql (dev) ou aguarde CI integration job.');
-    }
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
     }
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();

--- a/tests/Feature/Auditoria/TransactionLogsActivityTest.php
+++ b/tests/Feature/Auditoria/TransactionLogsActivityTest.php
@@ -33,12 +33,9 @@ beforeEach(function () {
     // skip-graceful pra nao confundir com falha real. Padrao do projeto:
     // veja Modules/Financeiro/Tests/Feature/TransactionObserverIntegrationTest.
     try {
-        $this->business = \App\Business::first();
+        $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         $this->markTestSkipped('Schema UltimatePOS ausente — rode local com DB_CONNECTION=mysql (dev) ou aguarde CI integration job.');
-    }
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB — rode seeder UltimatePOS antes.');
     }
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();

--- a/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
+++ b/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
@@ -52,12 +52,12 @@ beforeEach(function () {
 
     $this->cpfValidoId = DB::table('contacts')->insertGetId(array_merge($base, [
         'name' => 'PF Backfill Test Valido',
-        'tax_number' => '111.444.777-35', // CPF válido mod-11
+        'tax_number' => '111.444.777-35', // CPF válido mod-11 # pii-allowlist
     ]));
 
     $this->cnpjValidoId = DB::table('contacts')->insertGetId(array_merge($base, [
         'name' => 'PJ Backfill Test Valido',
-        'tax_number' => '11.444.777/0001-61', // CNPJ válido mod-11
+        'tax_number' => '11.444.777/0001-61', // CNPJ válido mod-11 # pii-allowlist
     ]));
 
     $this->cpfInvalidoId = DB::table('contacts')->insertGetId(array_merge($base, [
@@ -137,7 +137,7 @@ it('respeita filtro --business-id (Tier 0)', function () {
         'created_by' => $otherUser->id,
         'type' => 'customer',
         'name' => 'Contact em outro business',
-        'tax_number' => '111.444.777-35', // CPF válido — DEVE ser ignorado pelo filtro
+        'tax_number' => '111.444.777-35', // CPF válido — DEVE ser ignorado pelo filtro # pii-allowlist
         'mobile' => '11888888888',
         'cpf_cnpj' => null,
         'created_at' => now(),
@@ -166,7 +166,7 @@ it('NAO sobrescreve cpf_cnpj ja populado (Wagner guard 2026-05-21)', function ()
         'created_by' => $this->user->id,
         'type' => 'customer',
         'name' => 'Contact com cpf_cnpj LEGADO populado',
-        'tax_number' => '111.444.777-35', // CPF valido — TENTARIA backfill, mas tem cpf_cnpj
+        'tax_number' => '111.444.777-35', // CPF valido — TENTARIA backfill, mas tem cpf_cnpj # pii-allowlist
         'cpf_cnpj' => $existingValue,
         'mobile' => '11777777777',
         'created_at' => now(),
@@ -185,7 +185,7 @@ it('NAO sobrescreve cpf_cnpj ja populado (Wagner guard 2026-05-21)', function ()
 
     // E o tax_number original tambem preservado (back-compat).
     $taxNumberFinal = DB::table('contacts')->where('id', $contactComCpfCnpjPopuladoId)->value('tax_number');
-    expect($taxNumberFinal)->toBe('111.444.777-35');
+    expect($taxNumberFinal)->toBe('111.444.777-35'); // pii-allowlist (CPF/CNPJ sintético mod-11 de teste)
 });
 
 it('log JSON nao grava tax_number plain (LGPD)', function () {
@@ -207,9 +207,9 @@ it('log JSON nao grava tax_number plain (LGPD)', function () {
 
     // PII redacted — não pode aparecer nenhum tax_number completo no log.
     expect($content)->not->toContain('11144477735');
-    expect($content)->not->toContain('111.444.777-35');
+    expect($content)->not->toContain('111.444.777-35'); // pii-allowlist (CPF/CNPJ sintético mod-11 de teste)
     expect($content)->not->toContain('11444777000161');
-    expect($content)->not->toContain('11.444.777/0001-61');
+    expect($content)->not->toContain('11.444.777/0001-61'); // pii-allowlist (CPF/CNPJ sintético mod-11 de teste)
 
     // Mas tem o resumo numérico
     expect($content)->toContain('"valid_mod11": 2');

--- a/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
+++ b/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
@@ -31,10 +31,7 @@ beforeEach(function () {
         $this->markTestSkipped('Migration 2026_05_21_140000 ainda não rodou neste ambiente.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/BrasilApiLookupTest.php
+++ b/tests/Feature/Cliente/BrasilApiLookupTest.php
@@ -25,10 +25,7 @@ beforeEach(function () {
         $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory). Rode com DB_CONNECTION=mysql.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteAuditoriaTabTest.php
+++ b/tests/Feature/Cliente/ClienteAuditoriaTabTest.php
@@ -48,10 +48,7 @@ beforeEach(function () {
         $this->markTestSkipped('Coluna business_id ausente em activity_log -- rode migration 2021_03_16.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteAuditoriaTabTest.php
+++ b/tests/Feature/Cliente/ClienteAuditoriaTabTest.php
@@ -167,8 +167,8 @@ test('GET timeline -- PII CPF aparecendo em properties e mascarado em descriptio
         $this->contactId,
         $this->business->id,
         'updated',
-        ['tax_number' => '111.444.777-35'],
-        ['tax_number' => '999.888.777-66'],
+        ['tax_number' => '111.444.777-35'], // pii-allowlist (sintético)
+        ['tax_number' => '999.888.777-66'], // pii-allowlist (sintético)
         $this->user->id
     );
 

--- a/tests/Feature/Cliente/ClienteContatoEmailsExtrasTest.php
+++ b/tests/Feature/Cliente/ClienteContatoEmailsExtrasTest.php
@@ -25,10 +25,7 @@ beforeEach(function () {
         $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
@@ -35,10 +35,7 @@ beforeEach(function () {
         $this->markTestSkipped('Migration 2026_05_22_000000 (Wave B drawer) ainda nao rodou neste ambiente.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteEditInertiaTest.php
+++ b/tests/Feature/Cliente/ClienteEditInertiaTest.php
@@ -35,10 +35,7 @@ beforeEach(function () {
         $this->markTestSkipped('Migration 2026_05_21_140000 (BR fields) ainda não rodou neste ambiente.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteIaTabTest.php
+++ b/tests/Feature/Cliente/ClienteIaTabTest.php
@@ -271,7 +271,7 @@ test('com mock mode ativo, controller nao instancia Agent real (fixture fallback
 test('response da IA nao inclui tax_number plain do contact (defesa LGPD ADR 0093)', function () {
     // Atualiza contact com tax_number plain.
     DB::table('contacts')->where('id', $this->contactId)->update([
-        'tax_number' => '111.444.777-35',
+        'tax_number' => '111.444.777-35', // pii-allowlist (sintético)
     ]);
 
     $r = $this->postJson("/cliente/{$this->contactId}/ia/resumo");
@@ -279,5 +279,5 @@ test('response da IA nao inclui tax_number plain do contact (defesa LGPD ADR 009
 
     $body = $r->json();
     $bodyJson = json_encode($body);
-    expect($bodyJson)->not->toContain('111.444.777-35');
+    expect($bodyJson)->not->toContain('111.444.777-35'); // pii-allowlist (sintético)
 });

--- a/tests/Feature/Cliente/ClienteIaTabTest.php
+++ b/tests/Feature/Cliente/ClienteIaTabTest.php
@@ -37,10 +37,7 @@ beforeEach(function () {
         $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) -- rode com DB_CONNECTION=mysql (dev) ou CI integration job.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteLookupCnpjCepTest.php
+++ b/tests/Feature/Cliente/ClienteLookupCnpjCepTest.php
@@ -30,10 +30,7 @@ beforeEach(function () {
         $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory).');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/ClienteTypeOtherRouteTest.php
+++ b/tests/Feature/Cliente/ClienteTypeOtherRouteTest.php
@@ -58,13 +58,9 @@ test('controller $types e $inertiaTypes também aceitam other (3 camadas alinhad
  */
 test('GET /cliente?type=other renderiza Inertia com activeType=other (não customer)', function () {
     try {
-        $business = Business::first();
+        $business = test()->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         test()->markTestSkipped('DB indisponível: ' . $e->getMessage());
-    }
-
-    if (! $business) {
-        test()->markTestSkipped('Sem business no banco.');
     }
 
     $user = User::where('business_id', $business->id)

--- a/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
+++ b/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
@@ -39,10 +39,7 @@ beforeEach(function () {
         $this->markTestSkipped('Schema NfeBrasil ausente — rode migrate.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/Show/VehiclesTabTest.php
+++ b/tests/Feature/Cliente/Show/VehiclesTabTest.php
@@ -32,10 +32,7 @@ beforeEach(function () {
         $this->markTestSkipped('Schema Modules/OficinaAuto ausente neste ambiente — migration vehicles não rodou.');
     }
 
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {
         $this->markTestSkipped('Sem user no business.');

--- a/tests/Feature/Cliente/StoreContactRequestTest.php
+++ b/tests/Feature/Cliente/StoreContactRequestTest.php
@@ -27,12 +27,9 @@ uses(DatabaseTransactions::class);
 
 beforeEach(function () {
     try {
-        $this->business = Business::first();
+        $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         $this->markTestSkipped('Schema UltimatePOS ausente — rode com DB_CONNECTION=mysql dev.');
-    }
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
     }
 
     $this->user = User::where('business_id', $this->business->id)->first();

--- a/tests/Feature/Home/HomeIndexInertiaTest.php
+++ b/tests/Feature/Home/HomeIndexInertiaTest.php
@@ -26,13 +26,9 @@ use Spatie\Permission\Models\Permission;
 function homeBootstrap(): User
 {
     try {
-        $business = Business::first();
+        $business = test()->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
     } catch (\Throwable $e) {
         test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
-    }
-
-    if (! $business) {
-        test()->markTestSkipped('Sem business no banco.');
     }
 
     $user = User::where('business_id', $business->id)
@@ -81,10 +77,7 @@ it('renderiza Inertia component Home/Index com shape esperado', function () {
 });
 
 it('customer redirect preservado (user_type=user_customer → 302)', function () {
-    $business = Business::first();
-    if (! $business) {
-        $this->markTestSkipped('Sem business.');
-    }
+    $business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
 
     $customer = User::where('business_id', $business->id)
         ->where('user_type', 'user_customer')

--- a/tests/Feature/Modules/Financeiro/TransactionObserverIntegrationTest.php
+++ b/tests/Feature/Modules/Financeiro/TransactionObserverIntegrationTest.php
@@ -49,10 +49,7 @@ uses(DatabaseTransactions::class);
 
 beforeEach(function () {
     // Dependencias de DB
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB — rode seeder UltimatePOS antes.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {

--- a/tests/Feature/Modules/Financeiro/TransactionPaymentObserverTest.php
+++ b/tests/Feature/Modules/Financeiro/TransactionPaymentObserverTest.php
@@ -28,10 +28,7 @@ use Modules\Financeiro\Models\TituloBaixa;
 uses(DatabaseTransactions::class);
 
 beforeEach(function () {
-    $this->business = \App\Business::first();
-    if (! $this->business) {
-        $this->markTestSkipped('Sem business em DB.');
-    }
+    $this->business = $this->seededTenant(); // biz=1 canônico (ADR 0101) — skip acionável se o seed faltar
 
     $this->user = \App\User::where('business_id', $this->business->id)->first();
     if (! $this->user) {


### PR DESCRIPTION
> **Depends-on: #2615 (PR-a — trait WithSeededTenant).** Base deste PR é `sdd/f2-fv-b4-a`; após merge do PR-a em main, retarget pra `main`.

## O que é

PR-b da frente **FV-B4** (fase 2 da reestruturação SDD — US-GOV-017, plano-mãe [`memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md`](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) §4 — "B4 tests/ raiz + trait WithSeededTenant").

Substituição **mecânica, comportamento-idêntico** do padrão `Business::first()` + guard `if (!$business) markTestSkipped(...)` pelo helper `$this->seededTenant()` (trait do PR-a) em **20 arquivos** de `tests/` raiz: Auditoria (5) · Cliente (12) · Home (1) · Modules/Financeiro (2). **+21/−86 (107 linhas)** — zero mudança de asserção, só setup/guard.

## Por que comportamento é idêntico

| Cenário | Antes (`Business::first()` + guard) | Depois (`seededTenant()`) |
|---|---|---|
| Seed canônico presente | primeiro Business = biz=1 | biz=1 explícito (ADR 0101); fallback `orderBy('id')->first()` cobre schemas montados pelo teste |
| Tabela vazia | guard → `markTestSkipped('Sem business em DB.')` | helper → skip ACIONÁVEL (mensagem diz COMO seedar) |
| Chamada dentro de try/catch `\Throwable` (Auditoria/*, ClienteTypeOther, HomeIndex) | exceção DB → catch → skip | exceção de skip cai no catch → re-skip — desfecho continua *skipped* |
| Funções standalone (`homeBootstrap`, closures `test()`) | `Business::first()` | `test()->seededTenant()` (TestCase tem o trait) |

## Re-derive (grep no código real)

```
# ANTES — no commit PR-a (b52b8d8eb):
$ grep -rn "Business::first()" tests/ | wc -l   → 39
$ grep -rln "Business::first()" tests/ | wc -l  → 30 arquivos

# DEPOIS — este PR (0193f4018):
$ grep -rn "Business::first()" tests/ | wc -l   → 18
$ grep -rln "Business::first()" tests/ | wc -l  → 10 arquivos
```

## Justificativa das 18 ocorrências restantes (4 categorias)

1. **Doc-only (4)** — `tests/Support/WithSeededTenant.php` (3× em docblock do próprio trait) + `tests/Contract/README.md` (1×): menções em documentação, não chamadas.
2. **Padrão `?? Business::create([...])` (9)** — `tests/Feature/Contact/ContactBucket*` + `ContactSyncCanonOfficeimpressoTest`: semântica DIFERENTE (cria tenant próprio quando ausente, não skip). Substituir por `seededTenant()` MUDARIA comportamento (skip em vez de create) — fora do escopo comportamento-idêntico deste PR.
3. **Lane Browser/visreg (4)** — `tests/Browser/CoreScreens/*`: seeding próprio (`VisregTenantSeeder` no workflow, transação não cruza o subprocesso do server) com guards já documentados inline; candidata a follow-up da lane browser, fora do escopo "tests/ raiz Feature" do B4.
4. **Runner Contract estático (1)** — `tests/Contract/AutosaveContractRunner.php:200` (`setupContext(object $testCase)`): contexto compartilhado estático, substituível via `resolveSeededTenant()` em follow-up — mantido fora pra preservar 1-intent mecânico.

CI do PR é o gate (sem pest local — CT 100 inacessível desta máquina).

🤖 Generated with [Claude Code](https://claude.com/claude-code)