### PR TITLE
feat(governance): snapshot diário do scorecard SDD em mcp_sdd_scorecard_history (GT-G7 1/2)

### DIFF
--- a/Modules/Governance/Console/Commands/SddScorecardSnapshotCommand.php
+++ b/Modules/Governance/Console/Commands/SddScorecardSnapshotCommand.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+/**
+ * governance:sdd-scorecard-snapshot — GT-G7 (plano SDD 2026-06-12 §2 GARANTIDA).
+ *
+ * Roda `node scripts/governance/sdd-scorecard.mjs --json`, cruza com o baseline
+ * versionado (armed por métrica — ADR 0275 §3), computa composta v1 (média simples
+ * das ARMADAS normalizadas — ADR 0275 §4) + alertas (armada regrediu / fonte
+ * vermelha) e persiste 1 row/dia em `mcp_sdd_scorecard_history` (re-run substitui).
+ * `--input`/`--baseline` aceitam fixtures em testes/CI sem node.
+ *
+ * @see memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md
+ */
+class SddScorecardSnapshotCommand extends Command
+{
+    protected $signature = 'governance:sdd-scorecard-snapshot
+                            {--input= : Path de JSON pré-gerado do scorecard (testes/CI sem node)}
+                            {--baseline= : Path do baseline armed (default governance/sdd-scorecard-baseline.json)}
+                            {--date= : Data do snapshot Y-m-d (default hoje)}';
+
+    protected $description = 'Snapshot diário do scorecard SDD (composta v1 + alertas) em mcp_sdd_scorecard_history — GT-G7, ADR 0275';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('mcp_sdd_scorecard_history')) {
+            $this->error('Tabela mcp_sdd_scorecard_history não existe — rode `php artisan migrate` primeiro.');
+
+            return self::FAILURE;
+        }
+
+        $date = (string) ($this->option('date') ?: now()->format('Y-m-d'));
+
+        try {
+            $scorecard = $this->loadScorecard();
+        } catch (\Throwable $e) {
+            $this->error('Falha ao medir scorecard SDD: '.$e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $baselinePath = (string) ($this->option('baseline') ?: base_path('governance/sdd-scorecard-baseline.json'));
+        $baseline = is_file($baselinePath)
+            ? (json_decode((string) file_get_contents($baselinePath), true) ?: [])
+            : [];
+
+        $resumo = $this->summarize($scorecard, $baseline['metrics'] ?? []);
+
+        // Idempotência por dia: re-run substitui (delete + insert atômicos na
+        // mesma snapshot_date — transaction evita dia sem row se insert falhar).
+        DB::transaction(function () use ($date, $resumo, $scorecard): void {
+            DB::table('mcp_sdd_scorecard_history')->where('snapshot_date', $date)->delete();
+            DB::table('mcp_sdd_scorecard_history')->insert([
+                'snapshot_date' => $date,
+                'composta'      => $resumo['composta'],
+                'payload'       => json_encode([
+                    'composta'      => $resumo['composta'],
+                    'composta_k'    => $resumo['k'],
+                    'vivas'         => $resumo['vivas'],
+                    'metrics_total' => $resumo['total'],
+                    'alerts'        => $resumo['alerts'],
+                    'scorecard'     => $scorecard,
+                ], JSON_UNESCAPED_UNICODE),
+                'created_at'    => now(),
+                'updated_at'    => now(),
+            ]);
+        });
+
+        $this->info(sprintf(
+            'Snapshot SDD OK — %s · composta %s (k=%d) · %d/%d vivas · %d alertas',
+            $date,
+            $resumo['composta'] ?? '—',
+            $resumo['k'],
+            $resumo['vivas'],
+            $resumo['total'],
+            count($resumo['alerts']),
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /** @return array{metrics: array<string, array<string, mixed>>} */
+    private function loadScorecard(): array
+    {
+        if ($input = $this->option('input')) {
+            $raw = (string) file_get_contents((string) $input);
+        } else {
+            $process = new Process(['node', 'scripts/governance/sdd-scorecard.mjs', '--json'], base_path(), null, null, 120);
+            $process->mustRun();
+            $raw = $process->getOutput();
+        }
+
+        $json = json_decode($raw, true);
+        if (! is_array($json) || ! isset($json['metrics']) || ! is_array($json['metrics'])) {
+            throw new RuntimeException('output do sdd-scorecard.mjs não é JSON válido com chave `metrics`');
+        }
+
+        return $json;
+    }
+
+    /**
+     * Composta v1 (ADR 0275 §4): média simples das métricas ARMADAS normalizadas
+     * (score = clamp((value-baseline)/(target-baseline))×100; invertida pra "down").
+     * Alertas: armada que regrediu vs baseline + fonte vermelha (media e parou).
+     *
+     * @return array{vivas: int, total: int, k: int, composta: float|null, alerts: list<string>}
+     */
+    private function summarize(array $scorecard, array $baseMetrics): array
+    {
+        $vivas = 0;
+        $scores = [];
+        $alerts = [];
+
+        foreach (($scorecard['metrics'] ?? []) as $name => $m) {
+            $measured = ($m['status'] ?? null) === 'measured' && is_numeric($m['value'] ?? null);
+            if ($measured) {
+                $vivas++;
+            }
+            $b = $baseMetrics[$name] ?? null;
+            if ($b === null) {
+                continue;
+            }
+            $bMeasured = ($b['status'] ?? null) === 'measured' && is_numeric($b['value'] ?? null);
+            if ($bMeasured && ! $measured) {
+                $alerts[] = "{$name}: fonte vermelha (media no baseline, não mediu agora)";
+                continue;
+            }
+            if (! $bMeasured || ! $measured) {
+                continue;
+            }
+
+            $down = ($m['direction'] ?? 'up') === 'down';
+            $value = (float) $m['value'];
+            $base = (float) $b['value'];
+            $armed = ($b['armed'] ?? false) === true;
+
+            if ($armed && ($down ? $value > $base : $value < $base)) {
+                $alerts[] = sprintf('%s: %s → %s (armada — só pode %s)', $name, $b['value'], $m['value'], $down ? 'descer' : 'subir');
+            }
+            if ($armed && is_numeric($m['target'] ?? null)) {
+                $scores[] = $this->normalize($value, $base, (float) $m['target'], $down);
+            }
+        }
+
+        $k = count($scores);
+
+        return [
+            'vivas'    => $vivas,
+            'total'    => count($scorecard['metrics'] ?? []),
+            'k'        => $k,
+            'composta' => $k > 0 ? round(array_sum($scores) / $k, 1) : null,
+            'alerts'   => $alerts,
+        ];
+    }
+
+    private function normalize(float $value, float $baseline, float $target, bool $down): float
+    {
+        $den = $down ? $baseline - $target : $target - $baseline;
+        if ($den == 0.0) { // baseline já no alvo — binário
+            return ($down ? $value <= $target : $value >= $target) ? 100.0 : 0.0;
+        }
+        $num = $down ? $baseline - $value : $value - $baseline;
+
+        return max(0.0, min(1.0, $num / $den)) * 100;
+    }
+}

--- a/Modules/Governance/Database/Migrations/2026_06_12_100000_create_mcp_sdd_scorecard_history_table.php
+++ b/Modules/Governance/Database/Migrations/2026_06_12_100000_create_mcp_sdd_scorecard_history_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Histórico diário do scorecard SDD (GT-G7 — ADR 0275 §1): 1 row/dia com payload
+ * JSON do scorecard + composta v1. Cross-tenant INTENCIONAL — sem `business_id`,
+ * precedente `mcp_briefs` + `mcp_module_grades_history` (Constituição v2 Art. 6 —
+ * métrica do projeto, não do tenant). Alimentado por `governance:sdd-scorecard-snapshot`
+ * (daily 07:00 BRT); consumido pelo card SDD em /governance e pelo brief (GT-G8).
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('mcp_sdd_scorecard_history')) {
+            return;
+        }
+
+        Schema::create('mcp_sdd_scorecard_history', function (Blueprint $table) {
+            $table->id();
+            $table->date('snapshot_date')->unique();
+            $table->json('payload');                       // scorecard completo + resumo (vivas, alerts, k)
+            $table->decimal('composta', 5, 1)->nullable(); // v1 — null enquanto 0 métricas armadas (ADR 0275 §4)
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_sdd_scorecard_history');
+    }
+};

--- a/Modules/Governance/Providers/GovernanceServiceProvider.php
+++ b/Modules/Governance/Providers/GovernanceServiceProvider.php
@@ -62,6 +62,7 @@ class GovernanceServiceProvider extends ServiceProvider
                 \Modules\Governance\Console\Commands\ModuleGradeV4Command::class,         // v4 (Wave 21 — scoped scorecards por bucket)
                 \Modules\Governance\Console\Commands\ModuleGradeSnapshotCommand::class,
                 \Modules\Governance\Console\Commands\ScorecardSnapshotCommand::class,
+                \Modules\Governance\Console\Commands\SddScorecardSnapshotCommand::class,    // GT-G7 — snapshot diário scorecard SDD (ADR 0275)
                 \Modules\Governance\Console\Commands\ObservabilityAggregateCommand::class,  // Wave 26 Agent 3 — ADR 0162
                 \Modules\Governance\Console\Commands\ScorecardInitiativeSyncCommand::class, // Wave 28 Agent 1 — Initiatives Cortex-style
                 \Modules\Governance\Console\Commands\GovernanceAuditCommand::class,        // ADR 0216 — DriftChecker orchestrator

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -227,6 +227,24 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // GT-G7 (ADR 0275 §1) — snapshot diário do scorecard SDD em
+        // mcp_sdd_scorecard_history (composta v1 + alertas) via agregador node
+        // determinístico. 1 row/dia, re-run substitui. 07:10 BRT — 10min após
+        // governance:scorecard-snapshot (07:00) pra evitar disputa DB (mesmo
+        // precedente do stagger 06:05 do module:grade-snapshot). O brief das
+        // 07h pega o snapshot de ontem; o das 11h pega o de hoje (GT-G8).
+        $schedule->command('governance:sdd-scorecard-snapshot')
+            ->dailyAt('07:10')
+            ->timezone('America/Sao_Paulo')
+            ->onOneServer()
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule governance:sdd-scorecard-snapshot FALHOU — histórico SDD defasado (GT-G7)'
+                );
+            });
+
         // Wave 28 Agent 1 (2026-05-17) — Initiatives Cortex-style.
         // Sync diário Initiatives ↔ scorecards: abre breach (rule abaixo target),
         // fecha recuperadas (score_after >= target), expira deadlines passadas.


### PR DESCRIPTION
## O quê

Frente **GT-G7** da Fase 2 da reestruturação SDD (US-GOV-017 fase 2 · [plano-mãe §4](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md) · [ADR 0275](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md)) — PR 1/2 do stack.

- **Comando `governance:sdd-scorecard-snapshot`**: roda o agregador node determinístico (`scripts/governance/sdd-scorecard.mjs --json`), cruza com o baseline armed (`governance/sdd-scorecard-baseline.json` — ADR 0275 §3), computa **composta v1** (média simples das ARMADAS normalizadas, k explícito — ADR 0275 §4) + **alertas** (armada regrediu / fonte vermelha) e persiste **1 row/dia** (re-run substitui — delete+insert em transaction). `--input`/`--baseline` aceitam fixtures (CI sem node).
- **Migration `mcp_sdd_scorecard_history`**: `snapshot_date` UNIQUE + `payload` JSON + `composta` decimal(5,1) nullable. **Cross-tenant INTENCIONAL sem `business_id`** — precedente `mcp_briefs`/`mcp_module_grades_history` (Constituição v2 Art. 6: métrica do projeto, não do tenant).
- **Kernel**: daily **07:10 America/Sao_Paulo** (stagger 10min pós `governance:scorecard-snapshot` 07:00 — mesmo precedente do 06:05 do `module:grade-snapshot`), `onOneServer` + `withoutOverlapping` + `environments(['live'])` + `onFailure` log.

## Stack (≤300 linhas/PR, 1 intent)

1. **este PR** — migration + comando + provider + Kernel (230 linhas)
2. `sdd/f2-gt-g7-test` — Pest + card composta v1 no dashboard (depends-on este)
3. `sdd/f2-gt-g8` — linha SDD no Daily Brief (depends-on 2)

## Validação

Testes Pest do comando (fixtures `--input`/`--baseline`, idempotência, schedule) vêm no PR 2/2 — CI deste branch roda a suite existente; gate de merge é o CI (sem run local, hook block-test-fora-ct100).

Refs: US-GOV-017 fase 2 (GT-G7) · ADR 0275 · ADR 0091

🤖 Generated with [Claude Code](https://claude.com/claude-code)
