### PR TITLE
feat(brief): linha SDD determinística no Daily Brief — só quando muda ou tem vermelho (GT-G8)

### DIFF
--- a/Modules/Brief/Console/Commands/GenerateBriefCommand.php
+++ b/Modules/Brief/Console/Commands/GenerateBriefCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Modules\Brief\Services\BriefGeneratorService;
 use Modules\Brief\Services\BriefValidator;
+use Modules\Governance\Services\SddBriefLineService;
 use Throwable;
 
 /**
@@ -42,6 +43,12 @@ final class GenerateBriefCommand extends Command
 
             return self::FAILURE;
         }
+
+        // GT-G8 (ADR 0275) — linha SDD determinística (pós-LLM) na seção FLAGS:
+        // só aparece quando a composta mudou vs último snapshot da
+        // mcp_sdd_scorecard_history OU há alerta (armada regrediu/fonte
+        // vermelha). inject() é best-effort — brief nunca falha por causa dela.
+        $content = app(SddBriefLineService::class)->inject($content);
 
         $aggregatedHash = hash('sha256', $content);
 

--- a/Modules/Governance/Config/config.php
+++ b/Modules/Governance/Config/config.php
@@ -118,4 +118,12 @@ return [
      * Substitui `governance:secrets` (ADR 0215) — mas trait permite override por checker.
      */
     'drift_centrifugo_channel' => env('GOVERNANCE_DRIFT_CHANNEL', 'governance:drift'),
+
+    /*
+     * Kill-switch GT-G8 (default ON) — linha SDD determinística no Daily Brief.
+     * `GOVERNANCE_SDD_BRIEF_LINE=false` no .env desliga o inject() sem deploy:
+     * SddBriefLineService devolve o brief intacto (zero linha, zero query).
+     * @see Modules\Governance\Services\SddBriefLineService
+     */
+    'sdd_brief_line' => env('GOVERNANCE_SDD_BRIEF_LINE', true),
 ];

--- a/Modules/Governance/Services/SddBriefLineService.php
+++ b/Modules/Governance/Services/SddBriefLineService.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * GT-G8 — linha SDD do Daily Brief (plano SDD 2026-06-12 §2 GARANTIDA:
+ * "leitura sem esforço — linha SDD no brief diário, só quando muda ou tem vermelho").
+ *
+ * Lê os 2 últimos snapshots de `mcp_sdd_scorecard_history` (GT-G7) e decide:
+ *  - composta MUDOU vs snapshot anterior (1º snapshot conta como mudança) → linha
+ *  - métrica armada regrediu OU fonte vermelha (alerts não-vazio)        → linha
+ *  - nada mudou e zero alertas → null (brief não ganha ruído diário)
+ *
+ * Formato: `SDD: composta NN (ΔN) · X/10 vivas · alerta: <métrica>` — emoji
+ * 🔴 (tem alerta) / 🟡 (só mudança) segue a convenção da seção FLAGS.
+ * Determinística (pós-LLM): `inject()` é chamado por GenerateBriefCommand
+ * DEPOIS do Brain B gerar o markdown — o modelo nunca inventa esse número.
+ * Degrada graciosamente: tabela ausente/sem rows/erro → brief intacto.
+ *
+ * @see Modules/Brief/Console/Commands/GenerateBriefCommand.php (plug-point)
+ * @see memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md §4
+ */
+final class SddBriefLineService
+{
+    /**
+     * Injeta a linha SDD como 1º bullet da seção `## FLAGS`. Best-effort:
+     * qualquer falha (ou linha null) devolve o conteúdo intacto — o brief
+     * NUNCA quebra por causa da linha SDD.
+     */
+    public function inject(string $content): string
+    {
+        try {
+            $line = $this->line();
+        } catch (Throwable) {
+            return $content;
+        }
+
+        if ($line === null) {
+            return $content;
+        }
+
+        $injected = preg_replace('/^## FLAGS$/m', "## FLAGS\n- {$line}", $content, 1, $count);
+
+        return ($count === 1 && is_string($injected)) ? $injected : $content;
+    }
+
+    /**
+     * Linha SDD ou null quando não há nada digno de nota (sem mudança de
+     * composta E sem alerta) — ver regra no docblock da classe.
+     */
+    public function line(): ?string
+    {
+        if (! Schema::hasTable('mcp_sdd_scorecard_history')) {
+            return null;
+        }
+
+        $rows = DB::table('mcp_sdd_scorecard_history')
+            ->orderByDesc('snapshot_date')
+            ->limit(2)
+            ->get();
+
+        $latest = $rows->first();
+        if ($latest === null) {
+            return null;
+        }
+
+        $previous = $rows->get(1);
+        $payload = json_decode((string) $latest->payload, true) ?: [];
+        $alerts = array_values((array) ($payload['alerts'] ?? []));
+
+        $atual = $this->toFloat($latest->composta);
+        $anterior = $previous !== null ? $this->toFloat($previous->composta) : null;
+        $changed = $previous === null || $atual !== $anterior;
+
+        if (! $changed && $alerts === []) {
+            return null;
+        }
+
+        return sprintf(
+            '%s SDD: composta %s (%s) · %d/%d vivas%s',
+            $alerts !== [] ? '🔴' : '🟡',
+            $atual === null ? '—' : number_format($atual, 1, ',', '.'),
+            $this->formatDelta($atual, $previous !== null, $anterior),
+            (int) ($payload['vivas'] ?? 0),
+            (int) ($payload['metrics_total'] ?? 10),
+            $alerts !== [] ? ' · alerta: '.$this->alertSummary($alerts) : '',
+        );
+    }
+
+    /** Δ assinado pt-BR; 'Δ—' quando não há par comparável (1º snapshot / composta nula). */
+    private function formatDelta(?float $atual, bool $hasPrevious, ?float $anterior): string
+    {
+        if (! $hasPrevious || $atual === null || $anterior === null) {
+            return 'Δ—';
+        }
+
+        $delta = round($atual - $anterior, 1);
+
+        return 'Δ'.($delta > 0 ? '+' : '').number_format($delta, 1, ',', '.');
+    }
+
+    /** Nome da 1ª métrica em alerta + contagem das demais ("ghost_count +2"). */
+    private function alertSummary(array $alerts): string
+    {
+        $metric = trim(explode(':', (string) $alerts[0], 2)[0]);
+        $rest = count($alerts) - 1;
+
+        return $rest > 0 ? "{$metric} +{$rest}" : $metric;
+    }
+
+    private function toFloat(mixed $value): ?float
+    {
+        return $value === null ? null : (float) $value;
+    }
+}

--- a/Modules/Governance/Services/SddBriefLineService.php
+++ b/Modules/Governance/Services/SddBriefLineService.php
@@ -32,9 +32,14 @@ final class SddBriefLineService
      * Injeta a linha SDD como 1º bullet da seção `## FLAGS`. Best-effort:
      * qualquer falha (ou linha null) devolve o conteúdo intacto — o brief
      * NUNCA quebra por causa da linha SDD.
+     * Kill-switch: `governance.sdd_brief_line` false → no-op (default ON).
      */
     public function inject(string $content): string
     {
+        if (! (bool) config('governance.sdd_brief_line', true)) {
+            return $content;
+        }
+
         try {
             $line = $this->line();
         } catch (Throwable) {

--- a/Modules/Governance/Tests/Feature/SddBriefLineServiceTest.php
+++ b/Modules/Governance/Tests/Feature/SddBriefLineServiceTest.php
@@ -84,6 +84,13 @@ it('alerta com composta estável → linha 🔴 com nome da métrica (+N quando 
         ->toContain('🔴 SDD: composta 12,5 (Δ0,0) · 2/10 vivas · alerta: ghost_count +1');
 });
 
+it('kill-switch OFF → inject vira no-op mesmo com alerta vermelho', function () {
+    config(['governance.sdd_brief_line' => false]);
+    sddG8Snapshot('2026-06-12', 12.5, alerts: ['ghost_count: 27 → 30 (armada — só pode descer)']);
+
+    expect((new SddBriefLineService())->inject(sddG8Brief()))->toBe(sddG8Brief());
+});
+
 it('inject coloca a linha como 1º bullet da seção FLAGS sem quebrar o markdown', function () {
     sddG8Snapshot('2026-06-12', 12.5, alerts: ['ghost_count: 27 → 30 (armada — só pode descer)']);
 

--- a/Modules/Governance/Tests/Feature/SddBriefLineServiceTest.php
+++ b/Modules/Governance/Tests/Feature/SddBriefLineServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Modules\Governance\Services\SddBriefLineService;
+
+/**
+ * Tests pra linha SDD do Daily Brief (GT-G8 — ADR 0275 + plano SDD §2 GARANTIDA).
+ * Regra: linha SÓ aparece quando (a) composta mudou vs último snapshot OU
+ * (b) métrica armada regrediu / fonte vermelha (alerts não-vazio).
+ *
+ * @see Modules/Governance/Services/SddBriefLineService.php
+ * @see Modules/Brief/Console/Commands/GenerateBriefCommand.php (plug-point inject)
+ */
+
+uses(RefreshDatabase::class);
+
+function sddG8Snapshot(string $date, ?float $composta, array $alerts = [], int $vivas = 2): void
+{
+    DB::table('mcp_sdd_scorecard_history')->insert([
+        'snapshot_date' => $date,
+        'composta'      => $composta,
+        'payload'       => json_encode([
+            'composta'      => $composta,
+            'composta_k'    => 2,
+            'vivas'         => $vivas,
+            'metrics_total' => 10,
+            'alerts'        => $alerts,
+            'scorecard'     => ['metrics' => []],
+        ]),
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+}
+
+function sddG8Brief(): string
+{
+    return "## ESTADO MACRO\n- x\n\n## EM VOO AGORA\n- x\n\n## DECISÕES RECENTES (24h)\n- x\n\n"
+        ."## SKILLS USO 7d\n- x\n\n## CHARTERS APODRECENDO\n—\n\n## FLAGS\n- 🟢 Migration aging: ok\n\n"
+        ."## METADATA\n- Gerado: hoje\n---END---";
+}
+
+it('sem snapshot nenhum → null (brief intacto)', function () {
+    $svc = new SddBriefLineService();
+
+    expect($svc->line())->toBeNull()
+        ->and($svc->inject(sddG8Brief()))->toBe(sddG8Brief());
+});
+
+it('1º snapshot conta como mudança — linha 🟡 com Δ— e X/10 vivas', function () {
+    sddG8Snapshot('2026-06-12', 12.5);
+
+    $line = (new SddBriefLineService())->line();
+
+    expect($line)->toContain('🟡 SDD: composta 12,5 (Δ—) · 2/10 vivas')
+        ->and($line)->not->toContain('alerta:');
+});
+
+it('composta estável e zero alertas → null (sem ruído diário)', function () {
+    sddG8Snapshot('2026-06-11', 12.5);
+    sddG8Snapshot('2026-06-12', 12.5);
+
+    expect((new SddBriefLineService())->line())->toBeNull();
+});
+
+it('composta mudou → linha 🟡 com Δ assinado', function () {
+    sddG8Snapshot('2026-06-11', 12.5);
+    sddG8Snapshot('2026-06-12', 14.0);
+
+    expect((new SddBriefLineService())->line())
+        ->toContain('🟡 SDD: composta 14,0 (Δ+1,5) · 2/10 vivas');
+});
+
+it('alerta com composta estável → linha 🔴 com nome da métrica (+N quando vários)', function () {
+    sddG8Snapshot('2026-06-11', 12.5);
+    sddG8Snapshot('2026-06-12', 12.5, alerts: [
+        'ghost_count: 27 → 30 (armada — só pode descer)',
+        'front_door_coverage: fonte vermelha (media no baseline, não mediu agora)',
+    ]);
+
+    expect((new SddBriefLineService())->line())
+        ->toContain('🔴 SDD: composta 12,5 (Δ0,0) · 2/10 vivas · alerta: ghost_count +1');
+});
+
+it('inject coloca a linha como 1º bullet da seção FLAGS sem quebrar o markdown', function () {
+    sddG8Snapshot('2026-06-12', 12.5, alerts: ['ghost_count: 27 → 30 (armada — só pode descer)']);
+
+    $out = (new SddBriefLineService())->inject(sddG8Brief());
+
+    expect($out)->toContain("## FLAGS\n- 🔴 SDD: composta 12,5")
+        ->and($out)->toContain('- 🟢 Migration aging: ok') // bullets originais preservados
+        ->and(trim($out))->toEndWith('---END---');
+});

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6220,7 +6220,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 5
+			count: 6
 			path: Modules/Governance/Config/config.php
 
 		-


### PR DESCRIPTION
## O quê

**depends-on PR-2** (#2618 — stack: #2617 → #2618 → este; base é `sdd/f2-gt-g7-test`).

Frente **GT-G8** da Fase 2 SDD (US-GOV-017 fase 2 · [plano-mãe §2 GARANTIDA](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md): "leitura sem esforço — linha SDD no brief diário, só quando muda ou tem vermelho").

- **`SddBriefLineService`** (Governance): lê os 2 últimos snapshots de `mcp_sdd_scorecard_history` (GT-G7) e gera `SDD: composta NN (ΔN) · X/10 vivas · alerta: <métrica>` **SÓ quando** (a) composta mudou vs último snapshot (1º conta como mudança) **OU** (b) métrica armada regrediu / fonte vermelha (alerts do payload). Estável + zero alertas → null (brief sem ruído diário).
- **Plug-point**: o gerador do brief é `GenerateBriefCommand` (`brief:generate`, pipeline ADR 0091, grava em `mcp_briefs`). A linha é injetada **PÓS-LLM** (determinística — o modelo nunca inventa esse número) como 1º bullet da seção `## FLAGS`, ANTES da validação (entra no token count do BriefValidator). Best-effort: tabela ausente/sem rows/erro → brief intacto. Emoji 🔴/🟡 segue convenção FLAGS.
- **Pest (6 casos)**: null sem snapshot · 1º snapshot `Δ—` · estável+sem alerta → null · Δ assinado pt-BR · alerta com nome da métrica `+N` · inject preserva bullets originais e `---END---`. `Modules/Governance/Tests` no phpunit.xml (linha 50).

Refs: US-GOV-017 fase 2 (GT-G8) · ADR 0275 · ADR 0091

---

## Adendo — kill-switch GT-G8 (commit `d8f48e0`)

O card da frente exige **flag de config como kill-switch, default ON**. A v1 chamava `SddBriefLineService::inject()` incondicionalmente. Adicionado:

1. **`Modules/Governance/Config/config.php`** — chave `'sdd_brief_line' => env('GOVERNANCE_SDD_BRIEF_LINE', true)` com comentário "kill-switch GT-G8 (default ON)". `GOVERNANCE_SDD_BRIEF_LINE=false` no `.env` desliga sem deploy.
2. **`SddBriefLineService::inject()`** — guard na 1ª linha: `if (! (bool) config('governance.sdd_brief_line', true)) { return $content; }`. Flag OFF → brief devolvido intacto (zero linha SDD, **zero query** — short-circuit antes de tocar `mcp_sdd_scorecard_history`). `inject()` é o único plug-point (GenerateBriefCommand:51), então o guard cobre 100% do kill-switch.
3. **Pest (+1 caso)**: `kill-switch OFF → inject vira no-op mesmo com alerta vermelho` — `config(['governance.sdd_brief_line' => false])` + snapshot com alerta armado → `inject(brief) === brief`.

+20 linhas · 3 arquivos · 1 intent.

### Evidência local (honesta)

- `php -l` **verde** nos 3 arquivos editados (config, service, test).
- Resolução do config **verificada** fora do framework (shim `env()`): chave presente, default `true` com `GOVERNANCE_SDD_BRIEF_LINE` unset; flag flipa pra `false` quando a env var é setada.
- **Pest CI-gated**: o worktree não tem `vendor/` nem `.env` e o caso novo usa `RefreshDatabase` + insert em `mcp_sdd_scorecard_history` (precisa de DB migrado / CT 100). **Não rodado localmente — sem output fabricado.** Roda no CI junto dos outros 6 casos. O caso adicionado reusa apenas helpers já provados pela suíte verde (`sddG8Snapshot`, `sddG8Brief`) + override padrão `config([...])`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
