### PR TITLE
feat(governance): tela DS Rollout + Ledger de Conformidade DS (censo ds-ledger.mjs)

### DIFF
--- a/Modules/Governance/Http/Controllers/DsRolloutController.php
+++ b/Modules/Governance/Http/Controllers/DsRolloutController.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * DS Rollout — plano de portar o Design System inteiro em ondas medíveis + o
+ * Ledger de Conformidade que prova "tudo aplicado" mecanicamente.
+ *
+ * Tradução F3 (PROTOCOL §2) do protótipo Cowork `DS Rollout - Ondas e Testes.html`
+ * (handoff claude.ai/design, sessão 2026-06-12). O protótipo respondeu à pergunta
+ * de Wagner "quantas ondas pra portar o DS? com teste pra ver se tudo foi aplicado".
+ *
+ * O conteúdo do PLANO (blocos A/B/C/D, medição @main, provas) é estático e vive no
+ * componente `Pages/governance/DsRollout.tsx` — é o próprio design, não dado de runtime.
+ *
+ * O **Ledger** (a parte "viva") entra por prop `census`, lido de
+ * `governance/ds-ledger.json` — o artefato carimbado (SHA + timestamp) que o
+ * `scripts/ds-ledger.mjs` gera rodando os checks DS (eslint ds/*, paleta crua,
+ * conformance-gate, components-tree-guard) por Page. Sem o artefato (checkout antes
+ * do 1º censo) cai no snapshot estático ROTULADO `TODO ledger` — trava de governança:
+ * a tela só mostra número que veio de gate rodando, nunca palavra.
+ *
+ * Render estático (lê 1 JSON local, zero query) → eager, sem Inertia::defer (mesmo
+ * espírito do compliance_pct do DashboardController).
+ *
+ * Refs: ADR 0209 (ratchet), 0235/0190 (roxo canônico), 0239 (gov DS git=SSOT),
+ *       0240 (evidência fecha task), PROTOCOL §2 (F3 tradução).
+ */
+class DsRolloutController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index(): Response
+    {
+        return Inertia::render('governance/DsRollout', [
+            'census' => $this->loadCensus(),
+        ]);
+    }
+
+    /**
+     * Carrega o Ledger REAL (`governance/ds-ledger.json`, gerado por
+     * `npm run ds:ledger -- --write`) — censo carimbado com SHA + timestamp. Se o
+     * artefato não existir (checkout fresco, antes do 1º censo), cai no snapshot
+     * estático ROTULADO `TODO ledger`, honrando a trava de governança: a tela só
+     * mostra número que veio de gate rodando.
+     *
+     * @return array<string, mixed>
+     */
+    private function loadCensus(): array
+    {
+        $path = base_path('governance/ds-ledger.json');
+
+        if (is_file($path)) {
+            $json = json_decode((string) file_get_contents($path), true);
+            if (is_array($json) && isset($json['ledger']) && is_array($json['ledger'])) {
+                return $json;
+            }
+        }
+
+        return $this->staticFallback();
+    }
+
+    /**
+     * Snapshot estático (não-medido) — só aparece quando o censo ainda não rodou.
+     * Marcado `measured=false` + label `TODO ledger` pra nunca passar por número real.
+     *
+     * @return array<string, mixed>
+     */
+    private function staticFallback(): array
+    {
+        $todo = ['tokens' => 'na', 'primitivos' => 'na', 'probe' => 'na', 'dark' => 'na', 'approved' => 'na'];
+
+        return [
+            'ledger' => [
+                [
+                    'screen' => 'Atendimento / Caixa',
+                    'note' => 'o ouro · referência',
+                    'reference' => true,
+                    'cells' => ['tokens' => 'ref', 'primitivos' => 'ref', 'probe' => 'na', 'dark' => 'na', 'approved' => 'yes'],
+                ],
+                ['screen' => 'Rode `npm run ds:ledger -- --write`', 'note' => 'censo ainda não rodou', 'cells' => $todo],
+            ],
+            'progressPct' => 0,
+            'progressLabel' => 'snapshot estático · TODO ledger',
+            'measured' => false,
+            'measuredAgainstSha' => null,
+            'generatedAt' => null,
+            'treeGuard' => null,
+            'counts' => ['screens' => 0, 'done' => 0, 'references' => 1],
+        ];
+    }
+}

--- a/Modules/Governance/Http/routes.php
+++ b/Modules/Governance/Http/routes.php
@@ -8,6 +8,7 @@ use Modules\Governance\Http\Controllers\PoliciesController;
 use Modules\Governance\Http\Controllers\AuditController;
 use Modules\Governance\Http\Controllers\DriftAlertsController;
 use Modules\Governance\Http\Controllers\ModuleGradeController;
+use Modules\Governance\Http\Controllers\DsRolloutController;
 
 /*
 |--------------------------------------------------------------------------
@@ -60,6 +61,13 @@ Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezo
             ->middleware('throttle:30,1')
             ->name('module-grades.show')
             ->where('name', '[A-Za-z0-9_-]+');
+
+        // DS Rollout — plano de portar o DS em ondas + Ledger de Conformidade
+        // (tradução F3 do protótipo Cowork · handoff claude.ai/design 2026-06-12).
+        // Static render → throttle leve 60/min.
+        Route::get('/ds-rollout', [DsRolloutController::class, 'index'])
+            ->middleware('throttle:60,1')
+            ->name('ds-rollout.index');
 
         // Install hooks (ADR 0024 — pattern padronizado BaseModuleInstallController)
         Route::get('install',           [InstallController::class, 'index'])

--- a/Modules/Governance/Resources/menus/topnav.php
+++ b/Modules/Governance/Resources/menus/topnav.php
@@ -20,5 +20,6 @@ return [
         ['label' => 'governance::governance.menu.audit',     'href' => '/governance/audit',    'icon' => 'Search',          'can' => 'governance.audit.view'],
         ['label' => 'governance::governance.menu.drift',     'href' => '/governance/drift',    'icon' => 'AlertTriangle',   'can' => 'governance.dashboard.view'],
         ['label' => 'Module Grades',                          'href' => '/governance/module-grades', 'icon' => 'Gauge',     'can' => 'governance.dashboard.view'],
+        ['label' => 'DS Rollout',                             'href' => '/governance/ds-rollout',    'icon' => 'Waves',     'can' => 'governance.dashboard.view'],
     ],
 ];

--- a/Modules/Governance/SCOPE.md
+++ b/Modules/Governance/SCOPE.md
@@ -7,6 +7,7 @@ contains:
   - "AuditController — drill-down mcp_audit_log filtrável (período/actor/endpoint/status)"
   - "DriftAlertsController — runtime scan SCOPE.md vs filesystem real + persisted alerts cron"
   - "ModuleGradeController — /governance/module-grades Index ranking 34 módulos + Show drill-down 9 dimensões v3 + dossier markdown (ADR 0155 + Charter Goal 9 2026-05-17)"
+  - "DsRolloutController — /governance/ds-rollout plano de portar o DS em ondas + Ledger de Conformidade DS (tradução F3 protótipo Cowork · census via scripts/ds-ledger.mjs)"
   - "InstallController — install/uninstall hooks (ADR 0024)"
   - "DataController — sidebar/permissions hooks (UltimatePOS pattern)"
   - "ActionGate middleware — runtime gate (modo warn|strict por config)"
@@ -39,6 +40,7 @@ routes:
   - "GET  /governance/drift                        → DriftAlertsController@index         (governance.drift.index)"
   - "GET  /governance/module-grades                → ModuleGradeController@index         (governance.module-grades.index)"
   - "GET  /governance/module-grades/{name}         → ModuleGradeController@show          (governance.module-grades.show)"
+  - "GET  /governance/ds-rollout                    → DsRolloutController@index           (governance.ds-rollout.index)"
   - "GET  /governance/install{,/uninstall,/update} → InstallController@*                 (governance.install.*)"
 db_tables_owned:
   - mcp_governance_rules (compartilha com ADS — ActionGate lê, ADS write rules de decision flow)

--- a/governance/ds-ledger.json
+++ b/governance/ds-ledger.json
@@ -1,0 +1,415 @@
+{
+  "ledger": [
+    {
+      "screen": "Atendimento",
+      "note": "o ouro · referência",
+      "reference": true,
+      "cells": {
+        "tokens": "ref",
+        "primitivos": "ref",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Admin",
+      "note": "36 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Auditoria",
+      "note": "2 arquivo(s)",
+      "cells": {
+        "tokens": "yes",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Cliente",
+      "note": "39 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Essentials",
+      "note": "13 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "NfeBrasil",
+      "note": "9 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Sells",
+      "note": "44 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Settings",
+      "note": "8 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "superadmin",
+      "note": "2 arquivo(s)",
+      "cells": {
+        "tokens": "yes",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Tarefas",
+      "note": "1 arquivo(s)",
+      "cells": {
+        "tokens": "yes",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Whatsapp",
+      "note": "15 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "ComunicacaoVisual",
+      "note": "1 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Financeiro",
+      "note": "61 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Fiscal",
+      "note": "23 arquivo(s)",
+      "cells": {
+        "tokens": "yes",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "governance",
+      "note": "7 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Jana",
+      "note": "18 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Manufacturing",
+      "note": "1 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Nfse",
+      "note": "3 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "OficinaAuto",
+      "note": "32 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "ProjectMgmt",
+      "note": "9 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Purchase",
+      "note": "4 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "RecurringBilling",
+      "note": "16 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "Repair",
+      "note": "13 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "yes"
+      }
+    },
+    {
+      "screen": "TransactionPayment",
+      "note": "3 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Vestuario",
+      "note": "1 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "yes",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "ads",
+      "note": "19 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Compras",
+      "note": "5 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "ConsultaOs",
+      "note": "5 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "kb",
+      "note": "26 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "MemCofre",
+      "note": "6 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Ponto",
+      "note": "26 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Produto",
+      "note": "8 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "Site",
+      "note": "7 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "StockAdjustment",
+      "note": "2 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "StockTransfer",
+      "note": "2 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    },
+    {
+      "screen": "team-mcp",
+      "note": "3 arquivo(s)",
+      "cells": {
+        "tokens": "no",
+        "primitivos": "no",
+        "probe": "na",
+        "dark": "na",
+        "approved": "no"
+      }
+    }
+  ],
+  "progressPct": 9,
+  "progressLabel": "adoção tokens + primitivos (censo Onda 0)",
+  "measured": true,
+  "measuredAgainstSha": "b04b1e411",
+  "generatedAt": "2026-06-12T19:24:28.427Z",
+  "treeGuard": {
+    "pass": true,
+    "violations": 0
+  },
+  "counts": {
+    "screens": 35,
+    "done": 3,
+    "references": 1
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "pageheader:guard:write": "node scripts/pageheader-migration-guard.mjs --write",
     "ds:report": "node scripts/ds-report.mjs",
     "ds:report:write": "node scripts/ds-report.mjs --write",
+    "ds:ledger": "node scripts/ds-ledger.mjs",
+    "ds:ledger:write": "node scripts/ds-ledger.mjs --write",
     "design:review": "node prototipo-ui/audit/review-gen.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/resources/js/Pages/governance/DsRollout.casos.md
+++ b/resources/js/Pages/governance/DsRollout.casos.md
@@ -1,0 +1,65 @@
+---
+casos: DS Rollout · Ledger de Conformidade DS · /governance/ds-rollout
+irmaos: DsRollout.charter.md (lei)
+tecnica: Caso de uso = narrativa + critério de aceite verificável
+owner: wagner
+last_run: "2026-06-12"
+---
+
+# Casos de uso — /governance/ds-rollout
+
+> **Status:** ✅ passa (provado por teste) · 🧪 em teste (Pest escrito, aguarda run verde) · ⬜ não verificado · ❌ quebrou.
+
+> Tradução F3 do protótipo Cowork `DS Rollout - Ondas e Testes`. Persona: Wagner [W] (decide onda a onda). O placar prova "tudo aplicado" mecanicamente — o teste-mãe desta tela é o próprio `scripts/ds-ledger.mjs`.
+
+## UC-DSR-01 — O placar só mostra número que veio de gate rodando
+Status: ⬜ (manual/visual — abrir com e sem `governance/ds-ledger.json`)
+Com o artefato presente, o Ledger renderiza as linhas medidas + o carimbo `● medido @sha · timestamp`.
+Sem o artefato, o `DsRolloutController` cai no `staticFallback()` e a tela mostra o badge âmbar
+`▲ snapshot estático · TODO ledger` com `0%` — nunca um número real não-medido.
+**Pronto quando:** apagar `governance/ds-ledger.json` faz a tela exibir "TODO ledger"; recriar via
+`npm run ds:ledger -- --write` faz aparecer o `%` real carimbado com o SHA.
+
+## UC-DSR-02 — O censo reproduz a "Medição real" do design
+Status: 🧪 (cobertura futura — assert no output de `ds-ledger.mjs --json`)
+`scripts/ds-ledger.mjs` mede por Page: eslint `ds/*` (cor arbitrária + status-text + primitivos nativos)
++ paleta Tailwind crua + `conformance-gate` + `components-tree-guard`. O piloto `Produto/Create` cai em
+**tokens** (`stone/rose` cru) **e primitivos** (`<input type=checkbox>` nativo, pego por `ds/no-native-checkbox`).
+**Pronto quando:** `node scripts/ds-ledger.mjs --json` lista `Produto` com `cells.tokens="no"` e `cells.primitivos="no"`.
+
+## UC-DSR-03 — probe e dark nunca fingem verde
+Status: ⬜ (manual/visual — inspecionar células das colunas Probe/Dark)
+Probe G1–13 e Dark exigem render de browser (Camada 2). O censo estático NÃO os mede e renderiza `–`
+("não medido") com tooltip explicativo — jamais `✓`.
+**Pronto quando:** toda linha não-referência mostra `–` em Probe e Dark, com `title` "não medido por censo estático".
+
+## UC-DSR-04 — O Ledger renderiza as linhas reais do census
+Status: 🧪 (cobertura futura — assert que a tabela tem N=counts.screens+references linhas)
+A tabela do Ledger é populada da prop `census.ledger` (não hardcoded). Linha-referência (`Atendimento`)
+aparece com `★` e destaque, fora da conta do `%`. A barra de progresso reflete `census.progressPct`.
+**Pronto quando:** o nº de linhas = `census.counts.screens + census.counts.references` e a barra = `progressPct%`.
+
+## UC-DSR-05 — Banner da árvore de componentes reflete o guard
+Status: ⬜ (manual/visual — conferir badge "árvore Components/")
+O census carrega `treeGuard` (de `components-tree-guard`). Pass → badge verde `✓ canônica`; fail → badge
+vermelho com a contagem de violações.
+**Pronto quando:** o badge bate com `node scripts/components-tree-guard.mjs` (exit 0 = ✓).
+
+## UC-DSR-06 — A tela é canon (não recria o débito do protótipo)
+Status: 🧪 (cobertura: eslint `ds/*` = 0 nesta tela · CI ESLint ratchet)
+Usa `@/Components/PageHeader` v3.8 (não o `shared/` congelado), `KpiCard`, primitivos de layout
+`<Inline>/<Grid>` e tokens semânticos (`text-success`/`text-destructive`/`text-warning`) — zero `<style>`
+OKLCH cru e zero violação `ds/*`.
+**Pronto quando:** `eslint resources/js/Pages/governance/DsRollout.tsx` = 0 warnings `ds/*`.
+
+## UC-DSR-07 — As ondas seguem Tier-0 (a tela não executa nada)
+Status: ⬜ (manual — a tela é read-only; nenhuma ação muta token/tela)
+A tela é puramente informativa/medição. Tokenizar cor e portar telas (as ondas) permanecem Tier-0,
+travadas no "vai" de Wagner onda a onda — fora desta tela.
+**Pronto quando:** não há nenhuma ação na tela que edite token, CSS ou Page.
+
+## UC-DSR-08 — Acesso (auth + permissão)
+Status: ⬜ (manual — rota sob `auth` + `governance.dashboard.view`)
+`/governance/ds-rollout` exige login e a permissão `governance.dashboard.view` (mesma família das demais
+telas de governança). Item de nav só aparece com a permissão.
+**Pronto quando:** usuário sem `governance.dashboard.view` não vê o link nem acessa a rota.

--- a/resources/js/Pages/governance/DsRollout.charter.md
+++ b/resources/js/Pages/governance/DsRollout.charter.md
@@ -3,7 +3,7 @@ page: /governance/ds-rollout
 component: resources/js/Pages/governance/DsRollout.tsx
 owner: wagner
 status: draft
-last_validated: 2026-06-12
+last_validated: "2026-06-12"
 parent_module: Governance
 related_adrs: [189, 190, 209, 239, 240, 114]
 tier: A

--- a/resources/js/Pages/governance/DsRollout.charter.md
+++ b/resources/js/Pages/governance/DsRollout.charter.md
@@ -1,0 +1,71 @@
+---
+page: /governance/ds-rollout
+component: resources/js/Pages/governance/DsRollout.tsx
+owner: wagner
+status: draft
+last_validated: 2026-06-12
+parent_module: Governance
+related_adrs: [189, 190, 209, 239, 240, 114]
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /governance/ds-rollout
+
+> **Status:** draft — aguardando aprovação visual de Wagner (gate F2 do PROTOCOL: Wagner aprova SCREENSHOT, não tabela).
+> Tradução F3 (PROTOCOL §2) do protótipo Cowork `DS Rollout - Ondas e Testes.html` (handoff claude.ai/design, sessão 2026-06-12).
+> Origem: Wagner perguntou "quantas ondas pra portar todo o DS? com teste pra ver se tudo foi aplicado" → o protótipo respondeu com o plano + o **Ledger de Conformidade**.
+
+---
+
+## Mission
+
+Mostrar, numa tela só, o **plano medível** de portar o Design System inteiro pro padrão canônico — em ~16–18 ondas, 4 blocos (Fundação já existe → portar telas → Atendimento por último → trava) — e o **Ledger de Conformidade DS**: o placar por-tela × por-teste que prova "tudo aplicado" mecanicamente, não na palavra de ninguém. Wagner libera onda a onda olhando o verde do placar.
+
+---
+
+## Goals — Features (faz)
+
+- AppShellV2 + `<PageHeader>` canon (`@/Components/PageHeader` v3.8 · ADR 0189/0190) — **não** o `shared/PageHeader` congelado.
+- Banda de métrica via `<KpiGrid cols=4>` + `<KpiCard>` shared (7→1–2 fundação · 14 portar · 2 atendimento · 1 trava).
+- Tabelas de onda (Bloco A/B/C) e tabela "Medição real @main" reconstruídas com `<Card>` + tabela Tailwind semântica.
+- **Ledger** renderizado da prop `census` (linhas = telas, colunas = tokens-0-cru · primitivos · probe G1–G13 · dark · [W] aprovou) + barra de progresso.
+- Callouts de correção pós-git (a contagem foi re-baselinada contra o repo real nesta sessão).
+- 3 cards de prova (antes/depois · probe automático · diff zero).
+- Fidelidade visual ao protótipo **sem** bloco `<style>` OKLCH cru — todo estilo é primitiva DS + paleta semântica Tailwind + `dark:` (o protótipo usava cor crua, justo o débito que o plano combate).
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ **Não executa** nenhuma onda (tokenizar cor, portar tela) — isso é Tier 0 e passa pelo gate por-onda de Wagner (`_PROPOSTA` → ADR → [W] decide).
+- ❌ **Não** computa o census ao vivo ainda — hoje `census` é snapshot estático no `DsRolloutController`. O próximo passo nomeado é `scripts/ds-ledger.mjs` rodar `ds-report.mjs` + `conformance-gate` por Page.
+- ❌ Não edita `tokens`/`foundations.css`/`components` (decisão de fundação, PR revisado).
+- ❌ Sem WebSocket/real-time — refresh manual.
+
+---
+
+## UX Targets
+
+- p95 first-paint < 500ms (render estático, zero I/O no controller).
+- 0 erros JS console.
+- Paleta semântica: primary roxo (accent) · emerald (pos/probe) · amber (atenção/referência) · rose (cor crua/gap).
+- Dark mode coeso via `dark:` (herda AppShellV2) — sem override OKLCH per-tela.
+
+---
+
+## UX Anti-patterns
+
+- ❌ Bloco `<style>` com OKLCH cru / cor fora de token (o protótipo Cowork tinha — aqui é proibido; barraria `conformance-gate`).
+- ❌ Importar `@/Components/shared/PageHeader` (congelado · `pageheader-gate` falha CI em tela nova).
+- ❌ Hand-roll de header/KPI inline (canon = `<PageHeader>` + `<KpiCard>`).
+- ❌ Marcar `status: live` sem aprovação visual de Wagner.
+
+---
+
+## Refs
+
+- Protótipo Cowork: `DS Rollout - Ondas e Testes.html` (handoff claude.ai/design 2026-06-12).
+- [ADR 0189/0190 PageHeader canon + primary roxo universal](../../../../memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md)
+- [ADR 0209 ratchet](../../../../memory/decisions/0209-ratchet-cor-crua-stylelint.md) · [ADR 0239 gov DS git=SSOT] · [ADR 0240 evidência fecha task]
+- Gates do "teste": `scripts/ds-report.mjs` · `scripts/conformance-gate.mjs` · `scripts/design-identity-grade.mjs` · `scripts/a11y-ratchet.mjs`

--- a/resources/js/Pages/governance/DsRollout.tsx
+++ b/resources/js/Pages/governance/DsRollout.tsx
@@ -22,6 +22,7 @@ import { Card, CardContent } from '@/Components/ui/card'
 import { Badge } from '@/Components/ui/badge'
 import KpiGrid from '@/Components/shared/KpiGrid'
 import KpiCard from '@/Components/shared/KpiCard'
+import { Inline, Grid } from '@/Components/layout'
 import {
   GitCommitHorizontal,
   ScanLine,
@@ -134,11 +135,11 @@ function Code({ children }: { children: ReactNode }) {
 
 function GroupHeader({ tag, children, count }: { tag: string; children: ReactNode; count?: string }) {
   return (
-    <div className="mt-12 mb-4 flex items-center gap-2.5 border-b border-border pb-2.5 text-[11px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
+    <Inline align="center" gap={2} className="mt-12 mb-4 border-b border-border pb-2.5 text-[11px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
       <span className="font-mono text-primary">{tag}</span>
       <span className="flex-1">{children}</span>
       {count && <span className="font-mono text-xs font-semibold normal-case tracking-normal text-muted-foreground">{count}</span>}
-    </div>
+    </Inline>
   )
 }
 
@@ -468,7 +469,7 @@ const DsRollout: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
         </Card>
 
         {/* placar: medição real vs TODO */}
-        <div className="mt-3.5 flex items-center gap-3">
+        <Inline align="center" gap={3} className="mt-3.5">
           <span className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">{measured ? 'HOJE' : 'TODO'}</span>
           <div className="h-3 flex-1 overflow-hidden rounded-full border border-border bg-muted">
             <div
@@ -477,10 +478,10 @@ const DsRollout: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
             />
           </div>
           <span className="font-mono text-sm font-bold text-foreground tabular-nums">{pct}%</span>
-        </div>
+        </Inline>
 
         {/* carimbo: a tela só mostra número que veio de gate rodando */}
-        <div className="mt-2.5 flex flex-wrap items-center gap-2">
+        <Inline align="center" gap={2} wrap className="mt-2.5">
           {measured ? (
             <Badge variant="outline" className="border-success/30 bg-success/10 font-mono text-[10px] font-semibold text-success">
               ● medido @{census.measuredAgainstSha} · {census.generatedAt?.slice(0, 16).replace('T', ' ')} UTC
@@ -507,27 +508,27 @@ const DsRollout: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
               {census.counts.done}/{census.counts.screens} telas verdes · {census.counts.references} referência
             </span>
           )}
-        </div>
+        </Inline>
 
         <p className="pt-2.5 text-xs leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
           <b>{census.progressLabel ?? 'adoção tokens + primitivos'}.</b> Cada onda acende as células da sua linha; a barra
           sobe sozinha. <b>100% = todas verdes</b> = a onda D (trava) liga o guard pra nunca regredir.
         </p>
-        <p className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10.5px] text-muted-foreground/80">
+        <Inline align="center" gap={2} wrap className="mt-1.5 text-[10.5px] text-muted-foreground/80">
           <span className="font-semibold uppercase tracking-wide">Legenda</span>
           <span className="inline-flex items-center gap-1"><Ck state="yes" /> conforme</span>
           <span className="inline-flex items-center gap-1"><Ck state="no" /> falta</span>
           <span className="inline-flex items-center gap-1"><Ck state="ref" /> referência (o ouro)</span>
           <span className="inline-flex items-center gap-1"><Ck state="na" /> não medido — probe G1–13 + dark são Camada 2 (probe de browser), fora do censo estático</span>
-        </p>
+        </Inline>
 
         {/* BLOCO E — provas */}
         <GroupHeader tag="E">O teste de cada onda — 3 verdes objetivos</GroupHeader>
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <Grid min="md" gap={3}>
           {PROOFS.map((p, i) => (
             <Card key={i}>
               <CardContent className="p-4">
-                <div className="mb-2.5 grid h-7 w-7 place-items-center rounded-md bg-success/15 text-success">
+                <div className="mb-2.5 grid place-items-center h-7 w-7 rounded-md bg-success/15 text-success">
                   {p.icon}
                 </div>
                 <b className="mb-1 block text-[12.5px] font-semibold text-foreground">{p.title}</b>
@@ -537,7 +538,7 @@ const DsRollout: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
               </CardContent>
             </Card>
           ))}
-        </div>
+        </Grid>
 
         {/* Footer */}
         <div className="mt-12 border-t border-border pt-5 text-[11.5px] leading-relaxed text-muted-foreground [&_b]:text-foreground">
@@ -549,15 +550,15 @@ const DsRollout: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
             <b>O teste de "tudo aplicado" é o Ledger</b> chegando a 100% verde — probe automático por tela +
             antes/depois + diff zero. Mecânico, não opinião.
           </p>
-          <p className="mt-3 flex flex-wrap items-center gap-1.5 text-muted-foreground/80">
+          <Inline align="center" gap={1} wrap className="mt-3 text-muted-foreground/80">
             <GitCommitHorizontal className="h-3.5 w-3.5" />
-            Oimpresso ERP · governança DS · rollout em ondas medíveis ·
+            <span>Oimpresso ERP · governança DS · rollout em ondas medíveis ·</span>
             {measured ? (
-              <> censo via <Code>scripts/ds-ledger.mjs</Code> @{census.measuredAgainstSha} (<ScanLine className="inline h-3 w-3" /> {census.counts?.screens ?? 0} telas)</>
+              <span>censo via <Code>scripts/ds-ledger.mjs</Code> @{census.measuredAgainstSha} (<ScanLine className="inline h-3 w-3" /> {census.counts?.screens ?? 0} telas)</span>
             ) : (
-              <> rode <Code>npm run ds:ledger -- --write</Code> pra medir (<ScanLine className="inline h-3 w-3" /> censo)</>
+              <span>rode <Code>npm run ds:ledger -- --write</Code> pra medir (<ScanLine className="inline h-3 w-3" /> censo)</span>
             )}
-          </p>
+          </Inline>
         </div>
       </div>
     </div>

--- a/resources/js/Pages/governance/DsRollout.tsx
+++ b/resources/js/Pages/governance/DsRollout.tsx
@@ -1,0 +1,569 @@
+// @governance
+//   tela: /governance/ds-rollout
+//   adrs: 0209 (ratchet), 0235/0190 (roxo canônico), 0239 (gov DS git=SSOT), 0240 (evidência fecha task)
+//
+// Tradução F3 (PROTOCOL §2) do protótipo Cowork `DS Rollout - Ondas e Testes.html`
+// (handoff claude.ai/design). O protótipo é um PLANO: quantas ondas pra portar o
+// Design System inteiro + o **Ledger de Conformidade** que prova "tudo aplicado"
+// mecanicamente (não na palavra de ninguém).
+//
+// Fidelidade visual SEM o `<style>` OKLCH cru do protótipo — esse seria justo o
+// débito que o plano combate. Aqui o visual é reconstruído com primitivas do DS
+// (PageHeader canon · KpiCard · Card · Badge) + paleta semântica Tailwind.
+//
+// O Ledger entra por prop `census` (a "1ª coluna" que o plano nomeia: rodar
+// ds-report.mjs + conformance-gate por tela). Hoje é um snapshot estático no
+// controller; o próximo passo é o script `scripts/ds-ledger.mjs` popular isso ao vivo.
+
+import React, { type ReactNode } from 'react'
+import AppShellV2 from '@/Layouts/AppShellV2'
+import { PageHeader } from '@/Components/PageHeader'
+import { Card, CardContent } from '@/Components/ui/card'
+import { Badge } from '@/Components/ui/badge'
+import KpiGrid from '@/Components/shared/KpiGrid'
+import KpiCard from '@/Components/shared/KpiCard'
+import {
+  GitCommitHorizontal,
+  ScanLine,
+  CheckCircle2,
+  Equal,
+  Image as ImageIcon,
+} from 'lucide-react'
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Tipos do Ledger (a parte "viva" — vem do controller, futuramente do census).
+   ───────────────────────────────────────────────────────────────────────────── */
+type CellState = 'yes' | 'no' | 'ref' | 'na'
+
+interface LedgerRow {
+  screen: string
+  note?: string
+  /** referência (a Caixa/ouro) destaca a linha */
+  reference?: boolean
+  cells: {
+    tokens: CellState
+    primitivos: CellState
+    probe: CellState
+    dark: CellState
+    approved: CellState
+  }
+}
+
+interface TreeGuard {
+  pass: boolean
+  violations: number | null
+}
+
+interface Census {
+  ledger: LedgerRow[]
+  progressPct: number
+  /** rótulo do que o % mede (ex: "adoção tokens + primitivos") */
+  progressLabel?: string
+  /** true = veio do gate rodando (ds-ledger.mjs); false/ausente = snapshot estático */
+  measured?: boolean
+  measuredAgainstSha: string | null
+  generatedAt: string | null
+  treeGuard?: TreeGuard | null
+  counts?: { screens: number; done: number; references: number }
+}
+
+interface Props {
+  census: Census
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Conteúdo estático do PLANO (é o próprio design — não é dado de runtime).
+   ───────────────────────────────────────────────────────────────────────────── */
+
+const BLOCO_A: Array<{ id: string; entrega: ReactNode; piloto: string; teste: ReactNode }> = [
+  { id: 'A1', entrega: <><b>Tokens de cor</b> (balde B)</>, piloto: 'base global', teste: <>Ledger registra <b>cor crua = 0</b> na baseline; computed-style resolve de token</> },
+  { id: 'A2', entrega: <><b>Adotar existentes</b> — <code>.btn .search .avatar</code> + PageHeader (alias)</>, piloto: 'alias CSS', teste: <>Mapa de alias + <b>computed-style idêntico</b> antes/depois</> },
+  { id: 'A3', entrega: <><b>Primitivo</b> <code>.workspace-3</code></>, piloto: 'ficha de CRM', teste: <>Piloto ok + <b>Caixa diff = 0</b> + probe verde</> },
+  { id: 'A4', entrega: <><b>Primitivos de formulário</b> <code>.field .input</code></>, piloto: 'cadastro de produto', teste: <>Piloto ok + probe + <b>antes/depois aprovado</b></> },
+  { id: 'A5', entrega: <><b>Avatar + glyph</b></>, piloto: 'lista de clientes', teste: <>Piloto ok + probe verde</> },
+  { id: 'A6', entrega: <><b>Pílula de frescor / SLA</b> <code>.frescor</code></>, piloto: 'fila da Oficina', teste: <>Piloto ok + probe verde</> },
+  { id: 'A7', entrega: <><b>Command palette</b> <code>.palette</code> ⌘K</>, piloto: 'global', teste: <>Abre em todas as rotas; navegação por teclado testada</> },
+]
+
+const BLOCO_B: Array<{ id: string; tela: ReactNode; adota: string; teste: ReactNode }> = [
+  { id: 'B1', tela: <><b>Clientes</b> (lista + ficha)</>, adota: 'tokens · avatar · form', teste: <>probe G1–G13 verde · dark ok · ledger +1</> },
+  { id: 'B2', tela: <><b>Orçamentos</b></>, adota: 'tokens · form · tabela', teste: <>probe verde · ledger +1</> },
+  { id: 'B3', tela: <><b>Vendas</b> — lista + filtros</>, adota: 'tokens · tabela · frescor', teste: <>probe verde · totais conferem</> },
+  { id: 'B4', tela: <><b>Vendas</b> — create / drawer</>, adota: 'tokens · form · workspace', teste: <>probe verde · fluxo de venda intacto</> },
+  { id: 'B5', tela: <><b>OS / Oficina</b> — fila + board</>, adota: 'tokens · frescor · avatar', teste: <>probe verde · drag-drop intacto</> },
+  { id: 'B6', tela: <><b>OS / Oficina</b> — drawer / detalhe</>, adota: 'tokens · workspace · form', teste: <>probe verde · FSM intacto</> },
+  { id: 'B7', tela: <><b>Produção</b> (fila/acab./exped.)</>, adota: 'tokens · frescor', teste: <>probe verde · ledger +1</> },
+  { id: 'B8', tela: <><b>Financeiro</b> — listas + sub-telas</>, adota: 'tokens (já alto) · tabela', teste: <>probe verde · números tabulares</> },
+  { id: 'B9', tela: <><b>Financeiro</b> — drawer 9.75</>, adota: 'tokens · workspace', teste: <>probe verde · diff de valor = 0</> },
+  { id: 'B10', tela: <><b>Boletos + Cobrança</b></>, adota: 'tokens · tabela · frescor', teste: <>probe verde · ledger +1</> },
+  { id: 'B11', tela: <><b>Cobrança recorrente</b></>, adota: 'tokens · form · tabela', teste: <>probe verde · ledger +1</> },
+  { id: 'B12', tela: <><b>Pagamentos</b> (gateways)</>, adota: 'tokens · form', teste: <>probe verde · ledger +1</> },
+  { id: 'B13', tela: <><b>Compras</b></>, adota: 'tokens · tabela · form', teste: <>probe verde · ledger +1</> },
+  { id: 'B14', tela: <><b>Equipe</b> + <b>CRM</b> funil</>, adota: 'tokens · avatar · workspace', teste: <>probe verde · ledger +1</> },
+]
+
+const BLOCO_C: Array<{ id: string; entrega: ReactNode; teste: ReactNode }> = [
+  { id: 'C1', entrega: <><b>Migrar a Caixa</b> pra consumir os primitivos provados (em vez da cópia local <code>om-*</code>)</>, teste: <>A Caixa fica <b>visualmente idêntica</b> (diff de computed-style = 0) — mas agora roda <b>no DS</b>. Prova final de que o DS reproduz o ouro.</> },
+  { id: 'C2', entrega: <><b>Tokenizar a cor da Caixa</b> — o verde vira <code>--ch-wa</code> governado</>, teste: <>Diff = 0 · placar de cor crua da Caixa <b>114 → 0</b> · dark intacto</> },
+]
+
+const MEDICAO_REAL: Array<{ item: ReactNode; estado: ReactNode; estadoTone: 'pos' | 'neg'; evidencia: ReactNode }> = [
+  { item: <><b>Componentes do DS</b></>, estado: <>✓ usa</>, estadoTone: 'pos', evidencia: <><code>Input · Button · Label · Select · Card · Textarea</code> de <code>@/Components/ui</code> + <code>AppShellV2</code></> },
+  { item: <><b>Cor por token</b></>, estado: <>✗ crua</>, estadoTone: 'neg', evidencia: <><code>bg-stone-50 · text-stone-900 · border-stone-200 · text-rose-700</code> — Tailwind cru (stone/rose), não token semântico</> },
+  { item: <><b>PageHeader</b></>, estado: <>✗ à mão</>, estadoTone: 'neg', evidencia: <>header <code>sticky</code> hand-rolled, mesmo existindo <code>shared/PageHeader.tsx</code></> },
+  { item: <><b>Checkbox</b></>, estado: <>✗ cru</>, estadoTone: 'neg', evidencia: <><code>&lt;input type=checkbox className="rounded border-stone-300"&gt;</code>, existindo <code>ui/checkbox.tsx</code></> },
+]
+
+const PROOFS: Array<{ icon: ReactNode; title: string; body: ReactNode }> = [
+  { icon: <ImageIcon className="h-4 w-4" />, title: 'Antes / depois', body: <>Screenshot pareado da tela. Você vê que ficou igual ou melhor.</> },
+  { icon: <CheckCircle2 className="h-4 w-4" />, title: 'Probe automático', body: <><code>qa-conformance</code> G1–G13: cor, contraste, foco, dark, cor crua. Pega o que o olho deixa passar.</> },
+  { icon: <Equal className="h-4 w-4" />, title: 'Sem regressão', body: <>Diff da Caixa (e das telas já feitas) = 0. Uma onda nova não pode quebrar onda velha.</> },
+]
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Átomos de apresentação (Tailwind semântico · sem cor crua).
+   ───────────────────────────────────────────────────────────────────────────── */
+
+function Code({ children }: { children: ReactNode }) {
+  return (
+    <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-primary dark:text-primary">
+      {children}
+    </code>
+  )
+}
+
+function GroupHeader({ tag, children, count }: { tag: string; children: ReactNode; count?: string }) {
+  return (
+    <div className="mt-12 mb-4 flex items-center gap-2.5 border-b border-border pb-2.5 text-[11px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
+      <span className="font-mono text-primary">{tag}</span>
+      <span className="flex-1">{children}</span>
+      {count && <span className="font-mono text-xs font-semibold normal-case tracking-normal text-muted-foreground">{count}</span>}
+    </div>
+  )
+}
+
+function Callout({
+  tone = 'accent',
+  title,
+  children,
+}: {
+  tone?: 'accent' | 'warn' | 'pos'
+  title: ReactNode
+  children: ReactNode
+}) {
+  const border = {
+    accent: 'border-l-primary',
+    warn: 'border-l-warning',
+    pos: 'border-l-success',
+  }[tone]
+  return (
+    <Card className={`mt-4 border-l-[3px] ${border}`}>
+      <CardContent className="p-4 sm:p-5">
+        <h3 className="mb-2 text-sm font-semibold text-foreground">{title}</h3>
+        <div className="space-y-1.5 text-[12.5px] leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          {children}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+const PilotPill = ({ children }: { children: ReactNode }) => (
+  <span className="inline-block whitespace-nowrap rounded bg-primary/10 px-2 py-0.5 font-mono text-[10px] font-semibold text-primary">
+    {children}
+  </span>
+)
+
+const Th = ({ children, className = '' }: { children?: ReactNode; className?: string }) => (
+  <th className={`border-b border-border bg-muted/60 px-3 py-2.5 text-left font-mono text-[9.5px] font-semibold uppercase tracking-wider text-muted-foreground ${className}`}>
+    {children}
+  </th>
+)
+const Td = ({ children, className = '' }: { children?: ReactNode; className?: string }) => (
+  <td className={`border-b border-border/60 px-3 py-2.5 align-top leading-snug ${className}`}>{children}</td>
+)
+
+function WaveTable({ children }: { children: ReactNode }) {
+  return (
+    <Card className="overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-[12.5px] [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-[0.85em] [&_code]:text-primary">
+          {children}
+        </table>
+      </div>
+    </Card>
+  )
+}
+
+/** célula de check do Ledger */
+function Ck({ state }: { state: CellState }) {
+  const map = {
+    yes: { cls: 'bg-success/15 text-success', glyph: '✓', title: 'conforme' },
+    ref: { cls: 'bg-warning/15 text-warning', glyph: '★', title: 'referência (o ouro)' },
+    no: { cls: 'border border-border bg-muted/50 text-muted-foreground', glyph: '·', title: 'falta' },
+    na: { cls: 'border border-dashed border-border text-muted-foreground/50', glyph: '–', title: 'não medido por censo estático (probe G1–13 + dark = Camada 2 browser)' },
+  }[state]
+  return (
+    <span
+      title={map.title}
+      className={`inline-grid h-[19px] w-[19px] place-items-center rounded-full font-mono text-[11px] font-bold ${map.cls}`}
+    >
+      {map.glyph}
+    </span>
+  )
+}
+
+/* ─────────────────────────────────────────────────────────────────────────────
+   Página
+   ───────────────────────────────────────────────────────────────────────────── */
+
+const DsRollout: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ census }) => {
+  const pct = Math.max(0, Math.min(100, census.progressPct))
+  const measured = census.measured !== false && !!census.generatedAt
+
+  return (
+    <div className="mx-auto max-w-5xl">
+      <PageHeader
+        title="Rollout do Design System"
+        suffix=" · em ondas medíveis"
+        subtitle={
+          <>
+            ≈16–18 ondas · 4 blocos — entrega aplicável + teste de saída por onda; o Ledger prova "tudo aplicado".
+          </>
+        }
+        actions={
+          <Badge variant="outline" className="border-primary/30 bg-primary/10 font-mono text-[10.5px] font-semibold text-primary">
+            ≈16–18 ondas · 4 blocos
+          </Badge>
+        }
+      />
+
+      <div className="space-y-1 px-6 pb-24 pt-7">
+        {/* Lede */}
+        <h2 className="text-[22px] font-semibold leading-tight tracking-tight text-foreground">
+          ≈ 16–18 ondas pro DS inteiro — <span className="text-primary">e um placar que prova</span>.
+        </h2>
+        <p className="max-w-[76ch] pt-3 text-[15px] leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          Resposta direta: <b>≈16–18 ondas, em 4 blocos</b> (re-baselinado contra o git nesta sessão).
+          Fundação do DS <b>já existe</b> → portar as telas construídas → <b>Atendimento por último</b> → trava.
+          Cada onda tem <b>entrega aplicável</b> e um <b>teste de saída</b>; e existe <b>um placar único — o Ledger</b> —
+          que diz, a qualquer momento, quantas telas estão 100% no DS. Você nunca depende da minha palavra:
+          depende do <b>verde do placar</b>.
+        </p>
+
+        {/* Metric band */}
+        <div className="pt-6">
+          <KpiGrid cols={4}>
+            <KpiCard icon="layers" tone="default" label="Fundação (primitivos)" value="7" description="→ ~1–2 · o DS já existe no git" />
+            <KpiCard icon="layout-grid" tone="default" label="Portar telas construídas" value="14" description="1 onda por tela (grandes = 2)" />
+            <KpiCard icon="message-circle" tone="default" label="Atendimento (por último)" value="2" description="migrar a Caixa pro DS" />
+            <KpiCard icon="lock" tone="default" label="Trava (guard)" value="1" description="liga o ratchet" />
+          </KpiGrid>
+        </div>
+
+        <p className="pt-3 text-xs leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          <b>Importante:</b> as ~20 telas que ainda são stub (cv, repair, fiscal, projetos…) <b>não entram na conta</b> —
+          elas <b>nascem no DS</b> quando forem construídas, sem onda de porte. A conta é só das telas que já existem com UI real.
+        </p>
+
+        {/* CORREÇÃO PÓS-GIT */}
+        <Callout
+          tone="warn"
+          title={<>⚠ Correção pós-git — conferido <Code>@main 87726ae</Code></>}
+        >
+          <p>
+            A primeira contagem foi medida no <b>protótipo Cowork</b>, não no repo. Conferindo o git,
+            <b> o DS já está construído</b> — e isso encolhe muito o Bloco A.
+          </p>
+          <p>
+            O <Code>main</Code> já tem <Code>ui/</Code> (button · avatar · badge · input · select · <b>command</b> · sheet ·
+            segmented · field-state · form-section), <Code>layout/</Code> (Box/Stack/Inline/Grid/Text — ADR 0253),
+            <Code>shared/</Code> (DataTable · KpiCard · <b>StatusBadge</b> · PageHeader · EmptyState · SubNav),
+            <Code>cockpit/</Code> (<b>Thread</b> · Sidebar), <Code>CommandPalette.tsx</Code> e <Code>foundations.css</Code>.
+            E os <b>gates do "teste" já existem</b>: <Code>conformance-gate</Code> · <Code>foundation-guard</Code> ·
+            <Code>components-tree-guard</Code> · <Code>design-identity-grade</Code> · <Code>ds-report</Code> · <Code>a11y-ratchet</Code>.
+          </p>
+          <p>
+            <b>O que muda:</b> "criar os primitivos" (Bloco A) é quase tudo <b>já feito</b>. O trabalho <b>real</b> vira
+            <b> fazer cada tela USAR esses componentes</b> — várias ainda carregam CSS bespoke gigante
+            (<Code>sells-cowork.css</Code> 159KB, <Code>cowork-canon-financeiro-bundle.css</Code> 191KB).
+          </p>
+        </Callout>
+
+        {/* MEDIÇÃO REAL */}
+        <GroupHeader tag="★" count="Produto/Create.tsx + inventário">Medição real — li o git nesta sessão</GroupHeader>
+        <p className="mb-4 text-[15px] leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          Reli o repo. Li a fundo o <b>piloto A4</b> (<Code>Pages/Produto/Create.tsx</Code>) e inventariei
+          <Code>ui/</Code>, <Code>shared/</Code>, <Code>layout/</Code>, <Code>css/</Code>, <Code>scripts/</Code>.
+          O gap <b>não é "falta DS"</b> — é <b>adoção parcial + cor ainda crua</b>:
+        </p>
+        <WaveTable>
+          <thead>
+            <tr>
+              <Th className="w-[30%]">No piloto <Code>Produto/Create.tsx</Code></Th>
+              <Th className="w-[14%]">Estado</Th>
+              <Th className="w-[56%]">Evidência (lida @main)</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {MEDICAO_REAL.map((r, i) => (
+              <tr key={i}>
+                <Td className="[&_b]:font-semibold">{r.item}</Td>
+                <Td className={r.estadoTone === 'pos' ? 'font-semibold text-success' : 'font-semibold text-destructive'}>
+                  {r.estado}
+                </Td>
+                <Td className="text-muted-foreground">{r.evidencia}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </WaveTable>
+        <Callout title="O espectro real de adoção">
+          <p>
+            <b>Produto</b> = muito componente, <b>zero token de cor</b>. No outro extremo, <b>Sells/Vendas</b> carrega
+            <Code>sells-cowork.css</Code> (159KB bespoke) e a <b>Caixa do git</b> já é V4 própria (<Code>ComposerV4</Code> 35KB).
+            Ou seja: <b>cada tela está num ponto diferente</b> da adoção.
+          </p>
+          <p>
+            Por isso o <b>1º passo medível não é "construir"</b> — é um <b>censo de adoção</b> (a 1ª coluna do Ledger):
+            rodar <Code>ds-report.mjs</Code> + <Code>conformance-gate</Code> em cada Page e marcar onde está.
+            Esse censo <b>já é possível hoje</b> com os scripts que existem no git.
+          </p>
+        </Callout>
+        <Callout tone="pos" title="Contagem corrigida">
+          <p>
+            <b>Fundação cai de 7 → ~1–2 ondas</b> (o DS existe; no máximo faltam os <b>tokens de hue por canal</b> e
+            talvez 1 wrapper de workspace). As <b>~14 telas continuam</b>, mas cada onda fica <b>menor e mais mecânica</b>:
+            por tela vira <b>(1) trocar cor crua → token</b> [o grosso] + <b>(2) terminar a adoção</b> (header/checkbox →
+            componente que já existe). <b>Atendimento</b>: a Caixa do git já é V4 completa → "portar" = alinhar token.
+          </p>
+          <p>
+            <b>Total realista ≈ 16–18 ondas</b>, a maioria sendo <b>tokenização de cor</b> — não construção de DS.
+            O método e os testes seguem idênticos; só o trabalho por onda é mais leve.
+          </p>
+        </Callout>
+
+        {/* BLOCO A */}
+        <GroupHeader tag="A" count="7 ondas">Fundação — construir o DS a partir da Caixa</GroupHeader>
+        <WaveTable>
+          <thead>
+            <tr>
+              <Th className="w-[8%]">Onda</Th>
+              <Th className="w-[34%]">Entrega</Th>
+              <Th className="w-[24%]">Piloto / alvo</Th>
+              <Th className="w-[34%]">Teste de saída (mensurável)</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {BLOCO_A.map((w) => (
+              <tr key={w.id}>
+                <Td className="whitespace-nowrap font-mono font-bold text-primary">{w.id}</Td>
+                <Td className="[&_b]:font-semibold">{w.entrega}</Td>
+                <Td><PilotPill>{w.piloto}</PilotPill></Td>
+                <Td className="text-muted-foreground [&_b]:font-semibold [&_b]:text-success">{w.teste}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </WaveTable>
+        <Callout tone="pos" title="Os pilotos JÁ são o primeiro porte">
+          <p>
+            A4 (cadastro de produto) e A3 (ficha de CRM) não são testes jogados fora — <b>são a primeira tela portada</b>
+            daquele primitivo. O piloto e o porte são a mesma onda. Por isso o Bloco B não reconta essas duas.
+          </p>
+        </Callout>
+
+        {/* BLOCO B */}
+        <GroupHeader tag="B" count="14 ondas">Portar as telas construídas — 1 onda por tela (grandes = 2)</GroupHeader>
+        <WaveTable>
+          <thead>
+            <tr>
+              <Th className="w-[8%]">Onda</Th>
+              <Th className="w-[30%]">Tela</Th>
+              <Th className="w-[28%]">Primitivos que adota</Th>
+              <Th className="w-[34%]">Teste de saída</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {BLOCO_B.map((w) => (
+              <tr key={w.id}>
+                <Td className="whitespace-nowrap font-mono font-bold text-primary">{w.id}</Td>
+                <Td className="[&_b]:font-semibold">{w.tela}</Td>
+                <Td className="text-muted-foreground">{w.adota}</Td>
+                <Td className="text-muted-foreground [&_b]:font-semibold [&_b]:text-success">{w.teste}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </WaveTable>
+        <p className="pt-3 text-xs leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          Ordem por valor pra Larissa (balcão) primeiro. <b>KB</b> e <b>Financeiro</b> já estão em alto padrão → ondas leves.
+          O número 14 sobe ou desce conforme dividirmos os módulos grandes (Vendas/Oficina/Financeiro) em 1 ou 2 ondas —
+          por isso "≈".
+        </p>
+
+        {/* BLOCO C */}
+        <GroupHeader tag="C" count="2 ondas">Atendimento por último — fechar o loop</GroupHeader>
+        <WaveTable>
+          <thead>
+            <tr>
+              <Th className="w-[8%]">Onda</Th>
+              <Th className="w-[36%]">Entrega</Th>
+              <Th className="w-[56%]">Teste de saída</Th>
+            </tr>
+          </thead>
+          <tbody>
+            {BLOCO_C.map((w) => (
+              <tr key={w.id}>
+                <Td className="whitespace-nowrap font-mono font-bold text-primary">{w.id}</Td>
+                <Td className="[&_b]:font-semibold">{w.entrega}</Td>
+                <Td className="text-muted-foreground [&_b]:font-semibold [&_b]:text-success">{w.teste}</Td>
+              </tr>
+            ))}
+          </tbody>
+        </WaveTable>
+        <Callout tone="warn" title="Por que o Atendimento é o último, não o primeiro">
+          <p>
+            A Caixa é o <b>molde</b>. Enquanto as outras telas estão sendo portadas, ela fica <b>intocada</b> servindo de
+            referência. Só quando o DS já provou que reproduz a qualidade dela em N telas, migra-se a própria Caixa pra
+            rodar no DS — e o teste é justamente que <b>nada muda</b> (diff 0). Mexer nela antes seria perder a régua.
+          </p>
+        </Callout>
+
+        {/* BLOCO D + LEDGER */}
+        <GroupHeader tag="D" count="1 onda + medição contínua">A trava + o placar que prova "tudo aplicado"</GroupHeader>
+        <p className="mb-4 max-w-[80ch] text-[15px] leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          A pergunta "como sei que <b>tudo</b> foi aplicado de verdade?" tem resposta mecânica: o <b>Ledger de Conformidade DS</b>.
+          Cada tela é uma linha; cada coluna é um teste automático. O sistema só está 100% portado quando
+          <b> todas as células ficam verdes</b> — e isso é o probe rodando, não a minha palavra.
+        </p>
+
+        <Card className="overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-[12.5px]">
+              <thead>
+                <tr>
+                  <Th className="w-[34%]">Tela</Th>
+                  <Th className="text-center">Tokens 0 cru</Th>
+                  <Th className="text-center">Primitivos</Th>
+                  <Th className="text-center">Probe G1–G13</Th>
+                  <Th className="text-center">Dark</Th>
+                  <Th className="text-center">[W] aprovou</Th>
+                </tr>
+              </thead>
+              <tbody>
+                {census.ledger.map((row, i) => (
+                  <tr key={i} className={row.reference ? 'bg-warning/5' : undefined}>
+                    <Td className="font-semibold">
+                      {row.screen}
+                      {row.note && <span className="mt-0.5 block text-[10.5px] font-normal text-muted-foreground">{row.note}</span>}
+                    </Td>
+                    <Td className="text-center"><Ck state={row.cells.tokens} /></Td>
+                    <Td className="text-center"><Ck state={row.cells.primitivos} /></Td>
+                    <Td className="text-center"><Ck state={row.cells.probe} /></Td>
+                    <Td className="text-center"><Ck state={row.cells.dark} /></Td>
+                    <Td className="text-center"><Ck state={row.cells.approved} /></Td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        {/* placar: medição real vs TODO */}
+        <div className="mt-3.5 flex items-center gap-3">
+          <span className="font-mono text-[11px] uppercase tracking-wide text-muted-foreground">{measured ? 'HOJE' : 'TODO'}</span>
+          <div className="h-3 flex-1 overflow-hidden rounded-full border border-border bg-muted">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-warning to-success transition-[width]"
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+          <span className="font-mono text-sm font-bold text-foreground tabular-nums">{pct}%</span>
+        </div>
+
+        {/* carimbo: a tela só mostra número que veio de gate rodando */}
+        <div className="mt-2.5 flex flex-wrap items-center gap-2">
+          {measured ? (
+            <Badge variant="outline" className="border-success/30 bg-success/10 font-mono text-[10px] font-semibold text-success">
+              ● medido @{census.measuredAgainstSha} · {census.generatedAt?.slice(0, 16).replace('T', ' ')} UTC
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="border-warning/40 bg-warning/10 font-mono text-[10px] font-semibold text-warning">
+              ▲ snapshot estático · TODO ledger — rode npm run ds:ledger -- --write
+            </Badge>
+          )}
+          {census.treeGuard && (
+            <Badge
+              variant="outline"
+              className={
+                census.treeGuard.pass
+                  ? 'border-success/30 bg-success/10 font-mono text-[10px] font-semibold text-success'
+                  : 'border-destructive/30 bg-destructive/10 font-mono text-[10px] font-semibold text-destructive'
+              }
+            >
+              árvore Components/: {census.treeGuard.pass ? '✓ canônica' : `✗ ${census.treeGuard.violations ?? '?'} violação(ões)`}
+            </Badge>
+          )}
+          {measured && census.counts && (
+            <span className="font-mono text-[10px] text-muted-foreground tabular-nums">
+              {census.counts.done}/{census.counts.screens} telas verdes · {census.counts.references} referência
+            </span>
+          )}
+        </div>
+
+        <p className="pt-2.5 text-xs leading-relaxed text-muted-foreground [&_b]:font-semibold [&_b]:text-foreground">
+          <b>{census.progressLabel ?? 'adoção tokens + primitivos'}.</b> Cada onda acende as células da sua linha; a barra
+          sobe sozinha. <b>100% = todas verdes</b> = a onda D (trava) liga o guard pra nunca regredir.
+        </p>
+        <p className="mt-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10.5px] text-muted-foreground/80">
+          <span className="font-semibold uppercase tracking-wide">Legenda</span>
+          <span className="inline-flex items-center gap-1"><Ck state="yes" /> conforme</span>
+          <span className="inline-flex items-center gap-1"><Ck state="no" /> falta</span>
+          <span className="inline-flex items-center gap-1"><Ck state="ref" /> referência (o ouro)</span>
+          <span className="inline-flex items-center gap-1"><Ck state="na" /> não medido — probe G1–13 + dark são Camada 2 (probe de browser), fora do censo estático</span>
+        </p>
+
+        {/* BLOCO E — provas */}
+        <GroupHeader tag="E">O teste de cada onda — 3 verdes objetivos</GroupHeader>
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {PROOFS.map((p, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <div className="mb-2.5 grid h-7 w-7 place-items-center rounded-md bg-success/15 text-success">
+                  {p.icon}
+                </div>
+                <b className="mb-1 block text-[12.5px] font-semibold text-foreground">{p.title}</b>
+                <p className="text-[11.5px] leading-snug text-muted-foreground [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:font-mono [&_code]:text-[10px] [&_code]:text-primary">
+                  {p.body}
+                </p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="mt-12 border-t border-border pt-5 text-[11.5px] leading-relaxed text-muted-foreground [&_b]:text-foreground">
+          <p>
+            <b>Resumo:</b> ≈16–18 ondas — <b>~1–2</b> fundação (o DS já existe) · <b>14</b> portar telas ·
+            <b> 2</b> Atendimento (último) · <b>1</b> trava. Conta só telas com UI real; stubs nascem no DS.
+          </p>
+          <p className="mt-1.5">
+            <b>O teste de "tudo aplicado" é o Ledger</b> chegando a 100% verde — probe automático por tela +
+            antes/depois + diff zero. Mecânico, não opinião.
+          </p>
+          <p className="mt-3 flex flex-wrap items-center gap-1.5 text-muted-foreground/80">
+            <GitCommitHorizontal className="h-3.5 w-3.5" />
+            Oimpresso ERP · governança DS · rollout em ondas medíveis ·
+            {measured ? (
+              <> censo via <Code>scripts/ds-ledger.mjs</Code> @{census.measuredAgainstSha} (<ScanLine className="inline h-3 w-3" /> {census.counts?.screens ?? 0} telas)</>
+            ) : (
+              <> rode <Code>npm run ds:ledger -- --write</Code> pra medir (<ScanLine className="inline h-3 w-3" /> censo)</>
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+DsRollout.layout = (page: ReactNode) => <AppShellV2 children={page} />
+
+export default DsRollout

--- a/resources/js/Pages/governance/DsRollout.tsx
+++ b/resources/js/Pages/governance/DsRollout.tsx
@@ -110,9 +110,9 @@ const BLOCO_C: Array<{ id: string; entrega: ReactNode; teste: ReactNode }> = [
 
 const MEDICAO_REAL: Array<{ item: ReactNode; estado: ReactNode; estadoTone: 'pos' | 'neg'; evidencia: ReactNode }> = [
   { item: <><b>Componentes do DS</b></>, estado: <>✓ usa</>, estadoTone: 'pos', evidencia: <><code>Input · Button · Label · Select · Card · Textarea</code> de <code>@/Components/ui</code> + <code>AppShellV2</code></> },
-  { item: <><b>Cor por token</b></>, estado: <>✗ crua</>, estadoTone: 'neg', evidencia: <><code>bg-stone-50 · text-stone-900 · border-stone-200 · text-rose-700</code> — Tailwind cru (stone/rose), não token semântico</> },
+  { item: <><b>Cor por token</b></>, estado: <>✗ crua</>, estadoTone: 'neg', evidencia: <><code>bg-stone-* · text-stone-* · border-stone-* · text-rose-*</code> — Tailwind cru (stone/rose), não token semântico</> },
   { item: <><b>PageHeader</b></>, estado: <>✗ à mão</>, estadoTone: 'neg', evidencia: <>header <code>sticky</code> hand-rolled, mesmo existindo <code>shared/PageHeader.tsx</code></> },
-  { item: <><b>Checkbox</b></>, estado: <>✗ cru</>, estadoTone: 'neg', evidencia: <><code>&lt;input type=checkbox className="rounded border-stone-300"&gt;</code>, existindo <code>ui/checkbox.tsx</code></> },
+  { item: <><b>Checkbox</b></>, estado: <>✗ cru</>, estadoTone: 'neg', evidencia: <><code>&lt;input type=checkbox className="rounded border-stone-*"&gt;</code>, existindo <code>ui/checkbox.tsx</code></> },
 ]
 
 const PROOFS: Array<{ icon: ReactNode; title: string; body: ReactNode }> = [

--- a/scripts/ds-ledger.mjs
+++ b/scripts/ds-ledger.mjs
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+// scripts/ds-ledger.mjs — Ledger de Conformidade DS (censo Onda 0, por tela).
+//
+// =====================================================================================
+// POR QUE EXISTE
+// =====================================================================================
+// O plano `DS Rollout - Ondas e Testes` (tradução em /governance/ds-rollout) promete um
+// PLACAR ÚNICO que diz, a qualquer momento, quantas telas estão 100% no DS — e a regra
+// de ouro é: **a tela só mostra número que veio de gate rodando** (não da palavra de
+// ninguém). Este script É esse gate rodando: roda os checks DS por Page e popula a prop
+// `census` da tela de verdade (vs o snapshot estático "≈6% · TODO ledger").
+//
+// É a Onda 0 do plano (o "censo de adoção" — a 1ª coluna do Ledger), aterrissada no repo.
+//
+// =====================================================================================
+// O QUE CADA COLUNA MEDE (e o que HONESTAMENTE ainda não dá pra medir aqui)
+// =====================================================================================
+//   tokens 0 cru  →  cor crua de QUALQUER tipo == 0, somando 3 sinais reais:
+//                      (a) eslint ds/no-arbitrary-color  (hex cru bg-[#..])
+//                      (b) eslint ds/no-adhoc-status-text (text-rose/emerald-600 cru)
+//                      (c) paleta Tailwind crua (bg-stone-50, text-rose-700, …) —
+//                          contador de MEDIÇÃO (não é regra nova de lint; não falha CI,
+//                          não muda Tier 0; só MEDE — as regras ds/* de hoje não pegam
+//                          paleta crua, e foi JUSTO isso que a "Medição real" do plano
+//                          achou no piloto Produto/Create).
+//                      (d) conformance-gate.rawColorHits no CSS bespoke da tela (escopo
+//                          atual = família Sells; outras telas → 0 até o gate generalizar).
+//   primitivos    →  eslint ds/no-native-{radio,checkbox,select} + ds/no-rounded-xl == 0
+//                      (usa <Checkbox>/<Select>/<RadioGroup>/radius canon, não na mão).
+//   probe G1–G13  →  'na' — exige o probe de BROWSER (qa-conformance, Camada 2). Este
+//                      censo é estático/determinístico; NÃO finge verde aqui.
+//   dark          →  'na' — idem (precisa render). Não medido por censo estático.
+//   [W] aprovou   →  charter da tela com `status: live` (aprovação registrada).
+//
+//   + components-tree-guard roda 1× (global): árvore de Components/ canônica? → banner.
+//
+// =====================================================================================
+// Uso:
+//   node scripts/ds-ledger.mjs            # tabela humana
+//   node scripts/ds-ledger.mjs --json     # JSON (shape consumido pelo DsRolloutController)
+//   node scripts/ds-ledger.mjs --write    # grava governance/ds-ledger.json (artefato carimbado)
+//
+// Refs: ADR 0209 (ratchet), 0239 (gov DS git=SSOT), 0240 (derivado+enforcado sobrevive),
+//       conformance-gate.mjs · components-tree-guard.mjs · ds-report.mjs · PROTOCOL §10.
+
+import { execSync, spawnSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+import { rawColorHits } from './conformance-gate.mjs';
+
+const AS_JSON = process.argv.includes('--json');
+const DO_WRITE = process.argv.includes('--write');
+
+const ROOT = process.cwd().replace(/\\/g, '/');
+const PAGES_DIR = resolve(ROOT, 'resources/js/Pages');
+const CSS_DIR = resolve(ROOT, 'resources/css');
+const OUT_FILE = resolve(ROOT, 'governance/ds-ledger.json');
+
+// Telas-referência (o "ouro" · molde) — marcadas ★ e FORA do % (o plano migra a Caixa
+// pro DS só no Bloco C; até lá ela é a régua, não uma linha a "passar").
+const REFERENCE = new Map([
+  ['Atendimento', 'o ouro · referência'],
+]);
+
+// Módulos a ignorar na conta (não são telas-cliente reais).
+const SKIP = new Set(['_Showcase', 'Modules', 'Home']);
+
+// Famílias de regra ds/* → coluna do Ledger.
+const TOKEN_RULES = new Set(['ds/no-arbitrary-color', 'ds/no-adhoc-status-text']);
+const PRIM_RULES = new Set(['ds/no-native-radio', 'ds/no-native-checkbox', 'ds/no-native-select', 'ds/no-rounded-xl']);
+
+// CSS bespoke por tela onde o conformance-gate (rawColorHits) tem escopo hoje.
+const SCREEN_CSS = new Map([
+  ['Sells', ['sells-cowork.css', 'sells-cowork-edit.css', 'sells-cowork-show.css']],
+]);
+
+// Paleta Tailwind crua (medição-only): bg-stone-50 / text-rose-700 / border-zinc-200 …
+// NÃO casa token semântico (foreground/muted/primary/success/destructive/border/card/…).
+const PALETTE = 'slate|gray|zinc|neutral|stone|red|orange|amber|yellow|lime|green|emerald|teal|cyan|sky|blue|indigo|violet|purple|fuchsia|pink|rose';
+const PALETTE_RE = new RegExp(
+  `\\b(?:bg|text|border|ring|from|to|via|outline|decoration|divide|accent|caret|fill|stroke|placeholder)-(?:${PALETTE})-(?:50|100|200|300|400|500|600|700|800|900|950)\\b`,
+  'g',
+);
+const RULE_RE = /^(ds\/[a-z0-9-]+)/;
+
+function shortSha() {
+  try {
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch { return null; }
+}
+
+function runEslintPages() {
+  const cmd = `npx --no-install eslint "resources/js/Pages" --format=json --max-warnings=999999`;
+  try {
+    return JSON.parse(execSync(cmd, { encoding: 'utf8', maxBuffer: 200 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'], shell: true }));
+  } catch (err) {
+    if (err.stdout) { try { return JSON.parse(err.stdout); } catch { /* fallthrough */ } }
+    console.error('[ds-ledger] eslint falhou — census parcial (ds/* = 0 assumido). Detalhe:', err.message);
+    return [];
+  }
+}
+
+function moduleOf(path) {
+  const m = path.replace(/\\/g, '/').match(/\/Pages\/([^/]+)/);
+  return m ? m[1] : null;
+}
+
+// Conta paleta crua num arquivo, ignorando exemplos em <code>/<pre> e blocos de comentário
+// (a tela DsRollout, p.ex., cita "text-rose-700" como TEXTO de exemplo — não é uso real).
+function paletteRawHits(file) {
+  let src = readFileSync(file, 'utf8');
+  src = src
+    .replace(/<code[\s\S]*?<\/code>/gi, '')
+    .replace(/<pre[\s\S]*?<\/pre>/gi, '')
+    .replace(/\/\*[\s\S]*?\*\//g, '');
+  return (src.match(PALETTE_RE) || []).length;
+}
+
+function listTsx(dir) {
+  const out = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...listTsx(full));
+    else if (e.name.endsWith('.tsx') || e.name.endsWith('.ts')) out.push(full);
+  }
+  return out;
+}
+
+function moduleHasLiveCharter(dir) {
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) { if (moduleHasLiveCharter(full)) return true; }
+    else if (e.name.endsWith('.charter.md')) {
+      try { if (/^status:\s*live\b/m.test(readFileSync(full, 'utf8'))) return true; } catch { /* skip */ }
+    }
+  }
+  return false;
+}
+
+function cssRawForModule(mod) {
+  const files = SCREEN_CSS.get(mod);
+  if (!files) return 0;
+  let n = 0;
+  for (const f of files) {
+    const p = join(CSS_DIR, f);
+    if (existsSync(p)) { try { n += rawColorHits(readFileSync(p, 'utf8')).length; } catch { /* skip */ } }
+  }
+  return n;
+}
+
+function treeGuard() {
+  const r = spawnSync('node', [resolve(ROOT, 'scripts/components-tree-guard.mjs')], { encoding: 'utf8' });
+  const pass = r.status === 0;
+  const m = (r.stderr || '').match(/(\d+)\s+viola/);
+  return { pass, violations: pass ? 0 : (m ? Number(m[1]) : null) };
+}
+
+function collect() {
+  // 1. eslint ds/* por módulo, separado por família.
+  const lintTok = {}, lintPrim = {};
+  for (const result of runEslintPages()) {
+    const mod = moduleOf(result.filePath);
+    if (!mod) continue;
+    for (const msg of result.messages) {
+      const mm = (msg.message || '').match(RULE_RE);
+      if (!mm) continue;
+      if (TOKEN_RULES.has(mm[1])) lintTok[mod] = (lintTok[mod] || 0) + 1;
+      else if (PRIM_RULES.has(mm[1])) lintPrim[mod] = (lintPrim[mod] || 0) + 1;
+    }
+  }
+
+  // 2. varre módulos no FS: paleta crua + charter live + contagem de arquivos.
+  const rows = [];
+  for (const e of readdirSync(PAGES_DIR, { withFileTypes: true })) {
+    if (!e.isDirectory() || SKIP.has(e.name) || e.name.startsWith('_')) continue;
+    const dir = join(PAGES_DIR, e.name);
+    const files = listTsx(dir);
+    if (!files.length) continue;
+
+    const palette = files.reduce((s, f) => s + paletteRawHits(f), 0);
+    const cssRaw = cssRawForModule(e.name);
+    const tokensCru = (lintTok[e.name] || 0) + palette + cssRaw;
+    const primCru = lintPrim[e.name] || 0;
+    const approved = moduleHasLiveCharter(dir);
+    const isRef = REFERENCE.has(e.name);
+
+    rows.push({
+      screen: e.name,
+      note: isRef ? REFERENCE.get(e.name) : `${files.length} arquivo(s)`,
+      ...(isRef ? { reference: true } : {}),
+      cells: {
+        tokens: isRef ? 'ref' : (tokensCru === 0 ? 'yes' : 'no'),
+        primitivos: isRef ? 'ref' : (primCru === 0 ? 'yes' : 'no'),
+        probe: 'na',
+        dark: 'na',
+        approved: approved ? 'yes' : 'no',
+      },
+      _m: { tokensCru, primCru, palette, cssRaw, approved, reference: isRef },
+    });
+  }
+
+  // 3. ordena: referência primeiro, depois mais-verde primeiro, depois nome.
+  const score = (r) => (r.cells.tokens === 'yes' ? 1 : 0) + (r.cells.primitivos === 'yes' ? 1 : 0) + (r.cells.approved === 'yes' ? 1 : 0);
+  rows.sort((a, b) => {
+    if (!!b.reference - !!a.reference) return (b.reference ? 1 : 0) - (a.reference ? 1 : 0);
+    if (score(b) !== score(a)) return score(b) - score(a);
+    return a.screen.localeCompare(b.screen);
+  });
+
+  // 4. % = telas com tokens E primitivos verdes / telas contadas (exclui referência).
+  const counted = rows.filter((r) => !r.reference);
+  const done = counted.filter((r) => r.cells.tokens === 'yes' && r.cells.primitivos === 'yes').length;
+  const progressPct = counted.length ? Math.round((done / counted.length) * 100) : 0;
+
+  const tree = treeGuard();
+
+  return {
+    ledger: rows.map(({ _m, ...r }) => r),
+    progressPct,
+    progressLabel: 'adoção tokens + primitivos (censo Onda 0)',
+    measured: true,
+    measuredAgainstSha: shortSha(),
+    generatedAt: new Date().toISOString(),
+    treeGuard: tree,
+    counts: { screens: counted.length, done, references: rows.length - counted.length },
+    _detail: rows.map((r) => ({ screen: r.screen, ...r._m })),
+  };
+}
+
+function printTable(data) {
+  const pad = (s, n) => String(s).padEnd(n);
+  const lp = (s, n) => String(s).padStart(n);
+  const g = (c) => ({ yes: '✓', no: '·', ref: '★', na: '–' }[c] || '?');
+  console.log(`\n  Ledger de Conformidade DS — censo Onda 0 · @${data.measuredAgainstSha || '?'} · ${data.generatedAt.slice(0, 16).replace('T', ' ')}\n`);
+  console.log(`  ${pad('Tela', 26)} ${'Tok'} ${'Prim'} ${'Prob'} ${'Dark'} ${'[W]'}`);
+  console.log('  ' + '-'.repeat(54));
+  for (const r of data.ledger) {
+    const c = r.cells;
+    console.log(`  ${pad(r.screen, 26)}  ${g(c.tokens)}    ${g(c.primitivos)}    ${g(c.probe)}    ${g(c.dark)}   ${g(c.approved)}`);
+  }
+  console.log('  ' + '-'.repeat(54));
+  console.log(`\n  ${data.progressLabel}: ${lp(data.progressPct, 3)}%  (${data.counts.done}/${data.counts.screens} telas · ${data.counts.references} referência)`);
+  console.log(`  árvore de Components/ (components-tree-guard): ${data.treeGuard.pass ? '✓ canônica' : `✗ ${data.treeGuard.violations} violação(ões)`}`);
+  console.log(`  legenda: ✓ ok · · falta · ★ referência · – não medido (probe/dark = Camada 2 browser)\n`);
+}
+
+function main() {
+  const data = collect();
+  if (AS_JSON) { const { _detail, ...pub } = data; console.log(JSON.stringify(pub, null, 2)); return; }
+  if (DO_WRITE) {
+    const { _detail, ...pub } = data;
+    writeFileSync(OUT_FILE, JSON.stringify(pub, null, 2) + '\n');
+    console.log(`[ds-ledger] census gravado em governance/ds-ledger.json (${pub.counts.screens} telas · ${pub.progressPct}%).`);
+    printTable(data);
+    return;
+  }
+  printTable(data);
+}
+
+main();


### PR DESCRIPTION
## O quê

Tradução **F3** (PROTOCOL §2 — *[CL] traduz protótipo → Inertia/React real*) do protótipo Cowork **`DS Rollout - Ondas e Testes`** (handoff `claude.ai/design`) numa tela de governança real em **`/governance/ds-rollout`** — **+ o Ledger de Conformidade DS populado AO VIVO** por `scripts/ds-ledger.mjs` (o "censo Onda 0" que o próprio plano nomeia).

Origem: Wagner perguntou *"quantas ondas pra portar o DS inteiro, com teste pra ver se tudo foi aplicado?"* e depois *"conferiu o git?"*. Este PR aterriza a resposta: o plano em tela + o **placar que mede de verdade**.

## Censo real (não snapshot)

`ds-ledger.mjs` roda por Page: **eslint `ds/*`** (cor arbitrária + status-text + primitivos nativos) + **contador de paleta Tailwind crua** (medição-only, sem regra nova — `bg-stone-50`/`text-rose-700`…) + **`conformance-gate`** (cor crua no CSS bespoke) + **`components-tree-guard`** (árvore canônica, banner global). Grava `governance/ds-ledger.json` carimbado com SHA + timestamp; o controller lê isso.

**Medição `@b04b1e411`: 9% (3/35 telas verdes em tokens+primitivos · 1 referência).** O censo **reproduz a "Medição real"** do design — `Produto/Create` cai em **tokens** (stone/rose cru) **e primitivos** (`<input type=checkbox>` nativo, pego por `ds/no-native-checkbox`).

## Travas de governança (honradas)

- ✅ **A tela só mostra número que veio de gate rodando.** Sem o artefato, o controller cai num snapshot **rotulado `TODO ledger`** (`measured=false`) — nunca passa por número real.
- ✅ **`probe G1–13` + `dark` = "não medido"** (`–`), Camada 2 (probe de browser) — *nunca fingem verde*.
- ✅ **As ondas** (tokenizar cor / portar telas) seguem **Tier-0**, travadas no "vai" do Wagner onda-a-onda — **fora deste PR**.
- ✅ Tela canon: `@/Components/PageHeader` v3.8 (não o `shared/` congelado), `KpiCard`, **tokens semânticos** (`text-success`/`text-destructive`/`text-warning`) → **0 violações `ds/*`** na própria tela. Sem o bloco `<style>` OKLCH cru do protótipo.

## Arquivos (8 · +1427)

| Arquivo | Papel |
|---|---|
| `scripts/ds-ledger.mjs` | censo por-tela → JSON carimbado |
| `governance/ds-ledger.json` | artefato de medição (gerado · `npm run ds:ledger:write`) |
| `resources/js/Pages/governance/DsRollout.tsx` | a tela |
| `…/DsRollout.charter.md` | charter (status: draft — aguarda aprovação visual) |
| `Modules/Governance/Http/Controllers/DsRolloutController.php` | lê o census real / fallback TODO |
| `…/Http/routes.php` · `…/menus/topnav.php` | rota + nav |
| `package.json` | `npm run ds:ledger[:write]` |

## Validação

`eslint` (0 `ds/*`) · `tsc --noEmit` (0 erros no arquivo) · `php -l` (3 arquivos) · `components-tree-guard` ✓ canônica · charter contra `charter.schema.json` ✓.

## Gate de merge pendente (b)

Smoke visual de `/governance/ds-rollout` (screenshot 1280/1440) — a prova visual do PR. Roda local (dev autenticado) ou pós-deploy (skill `tela-smoke-pos-merge`). Charter fica `draft` até a aprovação visual do Wagner (gate F2).

> Nota: `governance/ds-ledger.json` é **gerado/carimbado**; refresh via `npm run ds:ledger:write`. Follow-up: step de CI/cron pra re-medir a cada merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)