### PR TITLE
fix(cliente): KPIs do placar Cliente reais server-side (fim do número sem prova)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -633,11 +633,47 @@ class ContactController extends Controller
             ->whereIn('transactions.payment_status', ['due', 'partial'])
             ->sum(DB::raw("final_total - {$totalPaidSub}"));
 
+        // Onda 3 (2026-06-12) — counts reais server-side dos 3 KPIs que vinham
+        // estimados client-side sobre a página (50 rows): VIPs · Sem compra 90d · Novos.
+        // Fecha o "número sem prova" do placar (charter Goal "Onda 3 plug backend").
+        $vips = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'vip')
+            ? (clone $base)->where('contacts.vip', 1)->count()
+            : 0;
+
+        $novos_mes = (clone $base)
+            ->where('contacts.created_at', '>=', now()->startOfMonth())
+            ->count();
+
+        // "Sem compra 90d" (risco churn) = JÁ comprou (venda não-draft) mas NADA nos
+        // últimos 90d. Alinha com a FrescorPill (last_purchase_at = MAX(transaction_date
+        // WHERE status != 'draft')) — não conta nunca-comprou (esses são "sem histórico",
+        // não churn). Subquery scoped por business_id (Tier 0 explícito · ADR 0093).
+        $sem_compra_90d = (clone $base)
+            ->whereExists(function ($q) use ($business_id) {
+                $q->select(DB::raw(1))->from('transactions')
+                  ->whereColumn('transactions.contact_id', 'contacts.id')
+                  ->where('transactions.business_id', $business_id)
+                  ->where('transactions.type', 'sell')
+                  ->where('transactions.status', '!=', 'draft');
+            })
+            ->whereNotExists(function ($q) use ($business_id) {
+                $q->select(DB::raw(1))->from('transactions')
+                  ->whereColumn('transactions.contact_id', 'contacts.id')
+                  ->where('transactions.business_id', $business_id)
+                  ->where('transactions.type', 'sell')
+                  ->where('transactions.status', '!=', 'draft')
+                  ->where('transactions.transaction_date', '>=', now()->subDays(90));
+            })
+            ->count();
+
         return [
             'total' => (int) $total,
             'com_os_aberta' => (int) $com_os_aberta,
             'com_atraso' => (int) $com_atraso,
             'valor_total_aberto' => $valor_total_aberto,
+            'vips' => (int) $vips,
+            'sem_compra_90d' => (int) $sem_compra_90d,
+            'novos_mes' => (int) $novos_mes,
         ];
     }
 

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -103,6 +103,10 @@ interface ClienteKpis {
   total: number;
   com_os_aberta: number;
   com_atraso: number;
+  // Onda 3 — counts reais server-side (antes estimados client-side sobre a página).
+  vips: number;
+  sem_compra_90d: number;
+  novos_mes: number;
   valor_total_aberto: number;
 }
 
@@ -687,32 +691,9 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
     return r;
   }, [rows, statusFilter, tipoFilter, ufFilter, tagsFilter, staleFilter, saldoFilter, recentMonthFilter]);
 
-  // PTDP Onda 2 — counts pros 5 KPI cards. Ativos + ComSaldo usam `kpis`
-  // reais do backend; VIPs + Sem90 + Novos vêm estimados das `rows` da página
-  // atual (Onda 3 plug backend dedicado quando volume de cadastros pedir).
-  const kpiCounts = useMemo(() => {
-    const now = Date.now();
-    const cutoff90 = now - 90 * 86400000;
-    const monthStart = new Date();
-    monthStart.setDate(1);
-    monthStart.setHours(0, 0, 0, 0);
-    const monthStartTs = monthStart.getTime();
-    let vipsCount = 0;
-    let sem90Count = 0;
-    let novosCount = 0;
-    for (const x of rows) {
-      if (x.vip) vipsCount++;
-      if (x.last_purchase_at) {
-        const t = new Date(x.last_purchase_at).getTime();
-        if (!Number.isNaN(t) && t < cutoff90) sem90Count++;
-      }
-      if (x.created_at) {
-        const t = new Date(x.created_at).getTime();
-        if (!Number.isNaN(t) && t >= monthStartTs) novosCount++;
-      }
-    }
-    return { vipsCount, sem90Count, novosCount };
-  }, [rows]);
+  // Onda 3 (2026-06-12) — os 5 counts dos KPI cards agora vêm TODOS reais do backend
+  // (`kpis.*`, scoped business_id). Removido o estimado client-side sobre as 50 rows da
+  // página (que mostrava "número sem prova": VIPs/Sem90/Novos da amostra, não do negócio).
 
   // KB-9.75 Slice A — reset row focus when the result set shrinks/changes.
   useEffect(() => {
@@ -1031,9 +1012,9 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
         <KpiStripClickable
           ativos={kpis?.com_os_aberta ?? 0}
           comSaldo={kpis?.com_atraso ?? 0}
-          vips={kpiCounts.vipsCount}
-          sem90={kpiCounts.sem90Count}
-          novos={kpiCounts.novosCount}
+          vips={kpis?.vips ?? 0}
+          sem90={kpis?.sem_compra_90d ?? 0}
+          novos={kpis?.novos_mes ?? 0}
           activeKey={activeKpiKey}
           onApply={applyKpiCard}
         />

--- a/resources/js/Pages/Cliente/_components/KpiStripClickable.tsx
+++ b/resources/js/Pages/Cliente/_components/KpiStripClickable.tsx
@@ -18,9 +18,9 @@
 //   - Constituição UI v2 · ADR UI-0013 (camada 4-Módulo)
 //   - PT-01 Slot 1 estende (não substitui PageHeader/KpiCard global)
 //
-// **Limitação atual (Onda 2):** counts de VIPs · Sem compra · Novos vêm
-// estimados das `rows` da página atual (Onda 3 plug backend real). Counts
-// de Ativos + Com saldo usam `kpis` reais já existentes.
+// **Onda 3 (2026-06-12 · fechada):** TODOS os 5 counts vêm reais do backend
+// (`kpis.*`, scoped business_id em ContactController::buildClienteIndexKpis). Antes,
+// VIPs/Sem-compra/Novos eram estimados sobre as 50 rows da página — "número sem prova".
 
 import type { ComponentType } from 'react';
 import { AlertCircle, Clock, Star, UserPlus, Users } from 'lucide-react';
@@ -52,11 +52,11 @@ export interface KpiStripClickableProps {
   ativos: number;
   /** Total real com saldo aberto (kpis.com_atraso). */
   comSaldo: number;
-  /** Estimado client-side (rows.filter vip). */
+  /** Total real VIP (kpis.vips · contacts.vip=1). */
   vips: number;
-  /** Estimado client-side (stale > 90d). */
+  /** Total real sem compra 90d / risco churn (kpis.sem_compra_90d). */
   sem90: number;
-  /** Estimado client-side (created_at >= mês atual). */
+  /** Total real novos no mês (kpis.novos_mes · created_at >= início do mês). */
   novos: number;
   /** Card ativo (null = nenhum). */
   activeKey: KpiKey | null;

--- a/tests/Feature/Cliente/ClienteKpisServerSideTest.php
+++ b/tests/Feature/Cliente/ClienteKpisServerSideTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * P0 — KPIs do placar Cliente: número que veio de query, não de amostra.
+ *
+ * Antes, 3 dos 5 cards (VIPs · Sem compra 90d · Novos) eram estimados client-side
+ * sobre as 50 rows da página — "número sem prova" (o mesmo pecado que o Ledger DS
+ * combate). Agora os 5 vêm reais de ContactController::buildClienteIndexKpis,
+ * scoped business_id (Tier 0 · ADR 0093).
+ *
+ * Estratégia (canon ClienteListagemTurbinadaTest): structural guards do query exato
+ * (a semântica É a corretude) + wiring frontend. Prova do NÚMERO real = smoke
+ * pós-deploy (Wagner confere o placar renderizado).
+ *
+ * Refs: charter Cliente/Index "Onda 3 plug backend" · ADR 0093 · FrescorPill (last_purchase_at).
+ */
+
+$controller = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+$index = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+$strip = __DIR__ . '/../../../resources/js/Pages/Cliente/_components/KpiStripClickable.tsx';
+
+test('P0 — buildClienteIndexKpis devolve os 3 counts reais (vips/sem_compra_90d/novos_mes)', function () use ($controller) {
+    $src = file_get_contents($controller);
+    expect($src)
+        ->toContain("'vips' => (int) \$vips")
+        ->toContain("'sem_compra_90d' => (int) \$sem_compra_90d")
+        ->toContain("'novos_mes' => (int) \$novos_mes");
+});
+
+test('P0 — VIPs conta contacts.vip=1 com guard de coluna (compat pré-migration Wave B)', function () use ($controller) {
+    $src = file_get_contents($controller);
+    expect($src)
+        ->toContain("Schema::hasColumn('contacts', 'vip')")
+        ->toContain("->where('contacts.vip', 1)");
+});
+
+test('P0 — Novos do mês = created_at >= início do mês', function () use ($controller) {
+    $src = file_get_contents($controller);
+    expect($src)->toContain("->where('contacts.created_at', '>=', now()->startOfMonth())");
+});
+
+test('P0 — Sem compra 90d (risco churn) = já comprou (não-draft) mas nada nos últimos 90d', function () use ($controller) {
+    $src = file_get_contents($controller);
+    // Bloco sem_compra_90d: whereExists (comprou) + whereNotExists (não nos 90d).
+    expect($src)
+        ->toContain('$sem_compra_90d = (clone $base)')
+        ->toContain('->whereExists(function ($q) use ($business_id) {')
+        ->toContain('->whereNotExists(function ($q) use ($business_id) {')
+        ->toContain("->where('transactions.status', '!=', 'draft')")
+        ->toContain("->where('transactions.transaction_date', '>=', now()->subDays(90))");
+});
+
+test('P0 — Tier 0: subqueries do sem_compra_90d scoped por business_id (ADR 0093)', function () use ($controller) {
+    $src = file_get_contents($controller);
+    // A subquery em transactions filtra business_id explícito (não só via join contact).
+    expect(substr_count($src, "->where('transactions.business_id', \$business_id)"))
+        ->toBeGreaterThanOrEqual(2); // exists + notExists do sem_compra_90d
+});
+
+test('P0 — frontend usa os counts reais do backend (kpis.*), não estimativa client-side', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain('vips={kpis?.vips ?? 0}')
+        ->toContain('sem90={kpis?.sem_compra_90d ?? 0}')
+        ->toContain('novos={kpis?.novos_mes ?? 0}')
+        // interface ClienteKpis expandida.
+        ->toContain('sem_compra_90d: number;')
+        ->toContain('novos_mes: number;')
+        // o estimado client-side (kpiCounts/vipsCount sobre rows) foi REMOVIDO.
+        ->not->toContain('kpiCounts')
+        ->not->toContain('vipsCount');
+});
+
+test('P0 — KpiStripClickable não anuncia mais "estimado client-side"', function () use ($strip) {
+    $src = file_get_contents($strip);
+    expect($src)
+        ->not->toContain('Estimado client-side')
+        ->toContain('Total real');
+});


### PR DESCRIPTION
## O quê (P0 da auditoria adversária da tela Cliente)

A tela `/contacts` mostra 5 KPI cards no topo. **3 deles — VIPs · Sem compra 90d · Novos — eram estimados client-side sobre as 50 rows da página**, exibidos como número do **negócio**. Para 13.432 cadastros, isso é número de **amostra** apresentado como verdade — o mesmo "número sem prova" que o Ledger DS (#2621) existe pra matar.

Agora os 5 vêm **reais do backend**, scoped `business_id` (Tier 0 · ADR 0093), no padrão dos 2 que já eram reais (`com_os_aberta`/`com_atraso`).

## Como

`ContactController::buildClienteIndexKpis` ganhou 3 counts:
- **`vips`** = `contacts.vip = 1` (com `Schema::hasColumn` guard p/ compat pré-migration Wave B)
- **`novos_mes`** = `created_at >= início do mês`
- **`sem_compra_90d`** (risco churn) = **já comprou** (venda não-`draft`) **mas nada nos últimos 90d** — `whereExists` + `whereNotExists`, alinhado com a `FrescorPill` (`last_purchase_at = MAX(transaction_date WHERE status != 'draft')`); exclui nunca-comprou (esses são "sem histórico", não churn). Subqueries com `business_id` explícito (Tier 0).

Frontend (`Cliente/Index.tsx`): usa `kpis.vips`/`kpis.sem_compra_90d`/`kpis.novos_mes`; **removido** o `useMemo` que estimava sobre `rows`.

## Fecha
Charter Cliente Goal **"Onda 3 — plug backend real dos KPIs"**. Resolve a fricção #1 da Larissa (saldo/fiado) deixar de aparecer falsamente como amostra.

## Prova
- `tests/Feature/Cliente/ClienteKpisServerSideTest.php` — 7 guards (query exato + Tier 0 scope + wiring frontend) · **passa local (22 assertions)**.
- Prova do **número renderizado** = smoke pós-deploy (Wagner confere o placar real).

## Não escopo (próximas fatias da "completar Cliente")
P1 (default sort garbage-first + subtítulo que duplica o nome) · P2 (badge 99+ · scrim drawer) · domínio PF/PJ ("Outros" em vez de "—"). A tokenização de cor (Onda 1 original) entra quando eu tocar essas linhas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)