### PR TITLE
fix(cliente): paginação server-side funcionando + FAB não cobre o pager

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -420,14 +420,20 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
     }
     router.reload({
       only: ['customers'],
-      data: { q: search || undefined, page: 1 },
+      data: { q: search || undefined, page: 1, per_page: perPageRef.current },
       preserveScroll: true,
       preserveState: true,
     });
   }, [search]);
 
   const [page, setPage] = useState(1);
-  const [perPage, setPerPage] = useState(25);
+  // Default 50 = default do backend (ContactController per_page). Antes era 25 e
+  // o placar mostrava "/ N" do servidor (50) divergindo do dropdown — bug Wagner.
+  const [perPage, setPerPage] = useState(50);
+  // Lê o perPage atual dentro do effect de busca sem virar dep (evita reload duplo
+  // ao trocar página + mantém o tamanho de página ao buscar).
+  const perPageRef = useRef(perPage);
+  perPageRef.current = perPage;
   const [sortKey, setSortKey] = useState<SortKey>('name');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [openContactId, setOpenContactId] = useState<number | null>(null);
@@ -1365,8 +1371,31 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
           </div>
 
           {meta && meta.total > 0 && (
-            <Pagination meta={meta} perPage={perPage} onPageChange={setPage} onPerPageChange={setPerPage} />
+            <Pagination
+              meta={meta}
+              perPage={perPage}
+              onPageChange={(p) => {
+                // Antes só atualizava o state (não buscava) → setas mortas. Agora
+                // manda page pro servidor (paginate() lê da query) — bug Wagner.
+                setPage(p);
+                router.reload({
+                  only: ['customers'],
+                  data: { q: search || undefined, page: p, per_page: perPage },
+                });
+              }}
+              onPerPageChange={(n) => {
+                setPerPage(n);
+                setPage(1);
+                router.reload({
+                  only: ['customers', 'kpis', 'tab_counts'],
+                  data: { q: search || undefined, page: 1, per_page: n },
+                });
+              }}
+            />
           )}
+          {/* Clearance pro FAB de atalhos (fixed bottom-4 right-4) não cobrir a
+              paginação quando rolado até o fim — bug "desalinhado" Wagner. */}
+          <div aria-hidden className="h-14" />
         </Deferred>
       </div>
 

--- a/tests/Feature/Cliente/ClientePaginacaoServerSideTest.php
+++ b/tests/Feature/Cliente/ClientePaginacaoServerSideTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bug Wagner (2026-06-12): "paginação não está funcionando" + "desalinhados".
+ *
+ * Causa: as setas/dropdown só atualizavam o state local (setPage/setPerPage) e
+ * NUNCA re-buscavam — o servidor ficava preso na página 1, per_page=50 default
+ * (13.432/50 ≈ 269 páginas) enquanto o dropdown mostrava 100. Setas mortas.
+ * O backend (paginate() + input('per_page')) JÁ suportava — era só o frontend
+ * não mandar page/per_page no router.reload.
+ *
+ * + FAB de atalhos (fixed bottom-4 right-4) cobria a paginação no fim da rolagem.
+ *
+ * Canon: structural guards (file_get_contents). Prova do clique real = smoke pós-deploy.
+ */
+
+$index = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+$controller = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+
+test('paginação — onPageChange manda page + per_page pro servidor (seta deixa de ser morta)', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain('onPageChange={(p) => {')
+        ->toContain('data: { q: search || undefined, page: p, per_page: perPage }');
+});
+
+test('paginação — onPerPageChange reseta page=1 e manda o novo per_page', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain('onPerPageChange={(n) => {')
+        ->toContain('data: { q: search || undefined, page: 1, per_page: n }');
+});
+
+test('paginação — perPage default 50 = default do backend (dropdown não diverge do "/ N")', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)->toContain('const [perPage, setPerPage] = useState(50)');
+});
+
+test('paginação — busca preserva o tamanho de página (per_page via ref, sem virar dep)', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain('const perPageRef = useRef(perPage)')
+        ->toContain('data: { q: search || undefined, page: 1, per_page: perPageRef.current }');
+});
+
+test('backend — buildClienteIndexCustomers já pagina via per_page (paginate lê page da query)', function () use ($controller) {
+    $src = file_get_contents($controller);
+    expect($src)
+        ->toContain("request()->input('per_page', 50)")
+        ->toContain('->paginate($perPage)');
+});
+
+test('alinhamento — spacer de clearance pro FAB de atalhos não cobrir a paginação', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)->toContain('Clearance pro FAB de atalhos');
+});


### PR DESCRIPTION
## Bug reportado (Wagner, screenshots prod)
1. **"paginação não está funcionando"** — `« ‹ 1 / 269 › »` com **100/página** e 13.432 cadastros não fecha (13.432/**50** ≈ 269). Clicar nas setas **não fazia nada**.
2. **"desalinhados"** — o FAB de atalhos (⌨ `?`, `fixed bottom-4 right-4`) cobre a paginação no fim da rolagem.

## Causa
As setas e o dropdown só atualizavam **state local** (`setPage`/`setPerPage`) e **nunca re-buscavam**. O servidor ficava preso em `page=1`, `per_page=50` (default), enquanto o dropdown mostrava o `perPage` do cliente (100) — daí o "269" e as setas mortas. O **backend já suportava** (`->paginate($perPage)` lê `page` da query; `request()->input('per_page', 50)`) — era **só o frontend não mandar**.

## Fix (frontend-only)
- `onPageChange`/`onPerPageChange` agora fazem `router.reload` com `page` + `per_page`.
- `perPage` default **25 → 50** (= default do backend) → o `/ N` para de divergir do dropdown.
- Busca preserva o tamanho de página (`per_page` via `ref`, sem virar dep → sem reload duplo).
- Spacer de clearance pro FAB não cobrir o pager.

> Não usa `preserveScroll`/`preserveState` (inválidos no `ReloadOptions` desta versão de Inertia — `reload` já preserva por default), então **net-zero tsc/eslint**.

## Prova
`tests/Feature/Cliente/ClientePaginacaoServerSideTest.php` — 6 guards (wiring page/per_page + default 50 + backend paginate) · **passa local (10 assertions)**. Prova do **clique real** = smoke pós-deploy.

> Toca `Index.tsx` junto do #2622 (KPIs), mas em **regiões disjuntas** (lá: interface/KpiStrip; aqui: estado do pager/handlers) → auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)