### PR TITLE
fix(cliente): subtítulo não duplica o nome (P1)

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -1247,19 +1247,26 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                                 </span>
                               )}
                             </div>
-                            {/* Sub-nome: fantasia (PJ) ou telefone (contato rápido). */}
-                            {(row.fantasia || row.mobile) && (
-                              <div className="text-[11px] text-muted-foreground/70 leading-tight mt-0.5 flex items-center gap-1">
-                                {row.fantasia ? (
-                                  <span className="truncate">{row.fantasia}</span>
-                                ) : (
-                                  <>
-                                    <Phone size={9} className="opacity-60" />
-                                    <span className="tabular-nums">{row.mobile}</span>
-                                  </>
-                                )}
-                              </div>
-                            )}
+                            {/* Sub-nome: fantasia (PJ) ou telefone. Suprime quando a fantasia
+                                == razão social (legado preenche fantasia = nome → duplicava
+                                a identidade na lista, desperdiçando a linha. Bug Wagner). */}
+                            {(() => {
+                              const f = row.fantasia?.trim();
+                              const fant = f && f.toLowerCase() !== row.name.trim().toLowerCase() ? f : null;
+                              if (!fant && !row.mobile) return null;
+                              return (
+                                <div className="text-[11px] text-muted-foreground/70 leading-tight mt-0.5 flex items-center gap-1">
+                                  {fant ? (
+                                    <span className="truncate">{fant}</span>
+                                  ) : (
+                                    <>
+                                      <Phone size={9} className="opacity-60" />
+                                      <span className="tabular-nums">{row.mobile}</span>
+                                    </>
+                                  )}
+                                </div>
+                              );
+                            })()}
                           </td>
                           <td className="px-4 py-2.5">
                             <TipoPill tipo={row.tipo ?? null} />

--- a/tests/Feature/Cliente/ClienteSubtituloDedupTest.php
+++ b/tests/Feature/Cliente/ClienteSubtituloDedupTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bug Wagner (auditoria adversária da tela Cliente, P1): o subtítulo da linha
+ * repetia o nome — o legado preenche `fantasia` = razão social, então
+ * ".COM COMUNICAÇÃO E EVENTOS" aparecia DUAS vezes (título + subtítulo),
+ * desperdiçando a linha de identidade (a mais valiosa pra "achar em ≤3s").
+ *
+ * Fix: só mostra a fantasia como subtítulo quando ela DIFERE do nome
+ * (case-insensitive, trimmed); senão cai pro telefone ou nada.
+ *
+ * Canon: structural guard. Confirmação visual = smoke pós-deploy.
+ */
+
+$index = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+
+test('subtítulo — suprime a fantasia quando == razão social (não duplica o nome)', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain("f.toLowerCase() !== row.name.trim().toLowerCase()")
+        // fallback honesto: telefone ou nada (não renderiza o duplicado).
+        ->toContain('if (!fant && !row.mobile) return null;');
+});


### PR DESCRIPTION
## Bug (auditoria adversária · P1)
Na lista de contatos o **nome aparecia 2×** — título **e** subtítulo (ex: `.COM COMUNICAÇÃO E EVENTOS` repetido). O legado preenche `fantasia` = razão social, e a linha mostrava `fantasia` como subtítulo sempre. Desperdiça a linha de identidade — a mais valiosa pro job "achar o cliente em ≤3s".

## Fix
Só mostra a `fantasia` como subtítulo quando **difere** do nome (case-insensitive, trimmed); senão cai pro telefone, ou nada. Net-zero tsc/eslint.

## Prova
`ClienteSubtituloDedupTest` (guard) · confirmação visual = smoke pós-deploy.

> Toca `Index.tsx` em região disjunta de #2622/#2623 (já mergeados).

🤖 Generated with [Claude Code](https://claude.com/claude-code)