### PR TITLE
fix(cliente): sort server-side — default Recentes + cabeçalho funciona (P1b)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -881,9 +881,44 @@ class ContactController extends Controller
             });
         }
 
+        // Sort server-side (ligado 2026-06-12 · bug Wagner "alfabético → lixo de
+        // símbolo primeiro"). Default job-aligned = RECENTES (id desc) em vez de
+        // alfabético (que jogava ".COM"/"@"/"&"/"+" no topo). Whitelist anti-injeção;
+        // colunas agregadas (count/sum/max de transactions) via leftJoinSub 1:1.
+        $sortInput = (string) request()->input('sort', 'recent');
+        $hasDir = request()->filled('dir');
+        $dir = strtolower((string) request()->input('dir', 'desc')) === 'asc' ? 'asc' : 'desc';
+        $AGG = ['total_os', 'valor_aberto', 'last_os_at'];
+        $DIRECT = ['recent' => 'contacts.id', 'name' => 'contacts.name'];
+
+        if (in_array($sortInput, $AGG, true)) {
+            $totalPaidSub = '(SELECT COALESCE(SUM(tp.amount), 0) FROM transaction_payments tp WHERE tp.transaction_id = transactions.id)';
+            $aggSub = Transaction::query()
+                ->where('business_id', $business_id)
+                ->where('type', 'sell')
+                ->groupBy('contact_id')
+                ->select(
+                    'contact_id',
+                    DB::raw('COUNT(*) AS total_os'),
+                    DB::raw('MAX(transaction_date) AS last_os_at'),
+                    DB::raw("SUM(CASE WHEN payment_status IN ('due','partial') THEN (final_total - {$totalPaidSub}) ELSE 0 END) AS valor_aberto"),
+                );
+            // $sortInput é whitelisted (in_array $AGG) → seguro no orderByRaw.
+            $contactsQuery->leftJoinSub($aggSub, 'cli_agg', 'cli_agg.contact_id', '=', 'contacts.id')
+                ->orderByRaw("cli_agg.{$sortInput} IS NULL")   // sem histórico por último
+                ->orderBy("cli_agg.{$sortInput}", $dir);
+        } else {
+            $col = $DIRECT[$sortInput] ?? $DIRECT['recent'];
+            // Default dir: recent=desc (mais novo), name=asc (alfabético natural) salvo dir explícito.
+            if (! $hasDir) {
+                $dir = $col === 'contacts.name' ? 'asc' : 'desc';
+            }
+            $contactsQuery->orderBy($col, $dir);
+        }
+
         $contacts = $contactsQuery
             ->select($selectCols)
-            ->orderBy('contacts.name', 'asc')
+            ->orderBy('contacts.id', 'desc')   // tie-breaker determinístico (paginação estável)
             ->paginate($perPage)
             ->withQueryString();
 

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -271,7 +271,7 @@ export interface ClienteIndexPageProps {
 }
 
 type StatusFilter = '' | 'late' | 'active' | 'idle';
-type SortKey = 'name' | 'total_os' | 'valor_aberto' | 'last_os_at';
+type SortKey = 'recent' | 'name' | 'total_os' | 'valor_aberto' | 'last_os_at';
 type SortDir = 'asc' | 'desc';
 
 const STATUS_FILTER_STORAGE_KEY = 'oimpresso.cliente.lastStatus';
@@ -424,7 +424,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
     }
     router.reload({
       only: ['customers'],
-      data: { q: search || undefined, page: 1, per_page: perPageRef.current },
+      data: { q: search || undefined, page: 1, per_page: perPageRef.current, sort: sortRef.current.key, dir: sortRef.current.dir },
       preserveScroll: true,
       preserveState: true,
     });
@@ -438,8 +438,12 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
   // ao trocar página + mantém o tamanho de página ao buscar).
   const perPageRef = useRef(perPage);
   perPageRef.current = perPage;
-  const [sortKey, setSortKey] = useState<SortKey>('name');
-  const [sortDir, setSortDir] = useState<SortDir>('asc');
+  // Default 'recent' (id desc) — job-aligned, sem lixo alfabético de símbolo no topo.
+  const [sortKey, setSortKey] = useState<SortKey>('recent');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+  // Lê o sort atual nos reloads sem virar dep (igual perPageRef).
+  const sortRef = useRef({ key: sortKey, dir: sortDir });
+  sortRef.current = { key: sortKey, dir: sortDir };
   const [openContactId, setOpenContactId] = useState<number | null>(null);
   // 2026-06-08 (Wagner "arrumar botões da contacts") — aba-alvo do drawer ao abrir.
   // Consolidação ADR 0179: o menu ⋮ da linha não manda mais pra Blade legacy
@@ -773,18 +777,21 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
     return () => window.removeEventListener('keydown', onKey);
   }, [paletteOpen, cheatOpen, filteredRows, focusedIndex, openDrawer]);
 
+  // Sort server-side (bug Wagner): antes só mexia state e NÃO re-buscava (cabeçalho
+  // morto, igual paginação). Agora manda sort/dir pro backend (whitelist) e reseta
+  // pra página 1. name=asc default; demais (recent/total_os/valor_aberto/last_os_at)=desc.
   const handleSort = useCallback((key: SortKey) => {
-    setSortKey((prevKey) => {
-      if (key === prevKey) return prevKey;
-      return key;
+    const newDir: SortDir = key === sortKey
+      ? (sortDir === 'asc' ? 'desc' : 'asc')
+      : (key === 'name' ? 'asc' : 'desc');
+    setSortKey(key);
+    setSortDir(newDir);
+    setPage(1);
+    router.reload({
+      only: ['customers'],
+      data: { q: search || undefined, page: 1, per_page: perPageRef.current, sort: key, dir: newDir },
     });
-    setSortDir((prevDir) => {
-      if (key === sortKey) {
-        return prevDir === 'asc' ? 'desc' : 'asc';
-      }
-      return key === 'last_os_at' || key === 'valor_aberto' ? 'desc' : 'asc';
-    });
-  }, [sortKey]);
+  }, [sortKey, sortDir, search]);
 
   // Wave G — pills array removido (substituído por 6 FilterDropdown — ver nav acima).
   // KPIs/contadores ficam no header (subtítulo inline) + count "X de Y" ao lado dos filtros.
@@ -1361,7 +1368,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                 setPage(p);
                 router.reload({
                   only: ['customers'],
-                  data: { q: search || undefined, page: p, per_page: perPage },
+                  data: { q: search || undefined, page: p, per_page: perPage, sort: sortRef.current.key, dir: sortRef.current.dir },
                 });
               }}
               onPerPageChange={(n) => {
@@ -1369,7 +1376,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                 setPage(1);
                 router.reload({
                   only: ['customers', 'kpis', 'tab_counts'],
-                  data: { q: search || undefined, page: 1, per_page: n },
+                  data: { q: search || undefined, page: 1, per_page: n, sort: sortRef.current.key, dir: sortRef.current.dir },
                 });
               }}
             />

--- a/tests/Feature/Cliente/ClienteSortServerSideTest.php
+++ b/tests/Feature/Cliente/ClienteSortServerSideTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Bug Wagner (P1b): a lista vinha alfabética (server hardcoded `name asc`) → lixo de
+ * símbolo no topo (".COM", "@", "&", "+"), enterrando os clientes recorrentes. E o
+ * sort de coluna estava meio-ligado (state local, backend ignorava, header morto).
+ *
+ * Fix: sort SERVER-SIDE com whitelist. Default job-aligned = RECENTES (id desc).
+ * Colunas agregadas (total_os/valor_aberto/last_os_at) via leftJoinSub 1:1.
+ * Frontend manda sort/dir em todo reload e o cabeçalho re-busca de verdade.
+ *
+ * Canon: structural guards. Prova da ordem real + perf = smoke pós-deploy.
+ */
+
+$controller = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+$index = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+
+test('backend — sort lido com whitelist + default RECENTES (id desc), não mais name asc', function () use ($controller) {
+    $src = file_get_contents($controller);
+    expect($src)
+        ->toContain("request()->input('sort', 'recent')")
+        ->toContain("'recent' => 'contacts.id'")
+        ->toContain("'name' => 'contacts.name'")
+        // o hardcoded antigo (name asc na paginação) saiu
+        ->not->toContain("->orderBy('contacts.name', 'asc')\n            ->paginate");
+});
+
+test('backend — colunas agregadas via leftJoinSub (whitelist anti-injeção) + NULLs por último', function () use ($controller) {
+    $src = file_get_contents($controller);
+    expect($src)
+        ->toContain("\$AGG = ['total_os', 'valor_aberto', 'last_os_at']")
+        ->toContain('leftJoinSub($aggSub, \'cli_agg\'')
+        ->toContain('orderByRaw("cli_agg.{$sortInput} IS NULL")')
+        // tie-breaker determinístico pra paginação estável
+        ->toContain("->orderBy('contacts.id', 'desc')   // tie-breaker");
+});
+
+test('frontend — SortKey ganha "recent" e é o default (dir desc)', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain("type SortKey = 'recent' | 'name'")
+        ->toContain("useState<SortKey>('recent')")
+        ->toContain("useState<SortDir>('desc')");
+});
+
+test('frontend — handleSort re-busca server-side (cabeçalho deixa de ser morto)', function () use ($index) {
+    $src = file_get_contents($index);
+    expect($src)
+        ->toContain('sort: key, dir: newDir')
+        // os reloads de busca/página carregam o sort atual via ref
+        ->toContain('sort: sortRef.current.key, dir: sortRef.current.dir');
+});


### PR DESCRIPTION
## Bug (auditoria adversária · P1b)
A lista vinha **alfabética** (server `orderBy('name','asc')` hardcoded) → lixo de símbolo (`.COM`, `@`, `&`, `+`) no topo, **enterrando os clientes recorrentes** (contra o job "achar em ≤3s"). E o **sort de coluna estava meio-ligado** (`sortKey`/`sortDir` em state, backend ignorava, header "morto" — exatamente como a paginação estava antes).

## Fix (server-side, padrão da paginação)
**Backend** — sort lido com **whitelist** (anti-injeção):
- **Default job-aligned = Recentes** (`contacts.id` desc) em vez de alfabético → mata o garbage-first.
- `name` → coluna direta (asc).
- `total_os` / `valor_aberto` / `last_os_at` → **`leftJoinSub` 1:1** (mirror do `$stats` existente), `NULLs` (sem histórico) por último, **tie-breaker `id desc`** (paginação estável). Join só quando ordena por agregado (perf).

**Frontend** — `SortKey` ganha `'recent'` (default, dir `desc` → some a seta mentindo no header "Cliente ↑"); `handleSort` e **todos os reloads** (busca/página/perPage) mandam `sort`/`dir` (via `ref`, sem virar dep).

## Prova
`ClienteSortServerSideTest` — 4 guards (whitelist + default + joinSub + wiring) · **passa local (13 assertions)**. Net-zero tsc/eslint.
Ordem real renderizada **+ perf da agregação por coluna** = **smoke pós-deploy** (gate).

> Toca `Index.tsx` em regiões disjuntas de #2624 (subtítulo) → auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)