### PR TITLE
test(governance): Pest do snapshot SDD + card composta v1 no dashboard (GT-G7 2/2)

### DIFF
--- a/Modules/Governance/Http/Controllers/DashboardController.php
+++ b/Modules/Governance/Http/Controllers/DashboardController.php
@@ -54,6 +54,9 @@ class DashboardController extends Controller
             'audit_highlights'  => $this->buildAuditHighlightsPayload(),
             'health_kpis'       => $health['kpis'],
             'narratives'        => $health['narratives'],
+            // GT-G7 — card SDD (ADR 0275). Deferred: Page TEM <Deferred> wrapper
+            // (diferente do rollback W7 #953 — aqui o frontend já nasce preparado).
+            'sdd'               => Inertia::defer(fn () => $this->buildSddPayload()),
             // Configs estáticas — eager (zero I/O).
             'actiongate_mode'   => config('governance.actiongate_mode', 'warn'),
             'next_review_at'    => config('governance.next_review_at'),
@@ -138,6 +141,48 @@ class DashboardController extends Controller
             'actors_registered'    => $actorsCount,
             'audit_highlights'     => $auditHighlightsCount,
             'compliance_pct'       => $compliancePct,
+        ];
+    }
+
+    /**
+     * GT-G7 — resumo SDD do último snapshot diário (mcp_sdd_scorecard_history)
+     * + Δ da composta vs snapshot anterior. Degrada graciosamente (tabela
+     * ausente ou sem rows → null; card mostra empty-state).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function buildSddPayload(): ?array
+    {
+        if (! Schema::hasTable('mcp_sdd_scorecard_history')) {
+            return null;
+        }
+
+        $rows = DB::table('mcp_sdd_scorecard_history')
+            ->orderByDesc('snapshot_date')
+            ->limit(2)
+            ->get();
+
+        $latest = $rows->first();
+        if ($latest === null) {
+            return null;
+        }
+
+        $previous = $rows->get(1);
+        $payload = json_decode((string) $latest->payload, true) ?: [];
+
+        $delta = null;
+        if ($latest->composta !== null && $previous !== null && $previous->composta !== null) {
+            $delta = round((float) $latest->composta - (float) $previous->composta, 1);
+        }
+
+        return [
+            'snapshot_date' => (string) $latest->snapshot_date,
+            'composta'      => $latest->composta !== null ? (float) $latest->composta : null,
+            'composta_k'    => (int) ($payload['composta_k'] ?? 0),
+            'delta'         => $delta,
+            'vivas'         => (int) ($payload['vivas'] ?? 0),
+            'metrics_total' => (int) ($payload['metrics_total'] ?? 10),
+            'alerts'        => array_values((array) ($payload['alerts'] ?? [])),
         ];
     }
 

--- a/Modules/Governance/Tests/Feature/SddScorecardSnapshotCommandTest.php
+++ b/Modules/Governance/Tests/Feature/SddScorecardSnapshotCommandTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tests pra `governance:sdd-scorecard-snapshot` (GT-G7 — ADR 0275).
+ * Fixtures via --input/--baseline (CI safe — sem node, sem repo scan).
+ *
+ * @see Modules/Governance/Console/Commands/SddScorecardSnapshotCommand.php
+ */
+
+uses(RefreshDatabase::class);
+
+function sddG7ScorecardFixture(float $ghost = 27.0, float $door = 63.9): string
+{
+    $path = sys_get_temp_dir().'/sdd-g7-scorecard.json';
+    file_put_contents($path, json_encode(['metrics' => [
+        'ghost_count'          => ['status' => 'measured', 'value' => $ghost, 'direction' => 'down', 'target' => 0],
+        'front_door_coverage'  => ['status' => 'measured', 'value' => $door, 'direction' => 'up', 'target' => 100],
+        'full_suite_pass_rate' => ['status' => 'not_yet_measured', 'value' => null, 'direction' => 'up', 'target' => 100],
+    ]]));
+
+    return $path;
+}
+
+function sddG7BaselineFixture(): string
+{
+    $path = sys_get_temp_dir().'/sdd-g7-baseline.json';
+    file_put_contents($path, json_encode(['metrics' => [
+        'ghost_count'          => ['status' => 'measured', 'value' => 27, 'direction' => 'down', 'armed' => true],
+        'front_door_coverage'  => ['status' => 'measured', 'value' => 63.9, 'direction' => 'up', 'armed' => true],
+        'full_suite_pass_rate' => ['status' => 'not_yet_measured', 'value' => null, 'direction' => 'up', 'armed' => false],
+    ]]));
+
+    return $path;
+}
+
+it('persiste 1 row/dia com composta v1 (média das armadas) + resumo no payload', function () {
+    expect(Schema::hasTable('mcp_sdd_scorecard_history'))->toBeTrue();
+
+    $this->artisan('governance:sdd-scorecard-snapshot', [
+        '--input'    => sddG7ScorecardFixture(),
+        '--baseline' => sddG7BaselineFixture(),
+        '--date'     => '2026-06-12',
+    ])->expectsOutputToContain('Snapshot SDD OK')->assertExitCode(0);
+
+    $row = DB::table('mcp_sdd_scorecard_history')->where('snapshot_date', '2026-06-12')->first();
+    expect($row)->not->toBeNull();
+    // ghost 27→27 (0% do caminho) + door 63.9→63.9 (0%) → composta 0.0, k=2
+    expect((float) $row->composta)->toBe(0.0);
+
+    $payload = json_decode($row->payload, true);
+    expect($payload['composta_k'])->toBe(2)
+        ->and($payload['vivas'])->toBe(2)
+        ->and($payload['metrics_total'])->toBe(3)
+        ->and($payload['alerts'])->toBe([])
+        ->and($payload['scorecard']['metrics'])->toHaveKey('ghost_count');
+});
+
+it('é idempotente por dia — re-run substitui a row e registra alerta de regressão armada', function () {
+    $args = ['--baseline' => sddG7BaselineFixture(), '--date' => '2026-06-12'];
+
+    $this->artisan('governance:sdd-scorecard-snapshot', $args + ['--input' => sddG7ScorecardFixture()])->assertExitCode(0);
+    $this->artisan('governance:sdd-scorecard-snapshot', $args + ['--input' => sddG7ScorecardFixture()])->assertExitCode(0);
+    expect(DB::table('mcp_sdd_scorecard_history')->count())->toBe(1);
+
+    // ghost_count regrediu (27 → 30, armada "só desce") — re-run do dia substitui + alerta
+    $this->artisan('governance:sdd-scorecard-snapshot', $args + ['--input' => sddG7ScorecardFixture(ghost: 30.0)])->assertExitCode(0);
+    expect(DB::table('mcp_sdd_scorecard_history')->count())->toBe(1);
+
+    $payload = json_decode(DB::table('mcp_sdd_scorecard_history')->value('payload'), true);
+    expect($payload['alerts'])->toHaveCount(1)
+        ->and($payload['alerts'][0])->toContain('ghost_count');
+});
+
+it('schedule governance:sdd-scorecard-snapshot registrado daily 07:10 BRT', function () {
+    $schedule = app(\Illuminate\Console\Scheduling\Schedule::class);
+    $event = collect($schedule->events())
+        ->first(fn ($e) => str_contains((string) $e->command, 'governance:sdd-scorecard-snapshot'));
+
+    expect($event)->not->toBeNull('Schedule não registrado em app/Console/Kernel.php');
+    expect($event->expression)->toBe('10 7 * * *');
+    expect($event->timezone)->toBe('America/Sao_Paulo');
+});

--- a/resources/js/Pages/governance/Dashboard.tsx
+++ b/resources/js/Pages/governance/Dashboard.tsx
@@ -3,7 +3,7 @@
 //   adrs: 0079 (Constituição Art. 8+9), 0086 (Fase 5 MVP)
 
 import React, { type ReactNode } from 'react'
-import { Link } from '@inertiajs/react'
+import { Deferred, Link } from '@inertiajs/react'
 import AppShellV2 from '@/Layouts/AppShellV2'
 import { Card, CardContent } from '@/Components/ui/card'
 import { Badge } from '@/Components/ui/badge'
@@ -51,7 +51,18 @@ interface HealthKpis {
   last_narrative: { severity: 'info' | 'warning' | 'critical'; message: string; generated_at: string } | null
 }
 
+interface SddPayload {
+  snapshot_date: string
+  composta: number | null
+  composta_k: number
+  delta: number | null
+  vivas: number
+  metrics_total: number
+  alerts: string[]
+}
+
 interface Props {
+  sdd?: SddPayload | null
   kpis: {
     pending_adrs: number
     active_policies: number
@@ -117,6 +128,7 @@ function truncate(text: string, max: number): string {
 }
 
 const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
+  sdd,
   kpis,
   pending_adrs,
   audit_highlights,
@@ -189,6 +201,46 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
           description={`v1.1.0 — próx revisão ${next_review_at}`}
         />
       </KpiGrid>
+
+      <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400 mt-4">
+        SDD — Reestruturação (ADR 0275)
+      </h2>
+
+      <Deferred data="sdd" fallback={<p className="text-sm text-zinc-400">Carregando scorecard SDD…</p>}>
+        {sdd ? (
+          <KpiGrid cols={3}>
+            <KpiCard
+              icon="gauge"
+              tone={sdd.delta !== null && sdd.delta < 0 ? 'danger' : 'info'}
+              label={`Composta v1 (k=${sdd.composta_k})`}
+              value={sdd.composta === null ? '—' : sdd.composta.toLocaleString('pt-BR', { minimumFractionDigits: 1, maximumFractionDigits: 1 })}
+              description={
+                sdd.delta === null
+                  ? `snapshot ${sdd.snapshot_date} — sem Δ (1º snapshot ou composta nula)`
+                  : `Δ vs ontem: ${sdd.delta > 0 ? '+' : ''}${sdd.delta.toLocaleString('pt-BR')} · ${sdd.snapshot_date}`
+              }
+            />
+            <KpiCard
+              icon="activity"
+              tone="info"
+              label="Métricas vivas"
+              value={`${sdd.vivas}/${sdd.metrics_total}`}
+              description="fontes medindo de verdade (status measured)"
+            />
+            <KpiCard
+              icon="alert-triangle"
+              tone={sdd.alerts.length > 0 ? 'danger' : 'success'}
+              label="Alertas SDD"
+              value={sdd.alerts.length.toString()}
+              description={sdd.alerts.length > 0 ? truncate(sdd.alerts[0], 70) : 'nenhuma métrica armada regrediu'}
+            />
+          </KpiGrid>
+        ) : (
+          <p className="text-sm text-zinc-500">
+            Sem snapshot SDD ainda — cron `governance:sdd-scorecard-snapshot` roda 07:00 BRT.
+          </p>
+        )}
+      </Deferred>
 
       <h2 className="text-sm font-semibold uppercase tracking-widest text-zinc-500 dark:text-zinc-400 mt-4">
         Saúde do ecossistema

--- a/resources/js/Pages/governance/Dashboard.tsx
+++ b/resources/js/Pages/governance/Dashboard.tsx
@@ -237,7 +237,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
           </KpiGrid>
         ) : (
           <p className="text-sm text-zinc-500">
-            Sem snapshot SDD ainda — cron `governance:sdd-scorecard-snapshot` roda 07:00 BRT.
+            Sem snapshot SDD ainda — cron `governance:sdd-scorecard-snapshot` roda 07:10 BRT.
           </p>
         )}
       </Deferred>


### PR DESCRIPTION
> ♻️ **Recriado de #2618** — o --delete-branch no merge da base (#2617) squashada fechou o PR empilhado. Conteúdo idêntico (cherry-pick a78ceab2f + f16b64c6e sobre main).

## O quê

**depends-on PR-1** (#2617 — merge primeiro; base deste PR é `sdd/f2-gt-g7`).

Frente **GT-G7** PR 2/2 (US-GOV-017 fase 2 · ADR 0275):

- **`SddScorecardSnapshotCommandTest`** (Pest, fixtures via `--input`/`--baseline` — sem node, sem repo scan): composta v1 + resumo no payload · idempotência por dia (re-run substitui) + alerta de regressão armada · schedule daily 07:10 America/Sao_Paulo registrado no Kernel.
- **DashboardController**: prop `sdd` via **`Inertia::defer`** (query só roda quando o reload pede); payload com Δ da composta vs snapshot anterior; degrada graciosamente (tabela ausente/sem rows → null → empty-state).
- **Dashboard.tsx**: seção "SDD — Reestruturação (ADR 0275)" com 3 KpiCards (composta v1 **com k explícito** + Δ · métricas vivas X/10 · alertas) dentro de `<Deferred>` com fallback. Empty-state cita o horário real do cron (07:10 BRT) alinhado ao Kernel + ao assert do Pest (`10 7 * * *`).

## Cobertura real do teste (correção de honestidade)

⚠️ **`SddScorecardSnapshotCommandTest` está registrado no `phpunit.xml`, mas NENHUM workflow de CI o executa hoje.** O subset do `ci.yml` (job "PHP / Pest (Unit)", linha ~101) roda só `tests/Feature/Form`, `tests/Feature/Services/FeatureFlagServiceTest.php` e dois testes de `Modules/Jana` — **não inclui `Modules/Governance/Tests`**. O `modules-pest.yml` (matrix) cobre Arquivos/ComunicacaoVisual/Fiscal/NfeBrasil/Repair/Vestuario — **também não cobre Governance**.

Consequência: o check verde "PHP / Pest (Unit)" **NÃO exercita** este teste. Validação real do Pest fica pro flip da nightly CT 100 (**FV-F3**) — adicionar `Modules/Governance` ao subset de CI é gap sistêmico de outra frente, fora do escopo deste PR.

## Checklist revisão G7 (pre-flight da frente)

- ✅ Migration segue padrão `mcp_*` (snapshot_date UNIQUE, payload JSON, composta) — PR-1
- ✅ Comando idempotente por dia (delete+insert em transaction) — PR-1
- ✅ Kernel imita vizinhos (timezone America/Sao_Paulo + stagger anti-disputa DB) — PR-1
- 🟡 `Modules/Governance/Tests` registrado no phpunit.xml, **porém fora do subset de CI** (ver "Cobertura real do teste") — execução só na nightly CT 100 (FV-F3)
- ✅ Card usa `Inertia::defer` + `<Deferred>` (skill inertia-defer-default)

Refs: US-GOV-017 fase 2 (GT-G7) · ADR 0275 §4 · plano-mãe memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md §4

🤖 Generated with [Claude Code](https://claude.com/claude-code)

