### PR TITLE
fix(ci): nightly full-suite roda contra MySQL real, não sqlite vazio (C1 triage Q2)

### DIFF
--- a/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
+++ b/memory/requisitos/Infra/RUNBOOK-ct100-fullsuite.md
@@ -3,7 +3,7 @@ title: "Full-suite Pest MySQL nightly no CT 100 (FV-F3 — diagnostica, nunca re
 module: "Infra"
 owner: "W"
 status: "ativo"
-last_validated: "2026-06-12"
+last_validated: "2026-06-13"
 preconditions:
   - "Acesso SSH root@100.99.207.66 (Tailscale, BatchMode)"
   - "Container mysql-workers up na rede docker-host_default"
@@ -78,5 +78,6 @@ ssh -o BatchMode=yes root@100.99.207.66 cat /opt/oimpresso-fullsuite/runs/latest
 | junit.xml 0 bytes / ausente | run morto antes do flush (OOM/timeout) — ver fim do `run.log`; subir `FULLSUITE_TIMEOUT` ou rodar chunked (abaixo) |
 | migrate falha | schema baseline mudou em main — rodar de novo (DB é recriada do zero a cada run) |
 | disco | retenção automática mantém 14 runs; clone+vendor ~2,5 GB |
+| **suite roda em sqlite e não MySQL** (`no such table` em massa, `near "MODIFY": syntax error`) | **C1 (corrigido 2026-06-13):** `phpunit.xml:72-73` tem `<env DB_CONNECTION=sqlite>` **sem `force=`** — o PHPUnit só seta se a var ainda não existir. O `docker run` do pest agora passa `-e DB_CONNECTION=mysql` + `DB_*` reais (passo 6), então o `<env>` sqlite é ignorado e o pest usa o MySQL seedado. Se reaparecer: conferir que os `-e DB_*` continuam no `docker run` do pest. Ver triage Q2 `memory/sessions/2026-06-13-sdd-f2b-triage-q2.md`. |
 
 **Modo chunked** (fallback se a suite inteira estourar memória): rodar por diretório com um junit por chunk, ex. `--log-junit /artifacts/junit-unit.xml tests/Unit`, depois `Modules/<X>/Tests` um a um, e somar os summaries.

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -167,8 +167,16 @@ docker rm -f oimpresso-fullsuite-run >/dev/null 2>&1 || true
 PEST_EXIT=0
 for attempt in $(seq 1 12); do
   PEST_EXIT=0
+  # C1 (triage Q2 2026-06-13): phpunit.xml <env DB_CONNECTION=sqlite> NAO tem force=,
+  # entao o PHPUnit so seta a var se ela ainda NAO existir no ambiente. Sem estes -e,
+  # o pest rodava contra sqlite :memory: VAZIO (sem schema/seed) — ~880 'no such table'
+  # / 'near MODIFY syntax error' (DDL MySQL-only). Passando DB_* como env REAL do
+  # container, o <env> sqlite e ignorado e o pest usa o MySQL seedado (mysql-schema.sql
+  # + migrate + seed biz=1/biz=2 dos passos 3-5). ADR 0101 (testes MySQL real, nao sqlite).
   timeout -s TERM "$TIMEOUT_S" docker run --rm --name oimpresso-fullsuite-run \
     --network "$NET" -v "$CODE":/workspace -v "$RUN_DIR":/artifacts \
+    -e DB_CONNECTION=mysql -e "DB_HOST=$DB_HOST" -e "DB_PORT=$DB_PORT" \
+    -e "DB_DATABASE=$DB_DATABASE" -e "DB_USERNAME=$DB_USERNAME" -e "DB_PASSWORD=$DB_PASSWORD" \
     -w /workspace --entrypoint php "$IMAGE" -d memory_limit=2G \
     vendor/bin/pest --log-junit /artifacts/junit.xml --colors=never \
     2>&1 | tee "$RUN_DIR/pest-out.txt" || PEST_EXIT=$?


### PR DESCRIPTION
## O quê

**C1 da triage Q2** ([#2631](https://github.com/wagnerra23/oimpresso.com/pull/2631)) — o maior ROI da Fase 2b.

O nightly FV-F3 era anunciado como "MySQL real" mas rodava contra **sqlite :memory: vazio**: `phpunit.xml:72-73` tem `<env DB_CONNECTION=sqlite>` **sem `force=`**, e o PHPUnit só seta a var se ela ainda não existir no ambiente. O `docker run` do pest não passava `DB_*` como env real → sqlite vencia → ~880 `no such table` de 1.521 falhas.

## Fix

Passa `-e DB_CONNECTION=mysql` + `DB_*` reais no `docker run` do pest (passo 6 do `ct100-fullsuite.sh`). O `<env>` sqlite passa a ser ignorado e o pest usa o MySQL que o script já seeda (passos 3-5). **Não toca `phpunit.xml` global** — o CI rápido `Pest (Unit)` mantém sqlite de propósito (velocidade).

## Validação

Re-rodar o nightly no CT 100 (em curso) — esperado: junit cai de **~1.521 → ~150-300** e mensagens passam a dizer `Connection: mysql`. Resultado anexado quando o run (4h max) terminar.

Refs: US-GOV-017 fase 2b

<!-- no-ui-smoke: ci script -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)