### PR TITLE
docs(essentials): corrige casing Modules/Kb → Modules/KB (zera ghost advisory)

### DIFF
--- a/memory/requisitos/Essentials/BRIEFING.md
+++ b/memory/requisitos/Essentials/BRIEFING.md
@@ -33,7 +33,7 @@ Origem: módulo opcional UltimatePOS v6 — preservado intencionalmente como **s
 | HRM (allowance/deduction/shift/payroll) | 🟡 legacy | Usado biz=4 minimal; backlog ADR feature-wish para evolução |
 | Sales Target | 🟡 legacy | Pouco uso; possível candidato a desativar |
 | Holiday | ✅ em prod | Gestão de feriados por business |
-| KnowledgeBase | 🟡 legacy | Sobreposição com Modules/Kb candidato a migração |
+| KnowledgeBase | 🟡 legacy | Sobreposição com Modules/KB candidato a migração |
 | Message | 🟡 legacy | Mensagens internas — sobreposição com Modules/Jana ConvSidePanel |
 
 ## Arquitetura


### PR DESCRIPTION
## O quê

`Essentials/BRIEFING.md:36` escrevia `Modules/Kb` (casing errado — o módulo real é `Modules/KB`). O detector anti-ghost (KL-A2) flagava como ghost, fazendo o `anti-ghost ratchet (advisory)` nagar em **todo PR aberto após o merge** dessa linha. Fix de 1 char.

Era a única ocorrência de casing errado em `memory/`.

Refs: US-GOV-017 fase 2b

<!-- no-ui-smoke: docs only -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)