### PR TITLE
fix(paymentgateway): config_json json→longtext alinha schema ao cast (US-GOV-018 frente B)

### DIFF
--- a/Modules/PaymentGateway/Database/Migrations/2026_06_13_080000_alter_payment_gateway_credentials_config_json_to_longtext.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_06_13_080000_alter_payment_gateway_credentials_config_json_to_longtext.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-GOV-018 Frente B — `config_json`: json → longtext.
+ *
+ * A coluna foi criada como `json()` (2026_05_19_120000:30) mas o Model casta
+ * `encrypted:array` (PaymentGatewayCredential.php:66 — Crypt::encryptString
+ * produz um blob base64, que NÃO é JSON válido). SQLite TEXT aceitava o blob;
+ * o MySQL 8 strict rejeita com SQLSTATE[22032] 3140 "Invalid JSON text" — 212
+ * falhas no nightly full-suite (run 20260613-003042, sha d14f5436), reproduzidas
+ * byte-a-byte no retest adversarial (counterfactual: ALTER … LONGTEXT aceita).
+ * O próprio EncryptedCredentialCastTest.php:40 já declara a coluna como `text()`.
+ * Esta migration alinha o schema de produção ao que o cast exige.
+ *
+ * Multi-tenant Tier 0 (business_id) preservado — ALTER COLUMN não toca tenancy.
+ * Idempotente: só altera se a coluna ainda for json (no-op em sqlite, onde json
+ * já é TEXT por baixo). O blob cifrado já é string, então json→longtext preserva
+ * 100% dos dados.
+ *
+ * @see Modules/PaymentGateway/Models/PaymentGatewayCredential.php:66
+ * Refs: US-GOV-018 fase 2b · ADR 0170
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        $type = $this->configJsonType();
+        if ($type !== null && str_contains(strtolower($type), 'json')) {
+            DB::statement('ALTER TABLE payment_gateway_credentials MODIFY config_json LONGTEXT NOT NULL');
+        }
+        // sqlite (CI rápido Unit): json mapeia pra TEXT — nada a fazer.
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        $type = $this->configJsonType();
+        // Reversão de schema. CAVEAT: se houver linhas com blob cifrado (não-JSON),
+        // o MySQL recusará a volta pra JSON (3140) — comportamento correto, pois o
+        // dado não é JSON válido. Só roda em mysql com a coluna não-json.
+        if (DB::getDriverName() === 'mysql' && $type !== null && ! str_contains(strtolower($type), 'json')) {
+            DB::statement('ALTER TABLE payment_gateway_credentials MODIFY config_json JSON NOT NULL');
+        }
+    }
+
+    /**
+     * DATA_TYPE atual de config_json (null em não-mysql → up/down viram no-op).
+     */
+    private function configJsonType(): ?string
+    {
+        if (DB::getDriverName() !== 'mysql') {
+            return null;
+        }
+
+        $col = DB::selectOne(
+            'SELECT DATA_TYPE FROM information_schema.COLUMNS '
+            .'WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND COLUMN_NAME = ?',
+            ['payment_gateway_credentials', 'config_json']
+        );
+
+        return $col->DATA_TYPE ?? null;
+    }
+};


### PR DESCRIPTION
## O quê

**Frente B do P0 US-GOV-018.** `payment_gateway_credentials.config_json` foi criada como `json()` (strict no MySQL 8) mas o Model casta `encrypted:array` (`Crypt::encryptString` → blob base64, **não é JSON válido**) → SQLSTATE 3140 "Invalid JSON text" em **212 testes** do nightly. SQLite TEXT mascarava; MySQL rejeita. Migration alinha a coluna ao que o cast exige.

Reproduzido byte-a-byte no retest adversarial (counterfactual: `ALTER … LONGTEXT` aceita o blob). O próprio `EncryptedCredentialCastTest:40` já declara `text()`.

## Segurança
- **Idempotente:** só altera se ainda for `json` (no-op em sqlite + em re-run).
- **Dados preservados:** o blob cifrado já é string; `json→longtext` não perde nada.
- **Tier 0:** `business_id` intacto (ALTER COLUMN não toca tenancy).
- `down()` presente (reverte schema; caveat documentado — não volta pra JSON se houver blob cifrado).

## ⚠️ NÃO MERGEAR no automático
Toca uma **tabela de credenciais de gateway de clientes reais** e (se houver auto-deploy ADR 0269) roda em prod no merge. **Wagner decide o merge.** Validação local: `php -l` ✅; validação real = re-rodar o nightly (frente A precisa rodar junto pra suite ficar verde — esta sozinha mata os 212 Invalid-JSON mas não as ~850 da frente A).

## Irmãs latentes (fora deste PR — flag)
Mesmo padrão `json('config_json')` + cripto em `Modules/Jana/…copiloto_meta_fontes` e `Modules/RecurringBilling/…rb_boleto_credentials` (este **codeowned**). Não exercitadas pelos 212, mas latentes — avaliar em follow-up.

Refs: US-GOV-018 · ADR 0170 · #2632 (C1)

<!-- no-ui-smoke: migration -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)