### PR TITLE
docs(sdd): avaliador adversarial do processo no fluxo + scorecard salvo (~52/100)

### DIFF
--- a/.claude/skills/sdd-avaliar/SKILL.md
+++ b/.claude/skills/sdd-avaliar/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: sdd-avaliar
+description: >
+  Use ANTES de promover qualquer gate SDD a required (calendário ADR 0275), AO
+  FECHAR cada onda do programa SDD (Semana 0/1-2/2-4/4-6), ou em checkpoint
+  quinzenal de honestidade do processo — OU quando Wagner pedir "rode o avaliador
+  adversarial do SDD", "nota do processo SDD", "scorecard SDD", "o que falta de
+  ondas", "/sdd-avaliar". Dispara o workflow `.claude/workflows/sdd-avaliador-processo.js`
+  (7 skeptics adversariais, 1 por stream SA/FV/KL/GT/Charters/Fase2b/Promoções),
+  que VERIFICA o estado REAL em git+gh+MCP (não o plano), pontua sucesso 0-100 por
+  stream, lista modos de falha, e escreve um session log `YYYY-MM-DD-sdd-avaliacao-*.md`.
+  É o sistema imunológico do SDD: caça "a suite mente" (gate que não morde, baseline
+  nunca armado, métrica de forma não de correção, feito-que-depende-de-algo-que-nunca-rodou).
+---
+
+# sdd-avaliar — avaliador adversarial do processo SDD
+
+## Por que existe
+A noite 2026-06-13 provou: análise sozinha errou a diagnose **3× seguidas**; só a
+revisão adversarial + reprodução acertaram. O risco-mãe do programa SDD é **declarar
+vitória sobre estrutura-pronta em vez de problema-resolvido** ("a suite mente").
+Este avaliador é a defesa mecânica contra isso, recorrente — não um one-off.
+Ref: [`memory/sessions/2026-06-13-sdd-avaliacao-adversarial-processo.md`](../../../memory/sessions/2026-06-13-sdd-avaliacao-adversarial-processo.md).
+
+## Como rodar
+```
+Workflow({ name: "sdd-avaliador-processo" })
+```
+(ou via este skill quando o trigger casar). Read-only — não edita/commita.
+Demora ~6-10min, ~700k-800k tokens (7 agents Opus + síntese).
+
+## Quando rodar (cadência — gate de processo)
+1. **Antes de promover gate a required** (ADR 0275 calendário): se o stream do gate
+   tem score < 70 OU o gate é advisory-que-não-morde, **NÃO promove**. Fecha o risco
+   "gate que mede mas não morde" + "diagnose-thrash".
+2. **Ao fechar cada onda** (Semana 0/1-2/2-4/4-6): audita "feito-verificado vs
+   ilusório" antes de declarar a onda done.
+3. **Checkpoint quinzenal**: re-mede o `score_composto`; alvo é subir, não cair.
+
+## O que faz (mecânica)
+- 1 skeptic por stream, cada um **verifica o artefato em origin/main** (gh/git/git show)
+  e **roda o script local** (anchor-lint, sdd-scorecard, foundation-ratchet, gate-selftest)
+  pra medir LIVE — não confia em número de documento (que envelhece).
+- Para o nightly full-suite: mede o **FLOOR** (interseção de ≥2 runs no CT 100), nunca
+  1 run (o número é não-determinístico: floor ± banda).
+- Saída: scorecard por stream (0-100) + etapas com nota+modo-de-falha + "o que falta de
+  ondas" + top-5 riscos sistêmicos + veredito + nota composta do processo.
+
+## Salvar a saída
+Sempre escrever o scorecard num session log `memory/sessions/YYYY-MM-DD-sdd-avaliacao-*.md`
+(schema session.schema.json) e commitar — é o registro de honestidade do processo ao
+longo do tempo. O `score_composto` é candidato a 11ª métrica do scorecard SDD (ADR 0275).
+
+## Trio do sistema imunológico SDD
+- **sdd-avaliar** (este) — audita o PROCESSO (estrutura vs correção).
+- **Refutador G5** (`PROTOCOLO-REFUTADOR-BACKFILL.md`) — valida cada LOTE IA antes do merge.
+- **Reprodução** (DB scratch / counterfactual) — valida cada DIAGNOSE custosa antes de virar P0.
+
+Regra de ouro: nenhuma onda fecha, nenhum gate vira required, e nenhuma diagnose vira
+decisão custosa sem passar pelo membro certo do trio.

--- a/.claude/workflows/sdd-avaliador-processo.js
+++ b/.claude/workflows/sdd-avaliador-processo.js
@@ -1,0 +1,72 @@
+export const meta = {
+  name: 'sdd-avaliador-processo',
+  description: 'Avaliador ADVERSARIAL do programa SDD: 1 skeptic por stream verifica o estado REAL em git+gh+MCP (não o plano), pontua sucesso 0-100, lista modos de falha. Síntese = scorecard + ondas que faltam + riscos sistêmicos. Re-rodável; gate de processo antes de promover required / ao fechar onda.',
+  whenToUse: 'Antes de promover qualquer gate a required (ADR 0275), ao fechar cada onda (Sem 0/1-2/2-4/4-6), ou em checkpoint quinzenal de honestidade do processo. Read-only.',
+  phases: [
+    { title: 'Avaliar', detail: '7 streams verificados contra git/gh, não contra o plano' },
+    { title: 'Síntese', detail: 'scorecard + ondas restantes + riscos sistêmicos' },
+  ],
+}
+
+const REPO = 'wagnerra23/oimpresso.com'
+
+// CONTEXTO genérico: o avaliador DESCOBRE o estado atual (não confia em PRs hard-coded).
+const CONTEXTO = `PROGRAMA: reestruturação SDD do oimpresso. Plano-mãe: memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md (ondas Semana 0/1-2/2-4/4-6). ADRs fundação: 0273 (anchor), 0274 (slug/alias), 0275 (scorecard 10 métricas + calendário promoções), 0276 (decisão-pelo-fluxo). US guarda-chuva: US-GOV-016 (Semana 0), US-GOV-017 (Fase 1+2), US-GOV-018 (P0 harness Fase 2b).
+DESCUBRA o estado ATUAL (não confie em números de documento — eles envelhecem):
+- gh pr list -R ${REPO} --state all --search "<termo>" + git log origin/main --grep + git show origin/main:<arquivo> pra ver se o artefato existe e FAZ o que diz.
+- gh api repos/${REPO}/branches/main/protection pra ver quais checks são required (advisory ≠ required).
+- Onde existir: rode o script local (anchor-lint.mjs, sdd-scorecard.mjs, foundation-ratchet.mjs, gate-selftest.mjs) pra medir LIVE.
+- Nightly full-suite: artefatos em /opt/oimpresso-fullsuite/runs/* no CT 100 (SSH key-based root@100.99.207.66) — o número é NÃO-determinístico (medir o FLOOR = interseção de ≥2 runs, não 1 run).`
+
+const STREAMS = [
+  { key: 'sa-anchors', nome: 'SA — Anchors spec↔código', passos: 'A1 ADR 0273 formato+sentinela · A2/A3 anchor-lint.mjs + anchor-drift · A4 backfill mecânico placeholders · A5 batch IA + refutador G5 · A6 fila Wagner · A10 anchor-gate required.' },
+  { key: 'fv-fullsuite', nome: 'FV — Full-suite / testes', passos: 'F1 JUnit · F2 composite pest-mysql · F3 nightly MySQL CT 100 (não-determinístico — medir floor) · Q1 foundation-ratchet · Q2 triage · Q3 quarentena · B1-B4 burn-down · C1 fix harness MySQL · US-GOV-018 (harness re-diagnosticado).' },
+  { key: 'kl-knowledge', nome: 'KL — Knowledge / ghost / decay', passos: 'anti-ghost por módulo · codemod renames · ADR 0274 slug/alias · E1 identidade órfãs · E2 renames · E2b re-seed Meilisearch · E3 BRIEFINGs · trilha C decay C1-C5 · trilha D RAGAS D1-D4.' },
+  { key: 'gt-governance', nome: 'GT — Governance scorecard', passos: 'G1 ADR 0275 · G2 agregador · G3 meta-catraca · G4 protection-drift+watchdog · G5 refutador+ledger · G6 gate-selftest · G7 snapshot history · G8 linha SDD no brief.' },
+  { key: 'charters-fluxo', nome: 'Charters + fluxo-novo', passos: 'backfill us:/component: nos charters · template/schema fluxo-novo (SPEC nasce com anchor) · grace-period memory-schemas · skill memory-schema-preflight.' },
+  { key: 'fase2b-harness', nome: 'Fase 2b — P0 harness (US-GOV-018)', passos: 'Frente A harness/imagem (mysql-client + teardown FK-off + PSR-4 migrations puladas, ~850) · Frente B config_json json→longtext (212) · Frente C testes era-sqlite isolamento · dívida residual ~490 (assertions+app-bugs).' },
+  { key: 'promocoes-required', nome: 'Semanas 4-6 — promoções a required', passos: 'R1 full-suite não-quarentenado · C2 coverage · T1 mapa teste↔arquivo · T2 TDAD-lite · SA-A10 anchor-gate · GT-G3 required. Máx 1 promoção/semana.' },
+]
+
+const SCHEMA = {
+  type: 'object',
+  properties: {
+    stream: { type: 'string' },
+    etapas: { type: 'array', items: { type: 'object', properties: {
+      etapa: { type: 'string' },
+      status: { type: 'string', enum: ['FEITO-VERIFICADO', 'FEITO-NÃO-VERIFICADO/ILUSÓRIO', 'PARCIAL', 'BLOQUEADO', 'NÃO-INICIADO', 'REVERTIDO'] },
+      score: { type: 'number' },
+      evidencia: { type: 'string' },
+      modos_de_falha: { type: 'array', items: { type: 'string' } },
+    }, required: ['etapa', 'status', 'score', 'evidencia', 'modos_de_falha'] } },
+    score_stream: { type: 'number' },
+    o_que_falta: { type: 'string' },
+    risco_sistemico_top: { type: 'string' },
+  },
+  required: ['stream', 'etapas', 'score_stream', 'o_que_falta', 'risco_sistemico_top'],
+}
+
+const prompt = (s) => `Você é um AVALIADOR ADVERSARIAL do stream "${s.nome}" do programa SDD do oimpresso. Working dir D:/oimpresso.com. READ-ONLY: NÃO edita/commita. VERIFIQUE o estado REAL — não confie no plano nem no que dizem que foi feito.
+
+${CONTEXTO}
+
+SEU STREAM — passos: ${s.passos}
+
+MÉTODO (verificar, não opinar — análise sozinha já errou 3× onde reprodução acertou):
+1. Confirme cada etapa pelo ARTEFATO em origin/main (gh/git/git show); não marque FEITO sem ver. Rode o script local pra medir LIVE onde existir.
+2. CETICISMO "a suite mente": procure gate que não morde (advisory perene? fixture vazia?), catraca cujo baseline nunca foi armado de verdade (nº-de-ADR ≠ medição), métrica de FORMA não de CORREÇÃO, "feito" que depende de algo que nunca rodou (CT 100/secret/máquina externa), número não-determinístico vendido como estável.
+3. score 0-100/etapa: 90-100 FEITO-VERIFICADO (morde/funciona, provado); 60-85 PARCIAL/advisory-ok; 30-55 ILUSÓRIO ou BLOQUEADO; 0-25 NÃO-INICIADO/REVERTIDO. Na dúvida, pontue baixo + diga por quê.
+4. modos_de_falha específicos (arquivo:linha, dependência, premissa).
+
+Retorne JSON no schema. score_stream = média ponderada honesta. o_que_falta = onda/passo que resta. risco_sistemico_top = maior risco do stream.`
+
+phase('Avaliar')
+log(`${STREAMS.length} avaliadores adversariais (verificam git/gh, não o plano)`)
+const avals = await parallel(STREAMS.map(s => () => agent(prompt(s), { label: `aval:${s.key}`, phase: 'Avaliar', schema: SCHEMA, model: 'opus' })))
+const ok = avals.filter(Boolean)
+
+phase('Síntese')
+const sintese = await agent(`Sintetize a avaliação ADVERSARIAL do programa SDD num SCORECARD executável. ${ok.length} streams verificados (JSON): ${JSON.stringify(ok)}
+Markdown enxuto (sem frontmatter): 1) Scorecard por stream (tabela score+status+maior-risco) + score_composto ponderado (peso maior pros streams que destravam o resto: FV/Fase2b ×1.8, SA/GT ×1.3). 2) Etapas que importam com nota+modo-de-falha (FEITO-VERIFICADO vs ILUSÓRIO vs FALTA). 3) O QUE FALTA DE ONDAS (mapa Sem 0/1-2/2-4/4-6 → rodou vs resta + caminho crítico). 4) TOP 5 RISCOS SISTÊMICOS. 5) VEREDITO (1 parágrafo: no caminho? nota honesta do processo + maior alavanca). Direto ao Wagner.`, { label: 'sintese:avaliador', phase: 'Síntese' })
+
+return { streams: ok, sintese, score_medio: Math.round(ok.reduce((a, r) => a + (r.score_stream || 0), 0) / (ok.length || 1)) }

--- a/memory/sessions/2026-06-13-sdd-avaliacao-adversarial-processo.md
+++ b/memory/sessions/2026-06-13-sdd-avaliacao-adversarial-processo.md
@@ -1,0 +1,63 @@
+---
+date: "2026-06-13"
+topic: "Avaliação adversarial do processo SDD inteiro (scorecard ~52/100) + correção da diagnose C1 por reprodução + como o avaliador adversarial entra no fluxo permanente"
+authors: [W, C]
+related_adrs: ["0273-anchor-spec-codigo-formato-canonico-fluxo-novo", "0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes", "0276-decisao-pelo-fluxo-classes-pares-adversariais"]
+prs: []
+---
+
+# Avaliação adversarial do processo SDD + correção C1 reproduzida + avaliador no fluxo
+
+> Origem: noite 2026-06-13. Wagner pediu (1) status das ondas, (2) "crie um avaliador adversário de todo o processo com nota e modos de falha", (3) "como aproveitar essa análise e incluir no fluxo". Este doc é o artefato canônico do scorecard + a institucionalização do método.
+
+## 1. Scorecard adversarial do processo — **~52/100** (composto ponderado; média simples 49)
+
+7 streams verificados em git/gh (não no plano), por skeptics adversariais.
+
+| Stream | Nota | Maior risco |
+|---|:--:|---|
+| **GT** governança | 84 | mede estrutura-pronta, não correção; G7→G8 sem row real em prod |
+| **SA** anchors | 58 | DUAS definições contraditórias de `anchor_coverage` (lint 1.8% vs scorecard 2.8%), nenhuma armada |
+| **Charters** | 56 | artefato sem enforcement: SPEC pode nascer sem anchor e nada barra (`v1_files=0`) |
+| **KL** knowledge | 54 | os 4 renames "feitos" NÃO moveram `ghost_count` (segue 27); RAGAS baseline zerado |
+| **FV** full-suite | 52 | número NÃO-determinístico (floor 1514, banda 683, faixa 1514–2197); toda catraca herda o ruído |
+| **Fase 2b** harness | 31 | confunde diagnóstico mergeado com problema resolvido; Frentes A+C em 0% |
+| **Semanas 4-6** promoções | 9 | a fundação que vira "required" é não-determinística E vive FORA do CI |
+
+## 2. O que falta de ondas
+
+- **Semana 0 (fundação) — ~80% rodou.** GT G1-G8, SA A1-A3, KL gates/baselines, Charters template. Resta: armar baselines DE VERDADE (3 runs reais, não nº-de-ADR) + atualizar skill memory-schema-preflight + regenerar scorecard.json stale.
+- **Semana 1-2 (FV burn-down) — ~40%, RE-DIAGNOSTICADA.** F1/F2/Q1 infra, B1/B4 lanes, C1 (#2632) flipou MySQL e REFUTOU a triage. Q3 quarentena REVERTIDA. **Caminho crítico real = US-GOV-018, Frente A (~850) = 0% ← MAIOR ALAVANCA · Frente C = 0%.**
+- **Semana 2-4 (backfill IA + identidade) — ~15%.** Infra refutador G5 mergeada (#2588) mas ledger vazio (lote IA só na máquina Felipe). SA-A4 (#2611) bloqueado em review. KL-E2/E3 parado na decisão Wagner das 34 órfãs (15min). 1-clique alto-ROI: armar baseline RAGAS.
+- **Semana 4-6 (promoções a required) — 0%, integralmente bloqueado.** Zero flips. Múltiplas semanas do 1º flip (depende de tudo acima).
+
+## 3. Top 5 riscos sistêmicos
+1. **Não-determinismo do nightly contamina toda medição** (floor 1514 ± 683, executionOrder random, eixo ERROR). Foi por isso que a análise errou 3× e só a reprodução acertou. "7 nightlies verdes" sobre esse número = teatro.
+2. **Gates que medem mas não mordem** (advisory-permanente: anchor-drift, foundation-ratchet, ghost-gate, scorecard, ledger-check, RAGAS).
+3. **Diagnose-thrash**: diagnóstico mergeado confundido com problema resolvido; docs canon (#2631/#2635) com conclusão refutada em main. O método anti-ilusão (reprodução > análise) foi aplicado só ao diagnóstico, nunca à execução.
+4. **Métrica-manchete não move com a correção** + definições contraditórias (`ghost_count`=27 pós-rename; coverage 1.8% vs 2.8%).
+5. **Dependência de CT 100 / Felipe / secrets / Wagner** — "feito que depende de algo que nunca rodou" em 4 dos 7 streams.
+
+## 4. Veredito
+Estruturalmente no caminho, mas **perigosamente perto de declarar vitória sobre estrutura-pronta em vez de problema-resolvido.** Semana-0 (governança) feita com qualidade rara e auto-crítica verificável. Mas o motor de que tudo depende — **suite determinística** — está quebrado, com ~56% do vermelho (Frente A) em 0%. **Maior alavanca: consertar o harness (US-GOV-018 A+C) até a suite ser determinística e rodar DENTRO do CI** — destrava R1/T1/T2/coverage e torna cada diagnose um fato reproduzível.
+
+## 5. A LIÇÃO-MÃE da noite (reprodução > análise)
+A diagnose da Fase 2b foi corrigida **3× seguidas** — isolamento → schema-incompleto → harness/mysql-binary. Cada erro foi pego pela **revisão adversarial**; o terceiro, decisivo, só por **reprodução byte-a-byte** (DB scratch no CT 100). Três rodadas de análise minha não acharam o que uma reprodução achou em minutos. **Regra:** nenhuma diagnose vira P0/decisão custosa sem refutador (≥ modelo gerador, sessão fresca) e, quando há ambiente, sem reprodução. Vale tanto pro Fable 5 quanto pro Opus — é o seguro que cobre o gap de qualquer modelo.
+
+## 6. COMO INCLUIR NO FLUXO (a institucionalização)
+O avaliador adversarial vira parte recorrente do SDD, não um one-off:
+
+- **Mecanismo:** workflow re-rodável [`.claude/workflows/sdd-avaliador-processo.js`](../../.claude/workflows/sdd-avaliador-processo.js) + skill [`sdd-avaliar`](../../.claude/skills/sdd-avaliar/SKILL.md) que o dispara. Verifica estado REAL em git/gh (não o plano), pontua 0-100 por stream, lista modos de falha, calcula `score_composto`.
+- **Cadência (gate de processo):**
+  1. **Antes de promover QUALQUER gate a required** (calendário ADR 0275) — rodar o avaliador; se o stream do gate < 70 OU o gate é advisory-que-não-morde, NÃO promove. Fecha o risco #2 e #3.
+  2. **Ao FECHAR cada onda** (Semana 0/1-2/2-4/4-6) — o avaliador audita "feito-verificado vs ilusório" antes de declarar a onda done. Fecha o risco "declarar vitória sobre estrutura".
+  3. **Checkpoint dated** (ex quinzenal) — re-mede o score_composto; alvo subir, não cair.
+- **Saída canônica:** cada run escreve um session log `YYYY-MM-DD-sdd-avaliacao-*.md` (como este) com o scorecard. O `score_composto` pode virar a 11ª métrica do scorecard SDD (ADR 0275) — "honestidade do processo".
+- **Regra de ouro herdada:** o avaliador é cético por construção (caça "a suite mente"); o refutador (G5) valida lote IA; a reprodução valida diagnose custosa. Os três são o sistema imunológico do SDD.
+
+## Estado da noite (para retomada)
+- **Em main:** Fase 2 SDD completa (#2587-2610, #2612, #2615-2630), C1 (#2632), ghost-fix (#2633), triage (#2631), US docs (#2634/#2635), Frente B config_json (#2636).
+- **Trava em Wagner:** #2611 (code-owner fiscal SA-A4).
+- **Em execução paralela:** Frente A do US-GOV-018 (harness — outra aba).
+- **Decisões de produto abertas:** US-SELL-045 (totals morto), 046 (grade-avancada órfão).
+- **Backlog:** US-SELL-047 (teste isolamento real), 048 (higiene snapshots), US-GOV-018 Frentes A/C, dívida residual ~490 (assertions+app-bugs).


### PR DESCRIPTION
## O quê

Atende "salve tudo" + "como aproveitar essa análise e incluir no fluxo".

1. **Salva o scorecard** — `memory/sessions/2026-06-13-sdd-avaliacao-adversarial-processo.md`: scorecard adversarial do programa SDD (~52/100), o que falta de ondas (Sem 0/1-2/2-4/4-6), top-5 riscos sistêmicos, veredito, e a **lição-mãe** (reprodução > análise — diagnose corrigida 3× na noite).
2. **Institucionaliza o avaliador** — `.claude/workflows/sdd-avaliador-processo.js` (re-rodável, 7 skeptics que verificam git/gh, medem o floor não-determinístico) + skill `sdd-avaliar` (Tier B) com a **cadência**: rodar antes de promover qualquer gate a required, ao fechar cada onda, e em checkpoint quinzenal.

## Por que importa
O risco-mãe do programa é "declarar vitória sobre estrutura-pronta em vez de problema-resolvido" (a auditoria SDD chama de "a suite mente"). Este avaliador vira a **defesa mecânica recorrente** contra isso — completa o trio imunológico: **sdd-avaliar** (processo) + **refutador G5** (lote IA) + **reprodução** (diagnose custosa).

Refs: US-GOV-017/018 · ADR 0275 · ADR 0276

<!-- no-ui-smoke: docs + workflow/skill -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)