### PR TITLE
fix(ds): camada canônica consome o DS — badge/KpiCard/EmptyState tokenizam status (Onda M1)

### DIFF
--- a/resources/js/Components/shared/EmptyState.tsx
+++ b/resources/js/Components/shared/EmptyState.tsx
@@ -35,10 +35,10 @@ interface Props {
 }
 
 const variantStyles: Record<Variant, { icon: string; iconBg: string }> = {
-  default: { icon: 'text-muted-foreground',           iconBg: 'bg-muted' },
-  search:  { icon: 'text-blue-600 dark:text-blue-400', iconBg: 'bg-blue-500/10' },
-  error:   { icon: 'text-destructive',                 iconBg: 'bg-destructive/10' },
-  success: { icon: 'text-emerald-600 dark:text-emerald-400', iconBg: 'bg-emerald-500/10' },
+  default: { icon: 'text-muted-foreground', iconBg: 'bg-muted' },
+  search:  { icon: 'text-info',             iconBg: 'bg-info/10' },
+  error:   { icon: 'text-destructive',      iconBg: 'bg-destructive/10' },
+  success: { icon: 'text-success',          iconBg: 'bg-success/10' },
 };
 
 export default function EmptyState({

--- a/resources/js/Components/shared/KpiCard.tsx
+++ b/resources/js/Components/shared/KpiCard.tsx
@@ -32,10 +32,10 @@ const kpiCardVariants = cva(
     variants: {
       tone: {
         default: 'border-border',
-        success: 'border-emerald-500/20 bg-emerald-500/5',
-        warning: 'border-amber-500/20 bg-amber-500/5',
+        success: 'border-success/20 bg-success/5',
+        warning: 'border-warning/20 bg-warning/5',
         danger: 'border-destructive/20 bg-destructive/5',
-        info: 'border-blue-500/20 bg-blue-500/5',
+        info: 'border-info/20 bg-info/5',
       },
       size: {
         default: 'p-4 gap-2',
@@ -56,10 +56,10 @@ const iconContainerVariants = cva(
     variants: {
       tone: {
         default: 'bg-muted text-muted-foreground',
-        success: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
-        warning: 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+        success: 'bg-success/10 text-success',
+        warning: 'bg-warning/10 text-warning',
         danger: 'bg-destructive/10 text-destructive',
-        info: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+        info: 'bg-info/10 text-info',
       },
       size: {
         default: 'h-9 w-9',
@@ -181,7 +181,7 @@ function Delta({
   const color = neutral
     ? 'text-muted-foreground'
     : good
-      ? 'text-emerald-600 dark:text-emerald-400'
+      ? 'text-success'
       : 'text-destructive';
 
   const sign = value > 0 ? '+' : '';

--- a/resources/js/Components/ui/badge.tsx
+++ b/resources/js/Components/ui/badge.tsx
@@ -18,16 +18,18 @@ const badgeVariants = cva(
           "border-border text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         ghost: "[a&]:hover:bg-accent [a&]:hover:text-accent-foreground",
         link: "text-primary underline-offset-4 [a&]:hover:underline",
-        // Status pills (tom soft) — Onda G. Espelham o STATUS_STYLE hand-rolled (migração 1:1).
-        // Distintos de `destructive` (sólido = AÇÃO destrutiva); estos são ESTADO.
+        // Status pills (tom soft) — ESTADO, não AÇÃO. Onda M1 (maturidade DS): tokenizado
+        // nos pares semânticos `-soft/-fg` (inertia.css). O token já carrega light+dark →
+        // sem `dark:` cru. Mata a autocontradição: a camada canônica agora consome o DS
+        // que ela mesma exige das Pages (regra ds/no-adhoc-status-text). Migração 1:1 visual.
         success:
-          "bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300",
+          "bg-success-soft text-success-fg border-success/20",
         warning:
-          "bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300",
+          "bg-warning-soft text-warning-fg border-warning/20",
         danger:
-          "bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300",
+          "bg-destructive-soft text-destructive-fg border-destructive/20",
         info:
-          "bg-sky-50 text-sky-700 border-sky-200 dark:bg-sky-950/40 dark:text-sky-300",
+          "bg-info-soft text-info-fg border-info/20",
         neutral: "bg-muted text-muted-foreground border-border",
       },
     },

--- a/tests/Feature/Ds/CanonStatusTokensTest.php
+++ b/tests/Feature/Ds/CanonStatusTokensTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Onda M1 (maturidade do DS) · sub-item (a): mata a autocontradição da camada canônica.
+ *
+ * O sênior achou a "arma fumegante": `ui/badge.tsx` + `shared/KpiCard.tsx` +
+ * `shared/EmptyState.tsx` hardcodavam paleta crua (emerald/amber/rose/sky/blue-NNN)
+ * — exatamente o que a regra `ds/no-adhoc-status-text` proíbe nas Pages. A camada
+ * canônica exigia das telas um DS que ela mesma NÃO consumia.
+ *
+ * Fix: variantes de STATUS passam a consumir os pares semânticos do `inertia.css`
+ * (`-soft/-fg` pra pills soft do badge; base `success/warning/info` + opacidade pros
+ * tints do KpiCard/EmptyState). O token carrega light+dark → sem `dark:` cru.
+ *
+ * Canon: structural guard. Prova visual (pills idênticas) = smoke pós-deploy.
+ * NÃO cobre StatusBadge.tsx (mapa sólido + nuance orange) nem VendaDerivadaCard.tsx
+ * (card autoral) — ondas seguintes de M1, escopo deliberadamente separado.
+ */
+
+$ui = __DIR__ . '/../../../resources/js/Components/ui';
+$shared = __DIR__ . '/../../../resources/js/Components/shared';
+
+test('badge — pills de status consomem tokens -soft/-fg (não paleta crua)', function () use ($ui) {
+    $src = file_get_contents($ui . '/badge.tsx');
+    expect($src)
+        ->toContain('bg-success-soft text-success-fg border-success/20')
+        ->toContain('bg-warning-soft text-warning-fg border-warning/20')
+        ->toContain('bg-destructive-soft text-destructive-fg border-destructive/20')
+        ->toContain('bg-info-soft text-info-fg border-info/20')
+        // a paleta crua antiga saiu por completo das variantes de status
+        ->not->toContain('bg-emerald-50')
+        ->not->toContain('bg-amber-50')
+        ->not->toContain('bg-rose-50')
+        ->not->toContain('bg-sky-50');
+});
+
+test('KpiCard — tones e ícone consomem tokens semânticos (não emerald/amber/blue)', function () use ($shared) {
+    $src = file_get_contents($shared . '/KpiCard.tsx');
+    expect($src)
+        ->toContain('border-success/20 bg-success/5')
+        ->toContain('border-warning/20 bg-warning/5')
+        ->toContain('border-info/20 bg-info/5')
+        ->toContain('bg-success/10 text-success')
+        ->toContain('bg-info/10 text-info')
+        // delta positivo via token
+        ->toContain("? 'text-success'")
+        ->not->toContain('emerald-500')
+        ->not->toContain('amber-500')
+        ->not->toContain('blue-500');
+});
+
+test('EmptyState — variantes search/success consomem info/success token', function () use ($shared) {
+    $src = file_get_contents($shared . '/EmptyState.tsx');
+    expect($src)
+        ->toContain("icon: 'text-info'")
+        ->toContain("iconBg: 'bg-info/10'")
+        ->toContain("icon: 'text-success'")
+        ->toContain("iconBg: 'bg-success/10'")
+        ->not->toContain('text-blue-600')
+        ->not->toContain('text-emerald-600');
+});
+
+test('camada canônica de status — zero paleta crua nos 3 arquivos', function () use ($ui, $shared) {
+    $files = [$ui . '/badge.tsx', $shared . '/KpiCard.tsx', $shared . '/EmptyState.tsx'];
+    foreach ($files as $f) {
+        $src = file_get_contents($f);
+        // shades numéricos de paleta crua (emerald-500, sky-50, blue-600…) = 0
+        expect(preg_match('/(emerald|amber|rose|sky|blue|red|green|yellow|orange|teal|lime|indigo|violet)-(50|100|200|300|400|500|600|700|800|900|950)/', $src))
+            ->toBe(0, "paleta crua encontrada em " . basename($f));
+    }
+});


### PR DESCRIPTION
## Onda M1 (maturidade do DS) · sub-item (a): mata a autocontradição

A [auditoria sênior de maturidade do DS](../blob/main/memory/sessions/2026-06-13-auditoria-senior-maturidade-ds-oimpresso.md) (nota **61/100**, 14 dimensões) achou a "arma fumegante": a **camada canônica se autocontradiz**. `ui/badge.tsx`, `shared/KpiCard.tsx` e `shared/EmptyState.tsx` hardcodavam paleta crua (`emerald/amber/rose/sky/blue-NNN`) — **exatamente o que a regra `ds/no-adhoc-status-text` proíbe nas Pages**. O DS exigia das telas o que ele mesmo não consumia.

## O quê

| Arquivo | Antes | Depois |
|---|---|---|
| `ui/badge.tsx` | `bg-emerald-50 text-emerald-700 … dark:…` | `bg-success-soft text-success-fg border-success/20` |
| `shared/KpiCard.tsx` | `bg-emerald-500/10 text-emerald-600 dark:…` | `bg-success/10 text-success` |
| `shared/EmptyState.tsx` | `text-blue-600 dark:text-blue-400` | `text-info` |

Os pares `-soft/-fg` (e a base `success/warning/info`) carregam **light+dark** no token → caem os `dark:` crus. Migração **1:1 visual** — os oklch foram afinados (PR #2639) pra equivaler à paleta antiga.

## Prova

- ✅ **build:inertia** verde (1m46s) — as 8 classes `.bg-success-soft`/`.text-success-fg`/… **resolvem** no CSS gerado.
- ✅ **teste-guarda** (`tests/Feature/Ds/CanonStatusTokensTest.php`) — 4 testes / 26 asserts: trava **0 paleta crua** nos 3 arquivos.
- ✅ conformance-gate + foundation-guard + eslint `ds/*` verdes.

## Fora de escopo (ondas seguintes de M1, deliberado)

- `shared/StatusBadge.tsx` — mapa sólido grande + nuance `orange` (Risco Alto ≠ Médio) → decisão semântica própria.
- `shared/VendaDerivadaCard.tsx` — card autoral → "extrair, não repintar".

Refs: DS-MATURIDADE ONDA-M1

🤖 Generated with [Claude Code](https://claude.com/claude-code)