### PR TITLE
fix(ds): StatusBadge consome o DS — mapa de status app-wide tokenizado (Onda M1)

### DIFF
--- a/resources/js/Components/shared/StatusBadge.tsx
+++ b/resources/js/Components/shared/StatusBadge.tsx
@@ -23,16 +23,16 @@ const mappings: Record<string, Record<string, StatusEntry>> = {
   intercorrencia: {
     rascunho:  { variant: 'outline',     label: 'Rascunho' },
     pendente:  { variant: 'secondary',   label: 'Pendente' },
-    aprovada:  { variant: 'default',     label: 'Aprovada',  className: 'bg-emerald-600 hover:bg-emerald-700' },
+    aprovada:  { variant: 'default',     label: 'Aprovada',  className: 'bg-success text-success-foreground hover:bg-success/90' },
     rejeitada: { variant: 'destructive', label: 'Rejeitada' },
-    aplicada:  { variant: 'default',     label: 'Aplicada',  className: 'bg-blue-600 hover:bg-blue-700' },
+    aplicada:  { variant: 'default',     label: 'Aplicada',  className: 'bg-info text-info-foreground hover:bg-info/90' },
     cancelada: { variant: 'outline',     label: 'Cancelada' },
   },
   aprovacao: {
     pendente:  { variant: 'secondary',   label: 'Pendente' },
-    aprovada:  { variant: 'default',     label: 'Aprovada',  className: 'bg-emerald-600 hover:bg-emerald-700' },
+    aprovada:  { variant: 'default',     label: 'Aprovada',  className: 'bg-success text-success-foreground hover:bg-success/90' },
     rejeitada: { variant: 'destructive', label: 'Rejeitada' },
-    aprovada_em_lote: { variant: 'default', label: 'Lote OK', className: 'bg-emerald-600' },
+    aprovada_em_lote: { variant: 'default', label: 'Lote OK', className: 'bg-success text-success-foreground' },
   },
   prioridade: {
     baixa:   { variant: 'outline',     label: 'Baixa' },
@@ -42,27 +42,27 @@ const mappings: Record<string, Record<string, StatusEntry>> = {
   },
   payment: {
     pending:        { variant: 'secondary',   label: 'Pendente' },
-    partial:        { variant: 'default',     label: 'Parcial',    className: 'bg-amber-600 hover:bg-amber-700' },
-    paid:           { variant: 'default',     label: 'Pago',       className: 'bg-emerald-600 hover:bg-emerald-700' },
+    partial:        { variant: 'default',     label: 'Parcial',    className: 'bg-warning text-warning-foreground hover:bg-warning/90' },
+    paid:           { variant: 'default',     label: 'Pago',       className: 'bg-success text-success-foreground hover:bg-success/90' },
     due:            { variant: 'destructive', label: 'Vencido' },
     overdue:        { variant: 'destructive', label: 'Atrasado' },
   },
   financeiro_titulo: {
     aberto:    { variant: 'secondary',   label: 'Aberto' },
-    parcial:   { variant: 'default',     label: 'Parcial',   className: 'bg-amber-600 hover:bg-amber-700' },
-    quitado:   { variant: 'default',     label: 'Quitado',   className: 'bg-emerald-600 hover:bg-emerald-700' },
+    parcial:   { variant: 'default',     label: 'Parcial',   className: 'bg-warning text-warning-foreground hover:bg-warning/90' },
+    quitado:   { variant: 'default',     label: 'Quitado',   className: 'bg-success text-success-foreground hover:bg-success/90' },
     cancelado: { variant: 'outline',     label: 'Cancelado' },
   },
   importacao: {
     pendente:    { variant: 'secondary', label: 'Pendente' },
-    processando: { variant: 'default',   label: 'Processando', className: 'bg-blue-600' },
-    sucesso:     { variant: 'default',   label: 'Sucesso',     className: 'bg-emerald-600' },
+    processando: { variant: 'default',   label: 'Processando', className: 'bg-info text-info-foreground' },
+    sucesso:     { variant: 'default',   label: 'Sucesso',     className: 'bg-success text-success-foreground' },
     erro:        { variant: 'destructive', label: 'Erro' },
   },
   nfse: {
     rascunho:    { variant: 'outline',     label: 'Rascunho' },
-    processando: { variant: 'default',     label: 'Processando', className: 'bg-blue-600 hover:bg-blue-700' },
-    emitida:     { variant: 'default',     label: 'Emitida',     className: 'bg-emerald-600 hover:bg-emerald-700' },
+    processando: { variant: 'default',     label: 'Processando', className: 'bg-info text-info-foreground hover:bg-info/90' },
+    emitida:     { variant: 'default',     label: 'Emitida',     className: 'bg-success text-success-foreground hover:bg-success/90' },
     cancelada:   { variant: 'outline',     label: 'Cancelada' },
     erro:        { variant: 'destructive', label: 'Erro' },
   },
@@ -73,30 +73,33 @@ const mappings: Record<string, Record<string, StatusEntry>> = {
   },
   // Onda 1 PR D 2026-05-26 — status de Vehicle (OficinaAuto). Frota Martinho.
   vehicle: {
-    active:         { variant: 'default',     label: 'Ativo',           className: 'bg-emerald-600 hover:bg-emerald-700' },
-    in_service:     { variant: 'default',     label: 'Em serviço',      className: 'bg-blue-600 hover:bg-blue-700' },
-    awaiting_parts: { variant: 'default',     label: 'Aguardando peças', className: 'bg-amber-600 hover:bg-amber-700' },
+    active:         { variant: 'default',     label: 'Ativo',           className: 'bg-success text-success-foreground hover:bg-success/90' },
+    in_service:     { variant: 'default',     label: 'Em serviço',      className: 'bg-info text-info-foreground hover:bg-info/90' },
+    awaiting_parts: { variant: 'default',     label: 'Aguardando peças', className: 'bg-warning text-warning-foreground hover:bg-warning/90' },
     inactive:       { variant: 'outline',     label: 'Inativo' },
     written_off:    { variant: 'destructive', label: 'Baixado' },
   },
   ads_destination: {
     blocked:        { variant: 'destructive', label: 'Bloqueado' },
-    pending_wagner: { variant: 'default',     label: 'Aguardando você', className: 'bg-amber-600 hover:bg-amber-700' },
-    brain_b:        { variant: 'default',     label: 'Brain B',          className: 'bg-blue-600 hover:bg-blue-700' },
-    brain_a:        { variant: 'default',     label: 'Brain A',          className: 'bg-emerald-600 hover:bg-emerald-700' },
+    pending_wagner: { variant: 'default',     label: 'Aguardando você', className: 'bg-warning text-warning-foreground hover:bg-warning/90' },
+    brain_b:        { variant: 'default',     label: 'Brain B',          className: 'bg-info text-info-foreground hover:bg-info/90' },
+    brain_a:        { variant: 'default',     label: 'Brain A',          className: 'bg-success text-success-foreground hover:bg-success/90' },
     queued:         { variant: 'outline',     label: 'Na fila' },
   },
+  // Ramp de severidade de 4 níveis SEM token "orange" (Onda M1): colapsa nos 3
+  // semânticos (success→warning→destructive); o ÁPICE (Crítico) pulsa pra ficar
+  // visualmente distinto do Alto. Ambos vermelhos, label reforça. DS-puro.
   ads_risco: {
-    Baixo:   { variant: 'default',     label: 'Risco Baixo',   className: 'bg-emerald-600 hover:bg-emerald-700' },
-    Médio:   { variant: 'default',     label: 'Risco Médio',   className: 'bg-amber-600 hover:bg-amber-700' },
-    Alto:    { variant: 'default',     label: 'Risco Alto',    className: 'bg-orange-600 hover:bg-orange-700' },
-    Crítico: { variant: 'destructive', label: 'Risco Crítico' },
+    Baixo:   { variant: 'default',     label: 'Risco Baixo',   className: 'bg-success text-success-foreground hover:bg-success/90' },
+    Médio:   { variant: 'default',     label: 'Risco Médio',   className: 'bg-warning text-warning-foreground hover:bg-warning/90' },
+    Alto:    { variant: 'destructive', label: 'Risco Alto' },
+    Crítico: { variant: 'destructive', label: 'Risco Crítico', className: 'animate-pulse' },
   },
   mcp_status: {
-    ok:             { variant: 'default',     label: 'ok',             className: 'bg-emerald-600 hover:bg-emerald-700' },
-    denied:         { variant: 'default',     label: 'denied',         className: 'bg-amber-600 hover:bg-amber-700' },
+    ok:             { variant: 'default',     label: 'ok',             className: 'bg-success text-success-foreground hover:bg-success/90' },
+    denied:         { variant: 'default',     label: 'denied',         className: 'bg-warning text-warning-foreground hover:bg-warning/90' },
     error:          { variant: 'destructive', label: 'error' },
-    quota_exceeded: { variant: 'default',     label: 'quota_exceeded', className: 'bg-orange-600 hover:bg-orange-700' },
+    quota_exceeded: { variant: 'destructive', label: 'quota_exceeded' },
   },
   // Admin Center (Centro de Operações) — semáforo green/yellow/red dos health
   // snapshots + estado online/offline de infra. Substitui bg-(green|amber|red)-100

--- a/tests/Feature/Ds/CanonStatusTokensTest.php
+++ b/tests/Feature/Ds/CanonStatusTokensTest.php
@@ -62,8 +62,23 @@ test('EmptyState — variantes search/success consomem info/success token', func
         ->not->toContain('text-emerald-600');
 });
 
-test('camada canônica de status — zero paleta crua nos 3 arquivos', function () use ($ui, $shared) {
-    $files = [$ui . '/badge.tsx', $shared . '/KpiCard.tsx', $shared . '/EmptyState.tsx'];
+test('StatusBadge — mapa de status app-wide consome success/warning/info (não emerald/amber/blue/orange)', function () use ($shared) {
+    $src = file_get_contents($shared . '/StatusBadge.tsx');
+    expect($src)
+        ->toContain('bg-success text-success-foreground hover:bg-success/90')
+        ->toContain('bg-warning text-warning-foreground hover:bg-warning/90')
+        ->toContain('bg-info text-info-foreground hover:bg-info/90')
+        // ramp de severidade: orange "Risco Alto" virou destructive; Crítico pulsa (ápice distinto)
+        ->toContain("Alto:    { variant: 'destructive', label: 'Risco Alto' }")
+        ->toContain("Crítico: { variant: 'destructive', label: 'Risco Crítico', className: 'animate-pulse' }")
+        ->not->toContain('bg-orange-600')
+        ->not->toContain('bg-emerald-600')
+        ->not->toContain('bg-amber-600')
+        ->not->toContain('bg-blue-600');
+});
+
+test('camada canônica de status — zero paleta crua nos 4 arquivos', function () use ($ui, $shared) {
+    $files = [$ui . '/badge.tsx', $shared . '/KpiCard.tsx', $shared . '/EmptyState.tsx', $shared . '/StatusBadge.tsx'];
     foreach ($files as $f) {
         $src = file_get_contents($f);
         // shades numéricos de paleta crua (emerald-500, sky-50, blue-600…) = 0


### PR DESCRIPTION
## Onda M1 · sub-item (a) cont.: o maior chunk de paleta crua canônica

`shared/StatusBadge.tsx` é o mapa de status usado em **~12 domínios** (intercorrência, aprovação, payment, financeiro, nfse, vehicle, ads, mcp…). Hardcodava `bg-{emerald,amber,blue,orange}-600` — enquanto as entradas `admin_health`/`admin_reachable` **no mesmo arquivo** já usavam tokens. Esta PR estende o padrão que o próprio arquivo já tinha.

| Antes | Depois |
|---|---|
| `bg-emerald-600 hover:bg-emerald-700` | `bg-success text-success-foreground hover:bg-success/90` |
| `bg-amber-600 hover:bg-amber-700` | `bg-warning text-warning-foreground hover:bg-warning/90` |
| `bg-blue-600 hover:bg-blue-700` | `bg-info text-info-foreground hover:bg-info/90` |

### Ramp de severidade sem token "orange"

`ads_risco` tinha 4 níveis (Baixo/Médio/Alto/Crítico) usando `orange-600` no Alto. Sem token orange, colapsa nos **3 semânticos** (success→warning→destructive) e o **ápice (Crítico) ganha `animate-pulse`** pra ficar distinto do Alto. 4 níveis legíveis, DS-puro, label reforça. Idem `mcp_status.quota_exceeded`.

## Prova
- ✅ **build:inertia** verde (1m17s) — classes resolvem (os tokens já eram usados por admin_health).
- ✅ **teste-guarda** estendido — 5 testes / 36 asserts: **0 paleta crua nos 4 arquivos canônicos de status**.
- ✅ eslint `ds/*` verde.

## Falta de M1 sub-item (a)
`shared/VendaDerivadaCard.tsx` — card autoral ("extrair, não repintar") → PR próprio.

Refs: DS-MATURIDADE ONDA-M1

🤖 Generated with [Claude Code](https://claude.com/claude-code)