### PR TITLE
feat(ds): catraca trava a camada canônica em 0 paleta crua (Onda M1 · keystone)

### DIFF
--- a/.github/workflows/ds-canon-color-guard.yml
+++ b/.github/workflows/ds-canon-color-guard.yml
@@ -1,0 +1,65 @@
+name: DS canon color guard (camada canônica sem paleta crua)
+
+# Auditoria sênior de maturidade do DS (2026-06-13, nota 61/100): a camada canônica
+# se autocontradizia — `ui/badge.tsx` hardcodava `bg-emerald-50`, a paleta crua que a
+# própria regra `ds/*` proíbe nas Pages. Os `ds/*` do eslint IGNORAM Components/ui/**
+# (confiam, não forçam). Este gate FECHA o buraco: o canon de cor consome TOKEN.
+#
+# Node puro (fs), sem deps, sem npm ci. Comando local: npm run ds:canon:check
+# Lei do projeto (ADR 0240): derivado + enforcado sobrevive. Onda M1.
+
+on:
+  push:
+    branches: [main, 6.7-react]
+    paths:
+      - 'resources/js/Components/ui/**'
+      - 'resources/js/Components/shared/**'
+      - 'scripts/ds-canon-color-guard.mjs'
+      - 'package.json'
+      - '.github/workflows/ds-canon-color-guard.yml'
+  pull_request:
+    paths:
+      - 'resources/js/Components/ui/**'
+      - 'resources/js/Components/shared/**'
+      - 'scripts/ds-canon-color-guard.mjs'
+      - 'package.json'
+      - '.github/workflows/ds-canon-color-guard.yml'
+
+concurrency:
+  group: ds-canon-color-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ds-canon-color:
+    name: DS canon · cor crua na camada canônica (teto 0 + allowlist autoral)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+
+      - name: DS canon color guard (falha se ui/ ou shared/ usar paleta crua)
+        run: node scripts/ds-canon-color-guard.mjs
+
+      - name: Diagnóstico em caso de falha
+        if: failure()
+        run: |
+          echo ""
+          echo "❌ A camada canônica do DS (Components/ui|shared) está usando paleta crua."
+          echo "   O canon é a FONTE dos tokens — não pode hardcodar emerald/amber/sky/slate-NNN."
+          echo ""
+          echo "Troque por token semântico:"
+          echo "  status soft  → bg-success-soft text-success-fg · bg-warning/10 · text-info"
+          echo "  status sólido→ bg-success text-success-foreground hover:bg-success/90"
+          echo "  neutro       → bg-muted · text-muted-foreground · border-border"
+          echo "  marca        → bg-primary · ring-ring · bg-accent"
+          echo ""
+          echo "Componente AUTORAL (identidade desenhada, 'extrair não repintar')?"
+          echo "  → ALLOWLIST em scripts/ds-canon-color-guard.mjs no MESMO PR, com justificativa."
+          echo ""
+          echo "Refs: memory/sessions/2026-06-13-auditoria-senior-maturidade-ds-oimpresso.md (Onda M1)"
+          echo "      ADR 0209 (ds/* ratchet) · ADR 0240 (derivado+enforcado)"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ds:report:write": "node scripts/ds-report.mjs --write",
     "ds:ledger": "node scripts/ds-ledger.mjs",
     "ds:ledger:write": "node scripts/ds-ledger.mjs --write",
+    "ds:canon:check": "node scripts/ds-canon-color-guard.mjs",
     "design:review": "node prototipo-ui/audit/review-gen.mjs",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/resources/js/Components/ui/field-state.tsx
+++ b/resources/js/Components/ui/field-state.tsx
@@ -5,7 +5,8 @@ import { cn } from "@/Lib/utils"
 
 /**
  * Estados de campo canon Onda F — completam o trio da A2 + obrigatório.
- * Substituem os `<p className="text-rose-600">` / `text-emerald-600` soltos.
+ * Substituem os `<p>` de erro/sucesso soltos com cor crua por tokens semânticos
+ * (text-destructive / text-success), anunciados por screen reader.
  */
 
 /** Erro de validação. role=alert (anunciado por screen reader). Não renderiza vazio. */

--- a/resources/js/Components/ui/resizable.tsx
+++ b/resources/js/Components/ui/resizable.tsx
@@ -30,7 +30,7 @@ const ResizableHandle = ({
 }) => (
   <ResizablePrimitive.PanelResizeHandle
     className={cn(
-      "relative flex w-1 items-center justify-center bg-border hover:bg-blue-400 transition-colors after:absolute after:inset-y-0 after:left-1/2 after:w-2 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-1 data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-2 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+      "relative flex w-1 items-center justify-center bg-border hover:bg-primary transition-colors after:absolute after:inset-y-0 after:left-1/2 after:w-2 after:-translate-x-1/2 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 data-[panel-group-direction=vertical]:h-1 data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-2 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
       className,
     )}
     {...props}

--- a/scripts/ds-canon-color-guard.mjs
+++ b/scripts/ds-canon-color-guard.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+// scripts/ds-canon-color-guard.mjs — catraca: a camada canônica NÃO usa paleta crua
+//
+// =====================================================================================
+// POR QUE EXISTE
+// =====================================================================================
+// Auditoria sênior de maturidade do DS (2026-06-13, nota 61/100): a "arma fumegante"
+// era a camada canônica SE AUTOCONTRADIZENDO. `ui/badge.tsx` hardcodava `bg-emerald-50`
+// — exatamente a paleta crua que a regra `ds/no-adhoc-status-text` proíbe nas Pages.
+//
+// O buraco: os `ds/*` do eslint IGNORAM `Components/ui/**` (eslint.config.js:133) com a
+// justificativa "camada canônica onde os padrões legitimamente vivem". A regra CONFIA
+// que o canon é limpo — mas nada FORÇA. Foi assim que o badge cru passou meses.
+//
+// Este guard FECHA o buraco: o canon de cor (ui/ + shared/) consome TOKEN, não paleta.
+// Lei do projeto (ADR 0240): "derivado + enforcado sobrevive / escrito + lembrado
+// apodrece". Sem catraca, a autocontradição volta no próximo PR.
+//
+// =====================================================================================
+// O QUE VALIDA
+// =====================================================================================
+// Varre `resources/js/Components/{ui,shared}/*.tsx` por shade numérico de paleta crua
+// do Tailwind (emerald-500, sky-50, blue-600, slate-900…). Comentários são removidos
+// antes da varredura (descrever cor antiga em doc-comment é legítimo). Teto = 0.
+//
+// ALLOWLIST: componentes AUTORAIS ("extrair, não repintar" — identidade desenhada
+// verbatim de protótipo, tokenizar à força destruiria a arte). Entrada nova na
+// allowlist = decisão consciente no MESMO PR (aparece no diff pro reviewer), com
+// justificativa. Sem baseline JSON: a allowlist É o estado canônico.
+//
+// Comando local: npm run ds:canon:check
+//
+// Refs: auditoria-senior-maturidade-ds-oimpresso.md (Onda M1) · ADR 0209 (ds/* ratchet) ·
+//       ADR 0240 (derivado+enforcado) · eslint.config.js:121-166 (escopo ds/* = telas)
+
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import { resolve, join, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const SCAN_DIRS = [
+  'resources/js/Components/ui',
+  'resources/js/Components/shared',
+];
+
+// ── ALLOWLIST · componentes autorais (identidade desenhada · "extrair, não repintar") ──
+// Entrada nova = editar AQUI no mesmo PR, com justificativa. Caminho relativo ao ROOT.
+const ALLOWED = new Map([
+  [
+    'resources/js/Components/shared/VendaDerivadaCard.tsx',
+    'card autoral "OS gerou venda" — mapeamento verbatim do protótipo Cowork (tokens .ofc-venda-* · ADR 0192). Identidade desenhada (gradiente), não repintar; tokenização própria via extração futura.',
+  ],
+]);
+
+// Paletas nomeadas do Tailwind (cor crua). NÃO inclui tokens semânticos (success,
+// warning, info, destructive, primary, muted, border, foreground, accent, ring…).
+const TW_PALETTES = [
+  'slate', 'gray', 'zinc', 'neutral', 'stone',
+  'red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal',
+  'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose',
+];
+const SHADES = '(?:50|100|200|300|400|500|600|700|800|900|950)';
+// prefixo de cor (-? cobre arbitrary, mas aqui pegamos a forma `palette-shade` em
+// qualquer utilitário: bg-/text-/border-/ring-/from-/to-/via-/fill-/stroke-/divide-/…)
+const RAW_RE = new RegExp(`\\b(?:${TW_PALETTES.join('|')})-${SHADES}\\b`, 'g');
+
+/** Remove comentários de bloco e de linha (cor crua em doc-comment é legítima). */
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')   // /* … */
+    .replace(/^\s*\/\/.*$/gm, '')        // linha inteira //
+    .replace(/([^:])\/\/.*$/gm, '$1');   // // no fim de linha (preserva https:// via [^:])
+}
+
+function tsxFiles(dir) {
+  const abs = resolve(ROOT, dir);
+  if (!existsSync(abs)) return [];
+  return readdirSync(abs)
+    .filter((f) => f.endsWith('.tsx') || f.endsWith('.ts'))
+    .map((f) => join(dir, f).replace(/\\/g, '/'));
+}
+
+const offenders = [];
+let scanned = 0;
+
+for (const dir of SCAN_DIRS) {
+  for (const rel of tsxFiles(dir)) {
+    if (ALLOWED.has(rel)) continue;
+    scanned++;
+    const src = stripComments(readFileSync(resolve(ROOT, rel), 'utf8'));
+    const hits = [...src.matchAll(RAW_RE)].map((m) => m[0]);
+    if (hits.length) {
+      const uniq = [...new Set(hits)];
+      offenders.push({ rel, count: hits.length, sample: uniq.slice(0, 6) });
+    }
+  }
+}
+
+if (offenders.length) {
+  console.error('\n✗ [ds-canon-color-guard] camada canônica usando PALETA CRUA (teto = 0):\n');
+  for (const o of offenders) {
+    console.error(`  ${o.rel} — ${o.count} ocorrência(s): ${o.sample.join(', ')}`);
+  }
+  console.error('\nO canon do DS consome TOKEN, não paleta. Troque por token semântico:');
+  console.error('  status:  bg-success-soft/text-success-fg · bg-warning/10 · text-info · bg-destructive/5');
+  console.error('  sólido:  bg-success text-success-foreground hover:bg-success/90 (ver StatusBadge admin_health)');
+  console.error('  neutro:  bg-muted · text-muted-foreground · border-border · text-foreground');
+  console.error('  marca:   bg-primary · ring-ring · bg-accent');
+  console.error('\nComponente AUTORAL (identidade desenhada, "extrair não repintar")?');
+  console.error('  → adicione à ALLOWLIST em scripts/ds-canon-color-guard.mjs no MESMO PR, com justificativa.');
+  console.error('\nRefs: Onda M1 (maturidade DS) · ADR 0209 · ADR 0240\n');
+  process.exit(1);
+}
+
+console.log(`✅ [ds-canon-color-guard] ${scanned} arquivo(s) canônico(s) (ui/ + shared/) sem paleta crua · ${ALLOWED.size} autoral allowlisted.`);

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -66,6 +66,10 @@
       "nome": "CSS size ratchet (congelar sprawl · MANUAL-CSS-JS#1)",
       "classe": "gate"
     },
+    "ds-canon-color-guard.yml": {
+      "nome": "DS canon color guard (camada canônica sem paleta crua)",
+      "classe": "gate"
+    },
     "deploy.yml": {
       "nome": "Deploy to Hostinger",
       "classe": "deploy"


### PR DESCRIPTION
## Onda M1 · keystone: a catraca que torna a autocontradição IM-REGRESSÍVEL

A [auditoria sênior](../blob/main/memory/sessions/2026-06-13-auditoria-senior-maturidade-ds-oimpresso.md) achou **por que** o badge cru passou meses: os `ds/*` do eslint **ignoram `Components/ui/**`** ([eslint.config.js:133](../blob/main/eslint.config.js#L133)) — *"camada canônica onde os padrões legitimamente vivem"*. A regra **confia** que o canon é limpo, mas **nada força**.

Fechar os PRs #2641 + #2643 (tokenizar badge/KpiCard/EmptyState/StatusBadge) sem isto deixaria a porta aberta pra autocontradição voltar no próximo PR. **Lei do projeto (ADR 0240): derivado + enforcado sobrevive.**

## O quê

- **`scripts/ds-canon-color-guard.mjs`** — varre `ui/` + `shared/` por shade de paleta crua (`emerald-500`, `sky-50`, `slate-900`…), **ignora comentários**, teto **0**. Allowlist pra componente **autoral** (`VendaDerivadaCard` — *"extrair, não repintar"*). Sem baseline JSON: a allowlist **É** o estado canônico (vive no diff).
- **`.github/workflows/ds-canon-color-guard.yml`** — job CI espelhando `components-tree-guard`.
- **`package.json`** — `npm run ds:canon:check`.
- **Fixes residuais** pra zerar o canon: `resizable.tsx` (`hover:bg-blue-400` → `hover:bg-primary`) + `field-state.tsx` (cor crua só num doc-comment → reescrito).

## Prova de que MORDE

Injetei `bg-rose-500` no `badge.tsx` → gate **exit 1** (`badge.tsx — 1 ocorrência: rose-500`). Restaurei → **exit 0** (`48 arquivos limpos · 1 allowlisted`). Build verde.

## Resultado

M1 sub-item (a) **fecha**: a camada canônica consome o DS que ela exige das telas, **e a catraca impede a regressão**.

Refs: DS-MATURIDADE ONDA-M1 · ADR 0209 · ADR 0240

🤖 Generated with [Claude Code](https://claude.com/claude-code)