### PR TITLE
feat(ds): tokens de motion — vocabulário de duração + easing (Onda M1 · D8)

### DIFF
--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-13T12:25:48.011Z",
-    "total_lines": 20395,
+    "generated_at": "2026-06-13T13:37:54.054Z",
+    "total_lines": 20407,
     "file_count": 29,
     "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
     "refs": [
@@ -22,7 +22,7 @@
     "resources/css/fin-output.css": 1004,
     "resources/css/fiscal-cockpit.css": 1381,
     "resources/css/foundations.css": 45,
-    "resources/css/inertia.css": 396,
+    "resources/css/inertia.css": 408,
     "resources/css/kb.css": 184,
     "resources/css/screen-grade.css": 16,
     "resources/css/sells-cowork-curadoria.css": 312,

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -176,6 +176,18 @@
   --radius-lg: 0.5rem;
   --radius-md: calc(0.5rem - 2px);
   --radius-sm: calc(0.5rem - 4px);
+
+  /* Motion — Onda M1 (maturidade DS · dimensão D8). Vocabulário nomeado de duração
+     + easing. Antes: durations cruas espalhadas (150ms, .12s) sem easing nomeado.
+     Princípios: micro-interação (hover/focus/toggle) 120–150ms · overlay/sheet 240ms ·
+     nada acima de 360ms. Consumidor deve respeitar prefers-reduced-motion (M4 a11y). */
+  --duration-fast: 120ms;
+  --duration-base: 150ms;
+  --duration-slow: 240ms;
+  --duration-slower: 360ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);   /* default — entra e sai */
+  --ease-out: cubic-bezier(0, 0, 0.2, 1);         /* entrada (aparecer/expandir) */
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);          /* saída (sumir/recolher) */
 }
 
 /* ==========================================================================
@@ -248,7 +260,7 @@
   body {
     background-color: var(--color-background);
     color: var(--color-foreground);
-    transition: background-color 150ms ease, color 150ms ease;
+    transition: background-color var(--duration-base) var(--ease-standard), color var(--duration-base) var(--ease-standard);
   }
 }
 


### PR DESCRIPTION
## Onda M1 · dimensão D8 (Motion): de 20/100 pra um vocabulário real

A [auditoria sênior](../blob/main/memory/sessions/2026-06-13-auditoria-senior-maturidade-ds-oimpresso.md) deu **Motion = 20/100** (gap 80%): *"ZERO tokens de motion, só durations cruas espalhadas (150ms, .12s) sem easing nomeado"*.

## O quê
- **`@theme`** — escala nomeada:
  - `--duration-fast/base/slow/slower` = 120/150/240/360ms
  - `--ease-standard/out/in` (cubic-bezier)
  - princípios no comentário: micro-interação 120–150ms · overlay/sheet 240ms · nada >360ms
- **`body`** — a transição global app-wide passa a **consumir** os tokens (não vira shelf tool). Duration casa **exato** (150ms = `--duration-base`); easing imperceptível num fade de cor que só dispara no toggle de tema.
- **css-size baseline** — `inertia.css` 396→408 (decisão consciente, tokens novos).

## Prova
- ✅ build verde · conformance + foundation-guard verdes · css-size atualizado.

`prefers-reduced-motion` (consumidor respeita) fica pra **M4 (a11y)**.

Refs: DS-MATURIDADE ONDA-M1

🤖 Generated with [Claude Code](https://claude.com/claude-code)