### PR TITLE
fix(whatsapp): macro_variant_id no $fillable de Message (A/B tracking persiste)

### DIFF
--- a/Modules/Whatsapp/Entities/Message.php
+++ b/Modules/Whatsapp/Entities/Message.php
@@ -91,6 +91,8 @@ class Message extends Model
         'sender_user_id', 'sender_kind',
         'cost_centavos',
         'is_internal_note',
+        // US-WA-049 — A/B tracking de variante de macro (MacroExecutor grava macro_variant_id)
+        'macro_variant_id',
         // US-WA-072 — mídia
         'media_url', 'media_mime', 'media_size_bytes',
         'media_duration_s', 'media_thumbnail_url',


### PR DESCRIPTION
## Bug (par adversarial · ADR 0276 · re-triage eixo FAILURE · US-GOV-018)

Feature **US-WA-049** (A/B tracking de variante de macro) quebrada em prod.

`MacroExecutor::doExecute` (`Modules/Whatsapp/Services/Macros/MacroExecutor.php:88-100`) faz:

```php
Message::query()->create([
    ...,
    'macro_variant_id' => $variant?->id,
]);
```

Mas `macro_variant_id` **não estava** no array `$fillable` de `Modules/Whatsapp/Entities/Message.php`. O mass-assignment do Eloquent descartava a chave **silenciosamente** — a coluna `messages.macro_variant_id` existe no schema, mas nunca era populada. Sem o `macro_variant_id` no outbound, o response tracking não tinha como parear a resposta com a variante enviada.

## Fix (mínimo · 1 intent)

Adiciona `'macro_variant_id'` ao `$fillable` de `Message.php` (+2 linhas, comentário incluso).

- `business_id` global scope (`HasBusinessScope`, multi-tenant Tier 0) **intacto**.
- `macro_variant_id` é FK nullable, sem PII.

## Evidência do refutador / teste confirmante

`Modules/Whatsapp/Tests/Feature/MacroVariantPickerTest.php`:

- **R-WA-049-PICKER-007** (linha 296): `expect($msg->macro_variant_id)->toBe($variant->id)` — falhava porque o valor nunca persistia.
- **R-WA-049-TRACKER-008 / 009 / 010**: criam outbounds com `macro_variant_id` via mass-assignment (linhas 326, 369, 411); dependem da persistência pra o tracker achar o outbound dentro da janela 24h.

Não rodei Pest local (CT100-only, hook `block-test-fora-ct100`) — verificação por leitura: com a chave no `$fillable`, o `create()` do MacroExecutor passa a persistir e a assertion 007 é satisfeita.

Refs: US-GOV-018 re-triage