### PR TITLE
fix(superadmin): registra comando superadmin:health no ServiceProvider

### DIFF
--- a/Modules/Superadmin/Providers/SuperadminServiceProvider.php
+++ b/Modules/Superadmin/Providers/SuperadminServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
 use Modules\PaymentGateway\Events\CobrancaPaga;
 use Modules\PaymentGateway\Events\CobrancaVencida;
+use Modules\Superadmin\Console\SuperadminHealthCommand;
 use Modules\Superadmin\Entities\Subscription;
 use Modules\Superadmin\Entities\SuperadminFrontendPage;
 use Modules\Superadmin\Listeners\OnCobrancaPagaUpdateSubscription;
@@ -45,6 +46,12 @@ class SuperadminServiceProvider extends ServiceProvider
         $this->registerScheduleCommands();
         $this->registerPaymentGatewayListeners();
         $this->registerBusinessAutoSubscriptionObserver();
+
+        // Wave 23 D9.c — registra o health-check command (espelha ConnectorServiceProvider).
+        // Sem este registro o comando superadmin:health nunca aparece em Artisan::all().
+        $this->commands([
+            SuperadminHealthCommand::class,
+        ]);
 
         view::composer('superadmin::layouts.partials.active_subscription', function ($view) {
             $business_id = session()->get('user.business_id');


### PR DESCRIPTION
## Bug (eixo FAILURE — US-GOV-018 re-triage, par adversarial ADR 0276)

`Modules/Superadmin/Console/SuperadminHealthCommand.php` existe com a signature `superadmin:health`, mas `Modules/Superadmin/Providers/SuperadminServiceProvider.php` **nunca o registrava** — não havia chamada a `$this->commands([...])` no `boot()`. Consequência: o comando jamais aparecia em `Artisan::all()`, `php artisan superadmin:health` retornaria "command not found", e o health-check D9.c agendado (06:20 BRT) nunca rodaria.

## Fix (mínimo · 1 intent)

- Importa `Modules\Superadmin\Console\SuperadminHealthCommand`.
- Adiciona `$this->commands([SuperadminHealthCommand::class]);` no `boot()`.

Espelha o módulo gêmeo `ConnectorServiceProvider` (linhas 43-47), que já registra `ConnectorHealthCommand` da mesma forma. Nenhuma refatoração além do necessário.

## Teste confirmante

`Modules/Superadmin/Tests/Feature/Wave23CrossTenantIsolationTest.php`, cenário 5:

```php
it('comando superadmin:health está registrado em artisan', function () {
    $commands = Artisan::all();
    expect($commands)->toHaveKey('superadmin:health');
});
```

Antes do fix essa asserção falha (chave ausente). Depois do registro, a signature `superadmin:health` do command passa a constar em `Artisan::all()` → asserção verde. Os cenários de smoke (`superadmin:health executa sem fatal`, `--detail mostra tabela`) também dependiam deste registro.

## Verificação

Pest não rodado localmente (CT100-only, hook `block-test-fora-ct100`). Fix verificado por leitura: registro idêntico ao pattern Connector já validado em produção.

Refs: US-GOV-018 re-triage (eixo FAILURE, superadmin-health) · Wave23CrossTenantIsolationTest cenário 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)