### PR TITLE
fix(whatsapp): enforce 1 grant ativo por (canal,user) em channel_user_access

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_12_160000_create_channel_user_access_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_12_160000_create_channel_user_access_table.php
@@ -14,9 +14,14 @@ use Illuminate\Support\Facades\Schema;
  * `whatsapp_business_phones`) — não migra, não substitui. Filtragem de inbox
  * por canais permitidos vai pra US-WA-069.
  *
- * Soft revoke (revoked_at NULL = ativo) preserva audit history. UNIQUE inclui
- * revoked_at pra permitir re-grant após revoke (1 par canal/user pode ter N
- * rows históricas mas só 1 com revoked_at IS NULL).
+ * Soft revoke (revoked_at NULL = ativo) preserva audit history.
+ *
+ * ⚠️ CORRIGIDO em 2026_06_13_120000_enforce_single_active_channel_user_access:
+ * o UNIQUE(channel_id, user_id, revoked_at) abaixo NÃO garante "só 1 row
+ * revoked_at=NULL por par" — NULLs são DISTINTOS em índice UNIQUE (MySQL/MariaDB/
+ * SQLite/SQL padrão), então dois grants ativos não colidiam. O enforcement real
+ * vive na migration corretiva (coluna gerada `revoked_marker` + UNIQUE). Mantido
+ * aqui como histórico append-only; não confie neste UNIQUE pro invariante.
  *
  * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — `business_id` global scope
  * via trait HasBusinessScope no Model.
@@ -45,9 +50,10 @@ return new class extends Migration
             $table->timestamps();
 
             // UNIQUE inclui revoked_at — permite re-grant após revoke.
-            // MySQL trata NULLs como distintos em UNIQUE → múltiplas rows
-            // revoked_at != NULL podem coexistir; apenas 1 row revoked_at=NULL
-            // por (channel_id, user_id).
+            // ⚠️ NÃO enforça "1 ativo por par": NULLs são distintos em UNIQUE,
+            // então dois revoked_at=NULL coexistem. Invariante real é garantido
+            // pela migration 2026_06_13_120000 (coluna gerada + UNIQUE), que
+            // também DROPA este índice. Mantido aqui só como histórico.
             $table->unique(
                 ['channel_id', 'user_id', 'revoked_at'],
                 'cua_channel_user_unq'

--- a/Modules/Whatsapp/Database/Migrations/2026_06_13_120000_enforce_single_active_channel_user_access.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_06_13_120000_enforce_single_active_channel_user_access.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * channel_user_access — enforça "no máx 1 grant ATIVO por (channel_id, user_id)".
+ *
+ * BUG corrigido (US-GOV-018 / US-WA-068, ADR 0135): a migration de criação
+ * (2026_05_12_160000) definiu UNIQUE(channel_id, user_id, revoked_at) achando
+ * que isso garantiria "só 1 row revoked_at=NULL por par". ERRADO — em MySQL,
+ * MariaDB, SQLite e SQL padrão, valores NULL são tratados como DISTINTOS num
+ * índice UNIQUE. Logo DUAS rows com revoked_at=NULL (= dois grants ativos do
+ * mesmo user no mesmo canal) NÃO colidiam. O contrato de ACL não era enforced
+ * pelo schema (guard test R-WA-068-005 falhava no nightly MySQL).
+ *
+ * Solução (enforcement de banco — Tier 0): coluna gerada VIRTUAL `revoked_marker`
+ * que vale `1` quando ativo (revoked_at NULL) e `NULL` quando revogado, e
+ * UNIQUE(channel_id, user_id, revoked_marker):
+ *   - ativos    → marker=1    → no máx 1 por (channel_id,user_id) [colidem]
+ *   - revogados → marker=NULL → coexistem N (NULLs distintos) → preserva history
+ *                               e permite re-grant após revoke (R-WA-068-004/006)
+ *
+ * Por que VIRTUAL e não STORED: o SQLite só aceita coluna gerada VIRTUAL via
+ * `ALTER TABLE ADD COLUMN` (STORED é proibido em ALTER) — e as suites com
+ * RefreshDatabase rodam todas as migrations contra SQLite :memory:. VIRTUAL +
+ * UNIQUE é suportado em MySQL 5.7.8+, MariaDB 10.2+ (InnoDB) e SQLite 3.31+.
+ *
+ * Append-only: não edita a migration de criação. Idempotente (hasTable/
+ * hasColumn/hasIndex) e reversível (down()).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): a higienização de duplicados roda como
+ * SUPERADMIN (migration sem sessão de business) — opera cross-tenant
+ * explicitamente. O UNIQUE escopa por channel_id, que já pertence a 1 business.
+ *
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-068
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('channel_user_access')) {
+            return; // tabela ainda não criada — a migration de criação cuida disso
+        }
+
+        // 1) Coluna gerada VIRTUAL: 1=ativo (revoked_at NULL), NULL=revogado.
+        if (! Schema::hasColumn('channel_user_access', 'revoked_marker')) {
+            Schema::table('channel_user_access', function (Blueprint $table) {
+                $table->integer('revoked_marker')
+                    ->virtualAs('case when revoked_at is null then 1 else null end')
+                    ->nullable()
+                    ->comment('GERADA: 1=ativo (revoked_at NULL), NULL=revogado. Enforce 1 grant ativo/(canal,user) via UNIQUE cua_active_grant_unq.');
+            });
+        }
+
+        // 2) Higieniza duplicados ATIVOS pré-existentes (deixados passar pelo
+        //    UNIQUE antigo) ANTES de criar o índice novo — senão a criação falha.
+        $this->revokeDuplicateActiveGrants();
+
+        // 3) UNIQUE real do invariante. Criado ANTES de dropar o antigo porque
+        //    tem channel_id como primeira coluna → cobre o índice exigido pela
+        //    FK cua_channel_fk (MySQL/MariaDB recusam dropar o último índice da FK).
+        if (! Schema::hasIndex('channel_user_access', 'cua_active_grant_unq')) {
+            Schema::table('channel_user_access', function (Blueprint $table) {
+                $table->unique(['channel_id', 'user_id', 'revoked_marker'], 'cua_active_grant_unq');
+            });
+        }
+
+        // 4) Remove o UNIQUE antigo (não enforça nada — NULLs distintos).
+        if (Schema::hasIndex('channel_user_access', 'cua_channel_user_unq')) {
+            Schema::table('channel_user_access', function (Blueprint $table) {
+                $table->dropUnique('cua_channel_user_unq');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('channel_user_access')) {
+            return;
+        }
+
+        // Restaura o UNIQUE antigo ANTES de remover o novo (cobre o índice da FK).
+        if (! Schema::hasIndex('channel_user_access', 'cua_channel_user_unq')) {
+            Schema::table('channel_user_access', function (Blueprint $table) {
+                $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+            });
+        }
+
+        // Dropa o índice novo antes da coluna gerada que ele referencia.
+        if (Schema::hasIndex('channel_user_access', 'cua_active_grant_unq')) {
+            Schema::table('channel_user_access', function (Blueprint $table) {
+                $table->dropUnique('cua_active_grant_unq');
+            });
+        }
+
+        if (Schema::hasColumn('channel_user_access', 'revoked_marker')) {
+            Schema::table('channel_user_access', function (Blueprint $table) {
+                $table->dropColumn('revoked_marker');
+            });
+        }
+    }
+
+    /**
+     * Soft-revoga grants ATIVOS duplicados, mantendo o mais recente (maior id)
+     * por (channel_id, user_id). Portável (query builder, sem UPDATE..JOIN) e
+     * idempotente — após rodar, nenhum par tem >1 ativo, então re-rodar é no-op.
+     *
+     * ⚠️ Timestamps ESCALONADOS (now()+i s) por uma razão sutil: neste ponto da
+     * migration o índice ANTIGO UNIQUE(channel_id, user_id, revoked_at) ainda
+     * existe. Revogar N rows do mesmo par com o MESMO revoked_at colidiria nele
+     * (revoked_at iguais não são distintos quando não-NULL). Escalonar garante
+     * revoked_at distintos. Pós-migration o índice real ignora revoked_at
+     * (usa revoked_marker), então o escalonamento é cosmético e inofensivo.
+     *
+     * SUPERADMIN: migration roda sem sessão de business — opera cross-tenant.
+     */
+    private function revokeDuplicateActiveGrants(): void
+    {
+        $duplicateGroups = DB::table('channel_user_access')
+            ->select('channel_id', 'user_id')
+            ->whereNull('revoked_at')
+            ->groupBy('channel_id', 'user_id')
+            ->havingRaw('count(*) > 1')
+            ->get();
+
+        foreach ($duplicateGroups as $group) {
+            $activeIds = DB::table('channel_user_access')
+                ->where('channel_id', $group->channel_id)
+                ->where('user_id', $group->user_id)
+                ->whereNull('revoked_at')
+                ->orderBy('id')
+                ->pluck('id')
+                ->all();
+
+            array_pop($activeIds); // mantém o maior id (mais recente) ativo
+
+            foreach (array_values($activeIds) as $i => $id) {
+                DB::table('channel_user_access')
+                    ->where('id', $id)
+                    ->update([
+                        'revoked_at' => now()->addSeconds($i),
+                        'updated_at' => now(),
+                    ]);
+            }
+        }
+    }
+};

--- a/Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php
@@ -62,7 +62,8 @@ beforeEach(function () {
         $table->timestamps();
     });
 
-    // Espelha migration channel_user_access (US-WA-068)
+    // Espelha migration channel_user_access (US-WA-068) + correção
+    // 2026_06_13 (enforce 1 grant ativo via coluna gerada + UNIQUE).
     Schema::create('channel_user_access', function ($table) {
         $table->bigIncrements('id');
         $table->unsignedInteger('business_id');
@@ -72,10 +73,17 @@ beforeEach(function () {
         $table->timestamp('granted_at');
         $table->timestamp('revoked_at')->nullable();
         $table->unsignedInteger('revoked_by_user_id')->nullable();
+        // Coluna gerada VIRTUAL: 1=ativo (revoked_at NULL), NULL=revogado.
+        // É o que faz o UNIQUE enforçar 1 ativo/(canal,user) — NULLs distintos
+        // deixam os revogados coexistirem (re-grant + history). Sem ela, dois
+        // grants ativos não colidiam (bug do UNIQUE com revoked_at NULL).
+        $table->integer('revoked_marker')
+            ->virtualAs('case when revoked_at is null then 1 else null end')
+            ->nullable();
         $table->timestamps();
         $table->unique(
-            ['channel_id', 'user_id', 'revoked_at'],
-            'cua_channel_user_unq'
+            ['channel_id', 'user_id', 'revoked_marker'],
+            'cua_active_grant_unq'
         );
         $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
     });


### PR DESCRIPTION
## Bug (US-WA-068 / US-GOV-018)

`UNIQUE(channel_id, user_id, revoked_at)` em `channel_user_access` **não** enforça o invariante "1 grant ativo por (canal, user)" — `NULL` é tratado como **distinto** em índice UNIQUE (MySQL/MariaDB/SQLite/SQL padrão), então duas rows com `revoked_at=NULL` (= dois grants ativos do mesmo user no mesmo canal) coexistiam sem `QueryException`. O guard test `R-WA-068-005` falhava no nightly MySQL full-suite. O contrato de ACL não estava enforced pelo schema.

## Fix — enforcement de banco (Tier 0, opção (a))

Nova migration `2026_06_13_120000_enforce_single_active_channel_user_access`:

- coluna gerada **VIRTUAL** `revoked_marker` = `1` quando ativo (`revoked_at NULL`), `NULL` quando revogado;
- `UNIQUE(channel_id, user_id, revoked_marker)` → ativos colidem (máx 1 por par); revogados coexistem (NULLs distintos → preserva history + permite re-grant após revoke);
- **VIRTUAL** e não STORED porque o SQLite só aceita coluna gerada via `ALTER ADD COLUMN` se for VIRTUAL — e suites com `RefreshDatabase` rodam todas as migrations contra SQLite `:memory:`. VIRTUAL+UNIQUE é suportado em MySQL 5.7.8+, MariaDB 10.2+ (InnoDB), SQLite 3.31+;
- **higieniza duplicados ativos pré-existentes** (que o índice antigo pode ter deixado passar) com timestamps escalonados **antes** de criar o índice — senão o índice antigo, ainda presente nesse ponto, colidiria;
- idempotente (`hasTable`/`hasColumn`/`hasIndex`), `down()` reversível, dedup `// SUPERADMIN` cross-tenant (ADR 0093).

`ChannelsController::grantUser` e `BackfillChannelAccessCommand` **já pré-checam** grant ativo (no-op gracioso) → sem regressão de UX; o constraint vira última-linha-de-defesa pra race/insert raw. Guard `Entity::creating()` **não** adicionado de propósito: dispararia antes do INSERT e quebraria a asserção `toThrow(QueryException)` de R-WA-068-005 — o enforcement Tier 0 é o de banco.

A migration de criação (`2026_05_12_160000`) teve só **comentários** corrigidos (documentavam a crença falsa que causou o bug); zero mudança de DDL, append-only.

## Verificação

- Repliquei o SQL **exato** emitido pelo Laravel (grammar SQLite/MySQL) contra **SQLite 3.49.1** (engine default dos testes): R-WA-068-002/003/004/005/006 ✅, migration em tabela limpa ✅, migration sobre **dados duplicados pré-existentes** (dedup escalona, sem colisão, history preservada) ✅, idempotência (re-run no-op) ✅, enforcement pós-migration ✅. O teste empírico inclusive pegou um bug intermediário (dedup com `now()` único colidindo no índice antigo) que foi corrigido.
- Verificação autoritativa MySQL: CI nightly + `php artisan test Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php` no CT 100.

## Refs

US-WA-068 · US-GOV-018 · ADR 0135 (omnichannel) · ADR 0093 (multi-tenant Tier 0)

<!-- no-ui-smoke: backend-only (migration + test PHP, sem .tsx/.blade) -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
