### PR TITLE
fix(ads): registra ads:health no AdsServiceProvider (D9.c)

### DIFF
--- a/Modules/ADS/Providers/AdsServiceProvider.php
+++ b/Modules/ADS/Providers/AdsServiceProvider.php
@@ -20,6 +20,7 @@ use Modules\ADS\Services\DecisionLinksService;
 use Modules\ADS\Services\UserScopeService;
 use Modules\ADS\Services\ContextForTaskService;
 use Modules\ADS\Http\Middleware\AdsApiAuth;
+use Modules\ADS\Console\Commands\AdsHealthCommand;
 use Modules\ADS\Console\Commands\ProcessBrainBCommand;
 use Modules\ADS\Console\Commands\LearnPatternsCommand;
 use Modules\ADS\Console\Commands\ReviewDecisionsCommand;
@@ -44,6 +45,7 @@ class AdsServiceProvider extends ServiceProvider
                 AutoGenerateTasksCommand::class,
                 PlanDecisionsCommand::class,
                 SkillScaffoldCommand::class,
+                AdsHealthCommand::class,
             ]);
         }
     }


### PR DESCRIPTION
## Bug (US-GOV-018 re-triage · eixo FAILURE · par adversarial ADR 0276)

`ads:health` nunca era registrado. A classe `Modules\ADS\Console\Commands\AdsHealthCommand` existe e é funcional, mas `AdsServiceProvider::boot()` omitia ela do array `$this->commands([...])` — então o comando não aparecia em `artisan list`.

## Fix (mínimo, 1 intent · 2 linhas)

- Import `use Modules\ADS\Console\Commands\AdsHealthCommand;`
- Entrada `AdsHealthCommand::class,` no array `commands([...])`

Mesmo padrão dos 6 comandos já registrados no módulo. Nenhum refactor.

## Evidência do refutador

A classe alvo está completa: signature `ads:health` com `--json`/`--alert`, `handle()` retorna 0 sem `--alert`, output JSON com `module = 'ADS'`, exatamente 6 checks (`summary.total = 6`) e os 6 nomes canônicos Brain B. O único elo faltante era o registro no provider.

## Teste confirmante

`Modules/ADS/Tests/Feature/AdsHealthCommandTest.php` (contrato D9.c · ADR 0155):
1. `ads:health` registrado em `Artisan::all()` — falhava antes (chave ausente), passa agora.
2. `--json` retorna estrutura com `module=ADS` e `summary.total=6`.
3. Output contém os 6 checks canônicos Brain B.

Pest não rodado local (CT100-only, hook `block-test-fora-ct100`). Fix verificado por leitura contra as assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
