### PR TITLE
fix(whatsapp): touch() upsert portável MySQL+SQLite

### DIFF
--- a/Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+++ b/Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
@@ -118,20 +118,30 @@ class CustomerMemoryRebuilder
     {
         $extId = $this->normalizeExternalId($customerExternalId);
         $when = $when ?? now();
+        $nowStr = now()->format('Y-m-d H:i:s');
+        $whenStr = $when->format('Y-m-d H:i:s');
 
-        // Upsert defensivo — race-safe via INSERT ... ON DUPLICATE KEY UPDATE
-        DB::table('customer_memory')->updateOrInsert(
-            [
+        // Upsert race-safe e portável (ADR 0093) — query builder `upsert()` emite
+        // `ON DUPLICATE KEY UPDATE` (MySQL) ou `ON CONFLICT DO UPDATE` (SQLite).
+        // Versão anterior usava updateOrInsert + `COALESCE(first_interaction_at, ?)`
+        // dentro do VALUES do INSERT: MySQL tolera, mas SQLite quebra ("no such
+        // column" — não dá pra referenciar a própria coluna no INSERT ... VALUES).
+        //
+        // first_interaction_at e created_at ficam FORA da lista de update: na
+        // colisão são preservados (semântica first-seen), no insert recebem o valor
+        // da linha nova. Só last_interaction_at/phone_normalized/updated_at mudam.
+        DB::table('customer_memory')->upsert(
+            [[
                 'business_id' => $businessId,
                 'customer_external_id' => $extId,
-            ],
-            [
-                'last_interaction_at' => $when,
-                'first_interaction_at' => DB::raw("COALESCE(first_interaction_at, '" . $when->format('Y-m-d H:i:s') . "')"),
+                'last_interaction_at' => $whenStr,
+                'first_interaction_at' => $whenStr,
                 'phone_normalized' => preg_replace('/\D+/', '', $extId) ?: null,
-                'updated_at' => now(),
-                'created_at' => DB::raw('COALESCE(created_at, NOW())'),
-            ]
+                'created_at' => $nowStr,
+                'updated_at' => $nowStr,
+            ]],
+            ['business_id', 'customer_external_id'],
+            ['last_interaction_at', 'phone_normalized', 'updated_at'],
         );
     }
 


### PR DESCRIPTION
## Problema

`CustomerMemoryRebuilder::touch()` usava `updateOrInsert` com `COALESCE(first_interaction_at, ?)` **dentro do `VALUES` do INSERT**. MySQL tolera referenciar a própria coluna no `INSERT ... VALUES`; **SQLite não** → `SQLSTATE[HY000] 1 no such column: first_interaction_at`. Derrubava 2 testes Pest no driver de teste (SQLite), pré-existentes e sem relação com o trabalho de auto-link em curso.

## Fix

Troca por query builder `upsert()`, que emite forma portável por driver:
- MySQL → `INSERT ... ON DUPLICATE KEY UPDATE`
- SQLite/Postgres → `INSERT ... ON CONFLICT (...) DO UPDATE`

A semântica *first-seen* fica **estrutural**: `first_interaction_at` e `created_at` ficam **fora da lista de update** → preservados na colisão, setados no insert. Só `last_interaction_at` / `phone_normalized` / `updated_at` mudam no re-touch. Depende do unique `customer_memory_biz_ext_uniq` (já existe em prod e no schema de teste).

## Verificação (driver SQLite, Herd)

44 verdes, 0 falhas:
- `CustomerMemoryRebuilderTest` — 15 ✓ (incl. as 2 que estavam vermelhas: *touch() UPSERT atômico* e *touch() não sobrescreve first_interaction_at*)
- `AutoLinkContactTest` + `CustomerMemoryBackfillCommandTest` + `ContactObserverCacheInvalidationTest` — 29 ✓

## Escopo

1 arquivo, 1 intent (`commit-discipline`). PR isolado off `main` — **não** entra na branch DS rollout nem no working tree da sessão paralela de auto-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)