### PR TITLE
test(governance): purge business_id=4 (cliente real) dos fixtures de test

### DIFF
--- a/Modules/Jana/Tests/Feature/Telemetry/LangfuseClientTest.php
+++ b/Modules/Jana/Tests/Feature/Telemetry/LangfuseClientTest.php
@@ -39,7 +39,7 @@ it('skipa todas chamadas quando LANGFUSE_ENABLED=false', function () {
     $client = new LangfuseClient;
     $traceId = $client->startTrace([
         'name' => 'jana-chat',
-        'business_id' => 4,
+        'business_id' => 1,
         'user_id' => 1,
         'input' => 'oi',
     ]);
@@ -58,7 +58,7 @@ it('em modo log NÃO chama Http nem dispatch fila', function () {
     $client = new LangfuseClient;
     $client->startTrace([
         'name' => 'jana-chat',
-        'business_id' => 4,
+        'business_id' => 1,
         'user_id' => 1,
         'input' => 'pergunta',
     ]);
@@ -75,7 +75,7 @@ it('em modo queue dispara LangfuseTraceJob com batch events', function () {
     $client = new LangfuseClient;
     $traceId = $client->startTrace([
         'name' => 'kb-answer',
-        'business_id' => 4,
+        'business_id' => 1,
         'user_id' => 1,
         'input' => 'qual é o faturamento?',
         'tool' => 'kb-answer',
@@ -87,7 +87,7 @@ it('em modo queue dispara LangfuseTraceJob com batch events', function () {
         return count($job->events) === 1
             && $job->events[0]['type'] === 'trace-create'
             && $job->events[0]['body']['name'] === 'kb-answer'
-            && $job->events[0]['body']['metadata']['business_id'] === 4
+            && $job->events[0]['body']['metadata']['business_id'] === 1
             && $job->events[0]['body']['metadata']['tool'] === 'kb-answer';
     });
 });
@@ -154,7 +154,7 @@ it('fail-open quando Http retorna 500 — não lança exception', function () {
     // Não deve lançar exception
     $traceId = $client->startTrace([
         'name' => 'jana-chat',
-        'business_id' => 4,
+        'business_id' => 1,
         'user_id' => 1,
         'input' => 'oi',
     ]);
@@ -221,7 +221,7 @@ it('skipa emissão quando sample_rate=0 (off por amostragem)', function () {
     $client = new LangfuseClient;
     $client->startTrace([
         'name' => 'jana-chat',
-        'business_id' => 4,
+        'business_id' => 1,
         'user_id' => 1,
         'input' => 'oi',
     ]);

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiWebhookTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiWebhookTest.php
@@ -16,7 +16,7 @@ uses(Tests\TestCase::class);
  *   3. Credential inexistente pra business_id → 404
  *   4. Credential sem webhook_secret cadastrado → 401 (fail-secure)
  *   5. Idempotência: 2x mesmo eventId → 1 linha só (UNIQUE)
- *   6. business_id isolado biz=4 vs biz=99 (multi-tenant Tier 0)
+ *   6. business_id isolado biz=98 vs biz=99 (multi-tenant Tier 0)
  *
  * Multi-tenant Tier 0: biz=1 padrão (ADR 0101 — nunca cliente real).
  */
@@ -122,22 +122,22 @@ it('idempotente — 2x mesmo eventId/nossoNumero NÃO duplica em DB', function (
     expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->count())->toBe(1);
 });
 
-it('multi-tenant Tier 0: biz=4 e biz=99 webhooks ISOLADOS', function () {
-    $secret4 = 'secret-biz-4';
+it('multi-tenant Tier 0: biz=98 e biz=99 webhooks ISOLADOS', function () {
+    $secret98 = 'secret-biz-98';
     $secret99 = 'secret-biz-99';
 
     PaymentGatewayCredential::query()->create([
-        'business_id'  => 4,
+        'business_id'  => 98,
         'gateway_key'  => 'sicoob_api',
         'ambiente'     => 'sandbox',
         'ativo'        => true,
         'config_json'  => [
-            'client_id'         => 'c4',
-            'client_secret'     => 's4',
-            'numero_cliente'    => 4,
+            'client_id'         => 'c98',
+            'client_secret'     => 's98',
+            'numero_cliente'    => 98,
             'codigo_modalidade' => 1,
-            'numero_conta'      => 4,
-            'webhook_secret'    => $secret4,
+            'numero_conta'      => 98,
+            'webhook_secret'    => $secret98,
         ],
     ]);
     PaymentGatewayCredential::query()->create([
@@ -155,12 +155,12 @@ it('multi-tenant Tier 0: biz=4 e biz=99 webhooks ISOLADOS', function () {
         ],
     ]);
 
-    // biz=4 com secret correto → 200
-    postSicoobWebhookSigned($this, 4, ['evento' => 'x', 'nossoNumero' => 'biz4-001'], $secret4)
+    // biz=98 com secret correto → 200
+    postSicoobWebhookSigned($this, 98, ['evento' => 'x', 'nossoNumero' => 'biz98-001'], $secret98)
         ->assertStatus(200);
 
-    // biz=99 usando SECRET DO biz=4 → 401 (não vaza segredo entre tenants)
-    postSicoobWebhookSigned($this, 99, ['evento' => 'x', 'nossoNumero' => 'biz99-001'], $secret4)
+    // biz=99 usando SECRET DO biz=98 → 401 (não vaza segredo entre tenants)
+    postSicoobWebhookSigned($this, 99, ['evento' => 'x', 'nossoNumero' => 'biz99-001'], $secret98)
         ->assertStatus(401);
 
     // biz=99 com secret correto → 200
@@ -168,7 +168,7 @@ it('multi-tenant Tier 0: biz=4 e biz=99 webhooks ISOLADOS', function () {
         ->assertStatus(200);
 
     // Eventos separados por business_id
-    expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->where('business_id', 4)->count())->toBe(1)
+    expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->where('business_id', 98)->count())->toBe(1)
         ->and(GatewayWebhookEvent::query()->withoutGlobalScopes()->where('business_id', 99)->count())->toBe(1);
 });
 

--- a/Modules/Whatsapp/Tests/Feature/FeedbackReindexCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/FeedbackReindexCommandTest.php
@@ -182,7 +182,7 @@ it('R-WA-FBR-004 — INDEX inclui só HOT (score >= 70)', function () {
 
 it('R-WA-FBR-005 — INDEX é multi-tenant (separado por business)', function () {
     $c1 = Contact::create(['business_id' => 1, 'name' => 'C1', 'mobile' => '+1', 'type' => 'customer']);
-    $c2 = Contact::create(['business_id' => 4, 'name' => 'C4', 'mobile' => '+4', 'type' => 'customer']);
+    $c2 = Contact::create(['business_id' => 99, 'name' => 'C99', 'mobile' => '+99', 'type' => 'customer']);
 
     ClientFeedback::create([
         'business_id' => 1, 'contact_id' => $c1->id,
@@ -191,10 +191,10 @@ it('R-WA-FBR-005 — INDEX é multi-tenant (separado por business)', function ()
         'persona_slug' => 'kamila-martinho', 'modulo_afetado' => 'financeiro',
     ]);
     ClientFeedback::create([
-        'business_id' => 4, 'contact_id' => $c2->id,
-        'literal' => 'feedback business 4',
+        'business_id' => 99, 'contact_id' => $c2->id,
+        'literal' => 'feedback business 99',
         'severity_nng' => 4, 'recorrente_count' => 5,
-        'persona_slug' => 'larissa-rota-livre', 'modulo_afetado' => 'sells',
+        'persona_slug' => 'tenant-adversario', 'modulo_afetado' => 'sells',
     ]);
 
     $gen = app(FeedbackIndexGenerator::class);
@@ -202,7 +202,7 @@ it('R-WA-FBR-005 — INDEX é multi-tenant (separado por business)', function ()
     $content = file_get_contents($path);
 
     expect($content)->toContain('biz=1');
-    expect($content)->toContain('biz=4');
+    expect($content)->toContain('biz=99');
 });
 
 it('R-WA-FBR-006 — generateArchive() agrupa COLD sem incluir literal PII', function () {

--- a/tests/Feature/Clarity/ClarityShareTest.php
+++ b/tests/Feature/Clarity/ClarityShareTest.php
@@ -36,7 +36,7 @@ function callClarityShare(array $opts = []): ?array
     return $method->invoke($middleware, $request);
 }
 
-function fakeUser(string $userType = 'user', int $businessId = 4): object
+function fakeUser(string $userType = 'user', int $businessId = 1): object
 {
     return new class($userType, $businessId) {
         public function __construct(public string $user_type, public int $business_id) {}
@@ -102,13 +102,13 @@ test('clarityShare retorna null quando cookie consent ausente', function () {
 
 test('clarityShare retorna config completa quando todos guards passam', function () {
     $result = callClarityShare([
-        'user' => fakeUser('user', 4),
+        'user' => fakeUser('user', 1),
         'cookie' => consentCookieAnalytics(true),
     ]);
 
     expect($result)->toBeArray()
         ->and($result['project_id'])->toBe('abc1234567')
-        ->and($result['business_id'])->toBe('4')
+        ->and($result['business_id'])->toBe('1')
         ->and($result['user_type'])->toBe('user')
         ->and($result['mask_strategy'])->toBe('mask-all');
 });


### PR DESCRIPTION
## Bug (US-GOV-018 re-triage · eixo FAILURE · par adversarial ADR 0276)

Vários fixtures de test usavam `business_id = 4` como default/cobaia técnica.
`biz=4` é o cliente **REAL** RotaLivre/Larissa (Tier 0). Usar como cobaia em
fixture/test é grave — risco de vazamento cross-tenant.

## Evidência do refutador

O guard estático **`tests/Unit/BusinessIdGuardTest.php`** varre `tests/` +
`Modules/*/Tests/**` e falha (`expect($violations)->toBeEmpty()`) se qualquer
linha não-comentário casar `'business_id' => 4`, `->business_id = 4`,
`businessId: 4`, `$businessId = 4`, `->business(4)`, etc. Regra Wagner: test
SEMPRE `biz=1`; adversário cross-tenant `biz=99`; **NUNCA 4**.

## Fix mínimo (só defaults de fixture — sem tocar lógica)

| Arquivo | Mudança |
|---|---|
| `Modules/Jana/.../LangfuseClientTest.php` | 5 inputs `business_id 4→1` + 1 assertion read-back acoplada (`=== 4 → === 1`) |
| `Modules/Whatsapp/.../FeedbackReindexCommandTest.php` (R-WA-FBR-005) | 2º tenant `4→99` (papel adversário) + persona real `larissa-rota-livre → tenant-adversario` + assert `biz=4 → biz=99` |
| `Modules/PaymentGateway/.../SicoobApiWebhookTest.php` | tenant-A `4→98` |
| `tests/Feature/Clarity/ClarityShareTest.php` | default param `$businessId 4→1` + caso explícito `4→1` |

### Notas de decisão
- **Sicoob 4→98 (não 1):** `beforeEach` já cria credencial `biz=1, sicoob_api, sandbox`; a UNIQUE `(business_id, gateway_key, ambiente)` faria `1` colidir. `99` já é o adversário no mesmo teste, então tenant-A vira `98` (id improvável não-real, mesmo espírito do `99`). Semântica de isolamento preservada.
- **ClarityShareTest:** não estava na triage original mas o guard pega a linha `function fakeUser(..., int $businessId = 4)` via `/\$businessId\s*=\s*4\b/` — sem corrigir, o guard continua vermelho. Fix idêntico (default de fixture → 1), assertion `'4'→'1'` acoplada.

## Verificação

- Réplica local do scan do guard (mesma regex + skip de comentários + skip do próprio arquivo): **0 violações**.
- `php -l` nos 4 arquivos: sem erros de sintaxe.
- Pest não rodado local (CT100-only). Asserções read-back ajustadas para casar os novos inputs.

Refs: US-GOV-018 re-triage · teste confirmante `tests/Unit/BusinessIdGuardTest.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)