### PR TITLE
feat(cliente): tela-linda slice 1 — Pills.tsx tokeniza ESTADO, preserva CATEGORIA

### DIFF
--- a/resources/js/Pages/Cliente/_components/Pills.tsx
+++ b/resources/js/Pages/Cliente/_components/Pills.tsx
@@ -33,6 +33,8 @@ export function TipoPill({ tipo }: TipoPillProps) {
   if (!tipo) {
     return <span className="text-xs text-muted-foreground/50" aria-hidden="true">—</span>;
   }
+  // PF verde / PJ violeta = COR DE CATEGORIA (identidade binária do protótipo Cowork),
+  // não estado → exceção documentada (decisão "B"), mantida crua de propósito.
   const cls =
     tipo === 'PJ'
       ? 'bg-violet-50 text-violet-700 dark:bg-violet-950/40 dark:text-violet-300'
@@ -52,6 +54,10 @@ export function TipoPill({ tipo }: TipoPillProps) {
 
 // ─── TagChip ─────────────────────────────────────────────────────────────────
 
+// ⚠️ EXCEÇÃO DE COR DE CATEGORIA (documentada · decisão Wagner "B"): as 9 cores
+// abaixo são IDENTIDADE (distinguir 9 tipos de tag de relance), não estado semântico.
+// Colapsar em success/warning/info/destructive destruiria a distinção → NÃO tokenizar.
+// Allowlist consciente vs a catraca de cor crua. (TipoPill PF/PJ idem, mais abaixo.)
 const TAG_COLORS: Record<string, string> = {
   varejo:
     'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/40',
@@ -123,15 +129,13 @@ export function calcFrescor(iso: string | null | undefined): FrescorState {
   return 'distante';
 }
 
+// Frescor é ESTADO semântico (saúde do relacionamento) → tokens -soft/-fg do DS
+// elevado (extraídos desta exata tela, #2639). Trocam light+dark sozinhos.
 const FRESCOR_STYLE: Record<FrescorState, string> = {
-  fresc:
-    'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900/40',
-  recente:
-    'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/40',
-  frio:
-    'bg-stone-50 text-stone-600 border-stone-200 dark:bg-stone-950/40 dark:text-stone-400 dark:border-stone-800',
-  distante:
-    'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40',
+  fresc: 'bg-success-soft text-success-fg border-success/20',
+  recente: 'bg-warning-soft text-warning-fg border-warning/20',
+  frio: 'bg-muted text-muted-foreground border-border',
+  distante: 'bg-destructive-soft text-destructive-fg border-destructive/20',
 };
 
 const FRESCOR_LABEL: Record<FrescorState, string> = {
@@ -210,9 +214,8 @@ export function SaldoCell({ valor }: SaldoCellProps) {
     <span
       className={
         'tabular-nums font-medium ' +
-        (isDevedor
-          ? 'text-rose-700 dark:text-rose-300'
-          : 'text-emerald-700 dark:text-emerald-300')
+        // Devedor = vermelho / crédito = verde — ESTADO semântico → token -fg.
+        (isDevedor ? 'text-destructive-fg' : 'text-success-fg')
       }
       title={isDevedor ? 'Cliente em débito' : 'Cliente com crédito (adiantamento)'}
     >
@@ -225,17 +228,18 @@ export function SaldoCell({ valor }: SaldoCellProps) {
 
 export type StatusValue = 'ativo' | 'inativo' | 'bloqueado' | string;
 
+// Status do cliente é ESTADO semântico → tokens -soft/-fg (light+dark no token).
 const STATUS_STYLE_MAP: Record<string, { bg: string; label: string }> = {
   ativo: {
-    bg: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
+    bg: 'bg-success-soft text-success-fg border-success/20',
     label: 'Ativo',
   },
   inativo: {
-    bg: 'bg-stone-50 text-stone-700 border-stone-200 dark:bg-stone-950/40 dark:text-stone-300',
+    bg: 'bg-muted text-muted-foreground border-border',
     label: 'Inativo',
   },
   bloqueado: {
-    bg: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
+    bg: 'bg-destructive-soft text-destructive-fg border-destructive/20',
     label: 'Bloqueado',
   },
 };

--- a/tests/Feature/Cliente/ClientePillsTokensTest.php
+++ b/tests/Feature/Cliente/ClientePillsTokensTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tela-linda Cliente · slice 1 (coração da listagem): Pills.tsx tokeniza o que é
+ * ESTADO semântico e PRESERVA o que é COR DE CATEGORIA.
+ *
+ * Os tokens -soft/-fg foram extraídos desta exata tela-ouro (#2639), então os pills
+ * semânticos ficam visualmente 1:1 (gate visual aprovado por Wagner via widget
+ * antes/depois). As 9 cores de tag + PF/PJ são identidade de categoria — colapsá-las
+ * nos 4 tokens semânticos apagaria a distinção → exceção documentada, mantida crua.
+ *
+ * Canon: structural guard. Prova visual = widget aprovado + smoke pós-deploy.
+ */
+
+$pills = __DIR__ . '/../../../resources/js/Pages/Cliente/_components/Pills.tsx';
+
+test('Pills — Status/Frescor/Saldo (ESTADO) consomem tokens semânticos', function () use ($pills) {
+    $src = file_get_contents($pills);
+    expect($src)
+        // StatusPill
+        ->toContain("ativo: {\n    bg: 'bg-success-soft text-success-fg border-success/20'")
+        ->toContain("bloqueado: {\n    bg: 'bg-destructive-soft text-destructive-fg border-destructive/20'")
+        // FrescorPill
+        ->toContain("fresc: 'bg-success-soft text-success-fg border-success/20'")
+        ->toContain("recente: 'bg-warning-soft text-warning-fg border-warning/20'")
+        ->toContain("distante: 'bg-destructive-soft text-destructive-fg border-destructive/20'")
+        // SaldoCell
+        ->toContain("isDevedor ? 'text-destructive-fg' : 'text-success-fg'")
+        // os pills de ESTADO não usam mais rose/emerald cru
+        ->not->toContain("text-rose-700 dark:text-rose-300")
+        ->not->toContain("bg-rose-50 text-rose-700 border-rose-200");
+});
+
+test('Pills — TagChip (9 cores) e TipoPill (PF/PJ) PRESERVAM cor de categoria', function () use ($pills) {
+    $src = file_get_contents($pills);
+    expect($src)
+        // o rainbow de categoria continua cru — de propósito (decisão "B")
+        ->toContain("'bg-amber-50 text-amber-700 border-amber-200")   // varejo
+        ->toContain("'bg-blue-50 text-blue-700 border-blue-200")      // corporativo
+        ->toContain("'bg-indigo-50 text-indigo-700 border-indigo-200") // agencia
+        ->toContain("bg-violet-50 text-violet-700")                    // PJ
+        // e a exceção está DOCUMENTADA no código (não é descuido)
+        ->toContain('EXCEÇÃO DE COR DE CATEGORIA')
+        ->toContain('COR DE CATEGORIA');
+});


### PR DESCRIPTION
## Tela-linda do Cliente · slice 1: o coração da listagem

Primeiro slice da tokenização da tela-querida do Cliente sobre o **DS elevado (M1)**. Agora que a fundação está sólida + travada, o alvo de adoção é íntegro.

**Gate visual APROVADO pelo Wagner** via widget antes/depois (render local down + prod deslogado → comparei os pills cor-crua `#ecfdf5/#047857` vs token `oklch(...)` lado a lado; os tokens `-soft/-fg` foram **extraídos destes exatos pills** no #2639, então é 1:1).

### Tokeniza o que é ESTADO semântico
| Pill | Antes | Depois |
|---|---|---|
| StatusPill | `bg-emerald-50/rose-50/stone-50…` | `success-soft / destructive-soft / muted` |
| FrescorPill | `emerald/amber/stone/rose` | `success / warning / muted / destructive` |
| SaldoCell | `text-rose-700 / text-emerald-700` | `text-destructive-fg / text-success-fg` |

### PRESERVA o que é COR DE CATEGORIA (exceção documentada · decisão "B")
`TagChip` (9 cores p/ distinguir varejo/atacado/corporativo/… de relance) + `TipoPill` (PF verde / PJ violeta) ficam **crus de propósito** — colapsar nos 4 tokens apagaria a distinção = abaixar o nível. Comentado no código + travado por teste.

## Prova
- ✅ **build** verde · **eslint** baseline delta **-30** (sem regressão) · **teste-guarda** 2/14 asserts (trava o split ESTADO-tokeniza / CATEGORIA-fica).

Escopo: só `Pills.tsx`. Drawer + sub-tabs = follow-ups com o mesmo cuidado.

Refs: DS-MATURIDADE (adoção pós-M1) · #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)