### PR TITLE
ci(sdd): reconcilia baseline foundation-ratchet FV-Q1 (69→71 + trava 96→75)

### DIFF
--- a/scripts/tests/baselines/foundation-ratchet-baseline.json
+++ b/scripts/tests/baselines/foundation-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "generated_by": "scripts/tests/foundation-ratchet.mjs --write",
   "counters": {
     "n_quarantine": 0,
-    "n_refresh_database": 69,
-    "n_business_first": 96
+    "n_refresh_database": 71,
+    "n_business_first": 75
   }
 }


### PR DESCRIPTION
## O quê

Reconcilia o baseline **stale** da catraca advisory `Foundation Ratchet` (`scripts/tests/baselines/foundation-ratchet-baseline.json`), que pintava **🔴 em TODO PR** — não por culpa de PR nenhum, mas porque o teto nasceu defasado da realidade.

```diff
   "counters": {
     "n_quarantine": 0,
-    "n_refresh_database": 69,
-    "n_business_first": 96
+    "n_refresh_database": 71,
+    "n_business_first": 75
   }
```

Só o JSON do baseline muda. **`.mjs` e `.yml` intactos.**

## Por que estava vermelho

Medição real contra `origin/main` (rodando o próprio script):

| contador | atual | baseline antigo | Δ |
|---|---:|---:|---|
| `n_refresh_database` | **71** | 69 | 🔴 +2 (falha) |
| `n_business_first` | 75 | 96 | 🟢 −21 (melhorou) |
| `n_quarantine` | 0 | 0 | — |

O baseline (69) foi cravado em #2594 (SDD Semana-0) **já +2 atrás da árvore** — a regra "medir na 1ª fonte real, nunca do plano" furou na largada.

## Decisão: Opção 2 (re-cravar), não Opção 1 (burn-down)

Os +2 `RefreshDatabase` vêm de **2 testes novos e legítimos** do próprio GT-SDD (ADR 0275), diffados via `git grep` baseline-commit→HEAD:

- `Modules/Governance/Tests/Feature/SddBriefLineServiceTest.php` (GT-G8)
- `Modules/Governance/Tests/Feature/SddScorecardSnapshotCommandTest.php` (GT-G7)

**Por que NÃO migrar pra `DatabaseTransactions` agora** (apesar de ser o espírito da catraca):

- O gate **required** `modules-pest.yml` roda em **sqlite `:memory:`**. Lá `mcp_sdd_scorecard_history` só existe se **migrada** → `RefreshDatabase` é **obrigatório**.
- `DatabaseTransactions`, por canon (**ADR 0101** / regra "não mocka DB"), **skipa em sqlite** e só roda no nightly MySQL (verbatim no header de `OficinaAuto/.../DemoOsSmokeTest.php`).
- Migrar esses 2 = **perder a cobertura da lógica SDD nova no gate required**.
- O burn-down `RefreshDatabase→DatabaseTransactions` é **sequenciado pós-R1** (nightly MySQL verde) no plano SDD — não é troca ad-hoc de 2 arquivos.

→ adição legítima ⇒ **Opção 2**.

**Bônus no mesmo `--force`:** travo o ganho real `n_business_first` 96→75 — queda do `Business::first()` cru após a migração pro trait `WithSeededTenant` (FV-B4). A catraca passa a barrar regressão acima de 75.

`--write --force` é o caminho que o **próprio script sanciona** pra subida consciente (diff do JSON auditável no PR).

## Verificação

- ✅ `node scripts/tests/foundation-ratchet.mjs` → **exit 0** (`✓ foundation ratchet OK`)
- ✅ `node scripts/tests/foundation-ratchet.test.mjs` → **10/10** (catraca ainda morde)
- ✅ diff = 2 valores; nenhum teste/feature tocado (commit-discipline: 1 PR = 1 intent)

## Escopo

PR **dedicado** FV-Q1 — sem mistura com feature/bug-fix. Advisory, não bloqueia merge; promoção a required só via calendário §4 do plano (semanas 4-6, pós-R1).

Refs: SDD Semana-0 frente FV-Q1 · `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` (§4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
