### PR TITLE
docs(skills): memory-schema-preflight sincroniza campo anchor + key anchor_format (ADR 0273) — SDD S0 SA

### DIFF
--- a/.claude/skills/memory-schema-preflight/SKILL.md
+++ b/.claude/skills/memory-schema-preflight/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: memory-schema-preflight
-description: ATIVAR ANTES de Write/Edit em `memory/requisitos/**/SPEC.md`, `memory/requisitos/**/RUNBOOK*.md`, `memory/decisions/*.md`, `memory/sessions/*.md`, `memory/handoffs/*.md`, `resources/js/Pages/**/*.charter.md`, OU antes de `git commit` que tocar esses paths. Carrega regras de schema canônico extraídas de `scripts/memory-schemas/*.schema.json` (status enum estrito, version como string quoted, dates como string quoted, related_adrs como list de slugs `^[0-9]{4}-[a-z0-9-]+$`, owner RUNBOOK enum letras únicas `W/F/M/L/E`, seções obrigatórias por tipo) e roda validator local antes de commit pra zerar o loop CI fail (~10min/iteração). Origem 2026-05-25 — 4 PRs (#1568/#1569/#1570/#1579) bloqueados em memory-schema-gate por erros previsíveis.
+description: ATIVAR ANTES de Write/Edit em `memory/requisitos/**/SPEC.md`, `memory/requisitos/**/RUNBOOK*.md`, `memory/decisions/*.md`, `memory/sessions/*.md`, `memory/handoffs/*.md`, `resources/js/Pages/**/*.charter.md`, OU antes de `git commit` que tocar esses paths. Carrega regras de schema canônico extraídas de `scripts/memory-schemas/*.schema.json` (status enum estrito, version como string quoted, dates como string quoted, related_adrs como list de slugs `^[0-9]{4}-[a-z0-9-]+$`, owner RUNBOOK enum letras únicas `W/F/M/L/E`, seções obrigatórias por tipo) e roda validator local antes de commit pra zerar o loop CI fail (~10min/iteração). Cobre também o campo anchor `**Implementado em:**` + key opcional `anchor_format` do fluxo novo de SPEC (ADR 0273, lint advisory `anchor-lint.mjs`). Origem 2026-05-25 — 4 PRs (#1568/#1569/#1570/#1579) bloqueados em memory-schema-gate por erros previsíveis.
 tier: B
 trigger: description-matching
 parent_adr: 0094
-related_adrs: [0094, 0095]
+related_adrs: [0094, 0095, 0273]
 ---
 
 # memory-schema-preflight — Tier B auto-trigger
@@ -47,6 +47,7 @@ related_adrs:                       # LIST de slugs, NUNCA integers
 parent_adr: "NNNN-kebab-slug"       # opcional, mesmo pattern
 related_proposals:                  # opcional, lista de slugs proposal
   - "kebab-slug"
+anchor_format: "v1"                 # opcional (ADR 0273) — enum SÓ "v1"; SPEC novo nasce com ela; 57 legados sem a key OK (grace-period)
 ---
 ```
 
@@ -58,6 +59,20 @@ related_proposals:                  # opcional, lista de slugs proposal
 **Recomendadas** (warnings, não bloqueiam):
 - `## Histórico`
 - `## Referências`
+
+**Campo anchor `**Implementado em:**` (ADR 0273 · `anchor_format: "v1"`) — fluxo NOVO:**
+
+- A key `anchor_format: "v1"` no frontmatter é OPCIONAL (enum só `"v1"`). Grace-period: os 57 SPECs legados SEM a key continuam válidos (regra "campo novo opcional até backfill" do [README memory-schemas](../../../scripts/memory-schemas/README.md)). SPEC novo nasce com ela — já vem no [`_TEMPLATE_SPEC.md`](../../../memory/requisitos/_TEMPLATE_SPEC.md).
+- Toda US ganha **1 linha** `**Implementado em:**` no corpo — no mínimo `_pendente_` enquanto a tela não existe (sentinela de **1ª classe**, NÃO é dívida de anchor). Gramática quando construída:
+
+  ```
+  **Implementado em:** `path/relativo.tsx` [· `Símbolo@metodo`] · verificado@<sha7> (<YYYY-MM-DD>)
+  **Implementado em:** _parcial_ · `path` · verificado@<sha7> (<data>) — o que falta
+  **Implementado em:** _pendente_ — justificativa opcional
+  ```
+
+  `sha7` = commit de `origin/main` onde o path foi verificado (proveniência). NUNCA `_[TODO]_` / `_[path]_` / `(a criar)` — placeholder legado conta como **não-coberto**.
+- Divisão de responsabilidade: `spec.schema.json` valida só a **key** do frontmatter; o **corpo** (`**Implementado em:**`) é validado pelo `anchor-lint.mjs` (advisory na fase F1 — não bloqueia merge).
 
 ### RUNBOOK.md — `memory/requisitos/<Mod>/RUNBOOK*.md`
 
@@ -157,6 +172,8 @@ Seções obrigatórias: `## Mission`, `## Goals`, `## Non-Goals`, `## UX targets
 | `/ must have required property 'last_validated'` (RUNBOOK) | adicionar `last_validated: "YYYY-MM-DD"` |
 | SPEC sem `## User stories \| ## Backlog ativo \| ## US ativas` | renomear seção existente OU criar nova com `## User stories — <contexto>` |
 | SPEC sem `## Histórico` ou `## Referências` | warning, não bloqueia merge (mas adicionar é boa prática) |
+| `/anchor_format must be equal to one of the allowed values` | `anchor_format: v2` → `anchor_format: "v1"` (único valor; AST v2 é evolução futura do ADR 0273) |
+| anchor-lint `placeholder` / `anchored_dead` numa US | trocar `_[TODO]_` / path-morto por `_pendente_` (não construída) OU path real + `verificado@<sha7> (<data>)` — NUNCA inventar path (advisory, não bloqueia) |
 
 ## Validador local — rodar ANTES de commit
 
@@ -170,6 +187,9 @@ echo "memory/requisitos/<Mod>/SPEC.md" | xargs -r .github/scripts/validate-memor
 npx ajv validate -s scripts/memory-schemas/spec.schema.json -d memory/requisitos/<Mod>/SPEC.md
 npx ajv validate -s scripts/memory-schemas/runbook.schema.json -d memory/requisitos/<Mod>/RUNBOOK*.md
 npx ajv validate -s scripts/memory-schemas/adr.schema.json -d memory/decisions/NNNN-kebab.md
+
+# Anchor spec↔código (ADR 0273) — corpo `**Implementado em:**`, advisory, node puro <0.1s, sem deps
+node scripts/governance/anchor-lint.mjs memory/requisitos/<Mod>/SPEC.md   # diff-aware (só o SPEC passado)
 ```
 
 **Batch validar tudo modificado vs main antes de PR:**
@@ -298,9 +318,11 @@ E adicionar no corpo:
 - `.github/workflows/memory-schema-gate.yml` — CI gate principal (AJV)
 - `.github/workflows/memory-schema-gate-extended.yml` — CI gate extended (sections + filename)
 - `.github/scripts/validate-memory-schema.sh` — script bash extra (SPEC/Session/Handoff sections)
+- `scripts/governance/anchor-lint.mjs` — lint do corpo `**Implementado em:**` (advisory F1) + `.github/workflows/anchor-drift.yml`
 - Sessão 2026-05-25 — origem do skill (4 PRs blocked + batch fix)
 - [ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (memory artifacts canônicos)
 - [ADR 0095](../../../memory/decisions/0095-skills-tiers-convencao-interna.md) — Skills tiers convenção interna
+- [ADR 0273](../../../memory/decisions/0273-anchor-spec-codigo-formato-canonico-fluxo-novo.md) — formato anchor spec↔código + sentinela `_pendente_` + key `anchor_format` (fluxo novo de SPEC)
 
 ## Pegadinhas validadas em CI real (2026-06-11 — 2 handoffs mergeados com gate vermelho)
 


### PR DESCRIPTION
## Resumo

Frente **SA (Spec Anchor)** da Semana 0 do [plano SDD](../blob/main/memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md). Ao re-derivar de `origin/main` (regra anti-stale do plano), constatei que **a frente SA já está inteiramente landed**:

| Deliverable do prompt SA | Estado em `origin/main` |
|---|---|
| ADR 0273 (formato anchor + sentinela `_pendente_` 1ª classe + fluxo novo) | ✅ `0273-anchor-spec-codigo-formato-canonico-fluxo-novo.md` — **#2592** |
| `spec.schema.json` campo anchor c/ grace-period | ✅ key `anchor_format` opcional (enum `v1`) — **#2592** |
| Template de SPEC com o campo | ✅ `_TEMPLATE_SPEC.md` (`anchor_format: "v1"` + `**Implementado em:** _pendente_`) — **#2592** |
| `anchor-lint.mjs` (node, sem deps, <5s, advisory) | ✅ `scripts/governance/anchor-lint.mjs` + `anchor-drift.yml` + `gates-registry` — **#2602** |

Criar `0273-formato-anchor-spec-sentinela-pendente.md` e `scripts/anchor-lint.mjs` (os nomes "novos" do meu prompt) **duplicaria canon** — proibido pela regra Tier 0 *"comparar e não duplicar"* (criaria um 2º ADR 0273 conflitante + um 2º lint num path órfão do workflow).

## O que este PR faz

Fecha o **único gap real** dentro das paths SA: o skill **`memory-schema-preflight`** — cujo trabalho é espelhar as regras do schema pros devs antes do commit — não mencionava a key `anchor_format` nem a gramática do campo `**Implementado em:**`, ficando dessincronizado do que #2592 mergeou.

- frontmatter SPEC ganha `anchor_format: "v1"` (opcional, grace-period dos 57 legados)
- bloco explicando a gramática `**Implementado em:**` (preenchido / `_parcial_` / `_pendente_` 1ª classe) + divisão de responsabilidade (schema valida a key; `anchor-lint` valida o corpo)
- 2 linhas no auto-fix table (enum `v1` + `placeholder`/`anchored_dead` → `_pendente_`)
- comando `node scripts/governance/anchor-lint.mjs <SPEC>` no validador local (testado: exit 0, advisory) + refs ADR 0273/script

## Números re-derivados de `origin/main`

`node scripts/governance/anchor-lint.mjs --json` (0.09s, node v22 puro):
- **57** SPECs · **787** US · `anchor_coverage` **1.8%**
- por estado: 708 `sem_campo` · 50 `placeholder` · 14 `anchored_ok` · 15 `anchored_dead` (0 `pendente`/`parcial` ainda)
- baseline do backfill **SA-A4/A5** (fora deste escopo — 1 PR = 1 intent)

## Escopo / disciplina

- 1 arquivo, **+24/−2 linhas** (≤300)
- Não toquei schema/template (já corretos) nem nada das frentes FV/KL/GT/Charters, nem workflows/Kernel
- `Refs: SDD Semana-0 SA`

> ⚠️ Decisão pra Wagner: se a intenção era eu **mesmo** ter produzido o ADR/lint num branch separado (e não reusar #2592/#2602), me avise — mas o estado atual de `main` torna isso redundante.

https://claude.ai/code/session_016HT8eT2MzJe3d2ZD56bDmC

---
_Generated by [Claude Code](https://claude.ai/code/session_016HT8eT2MzJe3d2ZD56bDmC)_