### PR TITLE
feat(cliente): tela-linda slice 2 — 9 componentes limpo-semânticos → tokens

### DIFF
--- a/resources/js/Pages/Cliente/_drawer/PlacasMainTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/PlacasMainTab.tsx
@@ -148,7 +148,7 @@ export default function PlacasMainTab({ contactId }: PlacasMainTabProps) {
 
   if (error) {
     return (
-      <div className="p-8 text-center text-sm text-rose-600" role="alert">
+      <div className="p-8 text-center text-sm text-destructive" role="alert">
         {error}
       </div>
     );

--- a/resources/js/Pages/Cliente/_show/ActionsMenu.tsx
+++ b/resources/js/Pages/Cliente/_show/ActionsMenu.tsx
@@ -187,7 +187,7 @@ export default function ActionsMenu({
           {permissions.delete && (
             <DropdownMenuItem
               onClick={handleDelete}
-              className="text-rose-700 dark:text-rose-400 focus:text-rose-700 focus:bg-rose-50 dark:focus:bg-rose-950/40"
+              className="text-destructive-fg focus:text-destructive-fg focus:bg-destructive-soft"
               data-testid="actions-delete"
             >
               <Trash2 className="mr-2 h-4 w-4" aria-hidden />

--- a/resources/js/Pages/Cliente/_show/AddDiscountModal.tsx
+++ b/resources/js/Pages/Cliente/_show/AddDiscountModal.tsx
@@ -110,7 +110,7 @@ export default function AddDiscountModal({
         <div className="p-5 space-y-3">
           <div>
             <label htmlFor="discount-date" className="text-xs font-medium text-muted-foreground mb-1.5 block">
-              Data <span className="text-rose-600">*</span>
+              Data <span className="text-destructive">*</span>
             </label>
             <Input
               id="discount-date"
@@ -123,7 +123,7 @@ export default function AddDiscountModal({
           </div>
           <div>
             <label htmlFor="discount-amount" className="text-xs font-medium text-muted-foreground mb-1.5 block">
-              Valor (R$) <span className="text-rose-600">*</span>
+              Valor (R$) <span className="text-destructive">*</span>
             </label>
             <Input
               id="discount-amount"
@@ -169,7 +169,7 @@ export default function AddDiscountModal({
             />
           </div>
           {error && (
-            <div className="rounded-md border border-rose-200 dark:border-rose-900 bg-rose-50 dark:bg-rose-950/40 p-3 text-xs text-rose-800 dark:text-rose-200" role="alert">
+            <div className="rounded-md border border-destructive/20 bg-destructive-soft p-3 text-xs text-destructive-fg" role="alert">
               {error}
             </div>
           )}

--- a/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
@@ -350,7 +350,7 @@ export default function DocumentsTab({
                     aria-label={`Excluir ${d.file_name}`}
                     data-testid={`document-delete-${d.id}`}
                   >
-                    <Trash2 size={14} className="text-rose-600 dark:text-rose-400" />
+                    <Trash2 size={14} className="text-destructive" />
                   </Button>
                 )}
               </li>
@@ -367,8 +367,8 @@ function AutosaveBadge({ status }: { status: 'idle' | 'saving' | 'saved' | 'erro
   // status já estreitado pra 'saving' | 'saved' | 'error' após o early return.
   const styles: Record<'saving' | 'saved' | 'error', string> = {
     saving: 'text-muted-foreground',
-    saved: 'text-emerald-700 dark:text-emerald-400',
-    error: 'text-rose-700 dark:text-rose-400',
+    saved: 'text-success-fg',
+    error: 'text-destructive-fg',
   };
   const labels: Record<'saving' | 'saved' | 'error', string> = {
     saving: 'Salvando…',

--- a/resources/js/Pages/Cliente/_show/LedgerTab.tsx
+++ b/resources/js/Pages/Cliente/_show/LedgerTab.tsx
@@ -299,10 +299,10 @@ export default function LedgerTab({
                         </span>
                       </td>
                       <td className="px-4 py-2.5 text-foreground">{line.description}</td>
-                      <td className="px-4 py-2.5 text-right tabular-nums text-rose-700 dark:text-rose-400">
+                      <td className="px-4 py-2.5 text-right tabular-nums text-destructive-fg">
                         {line.debit > 0 ? formatBRL(line.debit) : '—'}
                       </td>
-                      <td className="px-4 py-2.5 text-right tabular-nums text-emerald-700 dark:text-emerald-400">
+                      <td className="px-4 py-2.5 text-right tabular-nums text-success-fg">
                         {line.credit > 0 ? formatBRL(line.credit) : '—'}
                       </td>
                       <td className="px-4 py-2.5 text-right tabular-nums font-medium text-foreground">{formatBRL(line.balance)}</td>
@@ -339,7 +339,7 @@ export default function LedgerTab({
               aria-label="E-mail destinatário"
             />
             {emailFeedback && (
-              <p className={'text-xs mt-2 ' + (emailFeedback.startsWith('Falha') ? 'text-rose-700' : 'text-emerald-700')}>
+              <p className={'text-xs mt-2 ' + (emailFeedback.startsWith('Falha') ? 'text-destructive-fg' : 'text-success-fg')}>
                 {emailFeedback}
               </p>
             )}
@@ -381,18 +381,18 @@ function SummaryCardInner({
       <div className="grid grid-cols-3 gap-2 text-sm">
         <div>
           <div className="text-[10px] uppercase text-muted-foreground">Débito</div>
-          <div className="font-medium tabular-nums text-rose-700 dark:text-rose-400">{formatBRL(debit)}</div>
+          <div className="font-medium tabular-nums text-destructive-fg">{formatBRL(debit)}</div>
         </div>
         <div>
           <div className="text-[10px] uppercase text-muted-foreground">Crédito</div>
-          <div className="font-medium tabular-nums text-emerald-700 dark:text-emerald-400">{formatBRL(credit)}</div>
+          <div className="font-medium tabular-nums text-success-fg">{formatBRL(credit)}</div>
         </div>
         <div>
           <div className="text-[10px] uppercase text-muted-foreground">Saldo</div>
           <div
             className={
               'font-semibold tabular-nums ' +
-              (isNegative ? 'text-rose-700 dark:text-rose-400' : 'text-foreground')
+              (isNegative ? 'text-destructive-fg' : 'text-foreground')
             }
           >
             {formatBRL(balance)}

--- a/resources/js/Pages/Cliente/_show/PaymentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/PaymentsTab.tsx
@@ -139,7 +139,7 @@ export default function PaymentsTab({ contactId, payments: paymentsProp, canView
 
   if (error) {
     return (
-      <div className="rounded-lg border border-amber-200 bg-amber-50/50 dark:bg-amber-950/20 p-6 text-sm text-amber-800 dark:text-amber-200">
+      <div className="rounded-lg border border-warning/20 bg-warning-soft p-6 text-sm text-warning-fg">
         <p className="font-medium">Aguardando wiring</p>
         <p className="text-xs mt-1 opacity-80">{error}</p>
         <p className="text-xs mt-2">Parent (Show.tsx) deve passar <code className="font-mono">payments</code> via Inertia::defer.</p>
@@ -191,7 +191,7 @@ export default function PaymentsTab({ contactId, payments: paymentsProp, canView
                     )}
                   </td>
                   <td className="px-4 py-2.5 text-right tabular-nums">
-                    <span className={p.is_return ? 'text-rose-700' : 'text-emerald-700'}>
+                    <span className={p.is_return ? 'text-destructive-fg' : 'text-success-fg'}>
                       {p.is_return ? '−' : ''}
                       {formatBRL(p.amount)}
                     </span>

--- a/resources/js/Pages/Cliente/_show/RewardPointsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/RewardPointsTab.tsx
@@ -160,10 +160,10 @@ export default function RewardPointsTab({ reward_points: rewardProp, contactId }
                   </td>
                   <td className="px-4 py-3 text-xs font-medium text-foreground">{h.invoice_no || '—'}</td>
                   <td className="px-4 py-3 text-xs text-right tabular-nums text-foreground">{formatBRL(h.final_total)}</td>
-                  <td className="px-4 py-3 text-xs text-right tabular-nums text-emerald-700 dark:text-emerald-400">
+                  <td className="px-4 py-3 text-xs text-right tabular-nums text-success-fg">
                     {h.rp_earned > 0 ? `+${h.rp_earned}` : '—'}
                   </td>
-                  <td className="px-4 py-3 text-xs text-right tabular-nums text-amber-700 dark:text-amber-400">
+                  <td className="px-4 py-3 text-xs text-right tabular-nums text-warning-fg">
                     {h.rp_redeemed > 0 ? `-${h.rp_redeemed}` : '—'}
                   </td>
                   <td className="px-4 py-3 text-xs text-right tabular-nums text-muted-foreground">
@@ -193,7 +193,7 @@ function SummaryCard({
   value: number;
   accent: 'default' | 'muted' | 'success';
 }) {
-  const tone = accent === 'success' ? 'text-emerald-700 dark:text-emerald-300' : accent === 'muted' ? 'text-muted-foreground' : 'text-foreground';
+  const tone = accent === 'success' ? 'text-success-fg' : accent === 'muted' ? 'text-muted-foreground' : 'text-foreground';
   return (
     <div className="rounded-md border border-border bg-background p-3">
       <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">{label}</div>

--- a/resources/js/Pages/Cliente/_show/RiscoClienteCard.tsx
+++ b/resources/js/Pages/Cliente/_show/RiscoClienteCard.tsx
@@ -134,25 +134,26 @@ export default function RiscoClienteCard({ contact, stats }: Props) {
   const tier: 'healthy' | 'warn' | 'high' =
     score <= 3 ? 'healthy' : score <= 6 ? 'warn' : 'high';
 
+  // Ramp de risco = ESTADO semântico → tokens -soft/-fg (light+dark no token).
   const palette = {
     healthy: {
-      bg: 'bg-emerald-50 dark:bg-emerald-950/30',
-      text: 'text-emerald-700 dark:text-emerald-300',
-      border: 'border-emerald-200 dark:border-emerald-900/40',
+      bg: 'bg-success-soft',
+      text: 'text-success-fg',
+      border: 'border-success/20',
       Icon: CheckCircle2,
       label: 'Saudavel',
     },
     warn: {
-      bg: 'bg-amber-50 dark:bg-amber-950/30',
-      text: 'text-amber-700 dark:text-amber-300',
-      border: 'border-amber-200 dark:border-amber-900/40',
+      bg: 'bg-warning-soft',
+      text: 'text-warning-fg',
+      border: 'border-warning/20',
       Icon: AlertCircle,
       label: 'Atencao',
     },
     high: {
-      bg: 'bg-rose-50 dark:bg-rose-950/30',
-      text: 'text-rose-700 dark:text-rose-300',
-      border: 'border-rose-200 dark:border-rose-900/40',
+      bg: 'bg-destructive-soft',
+      text: 'text-destructive-fg',
+      border: 'border-destructive/20',
       Icon: AlertTriangle,
       label: 'Alto risco',
     },
@@ -188,10 +189,10 @@ export default function RiscoClienteCard({ contact, stats }: Props) {
           className={
             'h-full rounded-full transition-all ' +
             (tier === 'healthy'
-              ? 'bg-emerald-500'
+              ? 'bg-success'
               : tier === 'warn'
-              ? 'bg-amber-500'
-              : 'bg-rose-500')
+              ? 'bg-warning'
+              : 'bg-destructive')
           }
           style={{ width: `${(score / 10) * 100}%` }}
           aria-hidden
@@ -213,7 +214,7 @@ export default function RiscoClienteCard({ contact, stats }: Props) {
         </ul>
       ) : (
         <p className="mt-3 text-xs text-muted-foreground flex items-center gap-1.5">
-          <CheckCircle2 size={12} className="text-emerald-600 flex-shrink-0" />
+          <CheckCircle2 size={12} className="text-success flex-shrink-0" />
           Nenhum sinal de risco detectado.
         </p>
       )}

--- a/resources/js/Pages/Cliente/_show/SubscriptionsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SubscriptionsTab.tsx
@@ -155,11 +155,11 @@ export default function SubscriptionsTab({ subscriptions: subsProp, contactId }:
                 <td className="px-4 py-3 text-xs text-right tabular-nums text-foreground">{s.generated_count}</td>
                 <td className="px-4 py-3 text-xs">
                   {isStopped ? (
-                    <span className="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-amber-700 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-300">
+                    <span className="inline-flex items-center rounded-full border border-warning/20 bg-warning-soft px-2 py-0.5 text-[10px] uppercase tracking-wider text-warning-fg">
                       Pausada
                     </span>
                   ) : (
-                    <span className="inline-flex items-center rounded-full border border-emerald-300 bg-emerald-50 px-2 py-0.5 text-[10px] uppercase tracking-wider text-emerald-700 dark:border-emerald-700 dark:bg-emerald-950/30 dark:text-emerald-300">
+                    <span className="inline-flex items-center rounded-full border border-success/20 bg-success-soft px-2 py-0.5 text-[10px] uppercase tracking-wider text-success-fg">
                       Ativa
                     </span>
                   )}


### PR DESCRIPTION
## Tela-linda do Cliente · slice 2: os componentes limpo-semânticos

Continuação da adoção do DS na tela-querida (você escolheu *"sigo os limpos-semânticos às cegas, reviso em prod"*). Estes **9 arquivos usam SÓ ramp de status** (emerald=positivo · amber=atenção · rose/red=erro/débito) — **zero cor de categoria**, então a tokenização é mecânica e inequívoca.

| Arquivo | Semântica | → |
|---|---|---|
| RiscoClienteCard | ramp risco saudável/atenção/alto | success / warning / destructive |
| LedgerTab · PaymentsTab | débito / crédito | destructive-fg / success-fg |
| DocumentsTab · ActionsMenu · AddDiscountModal · PlacasMainTab | erro / delete | destructive |
| RewardPointsTab | ganho / resgate | success-fg / warning-fg |
| SubscriptionsTab | Ativa / Pausada | success-soft / warning-soft |

Token carrega light+dark → caem os `dark:` crus.

### Fora de escopo (pro teu olho na app)
Os **MISTOS** — `IATab` (violet accent + semântico), `KpiStripClickable`, tabs de form com `blue` — ficam pra quando você puder ver a app rodando (render local down + prod deslogado nesta sessão).

## Prova
- ✅ **build** verde · **eslint baseline delta -47** (sem regressão; a "regressão" que apareceu local era só nos arquivos wayfinder gitignored, fora do PR).

Review visual em prod quando logar.

Refs: DS-MATURIDADE (adoção pós-M1) · #2655

🤖 Generated with [Claude Code](https://claude.com/claude-code)