### PR TITLE
feat(governance): hook bloqueador red-first FV-T0 (motor de block, nasce advisory)

### DIFF
--- a/.claude/hooks/block-test-without-red.ps1
+++ b/.claude/hooks/block-test-without-red.ps1
@@ -1,0 +1,131 @@
+# block-test-without-red.ps1 - PreToolUse (red-first com DENTES / SDD Semana 0 passo FV-T0)
+#
+# Barra a criacao de um TESTE NOVO (*Test.php) que nao traz evidencia de ter FALHADO
+# vermelho antes. Complementa, do lado do TESTE e COM poder de bloqueio:
+#   - warn-red-first.ps1            (advisory, lado da PRODUCAO: "escreveu codigo sem teste")
+#   - nudge-test-contract-anchor.ps1 (advisory, "ancore a assercao num contrato, nao no codigo")
+# Esta e a peca P1 da auditoria 2026-06-12 que faltava: warn-red-first faz exit 0 hardcoded
+# (so sabe avisar); ESTE sabe exit 2 (bloqueia quando armado).
+#
+# POR QUE red-first do lado do teste: teste escrito DEPOIS do codigo e que nunca foi visto
+# VERMELHO tende a copiar o comportamento atual (tautologico) -- trava o drift em vez de
+# pega-lo (memory/proibicoes.md "Ideias avaliadas e DESCARTADAS" 2026-06-05). A evidencia
+# de red prova que o teste DISCRIMINA certo de errado.
+#
+# Origem: plano-mae memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md
+#         (Semana 0, frente FV, passo T0) + audit 2026-06-12 P1 item 5 (red-first hook bloqueador).
+# Padrao: warn-red-first.ps1 (ASCII puro PS 5.1, fail-open) + block-claim-without-evidence.ps1 (.claude/run/ + escape valve).
+#
+# NASCE EM MODO WARN (default) -- NAO bloqueia. Gates novos nascem advisory (plano §3 correcoes
+# 1 e 6; block-claim-without-evidence foi rebaixado a advisory por ADR 0224 com a regra canonica
+# "hook bloqueia SO o deterministico-obrigatorio"). O MOTOR de bloqueio (exit 2) esta implementado
+# e provado pelo .test.ps1; arma-lo = OIMPRESSO_REDFIRST_BLOCK_MODE=block.
+#
+# CRITERIO DE PROMOCAO A BLOCK (escrito ANTES da medicao -- espelha warn-red-first.ps1):
+#   - 14 dias de warn-red-first.ps1 com falso-positivo <10% (a medicao ja esta rodando)
+#   - PR + ADR propria + calendario de promocoes (max 1 promocao/semana -- plano §3 correcao 6)
+#   - flip = setar OIMPRESSO_REDFIRST_BLOCK_MODE=block (1 env, VISIVEL -- nunca silencioso)
+#
+# EVIDENCIA DE RED (qualquer UMA destrava a criacao do teste novo):
+#   1. cabecalho no proprio teste:  // red-first: rodei <cmd>, FALHOU com <erro> antes de implementar
+#   2. arquivo .claude/run/red-evidence-*.txt modificado <60min (saida do run vermelho)
+#   3. override legitimo no conteudo: red-first-override: <razao>
+#        (characterization de legado, golden/snapshot, regressao pos-bug onde o RED foi o bug report)
+#
+# So morde TESTE NOVO (Write de *Test.php nao-rastreado no git). Edit de teste existente
+# NAO re-exige red. Arquivo nao-teste nunca dispara. Fail-open em qualquer erro (exit 0).
+#
+# Env overrides (teste/tuning):
+#   OIMPRESSO_REDFIRST_BLOCK_MODE   = warn (default) | block | off
+#   OIMPRESSO_REDFIRST_REPO_ROOT    = raiz do repo git (default: 2 niveis acima deste script)
+#   OIMPRESSO_REDFIRST_EVID_MINUTES = janela do red-evidence-*.txt em minutos (default 60)
+
+$ErrorActionPreference = 'SilentlyContinue'
+try {
+    $mode = $env:OIMPRESSO_REDFIRST_BLOCK_MODE
+    if (-not $mode) { $mode = 'warn' }
+    if ($mode -eq 'off') { exit 0 }
+
+    $raw = [Console]::In.ReadToEnd()
+    if (-not $raw) { exit 0 }
+    $payload = $raw | ConvertFrom-Json
+    $tool = [string]$payload.tool_name
+    $path = [string]$payload.tool_input.file_path
+    if (-not $path) { exit 0 }
+
+    # So *Test.php (qualquer caminho)
+    $norm = $path -replace '\\', '/'
+    if ($norm -notmatch '(?i)Test\.php$') { exit 0 }
+
+    # So a CRIACAO conta: Edit/MultiEdit operam sobre arquivo ja existente -> nao re-exige red.
+    if ($tool -ne 'Write') { exit 0 }
+
+    # Raiz do repo (override pra teste isolado em repo temporario)
+    $repoRoot = $env:OIMPRESSO_REDFIRST_REPO_ROOT
+    if (-not $repoRoot) {
+        $hooksDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+        $repoRoot = Split-Path (Split-Path $hooksDir -Parent) -Parent
+    }
+    $rootNorm = ($repoRoot -replace '\\', '/').TrimEnd('/')
+
+    # Caminho relativo a raiz (se absoluto dentro do repo)
+    $rel = $norm
+    if ($rel.StartsWith($rootNorm + '/', [System.StringComparison]::OrdinalIgnoreCase)) {
+        $rel = $rel.Substring($rootNorm.Length + 1)
+    }
+
+    # Teste NOVO = nao rastreado no git. Se ja esta versionado, Write e overwrite de
+    # arquivo existente -> nao re-exige red (mesma semantica de Edit).
+    $tracked = & git -C $repoRoot ls-files --error-unmatch -- "$rel" 2>$null
+    if ($LASTEXITCODE -eq 0 -and $tracked) { exit 0 }
+
+    # Conteudo do Write (pra checar header de evidencia / override)
+    $content = [string]$payload.tool_input.content
+
+    # 3. Override legitimo (characterization/golden/regressao pos-bug)
+    $ov = [regex]::Match($content, '(?im)red-first-override:\s*(\S.*)$')
+    if ($ov.Success) {
+        Write-Host "[RED-FIRST/block - override aceito] $rel"
+        Write-Host ("  razao: " + $ov.Groups[1].Value.Trim())
+        exit 0
+    }
+
+    # 1. Cabecalho de evidencia de red no proprio teste
+    if ($content -match '(?im)red-first:\s*\S') { exit 0 }
+
+    # 2. Arquivo de evidencia recente em .claude/run/
+    $evidMin = 60
+    if ($env:OIMPRESSO_REDFIRST_EVID_MINUTES -match '^\d+$') { $evidMin = [int]$env:OIMPRESSO_REDFIRST_EVID_MINUTES }
+    $runDir = Join-Path $repoRoot '.claude/run'
+    if (Test-Path $runDir) {
+        $cutoff = (Get-Date).AddMinutes(-$evidMin)
+        $recent = Get-ChildItem $runDir -Filter 'red-evidence-*.txt' -ErrorAction SilentlyContinue |
+                  Where-Object { $_.LastWriteTime -gt $cutoff }
+        if ($recent) { exit 0 }
+    }
+
+    # Sem evidencia -> montar mensagem
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($rel)
+    $lines = @(
+        "",
+        "[RED-FIRST - teste novo sem evidencia de vermelho / SDD FV-T0]",
+        "  Teste NOVO ($base em $rel) sem prova de ter FALHADO vermelho antes (red-first evita teste tautologico).",
+        "  Satisfaca QUALQUER UMA:",
+        "    1. cabecalho no $base : // red-first: rodei <cmd>, FALHOU com <erro> antes de implementar",
+        "    2. .claude/run/red-evidence-*.txt salvo nos ultimos $evidMin min (saida do run vermelho)",
+        "    3. caso legitimo (characterization/golden/regressao pos-bug): red-first-override: <razao>",
+        "  Ref: memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md (FV-T0)."
+    )
+
+    if ($mode -eq 'block') {
+        foreach ($l in $lines) { [Console]::Error.WriteLine($l) }
+        [Console]::Error.WriteLine("  Modo BLOCK: criacao barrada (exit 2). Use override acima ou OIMPRESSO_REDFIRST_BLOCK_MODE=off.")
+        exit 2
+    }
+
+    # modo warn (default): avisa, NAO barra
+    foreach ($l in $lines) { Write-Host $l }
+    Write-Host "  Modo WARN (default): aviso advisory - exit 0, nao bloqueia. Promocao a block via ADR + env (ver cabecalho)."
+    Write-Host ""
+    exit 0
+} catch { exit 0 }

--- a/.claude/hooks/block-test-without-red.test.ps1
+++ b/.claude/hooks/block-test-without-red.test.ps1
@@ -1,0 +1,165 @@
+# Smoke test -- block-test-without-red.ps1 (SDD FV-T0 / red-first com DENTES)
+# Roda: powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-test-without-red.test.ps1
+#
+# Espelha warn-red-first.test.ps1: repos git TEMPORARIOS como fixture
+# (OIMPRESSO_REDFIRST_REPO_ROOT) pra que o estado do repo real nao contamine o
+# resultado. Prova que a catraca MORDE (modo block -> exit 2) E LIBERA corretamente
+# (override / header / evidencia / teste existente / arquivo nao-teste / modo off).
+#
+# NOTA: modo block escreve a mensagem em stderr e faz exit 2. NAO redirecionamos
+# stderr de processo nativo (evita NativeCommandError sob EAP=Stop no PS 5.1) --
+# a assercao primaria e o EXIT CODE; o stdout (modos warn/override) e checado a parte.
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path $MyInvocation.MyCommand.Path -Parent
+$hook = Join-Path $here 'block-test-without-red.ps1'
+
+$failures = 0
+$total = 0
+
+function New-FixtureRepo {
+    param([switch]$WithCommittedTest, [switch]$WithRedEvidence)
+
+    $dir = Join-Path $env:TEMP ("blockred-fixture-" + [Guid]::NewGuid().ToString('N').Substring(0, 8))
+    New-Item -ItemType Directory -Path $dir -Force | Out-Null
+    # NAO usar 2>$null em git nativo aqui: PS 5.1 + EAP Stop converte stderr
+    # redirecionado em NativeCommandError fatal. Config local neutraliza CRLF global.
+    & git -C $dir init -q
+    & git -C $dir config user.email "test@local"
+    & git -C $dir config user.name "fixture"
+    & git -C $dir config core.autocrlf false
+    & git -C $dir config core.safecrlf false
+    & git -C $dir config commit.gpgsign false
+
+    # Commit base: um arquivo de producao + readme (SEM teste)
+    New-Item -ItemType Directory -Path (Join-Path $dir 'app/Services') -Force | Out-Null
+    Set-Content -Path (Join-Path $dir 'app/Services/Foo.php') -Value '<?php class Foo {}' -Encoding Ascii
+    Set-Content -Path (Join-Path $dir 'README.txt') -Value 'fixture' -Encoding Ascii
+    & git -C $dir add -A
+    & git -C $dir commit -q -m "base sem teste"
+
+    if ($WithCommittedTest) {
+        New-Item -ItemType Directory -Path (Join-Path $dir 'tests/Unit') -Force | Out-Null
+        Set-Content -Path (Join-Path $dir 'tests/Unit/ExistenteTest.php') -Value '<?php class ExistenteTest {}' -Encoding Ascii
+        & git -C $dir add -A
+        & git -C $dir commit -q -m "teste ja versionado"
+    }
+
+    if ($WithRedEvidence) {
+        New-Item -ItemType Directory -Path (Join-Path $dir '.claude/run') -Force | Out-Null
+        Set-Content -Path (Join-Path $dir '.claude/run/red-evidence-novo.txt') `
+            -Value 'FAIL  Tests\Unit\NovoTest > soma  Failed asserting that 0 matches 2.' -Encoding Ascii
+    }
+
+    return $dir
+}
+
+function Test-Hook {
+    param(
+        [string]$Name,
+        [string]$FilePath,
+        [string]$RepoRoot,
+        [int]$ExpectExit,
+        [string]$Tool = 'Write',
+        [string]$Content = '',
+        [string]$Mode = 'warn',
+        [string]$ExpectStdout = $null
+    )
+
+    $script:total++
+    $env:OIMPRESSO_REDFIRST_BLOCK_MODE = $Mode
+    $env:OIMPRESSO_REDFIRST_REPO_ROOT = $RepoRoot
+
+    $ti = @{ file_path = $FilePath }
+    if ($Content -ne '') { $ti['content'] = $Content }
+    $payload = @{ tool_name = $Tool; tool_input = $ti } | ConvertTo-Json -Compress -Depth 10
+
+    # So stdout capturado (modos warn/override). Modo block escreve stderr + exit 2:
+    # stderr vai pro console (nao redirecionado) -- so checamos o exit code.
+    $output = $payload | & powershell -NoProfile -ExecutionPolicy Bypass -File $hook | Out-String
+    $exitCode = $LASTEXITCODE
+
+    $okExit = ($exitCode -eq $ExpectExit)
+    $okMsg = $true
+    if ($ExpectStdout) { $okMsg = ($output -match $ExpectStdout) }
+
+    if ($okExit -and $okMsg) {
+        Write-Host "  OK  $Name (exit=$exitCode)"
+    } else {
+        Write-Host "  FAIL $Name -- expected exit=$ExpectExit got exit=$exitCode; stdoutOk=$okMsg" -ForegroundColor Red
+        $script:failures++
+    }
+}
+
+Write-Host "=== block-test-without-red smoke (FV-T0) ==="
+
+$repo = New-FixtureRepo
+$repoTracked = New-FixtureRepo -WithCommittedTest
+$repoEvid = New-FixtureRepo -WithRedEvidence
+
+$novo = "$repo/tests/Unit/NovoTest.php"          # nao existe / untracked -> teste NOVO
+
+# T1: teste NOVO sem evidencia, modo BLOCK -> exit 2 (a catraca MORDE)
+Test-Hook -Name 'T1 novo-sem-evidencia BLOCK->2' `
+    -FilePath $novo -RepoRoot $repo -Mode 'block' -ExpectExit 2
+
+# T2: teste NOVO sem evidencia, modo WARN (default) -> exit 0 (avisa, NAO barra)
+Test-Hook -Name 'T2 novo-sem-evidencia WARN->0' `
+    -FilePath $novo -RepoRoot $repo -Mode 'warn' -ExpectExit 0 -ExpectStdout '\[RED-FIRST'
+
+# T3: teste NOVO com cabecalho red-first no content, modo BLOCK -> exit 0 (libera)
+Test-Hook -Name 'T3 novo-com-header-redfirst BLOCK->0' `
+    -FilePath $novo -RepoRoot $repo -Mode 'block' -ExpectExit 0 `
+    -Content '<?php // red-first: rodei pest NovoTest, FALHOU (assert 0==2) antes de implementar'
+
+# T4: teste NOVO com red-first-override, modo BLOCK -> exit 0 (libera + razao no stdout)
+Test-Hook -Name 'T4 novo-com-override BLOCK->0' `
+    -FilePath $novo -RepoRoot $repo -Mode 'block' -ExpectExit 0 -ExpectStdout 'override aceito' `
+    -Content '<?php // red-first-override: characterization de legado UPos sem red possivel'
+
+# T5: teste JA VERSIONADO (tracked), Write overwrite, modo BLOCK -> exit 0 (nao re-exige red)
+Test-Hook -Name 'T5 teste-existente-tracked BLOCK->0' `
+    -FilePath "$repoTracked/tests/Unit/ExistenteTest.php" -RepoRoot $repoTracked -Mode 'block' -ExpectExit 0 `
+    -Content '<?php class ExistenteTest { /* novo caso */ }'
+
+# T6: arquivo NAO-teste (producao), modo BLOCK -> exit 0 (nunca dispara)
+Test-Hook -Name 'T6 nao-teste BLOCK->0' `
+    -FilePath "$repo/app/Services/Bar.php" -RepoRoot $repo -Mode 'block' -ExpectExit 0 `
+    -Content '<?php class Bar {}'
+
+# T7: modo OFF -> exit 0 mesmo com teste novo sem evidencia
+Test-Hook -Name 'T7 modo-off->0' `
+    -FilePath $novo -RepoRoot $repo -Mode 'off' -ExpectExit 0
+
+# T8: tool EDIT (nao Write) em teste novo, modo BLOCK -> exit 0 (so criacao via Write morde)
+Test-Hook -Name 'T8 tool-edit BLOCK->0' `
+    -FilePath $novo -RepoRoot $repo -Mode 'block' -ExpectExit 0 -Tool 'Edit'
+
+# T9: teste NOVO sem header MAS com .claude/run/red-evidence-*.txt recente, modo BLOCK -> exit 0
+Test-Hook -Name 'T9 red-evidence-file BLOCK->0' `
+    -FilePath "$repoEvid/tests/Unit/NovoTest.php" -RepoRoot $repoEvid -Mode 'block' -ExpectExit 0 `
+    -Content '<?php class NovoTest {}'
+
+# T10: stdin vazio -> exit 0 (fail-open)
+$script:total++
+$env:OIMPRESSO_REDFIRST_BLOCK_MODE = 'block'
+$out10 = '' | & powershell -NoProfile -ExecutionPolicy Bypass -File $hook | Out-String
+if ($LASTEXITCODE -eq 0) { Write-Host "  OK  T10 stdin-vazio fail-open" }
+else { Write-Host "  FAIL T10 stdin-vazio -- exit=$LASTEXITCODE" -ForegroundColor Red; $failures++ }
+
+# T11: payload sem file_path -> exit 0 (fail-open)
+$script:total++
+$env:OIMPRESSO_REDFIRST_REPO_ROOT = $repo
+$out11 = '{"tool_name":"Write","tool_input":{}}' | & powershell -NoProfile -ExecutionPolicy Bypass -File $hook | Out-String
+if ($LASTEXITCODE -eq 0) { Write-Host "  OK  T11 payload-sem-path fail-open" }
+else { Write-Host "  FAIL T11 payload-sem-path -- exit=$LASTEXITCODE" -ForegroundColor Red; $failures++ }
+
+# Cleanup
+Remove-Item -Recurse -Force $repo, $repoTracked, $repoEvid -ErrorAction SilentlyContinue
+$env:OIMPRESSO_REDFIRST_BLOCK_MODE = $null
+$env:OIMPRESSO_REDFIRST_REPO_ROOT = $null
+$env:OIMPRESSO_REDFIRST_EVID_MINUTES = $null
+
+Write-Host ""
+Write-Host "Total: $total | Failures: $failures"
+if ($failures -gt 0) { exit 1 } else { exit 0 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -101,6 +101,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/warn-red-first.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-test-without-red.ps1"
           }
         ]
       },


### PR DESCRIPTION
## Escopo: SDD Semana-0 frente FV — só **T0** restou

Frente FV tinha 4 passos (F1/F2/Q1/T0). **Re-derivando de `origin/main` fresco** (regra anti-stale do plano), **F1, F2 e Q1 já estão em main** — feitos por sessões paralelas/anteriores da própria frente FV, todos com comentário referenciando o mesmo plano. Recriá-los seria duplicação proibida (CLAUDE.md: *"se já existe similar, EDITA — não cria novo"*). Por isso **1 PR só (T0)**, não 4.

| Passo | Estado em `origin/main` |
|---|---|
| **F1** upload JUnit | ✅ `ci.yml` já tem `junit-summary.mjs` + `upload-artifact@v4 if:always() if-no-files-found:error` + `workflow_dispatch` |
| **F2** composite pest+mysql | ✅ `.github/actions/pest-mysql-setup/action.yml` (PHP+deps+.env MySQL+migrate schema baseline+seed biz=1/biz=2 Tier 0) |
| **Q1** catraca quarentena | ✅ `foundation-ratchet.{mjs,yml}` + baseline + fixtures boa/ruim (`n_quarantine` só desce + 2 contadores) |
| **T0** hook **bloqueador** red-first | 🟡 só o advisory `warn-red-first.ps1` existia → **este PR entrega o motor de bloqueio** |

## O que este PR entrega

`block-test-without-red.ps1` — enforcement red-first **com dentes**, do lado do **TESTE** (a peça P1 da auditoria 2026-06-12 que faltava). `warn-red-first.ps1` (advisory, lado produção) e `nudge-test-contract-anchor.ps1` (advisory) só sabem `exit 0`; **este sabe `exit 2`** quando armado.

**Por quê:** teste escrito depois do código e nunca visto vermelho tende a copiar o comportamento atual (tautológico) — trava o drift em vez de pegá-lo (`memory/proibicoes.md` "Ideias DESCARTADAS" 2026-06-05). A evidência de red prova que o teste discrimina certo de errado.

- **Só morde TESTE NOVO** (`Write` de `*Test.php` não-rastreado no git). `Edit` de teste existente e arquivo não-teste nunca disparam.
- **Evidência destrava** (qualquer uma): cabeçalho `// red-first: rodei <cmd>, FALHOU com <erro>` no teste · `.claude/run/red-evidence-*.txt` <60min · override `red-first-override: <razão>` (characterization de legado / golden / regressão pós-bug).

## Decisão de design — nasce **advisory**, não bloqueia ainda

Re-derivando de main, `warn-red-first.ps1` já tem um **critério de promoção explícito** (bloquear exige 14d com FP<10% + ADR + calendário, *"NUNCA flip silencioso"*), e `block-claim-without-evidence` foi rebaixado a advisory por ADR 0224 (*"hook bloqueia SÓ o determinístico-obrigatório"*). Fazer block-by-default seria flip silencioso + exigiria ADR (proibido nesta frente) + **derrubaria as sessões irmãs** que criam testes agora.

Resolução: o **motor de bloqueio (`exit 2`) está implementado e provado**, mas armado em **modo `warn` por default** (`OIMPRESSO_REDFIRST_BLOCK_MODE`: `warn`|`block`|`off`). **Armar = 1 env var visível**, após os 14d de medição do `warn-red-first` + ADR. Critério escrito no cabeçalho do hook.

## Validação

- **Lógica determinística** (`git ls-files` tracked/untracked + regexes `Test.php$` / `red-first:` / `red-first-override:` + relativização de path) validada com harness `git`+`node` real: **11/11 OK**.
- `block-test-without-red.test.ps1` — **11 casos** provando que **MORDE** (modo `block` → `exit 2` em teste novo sem evidência) e **LIBERA** (override / header / `red-evidence` / teste existente / não-teste / modo `off` / fail-open).
- ⚠️ Smoke `.test.ps1` roda no **Windows/CT100** do dev (sem `pwsh` no runner nuvem). Sintaxe PS espelhada do `warn-red-first.ps1` comprovado em prod.

## Arquivos (3, +300 linhas)
- `.claude/hooks/block-test-without-red.ps1` (novo)
- `.claude/hooks/block-test-without-red.test.ps1` (novo)
- `.claude/settings.json` (+4 — registro no matcher `Write|Edit|MultiEdit`, após `warn-red-first.ps1`)

Refs: SDD Semana-0 FV · plano `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_011BQ8WgtWrLqZNaH8qP1QYw)_