### PR TITLE
test(teammcp): guards de schema cobrem o write-path completo — SKIP em vez de ERROR

### DIFF
--- a/Modules/TeamMcp/Tests/Feature/ActorPermissionMatrixTest.php
+++ b/Modules/TeamMcp/Tests/Feature/ActorPermissionMatrixTest.php
@@ -35,10 +35,17 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
-    if (! Schema::hasTable('mcp_actors')) {
-        $this->markTestSkipped(
-            'mcp_actors table missing — rode php artisan migrate primeiro'
-        );
+    // O beforeEach roda o McpActorsSeeder (abaixo) e os testes fazem McpActor::create —
+    // McpActor usa LogsActivity, que grava em activity_log a cada create. Schema parcial
+    // com mcp_actors presente mas activity_log ausente fazia o seeder/create estourar
+    // QueryException (ERROR) em vez de SKIP. Guard cobre o set completo do write-path.
+    foreach (['mcp_actors', 'activity_log'] as $tabela) {
+        if (! Schema::hasTable($tabela)) {
+            $this->markTestSkipped(
+                "Tabela {$tabela} ausente — rode migrate:fresh contra o dump completo ".
+                '(activity_log é dependência do trait LogsActivity em McpActor).'
+            );
+        }
     }
 
     // Reseta os 5 canonicos pra estado determinístico

--- a/Modules/TeamMcp/Tests/Feature/McpActorsSeederTest.php
+++ b/Modules/TeamMcp/Tests/Feature/McpActorsSeederTest.php
@@ -35,8 +35,16 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
-    if (! Schema::hasTable('mcp_actors')) {
-        $this->markTestSkipped('mcp_actors table missing — rode php artisan migrate primeiro (provider TeamMcp registra a migration).');
+    // Os testes rodam McpActorsSeeder, que cria actors via McpActor (LogsActivity →
+    // INSERT em activity_log). Schema parcial com mcp_actors presente mas activity_log
+    // ausente vira ERROR em vez de SKIP. Guard cobre o set completo do write-path.
+    foreach (['mcp_actors', 'activity_log'] as $tabela) {
+        if (! Schema::hasTable($tabela)) {
+            $this->markTestSkipped(
+                "Tabela {$tabela} ausente — rode migrate:fresh contra o dump completo ".
+                '(activity_log é dependência do trait LogsActivity em McpActor).'
+            );
+        }
     }
 });
 

--- a/Modules/TeamMcp/Tests/Feature/MultiTenantTokenIsolationTest.php
+++ b/Modules/TeamMcp/Tests/Feature/MultiTenantTokenIsolationTest.php
@@ -25,7 +25,8 @@ uses(Tests\TestCase::class);
  * Convenções:
  *   - biz=1 sempre (Wagner-superadmin), nunca biz=4 (ROTA LIVRE — ADR 0101)
  *   - Tokens fake (string aleatoria) — NUNCA token MCP real do servidor
- *   - SQLite guard pra schema completo (mcp_actors + mcp_tokens)
+ *   - Guard de schema completo: mcp_actors + activity_log (este NUNCA é tocado
+ *     diretamente, mas McpActor usa LogsActivity e grava nele a cada create)
  *   - PII Tier 0: zero email/credencial real
  *
  * @see Modules/TeamMcp/Entities/McpActor.php
@@ -36,11 +37,24 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
-    if (! Schema::hasTable('mcp_actors')) {
-        $this->markTestSkipped(
-            'mcp_actors table missing — rode php artisan migrate '.
-            '(provider TeamMcp registra a migration P0.4 ADR 0081).'
-        );
+    // O write-path destes testes toca DUAS tabelas, não uma: McpActor::create()
+    // grava em `mcp_actors` E em `activity_log` — McpActor usa o trait Spatie
+    // LogsActivity, que dispara um INSERT no activity_log a cada create/update
+    // (ACTIVITY_LOGGER_ENABLED default=true; não há override em phpunit.xml).
+    //
+    // Um guard de tabela única deixava passar o estado de schema PARCIAL onde
+    // `mcp_actors` existe mas `activity_log` não (ex: dump incompleto pré-Frente-C,
+    // 188 tabelas) — aí o INSERT no activity_log estourava QueryException (ERROR)
+    // em vez do markTestSkipped (SKIP), tornando a semântica do guard enganosa.
+    // Cobrir o set completo de tabelas do write-path restaura o SKIP limpo.
+    foreach (['mcp_actors', 'activity_log'] as $tabela) {
+        if (! Schema::hasTable($tabela)) {
+            $this->markTestSkipped(
+                "Tabela {$tabela} ausente — rode migrate:fresh contra o dump completo. ".
+                '(TeamMcp registra mcp_actors via ADR 0081; activity_log é dependência '.
+                'do trait LogsActivity em McpActor — ADR 0093/D7 LGPD.)'
+            );
+        }
     }
 });
 
@@ -234,7 +248,13 @@ it('mcp_actors table NAO tem coluna business_id — cross-tenant por design ADR 
 // ------------------------------------------------------------------
 
 afterEach(function () {
-    DB::table('mcp_actors')
-        ->whereIn('slug', ['test-dev-a-isolacao', 'test-dev-b-isolacao'])
-        ->delete();
+    // O afterEach roda MESMO quando o beforeEach deu markTestSkipped (Pest executa
+    // o teardown após skip). Sem o hasTable aqui, a limpeza estoura "no such table:
+    // mcp_actors" e o teste vira FAILED em vez de SKIPPED — exatamente o sintoma de
+    // guard enganoso que esta cleanup corrige. Guard => no-op quando schema ausente.
+    if (Schema::hasTable('mcp_actors')) {
+        DB::table('mcp_actors')
+            ->whereIn('slug', ['test-dev-a-isolacao', 'test-dev-b-isolacao'])
+            ->delete();
+    }
 });

--- a/Modules/TeamMcp/Tests/Feature/Wave18ServicesExtractionTest.php
+++ b/Modules/TeamMcp/Tests/Feature/Wave18ServicesExtractionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Schema;
 use Modules\TeamMcp\Http\Requests\ExportUsageCsvRequest;
 use Modules\TeamMcp\Http\Requests\UpdateQuotaRequest;
 use Modules\TeamMcp\Services\McpTokenIssuer;
@@ -47,18 +48,36 @@ describe('Wave 18 — Services extracted (D4)', function () {
     });
 
     it('McpTokenIssuer::countActive retorna int >= 0 pra user inexistente', function () {
+        // Guard de schema: countActive faz SELECT em mcp_tokens. Sem a tabela
+        // (schema parcial / dump incompleto) o teste estourava QueryException
+        // (ERROR) em vez de SKIP. Os smokes de container/reflection acima NÃO
+        // tocam DB e seguem rodando — por isso o guard é por-teste, não no topo.
+        if (! Schema::hasTable('mcp_tokens')) {
+            $this->markTestSkipped('Tabela mcp_tokens ausente — rode migrate:fresh contra o dump completo.');
+        }
         $svc = app(McpTokenIssuer::class);
         $count = $svc->countActive(99999999); // user inexistente — sem tokens
         expect($count)->toBe(0);
     });
 
     it('McpTokenIssuer::revoke retorna false pra token inexistente (idempotência)', function () {
+        // revoke faz McpToken::find() (SELECT em mcp_tokens) antes de qualquer
+        // efeito — sem a tabela vira ERROR. Guard por-teste pelo mesmo motivo acima.
+        if (! Schema::hasTable('mcp_tokens')) {
+            $this->markTestSkipped('Tabela mcp_tokens ausente — rode migrate:fresh contra o dump completo.');
+        }
         $svc = app(McpTokenIssuer::class);
         $applied = $svc->revoke(99999999); // token inexistente
         expect($applied)->toBeFalse();
     });
 
     it('TeamUsageAggregator::globalStats retorna array com 4 chaves', function () {
+        // globalStats() faz 4 SELECTs em mcp_audit_log — mesma exposição de schema
+        // que countActive/revoke, só que em outra tabela. Guard por-teste pra SKIP
+        // limpo quando o dump não trouxe mcp_audit_log.
+        if (! Schema::hasTable('mcp_audit_log')) {
+            $this->markTestSkipped('Tabela mcp_audit_log ausente — rode migrate:fresh contra o dump completo.');
+        }
         // Wave 18 — só smoke estrutural, sem rodar pesado em mcp_audit_log
         $svc = app(TeamUsageAggregator::class);
         $stats = $svc->globalStats();


### PR DESCRIPTION
## Contexto

Triagem US-GOV-021 (TeamMcp) flagou que no nightly fullsuite `20260613-100035` os 9 testes de `MultiTenantTokenIsolationTest` apareceram como **ERROR** (`QueryException` "Base table or view not found") em vez de **SKIP**, mesmo com o guard `Schema::hasTable('mcp_actors')` no `beforeEach`. O guard de tabela única não gateava de forma confiável contra schema incompleto (estado 188-table pré-Frente-C).

## Causa-raiz

O guard checa **uma** tabela, mas o write-path de cada teste toca **mais**:

- **`MultiTenant`/`ActorPermissionMatrix`/`McpActorsSeeder`:** `McpActor::create()` dispara Spatie **`LogsActivity`** → `INSERT` em **`activity_log`** (`ACTIVITY_LOGGER_ENABLED` default `true`, sem override em `phpunit.xml`). Em schema parcial com `mcp_actors` presente mas `activity_log` ausente → ERROR no INSERT, não SKIP. A tabela relacionada que faltava é **`activity_log`** — não `mcp_tokens`.
- **`Wave18ServicesExtraction`:** `countActive`/`revoke` fazem SELECT em **`mcp_tokens`**; `globalStats` em **`mcp_audit_log`**. Sem guard nenhum → ERROR.
- **Bônus (sqlite `:memory:`):** o `afterEach` de `MultiTenant` roda **mesmo após** `beforeEach markTestSkipped` (Pest executa teardown pós-skip) e estava sem guard → a limpeza `DELETE` virava **FAILED**, não SKIP.

"Conexão diferente" foi **descartado**: `Schema`, o model `McpActor` e o `Activity` model do Spatie resolvem todos pra conexão default.

## Mudança

| Arquivo | Mudança |
|---|---|
| `MultiTenantTokenIsolationTest` | `beforeEach` exige `mcp_actors` + `activity_log`; `afterEach` guardado; header corrigido |
| `Wave18ServicesExtractionTest` | guards **por-teste** (`mcp_tokens` em countActive/revoke; `mcp_audit_log` em globalStats) — os 5 smokes de container/reflection seguem rodando |
| `ActorPermissionMatrixTest` + `McpActorsSeederTest` | `beforeEach` exige `activity_log` (seeder/create disparam LogsActivity) |
| `Wave18RetryTeamMcpSaturationTest` | **sem mudança** — testes guardados são read-only SELECTs (`mcp_actors` basta) |

Padrão alinhado ao `TokensListAndRevokeTest` (guard multi-tabela + `afterEach` guardado), que já era o modelo correto no módulo.

## Por que (b) e não (a)

Remover o guard faria os testes darem ERROR no sqlite `:memory:` (default do `phpunit.xml`, sem `RefreshDatabase`) e em qualquer schema parcial. Fortalecer mantém SKIP limpo onde o schema está incompleto e RUN normal pós-US-GOV-020 (#2657, migrate:fresh contra o dump 364-table).

## Verificação

`vendor/bin/pest` nos 4 arquivos (sqlite `:memory:`): **28 skipped, 5 passed, 0 failed, 0 errors**. `php -l` limpo nos 4.

Refs: US-GOV-021 TeamMcp triage · adjacente a US-GOV-020 (#2657)

🤖 Generated with [Claude Code](https://claude.com/claude-code)