### PR TITLE
fix(cliente): status-dot compara EN canon (active/inactive) — corrige cor sempre vermelha

### DIFF
--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -489,9 +489,9 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
                     <span
                       aria-hidden
                       className={`h-1.5 w-1.5 rounded-full ${
-                        o.value === 'ativo'
+                        o.value === 'active'
                           ? 'bg-success'
-                          : o.value === 'inativo'
+                          : o.value === 'inactive'
                           ? 'bg-muted-foreground'
                           : 'bg-destructive'
                       }`}


### PR DESCRIPTION
## O que

Corrige o status-dot (bolinha colorida) do select de Status no drawer de Cliente (`ClassificacaoTab.tsx`).

## Bug

`STATUS_OPTIONS` carrega valores **EN canon** (`'active'`/`'inactive'`/`'blocked'`), mas o ternário da cor do dot comparava contra strings **PT-BR** (`'ativo'`/`'inativo'`). Como `o.value` nunca é `'ativo'`/`'inativo'`, os dois ramos eram sempre falsos e **todo** status caía no `else` → `bg-rose-500` (vermelho). A cor do dot não batia com o status selecionado.

## Fix

2 linhas — alinha as strings de comparação ao EN canon:

- `'ativo'` → `'active'`
- `'inativo'` → `'inactive'`

Resultado: active=verde, inactive=cinza, blocked=vermelho. Cores mantidas (raw Tailwind, consistentes com os `text-*-700` adjacentes — o sweep de DS ainda não tocou este arquivo).

## Notas

- Bug idêntico já corrigido na branch `feat/governance-ds-rollout-ledger` (commit `ff568c67e`), mas aquela branch divergiu pesado da `main` e seu PR (#2621) já mergeou — então este PR limpo é o que efetivamente leva o fix pra produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)