### PR TITLE
feat(ds): adoção em massa do DS — 329 tokenizações verificadas por adversário (132 arquivos, 32 módulos)

### DIFF
--- a/resources/js/Pages/Admin/_components/AiSuggestionPanel.tsx
+++ b/resources/js/Pages/Admin/_components/AiSuggestionPanel.tsx
@@ -70,7 +70,7 @@ export default function AiSuggestionPanel({
             const isUp = s.avg_delta > 0;
             const Arrow = isUp ? TrendingUp : TrendingDown;
             const toneCls = isUp
-              ? 'text-emerald-700 dark:text-emerald-400'
+              ? 'text-success-fg'
               : 'text-destructive';
             return (
               <li

--- a/resources/js/Pages/Admin/_components/DimensionProgressBar.tsx
+++ b/resources/js/Pages/Admin/_components/DimensionProgressBar.tsx
@@ -31,16 +31,16 @@ export default function DimensionProgressBar({
 
   const barClass =
     tone === 'ok'
-      ? 'bg-emerald-500/70 dark:bg-emerald-500/60'
+      ? 'bg-success/70'
       : tone === 'warn'
-        ? 'bg-amber-500/70 dark:bg-amber-500/60'
+        ? 'bg-warning/70'
         : 'bg-destructive/70';
 
   const labelTone =
     tone === 'ok'
-      ? 'text-emerald-700 dark:text-emerald-400'
+      ? 'text-success-fg'
       : tone === 'warn'
-        ? 'text-amber-700 dark:text-amber-400'
+        ? 'text-warning-fg'
         : 'text-destructive';
 
   return (
@@ -63,7 +63,7 @@ export default function DimensionProgressBar({
               className={cn(
                 'inline-flex items-center gap-0.5 rounded-md border px-1 py-0.5 text-[9px] font-medium',
                 dimension.paired_ok
-                  ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+                  ? 'border-success/20 bg-success-soft text-success-fg'
                   : 'border-destructive/40 bg-destructive/10 text-destructive',
               )}
             >

--- a/resources/js/Pages/Admin/_components/DriftAlertBanner.tsx
+++ b/resources/js/Pages/Admin/_components/DriftAlertBanner.tsx
@@ -35,12 +35,12 @@ export default function DriftAlertBanner({
       <div
         role="status"
         className={cn(
-          'flex items-center justify-between gap-3 rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-900 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200',
+          'flex items-center justify-between gap-3 rounded-md border border-success/20 bg-success-soft px-3 py-2 text-[12px] text-success-fg',
           className,
         )}
       >
         <span className="flex items-center gap-2">
-          <span className="inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+          <span className="inline-flex h-1.5 w-1.5 rounded-full bg-success" />
           Sem drifts &gt;{thresholdPts}pts nos últimos 7 dias — saúde estável.
         </span>
       </div>

--- a/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
+++ b/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
@@ -126,9 +126,9 @@ function HealthCard({
 }) {
   const toneCls =
     tone === 'ok'
-      ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+      ? 'border-success/20 bg-success-soft text-success-fg'
       : tone === 'warn'
-        ? 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300'
+        ? 'border-warning/20 bg-warning-soft text-warning-fg'
         : 'border-destructive/40 bg-destructive/10 text-destructive';
 
   return (

--- a/resources/js/Pages/Admin/_components/InitiativeBadge.tsx
+++ b/resources/js/Pages/Admin/_components/InitiativeBadge.tsx
@@ -55,7 +55,7 @@ export default function InitiativeBadge({ initiative, className, compact }: Prop
   const toneCls = (() => {
     switch (effectiveStatus) {
       case 'done':
-        return 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300';
+        return 'border-success/20 bg-success-soft text-success-fg';
       case 'overdue':
         return 'border-destructive/40 bg-destructive/10 text-destructive';
       case 'in_progress':

--- a/resources/js/Pages/Admin/_components/ModuleList.tsx
+++ b/resources/js/Pages/Admin/_components/ModuleList.tsx
@@ -259,9 +259,9 @@ function ModuleListItem({
   const statusTone = STATUS_TONE[module.status];
   const statusCls =
     module.status === 'ok'
-      ? 'text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40'
+      ? 'text-success-fg border-success/20 bg-success-soft'
       : module.status === 'warn'
-        ? 'text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40'
+        ? 'text-warning-fg border-warning/20 bg-warning-soft'
         : 'text-destructive border-destructive/40 bg-destructive/10';
 
   return (
@@ -317,7 +317,7 @@ function ModuleListItem({
             )}
             {module.paired_count > 0 && (
               <span
-                className="inline-flex items-center gap-0.5 rounded-md border border-amber-300 bg-amber-50 px-1 py-0.5 text-[9.5px] font-medium text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+                className="inline-flex items-center gap-0.5 rounded-md border border-warning/20 bg-warning-soft px-1 py-0.5 text-[9.5px] font-medium text-warning-fg"
                 title="Paired violations (anti-Goodhart)"
               >
                 paired×{module.paired_count}

--- a/resources/js/Pages/Admin/_components/ModuleReader.tsx
+++ b/resources/js/Pages/Admin/_components/ModuleReader.tsx
@@ -83,7 +83,7 @@ export default function ModuleReader({
   const statusTone = STATUS_TONE[module.status];
   const delta = module.score - module.meta;
   const TrendIcon = delta >= 0 ? TrendingUp : TrendingDown;
-  const trendCls = delta >= 0 ? 'text-emerald-700 dark:text-emerald-400' : 'text-destructive';
+  const trendCls = delta >= 0 ? 'text-success-fg' : 'text-destructive';
 
   const moduleInitiatives = initiatives.filter((i) => i.module === module.slug);
   const moduleSuggestions = aiSuggestions.filter((s) => s.module === module.slug);
@@ -285,7 +285,7 @@ export default function ModuleReader({
         {module.paired_count > 0 && (
           <section
             aria-label="Paired violations"
-            className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[11.5px] text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+            className="flex items-start gap-2 rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-[11.5px] text-warning-fg"
           >
             <Sparkles size={13} className="mt-0.5 shrink-0" />
             <div>
@@ -314,9 +314,9 @@ function Kpi({
   const toneCls = !tone
     ? 'text-foreground'
     : tone === 'ok'
-      ? 'text-emerald-700 dark:text-emerald-400'
+      ? 'text-success-fg'
       : tone === 'warn'
-        ? 'text-amber-700 dark:text-amber-400'
+        ? 'text-warning-fg'
         : 'text-destructive';
   return (
     <div className="rounded-md border border-border bg-background px-2.5 py-1.5">

--- a/resources/js/Pages/Admin/_components/ReviewReader.tsx
+++ b/resources/js/Pages/Admin/_components/ReviewReader.tsx
@@ -153,7 +153,7 @@ export default function ReviewReader({ screen, onAction, onResmoke, className }:
       {screen.desvios_count > 0 && (
         <div
           role="status"
-          className="flex items-center gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[11.5px] text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+          className="flex items-center gap-2 rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-[11.5px] text-warning-fg"
         >
           <AlertTriangle size={13} className="shrink-0" />
           <span>

--- a/resources/js/Pages/Admin/_components/RoundBadge.tsx
+++ b/resources/js/Pages/Admin/_components/RoundBadge.tsx
@@ -29,7 +29,7 @@ const STATUS_META: Record<
   },
   approved: {
     label: 'Aprovada',
-    cls: 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200',
+    cls: 'border-success/20 bg-success-soft text-success-fg',
     Icon: Check,
   },
   rejected: {
@@ -39,7 +39,7 @@ const STATUS_META: Record<
   },
   iterate: {
     label: 'Iterar',
-    cls: 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300',
+    cls: 'border-warning/20 bg-warning-soft text-warning-fg',
     Icon: RefreshCw,
   },
 };

--- a/resources/js/Pages/Admin/_components/ScreenList.tsx
+++ b/resources/js/Pages/Admin/_components/ScreenList.tsx
@@ -265,7 +265,7 @@ function ScreenListItem({
           )}
           {screen.desvios_count > 0 && (
             <span
-              className="rounded-md border border-amber-300 bg-amber-50 px-1 py-0.5 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+              className="rounded-md border border-warning/20 bg-warning-soft px-1 py-0.5 text-warning-fg"
               title="Desvios catalogados último round"
             >
               {screen.desvios_count} desvios

--- a/resources/js/Pages/Admin/_components/ScreenReviewSidebar.tsx
+++ b/resources/js/Pages/Admin/_components/ScreenReviewSidebar.tsx
@@ -164,7 +164,7 @@ function StatusBadges({
       )}
       {approved > 0 && (
         <span
-          className="rounded-md border border-emerald-300 bg-emerald-50 px-1 py-0.5 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200"
+          className="rounded-md border border-success/20 bg-success-soft px-1 py-0.5 text-success-fg"
           title="Aprovadas"
         >
           {approved} apv
@@ -172,7 +172,7 @@ function StatusBadges({
       )}
       {iterate > 0 && (
         <span
-          className="rounded-md border border-amber-300 bg-amber-50 px-1 py-0.5 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+          className="rounded-md border border-warning/20 bg-warning-soft px-1 py-0.5 text-warning-fg"
           title="Em iteração"
         >
           {iterate} iter

--- a/resources/js/Pages/Admin/_components/WidgetAdrTier0.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetAdrTier0.tsx
@@ -31,7 +31,7 @@ export default function WidgetAdrTier0({ data }: Props) {
 
   if (data.tier_0_alerts.length === 0) {
     return (
-      <div className="flex items-center gap-2 text-green-700">
+      <div className="flex items-center gap-2 text-success-fg">
         <span>✅</span>
         <span className="text-sm">Nenhuma ADR Tier 0 violada — sistema saudável.</span>
       </div>
@@ -40,17 +40,17 @@ export default function WidgetAdrTier0({ data }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="text-sm text-red-700 font-medium">
+      <div className="text-sm text-destructive-fg font-medium">
         {data.tier_0_alerts.length} violação(ões) detectada(s)
       </div>
       <ul className="space-y-2">
         {data.tier_0_alerts.map((alert, idx) => (
           <li
             key={`${alert.check}-${idx}`}
-            className="border-l-4 border-red-500 bg-red-50 p-3 text-sm"
+            className="border-l-4 border-destructive bg-destructive-soft p-3 text-sm"
           >
             <div className="flex items-center justify-between">
-              <span className="font-mono text-xs text-red-900">{alert.check}</span>
+              <span className="font-mono text-xs text-destructive-fg">{alert.check}</span>
               <a
                 href={`https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/${alert.adr}-*`}
                 target="_blank"
@@ -65,7 +65,7 @@ export default function WidgetAdrTier0({ data }: Props) {
             )}
             <div className="text-xs text-gray-500 mt-1">
               status:{' '}
-              <span className="font-medium text-red-700">{alert.status}</span>
+              <span className="font-medium text-destructive-fg">{alert.status}</span>
               {alert.last_run && ` · último run: ${alert.last_run}`}
             </div>
           </li>

--- a/resources/js/Pages/Admin/_components/WidgetBrainBCost.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetBrainBCost.tsx
@@ -17,17 +17,17 @@ const fmtBrl = (n: number): string =>
   `R$ ${n.toFixed(2).replace('.', ',')}`;
 
 const statusColor: Record<string, string> = {
-  green:   'text-green-700',
-  yellow:  'text-amber-700',
-  red:     'text-red-700',
-  unknown: 'text-gray-500',
+  green:   'text-success-fg',
+  yellow:  'text-warning-fg',
+  red:     'text-destructive-fg',
+  unknown: 'text-muted-foreground',
 };
 
 const statusBg: Record<string, string> = {
-  green:   'bg-green-100',
-  yellow:  'bg-amber-100',
-  red:     'bg-red-100',
-  unknown: 'bg-gray-100',
+  green:   'bg-success/10',
+  yellow:  'bg-warning/10',
+  red:     'bg-destructive/10',
+  unknown: 'bg-muted',
 };
 
 export default function WidgetBrainBCost({ data }: Props) {

--- a/resources/js/Pages/Admin/_components/WidgetCurador.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetCurador.tsx
@@ -54,7 +54,7 @@ export default function WidgetCurador({ data }: Props) {
           <div className="text-xs text-gray-500">total ativo</div>
         </div>
         <div className="border rounded p-2">
-          <div className="text-2xl font-semibold text-red-700">{data.sensitive_count}</div>
+          <div className="text-2xl font-semibold text-destructive-fg">{data.sensitive_count}</div>
           <div className="text-xs text-gray-500">sensitive vault</div>
         </div>
         <div className="border rounded p-2">

--- a/resources/js/Pages/Admin/_components/WidgetHealth.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetHealth.tsx
@@ -21,10 +21,10 @@ interface Props {
 }
 
 const statusColor: Record<string, string> = {
-  green: 'bg-green-500',
-  yellow: 'bg-amber-500',
-  red: 'bg-red-500',
-  unknown: 'bg-gray-400',
+  green: 'bg-success',
+  yellow: 'bg-warning',
+  red: 'bg-destructive',
+  unknown: 'bg-muted-foreground',
 };
 
 const statusEmoji: Record<string, string> = {
@@ -38,8 +38,8 @@ export default function WidgetHealth({ data }: Props) {
   if (!data.available) {
     return (
       <div className="text-sm space-y-2">
-        <p className="text-gray-600">
-          Snapshot ausente. <code className="text-xs bg-gray-100 px-1 rounded">{data.reason}</code>
+        <p className="text-muted-foreground">
+          Snapshot ausente. <code className="text-xs bg-muted px-1 rounded">{data.reason}</code>
         </p>
         {data.instructions && (
           <p className="text-xs text-gray-500 font-mono">{data.instructions}</p>

--- a/resources/js/Pages/Admin/_components/WidgetInfraStatus.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetInfraStatus.tsx
@@ -26,9 +26,9 @@ const labels: Record<string, string> = {
 };
 
 const statusColor: Record<string, string> = {
-  up:       'bg-green-500',
-  degraded: 'bg-amber-500',
-  down:     'bg-red-500',
+  up:       'bg-success',
+  degraded: 'bg-warning',
+  down:     'bg-destructive',
 };
 
 export default function WidgetInfraStatus({ data }: Props) {
@@ -47,7 +47,7 @@ export default function WidgetInfraStatus({ data }: Props) {
             />
             <span className="font-medium">{labels[key] ?? key}</span>
           </div>
-          <div className="text-gray-500">
+          <div className="text-muted-foreground">
             {host.status === 'up' && host.latency_ms != null
               ? `${host.latency_ms}ms`
               : host.status}

--- a/resources/js/Pages/Admin/_components/WidgetMcpServer.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetMcpServer.tsx
@@ -48,7 +48,7 @@ export default function WidgetMcpServer({ data }: Props) {
       <div className="flex items-center gap-2">
         <span
           className={`inline-block w-2.5 h-2.5 rounded-full ${
-            data.ping.reachable ? 'bg-green-500' : 'bg-red-500'
+            data.ping.reachable ? 'bg-success' : 'bg-destructive'
           }`}
         />
         <span className="font-medium">
@@ -60,7 +60,7 @@ export default function WidgetMcpServer({ data }: Props) {
       </div>
 
       {data.ping.error && (
-        <div className="text-xs text-red-700 bg-red-50 p-2 rounded">
+        <div className="text-xs text-destructive-fg bg-destructive-soft p-2 rounded">
           {data.ping.error}
         </div>
       )}

--- a/resources/js/Pages/Admin/_components/WidgetMutations.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetMutations.tsx
@@ -63,7 +63,7 @@ const ACTIONS: ActionConfig[] = [
       type: 'number',
       placeholder: 'auto = mais recente Wagner',
     }],
-    buttonClass: 'bg-amber-600 hover:bg-amber-700',
+    buttonClass: 'bg-warning hover:bg-warning/90',
   },
   {
     key: 'run_health',
@@ -72,7 +72,7 @@ const ACTIONS: ActionConfig[] = [
     description: 'Executa jana:health-check síncrono (cap 30s) + atualiza snapshot. W2/W4/W10 atualizam.',
     endpoint: '/admin/mutations/health-check/run-now',
     extraFields: [],
-    buttonClass: 'bg-green-600 hover:bg-green-700',
+    buttonClass: 'bg-success hover:bg-success/90',
   },
 ];
 
@@ -186,7 +186,7 @@ export default function WidgetMutations() {
 
             <label className="block">
               <span className="text-xs text-gray-600">
-                Razão (audit log) <span className="text-red-600">*obrigatório, ≥5 chars</span>
+                Razão (audit log) <span className="text-destructive">*obrigatório, ≥5 chars</span>
               </span>
               <textarea
                 value={reason}
@@ -222,7 +222,7 @@ export default function WidgetMutations() {
           {result && (
             <div
               className={`mt-3 p-2 rounded text-xs ${
-                result.ok ? 'bg-green-50 text-green-900' : 'bg-red-50 text-red-900'
+                result.ok ? 'bg-success-soft text-success-fg' : 'bg-destructive-soft text-destructive-fg'
               }`}
             >
               <div className="font-semibold mb-1">{result.ok ? '✓ Sucesso' : '✗ Falha'}</div>

--- a/resources/js/Pages/Admin/_components/WidgetVaultwarden.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetVaultwarden.tsx
@@ -31,7 +31,7 @@ export default function WidgetVaultwarden({ data }: Props) {
       <div className="flex items-center gap-2">
         <span
           className={`inline-block w-2.5 h-2.5 rounded-full ${
-            data.reachable ? 'bg-green-500' : 'bg-red-500'
+            data.reachable ? 'bg-success' : 'bg-destructive'
           }`}
         />
         <span className="font-medium">{data.url}</span>
@@ -47,7 +47,7 @@ export default function WidgetVaultwarden({ data }: Props) {
         <div className="border rounded p-2">
           <div
             className={`text-2xl font-semibold ${
-              (data.expiring_30d ?? 0) > 0 ? 'text-amber-700' : 'text-green-700'
+              (data.expiring_30d ?? 0) > 0 ? 'text-warning-fg' : 'text-success-fg'
             }`}
           >
             {data.expiring_30d ?? 0}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -270,11 +270,11 @@ export default function ConversationThreadV4({
       {/* Banner contato bloqueado */}
       {isBlocked && (
         <div
-          className="mx-4 mt-2.5 px-3.5 py-2.5 bg-red-50 border border-red-200 rounded-md text-[11.5px] text-red-900"
+          className="mx-4 mt-2.5 px-3.5 py-2.5 bg-destructive-soft border border-destructive/20 rounded-md text-[11.5px] text-destructive-fg"
           role="status"
           data-testid="caixa-unif-blocked-banner"
         >
-          <b className="block text-[12.5px] font-semibold text-red-950">
+          <b className="block text-[12.5px] font-semibold text-destructive-fg">
             Contato bloqueado.
           </b>
           <span>Mensagens deste número são descartadas. Desbloqueie pelo painel de Contexto.</span>

--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -336,7 +336,7 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
               </>
             )}
             {!qrLoading && qrError && (
-              <div className="text-sm text-red-700 dark:text-red-400 text-center px-4">
+              <div className="text-sm text-destructive-fg text-center px-4">
                 <AlertTriangle size={20} className="inline mr-2" aria-hidden />
                 {qrError}
               </div>
@@ -345,7 +345,7 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
             {!qrLoading && (qrState === 'paired' || qrState === 'connected') && !qrError && (
               <>
                 <CheckCircle2 size={48} className="text-emerald-600" aria-hidden />
-                <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">
+                <p className="text-sm font-medium text-success-fg">
                   Canal pareado com sucesso!
                 </p>
                 <p className="text-xs text-muted-foreground">Fechando…</p>

--- a/resources/js/Pages/Atendimento/Channels/Show.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Show.tsx
@@ -329,7 +329,7 @@ function ConfigTab({ channel }: { channel: ChannelUi }) {
       </dl>
 
       {channel.last_health_message && (
-        <div className="text-xs text-amber-700 dark:text-amber-400 flex items-start gap-1 border-t pt-2">
+        <div className="text-xs text-warning-fg flex items-start gap-1 border-t pt-2">
           <AlertTriangle size={12} className="mt-0.5 shrink-0" aria-hidden />
           {channel.last_health_message}
         </div>
@@ -386,7 +386,7 @@ function ConfigTab({ channel }: { channel: ChannelUi }) {
                 </>
               )}
               {!qrLoading && qrError && (
-                <div className="text-sm text-red-700 dark:text-red-400 text-center px-4">
+                <div className="text-sm text-destructive-fg text-center px-4">
                   <AlertTriangle size={20} className="inline mr-2" aria-hidden />
                   {qrError}
                 </div>

--- a/resources/js/Pages/Atendimento/Macros/Index.tsx
+++ b/resources/js/Pages/Atendimento/Macros/Index.tsx
@@ -316,7 +316,7 @@ export default function MacrosIndex({ macros, availableTags, availableStatuses }
                           variant="ghost"
                           onClick={() => destroy(m)}
                           aria-label={`Remover ${m.label}`}
-                          className="h-7 w-7 p-0 text-red-600 hover:text-red-700"
+                          className="h-7 w-7 p-0 text-destructive hover:text-destructive-fg"
                         >
                           <Trash2 size={13} aria-hidden />
                         </Button>
@@ -447,7 +447,7 @@ export default function MacrosIndex({ macros, availableTags, availableStatuses }
                         size="sm"
                         variant="ghost"
                         onClick={() => removeAction(idx)}
-                        className="h-7 w-7 p-0 text-red-600"
+                        className="h-7 w-7 p-0 text-destructive"
                         aria-label="Remover ação"
                       >
                         <X size={13} aria-hidden />

--- a/resources/js/Pages/Atendimento/Macros/Variants.tsx
+++ b/resources/js/Pages/Atendimento/Macros/Variants.tsx
@@ -305,7 +305,7 @@ export default function MacroVariants({ macro, variants }: Props) {
                           variant="ghost"
                           onClick={() => destroy(v)}
                           aria-label={`Remover ${v.label}`}
-                          className="h-7 w-7 p-0 text-red-600 hover:text-red-700"
+                          className="h-7 w-7 p-0 text-destructive hover:text-destructive-fg"
                         >
                           <Trash2 size={13} aria-hidden />
                         </Button>

--- a/resources/js/Pages/Cliente/_components/ActiveChip.tsx
+++ b/resources/js/Pages/Cliente/_components/ActiveChip.tsx
@@ -33,7 +33,7 @@ export function ActiveChip({ label, value, onRemove, variant = 'default' }: Acti
 
   const colors =
     variant === 'danger'
-      ? 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40'
+      ? 'bg-destructive-soft text-destructive-fg border-destructive/20'
       : 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900/40';
 
   return (

--- a/resources/js/Pages/Cliente/_drawer/AuditoriaTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/AuditoriaTab.tsx
@@ -175,7 +175,7 @@ export default function AuditoriaTab({ contact }: AuditoriaTabProps) {
       {/* Error state */}
       {error && (
         <div
-          className="p-4 text-xs text-rose-700 flex items-start gap-2 rounded-lg border border-rose-200 bg-rose-50"
+          className="p-4 text-xs text-destructive-fg flex items-start gap-2 rounded-lg border border-destructive/20 bg-destructive-soft"
           data-testid="auditoria-tab-error"
         >
           <AlertCircle size={14} className="flex-shrink-0 mt-0.5" />

--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -97,9 +97,9 @@ const TAG_OPTIONS = [
 // legado nasceu PT-BR (`ativo`/`inativo`/`bloqueado`). Normaliza EN canon
 // (sem migration retroativa de dados).
 const STATUS_OPTIONS: Array<{ value: 'active' | 'inactive' | 'blocked'; label: string; color: string }> = [
-  { value: 'active', label: 'Ativo', color: 'text-emerald-700' },
-  { value: 'inactive', label: 'Inativo', color: 'text-stone-700' },
-  { value: 'blocked', label: 'Bloqueado', color: 'text-rose-700' },
+  { value: 'active', label: 'Ativo', color: 'text-success-fg' },
+  { value: 'inactive', label: 'Inativo', color: 'text-muted-foreground' },
+  { value: 'blocked', label: 'Bloqueado', color: 'text-destructive-fg' },
 ];
 
 // Mapeamento alias PT-BR -> EN canon UPOS (cadastros pre-canon).
@@ -490,10 +490,10 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
                       aria-hidden
                       className={`h-1.5 w-1.5 rounded-full ${
                         o.value === 'ativo'
-                          ? 'bg-emerald-500'
+                          ? 'bg-success'
                           : o.value === 'inativo'
-                          ? 'bg-stone-400'
-                          : 'bg-rose-500'
+                          ? 'bg-muted-foreground'
+                          : 'bg-destructive'
                       }`}
                     />
                     {o.label}
@@ -583,7 +583,7 @@ interface FieldStatusProps {
 function FieldStatus({ saving, saved, backendError }: FieldStatusProps) {
   if (backendError) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {backendError}
       </p>
     );
@@ -597,7 +597,7 @@ function FieldStatus({ saving, saved, backendError }: FieldStatusProps) {
   }
   if (saved) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600" aria-live="polite">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-success-fg" aria-live="polite">
         <CheckCircle2 size={11} aria-hidden /> Salvo
       </p>
     );

--- a/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
@@ -423,7 +423,7 @@ interface FieldStatusProps {
 function FieldStatus({ saving, saved, backendError }: FieldStatusProps) {
   if (backendError) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {backendError}
       </p>
     );
@@ -437,7 +437,7 @@ function FieldStatus({ saving, saved, backendError }: FieldStatusProps) {
   }
   if (saved) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600" aria-live="polite">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-success-fg" aria-live="polite">
         <CheckCircle2 size={11} aria-hidden /> Salvo
       </p>
     );

--- a/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
@@ -61,7 +61,7 @@ function getCsrfToken(): string {
 
 // Onda 1 PR B' 2026-05-26 — Extraído pra constante única (atende UI Lint ratchet).
 // Evita 3 ocorrências literais idênticas (email/email_billing/email_nfe).
-const INVALID_INPUT_CLASS = 'border-rose-500 focus-visible:ring-rose-400';
+const INVALID_INPUT_CLASS = 'border-destructive focus-visible:ring-destructive';
 
 export default function ContatoTab({ contact, onSaved, disabled = false }: ContatoTabProps) {
   // Resolve tel inicial: prioriza `tel` (nova coluna Wave B), fallback pra mobile/landline UPOS legacy
@@ -477,14 +477,14 @@ interface FieldStatusProps {
 function FieldStatus({ error, errorId, saving, saved, backendError }: FieldStatusProps) {
   if (error) {
     return (
-      <p id={errorId} className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p id={errorId} className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {error}
       </p>
     );
   }
   if (backendError) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {backendError}
       </p>
     );
@@ -498,7 +498,7 @@ function FieldStatus({ error, errorId, saving, saved, backendError }: FieldStatu
   }
   if (saved) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600" aria-live="polite">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-success-fg" aria-live="polite">
         <CheckCircle2 size={11} aria-hidden /> Salvo
       </p>
     );

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -366,7 +366,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
                 </>
               ) : cepLookup === 'ok' ? (
                 <>
-                  <CheckCircle2 size={14} className="text-emerald-600" /> Encontrado
+                  <CheckCircle2 size={14} className="text-success-fg" /> Encontrado
                 </>
               ) : (
                 <>
@@ -377,7 +377,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
           </div>
           {cepLookupMsg && (
             <p
-              className={`mt-1 text-xs ${cepLookup === 'error' ? 'text-rose-600' : 'text-emerald-600'}`}
+              className={`mt-1 text-xs ${cepLookup === 'error' ? 'text-destructive' : 'text-success-fg'}`}
               role="status"
               aria-live="polite"
             >
@@ -561,14 +561,14 @@ interface FieldStatusProps {
 function FieldStatus({ error, errorId, saving, saved, backendError }: FieldStatusProps) {
   if (error) {
     return (
-      <p id={errorId} className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p id={errorId} className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {error}
       </p>
     );
   }
   if (backendError) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {backendError}
       </p>
     );
@@ -582,7 +582,7 @@ function FieldStatus({ error, errorId, saving, saved, backendError }: FieldStatu
   }
   if (saved) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600" aria-live="polite">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-success-fg" aria-live="polite">
         <CheckCircle2 size={11} aria-hidden /> Salvo
       </p>
     );

--- a/resources/js/Pages/Cliente/_drawer/IATab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IATab.tsx
@@ -381,7 +381,7 @@ function IaCard({
 
       {isError && (
         <div
-          className="mt-3 flex items-start gap-2 text-xs text-rose-700 dark:text-rose-400"
+          className="mt-3 flex items-start gap-2 text-xs text-destructive-fg"
           data-testid={`${testid}-error`}
         >
           <AlertCircle size={14} className="flex-shrink-0 mt-0.5" />
@@ -395,18 +395,18 @@ function IaCard({
 function UrgenciaPill({ urgencia }: { urgencia: 'alta' | 'media' | 'baixa' }) {
   const palette = {
     alta: {
-      bg: 'bg-rose-100 dark:bg-rose-950/40',
-      text: 'text-rose-700 dark:text-rose-300',
+      bg: 'bg-destructive-soft',
+      text: 'text-destructive-fg',
       label: 'ALTA',
     },
     media: {
-      bg: 'bg-amber-100 dark:bg-amber-950/40',
-      text: 'text-amber-700 dark:text-amber-300',
+      bg: 'bg-warning-soft',
+      text: 'text-warning-fg',
       label: 'MEDIA',
     },
     baixa: {
-      bg: 'bg-emerald-100 dark:bg-emerald-950/40',
-      text: 'text-emerald-700 dark:text-emerald-300',
+      bg: 'bg-success-soft',
+      text: 'text-success-fg',
       label: 'BAIXA',
     },
   }[urgencia] ?? {

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -643,7 +643,7 @@ export default function IdentificacaoTab({
       <div className="grid gap-4 md:grid-cols-2">
         <div className="md:col-span-2">
           <Label htmlFor="id-nome" className="cw-label">
-            {isPJ ? 'Razão social' : 'Nome completo'} <span className="text-rose-600">*</span>
+            {isPJ ? 'Razão social' : 'Nome completo'} <span className="text-destructive">*</span>
           </Label>
           <Input
             variant="cowork"
@@ -660,7 +660,7 @@ export default function IdentificacaoTab({
               scheduleAutosave('nome', v, prev);
             }}
             onBlur={(e) => handleBlur('nome', e.target.value)}
-            className={nomeError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+            className={nomeError ? 'border-destructive focus-visible:ring-destructive' : ''}
           />
           <FieldStatus
             error={nomeError}
@@ -721,7 +721,7 @@ export default function IdentificacaoTab({
                 scheduleAutosave('doc', masked, prev);
               }}
               onBlur={(e) => handleBlur('doc', e.target.value)}
-              className={docError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+              className={docError ? 'border-destructive focus-visible:ring-destructive' : ''}
             />
             {isPJ && (
               <Button
@@ -739,7 +739,7 @@ export default function IdentificacaoTab({
                   </>
                 ) : cnpjLookup === 'ok' ? (
                   <>
-                    <CheckCircle2 size={14} className="text-emerald-600" /> Encontrado
+                    <CheckCircle2 size={14} className="text-success-fg" /> Encontrado
                   </>
                 ) : (
                   <>
@@ -752,7 +752,7 @@ export default function IdentificacaoTab({
           {cnpjLookupMsg && (
             <p
               className={`mt-1 text-xs ${
-                cnpjLookup === 'error' ? 'text-rose-600' : 'text-emerald-600'
+                cnpjLookup === 'error' ? 'text-destructive' : 'text-success-fg'
               }`}
               role="status"
               aria-live="polite"
@@ -922,14 +922,14 @@ interface FieldStatusProps {
 function FieldStatus({ error, errorId, saving, saved, backendError }: FieldStatusProps) {
   if (error) {
     return (
-      <p id={errorId} className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p id={errorId} className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {error}
       </p>
     );
   }
   if (backendError) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-rose-600" role="alert">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
         <AlertCircle size={11} aria-hidden /> {backendError}
       </p>
     );
@@ -943,7 +943,7 @@ function FieldStatus({ error, errorId, saving, saved, backendError }: FieldStatu
   }
   if (saved) {
     return (
-      <p className="mt-1 inline-flex items-center gap-1 text-xs text-emerald-600" aria-live="polite">
+      <p className="mt-1 inline-flex items-center gap-1 text-xs text-success-fg" aria-live="polite">
         <CheckCircle2 size={11} aria-hidden /> Salvo
       </p>
     );

--- a/resources/js/Pages/Cliente/_show/SalesTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SalesTab.tsx
@@ -86,10 +86,10 @@ const PAYMENT_STATUS_LABELS: Record<string, string> = {
 };
 
 const PAYMENT_STATUS_STYLES: Record<string, string> = {
-  paid: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900',
-  due: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900',
+  paid: 'bg-success-soft text-success-fg border-success/20',
+  due: 'bg-warning-soft text-warning-fg border-warning/20',
   partial: 'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900',
-  overdue: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900',
+  overdue: 'bg-destructive-soft text-destructive-fg border-destructive/20',
 };
 
 export default function SalesTab({
@@ -328,10 +328,10 @@ export default function SalesTab({
                         )}
                       </td>
                       <td className="px-4 py-2.5 text-right tabular-nums text-foreground">{formatBRL(s.final_total)}</td>
-                      <td className="px-4 py-2.5 text-right tabular-nums text-emerald-700 dark:text-emerald-400">
+                      <td className="px-4 py-2.5 text-right tabular-nums text-success-fg">
                         {formatBRL(s.total_paid)}
                       </td>
-                      <td className="px-4 py-2.5 text-right tabular-nums text-rose-700 dark:text-rose-400">
+                      <td className="px-4 py-2.5 text-right tabular-nums text-destructive-fg">
                         {s.total_due > 0 ? formatBRL(s.total_due) : '—'}
                       </td>
                       <td className="px-4 py-2.5">
@@ -356,10 +356,10 @@ export default function SalesTab({
                       <td className="px-4 py-2.5 text-right tabular-nums font-semibold text-foreground">
                         {formatBRL(totals.final_total)}
                       </td>
-                      <td className="px-4 py-2.5 text-right tabular-nums font-semibold text-emerald-700 dark:text-emerald-400">
+                      <td className="px-4 py-2.5 text-right tabular-nums font-semibold text-success-fg">
                         {formatBRL(totals.total_paid)}
                       </td>
-                      <td className="px-4 py-2.5 text-right tabular-nums font-semibold text-rose-700 dark:text-rose-400">
+                      <td className="px-4 py-2.5 text-right tabular-nums font-semibold text-destructive-fg">
                         {formatBRL(totals.total_due)}
                       </td>
                       <td colSpan={2} />

--- a/resources/js/Pages/Compras/components/AcoesDropdown.tsx
+++ b/resources/js/Pages/Compras/components/AcoesDropdown.tsx
@@ -215,7 +215,7 @@ export default function AcoesDropdown({
                   action.onClick();
                 }}
                 className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left hover:bg-stone-50 focus:bg-stone-50 focus:outline-none ${
-                  action.variant === 'danger' ? 'text-rose-700 hover:bg-rose-50' : 'text-stone-700'
+                  action.variant === 'danger' ? 'text-destructive-fg hover:bg-destructive-soft' : 'text-stone-700'
                 }`}
               >
                 <span className="w-4 text-center text-base">{action.icon}</span>

--- a/resources/js/Pages/ComunicacaoVisual/Index.tsx
+++ b/resources/js/Pages/ComunicacaoVisual/Index.tsx
@@ -434,7 +434,7 @@ export default function Index({ bizName = 'oimpresso', materiais = [], podeCriar
                 {conferido && (
                   <p className="flex items-center gap-1.5 text-xs">
                     {Math.abs(conferido.total - totalLocal) < 0.01 ? (
-                      <Badge className="bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200">
+                      <Badge className="bg-success-soft text-success-fg border-success/20">
                         Conferido: {BRL.format(conferido.total)}
                       </Badge>
                     ) : (

--- a/resources/js/Pages/ConsultaOs/_components/OsPipeline.tsx
+++ b/resources/js/Pages/ConsultaOs/_components/OsPipeline.tsx
@@ -27,9 +27,9 @@ export function OsPipeline({ currentStage }: Props) {
                   className={cn(
                     'absolute top-[13px] left-1/2 right-[-50%] h-0.5 z-0',
                     isDone
-                      ? 'bg-green-500'
+                      ? 'bg-success'
                       : isActive
-                      ? 'bg-gradient-to-r from-green-500 to-border'
+                      ? 'bg-gradient-to-r from-success to-border'
                       : 'bg-border',
                   )}
                 />
@@ -39,7 +39,7 @@ export function OsPipeline({ currentStage }: Props) {
                 className={cn(
                   'relative z-10 flex items-center justify-center w-7 h-7 rounded-full border-2 transition-all',
                   isDone
-                    ? 'bg-green-500 border-green-500'
+                    ? 'bg-success border-success'
                     : isActive
                     ? 'bg-primary border-primary ring-4 ring-primary/15'
                     : 'bg-background border-border',
@@ -56,7 +56,7 @@ export function OsPipeline({ currentStage }: Props) {
                 className={cn(
                   'mt-2 text-[10px] font-medium text-center leading-tight px-0.5',
                   isDone
-                    ? 'text-green-600'
+                    ? 'text-success'
                     : isActive
                     ? 'text-primary font-semibold'
                     : 'text-muted-foreground',

--- a/resources/js/Pages/ConsultaOs/_components/OsStageBadge.tsx
+++ b/resources/js/Pages/ConsultaOs/_components/OsStageBadge.tsx
@@ -12,8 +12,8 @@ const variantClasses: Record<string, string> = {
   warning:     'bg-amber-50 text-amber-700 border-amber-200',
   info:        'bg-violet-50 text-violet-700 border-violet-200',
   cyan:        'bg-cyan-50 text-cyan-700 border-cyan-200',
-  success:     'bg-green-50 text-green-700 border-green-200',
-  destructive: 'bg-red-50 text-red-700 border-red-200',
+  success:     'bg-success-soft text-success-fg border-success/20',
+  destructive: 'bg-destructive-soft text-destructive-fg border-destructive/20',
 }
 
 export function OsStageBadge({ stage, className }: Props) {

--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -109,7 +109,7 @@ function Caixa({ caixas, stats, filters, links }: Props) {
       </PageHeader>
 
       {/* Banner explicativo — esta tela é WRAPPER, não substitui POS */}
-      <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+      <div className="rounded-md border border-info/20 bg-info-soft px-4 py-3 text-sm text-info-fg">
         <strong>ℹ️ Por que essa tela existe?</strong>
         <span className="ml-1">
           Fluxo de Caixa (mensal) ≠ Caixa do turno (POS). Esta é uma vista do Financeiro pros

--- a/resources/js/Pages/Financeiro/Cobranca/_components/DrawerCobranca.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/_components/DrawerCobranca.tsx
@@ -97,10 +97,10 @@ export default function DrawerCobranca({ cob, accounts, today, onClose }: Props)
 
           {cob.status === 'erro' && cob.erro_msg && (
             <div className="px-5 py-3 border-t border-stone-200">
-              <div className="text-[10px] uppercase tracking-widest text-rose-700 font-medium mb-2 flex items-center gap-1.5">
+              <div className="text-[10px] uppercase tracking-widest text-destructive-fg font-medium mb-2 flex items-center gap-1.5">
                 <AlertCircle className="h-3 w-3" />Erro do gateway
               </div>
-              <div className="bg-rose-50 border border-rose-200 rounded px-3 py-2 text-[11.5px] text-rose-900 font-mono">
+              <div className="bg-destructive-soft border border-destructive/20 rounded px-3 py-2 text-[11.5px] text-destructive-fg font-mono">
                 {cob.erro_msg}
               </div>
               {/* B6 "botões honestos" (2026-05-31): "Tentar reemitir" REMOVIDO —

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -163,7 +163,7 @@ function FinanceiroConciliacao({ linhas, stats, contas, filters }: Props) {
               className="text-[13px]"
             />
             {uploadForm.errors.arquivo && (
-              <p className="text-[11px] text-rose-600 mt-1">{uploadForm.errors.arquivo}</p>
+              <p className="text-[11px] text-destructive mt-1">{uploadForm.errors.arquivo}</p>
             )}
           </div>
           {contas.length > 0 && (

--- a/resources/js/Pages/Financeiro/Configuracoes/Contador.tsx
+++ b/resources/js/Pages/Financeiro/Configuracoes/Contador.tsx
@@ -282,7 +282,7 @@ function Contador({ accesses }: Props) {
                   <td className="px-4 py-3">{a.granted_at_label ?? '—'}</td>
                   <td className="px-4 py-3 text-xs">
                     {a.can_view_unificado && (
-                      <span className="mr-1 inline-block rounded bg-emerald-100 px-2 py-0.5 text-emerald-900">
+                      <span className="mr-1 inline-block rounded bg-success-soft px-2 py-0.5 text-success-fg">
                         Unificado
                       </span>
                     )}
@@ -292,7 +292,7 @@ function Contador({ accesses }: Props) {
                       </span>
                     )}
                     {!a.has_consent && (
-                      <span className="inline-block rounded bg-amber-100 px-2 py-0.5 text-amber-900">
+                      <span className="inline-block rounded bg-warning-soft px-2 py-0.5 text-warning-fg">
                         Sem consent
                       </span>
                     )}

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -42,7 +42,7 @@ interface Props {
 function StatusBadge({ account }: { account: Account }) {
   if (!account.complemento_id) {
     return (
-      <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200">
+      <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-warning-soft text-warning-fg">
         <AlertTriangle className="h-3 w-3" /> Faltam dados
       </span>
     );
@@ -55,7 +55,7 @@ function StatusBadge({ account }: { account: Account }) {
     );
   }
   return (
-    <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200">
+    <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-success-soft text-success-fg">
       <CheckCircle2 className="h-3 w-3" /> Ativo{account.carteira ? ` · Cart. ${account.carteira}` : ''}
     </span>
   );

--- a/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
@@ -38,8 +38,8 @@ interface Props {
 
 const STATUS_LABELS: Record<string, { label: string; color: string; icon: typeof Circle }> = {
   aberto: { label: 'Aberto', color: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-200', icon: Circle },
-  parcial: { label: 'Parcial', color: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200', icon: Hourglass },
-  quitado: { label: 'Pago', color: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200', icon: CheckCircle2 },
+  parcial: { label: 'Parcial', color: 'bg-warning-soft text-warning-fg', icon: Hourglass },
+  quitado: { label: 'Pago', color: 'bg-success-soft text-success-fg', icon: CheckCircle2 },
   cancelado: { label: 'Cancelado', color: 'bg-muted text-muted-foreground', icon: AlertTriangle },
 };
 

--- a/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
@@ -38,8 +38,8 @@ interface Props {
 
 const STATUS_LABELS: Record<string, { label: string; color: string; icon: typeof Circle }> = {
   aberto: { label: 'Aberto', color: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-200', icon: Circle },
-  parcial: { label: 'Parcial', color: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200', icon: Hourglass },
-  quitado: { label: 'Quitado', color: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200', icon: CheckCircle2 },
+  parcial: { label: 'Parcial', color: 'bg-warning-soft text-warning-fg', icon: Hourglass },
+  quitado: { label: 'Quitado', color: 'bg-success-soft text-success-fg', icon: CheckCircle2 },
   cancelado: { label: 'Cancelado', color: 'bg-muted text-muted-foreground', icon: AlertTriangle },
 };
 

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -331,7 +331,7 @@ function ResumoPanel({ resumo }: { resumo: Resumo }) {
       </div>
 
       {(resumo.a_receber.vencidos_qtd > 0 || resumo.a_pagar.vencidos_qtd > 0) && (
-        <Card className="border-amber-300 dark:border-amber-700">
+        <Card className="border-warning/40">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               Atenção: títulos vencidos

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -468,9 +468,9 @@ function FinMultiSelectContas({
 function StatusPill({ s }: { s: LancamentoStatus }) {
   const tone = statusTone(s);
   const cls = {
-    success:     'bg-success-soft text-success-fg border-success/20',
-    warning:     'bg-warning-soft text-warning-fg border-warning/20',
-    destructive: 'bg-destructive-soft text-destructive-fg border-destructive/20',
+    success:     'bg-emerald-50 text-emerald-700 border-emerald-200',
+    warning:     'bg-amber-50 text-amber-800 border-amber-200',
+    destructive: 'bg-rose-50 text-rose-700 border-rose-200',
     default:     'bg-stone-50 text-stone-700 border-stone-200',
   }[tone];
   return (
@@ -487,9 +487,9 @@ function StatusPill({ s }: { s: LancamentoStatus }) {
 function ApprovalPill({ s }: { s: 'pendente' | 'aprovado' | 'rejeitado' | null }) {
   if (!s) return null;
   const map = {
-    pendente:  { cls: 'bg-warning-soft text-warning-fg border-warning/20', icon: '⏳', label: 'Aprov?' },
-    aprovado:  { cls: 'bg-success-soft text-success-fg border-success/20', icon: '✓', label: 'Aprov.' },
-    rejeitado: { cls: 'bg-destructive-soft text-destructive-fg border-destructive/20', icon: '✗', label: 'Rejeit.' },
+    pendente:  { cls: 'bg-amber-50 text-amber-700 border-amber-200', icon: '⏳', label: 'Aprov?' },
+    aprovado:  { cls: 'bg-emerald-50 text-emerald-700 border-emerald-200', icon: '✓', label: 'Aprov.' },
+    rejeitado: { cls: 'bg-rose-50 text-rose-700 border-rose-200', icon: '✗', label: 'Rejeit.' },
   }[s];
   return (
     <span
@@ -2347,12 +2347,12 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                         </div>
                       )}
                       {selected.aprovacao_status === 'aprovado' && (
-                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-success-soft text-success-fg border-success/20">
+                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-emerald-50 text-emerald-700 border-emerald-200">
                           ✓ Aprovado — liberado pra pagamento
                         </span>
                       )}
                       {selected.aprovacao_status === 'rejeitado' && (
-                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-destructive-soft text-destructive-fg border-destructive/20">
+                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-rose-50 text-rose-700 border-rose-200">
                           ✗ Rejeitado — bloqueado pra pagamento
                         </span>
                       )}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -468,9 +468,9 @@ function FinMultiSelectContas({
 function StatusPill({ s }: { s: LancamentoStatus }) {
   const tone = statusTone(s);
   const cls = {
-    success:     'bg-emerald-50 text-emerald-700 border-emerald-200',
-    warning:     'bg-amber-50 text-amber-800 border-amber-200',
-    destructive: 'bg-rose-50 text-rose-700 border-rose-200',
+    success:     'bg-success-soft text-success-fg border-success/20',
+    warning:     'bg-warning-soft text-warning-fg border-warning/20',
+    destructive: 'bg-destructive-soft text-destructive-fg border-destructive/20',
     default:     'bg-stone-50 text-stone-700 border-stone-200',
   }[tone];
   return (
@@ -487,9 +487,9 @@ function StatusPill({ s }: { s: LancamentoStatus }) {
 function ApprovalPill({ s }: { s: 'pendente' | 'aprovado' | 'rejeitado' | null }) {
   if (!s) return null;
   const map = {
-    pendente:  { cls: 'bg-amber-50 text-amber-700 border-amber-200', icon: '⏳', label: 'Aprov?' },
-    aprovado:  { cls: 'bg-emerald-50 text-emerald-700 border-emerald-200', icon: '✓', label: 'Aprov.' },
-    rejeitado: { cls: 'bg-rose-50 text-rose-700 border-rose-200', icon: '✗', label: 'Rejeit.' },
+    pendente:  { cls: 'bg-warning-soft text-warning-fg border-warning/20', icon: '⏳', label: 'Aprov?' },
+    aprovado:  { cls: 'bg-success-soft text-success-fg border-success/20', icon: '✓', label: 'Aprov.' },
+    rejeitado: { cls: 'bg-destructive-soft text-destructive-fg border-destructive/20', icon: '✗', label: 'Rejeit.' },
   }[s];
   return (
     <span
@@ -2347,12 +2347,12 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                         </div>
                       )}
                       {selected.aprovacao_status === 'aprovado' && (
-                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-emerald-50 text-emerald-700 border-emerald-200">
+                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-success-soft text-success-fg border-success/20">
                           ✓ Aprovado — liberado pra pagamento
                         </span>
                       )}
                       {selected.aprovacao_status === 'rejeitado' && (
-                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-rose-50 text-rose-700 border-rose-200">
+                        <span className="inline-block px-2 py-0.5 rounded border text-[11px] font-medium bg-destructive-soft text-destructive-fg border-destructive/20">
                           ✗ Rejeitado — bloqueado pra pagamento
                         </span>
                       )}

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinAnexosPanel.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinAnexosPanel.tsx
@@ -127,7 +127,7 @@ export function FinAnexosPanel({ tituloId }: Props) {
       </div>
 
       {errorMsg && (
-        <div className="mb-2 text-[12px] text-rose-700 bg-rose-50 border border-rose-200 rounded px-2 py-1">
+        <div className="mb-2 text-[12px] text-destructive-fg bg-destructive-soft border border-destructive/20 rounded px-2 py-1">
           {errorMsg}
         </div>
       )}

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinEditPanel.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinEditPanel.tsx
@@ -222,7 +222,7 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
       </div>
 
       {form.hasErrors && (
-        <div className="rounded-md border border-rose-300 bg-rose-50 px-3 py-2 mt-3 text-[12px] text-rose-800">
+        <div className="rounded-md border border-destructive/30 bg-destructive-soft px-3 py-2 mt-3 text-[12px] text-destructive-fg">
           {Object.entries(form.errors).map(([key, msg]) => (
             <div key={key}>
               <b>{key}:</b> {msg as string}

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinOcrBoletoSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinOcrBoletoSheet.tsx
@@ -164,7 +164,7 @@ export function FinOcrBoletoSheet({ open, onClose }: Props) {
 
         <div className="mt-6 space-y-6">
           {error && (
-            <div className="text-[13px] text-rose-700 bg-rose-50 border border-rose-200 rounded px-3 py-2">
+            <div className="text-[13px] text-destructive-fg bg-destructive-soft border border-destructive/20 rounded px-3 py-2">
               {error}
             </div>
           )}
@@ -205,7 +205,7 @@ export function FinOcrBoletoSheet({ open, onClose }: Props) {
 
           {phase === 'preview' && extracted && (
             <div className="space-y-4">
-              <div className="bg-emerald-50 border border-emerald-200 rounded px-3 py-2 text-[12px] text-emerald-800">
+              <div className="bg-success-soft border border-success/20 rounded px-3 py-2 text-[12px] text-success-fg">
                 ✓ Extração bem-sucedida {extracted.confidence != null && (
                   <span className="ml-1 opacity-75">(confiança {Math.round(extracted.confidence * 100)}%)</span>
                 )}

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
@@ -145,7 +145,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos,
               Tokens <code>#V-</code> <code>#OS-</code> <code>#PC-</code> <code>#BL-</code> viram links clicáveis na lista.
             </p>
             {form.errors.cliente_descricao && (
-              <p className="text-[11px] text-rose-600">{form.errors.cliente_descricao}</p>
+              <p className="text-[11px] text-destructive">{form.errors.cliente_descricao}</p>
             )}
           </div>
 
@@ -168,7 +168,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos,
               </SelectContent>
             </Select>
             {form.errors.categoria_id && (
-              <p className="text-[11px] text-rose-600">{form.errors.categoria_id}</p>
+              <p className="text-[11px] text-destructive">{form.errors.categoria_id}</p>
             )}
           </div>
 
@@ -260,7 +260,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos,
               onChange={(e) => form.setData('vencimento', e.target.value)}
             />
             {form.errors.vencimento && (
-              <p className="text-[11px] text-rose-600">{form.errors.vencimento}</p>
+              <p className="text-[11px] text-destructive">{form.errors.vencimento}</p>
             )}
           </div>
 
@@ -287,7 +287,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos,
               </p>
             )}
             {form.errors.valor_total && (
-              <p className="text-[11px] text-rose-600">{form.errors.valor_total}</p>
+              <p className="text-[11px] text-destructive">{form.errors.valor_total}</p>
             )}
           </div>
 
@@ -304,7 +304,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos,
               className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-[13px] resize-none"
             />
             {form.errors.observacoes && (
-              <p className="text-[11px] text-rose-600">{form.errors.observacoes}</p>
+              <p className="text-[11px] text-destructive">{form.errors.observacoes}</p>
             )}
           </div>
 

--- a/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
@@ -99,8 +99,8 @@ function gateStatus(value: number | null, gate: Gate): { ok: boolean; emoji: str
   if (gate.op === '<=') ok = value <= gate.alvo;
   if (gate.op === '==') ok = value === gate.alvo;
   return ok
-    ? { ok: true, emoji: '✅', color: 'text-emerald-600 dark:text-emerald-400' }
-    : { ok: false, emoji: '🔴', color: 'text-red-600 dark:text-red-400' };
+    ? { ok: true, emoji: '✅', color: 'text-success-fg' }
+    : { ok: false, emoji: '🔴', color: 'text-destructive-fg' };
 }
 
 /**

--- a/resources/js/Pages/Manufacturing/Index.tsx
+++ b/resources/js/Pages/Manufacturing/Index.tsx
@@ -282,16 +282,15 @@ function Index({ productions = [], summary, business_locations = {}, filters = {
 function StatusPill({ isFinal }: { isFinal: number }) {
   if (isFinal) {
     return (
-      // eslint-disable-next-line no-restricted-syntax -- status pill dot-style (PT-01), não é mensagem de erro/validação de form
-      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-400">
-        <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" aria-hidden />
+      <span className="inline-flex items-center gap-1.5 text-xs font-medium text-success-fg">
+        <span className="h-1.5 w-1.5 rounded-full bg-success" aria-hidden />
         Finalizada
       </span>
     );
   }
   return (
-    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-amber-700 dark:text-amber-400">
-      <span className="h-1.5 w-1.5 rounded-full bg-amber-500" aria-hidden />
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-warning-fg">
+      <span className="h-1.5 w-1.5 rounded-full bg-warning" aria-hidden />
       Pendente
     </span>
   );

--- a/resources/js/Pages/MemCofre/Dashboard.tsx
+++ b/resources/js/Pages/MemCofre/Dashboard.tsx
@@ -264,7 +264,7 @@ export default function MemCofreDashboard({ stats, modules, recent_sources, cove
                         <div className="flex items-center gap-2">
                           <div className="flex-1 h-1.5 bg-muted rounded overflow-hidden">
                             <div
-                              className={`h-full ${m.trace_score >= 80 ? 'bg-emerald-500' : m.trace_score >= 40 ? 'bg-amber-500' : 'bg-red-500'}`}
+                              className={`h-full ${m.trace_score >= 80 ? 'bg-success' : m.trace_score >= 40 ? 'bg-warning' : 'bg-destructive'}`}
                               style={{ width: `${Math.min(100, m.trace_score)}%` }}
                             />
                           </div>
@@ -278,7 +278,7 @@ export default function MemCofreDashboard({ stats, modules, recent_sources, cove
                           <div className="flex items-center gap-2">
                             <div className="flex-1 h-1.5 bg-muted rounded overflow-hidden">
                               <div
-                                className={`h-full ${m.audit_score >= 80 ? 'bg-emerald-500' : m.audit_score >= 50 ? 'bg-amber-500' : 'bg-red-500'}`}
+                                className={`h-full ${m.audit_score >= 80 ? 'bg-success' : m.audit_score >= 50 ? 'bg-warning' : 'bg-destructive'}`}
                                 style={{ width: `${Math.min(100, m.audit_score)}%` }}
                               />
                             </div>
@@ -294,7 +294,7 @@ export default function MemCofreDashboard({ stats, modules, recent_sources, cove
                         <div className="flex items-center gap-2">
                           <div className="flex-1 h-1.5 bg-muted rounded overflow-hidden">
                             <div
-                              className={`h-full ${m.dod_pct >= 80 ? 'bg-emerald-500' : m.dod_pct >= 40 ? 'bg-amber-500' : 'bg-red-500'}`}
+                              className={`h-full ${m.dod_pct >= 80 ? 'bg-success' : m.dod_pct >= 40 ? 'bg-warning' : 'bg-destructive'}`}
                               style={{ width: `${Math.min(100, m.dod_pct)}%` }}
                             />
                           </div>
@@ -394,7 +394,7 @@ function CoverageDots({ coverage }: { coverage: Coverage | null }) {
         <div
           key={i}
           title={`${d.label}: ${d.on ? 'ok' : 'faltando'}`}
-          className={`w-2 h-2 rounded-full ${d.on ? 'bg-emerald-500' : 'bg-muted'}`}
+          className={`w-2 h-2 rounded-full ${d.on ? 'bg-success' : 'bg-muted'}`}
         />
       ))}
       <span className="ml-1 text-[10px] text-muted-foreground font-mono">{coverage.score}</span>

--- a/resources/js/Pages/Modules/Index.tsx
+++ b/resources/js/Pages/Modules/Index.tsx
@@ -79,10 +79,10 @@ const STATUS_LABEL: Record<StatusKey, string> = {
 };
 
 const STATUS_STYLE: Record<StatusKey, string> = {
-  active:       'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
-  inactive:     'bg-stone-50 text-stone-700 border-stone-200 dark:bg-stone-950/40 dark:text-stone-300',
-  errored:      'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
-  unregistered: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
+  active:       'bg-success-soft text-success-fg border-success/20',
+  inactive:     'bg-muted text-muted-foreground border-border',
+  errored:      'bg-destructive-soft text-destructive-fg border-destructive/20',
+  unregistered: 'bg-warning-soft text-warning-fg border-warning/20',
 };
 
 function rowStatus(m: ModuleRow): StatusKey {
@@ -167,7 +167,7 @@ export default function ModulesIndex({ modules }: Props) {
                 {counts.errored > 0 && (
                   <>
                     {' · '}
-                    <span className="text-rose-700 dark:text-rose-400">
+                    <span className="text-destructive-fg">
                       {counts.errored} com erro
                     </span>
                   </>
@@ -309,7 +309,7 @@ export default function ModulesIndex({ modules }: Props) {
                             </div>
                           )}
                           {m.error && (
-                            <div className="text-[11px] text-rose-600 dark:text-rose-400 line-clamp-1 mt-0.5">
+                            <div className="text-[11px] text-destructive-fg line-clamp-1 mt-0.5">
                               {m.error}
                             </div>
                           )}
@@ -591,7 +591,7 @@ function StatCard({
 }) {
   const toneClasses: Record<typeof tone, string> = {
     muted:       'text-muted-foreground bg-muted',
-    success:     'text-emerald-700 bg-emerald-100 dark:text-emerald-300 dark:bg-emerald-950',
+    success:     'text-success bg-success/10',
     destructive: 'text-destructive bg-destructive/10',
   };
   return (

--- a/resources/js/Pages/NfeBrasil/Tributacao/ImportCsv.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/ImportCsv.tsx
@@ -98,7 +98,7 @@ function ImportCsv({ colunas_obrigatorias }: Props) {
         </header>
 
         {success && (
-          <div className="flex items-start gap-2 px-4 py-3 rounded-md bg-emerald-50 text-emerald-900 border border-emerald-200">
+          <div className="flex items-start gap-2 px-4 py-3 rounded-md bg-success-soft text-success-fg border border-success/20">
             <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
             <p className="text-sm">{success}</p>
           </div>

--- a/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
+++ b/resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
@@ -137,7 +137,7 @@ function Index({ regras, config, templates }: Props) {
         </header>
 
         {success && (
-          <div className="flex items-start gap-2 px-4 py-3 rounded-md bg-emerald-50 text-emerald-900 border border-emerald-200 dark:bg-emerald-900/20 dark:text-emerald-200 dark:border-emerald-800">
+          <div className="flex items-start gap-2 px-4 py-3 rounded-md bg-success-soft text-success-fg border border-success/20">
             <CheckCircle2 className="h-5 w-5 mt-0.5 shrink-0" />
             <p className="text-sm">{success}</p>
           </div>

--- a/resources/js/Pages/Nfse/Emitir.tsx
+++ b/resources/js/Pages/Nfse/Emitir.tsx
@@ -103,7 +103,7 @@ export default function NfseEmitir({ config, venda, flash }: Props) {
         />
 
         {(semConfig || certAlerta) && (
-          <div className="flex items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800 dark:border-yellow-900 dark:bg-yellow-950/40 dark:text-yellow-300">
+          <div className="flex items-start gap-3 rounded-lg border border-warning/20 bg-warning-soft px-4 py-3 text-sm text-warning-fg">
             <AlertCircle size={16} className="shrink-0 mt-0.5" />
             <div>
               {semConfig
@@ -115,7 +115,7 @@ export default function NfseEmitir({ config, venda, flash }: Props) {
 
         {config?.cert_expira && config.cert_valido && (
           <div className="flex items-center gap-2 text-xs text-[color:var(--text-mute)]">
-            <span className="inline-block h-2 w-2 rounded-full bg-emerald-500" />
+            <span className="inline-block h-2 w-2 rounded-full bg-success" />
             Certificado válido até {config.cert_expira}
           </div>
         )}

--- a/resources/js/Pages/Nfse/Emitir.tsx
+++ b/resources/js/Pages/Nfse/Emitir.tsx
@@ -169,7 +169,7 @@ export default function NfseEmitir({ config, venda, flash }: Props) {
                     <Input
                       value={data.tomador_cnpj}
                       onChange={(e) => setData('tomador_cnpj', e.target.value)}
-                      placeholder="00.000.000/0000-00"
+                      placeholder="00.000.000/0000-00" // pii-allowlist máscara visual de input
                       className="mt-1"
                     />
                     {errors.tomador_cnpj && <p className="text-xs text-destructive mt-1">{errors.tomador_cnpj}</p>}
@@ -180,7 +180,7 @@ export default function NfseEmitir({ config, venda, flash }: Props) {
                     <Input
                       value={data.tomador_cpf}
                       onChange={(e) => setData('tomador_cpf', e.target.value)}
-                      placeholder="000.000.000-00"
+                      placeholder="000.000.000-00" // pii-allowlist máscara visual de input
                       className="mt-1"
                     />
                     {errors.tomador_cpf && <p className="text-xs text-destructive mt-1">{errors.tomador_cpf}</p>}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderFsmActionPanel.tsx
@@ -401,7 +401,7 @@ export default function ServiceOrderFsmActionPanel({
 
             <div className="text-xs text-muted-foreground space-y-1">
               {confirmAction.is_critical && (
-                <p className="text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                <p className="text-warning flex items-center gap-1">
                   <AlertTriangle size={12} />
                   Ação crítica — requer autorização explícita
                 </p>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemFormSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemFormSheet.tsx
@@ -206,7 +206,7 @@ export default function ServiceOrderItemFormSheet({
                         'flex items-center gap-3 rounded-md border px-3 py-2 text-left transition-all ' +
                         (selected
                           ? 'border-foreground bg-foreground/5'
-                          : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50')
+                          : 'border-border hover:border-muted-foreground/40 hover:bg-muted')
                       }
                       aria-pressed={selected}
                     >
@@ -218,7 +218,7 @@ export default function ServiceOrderItemFormSheet({
                       <span
                         className={
                           'h-3.5 w-3.5 rounded-full border-2 shrink-0 ' +
-                          (selected ? 'border-foreground bg-foreground' : 'border-slate-300')
+                          (selected ? 'border-foreground bg-foreground' : 'border-border')
                         }
                         aria-hidden
                       />

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStatusBadge.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStatusBadge.tsx
@@ -22,7 +22,7 @@ function resolveBadge({ status, isOverdue }: ServiceOrderStatusBadgeProps): Badg
   if (isOverdue && !['concluida', 'cancelada', 'entregue'].includes(status)) {
     return {
       label: 'Atrasada',
-      classes: 'bg-rose-100 text-rose-700 border-rose-300',
+      classes: 'bg-destructive-soft text-destructive-fg border-destructive/20',
     };
   }
 
@@ -36,7 +36,7 @@ function resolveBadge({ status, isOverdue }: ServiceOrderStatusBadgeProps): Badg
   if (status === 'cancelada') {
     return {
       label: 'Cancelada',
-      classes: 'bg-slate-100 text-slate-600 border-slate-200',
+      classes: 'bg-muted text-muted-foreground border-border',
     };
   }
   if (status === 'entregue') {
@@ -51,7 +51,7 @@ function resolveBadge({ status, isOverdue }: ServiceOrderStatusBadgeProps): Badg
     case 'aberta':
       return {
         label: 'Aberta',
-        classes: 'bg-slate-50 text-slate-700 border-slate-200',
+        classes: 'bg-muted text-muted-foreground border-border',
       };
     case 'orcamento':
       return {
@@ -76,7 +76,7 @@ function resolveBadge({ status, isOverdue }: ServiceOrderStatusBadgeProps): Badg
     default:
       return {
         label: status,
-        classes: 'bg-slate-100 text-slate-700 border-slate-200',
+        classes: 'bg-muted text-muted-foreground border-border',
       };
   }
 }

--- a/resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
@@ -279,10 +279,10 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
                       'px-3 py-1.5 text-xs font-medium transition-colors border-r border-border last:border-r-0 ' +
                       (isActive
                         ? danger
-                          ? 'bg-rose-100 text-rose-800 dark:bg-rose-950/60 dark:text-rose-200'
+                          ? 'bg-destructive-soft text-destructive-fg'
                           : 'bg-muted text-foreground'
                         : danger
-                          ? 'text-rose-700 hover:bg-rose-50 dark:text-rose-300 dark:hover:bg-rose-950/30'
+                          ? 'text-destructive hover:bg-destructive/10'
                           : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground')
                     }
                     aria-current={isActive ? 'true' : undefined}
@@ -370,9 +370,9 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
                       const rental = v.current_rental;
                       const isOverdue = Boolean(rental?.is_overdue);
                       const rowBg = isOverdue
-                        ? 'bg-rose-50/60 hover:bg-rose-50 dark:bg-rose-950/30 dark:hover:bg-rose-950/40'
+                        ? 'bg-destructive/10 hover:bg-destructive/15'
                         : v.current_status === 'manutencao'
-                          ? 'bg-amber-50/30 hover:bg-amber-50/50 dark:bg-amber-950/20 dark:hover:bg-amber-950/30'
+                          ? 'bg-warning/10 hover:bg-warning/15'
                           : 'hover:bg-muted/40';
                       return (
                         <tr
@@ -386,7 +386,7 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
                           <td className="px-3 py-2.5 font-medium text-foreground whitespace-nowrap">
                             {isOverdue && (
                               <span
-                                className="inline-block w-2 h-2 rounded-full bg-rose-500 mr-1.5 align-middle"
+                                className="inline-block w-2 h-2 rounded-full bg-destructive mr-1.5 align-middle"
                                 title="Atrasado"
                                 aria-label="Veículo com OS atrasada"
                               />
@@ -416,10 +416,10 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
                           <td className={
                             'px-3 py-2.5 text-right tabular-nums whitespace-nowrap ' +
                             (isOverdue
-                              ? 'text-rose-700 font-medium'
+                              ? 'text-destructive-fg font-medium'
                               : Number(rental?.valor_receber ?? 0) > 0
-                                ? 'text-amber-700 dark:text-amber-400'
-                                : 'text-emerald-700 dark:text-emerald-400')
+                                ? 'text-warning-fg'
+                                : 'text-success-fg')
                           }>
                             {formatBRL(rental?.valor_receber ?? 0)}
                           </td>
@@ -442,7 +442,7 @@ export default function VehiclesIndex({ vehicles, kpis, filters }: Props) {
                           <span className="text-muted-foreground/70"> (de {meta.total})</span>
                         )}
                       </td>
-                      <td className="px-3 py-2.5 text-right tabular-nums font-bold text-amber-700 dark:text-amber-400">
+                      <td className="px-3 py-2.5 text-right tabular-nums font-bold text-warning-fg">
                         {formatBRL(pageTotals.receber)}
                       </td>
                       <td className="px-3 py-2.5 text-xs text-muted-foreground">

--- a/resources/js/Pages/OficinaAuto/Vehicles/_components/VehicleStatusBadge.tsx
+++ b/resources/js/Pages/OficinaAuto/Vehicles/_components/VehicleStatusBadge.tsx
@@ -32,17 +32,17 @@ const LABELS: Record<string, string> = {
 
 const STYLES: Record<string, string> = {
   disponivel:
-    'bg-slate-50 text-slate-700 border-slate-200 dark:bg-slate-900/40 dark:text-slate-300 dark:border-slate-800',
+    'bg-muted text-muted-foreground border-border',
   locada:
     'bg-blue-50 text-blue-700 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900/40',
   locada_paga:
-    'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900/40',
+    'bg-success-soft text-success-fg border-success/20',
   manutencao:
-    'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/40',
+    'bg-warning-soft text-warning-fg border-warning/20',
   indisponivel:
-    'bg-slate-100 text-slate-600 border-slate-200 dark:bg-slate-900/60 dark:text-slate-400 dark:border-slate-800',
+    'bg-muted text-muted-foreground border-border',
   atrasada:
-    'bg-rose-100 text-rose-700 border-rose-300 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/50',
+    'bg-destructive-soft text-destructive-fg border-destructive/20',
 };
 
 export default function VehicleStatusBadge({ status, isOverdue = false, isPaid = false }: Props) {

--- a/resources/js/Pages/Ponto/Aprovacoes/Index.tsx
+++ b/resources/js/Pages/Ponto/Aprovacoes/Index.tsx
@@ -384,7 +384,7 @@ export default function AprovacoesIndex({ aprovacoes, filtros, contagens, tipos 
                           <td className="p-3 text-xs">
                             <div>{tipoLabel(a.tipo, tipos)}</div>
                             {a.impacta_apuracao && (
-                              <div className="text-[10px] text-amber-600 dark:text-amber-400 mt-0.5">
+                              <div className="text-[10px] text-warning-fg mt-0.5">
                                 impacta apuração
                               </div>
                             )}
@@ -479,7 +479,7 @@ export default function AprovacoesIndex({ aprovacoes, filtros, contagens, tipos 
           size="sm"
           onClick={handleBulkApprove}
           disabled={processing}
-          className="bg-emerald-600 hover:bg-emerald-700"
+          className="bg-success text-white hover:bg-success/90"
         >
           <CheckCheck size={14} className="mr-1" />
           Aprovar selecionadas
@@ -491,13 +491,13 @@ export default function AprovacoesIndex({ aprovacoes, filtros, contagens, tipos 
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
-              <Check size={16} className="text-emerald-600" /> Aprovar intercorrência
+              <Check size={16} className="text-success-fg" /> Aprovar intercorrência
             </AlertDialogTitle>
             <AlertDialogDescription>
               Confirma a aprovação de <strong>{approveTarget?.codigo}</strong> de{' '}
               <strong>{approveTarget?.colaborador.nome}</strong>?
               {approveTarget?.impacta_apuracao && (
-                <span className="block mt-2 text-xs text-amber-700 dark:text-amber-400">
+                <span className="block mt-2 text-xs text-warning-fg">
                   ⚠️ Esta intercorrência <strong>impacta a apuração</strong> — minutos de trabalho serão ajustados.
                 </span>
               )}

--- a/resources/js/Pages/Ponto/BancoHoras/Index.tsx
+++ b/resources/js/Pages/Ponto/BancoHoras/Index.tsx
@@ -119,7 +119,7 @@ export default function BancoHorasIndex({ saldos, totais }: Props) {
                         <td className="p-3 font-medium">{s.nome}</td>
                         <td className={cn(
                           'p-3 text-right font-mono font-semibold tabular-nums',
-                          s.saldo_minutos > 0 && 'text-emerald-600 dark:text-emerald-400',
+                          s.saldo_minutos > 0 && 'text-success-fg',
                           s.saldo_minutos < 0 && 'text-destructive',
                         )}>
                           {formatMinutes(s.saldo_minutos)}

--- a/resources/js/Pages/Ponto/BancoHoras/Show.tsx
+++ b/resources/js/Pages/Ponto/BancoHoras/Show.tsx
@@ -111,8 +111,8 @@ export default function BancoHorasShow({ saldo, movimentos }: Props) {
             <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Saldo atual</p>
             <p className={cn(
               'text-4xl font-bold font-mono mt-1',
-              saldo.saldo_minutos > 0 && 'text-emerald-600 dark:text-emerald-400',
-              saldo.saldo_minutos < 0 && 'text-red-600 dark:text-red-400',
+              saldo.saldo_minutos > 0 && 'text-success-fg',
+              saldo.saldo_minutos < 0 && 'text-destructive-fg',
             )}>
               {formatMinutes(saldo.saldo_minutos)}
             </p>
@@ -203,8 +203,8 @@ export default function BancoHorasShow({ saldo, movimentos }: Props) {
                         </td>
                         <td className={cn(
                           'p-2 text-right font-mono font-semibold',
-                          m.minutos > 0 && 'text-emerald-600 dark:text-emerald-400',
-                          m.minutos < 0 && 'text-red-600 dark:text-red-400',
+                          m.minutos > 0 && 'text-success-fg',
+                          m.minutos < 0 && 'text-destructive-fg',
                         )}>
                           {formatMinutes(m.minutos)}
                         </td>

--- a/resources/js/Pages/Ponto/Dashboard/Index.tsx
+++ b/resources/js/Pages/Ponto/Dashboard/Index.tsx
@@ -127,8 +127,8 @@ export default function DashboardIndex({
             <p>
               {new Date().toLocaleDateString('pt-BR', { day: '2-digit', month: 'long', year: 'numeric' })}
               {' · atualizado '}
-              <span className="inline-flex items-center gap-1 text-emerald-600">
-                <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 animate-pulse" aria-hidden />
+              <span className="inline-flex items-center gap-1 text-success">
+                <span className="h-1.5 w-1.5 rounded-full bg-success animate-pulse" aria-hidden />
                 {server_time}
               </span>
             </p>
@@ -303,7 +303,7 @@ function ApprovalRow({ item }: { item: Aprovacao }) {
       href={`/ponto/intercorrencias/${item.id}`}
       className="flex items-start gap-2 p-2 -mx-2 rounded hover:bg-accent transition-colors"
     >
-      <AlertTriangle size={14} className="text-amber-500 mt-0.5 shrink-0" />
+      <AlertTriangle size={14} className="text-warning mt-0.5 shrink-0" />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-1.5">
           <span className="text-sm font-medium truncate">{item.colaborador.nome}</span>

--- a/resources/js/Pages/Ponto/Espelho/Show.tsx
+++ b/resources/js/Pages/Ponto/Espelho/Show.tsx
@@ -150,8 +150,8 @@ export default function EspelhoShow({ colaborador, mes, totais, linhas }: Props)
 
         {/* Alerta divergências */}
         {totais.divergencias > 0 && (
-          <div className="flex items-center gap-2 rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-sm">
-            <AlertTriangle size={16} className="text-amber-600" />
+          <div className="flex items-center gap-2 rounded-lg border border-warning/40 bg-warning/5 p-3 text-sm">
+            <AlertTriangle size={16} className="text-warning-fg" />
             <span>
               <strong>{totais.divergencias}</strong> dia(s) com divergência detectada na apuração.
               Dias destacados em âmbar abaixo (heatmap e tabela).
@@ -198,7 +198,7 @@ export default function EspelhoShow({ colaborador, mes, totais, linhas }: Props)
                       id={`dia-${l.data}`}
                       className={cn(
                         'hover:bg-accent/30 transition-all scroll-mt-20',
-                        l.divergencia && 'bg-amber-500/5',
+                        l.divergencia && 'bg-warning/5',
                         l.is_weekend && 'text-muted-foreground',
                       )}
                     >
@@ -225,10 +225,10 @@ export default function EspelhoShow({ colaborador, mes, totais, linhas }: Props)
                         )}
                       </td>
                       <td className="p-2 text-right font-mono">{formatMinutes(l.trabalhado)}</td>
-                      <td className={cn('p-2 text-right font-mono', l.atraso > 0 && 'text-amber-600')}>
+                      <td className={cn('p-2 text-right font-mono', l.atraso > 0 && 'text-warning-fg')}>
                         {formatMinutes(l.atraso)}
                       </td>
-                      <td className={cn('p-2 text-right font-mono', l.falta > 0 && 'text-red-600')}>
+                      <td className={cn('p-2 text-right font-mono', l.falta > 0 && 'text-destructive-fg')}>
                         {formatMinutes(l.falta)}
                       </td>
                       <td className={cn('p-2 text-right font-mono', l.he > 0 && 'text-violet-600')}>

--- a/resources/js/Pages/Ponto/Intercorrencias/Create.tsx
+++ b/resources/js/Pages/Ponto/Intercorrencias/Create.tsx
@@ -224,9 +224,9 @@ export default function IntercorrenciasCreate({ colaboradores, tipos, ai_enabled
             )}
 
             {aiLastResult?.success && aiLastResult.data && (
-              <Alert className="border-emerald-500/40 bg-emerald-500/5">
-                <Sparkles size={14} className="text-emerald-600" />
-                <AlertTitle className="text-emerald-700 dark:text-emerald-400">
+              <Alert className="border-success/40 bg-success/5">
+                <Sparkles size={14} className="text-success-fg" />
+                <AlertTitle className="text-success-fg">
                   Classificado com {Math.round(aiLastResult.data.confianca * 100)}% de confiança
                   {aiLastResult.cached && ' (cache)'}
                 </AlertTitle>

--- a/resources/js/Pages/Ponto/Intercorrencias/Show.tsx
+++ b/resources/js/Pages/Ponto/Intercorrencias/Show.tsx
@@ -99,8 +99,8 @@ export default function IntercorrenciasShow({ intercorrencia: i }: Props) {
         )}
 
         {i.estado === 'APROVADA' && i.aprovador.nome && (
-          <Alert className="border-emerald-500/40">
-            <Check size={14} className="text-emerald-600" />
+          <Alert className="border-success/40">
+            <Check size={14} className="text-success-fg" />
             <AlertTitle>Aprovada por {i.aprovador.nome}</AlertTitle>
             <AlertDescription>Aprovada em {i.updated_at}</AlertDescription>
           </Alert>

--- a/resources/js/Pages/Ponto/_components/AlertInbox.tsx
+++ b/resources/js/Pages/Ponto/_components/AlertInbox.tsx
@@ -42,14 +42,14 @@ const tipoIconMap: Record<string, React.ComponentType<{ size?: number; className
 
 const severidadeStyles: Record<Severidade, { iconClass: string; bgClass: string; borderClass: string }> = {
   info: {
-    iconClass: 'text-blue-600 dark:text-blue-400',
-    bgClass: 'bg-blue-500/10',
-    borderClass: 'border-blue-500/20',
+    iconClass: 'text-info',
+    bgClass: 'bg-info/10',
+    borderClass: 'border-info/20',
   },
   warning: {
-    iconClass: 'text-amber-600 dark:text-amber-400',
-    bgClass: 'bg-amber-500/10',
-    borderClass: 'border-amber-500/20',
+    iconClass: 'text-warning',
+    bgClass: 'bg-warning/10',
+    borderClass: 'border-warning/20',
   },
   danger: {
     iconClass: 'text-destructive',
@@ -80,8 +80,8 @@ export default function AlertInbox({ alertas, title = 'O que precisa da sua aten
 
       {total === 0 ? (
         <div className="flex flex-col items-center justify-center py-8 text-center gap-2">
-          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/10">
-            <CheckCircle2 size={18} className="text-emerald-600 dark:text-emerald-400" />
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-success/10">
+            <CheckCircle2 size={18} className="text-success" />
           </div>
           <p className="text-sm font-medium text-foreground">Tudo em dia</p>
           <p className="text-xs text-muted-foreground">Nada pendente no momento.</p>

--- a/resources/js/Pages/Produto/Unificado/Index.tsx
+++ b/resources/js/Pages/Produto/Unificado/Index.tsx
@@ -188,7 +188,7 @@ function Kpi({ label, value, sub, tone = 'default', emphasize = false }: {
   label: string; value: string | number; sub?: string;
   tone?: 'default' | 'pos' | 'neg'; emphasize?: boolean;
 }) {
-  const toneClass = tone === 'pos' ? 'text-emerald-700' : tone === 'neg' ? 'text-rose-700' : 'text-foreground';
+  const toneClass = tone === 'pos' ? 'text-success-fg' : tone === 'neg' ? 'text-destructive-fg' : 'text-foreground';
   return (
     <div className={`px-5 py-4 ${emphasize ? 'bg-primary text-primary-foreground' : 'bg-card'}`}>
       <div className={`text-[10px] uppercase tracking-widest font-medium ${emphasize ? 'text-primary-foreground/70' : 'text-muted-foreground'}`}>{label}</div>
@@ -239,7 +239,7 @@ function TabelaProdutos({ rows, tweaks, onOpen }: { rows: ProdutoRow[]; tweaks: 
               {tweaks.showCost && (
                 <td className="pr-3 text-[12px] text-right tabular-nums">
                   <div className="text-foreground">{fmtBRL(r.cost)}</div>
-                  <div className={r.margin >= 0.5 ? 'text-emerald-700 text-[11px]' : r.margin >= 0.3 ? 'text-muted-foreground text-[11px]' : 'text-rose-700 text-[11px]'}>
+                  <div className={r.margin >= 0.5 ? 'text-success-fg text-[11px]' : r.margin >= 0.3 ? 'text-muted-foreground text-[11px]' : 'text-destructive-fg text-[11px]'}>
                     {fmtPct(r.margin)}
                   </div>
                 </td>
@@ -344,7 +344,7 @@ function ListaTabelas({ rows, produtos }: { rows: TabelaRow[]; produtos: Produto
                     <td className="text-[13px] font-medium">{p.name}</td>
                     <td className="text-[12.5px] text-right text-muted-foreground tabular-nums">{fmtBRL(p.price)}</td>
                     <td className="text-[13px] text-right font-semibold tabular-nums">{fmtBRL(tab)}</td>
-                    <td className={`pr-6 text-[12.5px] text-right tabular-nums ${m >= 0.4 ? 'text-emerald-700' : m >= 0.15 ? 'text-foreground' : 'text-rose-700'}`}>{fmtPct(m)}</td>
+                    <td className={`pr-6 text-[12.5px] text-right tabular-nums ${m >= 0.4 ? 'text-success-fg' : m >= 0.15 ? 'text-foreground' : 'text-destructive-fg'}`}>{fmtPct(m)}</td>
                   </tr>
                 );
               })}

--- a/resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
@@ -340,7 +340,7 @@ function BacklogIndex({
                     className={[
                       'border-b transition-colors',
                       sel ? 'bg-primary/5' : 'hover:bg-muted/40',
-                      t.is_blocked ? 'bg-red-50/40 dark:bg-red-950/10' : '',
+                      t.is_blocked ? 'bg-destructive-soft/40' : '',
                     ].filter(Boolean).join(' ')}
                   >
                     <td className="py-1.5 px-3">
@@ -367,7 +367,7 @@ function BacklogIndex({
                     </td>
                     <td className="py-1.5 px-3 text-center">
                       {t.due_date ? (
-                        <span className={`inline-flex items-center gap-1 text-[10px] ${t.is_overdue ? 'text-red-600 font-semibold' : 'text-muted-foreground'}`}>
+                        <span className={`inline-flex items-center gap-1 text-[10px] ${t.is_overdue ? 'text-destructive font-semibold' : 'text-muted-foreground'}`}>
                           {t.is_overdue ? <AlertCircle size={10} /> : <Calendar size={10} />}
                           {fmtDate(t.due_date)}
                         </span>

--- a/resources/js/Pages/ProjectMgmt/Board/DetailSheet.tsx
+++ b/resources/js/Pages/ProjectMgmt/Board/DetailSheet.tsx
@@ -425,7 +425,7 @@ export default function DetailSheet({ taskId, onClose }: Props) {
                   </span>
                 )}
                 {t?.is_blocked && (
-                  <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300">
+                  <span className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-semibold bg-destructive-soft text-destructive-fg">
                     <Lock size={10} /> blocked
                   </span>
                 )}
@@ -437,7 +437,7 @@ export default function DetailSheet({ taskId, onClose }: Props) {
                 {t?.module && <span className="bg-muted px-1.5 py-0.5 rounded">{t.module}</span>}
                 {t?.owner && <span className="bg-muted px-1.5 py-0.5 rounded">@{t.owner}</span>}
                 {t?.due_date && (
-                  <span className={`inline-flex items-center gap-1 ${t.is_overdue ? 'text-red-600 font-semibold' : 'text-muted-foreground'}`}>
+                  <span className={`inline-flex items-center gap-1 ${t.is_overdue ? 'text-destructive font-semibold' : 'text-muted-foreground'}`}>
                     {t.is_overdue ? <AlertCircle size={11} /> : <Calendar size={11} />}
                     {dueShort(t.due_date)}
                   </span>
@@ -497,7 +497,7 @@ export default function DetailSheet({ taskId, onClose }: Props) {
           )}
 
           {error && (
-            <div className="my-6 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/40 dark:text-red-200">
+            <div className="my-6 rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-sm text-destructive-fg">
               {error}
             </div>
           )}
@@ -572,7 +572,7 @@ export default function DetailSheet({ taskId, onClose }: Props) {
                     />
 
                     {postError && (
-                      <p className="mt-2 text-xs text-red-600 dark:text-red-400">{postError}</p>
+                      <p className="mt-2 text-xs text-destructive">{postError}</p>
                     )}
 
                     <div className="mt-2 flex justify-end">
@@ -707,7 +707,7 @@ export default function DetailSheet({ taskId, onClose }: Props) {
                       </Button>
                     </div>
                     {subtaskError && (
-                      <p className="mt-2 text-xs text-red-600 dark:text-red-400">{subtaskError}</p>
+                      <p className="mt-2 text-xs text-destructive">{subtaskError}</p>
                     )}
                   </div>
                 </div>
@@ -720,7 +720,7 @@ export default function DetailSheet({ taskId, onClose }: Props) {
                     <div className="flex items-center gap-2 text-xs">
                       {data.is_watching ? (
                         <>
-                          <Eye className="h-3.5 w-3.5 text-emerald-600 dark:text-emerald-400" />
+                          <Eye className="h-3.5 w-3.5 text-success-fg" />
                           <span>Você está seguindo esta task.</span>
                         </>
                       ) : (

--- a/resources/js/Pages/ProjectMgmt/Board/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Board/Index.tsx
@@ -388,7 +388,7 @@ function BoardIndex({ project, cycle, kanban, kpis, columns, epics = [], cycles 
       {conflictMessage && (
         <div
           role="alert"
-          className="mt-4 flex items-center justify-between rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200"
+          className="mt-4 flex items-center justify-between rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-sm text-warning-fg"
         >
           <span>{conflictMessage}</span>
           <button

--- a/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
@@ -268,7 +268,7 @@ function InboxIndex({ inbox = [], inbox_stats = EMPTY_INBOX_STATS, filters }: Pr
       {errorMsg && (
         <div
           role="alert"
-          className="mt-4 flex items-center justify-between rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200"
+          className="mt-4 flex items-center justify-between rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-sm text-warning-fg"
         >
           <span>{errorMsg}</span>
           <button type="button" onClick={() => setErrorMsg(null)} className="text-xs font-medium underline-offset-2 hover:underline">

--- a/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
@@ -253,7 +253,7 @@ function TriageIndex({
       {errorMsg && (
         <div
           role="alert"
-          className="mt-4 flex items-center justify-between rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-200"
+          className="mt-4 flex items-center justify-between rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-sm text-warning-fg"
         >
           <span>{errorMsg}</span>
           <button type="button" onClick={() => setErrorMsg(null)} className="text-xs font-medium underline-offset-2 hover:underline">

--- a/resources/js/Pages/Purchase/Create.tsx
+++ b/resources/js/Pages/Purchase/Create.tsx
@@ -398,7 +398,7 @@ function PurchaseCreate({
                         type="button"
                         size="sm"
                         variant="ghost"
-                        className="h-7 w-7 p-0 text-rose-600"
+                        className="h-7 w-7 p-0 text-destructive"
                         onClick={() => removerLinha(idx)}
                         title="Remover"
                       >

--- a/resources/js/Pages/Purchase/Edit.tsx
+++ b/resources/js/Pages/Purchase/Edit.tsx
@@ -389,7 +389,7 @@ function PurchaseEdit({
                       {brl(linha.purchase_price_inc_tax * linha.quantity)}
                     </td>
                     <td className="px-2 text-right">
-                      <Button type="button" size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-600" onClick={() => removerLinha(idx)} title="Remover">
+                      <Button type="button" size="sm" variant="ghost" className="h-7 w-7 p-0 text-destructive" onClick={() => removerLinha(idx)} title="Remover">
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>
                     </td>

--- a/resources/js/Pages/Purchase/Index.tsx
+++ b/resources/js/Pages/Purchase/Index.tsx
@@ -280,7 +280,7 @@ function PurchaseIndex({ rows, filters, business_locations, suppliers, order_sta
                   <td className="px-2"><PaymentPill s={r.payment_status} /></td>
                   <td className="px-2 text-right tabular-nums font-medium">{brl(r.final_total)}</td>
                   <td className="px-2 text-right tabular-nums">
-                    <span className={r.payment_due > 0 ? 'text-rose-700 font-medium' : 'text-stone-400'}>
+                    <span className={r.payment_due > 0 ? 'text-destructive-fg font-medium' : 'text-stone-400'}>
                       {brl(r.payment_due)}
                     </span>
                   </td>
@@ -302,7 +302,7 @@ function PurchaseIndex({ rows, filters, business_locations, suppliers, order_sta
                         </Button>
                       )}
                       {permissions.delete && (
-                        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-600" onClick={() => onDelete(r.id)} title="Excluir">
+                        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-destructive" onClick={() => onDelete(r.id)} title="Excluir">
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
                       )}

--- a/resources/js/Pages/Purchase/Show.tsx
+++ b/resources/js/Pages/Purchase/Show.tsx
@@ -338,7 +338,7 @@ function PurchaseShow({ purchase, permissions }: Props) {
               <span className="font-semibold">Total geral</span>
               <span className="tabular-nums font-semibold text-[15px]">{brl(purchase.final_total)}</span>
             </div>
-            <div className="flex justify-between text-emerald-700">
+            <div className="flex justify-between text-success-fg">
               <span>Pago</span><span className="tabular-nums">{brl(purchase.amount_paid)}</span>
             </div>
             <div className="flex justify-between">

--- a/resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx
@@ -99,25 +99,25 @@ const SEVERITY_TOKENS: Record<
   { bg: string; text: string; ring: string; icon: LucideIcon; iconColor: string }
 > = {
   info: {
-    bg: 'bg-sky-50',
-    text: 'text-sky-800',
-    ring: 'ring-sky-200',
+    bg: 'bg-info-soft',
+    text: 'text-info-fg',
+    ring: 'ring-info/20',
     icon: Info,
-    iconColor: 'text-sky-600',
+    iconColor: 'text-info',
   },
   warn: {
-    bg: 'bg-amber-50',
-    text: 'text-amber-800',
-    ring: 'ring-amber-200',
+    bg: 'bg-warning-soft',
+    text: 'text-warning-fg',
+    ring: 'ring-warning/20',
     icon: AlertTriangle,
-    iconColor: 'text-amber-600',
+    iconColor: 'text-warning',
   },
   bad: {
-    bg: 'bg-rose-50',
-    text: 'text-rose-800',
-    ring: 'ring-rose-200',
+    bg: 'bg-destructive-soft',
+    text: 'text-destructive-fg',
+    ring: 'ring-destructive/20',
     icon: XCircle,
-    iconColor: 'text-rose-600',
+    iconColor: 'text-destructive',
   },
 };
 
@@ -266,7 +266,7 @@ export default function ConfiguracoesIndex(props: PageProps) {
               <div className="flex items-center gap-3">
                 <span
                   className={`inline-flex h-6 w-11 items-center rounded-full p-0.5 transition-colors ${
-                    nfe_auto.ativo ? 'bg-emerald-500' : 'bg-stone-300'
+                    nfe_auto.ativo ? 'bg-success' : 'bg-stone-300'
                   }`}
                 >
                   <span
@@ -523,7 +523,7 @@ function GatewaysContent({ gateways }: { gateways: GatewayRow[] }) {
               </div>
             </div>
             {g.ativo ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-200">
+              <span className="inline-flex items-center gap-1 rounded-full bg-success-soft px-2 py-0.5 text-[11px] font-medium text-success-fg ring-1 ring-success/20">
                 <CheckCircle2 size={11} />
                 ativo
               </span>
@@ -598,7 +598,7 @@ function WebhookCard({ webhook }: { webhook: WebhookRow }) {
           onClick={handleCopy}
           className={`inline-flex shrink-0 items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-medium transition ${
             copied
-              ? 'bg-emerald-600 text-white'
+              ? 'bg-success text-white'
               : 'bg-white text-stone-700 ring-1 ring-stone-200 hover:bg-stone-50'
           }`}
           title="Copiar URL pra área de transferência"

--- a/resources/js/Pages/RecurringBilling/Faturas/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Faturas/Index.tsx
@@ -300,7 +300,7 @@ function CancelDialog({
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start gap-3">
-          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-rose-100 text-rose-700">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-destructive-soft text-destructive-fg">
             <AlertCircle size={20} />
           </div>
           <div className="min-w-0 flex-1">
@@ -344,7 +344,7 @@ function CancelDialog({
             type="button"
             onClick={() => onConfirm(motivo)}
             disabled={busy}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-rose-600 px-3 py-2 text-sm font-medium text-white shadow-sm hover:bg-rose-700 disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-lg bg-destructive px-3 py-2 text-sm font-medium text-destructive-foreground shadow-sm hover:bg-destructive/90 disabled:opacity-50"
           >
             <Ban size={14} />
             {busy ? 'Cancelando…' : 'Confirmar cancelamento'}
@@ -660,7 +660,7 @@ export default function FaturasIndex(props: PageProps) {
                           <div>{dateBR(inv.vencimento)}</div>
                           <div
                             className={`mt-0.5 text-[11px] ${
-                              inv.is_overdue ? 'font-medium text-rose-600' : 'text-stone-500'
+                              inv.is_overdue ? 'font-medium text-destructive-fg' : 'text-stone-500'
                             }`}
                           >
                             {dueLabel(inv.dias_delta_venc)}
@@ -677,7 +677,7 @@ export default function FaturasIndex(props: PageProps) {
                             <button
                               type="button"
                               onClick={() => setCancelTarget(inv)}
-                              className="inline-flex items-center gap-1 rounded-lg border border-rose-200 bg-white px-2.5 py-1 text-xs font-medium text-rose-700 hover:bg-rose-50"
+                              className="inline-flex items-center gap-1 rounded-lg border border-destructive/20 bg-white px-2.5 py-1 text-xs font-medium text-destructive-fg hover:bg-destructive-soft"
                               title="Cancelar fatura"
                             >
                               <Ban size={12} />

--- a/resources/js/Pages/RecurringBilling/Planos/Create.tsx
+++ b/resources/js/Pages/RecurringBilling/Planos/Create.tsx
@@ -383,11 +383,11 @@ function Field({
   return (
     <div>
       <label className="mb-1 block text-xs font-medium text-stone-700">
-        {label} {required && <span className="text-rose-600">*</span>}
+        {label} {required && <span className="text-destructive">*</span>}
       </label>
       {children}
       {hint && !error && <div className="mt-1 text-[11px] text-stone-500">{hint}</div>}
-      {error && <div className="mt-1 text-[11px] font-medium text-rose-600">{error}</div>}
+      {error && <div className="mt-1 text-[11px] font-medium text-destructive-fg">{error}</div>}
     </div>
   );
 }

--- a/resources/js/Pages/RecurringBilling/Planos/Edit.tsx
+++ b/resources/js/Pages/RecurringBilling/Planos/Edit.tsx
@@ -395,11 +395,11 @@ function Field({
   return (
     <div>
       <label className="mb-1 block text-xs font-medium text-stone-700">
-        {label} {required && <span className="text-rose-600">*</span>}
+        {label} {required && <span className="text-destructive">*</span>}
       </label>
       {children}
       {hint && !error && <div className="mt-1 text-[11px] text-stone-500">{hint}</div>}
-      {error && <div className="mt-1 text-[11px] font-medium text-rose-600">{error}</div>}
+      {error && <div className="mt-1 text-[11px] font-medium text-destructive-fg">{error}</div>}
     </div>
   );
 }

--- a/resources/js/Pages/RecurringBilling/Planos/Index.tsx
+++ b/resources/js/Pages/RecurringBilling/Planos/Index.tsx
@@ -204,7 +204,7 @@ function CicloDistribuicao({ kpis }: { kpis: KpisPayload }) {
 
 function StatusBadge({ ativo }: { ativo: boolean }) {
   return ativo ? (
-    <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700 ring-1 ring-emerald-200">
+    <span className="inline-flex items-center gap-1 rounded-full bg-success-soft px-2 py-0.5 text-[11px] font-medium text-success-fg ring-1 ring-success/20">
       <CheckCircle2 size={11} />
       ativo
     </span>
@@ -233,8 +233,8 @@ function FlashBanner({ flash }: { flash?: { success?: string; error?: string } }
     <div
       className={`mb-4 rounded-lg p-3 text-sm font-medium ring-1 ${
         isError
-          ? 'bg-rose-50 text-rose-800 ring-rose-200'
-          : 'bg-emerald-50 text-emerald-800 ring-emerald-200'
+          ? 'bg-destructive-soft text-destructive-fg ring-destructive/20'
+          : 'bg-success-soft text-success-fg ring-success/20'
       }`}
     >
       {msg}

--- a/resources/js/Pages/Repair/DeviceModels/Create.tsx
+++ b/resources/js/Pages/Repair/DeviceModels/Create.tsx
@@ -59,7 +59,7 @@ export default function DeviceModelCreate({ brands, devices }: Props) {
       <div className="rounded-lg border border-border bg-card p-5 space-y-4">
         <div>
           <Label htmlFor="name">
-            Nome do modelo <span className="text-rose-600">*</span>
+            Nome do modelo <span className="text-destructive">*</span>
           </Label>
           <Input
             id="name"

--- a/resources/js/Pages/Repair/DeviceModels/Edit.tsx
+++ b/resources/js/Pages/Repair/DeviceModels/Edit.tsx
@@ -68,7 +68,7 @@ export default function DeviceModelEdit({ model, brands, devices }: Props) {
       <div className="rounded-lg border border-border bg-card p-5 space-y-4">
         <div>
           <Label htmlFor="name">
-            Nome do modelo <span className="text-rose-600">*</span>
+            Nome do modelo <span className="text-destructive">*</span>
           </Label>
           <Input
             id="name"

--- a/resources/js/Pages/Repair/JobSheet/Show.tsx
+++ b/resources/js/Pages/Repair/JobSheet/Show.tsx
@@ -350,7 +350,7 @@ function JobSheetFsmPanel({ jobSheetId, endpoints, inPipelineInitial }: {
             <h3 className="font-semibold text-sm">Confirmar: {confirmAction.label}</h3>
             <div className="text-xs text-muted-foreground space-y-1">
               {confirmAction.is_critical && (
-                <p className="text-amber-600 flex items-center gap-1">
+                <p className="text-warning-fg flex items-center gap-1">
                   <AlertTriangle size={12} /> Ação crítica
                 </p>
               )}
@@ -513,7 +513,7 @@ export default function JobSheetShow({ job_sheet, fsm, permissions }: Props) {
                 <ul className="text-sm space-y-1">
                   {job_sheet.checklist.map((item, idx) => (
                     <li key={idx} className="flex items-center gap-2">
-                      <Check className="h-3 w-3 text-emerald-600" />
+                      <Check className="h-3 w-3 text-success-fg" />
                       {item}
                     </li>
                   ))}

--- a/resources/js/Pages/Repair/Status/Index.tsx
+++ b/resources/js/Pages/Repair/Status/Index.tsx
@@ -78,7 +78,7 @@ export default function StatusIndex({ statuses }: PageProps) {
                     {s.is_completed_status === 1 ? (
                       <Icon
                         name="circle-check"
-                        className="inline h-4 w-4 text-emerald-600 dark:text-emerald-400"
+                        className="inline h-4 w-4 text-success-fg"
                         aria-label="Status de conclusão"
                       />
                     ) : (

--- a/resources/js/Pages/Sells/_components/CobrancaDrawer.tsx
+++ b/resources/js/Pages/Sells/_components/CobrancaDrawer.tsx
@@ -202,7 +202,7 @@ export default function CobrancaDrawer({ venda, state, onClose }: Props) {
           {!isView && (
             <div className="p-4 space-y-4">
               {state.kind === 'error' && state.cob?.erro_msg && (
-                <div className="bg-rose-50 border border-rose-200 rounded-md p-3 text-[11.5px] text-rose-900">
+                <div className="bg-destructive-soft border border-destructive/20 rounded-md p-3 text-[11.5px] text-destructive-fg">
                   <div className="font-medium">Tentativa anterior falhou</div>
                   <div className="font-mono text-[10.5px] mt-1">{state.cob.erro_msg}</div>
                 </div>

--- a/resources/js/Pages/Sells/_components/CriarOsButton.tsx
+++ b/resources/js/Pages/Sells/_components/CriarOsButton.tsx
@@ -120,7 +120,7 @@ export default function CriarOsButton({
           disabled={submitting}
           className="text-sm"
         >
-          <CheckCircle2 size={12} className="mr-2 text-emerald-600" />
+          <CheckCircle2 size={12} className="mr-2 text-success" />
           {MODE_LABEL.auto}
         </DropdownMenuItem>
         <DropdownMenuItem

--- a/resources/js/Pages/Sells/_components/FiscalSection.tsx
+++ b/resources/js/Pages/Sells/_components/FiscalSection.tsx
@@ -89,7 +89,7 @@ export default function FiscalSection({ saleId, enabled = true }: Props) {
       </h3>
 
       {error && (
-        <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-xs text-rose-700 mb-2 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40">
+        <div className="rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-xs text-destructive-fg mb-2">
           <AlertTriangle size={11} className="inline mr-1" />
           {error}
         </div>
@@ -100,8 +100,8 @@ export default function FiscalSection({ saleId, enabled = true }: Props) {
           className={
             'rounded-md border px-3 py-2 text-xs mb-2 ' +
             (actionMsg.tone === 'success'
-              ? 'border-emerald-200 bg-emerald-50 text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300 dark:border-emerald-900/40'
-              : 'border-rose-200 bg-rose-50 text-rose-700 dark:bg-rose-950/40 dark:text-rose-300 dark:border-rose-900/40')
+              ? 'border-success/20 bg-success-soft text-success-fg'
+              : 'border-destructive/20 bg-destructive-soft text-destructive-fg')
           }
         >
           {actionMsg.tone === 'success' ? <CheckCircle2 size={11} className="inline mr-1" /> : <AlertTriangle size={11} className="inline mr-1" />}
@@ -198,7 +198,7 @@ function EmissaoRow({
             </div>
           )}
           {em.motivo && em.status !== 'autorizada' && (
-            <div className="text-xs text-rose-700 dark:text-rose-300 mt-1">{em.motivo}</div>
+            <div className="text-xs text-destructive-fg mt-1">{em.motivo}</div>
           )}
         </div>
       </div>

--- a/resources/js/Pages/Sells/_components/FsmActionPanel.tsx
+++ b/resources/js/Pages/Sells/_components/FsmActionPanel.tsx
@@ -318,7 +318,7 @@ export default function FsmActionPanel({ saleId, enabled, onTransition }: Props)
 
             <div className="text-xs text-muted-foreground space-y-1">
               {confirmAction.is_critical && (
-                <p className="text-amber-600 dark:text-amber-400 flex items-center gap-1">
+                <p className="text-warning flex items-center gap-1">
                   <AlertTriangle size={12} />
                   Ação crítica — requer autorização explícita
                 </p>

--- a/resources/js/Pages/Sells/_components/QuickPaymentDialog.tsx
+++ b/resources/js/Pages/Sells/_components/QuickPaymentDialog.tsx
@@ -193,7 +193,7 @@ export default function QuickPaymentDialog({
             />
           </div>
           {paymentError && (
-            <div className="rounded-md bg-rose-50 border border-rose-200 dark:bg-rose-950/40 dark:border-rose-900/40 px-2.5 py-2 text-xs text-rose-700 dark:text-rose-300">
+            <div className="rounded-md bg-destructive-soft border border-destructive/20 px-2.5 py-2 text-xs text-destructive-fg">
               {paymentError}
             </div>
           )}

--- a/resources/js/Pages/Sells/_components/QuickPaymentPopover.tsx
+++ b/resources/js/Pages/Sells/_components/QuickPaymentPopover.tsx
@@ -209,7 +209,7 @@ export default function QuickPaymentPopover({
             />
           </div>
           {paymentError && (
-            <div className="rounded-md bg-rose-50 border border-rose-200 dark:bg-rose-950/40 dark:border-rose-900/40 px-2.5 py-2 text-xs text-rose-700 dark:text-rose-300">
+            <div className="rounded-md bg-destructive-soft border border-destructive/20 px-2.5 py-2 text-xs text-destructive-fg">
               {paymentError}
             </div>
           )}

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -303,7 +303,7 @@ export default function SaleSheet({
         {error && !loading && (
           <div className="flex-1 flex items-center justify-center p-6 text-center">
             <div>
-              <AlertTriangle className="h-8 w-8 text-rose-500 mx-auto mb-2" />
+              <AlertTriangle className="h-8 w-8 text-destructive mx-auto mb-2" />
               <p className="text-sm text-foreground font-medium">Não foi possível carregar a venda</p>
               <p className="text-xs text-muted-foreground mt-1">{error}</p>
             </div>
@@ -318,7 +318,7 @@ export default function SaleSheet({
                 <span className="font-mono text-xs text-muted-foreground">#{data.invoice_no}</span>
                 <PaymentBadge status={data.payment_status} />
                 {data.shipping_status && data.shipping_status !== 'delivered' && (
-                  <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2.5 py-0.5 text-[11px] font-medium text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/40 dark:text-amber-300">
+                  <span className="inline-flex items-center rounded-full border border-warning/20 bg-warning-soft px-2.5 py-0.5 text-[11px] font-medium text-warning-fg">
                     Frete: {data.shipping_status}
                   </span>
                 )}
@@ -558,7 +558,7 @@ export default function SaleSheet({
                       />
                     </div>
                     {paymentError && (
-                      <div className="rounded-md bg-rose-50 border border-rose-200 dark:bg-rose-950/40 dark:border-rose-900/40 px-2.5 py-2 text-xs text-rose-700 dark:text-rose-300">
+                      <div className="rounded-md bg-destructive-soft border border-destructive/20 px-2.5 py-2 text-xs text-destructive-fg">
                         {paymentError}
                       </div>
                     )}
@@ -594,7 +594,7 @@ export default function SaleSheet({
                   <ul className="space-y-2">
                     {data.payments.map((p) => (
                       <li key={p.id} className="flex items-start gap-3 text-sm">
-                        <CheckCircle2 size={14} className="text-emerald-500 mt-0.5 flex-shrink-0" />
+                        <CheckCircle2 size={14} className="text-success mt-0.5 flex-shrink-0" />
                         <div className="flex-1 min-w-0">
                           <div className="flex items-baseline justify-between gap-2">
                             <span className="font-medium text-foreground tabular-nums">{formatBRL(p.amount)}</span>
@@ -889,9 +889,9 @@ function MiniKpi({
       className={
         'rounded-md border p-2.5 ' +
         (tone === 'warning'
-          ? 'border-amber-200 bg-amber-50/60 dark:border-amber-900/40 dark:bg-amber-950/30'
+          ? 'border-warning/20 bg-warning-soft'
           : tone === 'success'
-            ? 'border-emerald-200 bg-emerald-50/60 dark:border-emerald-900/40 dark:bg-emerald-950/30'
+            ? 'border-success/20 bg-success-soft'
             : 'border-border bg-muted/30')
       }
     >
@@ -899,9 +899,9 @@ function MiniKpi({
         className={
           'text-[10px] font-semibold uppercase tracking-wider ' +
           (tone === 'warning'
-            ? 'text-amber-700 dark:text-amber-400'
+            ? 'text-warning-fg'
             : tone === 'success'
-              ? 'text-emerald-700 dark:text-emerald-400'
+              ? 'text-success-fg'
               : 'text-muted-foreground')
         }
       >
@@ -911,9 +911,9 @@ function MiniKpi({
         className={
           'text-sm font-semibold tabular-nums mt-0.5 truncate ' +
           (tone === 'warning'
-            ? 'text-amber-700 dark:text-amber-300'
+            ? 'text-warning-fg'
             : tone === 'success'
-              ? 'text-emerald-700 dark:text-emerald-300'
+              ? 'text-success-fg'
               : 'text-foreground')
         }
         title={value}

--- a/resources/js/Pages/Settings/PaymentGateways/Index.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/Index.tsx
@@ -163,7 +163,7 @@ function PaymentGatewaysPage({ gateways, accounts, kpis, today, nfeCertificadoAt
       {hasWarn && (
         <div className="px-6 pt-3">
           <div className="bg-amber-50 border border-amber-200 rounded-md p-3 flex items-start gap-3 text-[11.5px]">
-            <AlertCircle className="h-4 w-4 text-amber-700 mt-0.5" />
+            <AlertCircle className="h-4 w-4 text-warning-fg mt-0.5" />
             <div className="flex-1 text-amber-900">
               <strong>Credencial(is) precisam de atenção</strong> — verifique no drawer de cada gateway abaixo (warn label).
             </div>
@@ -226,9 +226,9 @@ function PaymentGatewaysPage({ gateways, accounts, kpis, today, nfeCertificadoAt
                       <td className="px-2 py-2.5">
                         <span className={cn(
                           'inline-flex items-center gap-1 text-[10.5px] font-medium px-1.5 py-0.5 rounded border',
-                          g.ambiente === 'production' ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-amber-50 text-amber-700 border-amber-200',
+                          g.ambiente === 'production' ? 'bg-success-soft text-success-fg border-success/20' : 'bg-warning-soft text-warning-fg border-warning/20',
                         )}>
-                          <span className={cn('w-1 h-1 rounded-full', g.ambiente === 'production' ? 'bg-emerald-500' : 'bg-amber-500')} />
+                          <span className={cn('w-1 h-1 rounded-full', g.ambiente === 'production' ? 'bg-success' : 'bg-warning')} />
                           {g.ambiente === 'production' ? 'Produção' : 'Sandbox'}
                         </span>
                       </td>

--- a/resources/js/Pages/Settings/PaymentGateways/_components/ConfirmToggleModal.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/ConfirmToggleModal.tsx
@@ -31,7 +31,7 @@ export default function ConfirmToggleModal({ gateway, newValue, affectedCount = 
           <div className="flex items-start gap-3">
             <span className={cn(
               'w-9 h-9 rounded-md grid place-items-center shrink-0',
-              isDisabling ? 'bg-rose-100 text-rose-700' : 'bg-emerald-100 text-emerald-700',
+              isDisabling ? 'bg-destructive/10 text-destructive' : 'bg-success/10 text-success',
             )}>
               {isDisabling ? <AlertCircle className="h-4 w-4" /> : <Check className="h-4 w-4" />}
             </span>
@@ -46,14 +46,14 @@ export default function ConfirmToggleModal({ gateway, newValue, affectedCount = 
           </div>
 
           {isDisabling && affectedCount > 0 && (
-            <div className="mt-3 bg-rose-50 border border-rose-200 rounded p-3 text-[11.5px] text-rose-900">
+            <div className="mt-3 bg-destructive-soft border border-destructive/20 rounded p-3 text-[11.5px] text-destructive-fg">
               <strong>{affectedCount} cobrança(s) em aberto</strong> dependem deste gateway.
               Desativar bloqueia novas emissões — as existentes continuam pagas via webhook se o banco confirmar.
             </div>
           )}
 
           {!isDisabling && (
-            <div className="mt-3 bg-emerald-50 border border-emerald-200 rounded p-3 text-[11.5px] text-emerald-900">
+            <div className="mt-3 bg-success-soft border border-success/20 rounded p-3 text-[11.5px] text-success-fg">
               Gateway disponível imediatamente pra emissão de cobranças. Health check rodará em 1min.
             </div>
           )}
@@ -64,7 +64,7 @@ export default function ConfirmToggleModal({ gateway, newValue, affectedCount = 
         </div>
         <div className="px-5 py-3 border-t border-stone-200 bg-stone-50 flex gap-2 justify-end">
           <Btn variant="outline" onClick={onClose}>Cancelar</Btn>
-          <Btn variant="primary" onClick={() => { onConfirm(); onClose(); }} className={isDisabling ? '!bg-rose-600 hover:!bg-rose-700 !border-rose-600' : ''}>
+          <Btn variant="primary" onClick={() => { onConfirm(); onClose(); }} className={isDisabling ? '!bg-destructive hover:!bg-destructive/90 !border-destructive' : ''}>
             <Check className="h-3 w-3" />{isDisabling ? 'Desativar' : 'Ativar'}
           </Btn>
         </div>

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -549,9 +549,9 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                         <div className="flex items-center gap-2">
                           <span className={cn(
                             'inline-flex items-center justify-center w-4 h-4 rounded-full text-white text-[9px] shrink-0',
-                            e.processed_at && !e.error_message ? 'bg-emerald-500'
-                              : e.error_message ? 'bg-rose-500'
-                              : 'bg-amber-500',
+                            e.processed_at && !e.error_message ? 'bg-success'
+                              : e.error_message ? 'bg-destructive'
+                              : 'bg-warning',
                           )} title={e.processed_at && !e.error_message ? 'Processado' : e.error_message ? 'Erro' : 'Pendente'}>
                             {e.processed_at && !e.error_message ? <Check className="h-2.5 w-2.5" /> : e.error_message ? <X className="h-2.5 w-2.5" /> : '·'}
                           </span>
@@ -565,7 +565,7 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                           <span className="text-[10px] text-stone-400 tabular-nums shrink-0" title={e.when_iso}>{e.when}</span>
                         </div>
                         {e.error_message && (
-                          <div className="mt-1 ml-6 text-[10.5px] text-rose-700 truncate" title={e.error_message}>
+                          <div className="mt-1 ml-6 text-[10.5px] text-destructive-fg truncate" title={e.error_message}>
                             {e.error_message}
                           </div>
                         )}
@@ -614,7 +614,7 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                 {testStatus === 'testando' ? 'Testando…' : 'Rodar health check agora'}
               </Btn>
               {testStatus === 'ok' && (
-                <div className="bg-emerald-50 border border-emerald-200 rounded p-3 text-[11.5px] text-emerald-900 flex items-center gap-2">
+                <div className="bg-success-soft border border-success/20 rounded p-3 text-[11.5px] text-success-fg flex items-center gap-2">
                   <Check className="h-3.5 w-3.5" /><strong>Conexão OK</strong> · driver respondeu corretamente
                 </div>
               )}
@@ -696,7 +696,7 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
               <button
                 onClick={handleDelete}
                 disabled={deleting}
-                className="inline-flex items-center gap-1.5 h-8 px-3 rounded text-[12px] font-medium bg-rose-600 text-white hover:bg-rose-700 disabled:opacity-60"
+                className="inline-flex items-center gap-1.5 h-8 px-3 rounded text-[12px] font-medium bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-60"
               >
                 <Trash2 className="h-3 w-3" />{deleting ? 'Excluindo…' : 'Sim, excluir'}
               </button>

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -218,10 +218,10 @@ export default function SheetNovoGateway({ accounts, nfeCertificadoAtivo, onClos
 
                     {/* Onda 4e.UI #7 — destaque bancos com API moderna disponível (futuros drivers nativos PaymentGateway Onda 4f).
                         Tier S de maturidade Open Finance + Pix Cobrança REST, dados de WebSearch oficial 2026-05-23. */}
-                    <div className="mt-2 bg-amber-50/60 border border-amber-200 rounded px-2 py-1.5 text-[10px] text-amber-900 leading-snug">
+                    <div className="mt-2 bg-warning-soft border border-warning/20 rounded px-2 py-1.5 text-[10px] text-warning-fg leading-snug">
                       <span className="font-medium">Bancos com API moderna disponível</span> (futuros drivers nativos):
                       <div className="font-semibold mt-0.5">🔥 Bradesco · Itaú · BB · Sicredi · Sicoob · Santander · Caixa · BTG</div>
-                      <div className="text-[9.5px] text-amber-700 mt-0.5 italic">(hoje via CNAB — driver nativo + webhook em backlog Onda 4f)</div>
+                      <div className="text-[9.5px] text-warning-fg mt-0.5 italic">(hoje via CNAB — driver nativo + webhook em backlog Onda 4f)</div>
                     </div>
 
                     <div className="text-[10px] text-stone-500 mt-1.5">
@@ -474,7 +474,7 @@ export default function SheetNovoGateway({ accounts, nfeCertificadoAtivo, onClos
                     )}
                   </div>
                 ) : (
-                  <div className="bg-amber-50 border border-amber-200 rounded p-2.5 text-[10.5px] text-amber-900">
+                  <div className="bg-warning-soft border border-warning/20 rounded p-2.5 text-[10.5px] text-warning-fg">
                     <div className="font-semibold mb-0.5">⚠️ Cadastre o certificado A1 da empresa em Fiscal</div>
                     Sicoob API exige cert ICP-Brasil A1 do CNPJ — mesmo que NFe SEFAZ usa.{' '}
                     <a href="/fiscal/configuracao/certificado" target="_blank" rel="noopener noreferrer" className="underline font-medium">
@@ -562,7 +562,7 @@ export default function SheetNovoGateway({ accounts, nfeCertificadoAtivo, onClos
                 Webhook URL será gerada automaticamente — cole no painel do {d.nome} após criação.
               </div>
               {error && (
-                <div className="bg-rose-50 border border-rose-200 rounded p-2.5 text-[11px] text-rose-800">
+                <div className="bg-destructive-soft border border-destructive/20 rounded p-2.5 text-[11px] text-destructive-fg">
                   {error}
                 </div>
               )}

--- a/resources/js/Pages/Settings/PaymentGateways/_components/atoms-settings.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/atoms-settings.tsx
@@ -40,7 +40,7 @@ export function Toggle({ on, onConfirm, title }: { on: boolean; onConfirm: (newV
     <button
       onClick={e => { e.stopPropagation(); onConfirm(!on); }}
       title={title || (on ? 'Desativar' : 'Ativar')}
-      className={cn('inline-flex w-9 h-5 rounded-full p-0.5 transition cursor-pointer', on ? 'bg-emerald-500' : 'bg-stone-300')}
+      className={cn('inline-flex w-9 h-5 rounded-full p-0.5 transition cursor-pointer', on ? 'bg-success' : 'bg-stone-300')}
       aria-pressed={on}
       aria-label={on ? 'Ativo — clique pra desativar' : 'Inativo — clique pra ativar'}
     >
@@ -69,7 +69,7 @@ export function FileField({
       <div className={cn(
         'h-8 border rounded flex items-center gap-2 px-2 text-[11.5px] transition',
         hasFile
-          ? 'bg-emerald-50 border-emerald-300 text-emerald-700'
+          ? 'bg-success-soft border-success/30 text-success-fg'
           : 'bg-white border-stone-300 border-dashed text-stone-500 hover:border-stone-500',
       )}>
         <Upload className="h-3 w-3" />

--- a/resources/js/Pages/Site/Pricing.tsx
+++ b/resources/js/Pages/Site/Pricing.tsx
@@ -55,7 +55,7 @@ function SitePricing({ packages }: SitePricingProps) {
               }`}
             >
               Anual
-              <span className="ml-2 rounded-full bg-green-500/20 px-1.5 py-0.5 text-[10px] font-semibold text-green-600">
+              <span className="ml-2 rounded-full bg-success/20 px-1.5 py-0.5 text-[10px] font-semibold text-success">
                 −20%
               </span>
             </button>

--- a/resources/js/Pages/StockAdjustment/Create.tsx
+++ b/resources/js/Pages/StockAdjustment/Create.tsx
@@ -187,7 +187,7 @@ function StockAdjustmentCreate({
               <Label className="text-[12px] text-stone-600">Tipo de ajuste *</Label>
               <select
                 className={`mt-1 w-full h-9 px-2 rounded-md border text-[13px] ${
-                  form.data.adjustment_type === 'abnormal' ? 'border-rose-300 bg-rose-50/20' : 'border-stone-200'
+                  form.data.adjustment_type === 'abnormal' ? 'border-destructive/40 bg-destructive/5' : 'border-stone-200'
                 }`}
                 value={form.data.adjustment_type}
                 onChange={(e) => form.setData('adjustment_type', e.target.value as AdjustmentType)}
@@ -280,7 +280,7 @@ function StockAdjustmentCreate({
                       </td>
                     )}
                     <td className="px-2 text-right">
-                      <Button type="button" size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-600" onClick={() => removerLinha(idx)} title="Remover">
+                      <Button type="button" size="sm" variant="ghost" className="h-7 w-7 p-0 text-destructive" onClick={() => removerLinha(idx)} title="Remover">
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>
                     </td>
@@ -305,12 +305,12 @@ function StockAdjustmentCreate({
                   <Input
                     type="number"
                     step="0.01"
-                    className={`mt-1 h-9 text-[13px] tabular-nums ${recuperadoExcede ? 'border-rose-300' : ''}`}
+                    className={`mt-1 h-9 text-[13px] tabular-nums ${recuperadoExcede ? 'border-destructive/40' : ''}`}
                     value={form.data.total_amount_recovered}
                     onChange={(e) => form.setData('total_amount_recovered', Number(e.target.value))}
                   />
                   {recuperadoExcede && (
-                    <p className="text-rose-700 text-[11px] mt-1 flex items-center gap-1">
+                    <p className="text-destructive-fg text-[11px] mt-1 flex items-center gap-1">
                       <AlertCircle className="h-3 w-3" />
                       Recuperado não pode exceder o total ajustado ({brl(totalFinal)}).
                     </p>
@@ -318,10 +318,10 @@ function StockAdjustmentCreate({
                 </div>
                 <div className="space-y-1 text-[13px] pt-2 border-t border-stone-200">
                   <div className="flex justify-between"><span className="text-stone-500">Total ajustado</span><span className="tabular-nums">{brl(totalFinal)}</span></div>
-                  <div className="flex justify-between"><span className="text-stone-500">Recuperado</span><span className="tabular-nums text-emerald-700">- {brl(form.data.total_amount_recovered)}</span></div>
+                  <div className="flex justify-between"><span className="text-stone-500">Recuperado</span><span className="tabular-nums text-success-fg">- {brl(form.data.total_amount_recovered)}</span></div>
                   <div className="flex justify-between pt-2 mt-1 border-t border-stone-100">
                     <span className="font-semibold">Perda líquida</span>
-                    <span className="tabular-nums font-semibold text-[15px] text-rose-700">{brl(Math.max(0, totalFinal - (form.data.total_amount_recovered || 0)))}</span>
+                    <span className="tabular-nums font-semibold text-[15px] text-destructive-fg">{brl(Math.max(0, totalFinal - (form.data.total_amount_recovered || 0)))}</span>
                   </div>
                 </div>
               </>

--- a/resources/js/Pages/StockAdjustment/Index.tsx
+++ b/resources/js/Pages/StockAdjustment/Index.tsx
@@ -68,7 +68,7 @@ const formatDateTime = (v: string) => {
 
 const TYPE_PILL: Record<AdjustmentType, string> = {
   normal: 'bg-stone-50 text-stone-700 border-stone-200',
-  abnormal: 'bg-rose-50 text-rose-700 border-rose-200',
+  abnormal: 'bg-destructive-soft text-destructive-fg border-destructive/20',
 };
 
 const TYPE_LABEL: Record<AdjustmentType, string> = {
@@ -180,7 +180,7 @@ function StockAdjustmentIndex({ rows, filters, business_locations, permissions }
                     {permissions.view_purchase_price ? brl(r.final_total) : '—'}
                   </td>
                   <td className="px-2 text-right tabular-nums">
-                    <span className={r.total_amount_recovered > 0 ? 'text-emerald-700' : 'text-stone-400'}>
+                    <span className={r.total_amount_recovered > 0 ? 'text-success-fg' : 'text-stone-400'}>
                       {permissions.view_purchase_price ? brl(r.total_amount_recovered) : '—'}
                     </span>
                   </td>
@@ -191,7 +191,7 @@ function StockAdjustmentIndex({ rows, filters, business_locations, permissions }
                         <Eye className="h-3.5 w-3.5" />
                       </Button>
                       {permissions.delete && (
-                        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-600" onClick={() => onDelete(r.id)} title="Excluir">
+                        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-destructive" onClick={() => onDelete(r.id)} title="Excluir">
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
                       )}

--- a/resources/js/Pages/StockTransfer/Create.tsx
+++ b/resources/js/Pages/StockTransfer/Create.tsx
@@ -230,7 +230,7 @@ function StockTransferCreate({
               </div>
             </div>
             {origemDestinoIguais && (
-              <div className="mt-2 text-rose-700 text-[12px] flex items-center gap-1">
+              <div className="mt-2 text-destructive-fg text-[12px] flex items-center gap-1">
                 <AlertCircle className="h-3.5 w-3.5" />
                 Origem e destino não podem ser iguais.
               </div>
@@ -317,7 +317,7 @@ function StockTransferCreate({
                       </td>
                     )}
                     <td className="px-2 text-right">
-                      <Button type="button" size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-600" onClick={() => removerLinha(idx)} title="Remover">
+                      <Button type="button" size="sm" variant="ghost" className="h-7 w-7 p-0 text-destructive" onClick={() => removerLinha(idx)} title="Remover">
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>
                     </td>

--- a/resources/js/Pages/StockTransfer/Index.tsx
+++ b/resources/js/Pages/StockTransfer/Index.tsx
@@ -217,7 +217,7 @@ function StockTransferIndex({ rows, filters, business_locations, statuses, permi
                         <Printer className="h-3.5 w-3.5" />
                       </Button>
                       {permissions.delete && (
-                        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-rose-600" onClick={() => onDelete(r.id)} title="Excluir">
+                        <Button size="sm" variant="ghost" className="h-7 w-7 p-0 text-destructive" onClick={() => onDelete(r.id)} title="Excluir">
                           <Trash2 className="h-3.5 w-3.5" />
                         </Button>
                       )}

--- a/resources/js/Pages/TransactionPayment/Edit.tsx
+++ b/resources/js/Pages/TransactionPayment/Edit.tsx
@@ -199,7 +199,7 @@ function Edit({ payment_line, transaction, payment_types, accounts }: Props) {
                     ))}
                   </SelectContent>
                 </Select>
-                {form.errors.method && <p className="text-xs text-red-600 mt-1">{form.errors.method}</p>}
+                {form.errors.method && <p className="text-xs text-destructive-fg mt-1">{form.errors.method}</p>}
               </div>
               <div>
                 <Label htmlFor="paid_on">Data *</Label>
@@ -210,7 +210,7 @@ function Edit({ payment_line, transaction, payment_types, accounts }: Props) {
                   onChange={(e) => form.setData('paid_on', e.target.value)}
                   required
                 />
-                {form.errors.paid_on && <p className="text-xs text-red-600 mt-1">{form.errors.paid_on}</p>}
+                {form.errors.paid_on && <p className="text-xs text-destructive-fg mt-1">{form.errors.paid_on}</p>}
               </div>
               <div>
                 <Label htmlFor="amount">Valor (R$) *</Label>
@@ -223,7 +223,7 @@ function Edit({ payment_line, transaction, payment_types, accounts }: Props) {
                   onChange={(e) => form.setData('amount', e.target.value)}
                   required
                 />
-                {form.errors.amount && <p className="text-xs text-red-600 mt-1">{form.errors.amount}</p>}
+                {form.errors.amount && <p className="text-xs text-destructive-fg mt-1">{form.errors.amount}</p>}
               </div>
             </div>
 

--- a/resources/js/Pages/Vestuario/Etiquetas/Index.tsx
+++ b/resources/js/Pages/Vestuario/Etiquetas/Index.tsx
@@ -154,7 +154,7 @@ export default function EtiquetasIndex({ config }: Props) {
             <Badge variant="outline">{config.dpi} dpi</Badge>
             <Badge variant="outline">margem {config.margin_dots} dots</Badge>
             {config.qr_enabled ? (
-              <Badge className="bg-emerald-100 text-emerald-900">
+              <Badge className="bg-success-soft text-success-fg">
                 <QrCode className="mr-1 h-3 w-3" /> QR ativo
               </Badge>
             ) : (
@@ -254,14 +254,14 @@ export default function EtiquetasIndex({ config }: Props) {
                     disabled={items.length === 1}
                     aria-label="Remover item"
                   >
-                    <Trash2 className="h-4 w-4 text-rose-600" />
+                    <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
               </div>
             ))}
 
             {error && (
-              <div className="rounded border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-900">
+              <div className="rounded border border-destructive/20 bg-destructive-soft px-3 py-2 text-sm text-destructive-fg">
                 {error}
               </div>
             )}

--- a/resources/js/Pages/Whatsapp/_components/CaptureFeedbackSheet.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CaptureFeedbackSheet.tsx
@@ -309,7 +309,7 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
               </SelectContent>
             </Select>
             {isHighSeverity && (
-              <p className="mt-1 text-[11px] text-amber-700 inline-flex items-center gap-1">
+              <p className="mt-1 text-[11px] text-warning-fg inline-flex items-center gap-1">
                 ⚡ Severity ≥ 3 — vai criar MCP task automaticamente.
               </p>
             )}
@@ -395,7 +395,7 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
 
           {/* Errors */}
           {error && (
-            <div className="rounded-md border border-rose-300 bg-rose-50 px-3 py-2 text-xs text-rose-800 inline-flex items-center gap-2">
+            <div className="rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-xs text-destructive-fg inline-flex items-center gap-2">
               <AlertCircle size={14} />
               {error}
             </div>
@@ -403,7 +403,7 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
 
           {/* Success */}
           {savedOk && (
-            <div className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-800 inline-flex items-center gap-2">
+            <div className="rounded-md border border-success/20 bg-success-soft px-3 py-2 text-xs text-success-fg inline-flex items-center gap-2">
               <CheckCircle2 size={14} />
               Feedback salvo no canon. Persona + charter atualizados.
             </div>

--- a/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationThread.tsx
@@ -1452,7 +1452,7 @@ function StatusIcon({ status }: { status: string }) {
     case 'sent':      return <Check size={11} className="opacity-70" aria-label="enviada" />;
     case 'delivered': return <CheckCheck size={11} className="opacity-70" aria-label="entregue" />;
     case 'read':      return <CheckCheck size={13} strokeWidth={2.5} className="text-cyan-500 dark:text-cyan-400" aria-label="lida" />;
-    case 'failed':    return <AlertTriangle size={11} className="text-red-500 dark:text-red-400" aria-label="falhou" />;
+    case 'failed':    return <AlertTriangle size={11} className="text-destructive" aria-label="falhou" />;
     default:          return <span className="text-[9px] opacity-70">{status}</span>;
   }
 }

--- a/resources/js/Pages/Whatsapp/_components/InteractiveMessageDialog.tsx
+++ b/resources/js/Pages/Whatsapp/_components/InteractiveMessageDialog.tsx
@@ -553,7 +553,7 @@ export default function InteractiveMessageDialog({
         {tab === 'cta_url' && (
           <div className="space-y-3" data-testid="interactive-form-cta">
             {!supportsCtaUrl && (
-              <div className="rounded-md bg-amber-50 dark:bg-amber-950/30 text-amber-900 dark:text-amber-200 text-xs p-2">
+              <div className="rounded-md bg-warning-soft text-warning-fg text-xs p-2">
                 Botão CTA URL só está disponível em canais Meta Cloud. Este canal usa
                 <strong> {driverType}</strong> — selecione outra tab.
               </div>

--- a/resources/js/Pages/Whatsapp/_components/MicRecorder.tsx
+++ b/resources/js/Pages/Whatsapp/_components/MicRecorder.tsx
@@ -265,7 +265,7 @@ export default function MicRecorder({ disabled, onSend }: Props) {
           : <Mic size={14} aria-hidden />}
       </Button>
       {error && (
-        <span className="text-[10px] text-red-600 dark:text-red-400 max-w-[160px] truncate" title={error}>
+        <span className="text-[10px] text-destructive max-w-[160px] truncate" title={error}>
           {error}
         </span>
       )}

--- a/resources/js/Pages/_Showcase/Components.tsx
+++ b/resources/js/Pages/_Showcase/Components.tsx
@@ -344,7 +344,7 @@ export default function Showcase() {
             ))}
           </div>
           <BulkActionBar selectedCount={selected.length} onClear={() => setSelected([])}>
-            <Button variant="default" size="sm" className="bg-emerald-600 hover:bg-emerald-700">
+            <Button variant="default" size="sm" className="bg-success hover:bg-success/90">
               <CheckCheck size={14} className="mr-1" /> Aprovar em lote
             </Button>
             <Button variant="destructive" size="sm">

--- a/resources/js/Pages/ads/Admin/Conflicts.tsx
+++ b/resources/js/Pages/ads/Admin/Conflicts.tsx
@@ -84,10 +84,10 @@ const Conflicts: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
 
       {/* File lock conflicts */}
       {file_lock_conflicts.length > 0 && (
-        <Card className="border-amber-500/30 bg-amber-500/5">
+        <Card className="border-warning/30 bg-warning-soft">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <FileWarning className="w-5 h-5 text-amber-600" />
+              <FileWarning className="w-5 h-5 text-warning-fg" />
               File lock — decisões concorrentes
               <Badge className="ml-auto bg-amber-600">{file_lock_conflicts.length}</Badge>
             </CardTitle>
@@ -178,7 +178,7 @@ const Conflicts: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                     <div className="text-xs">
                       <span className="text-muted-foreground">IA apontou: </span>
                       {c.ai_issues.slice(0, 3).map((iss, j) => (
-                        <span key={j} className="text-red-700">{j > 0 && ', '}{iss}</span>
+                        <span key={j} className="text-destructive-fg">{j > 0 && ', '}{iss}</span>
                       ))}
                     </div>
                   )}

--- a/resources/js/Pages/ads/Admin/DecisaoShow.tsx
+++ b/resources/js/Pages/ads/Admin/DecisaoShow.tsx
@@ -347,7 +347,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
 
               {Array.isArray(chain.review_breakdown.issues) && chain.review_breakdown.issues.length > 0 && (
                 <div>
-                  <div className="text-xs font-medium text-red-700">Issues identificadas:</div>
+                  <div className="text-xs font-medium text-destructive-fg">Issues identificadas:</div>
                   <ul className="text-xs space-y-0.5 mt-1">
                     {chain.review_breakdown.issues.slice(0, 5).map((iss: string, i: number) => (
                       <li key={i} className="text-muted-foreground">• {iss}</li>
@@ -358,7 +358,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
 
               {Array.isArray(chain.review_breakdown.strengths) && chain.review_breakdown.strengths.length > 0 && (
                 <div>
-                  <div className="text-xs font-medium text-emerald-700">Pontos positivos:</div>
+                  <div className="text-xs font-medium text-success-fg">Pontos positivos:</div>
                   <ul className="text-xs space-y-0.5 mt-1">
                     {chain.review_breakdown.strengths.slice(0, 5).map((s: string, i: number) => (
                       <li key={i} className="text-muted-foreground">• {s}</li>

--- a/resources/js/Pages/ads/Admin/Decisoes.tsx
+++ b/resources/js/Pages/ads/Admin/Decisoes.tsx
@@ -92,12 +92,12 @@ const Decisoes: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ 
             onClick={() => setAutoRefresh(!autoRefresh)}
             className={`text-xs px-3 py-1.5 rounded-md border transition-colors flex items-center gap-1.5 ${
               autoRefresh
-                ? 'bg-emerald-50 text-emerald-700 border-emerald-300'
-                : 'bg-zinc-50 text-zinc-500 border-zinc-300'
+                ? 'bg-success-soft text-success-fg border-success/30'
+                : 'bg-muted text-muted-foreground border-border'
             }`}
             title={autoRefresh ? 'Auto-refresh a cada 10s' : 'Clique para reativar auto-refresh'}
           >
-            <span className={`w-2 h-2 rounded-full ${autoRefresh ? 'bg-emerald-500 animate-pulse' : 'bg-zinc-400'}`} />
+            <span className={`w-2 h-2 rounded-full ${autoRefresh ? 'bg-success animate-pulse' : 'bg-muted-foreground'}`} />
             {autoRefresh ? 'Live (10s)' : 'Pausado'}
           </button>
         )}

--- a/resources/js/Pages/ads/Admin/Graph.tsx
+++ b/resources/js/Pages/ads/Admin/Graph.tsx
@@ -126,7 +126,7 @@ function nodeData(n: GraphNode, icon: ReactNode): any {
         <div className="text-xs">{icon}</div>
         <div className="font-semibold text-xs leading-tight">{n.data.label}</div>
         {lines.length > 0 && (
-          <div className="text-[9px] text-zinc-500 mt-0.5">{lines.join(' · ')}</div>
+          <div className="text-[9px] text-muted-foreground mt-0.5">{lines.join(' · ')}</div>
         )}
       </div>
     ),

--- a/resources/js/Pages/ads/Admin/MetaSkills.tsx
+++ b/resources/js/Pages/ads/Admin/MetaSkills.tsx
@@ -344,7 +344,7 @@ function MetaSkillEditor({ onClose }: { onClose: () => void }) {
           </div>
 
           {validation && (
-            <div className={`text-xs rounded p-2 border ${validation.ok ? 'bg-emerald-50 border-emerald-200' : 'bg-red-50 border-red-200'}`}>
+            <div className={`text-xs rounded p-2 border ${validation.ok ? 'bg-success-soft border-success/20' : 'bg-destructive-soft border-destructive/20'}`}>
               {validation.ok ? (
                 <>
                   <strong>✓ Condição válida:</strong> {validation.samples_matched}/{validation.samples_total} patterns matchariam.

--- a/resources/js/Pages/ads/Admin/Patterns.tsx
+++ b/resources/js/Pages/ads/Admin/Patterns.tsx
@@ -85,10 +85,10 @@ const Patterns: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ 
 
       {/* Candidatos a promoção */}
       {candidates.length > 0 && (
-        <Card className="border-emerald-500/30 bg-emerald-500/5">
+        <Card className="border-success/30 bg-success-soft">
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
-              <Lightbulb className="w-5 h-5 text-emerald-600" />
+              <Lightbulb className="w-5 h-5 text-success-fg" />
               Padrões prontos pra promoção
               <Badge className="ml-auto bg-emerald-600">{candidates.length}</Badge>
             </CardTitle>
@@ -109,7 +109,7 @@ const Patterns: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ 
                       LB {c.wilson_lower_bound.toFixed(3)}
                     </span>
                   </div>
-                  <p className="text-xs text-muted-foreground pl-2 border-l-2 border-emerald-300">
+                  <p className="text-xs text-muted-foreground pl-2 border-l-2 border-success/30">
                     {c.recommendation}
                   </p>
                 </li>

--- a/resources/js/Pages/ads/Admin/Policy.tsx
+++ b/resources/js/Pages/ads/Admin/Policy.tsx
@@ -50,9 +50,9 @@ const Policy: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ ru
         description="Regras imutáveis do firewall. Read-only — mudança só via PR no git, aprovado por Wagner (ARQ-0006)."
       />
 
-      <Card className="border-amber-500/30 bg-amber-500/5">
+      <Card className="border-warning/30 bg-warning-soft">
         <CardContent className="py-4 flex items-start gap-3">
-          <Lock className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+          <Lock className="w-5 h-5 text-warning-fg shrink-0 mt-0.5" />
           <div className="text-sm">
             <p className="font-medium">Firewall imutável</p>
             <p className="text-muted-foreground">

--- a/resources/js/Pages/ads/Admin/Skills/Edit.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Edit.tsx
@@ -63,7 +63,7 @@ const Edit: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
           </CardHeader>
           <CardContent className="space-y-2">
             {data.frontmatter_yaml !== frontmatterYaml && (
-              <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              <div className="rounded-md border border-warning/30 bg-warning-soft px-3 py-2 text-xs text-warning-fg">
                 ⚠️ <strong>Frontmatter modificado.</strong> Mudanças aqui são <em>alto-impacto</em>:
                 <code className="px-1">description</code> afeta auto-activation;
                 <code className="px-1">name</code> é a chave do matching. Confira antes de salvar.
@@ -73,7 +73,7 @@ const Edit: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
               value={data.frontmatter_yaml}
               onChange={e => setData('frontmatter_yaml', e.target.value)}
               rows={8}
-              className={`font-mono text-xs ${data.frontmatter_yaml !== frontmatterYaml ? 'border-amber-400 bg-amber-50/30' : ''}`}
+              className={`font-mono text-xs ${data.frontmatter_yaml !== frontmatterYaml ? 'border-warning bg-warning-soft/50' : ''}`}
               spellCheck={false}
             />
             {errors.frontmatter_yaml && (

--- a/resources/js/Pages/ads/Admin/Skills/Review.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Review.tsx
@@ -61,7 +61,7 @@ const Review: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ dr
       />
 
       {flash && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-900">
+        <div className="rounded-md border border-success/20 bg-success-soft px-4 py-2 text-sm text-success-fg">
           {flash}
         </div>
       )}
@@ -105,7 +105,7 @@ const Review: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ dr
                   {d.test_runs_count > 0 ? (
                     <span>Test runs: {d.test_runs_pass}/{d.test_runs_count} passed</span>
                   ) : (
-                    <span className="text-amber-600">⚠️ Sem test runs anexados</span>
+                    <span className="text-warning-fg">⚠️ Sem test runs anexados</span>
                   )}
                   <Link href={`/ads/admin/skills/${d.skill_slug}/test`} className="inline-flex items-center gap-1 text-primary hover:underline">
                     Testar primeiro <ExternalLink className="w-3 h-3" />

--- a/resources/js/Pages/ads/Admin/Skills/Test.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Test.tsx
@@ -71,7 +71,7 @@ const Test: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
       />
 
       {flash && (
-        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-900">
+        <div className="rounded-md border border-success/20 bg-success-soft px-4 py-2 text-sm text-success-fg">
           {flash}
         </div>
       )}
@@ -175,7 +175,7 @@ const Test: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
                     <span className="inline-flex items-center gap-1"><Clock className="w-3 h-3" /> {r.latency_ms ?? '?'}ms</span>
                     <span className="inline-flex items-center gap-1"><Hash className="w-3 h-3" /> {r.output_tokens ?? '?'} tokens</span>
                     {r.pii_count > 0 && (
-                      <span className="inline-flex items-center gap-1 text-amber-600">
+                      <span className="inline-flex items-center gap-1 text-warning-fg">
                         <ShieldAlert className="w-3 h-3" /> {r.pii_count} PII redactions
                       </span>
                     )}

--- a/resources/js/Pages/ads/Admin/Tools.tsx
+++ b/resources/js/Pages/ads/Admin/Tools.tsx
@@ -95,7 +95,7 @@ const Tools: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ too
               {recent_executions.map(e => (
                 <li key={e.id} className="px-4 py-2 text-sm flex items-center gap-3">
                   {e.ok
-                    ? <CheckCircle2 className="w-4 h-4 text-emerald-600" />
+                    ? <CheckCircle2 className="w-4 h-4 text-success-fg" />
                     : <XCircle className="w-4 h-4 text-destructive" />}
                   <code className="text-xs">{e.tool_name}</code>
                   {e.is_read_only && <Badge variant="outline" className="text-xs">read</Badge>}
@@ -207,16 +207,16 @@ function ToolCard({ tool }: { tool: ToolItem }) {
                 )}
               </Button>
               {! tool.is_read_only && (
-                <span className="text-xs text-amber-600 inline-flex items-center gap-1">
+                <span className="text-xs text-warning-fg inline-flex items-center gap-1">
                   <AlertTriangle className="w-3 h-3" /> Tool de escrita — confirmação será solicitada
                 </span>
               )}
             </div>
             {result && (
-              <div className={`text-xs rounded p-2 ${result.ok ? 'bg-emerald-50 border border-emerald-200' : 'bg-red-50 border border-red-200'}`}>
+              <div className={`text-xs rounded p-2 ${result.ok ? 'bg-success-soft border border-success/20' : 'bg-destructive-soft border border-destructive/20'}`}>
                 <div className="flex items-center gap-1 font-medium mb-1">
                   {result.ok
-                    ? <><CheckCircle2 className="w-3 h-3 text-emerald-600" /> OK</>
+                    ? <><CheckCircle2 className="w-3 h-3 text-success-fg" /> OK</>
                     : <><XCircle className="w-3 h-3 text-destructive" /> Erro</>}
                 </div>
                 <pre className="whitespace-pre-wrap break-all text-[10px]">{JSON.stringify(result, null, 2).slice(0, 2000)}</pre>

--- a/resources/js/Pages/kb/_components/BlockRenderer.tsx
+++ b/resources/js/Pages/kb/_components/BlockRenderer.tsx
@@ -34,16 +34,16 @@ const calloutToneIcon: Record<KbCalloutTone, typeof Info> = {
 };
 
 const calloutToneClass: Record<KbCalloutTone, string> = {
-  info: 'border-blue-500/30 bg-blue-500/5 text-blue-900 dark:text-blue-100',
-  ok: 'border-emerald-500/30 bg-emerald-500/5 text-emerald-900 dark:text-emerald-100',
-  warn: 'border-amber-500/30 bg-amber-500/5 text-amber-900 dark:text-amber-100',
+  info: 'border-info/30 bg-info/5 text-info-fg',
+  ok: 'border-success/30 bg-success/5 text-success-fg',
+  warn: 'border-warning/30 bg-warning/5 text-warning-fg',
   bad: 'border-destructive/40 bg-destructive/5 text-foreground',
 };
 
 const calloutIconClass: Record<KbCalloutTone, string> = {
-  info: 'text-blue-600 dark:text-blue-400',
-  ok: 'text-emerald-600 dark:text-emerald-400',
-  warn: 'text-amber-600 dark:text-amber-400',
+  info: 'text-info',
+  ok: 'text-success',
+  warn: 'text-warning',
   bad: 'text-destructive',
 };
 

--- a/resources/js/Pages/kb/_components/HealthPanel.tsx
+++ b/resources/js/Pages/kb/_components/HealthPanel.tsx
@@ -121,14 +121,14 @@ function Quadrant({
 }) {
   const toneClass = {
     bad: 'border-destructive/30 bg-destructive/5',
-    warn: 'border-amber-500/30 bg-amber-500/5',
-    ok: 'border-emerald-500/30 bg-emerald-500/5',
+    warn: 'border-warning/30 bg-warning/5',
+    ok: 'border-success/30 bg-success/5',
     default: 'border-border bg-muted/20',
   };
   const titleClass = {
     bad: 'text-destructive',
-    warn: 'text-amber-700 dark:text-amber-400',
-    ok: 'text-emerald-700 dark:text-emerald-400',
+    warn: 'text-warning-fg',
+    ok: 'text-success-fg',
     default: 'text-muted-foreground',
   };
 

--- a/resources/js/Pages/kb/_components/NodeList.tsx
+++ b/resources/js/Pages/kb/_components/NodeList.tsx
@@ -206,7 +206,7 @@ export default function NodeList({
                     </span>
                   )}
                   {outdated && (
-                    <span className="text-[9.5px] font-semibold lowercase text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40 px-1.5 py-px rounded-sm">
+                    <span className="text-[9.5px] font-semibold lowercase text-warning-fg bg-warning-soft px-1.5 py-px rounded-sm">
                       revisar
                     </span>
                   )}

--- a/resources/js/Pages/kb/_components/NodeReader.tsx
+++ b/resources/js/Pages/kb/_components/NodeReader.tsx
@@ -222,16 +222,16 @@ export default function NodeReader({
             </span>
           )}
           {outdated && (
-            <span className="text-[9.5px] font-semibold lowercase text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/40 px-1.5 py-px rounded-sm">
+            <span className="text-[9.5px] font-semibold lowercase text-warning-fg bg-warning-soft px-1.5 py-px rounded-sm">
               precisa revisão
             </span>
           )}
           <span
             className={cn(
               'inline-flex items-center gap-1 text-[10px] font-medium px-1.5 py-px rounded-sm',
-              fresh.level === 'fresh' && 'text-emerald-700 bg-emerald-100 dark:text-emerald-300 dark:bg-emerald-900/30',
+              fresh.level === 'fresh' && 'text-success-fg bg-success-soft',
               fresh.level === 'aging' && 'text-blue-700 bg-blue-100 dark:text-blue-300 dark:bg-blue-900/30',
-              fresh.level === 'stale' && 'text-amber-700 bg-amber-100 dark:text-amber-300 dark:bg-amber-900/30',
+              fresh.level === 'stale' && 'text-warning-fg bg-warning-soft',
               fresh.level === 'expired' && 'text-destructive bg-destructive/10',
             )}
             title={`Última atualização ${fmtRelative(node.updated_at)}`}
@@ -392,7 +392,7 @@ export default function NodeReader({
         <button
           type="button"
           onClick={onVoteOutdated}
-          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[11.5px] font-medium text-amber-700 dark:text-amber-300 hover:border-amber-500/40 hover:bg-amber-500/5"
+          className="inline-flex items-center gap-1.5 rounded-md border border-border bg-card px-2.5 py-1 text-[11.5px] font-medium text-warning-fg hover:border-warning/40 hover:bg-warning/5"
           title="Marcar como possivelmente desatualizado"
         >
           <AlertTriangle size={12} /> Desatualizado{' '}

--- a/resources/js/Pages/kb/_components/TroubleshooterDialog.tsx
+++ b/resources/js/Pages/kb/_components/TroubleshooterDialog.tsx
@@ -261,8 +261,8 @@ function WizardView({
                   className={cn(
                     'font-semibold shrink-0',
                     p.answer
-                      ? 'text-emerald-600 dark:text-emerald-400'
-                      : 'text-amber-700 dark:text-amber-400',
+                      ? 'text-success'
+                      : 'text-warning-fg',
                   )}
                 >
                   {p.answer ? 'Sim' : 'Não'}

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -311,7 +311,7 @@ function CcSessionsIndex(props: Props) {
                         <td className="py-1.5 px-2 align-top">
                           {s.status === 'active' && <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200 text-[10px]">ativa</Badge>}
                           {s.status === 'closed' && <Badge variant="outline" className="text-[10px]">fechada</Badge>}
-                          {s.status === 'archived' && <Badge variant="outline" className="bg-gray-50 text-gray-700 text-[10px]">arquivada</Badge>}
+                          {s.status === 'archived' && <Badge variant="outline" className="bg-muted text-muted-foreground text-[10px]">arquivada</Badge>}
                         </td>
                       )}
                     </tr>

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -89,7 +89,7 @@ function TaskCard({ task, onDragStart }: { task: Task; onDragStart: (id: string)
         {task.owner && <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">{task.owner}</span>}
         {task.estimate_h && <span className="text-[10px] text-muted-foreground">{task.estimate_h}h</span>}
         {task.blocked_by.length > 0 && (
-          <span className="text-[10px] text-red-500">blk:{task.blocked_by.join(',')}</span>
+          <span className="text-[10px] text-destructive">blk:{task.blocked_by.join(',')}</span>
         )}
       </div>
     </div>

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -622,7 +622,7 @@ function TokensListDialog({
         </DialogHeader>
 
         {loading && <div className="py-6 text-sm text-muted-foreground">Carregando tokens…</div>}
-        {error && <div className="py-6 text-sm text-red-600">{error}</div>}
+        {error && <div className="py-6 text-sm text-destructive-fg">{error}</div>}
         {!loading && !error && tokens && tokens.length === 0 && (
           <div className="py-8 text-center text-sm text-muted-foreground">
             Nenhum token registrado pra esse dev ainda.


### PR DESCRIPTION
## Adoção em massa do DS — varredura paralela + adversário (Wagner: *"fazer threads, cobrir muito mais espaço"*)

Pipeline de 3 fases, **todas multi-agente em paralelo** (ondas de 4, gentil com o rate-limit do servidor):

| Fase | Threads | Resultado |
|---|---|---|
| **1 · Varredura** | 35 (1/módulo) | auditou `Pages/**` via origin/main, classificou cada cor: **360 propostos · 190 categoria · 169 incertos** (2.241 hits / 201 arquivos) |
| **2 · Adversário** | 33 | cético refutou cada um contra origin/main → kept 320 + fix 6, **REJEITOU 33 (~9%)** |
| **3 · Aplicação** | script | **329 edits, 132 arquivos, 0 miss** |

### Mapeamento (ESTADO → token)
`emerald/green→success` · `amber/yellow→warning` · `rose/red→destructive` · `blue/sky→info` (só info-state) · `stone/slate/gray→muted`. Token carrega light+dark → caem os `dark:` crus.

### PRESERVADO (categoria — o adversário e a varredura concordaram em manter cru)
Rainbows de status-map · accents de marca (violet/orange/etc) · séries de gráfico (hex) · skins de prototipo-ui.

## Prova (não na palavra — no verde do placar)
- ✅ **build** (2m10s, 132 arquivos compilam, tokens resolvem)
- ✅ **eslint baseline delta -189** sem regressão
- ✅ **conformance** + **ds-canon-color-guard** (a catraca da M1)
- 🎁 removido 1 `eslint-disable` morto em Manufacturing (tokenizar tornou a supressão de cor-crua desnecessária)

## Fora deste PR (deliberado)
- **169 INCERTOS** (skins de protótipo coesas, blue ambíguo, amber entrelaçado com tom de categoria) → **teu olho na app rodando**.
- **33 REJEITADOS** pelo adversário (categoria disfarçada, old não-único, visual arriscado).

Refs: DS-MATURIDADE (adoção pós-M1) · [ADR 0276](../blob/main/memory/decisions/0276-decisao-pelo-fluxo-classes-pares-adversariais.md) (pares adversariais) · #2639

🤖 Generated with [Claude Code](https://claude.com/claude-code)