### PR TITLE
fix(whatsapp): typo $i_ no AuthStateDriftCheckTest derrubava regression-guard Baileys (LC-bug-2)

### DIFF
--- a/Modules/Whatsapp/Tests/Feature/AuthStateDriftCheckTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AuthStateDriftCheckTest.php
@@ -68,7 +68,7 @@ function makeAuthStateRow(string $instanceId, int $count = 1, ?\Carbon\Carbon $u
     for ($i = 0; $i < $count; $i++) {
         DB::table('whatsapp_baileys_auth_state')->insert([
             'instance_id' => $instanceId,
-            'key_id' => "key_$i_" . uniqid(),
+            'key_id' => "key_{$i}_" . uniqid(),
             'value_encrypted' => null,
             'updated_at' => $updatedAt,
         ]);


### PR DESCRIPTION
## Contexto

Burn-down Fase 2b SDD · **LC-bug-2** da [triage Q2](memory/sessions/2026-06-13-sdd-f2b-triage-q2.md) (§3 — bugs confirmados).

## Problema

`Modules/Whatsapp/Tests/Feature/AuthStateDriftCheckTest.php:71` interpolava `"key_$i_"`. O PHP lê `$i_` como a variável **`i_`** (o `_` é caractere de identificador válido), que é undefined → `ErrorException: Undefined variable $i_` no harness de teste do Laravel, **derrubando todos os `it()` que chamam `makeAuthStateRow`** (R-WA-AUTH-DRIFT-01..05).

## Fix

`"key_$i_"` → `"key_{$i}_"` — delimita a variável de loop com chaves. 1 linha.

## Por que consertar (e não quarentenar)

Esse arquivo está explicitamente na lista **NÃO-quarentenar** da triage Q2 — é o `AUTH-DRIFT-CONV`, regression-guard do incident real Baileys 6.7.18→7.0.0 (2026-05-15, "failed to find key to decode mutation"). Silenciá-lo reabriria o risco de drift silencioso.

## Verificação

- ✅ `php -l` limpo.
- Semântica de interpolação PHP (`$i_` = variável `i_`, não `$i` + `_`) — fix de altíssima confiança, sem dependência de runtime.
- ⏳ Validação funcional = re-run do nightly CT 100.

## Não-objetivo

A triage mencionou um "NullDriver" junto deste cluster — **não há** referência a NullDriver no command nem no teste (grep limpo). Este PR fecha só o `$i_`, que é a causa real dos fails deste arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)