### PR TITLE
test(fsm): alinha spec #1 ao texto atual da mensagem fail-secure (LC-bug-4)

### DIFF
--- a/tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php
+++ b/tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php
@@ -164,13 +164,13 @@ it('1. action is_critical=true SEM role cadastrada bloqueia execução (fail-sec
         'key' => 'reabrir_para_revisao',
         'label' => 'Reabrir para revisão',
         'target_stage_id' => $e->id,
-        'is_critical' => true, // FALHA HOJE — campo não existe
+        'is_critical' => true, // coluna criada por 2026_05_12_010001_add_is_critical_to_sale_stage_actions
     ]);
 
     $subject = fsmCriticalSubject(1, $a->id);
 
     expect(fn () => (new ExecuteStageActionService)->execute($subject, 'reabrir_para_revisao', fsmCriticalUser(1)))
-        ->toThrow(UnauthorizedActionException::class, 'crítica e exige role explícita');
+        ->toThrow(UnauthorizedActionException::class, 'exige role configurada');
 
     // current_stage_id permanece — transação rollback
     expect($subject->fresh()->current_stage_id)->toBe($a->id);


### PR DESCRIPTION
## Contexto

Burn-down Fase 2b SDD · **LC-bug-4** da [triage Q2](memory/sessions/2026-06-13-sdd-f2b-triage-q2.md). Estudo de causa-raiz completo: [memory/sessions/2026-06-13-estudo-bug3-bug4-triage-q2.md](memory/sessions/2026-06-13-estudo-bug3-bug4-triage-q2.md).

## Correção do diagnóstico da triage

A triage marcou isto como **"fail-secure quebrado — UnauthorizedActionException not thrown — prioridade de segurança"**. **Falso.** Tracei caminho a caminho:

- `is_critical` persiste (migration `2026_05_12_010001` cria `boolean default false`; model tem cast `bool` + `$guarded=['id']`).
- `StageActionPolicy::grantsByPermission` retorna `false` pro subject do teste (`FsmCriticalTestSubject` não está no allowlist `SUBJECT_UPDATE_PERMISSION` — só `ServiceOrder`). Sem fail-open.
- `ExecuteStageActionService:93` **lança** `UnauthorizedActionException` quando `crítico && sem role && sem permission`. **O fail-secure FUNCIONA.**

O spec #1 falhava só porque esperava o substring **`'crítica e exige role explícita'`**, mas a mensagem atual (reescrita em US-SELL-031 + ADR 0265) é **`"Action crítica '...' exige role configurada em sale_stage_action_roles..."`**. A exception é lançada — a asserção é que estava com texto velho.

## Mudança

- Linha 173: `'crítica e exige role explícita'` → `'exige role configurada'` (substring verbatim da mensagem atual).
- Linha 167: comentário stale `// FALHA HOJE — campo não existe` → cita a migration que já criou `is_critical`.

**Zero mudança em código de produto** — ele está correto.

## Verificação

- ✅ `php -l` limpo.
- ✅ Substring novo é verbatim da mensagem lançada (alta confiança).
- ⏳ Se este teste rodar no CI do PR, valida aqui; senão, confirmação final = re-run do nightly CT 100. **Ressalva honesta:** a triage citou "2 fails" neste cluster; minha leitura fecha 1 (spec #1, mensagem). Um eventual 2º fail seria artefato de env (migration MySQL-only no sqlite), resolvido pelo fix de harness C1 — fora do escopo deste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)