### PR TITLE
fix(whatsapp): dispara CSAT na transição open→resolved do inbox (US-GOV-019)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -22,6 +22,7 @@ use Modules\Whatsapp\Entities\ChannelUserAccess;
 use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\Tag;
+use Modules\Whatsapp\Jobs\DispatchCsatJob;
 use Modules\Whatsapp\Jobs\SendInteractiveJob;
 use Modules\Whatsapp\Jobs\SendMediaJob;
 use Modules\Whatsapp\Services\Centrifugo\CentrifugoTokenIssuer;
@@ -1056,6 +1057,10 @@ class InboxController extends Controller
             'bot_handling' => ['nullable', 'boolean'],
         ]);
 
+        // Captura status ANTES da mutação pra detectar a transição → resolved
+        // (CSAT dispara só na transição, não em re-save de conversa já resolvida).
+        $previousStatus = $conversation->status;
+
         if (isset($payload['status'])) {
             $conversation->status = $payload['status'];
         }
@@ -1066,6 +1071,22 @@ class InboxController extends Controller
             $conversation->bot_handling = (bool) $payload['bot_handling'];
         }
         $conversation->save();
+
+        // US-GOV-019: pesquisa CSAT pós-resolução. Dispara SOMENTE na transição
+        // !resolved → resolved (não em re-save de conversa já resolvida). Job em
+        // fila carrega business_id explícito (Tier 0 ADR 0093 — fila sem session)
+        // e CsatDispatcher é idempotente (no-op se já há pending nas últimas 24h).
+        if (
+            isset($payload['status'])
+            && $payload['status'] === Conversation::STATUS_RESOLVED
+            && $previousStatus !== Conversation::STATUS_RESOLVED
+        ) {
+            DispatchCsatJob::dispatch(
+                businessId: $businessId,
+                conversationId: (int) $conversation->id,
+                resolvedBy: $userId,
+            );
+        }
 
         return back()->with('success', 'Conversa atualizada.');
     }


### PR DESCRIPTION
## Bug (re-triage eixo FAILURE — US-GOV-019)

`InboxController::updateStatus` (`Modules/Whatsapp/Http/Controllers/Admin/InboxController.php`, ~L1042-1071) persiste o novo status da conversa mas **nunca enfileira `DispatchCsatJob`**. A pesquisa CSAT pós-resolução (PR-6 CYCLE-07) está toda implementada — `DispatchCsatJob`, `CsatDispatcher::dispatchOnResolve`, `CsatResponseParser` — e exercitada pelos testes de unidade (Test 1-6 do `CsatFlowTest`), mas o **gatilho de produção** (atendente marca a conversa como resolvida na Caixa Unificada) nunca foi conectado. Resultado: nenhuma pesquisa CSAT era disparada em produção.

## Fix (mínimo — 1 intent, 21 linhas)

- Captura `$previousStatus` **antes** da mutação.
- Enfileira `DispatchCsatJob` **somente** na transição `!resolved → resolved` (guarda de transição — re-save de conversa já resolvida não redispara).
- Job recebe `business_id` **explícito** (Tier 0 ADR 0093 — fila não tem `session()`), `conversation_id` e `resolvedBy`. Espelha o padrão de dispatch já usado no controller (`SendMediaJob`/`SendInteractiveJob`).
- Idempotência defesa-em-profundidade: `CsatDispatcher::dispatchOnResolve` já é no-op se houver `CsatResponse` pending nas últimas 24h, então cliques repetidos no botão "resolver" não duplicam.

## Teste confirmante

`Modules/Whatsapp/Tests/Feature/CsatFlowTest.php` (dois casos que hoje falham e passam a passar):

1. **`updateStatus → resolved dispara DispatchCsatJob (Bus::fake)`** — assert que o job é despachado com `businessId === 1`, `conversationId === $conv->id`, `resolvedBy === 1`. Conv nasce `open` → `previousStatus='open'` → dispara. ✅
2. **`updateStatus → resolved 2x dispara Job só na transição (não duplica)`** — conv já está `resolved`; `Bus::assertNotDispatched`. `previousStatus='resolved'` → guarda bloqueia. ✅

## Multi-tenant (Tier 0 ADR 0093)

`business_id` vem de `session('user.business_id')`; o `findOrFail` já é scoped por `business_id`; o job carrega o tenant explícito e o `CsatDispatcher` usa `withoutGlobalScope` filtrando por `business_id` da própria conversa. Sem vazamento cross-tenant.

## Nota de teste

Suíte Pest **não rodada localmente** (execução CT100-only — hook bloqueia local). Confirmação por leitura do `CsatFlowTest` + assinatura do `DispatchCsatJob` (props públicas `businessId`/`conversationId`/`resolvedBy`).

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)