### PR TITLE
test(vestuario): conserta Pest Vestuario red — assertions corrompidas por redação Tier-0 (#2673 follow-up)

### DIFF
--- a/Modules/Vestuario/Tests/Feature/UsVest020EtiquetaTagControllerTest.php
+++ b/Modules/Vestuario/Tests/Feature/UsVest020EtiquetaTagControllerTest.php
@@ -225,7 +225,7 @@ it('blade vestuario::etiquetas.pdf compila e renderiza HTML válido', function (
     expect($html)->toContain('TAM:</strong> M');
     expect($html)->toContain('Azul');
     expect($html)->toContain('Verão 2026');
-    expect($html)->toContain('R$ [redacted Tier 0]');
+    expect($html)->toContain('R$ 49,90');
     expect($html)->toContain('7891000000014');
     expect($html)->toContain('CAMI-001-M-AZU');
     expect($html)->toContain('biz #1');

--- a/Modules/Vestuario/Tests/Feature/W27EtiquetaGradeTest.php
+++ b/Modules/Vestuario/Tests/Feature/W27EtiquetaGradeTest.php
@@ -96,7 +96,7 @@ it('gerarEtiqueta retorna ZPL com campos obrigatórios', function () {
             'colecao' => 'Verão 2026',
             'preco'   => 89.90,
             'sku'     => 'CAMI-042-M-AZU',
-            'businessId' => 4,
+            'businessId' => 1,
         ]
     );
 
@@ -106,7 +106,7 @@ it('gerarEtiqueta retorna ZPL com campos obrigatórios', function () {
     expect($result['zpl'])->toContain('TAM: M');
     expect($result['zpl'])->toContain('COR: Azul Marinho');
     expect($result['zpl'])->toContain('Verão 2026');
-    expect($result['zpl'])->toContain('R$ [redacted Tier 0]');
+    expect($result['zpl'])->toContain('R$ 89,90');
     expect($result['zpl'])->toContain('^BEN'); // EAN-13 barcode marker
     expect($result['zpl'])->toContain($result['ean13']);
     expect($result['zpl'])->toContain('CAMI-042-M-AZU');
@@ -114,7 +114,7 @@ it('gerarEtiqueta retorna ZPL com campos obrigatórios', function () {
     expect(strlen($result['ean13']))->toBe(13);
     expect($svc->validateEan13($result['ean13']))->toBeTrue();
 
-    expect($result['meta']['business_id'])->toBe(4);
+    expect($result['meta']['business_id'])->toBe(1);
     expect($result['meta']['product_id'])->toBe(42);
 });
 


### PR DESCRIPTION
## Contexto

PR #2673 (cria `Modules/Vestuario/Http/Controllers/DataController.php`) **mergeou com o check `Pest Vestuario` vermelho** (2 failed). A falha NÃO era do DataController — era corrupção de fixture nos testes, agora já em `main`. Este PR restaura o check pra verde.

## Causa-raiz

Um processo de redação Tier-0 substituiu literais de assertion pelo placeholder `[redacted Tier 0]`, e deixou `business_id=4` (cliente REAL RotaLivre — violação Tier 0) num fixture.

## Mudanças (só testes — código de produto intacto)

| Arquivo | Linha | Antes | Depois | Por quê |
|---|---|---|---|---|
| `W27EtiquetaGradeTest.php` | 109 | `'R$ [redacted Tier 0]'` | `'R$ 89,90'` | input `preco 89.90` → `number_format(89.90,2,',','.')` no `EtiquetaTagService::buildZpl` |
| `W27EtiquetaGradeTest.php` | 99 | `'businessId' => 4` | `'businessId' => 1` | biz=4 é cliente real → Tier 0; biz=1 é tenant canônico de teste |
| `W27EtiquetaGradeTest.php` | 117 | `->toBe(4)` (meta.business_id) | `->toBe(1)` | coerência com input |
| `UsVest020EtiquetaTagControllerTest.php` | 228 | `'R$ [redacted Tier 0]'` | `'R$ 49,90'` | input `preco 49.90` renderizado pelo blade `vestuario::etiquetas.pdf` (`number_format`) |

## Deixado intacto (legítimo, NÃO corrupção)

- `W27EtiquetaGradeTest.php:40` `->toBe(4)` — é o **check digit EAN-13** (GS1), documentado no comentário acima. Não é business_id.
- `Wave25/Wave27 SaturationTest` `'business_id' => 4` — strings dentro de **testes-guarda** que asseguram que o código NÃO usa biz=4. São a defesa contra essa exata violação.
- `EtiquetaTagService.php:263` — `R$ [redacted Tier 0]` num **docblock ilustrativo** (não-funcional; formatação real é `number_format` na linha 282). Código de produto — não tocado per instrução. **Vale um cleanup cosmético separado.**

## Validação

- `php -l` limpo nos 2 arquivos (Pest é CT100-only, não rodado local).
- CI `Pest Vestuario` deve passar — as 2 únicas falhas (`W27EtiquetaGradeTest` + `UsVest020EtiquetaTagControllerTest`) eram exatamente estas assertions.

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)