### PR TITLE
test: restaura assertions corrompidas por redação Tier-0 (fd96258ae)

### DIFF
--- a/Modules/RecurringBilling/Tests/Feature/InvoiceGeneratorServiceTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/InvoiceGeneratorServiceTest.php
@@ -284,5 +284,5 @@ test('8. Logga SubscriptionEvent kind=event-charge', function () {
     expect($event->kind)->toBe(SubscriptionEvent::KIND_CHARGE);
     expect($event->by_actor)->toBe('system:rb:generate-invoices');
     expect($event->body)->toContain('Fatura RB-');
-    expect($event->body)->toContain('R$ [redacted Tier 0]');
+    expect($event->body)->toContain('R$ 100,00');
 });

--- a/tests/Feature/Modules/Copiloto/ChatCopilotoAgentContextoNegocioTest.php
+++ b/tests/Feature/Modules/Copiloto/ChatCopilotoAgentContextoNegocioTest.php
@@ -72,9 +72,9 @@ it('com ctx Larissa, instructions inclui empresa + faturamento (3 ângulos) + cl
     expect($prompt)->toContain('LÍQUIDO');
     expect($prompt)->toContain('CAIXA');
     // Marcador de mês (2026-03 com 3 valores distintos: bruto/líquido/caixa)
-    expect($prompt)->toContain('2026-03: bruto R$ [redacted Tier 0] · líquido R$ [redacted Tier 0] · caixa R$ [redacted Tier 0]');
+    expect($prompt)->toContain('2026-03: bruto R$ 38.215,07 · líquido R$ 37.518,47 · caixa R$ 35.440,25');
     expect($prompt)->toContain('METAS ATIVAS');
-    expect($prompt)->toContain('Faturamento mensal: alvo R$ [redacted Tier 0] / realizado R$ [redacted Tier 0]');
+    expect($prompt)->toContain('Faturamento mensal: alvo R$ 80.000,00 / realizado R$ 31.513,29');
     expect($prompt)->toContain('MÓDULOS ATIVOS: Copiloto, Financeiro');
 });
 
@@ -94,9 +94,9 @@ it('MEM-FAT-1 — quando bruto≠líquido, o LLM vê 3 números distintos (não 
     $prompt = (string) $agent->instructions();
 
     // Os 3 valores devem aparecer literalmente — LLM NÃO pode reportar bruto pra "caixa"
-    expect($prompt)->toContain('R$ [redacted Tier 0]'); // bruto
-    expect($prompt)->toContain('R$ [redacted Tier 0]'); // líquido
-    expect($prompt)->toContain('R$ [redacted Tier 0]'); // caixa
+    expect($prompt)->toContain('R$ 38.215,07'); // bruto
+    expect($prompt)->toContain('R$ 37.518,47'); // líquido
+    expect($prompt)->toContain('R$ 35.440,25'); // caixa
     // Glossário no prompt deixa claro o que é cada um
     expect($prompt)->toContain('BRUTO    = total vendido');
     expect($prompt)->toContain('LÍQUIDO  = bruto menos devoluções');
@@ -121,7 +121,7 @@ it('MEM-FAT-1 BC-compat — registro antigo só com `valor` ainda funciona (fall
     $prompt = (string) $agent->instructions();
 
     // Fallback: bruto=liquido=caixa=valor (todos iguais ao único número disponível)
-    expect($prompt)->toContain('2026-01: bruto R$ [redacted Tier 0] · líquido R$ [redacted Tier 0] · caixa R$ [redacted Tier 0]');
+    expect($prompt)->toContain('2026-01: bruto R$ 4.140,82 · líquido R$ 4.140,82 · caixa R$ 4.140,82');
 });
 
 it('com ctx + memoria recall, ambos aparecem (ordem: base → ctx → memoria)', function () {


### PR DESCRIPTION
## Problema sistêmico

Um processo de **redação Tier-0** (que troca valores monetários pelo token `[redacted Tier 0]`) atingiu **assertions de teste** — substituiu literais reais (ex preço, total de fatura, faturamento de fixture) pelo token DENTRO de arquivos `.php` de teste, garantindo `ExpectationFailed` e contribuindo pro floor de falhas.

### Mecanismo confirmado + raio do `fd96258ae`

- `fd96258ae` ("restaura codebase apagado pelo squash do #2413") restaurou a árvore EXATA de `2bad43e` (#2412) — **14.969 arquivos** (`git show --stat`). Esse snapshot **já estava redactado**, então o commit re-propagou os tokens pro `main`.
- **Origem real é anterior:** os arquivos corrompidos nasceram redactados. Ex: `NumUfHeuristicPtBRTest.php` já trazia o token em `70e89d8f1` (#2279), antes do #2413. Nenhuma versão limpa existe em **nenhum ref** do git (`git rev-list --all` + scan de blobs = 0 hits) → a redação ocorreu na working tree ANTES do primeiro commit desses arquivos. `fd96258ae` foi o vetor de **reintrodução** no main, não a causa-raiz.

## Escopo total mapeado

`[redacted Tier 0]` em **~42 arquivos / ~115 ocorrências** sob `Modules/**/Tests/**` e `tests/**`. A esmagadora maioria é **cosmética** (comentário, título de `it()`, arg de mensagem de assert, ou string round-trip self-consistente) → **teste fica VERDE**. Só quebram o floor as ocorrências em **posição de assertion comparada** contra dados de fixture intactos.

### Classificação (fora Vestuario)

| arquivo:linha | 🔴/🟢 | valor original recuperado | fonte |
|---|---|---|---|
| `tests/.../Copiloto/ChatCopilotoAgentContextoNegocioTest.php:75` | 🔴 CORRIGIDO | `bruto R$ 38.215,07 · líquido R$ 37.518,47 · caixa R$ 35.440,25` | fixture `ctxLarissa()` L39 + `number_format($x,2,',','.')` (ChatCopilotoAgent L96-100) |
| `…ChatCopilotoAgentContextoNegocioTest.php:77` | 🔴 CORRIGIDO | `alvo R$ 80.000,00 / realizado R$ 31.513,29` | fixture L45 + agent L108-110 |
| `…ChatCopilotoAgentContextoNegocioTest.php:97-99` | 🔴 CORRIGIDO | `R$ 38.215,07` / `R$ 37.518,47` / `R$ 35.440,25` | fixture L86 (3 ângulos distintos) |
| `…ChatCopilotoAgentContextoNegocioTest.php:124` | 🔴 CORRIGIDO | `bruto R$ 4.140,82 · líquido R$ 4.140,82 · caixa R$ 4.140,82` | fixture L113 + fallback bruto=liquido=caixa |
| `Modules/RecurringBilling/.../InvoiceGeneratorServiceTest.php:287` | 🔴 CORRIGIDO | `R$ 100,00` | `makePlan(1, 100.0)` L277 + `InvoiceGeneratorService` L181-184 |
| `…ChatCopilotoAgentContextoNegocioTest.php:128/139` | 🟢 | (round-trip — `$memoria` injetado e asserido com o mesmo literal; verde) | — |
| `Modules/.../SemanticCacheServiceTest.php` (10×) | 🟢 | round-trip `gravar`→`buscar` mesmo literal; cache não parseia valor | — |
| `tests/.../MemoriaControllerTest.php` (5×), `MemoriaContratoTest.php` (6×), `BridgeMemoriaChatTest.php` (3×), `MetricasApuradorTest.php` (1×) | 🟢 | memória NullDriver armazena/retorna verbatim; valor não asserido | — |
| `Modules/Jana/.../BriefDiarioServiceTest.php` (8×), `BriefDiarioAgentTest.php` (1×), `Ai/Advisor/ProximaPerguntaServiceTest.php` (1×), `Ai/Clarify/Clarificador…`+`ClarifyCascade…` (3×), `Memoria/PesoRealRetrievalTest.php` (1×), `BriefDiarioChatTriggerTest.php` (1×) | 🟢 | comentário / fake-agent fixture / valor não asserido | — |
| `Modules/ComunicacaoVisual/.../OrcamentoCalculatorTest.php` (8×) | 🟢 | comentários + títulos de `it()`; literais numéricos (60.00/45.00/80.00…) intactos | — |
| `Modules/OficinaAuto/…` (ServiceOrderPrint/Observer/RichSheet, 5×) | 🟢 | comentários; assert usa `toMatch('/R\$\s*300[,.]00/')` intacto | — |
| `Modules/PaymentGateway/…CnabDriverTest` + `CnabRetornoProcessorTest` (7×) | 🟢 | comentário após `valorCentavos: 17550/25000/10000` (numérico intacto) | — |
| `Modules/Financeiro/…` (Cobranca/Fluxo/TituloRepo/UnificadoKpi, 4×) | 🟢 | título de `it()` / arg de msg de assert / docblock; valor comparado intacto | — |
| `Modules/Fiscal/…SpedMotor…:167` | 🟢 | arg de mensagem de `toBe(180.0, '…')`; valor `180.0` intacto | — |
| `Modules/KB/…KbRagService…:113`, `Officeimpresso/…Wave28…:17` | 🟢 | comentário/docblock | — |
| `Modules/RecurringBilling/…LgpdComplianceTest:81` | 🟢 | input do PiiRedactor; asserts checam EMAIL/PHONE, não o valor | — |
| `Modules/RecurringBilling/…RecurringV975SchemaTest:232` | 🟢 | fixture `body` inserida; teste asserta `kind`/count, não o body | — |
| `tests/Feature/Domain/Fsm/TransactionDocumentTest.php` (2×), `tests/Feature/Sells/SellsCreatePageTest.php` (3×), `tests/Contract/Fixtures/*` (2×), `tests/Unit/Utils/IncidentValorInfladoNumUfTest.php:17` | 🟢 | comentários/docblocks/títulos | — |

## ⚠️ Incertos — decisão Wagner (NÃO corrigidos, sem chute)

**`tests/Unit/Utils/NumUfHeuristicPtBRTest.php`** — 🔴 **funcional** (4 ocorrências), mas os **inputs do dataset foram redactados** e o formato exato é ambíguo:

- **L84 + L152** → esperado `2500.80`. Recuperável com confiança: **`'R$ 2.500,80'`** (o próprio comentário do código de produto `app/Utils/Util.php:49` documenta `"R$ 2.500,80" → 2500.80`).
- **L83 e L85** → ambos esperado `80.0`, grupo "símbolo de moeda + espaços". Múltiplas strings produzem 80.0 (`'R$ 80,00'`, `'R$ 80'`, …). O alinhamento de whitespace das keys (15 vs 18 espaços) indica que eram **strings diferentes** entre si. **Não dá pra reconstruir o exato sem chutar** → deixado pra Wagner. Como restaurar só L84/152 deixaria o arquivo ainda vermelho (L83/85), preferi **não tocar** o arquivo neste PR.

Sugestão pra Wagner: confirmar se L83=`'R$ 80,00'` e L85=`'R$ 80'` (ou as variantes reais que o teste pretendia cobrir).

## Zona de colisão

**`Modules/Whatsapp/Tests/**`** verificado: **zero ocorrências** do token → sem corrupção, sem conflito com a sessão que mexe no cluster Whatsapp.

## Estimativa de floor

Este PR remove **7 assertions vermelhas** em **2 arquivos de teste** (2 testes do `ChatCopilotoAgentContextoNegocioTest` + 1 do `InvoiceGeneratorServiceTest` ficam verdes; obs: várias assertions corrigidas estão no mesmo teste). **NumUfHeuristicPtBRTest** (1-2 testes adicionais) fica pendente da decisão Wagner sobre L83/85.

## Notas

- `php -l` OK nos 2 arquivos. Suíte **não rodada** (CT100-only).
- Produto (`app/Utils/Util.php`, `MeilisearchDriver`, `SellController`, migrations, templates NfeBrasil, etc.) **não tocado** — lá o token aparece só em **comentários** (legítimo/cosmético) ou é a saída real da feature de redação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
