### PR TITLE
fix(design): corrige link local quebrado no DESIGN.md (§16.8)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -367,7 +367,7 @@ Antes de criar componente custom, **buscar** em `resources/js/Components/`. Patt
 
 ### 16.8. Anti-padrões V2 (testes Pest CI varre)
 
-- ❌ `<AppShell>` sem V2 ([preferência](memory/claude/preference_persistent_layouts.md))
+- ❌ `<AppShell>` sem V2 (use o shell canônico [`AppShellV2.tsx`](resources/js/Layouts/AppShellV2.tsx))
 - ❌ `sessionStorage` (use `localStorage` com prefixo `oimpresso.`)
 - ❌ `bg-(gray|indigo|purple|pink|yellow|red|green)-[0-9]+`
 - ❌ `font-bold/extrabold/black` em h1-h3


### PR DESCRIPTION
## Bug — US-GOV-019: DESIGN.md link local quebrado

O teste `DesignEntryPointAndTombstonesTest` assertion **(a) HARD** exige que **todo link markdown LOCAL do `DESIGN.md`** (a "porta da frente" do design) resolva pra um arquivo existente. Estava falhando por **1 link órfão**.

### Link quebrado
Em **§16.8 Anti-padrões V2**:
```
- ❌ `<AppShell>` sem V2 ([preferência](memory/claude/preference_persistent_layouts.md))
```
O alvo `memory/claude/preference_persistent_layouts.md` foi **DELETADO** (não movido) no PR **#2383** — purga do legado `memory/claude/` (auto-mem pré-ADR 0061). O ponteiro ficou órfão.

### Correção
Alvo foi deletado, então **não é caso de tombstone** (a assertion (b) cuida de lápides em `_DesignSystem/`, não de links da porta). Repointo pro shell canônico vivo, que é semanticamente o que o próprio anti-padrão recomenda ("use o V2"):
```
- ❌ `<AppShell>` sem V2 (use o shell canônico [`AppShellV2.tsx`](resources/js/Layouts/AppShellV2.tsx))
```
`resources/js/Layouts/AppShellV2.tsx` já é referenciado em §6.5 do mesmo `DESIGN.md`.

### Validação
Replica estática exata do teste (mesmo regex `\]\(([^)]+)\)` + mesma checagem de existência relativa à raiz, mesmas exceções http/#/mailto): **0 links locais quebrados** após o fix. Assertion (b) intocada (não toquei `memory/requisitos/_DesignSystem/`).

Escopo: **só `DESIGN.md`** (1 linha). commit-discipline ✓

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)