### PR TITLE
fix(nfse): instrumenta cancelar() com OtelHelper::spanBiz nfse.cancelar (D9 Wave 28)

### DIFF
--- a/Modules/NFSe/Services/NfseEmissaoService.php
+++ b/Modules/NFSe/Services/NfseEmissaoService.php
@@ -200,9 +200,12 @@ class NfseEmissaoService
         // OtelHelper::spanBiz — observability webservice prefeitura SOAP cancelamento
         // (HTTP externo p99 crítico igual emissão). D9 Wave 28: span `nfse.cancelar`
         // na mesma família `nfse.*` do emitir, business_id do tenant (Tier 0).
+        // 3º arg = $extras (array<string,mixed>): tenant_id base já é auto-resolvido
+        // dentro do spanBiz; aqui anexamos o business_id da nota (cancelar pode rodar
+        // em job sem sessão, onde a auto-resolução cai em 0).
         OtelHelper::spanBiz('nfse.cancelar', function () use ($emissao, $motivo) {
             $this->cancelarInterno($emissao, $motivo);
-        }, $emissao->business_id);
+        }, ['nfse.business_id' => $emissao->business_id]);
     }
 
     private function cancelarInterno(NfseEmissao $emissao, string $motivo): void

--- a/Modules/NFSe/Services/NfseEmissaoService.php
+++ b/Modules/NFSe/Services/NfseEmissaoService.php
@@ -197,6 +197,16 @@ class NfseEmissaoService
 
     public function cancelar(NfseEmissao $emissao, string $motivo): void
     {
+        // OtelHelper::spanBiz — observability webservice prefeitura SOAP cancelamento
+        // (HTTP externo p99 crítico igual emissão). D9 Wave 28: span `nfse.cancelar`
+        // na mesma família `nfse.*` do emitir, business_id do tenant (Tier 0).
+        OtelHelper::spanBiz('nfse.cancelar', function () use ($emissao, $motivo) {
+            $this->cancelarInterno($emissao, $motivo);
+        }, $emissao->business_id);
+    }
+
+    private function cancelarInterno(NfseEmissao $emissao, string $motivo): void
+    {
         if ($emissao->isCancelada()) {
             throw new \Modules\NFSe\Exceptions\NfseJaCanceladaException($emissao->numero ?? '');
         }


### PR DESCRIPTION
## O que

Adiciona instrumentação OpenTelemetry ao método `NfseEmissaoService::cancelar()`, que chamava o webservice SOAP da prefeitura sem span — gap D9 (observability, Wave 28) detectado pelo `Wave28NfsePolishTest`.

## Por que

O cancelamento de NFSe tem p99 crítico igual à emissão (HTTP externo / SOAP prefeitura). Sem span, o cancelamento ficava invisível no tracing.

## Como

- Extrai o corpo de `cancelar()` para `cancelarInterno()` (private).
- Envolve em `OtelHelper::spanBiz('nfse.cancelar', ...)` passando `business_id` do tenant (Tier 0), espelhando o padrão do método gêmeo `emitir()` (span `nfse.emissao`).
- O service agora tem >=2 spans da família `nfse.*`.

## Testes (Wave28NfsePolishTest) — agora satisfeitos

- `D9 +1 span: cancelar() envolve em OtelHelper::spanBiz nfse.cancelar` (espera `OtelHelper::spanBiz('nfse.cancelar'`)
- `D9 +1 span: total spans canon nfse.* >= 2`
- (os assertions D2 cross-tenant de `business_id` já passavam — 3 sites de log preservados)

`php -l` OK. Suíte NÃO rodada localmente (CT100-only).

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)