### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — KB/Financeiro/NfeBrasil (US-GOV-019)

### DIFF
--- a/Modules/Financeiro/Services/TituloAutoService.php
+++ b/Modules/Financeiro/Services/TituloAutoService.php
@@ -686,6 +686,7 @@ class TituloAutoService
             return null;
         }
 
+        // SUPERADMIN: sync CashRegister sem session — business_id deduzido do CashRegister recebido
         // P1 — idempotência (já lançado)
         $existente = Titulo::withoutGlobalScopes()
             ->where('business_id', $cr->business_id)
@@ -705,6 +706,7 @@ class TituloAutoService
         // P4 — detect location via primeira transaction linked
         $location = $this->detectLocationFromCashRegister($cr);
 
+        // SUPERADMIN: sync CashRegister sem session — conta-mãe filtrada por business_id do CashRegister
         // R3 — conta-mãe Caixa do business (criada via seed da migration PR A)
         $contaCaixa = ContaBancaria::withoutGlobalScopes()
             ->where('business_id', $cr->business_id)
@@ -724,6 +726,7 @@ class TituloAutoService
         $userId   = $cr->user_id;
         $userName = 'Sistema';
         if ($userId) {
+            // SUPERADMIN: sync sem session — resolve nome do user por id do CashRegister (label-only)
             $user = \App\User::withoutGlobalScopes()->find($userId);
             if ($user) {
                 $userName = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));

--- a/Modules/KB/Services/KbCorpusBuilder.php
+++ b/Modules/KB/Services/KbCorpusBuilder.php
@@ -161,7 +161,7 @@ class KbCorpusBuilder
 
         // 2) Artigos editáveis (is_editable=true) — body_text = serialize blocks
         $editableQuery = KbNode::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: indexador roda CLI sem sessão — business_id explícito abaixo
             ->where('business_id', $this->businessId)
             ->whereNull('deleted_at')
             ->where('is_editable', true);
@@ -187,7 +187,7 @@ class KbCorpusBuilder
     public function count(): int
     {
         return (int) KbNode::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: count em CLI/health-check sem sessão — business_id explícito abaixo
             ->where('business_id', $this->businessId)
             ->whereNull('deleted_at')
             ->count();

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -742,6 +742,7 @@ class NfeService
 
         // ── 2. Carregar NfeEmissao (sem global scope p/ cross-tenant guard
         //      explícito — defesa em profundidade ADR 0093) ────────────────
+        // SUPERADMIN: carrega cross-tenant de propósito pra validar business_id no passo 3
         $emissao = NfeEmissao::withoutGlobalScopes()->find($nfeEmissaoId);
         if (! $emissao) {
             throw new RuntimeException("NfeEmissao {$nfeEmissaoId} não encontrada.");
@@ -757,6 +758,7 @@ class NfeService
 
         // ── 4. Idempotência: já cancelada? ──────────────────────────────────
         if ($emissao->status === 'cancelada') {
+            // SUPERADMIN: idempotência pós-guard — business_id já validado, filtrado explícito abaixo
             $eventoExistente = NfeEvento::withoutGlobalScopes()
                 ->where('business_id', $businessId)
                 ->where('emissao_id', $emissao->id)
@@ -939,6 +941,7 @@ class NfeService
     private function retransmitirInterno(int $businessId, int $nfeEmissaoId): NfeEmissao
     {
         // ── 1. Carrega NfeEmissao sem global scope (cross-tenant guard explícito) ──
+        // SUPERADMIN: carrega cross-tenant de propósito pra validar business_id no passo 2
         $emissao = NfeEmissao::withoutGlobalScopes()->find($nfeEmissaoId);
         if (! $emissao) {
             throw new RuntimeException("NfeEmissao {$nfeEmissaoId} não encontrada.");


### PR DESCRIPTION
## O quê

Anota o marcador `// SUPERADMIN:` exigido pelo `WithoutGlobalScopesCommentGuardTest` nas 8 chamadas `withoutGlobalScopes(` dos 3 arquivos abaixo. **Só documentação** — nenhuma semântica de isolamento multi-tenant alterada (ADR 0093 Tier 0 intacto).

## Padrão exigido pelo guard

O guard (`tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php`) faz varredura estática em `app/` + `Modules/<X>/`: toda chamada que casa `withoutGlobalScopes\s*\(` (plural) deve ter o token `SUPERADMIN` (case-insensitive, `/SUPERADMIN/i`) em comentário **na mesma linha OU em uma das 3 linhas acima**. A variante singular `withoutGlobalScope(...)` NÃO é varrida.

## Arquivos anotados + razão de cada bypass (todos legítimos)

| Arquivo:linha | Razão do bypass |
|---|---|
| `KB/Services/KbCorpusBuilder.php:164` | Indexador Meilisearch roda em CLI/job sem sessão; `business_id` filtrado explícito abaixo |
| `KB/Services/KbCorpusBuilder.php:190` | `count()` em CLI/health-check sem sessão; `business_id` explícito abaixo |
| `Financeiro/Services/TituloAutoService.php:690` | Sync CashRegister via observer sem sessão; `business_id` deduzido do CashRegister recebido |
| `Financeiro/Services/TituloAutoService.php:709` | Idem — conta-mãe Caixa filtrada por `business_id` do CashRegister |
| `Financeiro/Services/TituloAutoService.php:727` | Idem — resolve nome do user por id (label-only) |
| `NfeBrasil/Services/NfeService.php:745` | Carga cross-tenant DE PROPÓSITO → cross-tenant guard que lança `UnauthorizedActionException` no mismatch |
| `NfeBrasil/Services/NfeService.php:760` | Idempotência pós-guard; `business_id` já validado |
| `NfeBrasil/Services/NfeService.php:942` | Idem `retransmitirInterno` — carga cross-tenant seguida de guard explícito |

`php -l` OK nos 3 arquivos. Suíte NÃO rodada localmente (CT100-only; sqlite mascara bugs MySQL — proibicoes.md §Ambiente).

## ⚠️ Guard ainda NÃO fica verde só com este PR

Varredura local replicando a lógica exata do guard encontrou **89 violações pré-existentes** espalhadas por outros módulos (PaymentGateway, Whatsapp, Superadmin, OficinaAuto, KB Jobs/Controllers, NfeBrasil Jobs/Commands, ComunicacaoVisual, Jana, etc.) — fora do escopo dos 3 arquivos nomeados em US-GOV-019. Este PR fecha apenas a fatia desta sessão do swarm. As demais fatias precisam de PRs irmãos antes de o guard poder ser ligado em CI.

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)