### PR TITLE
test: migra @test legacy pro atributo PHP 8 #[Test] (US-GOV-019)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Adr0175ObserverContaOpcionalTest.php
+++ b/Modules/Financeiro/Tests/Feature/Adr0175ObserverContaOpcionalTest.php
@@ -10,6 +10,7 @@ use App\TransactionPayment;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\Financeiro\Models\TituloBaixa;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * ADR 0175 — Observer Financeiro permite baixa sem fin_contas_bancarias.
@@ -101,9 +102,7 @@ class Adr0175ObserverContaOpcionalTest extends FinanceiroTestCase
         parent::tearDown();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function observer_cria_titulo_baixa_mesmo_sem_fin_contas_bancarias()
     {
         // Pré-condição: biz=99 NÃO tem nenhuma fin_contas_bancarias

--- a/tests/Feature/Contact/ContactBrFieldsRestoredTest.php
+++ b/tests/Feature/Contact/ContactBrFieldsRestoredTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Contact;
 
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -27,9 +28,7 @@ use Tests\TestCase;
  */
 class ContactBrFieldsRestoredTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_has_all_br_fiscal_fields(): void
     {
         $expectedColumns = [

--- a/tests/Feature/Contact/ContactBucketALegacyAbsorptionTest.php
+++ b/tests/Feature/Contact/ContactBucketALegacyAbsorptionTest.php
@@ -9,6 +9,7 @@ use App\Contact;
 use App\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -27,7 +28,7 @@ use Tests\TestCase;
  */
 class ContactBucketALegacyAbsorptionTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_has_all_bucket_a_columns(): void
     {
         $expected = [
@@ -54,7 +55,7 @@ class ContactBucketALegacyAbsorptionTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_has_self_fk_relations_defined_on_model(): void
     {
         $contact = new Contact();
@@ -79,7 +80,7 @@ class ContactBucketALegacyAbsorptionTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_casts_bucket_a_bool_decimal_date_fields_correctly(): void
     {
         $business = Business::first() ?? Business::create([
@@ -119,7 +120,7 @@ class ContactBucketALegacyAbsorptionTest extends TestCase
         $fresh->forceDelete();
     }
 
-    /** @test */
+    #[Test]
     public function it_resolves_parent_and_sales_rep_via_self_fk(): void
     {
         $business = Business::first() ?? Business::create([
@@ -158,7 +159,7 @@ class ContactBucketALegacyAbsorptionTest extends TestCase
         $rep->forceDelete();
     }
 
-    /** @test */
+    #[Test]
     public function it_preserves_multi_tenant_scope_with_bucket_a_self_fk(): void
     {
         // Tier 0 IRREVOGAVEL (ADR 0093) — query scoped por business_id NUNCA

--- a/tests/Feature/Contact/ContactBucketBLegacyRawJsonTest.php
+++ b/tests/Feature/Contact/ContactBucketBLegacyRawJsonTest.php
@@ -8,6 +8,7 @@ use App\Business;
 use App\Contact;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -33,7 +34,7 @@ use Tests\TestCase;
  */
 class ContactBucketBLegacyRawJsonTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_has_legacy_source_and_legacy_raw_columns(): void
     {
         $this->assertTrue(
@@ -46,7 +47,7 @@ class ContactBucketBLegacyRawJsonTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_casts_legacy_raw_as_array_round_trip(): void
     {
         $business = Business::first() ?? Business::create([
@@ -92,7 +93,7 @@ class ContactBucketBLegacyRawJsonTest extends TestCase
         $fresh->forceDelete();
     }
 
-    /** @test */
+    #[Test]
     public function it_queries_via_json_extract_forensic(): void
     {
         $business = Business::first() ?? Business::create([
@@ -140,7 +141,7 @@ class ContactBucketBLegacyRawJsonTest extends TestCase
         $new->forceDelete();
     }
 
-    /** @test */
+    #[Test]
     public function it_exposes_cliente_desde_accessor_for_ui_storytelling(): void
     {
         $business = Business::first() ?? Business::create([
@@ -170,7 +171,7 @@ class ContactBucketBLegacyRawJsonTest extends TestCase
         $native->forceDelete();
     }
 
-    /** @test */
+    #[Test]
     public function it_preserves_multi_tenant_scope_with_legacy_raw(): void
     {
         $biz_a = Business::create([
@@ -219,7 +220,7 @@ class ContactBucketBLegacyRawJsonTest extends TestCase
         $biz_b->delete();
     }
 
-    /** @test */
+    #[Test]
     public function it_rejects_invalid_legacy_source_enum(): void
     {
         $business = Business::first() ?? Business::create([

--- a/tests/Feature/Contact/ContactSyncCanonOfficeimpressoTest.php
+++ b/tests/Feature/Contact/ContactSyncCanonOfficeimpressoTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\Contact;
 use App\Business;
 use App\Contact;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -31,7 +32,7 @@ use Tests\TestCase;
  */
 class ContactSyncCanonOfficeimpressoTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_has_canon_sync_columns_officeimpresso_codigo_and_dt_alteracao(): void
     {
         $this->assertTrue(
@@ -44,7 +45,7 @@ class ContactSyncCanonOfficeimpressoTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_dropped_legacy_source_column_redundant(): void
     {
         $this->assertFalse(
@@ -54,7 +55,7 @@ class ContactSyncCanonOfficeimpressoTest extends TestCase
         );
     }
 
-    /** @test */
+    #[Test]
     public function it_casts_officeimpresso_dt_alteracao_as_datetime(): void
     {
         $business = Business::first() ?? Business::create([
@@ -85,9 +86,8 @@ class ContactSyncCanonOfficeimpressoTest extends TestCase
 
     /**
      * Smoke test — pattern conflict detection do BaseApiController.
-     *
-     * @test
      */
+    #[Test]
     public function it_supports_base_api_controller_conflict_detection_pattern(): void
     {
         $business = Business::first() ?? Business::create([
@@ -129,7 +129,7 @@ class ContactSyncCanonOfficeimpressoTest extends TestCase
         $contact->forceDelete();
     }
 
-    /** @test */
+    #[Test]
     public function it_preserves_multi_tenant_scope_with_canon_sync_fields(): void
     {
         // Tier 0 IRREVOGAVEL (ADR 0093) — query scoped business_id NUNCA vaza.
@@ -176,7 +176,7 @@ class ContactSyncCanonOfficeimpressoTest extends TestCase
         $biz_b->delete();
     }
 
-    /** @test */
+    #[Test]
     public function it_supports_4_distinct_legacy_sync_fields_coexisting(): void
     {
         // Os 4 campos com propósitos distintos coexistem sem redundância:

--- a/tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php
+++ b/tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php
@@ -7,6 +7,7 @@ namespace Tests\Unit\Http\Requests\Cliente;
 use App\Http\Requests\Cliente\StoreContactRequest;
 use App\Http\Requests\Cliente\UpdateContactRequest;
 use App\Rules\BR\CpfCnpj;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -19,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class StoreContactRequestRulesTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_has_br_canon_keys_on_store(): void
     {
         $rules = (new StoreContactRequest)->rules();
@@ -33,7 +34,7 @@ class StoreContactRequestRulesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function it_has_br_canon_keys_on_update(): void
     {
         $rules = (new UpdateContactRequest)->rules();
@@ -47,7 +48,7 @@ class StoreContactRequestRulesTest extends TestCase
         }
     }
 
-    /** @test */
+    #[Test]
     public function cpf_cnpj_uses_canonical_rule_on_store(): void
     {
         $rules = (new StoreContactRequest)->rules();
@@ -65,7 +66,7 @@ class StoreContactRequestRulesTest extends TestCase
         $this->assertTrue($hasCpfCnpjRule, 'cpf_cnpj deve usar App\\Rules\\BR\\CpfCnpj');
     }
 
-    /** @test */
+    #[Test]
     public function cpf_cnpj_uses_canonical_rule_on_update(): void
     {
         $rules = (new UpdateContactRequest)->rules();
@@ -82,7 +83,7 @@ class StoreContactRequestRulesTest extends TestCase
         $this->assertTrue($hasCpfCnpjRule, 'cpf_cnpj deve usar App\\Rules\\BR\\CpfCnpj');
     }
 
-    /** @test */
+    #[Test]
     public function indicador_ie_restricted_to_1_2_9(): void
     {
         $rules = (new StoreContactRequest)->rules();
@@ -90,14 +91,14 @@ class StoreContactRequestRulesTest extends TestCase
         $this->assertContains('integer', $rules['indicador_ie']);
     }
 
-    /** @test */
+    #[Test]
     public function regime_restricted_to_canonical_set(): void
     {
         $rules = (new StoreContactRequest)->rules();
         $this->assertContains('in:simples,presumido,real,mei', $rules['regime']);
     }
 
-    /** @test */
+    #[Test]
     public function messages_do_not_leak_recived_value(): void
     {
         $messages = (new StoreContactRequest)->messages();

--- a/tests/Unit/Rules/BR/CpfCnpjTest.php
+++ b/tests/Unit/Rules/BR/CpfCnpjTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Tests\Unit\Rules\BR;
 
 use App\Rules\BR\CpfCnpj;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -29,37 +31,29 @@ class CpfCnpjTest extends TestCase
         return $error;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_accepts_null_and_empty(): void
     {
         $this->assertNull($this->validate(null));
         $this->assertNull($this->validate(''));
     }
 
-    /**
-     * @test
-     * @dataProvider validCpfs
-     */
+    #[Test]
+    #[DataProvider('validCpfs')]
     public function it_accepts_valid_cpf(string $cpf): void
     {
         $this->assertNull($this->validate($cpf));
     }
 
-    /**
-     * @test
-     * @dataProvider validCnpjs
-     */
+    #[Test]
+    #[DataProvider('validCnpjs')]
     public function it_accepts_valid_cnpj(string $cnpj): void
     {
         $this->assertNull($this->validate($cnpj));
     }
 
-    /**
-     * @test
-     * @dataProvider invalidDocs
-     */
+    #[Test]
+    #[DataProvider('invalidDocs')]
     public function it_rejects_invalid_doc(string $doc): void
     {
         $this->assertNotNull($this->validate($doc));

--- a/tests/Unit/Rules/BR/CpfCnpjTest.php
+++ b/tests/Unit/Rules/BR/CpfCnpjTest.php
@@ -63,7 +63,7 @@ class CpfCnpjTest extends TestCase
     {
         return [
             'cpf-puro-digitos' => ['11144477735'],
-            'cpf-com-mascara' => ['111.444.777-35'],
+            'cpf-com-mascara' => ['111.444.777-35'], // pii-allowlist (vetor fake mod-11 do validador CpfCnpj, não PII real)
         ];
     }
 
@@ -71,7 +71,7 @@ class CpfCnpjTest extends TestCase
     {
         return [
             'cnpj-puro-digitos' => ['11444777000161'],
-            'cnpj-com-mascara' => ['11.444.777/0001-61'],
+            'cnpj-com-mascara' => ['11.444.777/0001-61'], // pii-allowlist (vetor fake mod-11 do validador CpfCnpj, não PII real)
         ];
     }
 

--- a/tests/Unit/Utils/IncidentValorInfladoNumUfTest.php
+++ b/tests/Unit/Utils/IncidentValorInfladoNumUfTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Utils;
 
 use App\Utils\Util;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 /**
@@ -56,7 +57,7 @@ class IncidentValorInfladoNumUfTest extends TestCase
         return (string) $rounded;
     }
 
-    /** @test */
+    #[Test]
     public function num_uf_nao_trata_decimal_de_mais_de_2_casas_como_milhar(): void
     {
         // O valor EXATO que quebrou em prod (227,90 − 10,05% = 204.99605).
@@ -80,9 +81,8 @@ class IncidentValorInfladoNumUfTest extends TestCase
     /**
      * GUARD end-to-end (frontend round + backend num_uf): venda com desconto %
      * NUNCA pode gerar final_total inflado. Casos REAIS do incidente.
-     *
-     * @test
      */
+    #[Test]
     public function venda_com_desconto_percentual_nao_infla_o_final_total(): void
     {
         // [total_before_tax, desconto %, esperado] — vendas reais corrigidas em prod.


### PR DESCRIPTION
## O quê

Migra a anotação legacy `/** @test */` para o atributo PHP 8 `#[Test]` (`PHPUnit\Framework\Attributes\Test`) nos **8 arquivos** flagrados pelo guard `PhpunitTestAnnotationGuardTest`.

## Por quê

PHPUnit 12 **ignora silenciosamente** o doc-comment `@test` — testes com essa anotação **não rodam** (sem error, sem warning, sem skip), produzindo falsa cobertura. Histórico de recidiva: PR #393 (6 tests) + PR #437 (35 tests). O guard estático flagrava 8 arquivos antes desta mudança.

## Arquivos migrados (8)

| Arquivo | Ocorrências |
|---|---|
| `tests/Feature/Contact/ContactBrFieldsRestoredTest.php` | 1 |
| `tests/Feature/Contact/ContactBucketALegacyAbsorptionTest.php` | 5 |
| `tests/Feature/Contact/ContactBucketBLegacyRawJsonTest.php` | 6 |
| `tests/Feature/Contact/ContactSyncCanonOfficeimpressoTest.php` | 5 |
| `tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php` | 7 |
| `tests/Unit/Rules/BR/CpfCnpjTest.php` | 1 (+ 3 multi-line c/ `@dataProvider`) |
| `tests/Unit/Utils/IncidentValorInfladoNumUfTest.php` | 1 (+ 1 multi-line) |
| `Modules/Financeiro/Tests/Feature/Adr0175ObserverContaOpcionalTest.php` | 1 |

## Notas

- **`@dataProvider` → `#[DataProvider(...)]`**: em `CpfCnpjTest` as tags `@dataProvider` migraram para o atributo equivalente, com `use PHPUnit\Framework\Attributes\DataProvider;`.
- **Docblocks preservados**: onde havia texto descritivo antes do `@test` (ex. `ContactSyncCanon`, `IncidentValorInflado`), o texto foi mantido e só o `@test` virou atributo.
- **Zona de colisão respeitada**: nenhum arquivo em `Modules/Whatsapp/Tests/**` foi tocado (cluster editado por outra sessão). Nenhum dos 8 flagrados estava nessa pasta.

## Verificação

- Scan estático do guard re-rodado localmente: **0 violações** (antes: 8).
- `php -l` OK em todos os 8 arquivos.
- Suíte **não** rodada (CT100-only, conforme instrução).

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)