### PR TITLE
test(guard): fecha blind spots do BusinessIdGuard (biz=4 RotaLivre)

### DIFF
--- a/tests/Feature/Logging/OtlpHttpHandlerTest.php
+++ b/tests/Feature/Logging/OtlpHttpHandlerTest.php
@@ -39,7 +39,7 @@ function makeSpanRecord(array $extraAttrs = []): LogRecord
             'gen_ai.request.model' => 'claude-sonnet-4-6',
             'gen_ai.operation.name' => 'chat',
             'gen_ai.response.duration_ms' => 1234,
-            'gen_ai.business_id' => 4,
+            'gen_ai.business_id' => 1,
             'gen_ai.user.id' => 42,
             'gen_ai.conversation.id' => 99,
             'gen_ai.copiloto.prompt_chars' => 256,
@@ -97,13 +97,13 @@ it('exporta span com payload OTLP/JSON correto quando POST returns 200', functio
 
     $attrs = collect($span['attributes'])->keyBy('key');
     expect($attrs['gen_ai.system']['value']['stringValue'])->toBe('anthropic');
-    expect($attrs['gen_ai.business_id']['value']['intValue'])->toBe('4');
+    expect($attrs['gen_ai.business_id']['value']['intValue'])->toBe('1');
     expect($attrs['gen_ai.response.duration_ms']['value']['intValue'])->toBe('1234');
     expect($attrs['gen_ai.usage.input_tokens']['value']['intValue'])->toBe('100');
 
     // Dual-emit: cada int também tem irmã .str (stringValue) — workaround Langfuse v3
     // que só renderiza stringValue no UI. Quando upstream fixar, remover .str.
-    expect($attrs['gen_ai.business_id.str']['value']['stringValue'])->toBe('4');
+    expect($attrs['gen_ai.business_id.str']['value']['stringValue'])->toBe('1');
     expect($attrs['gen_ai.response.duration_ms.str']['value']['stringValue'])->toBe('1234');
     expect($attrs['gen_ai.usage.input_tokens.str']['value']['stringValue'])->toBe('100');
 });

--- a/tests/Feature/Modules/Copiloto/Mcp/McpAuthHealthTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/McpAuthHealthTest.php
@@ -98,7 +98,7 @@ it('McpAuth: token válido + user existe → 200 + audit ok', function () {
     $userMock = new class {
         public int $id = 1;
         public ?string $first_name = 'Wagner';
-        public ?int $business_id = 4;
+        public ?int $business_id = 1;
     };
 
     // Mock find

--- a/tests/Feature/Modules/Copiloto/MetricasApuradorTest.php
+++ b/tests/Feature/Modules/Copiloto/MetricasApuradorTest.php
@@ -104,7 +104,7 @@ it('totalInteracoesDia conta apenas role=user no dia certo do business', functio
 
     $apurador = new MetricasApurador();
 
-    expect($apurador->totalInteracoesDia(4, $hoje))->toBe(2);
+    expect($apurador->totalInteracoesDia(1, $hoje))->toBe(2);
     expect($apurador->totalInteracoesDia(8, $hoje))->toBe(1);
     expect($apurador->totalInteracoesDia(null, $hoje))->toBe(3); // plataforma agregada
 });
@@ -129,7 +129,7 @@ it('tokensMedioInteracao calcula média de assistant (in+out) com filtro de busi
     $apurador = new MetricasApurador();
 
     // (150 + 300) / 2 = 225
-    expect($apurador->tokensMedioInteracao(4, $hoje))->toBe(225);
+    expect($apurador->tokensMedioInteracao(1, $hoje))->toBe(225);
 });
 
 it('totalMemoriasAtivas conta valid_until=null e exclui soft-deleted', function () {
@@ -150,7 +150,7 @@ it('totalMemoriasAtivas conta valid_until=null e exclui soft-deleted', function 
 
     $apurador = new MetricasApurador();
 
-    expect($apurador->totalMemoriasAtivas(4, $hoje))->toBe(2);
+    expect($apurador->totalMemoriasAtivas(1, $hoje))->toBe(2);
     expect($apurador->totalMemoriasAtivas(8, $hoje))->toBe(1);
     expect($apurador->totalMemoriasAtivas(null, $hoje))->toBe(3);
 });
@@ -176,7 +176,7 @@ it('memoryBloatRatio = % fatos com valid_from <= 30d / total ativos', function (
     $apurador = new MetricasApurador();
 
     // 3 recentes / 4 total = 0.750
-    expect($apurador->memoryBloatRatio(4, $hoje))->toBe(0.750);
+    expect($apurador->memoryBloatRatio(1, $hoje))->toBe(0.750);
 });
 
 it('memoryBloatRatio retorna null quando não há fatos ativos', function () {
@@ -186,7 +186,7 @@ it('memoryBloatRatio retorna null quando não há fatos ativos', function () {
 
 it('latenciaP95Ms retorna null quando log do dia não existe', function () {
     $apurador = new MetricasApurador('canal-inexistente-xyz');
-    expect($apurador->latenciaP95Ms(4, CarbonImmutable::parse('2026-04-29')))->toBeNull();
+    expect($apurador->latenciaP95Ms(1, CarbonImmutable::parse('2026-04-29')))->toBeNull();
 });
 
 it('latenciaP95Ms parseia log otel-gen-ai e calcula p95 filtrado por business_id', function () {
@@ -199,12 +199,12 @@ it('latenciaP95Ms parseia log otel-gen-ai e calcula p95 filtrado por business_id
         $dur = $i * 100;
         $event = json_encode([
             'gen_ai.system'               => 'openai',
-            'gen_ai.business_id'          => 4,
+            'gen_ai.business_id'          => 1,
             'gen_ai.response.duration_ms' => $dur,
         ]);
         $linhas[] = "[2026-04-29 10:00:00] live.INFO: gen_ai.span {$event}";
     }
-    // 5 entradas de outro business (não devem entrar no p95 do biz=4)
+    // 5 entradas de outro business (não devem entrar no p95 do biz=1)
     for ($i = 1; $i <= 5; $i++) {
         $event = json_encode([
             'gen_ai.system'               => 'openai',
@@ -220,7 +220,7 @@ it('latenciaP95Ms parseia log otel-gen-ai e calcula p95 filtrado por business_id
     $logChannel = basename($logPath, '-' . $data->toDateString() . '.log');
     $apurador = new MetricasApurador($logChannel);
 
-    expect($apurador->latenciaP95Ms(4, $data))->toBe(1900); // ceil(0.95 * 20) - 1 = 18 → 1900
+    expect($apurador->latenciaP95Ms(1, $data))->toBe(1900); // ceil(0.95 * 20) - 1 = 18 → 1900
     expect($apurador->latenciaP95Ms(8, $data))->toBe(99999);
 
     @unlink($logPath);
@@ -248,14 +248,14 @@ it('apurar grava 1 linha em copiloto_memoria_metricas e é idempotente (upsert)'
 
     $apurador = new MetricasApurador();
 
-    $linha1 = $apurador->apurar(4, '2026-04-29');
+    $linha1 = $apurador->apurar(1, '2026-04-29');
     expect($linha1)->toBeInstanceOf(MemoriaMetrica::class);
     expect($linha1->total_interacoes_dia)->toBe(1);
     expect($linha1->total_memorias_ativas)->toBe(1);
     expect($linha1->tokens_medio_interacao)->toBe(150);
 
     // Re-apurar mesmo dia/business → upsert (não cria nova linha)
-    $linha2 = $apurador->apurar(4, '2026-04-29');
+    $linha2 = $apurador->apurar(1, '2026-04-29');
     expect(MemoriaMetrica::count())->toBe(1);
     expect($linha2->id)->toBe($linha1->id);
 
@@ -283,5 +283,5 @@ it('apurar para plataforma (business_id=null) agrega tudo', function () {
     $linha = $apurador->apurar(null, '2026-04-29');
 
     expect($linha->business_id)->toBeNull();
-    expect($linha->total_interacoes_dia)->toBe(2); // 4 + 8 agregados
+    expect($linha->total_interacoes_dia)->toBe(2); // biz 1 + biz 8 agregados
 });

--- a/tests/Unit/BusinessIdGuardTest.php
+++ b/tests/Unit/BusinessIdGuardTest.php
@@ -28,21 +28,29 @@ use Symfony\Component\Finder\Finder;
 
 /**
  * Padrões de detecção. Cada regex pega o uso de `4` como business_id de forma
- * inequívoca — sem pegar `decimal(7, 4)`, `char(4)` ou strings literais.
+ * inequívoca — sem pegar `decimal(7, 4)`, `char(4)`, `business_id => 14/40`
+ * (word-boundary `\b4\b`) ou comparações `=== 4`/`!== 4` em strings de
+ * meta-asserção. Cobre: chave de array (incl. prefixo namespaced tipo
+ * `gen_ai.business_id`), property/atribuição snake_case e camelCase, named arg,
+ * fluent builder e session key.
  */
 const BIZ_GUARD_PATTERNS = [
-    // Array PHP: 'business_id' => 4 (qualquer espaçamento)
-    '/[\'"]business_id[\'"]\s*=>\s*4\b/',
+    // Array PHP key (com ou sem prefixo namespaced): 'business_id' => 4,
+    // 'user.business_id' => 4, 'gen_ai.business_id' => 4 (qualquer espaçamento).
+    // O `[\w.]*` opcional cobre chaves prefixadas tipo OTel/atributo namespaced
+    // sem deixar de pegar a forma simples (prefixo vazio).
+    '/[\'"][\w.]*business_id[\'"]\s*=>\s*4\b/',
     // Atribuição: $x->business_id = 4 ou $x->business_id=4
     '/->business_id\s*=\s*4\b/',
+    // Property/atribuição snake_case: public ?int $business_id = 4; ou $business_id = 4
+    // (single `=` só — não pega comparação === / !== em strings de meta-asserção)
+    '/\$business_id\s*=\s*4\b/',
     // Named arg PHP: businessId: 4
     '/businessId\s*:\s*4\b/',
-    // Atribuição variável: $businessId = 4
+    // Atribuição variável camelCase: $businessId = 4
     '/\$businessId\s*=\s*4\b/',
     // Fluent builder: business(4)  (TransactionBuilder etc)
     '/->business\(4\)/',
-    // Session put: 'user.business_id' => 4
-    '/[\'"]user\.business_id[\'"]\s*=>\s*4\b/',
     // session(['business.id' => 4])
     '/[\'"]business\.id[\'"]\s*=>\s*4\b/',
 ];


### PR DESCRIPTION
## Por quê

Auditoria adversarial 2026-06-13 — o guard Tier-0 `tests/Unit/BusinessIdGuardTest.php` ficava **VERDE** mesmo com `business_id=4` (cliente real RotaLivre, Tier 0) ainda presente em fixtures, porque o regex não cobria todas as formas. `biz=4` NUNCA pode ser cobaia de fixture (risco fiscal real contra CNPJ da Larissa). Regra: teste usa `biz=1`; adversário cross-tenant `biz=99`.

## O que muda (2 partes, 1 intent)

### a) Endurece o regex do guard
Patterns adicionados/generalizados:
- **Chave prefixada (namespaced):** `/[\'][\w.]*business_id[\']\s*=>\s*4\b/` — pega `gen_ai.business_id => 4`, `user.business_id => 4` e a forma simples `business_id => 4` (absorve o antigo pattern `user.business_id`, removido por redundância).
- **Property/atribuição snake_case:** `/\$business_id\s*=\s*4\b/` — pega `public ?int $business_id = 4;` e `$business_id = 4`. Single `=` só → não pega `=== 4`/`!== 4` em strings de meta-asserção.
- **Fluent builder:** `/->business\(4\)/` (mantido).

Sem falsos positivos: word-boundary `\b4\b` (não pega `=> 14`, `40`, `444`), comparações `=== 4`/`!== 4`, nem `decimal(7,4)`. Validado localmente com:
- réplica do scan (tests/ + todos Modules/*/Tests) → **0 violações**
- 19 casos unitários hit/miss → **ALL GOOD**

### b) Conserta os leftovers (4 → 1, input + read-back coerentes)
| Arquivo | Forma | Antes → Depois |
|---|---|---|
| `tests/Feature/Logging/OtlpHttpHandlerTest.php` | chave prefixada | `gen_ai.business_id => 4` + 2 asserts `toBe('4')` → `1` |
| `tests/Feature/Modules/Copiloto/MetricasApuradorTest.php` | chave prefixada + chamadas | input `=> 4` + chamadas `apurar/latenciaP95Ms/...(4)` + asserts → `1` |
| `tests/Feature/Modules/Copiloto/Mcp/McpAuthHealthTest.php` | property snake_case | `public ?int $business_id = 4` → `1` |

**Bônus de correção:** em `MetricasApuradorTest` os inserts já eram `biz=1` mas os métodos eram chamados com `4` (latente: filtraria zero contra dados de biz=1). Agora coerente.

## Flag pra Wagner (não alterado por segurança)
`tests/Builders/TransactionBuilder.php:29` — o `->business(4)` está **dentro do docblock** (linha inicia com `*`, já pulada pelo skip-de-comentário do guard) e o **default real do builder é `biz=1`** (todos os entry points `venda()`/`compra()`/etc usam `->set('business_id', 1)`). Não é violação real, builder compartilhado por muitos testes — deixado intacto conforme orientação.

## Não rodei a suíte (CT100-only)
Validação local: `php -l` nos 4 arquivos (clean) + réplica do scan do guard (0 violações).

Refs: US-GOV-019 (hygiene Tier-0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)