### PR TITLE
fix(hooks): pii-redactor escaneia só git commit, libera debug por CPF/CNPJ

### DIFF
--- a/.claude/hooks/pii-redactor.ps1
+++ b/.claude/hooks/pii-redactor.ps1
@@ -1,13 +1,19 @@
-# Hook PreToolUse - BLOQUEIA Bash que vai commitar/printar PII (CPF/CNPJ/cartao).
+# Hook PreToolUse - BLOQUEIA git commit que levaria PII real (CPF/CNPJ/cartao) pro repo.
 # US-COPI-086 (Cycle 01) - LGPD Art. 7 (principio de minimizacao).
 #
-# Escaneia commands de git commit OR scripts que produzem output.
-# Em particular, blocking matrix:
-#   - git commit -m "..." com PII no message
-#   - git commit + git diff --staged contendo PII (escaneia o staged)
-#   - cat/tail/grep de log com PII detectada na saida esperada
+# Escopo (opcao B, 2026-06-13 - ver memory/sessions deste dia):
+#   SO inspeciona `git commit`. Escaneia:
+#     - a mensagem do commit (texto do comando, ex: -m "...")
+#     - o staged diff (git diff --staged)
+#   Ambos acabam no historico git -> sincronizam pro MCP server visivel ao time.
 #
-# Whitelist: PIIs reconhecidamente fake/fixture (123.456.789-09, 11.222.333/0001-81)
+#   Comandos NAO-commit (mysql/grep/ssh/echo/cat ...) NAO sao mais inspecionados,
+#   mesmo contendo CPF/CNPJ. Num ERP brasileiro, debug legitimo por CPF/CNPJ
+#   (consultar producao, grep de log, snapshot Firebird) e operacao normal e
+#   nao deve ser bloqueado. A versao anterior bloqueava esses comandos sem bypass.
+#
+# Bypass: adicione --allow-pii ao git commit (E confirme com Wagner).
+# Whitelist: PIIs reconhecidamente fake/fixture (ver array $fakeWhitelist abaixo).
 
 $ErrorActionPreference = 'Stop'
 $rawInput = [Console]::In.ReadToEnd()
@@ -25,6 +31,11 @@ if ($tool -ne 'Bash') { exit 0 }
 $cmd = $payload.tool_input.command
 if (-not $cmd) { exit 0 }
 
+# Opcao B: so age em git commit. Qualquer outro comando passa direto (sem inspecao).
+if ($cmd -notmatch '^\s*git\s+commit\b') { exit 0 }
+# Bypass justificado.
+if ($cmd -match '--allow-pii') { exit 0 }
+
 # Fixtures fake bem conhecidos (whitelist)
 $fakeWhitelist = @(
     '123\.456\.789-09',
@@ -36,14 +47,14 @@ $fakeWhitelist = @(
     '5555[\s-]?5555[\s-]?5555[\s-]?4444'   # Mastercard test
 )
 
-# Padrões PII reais (regex)
+# Padroes PII reais (regex)
 $piiPatterns = @{
-    'cpf'   = '\b\d{3}\.\d{3}\.\d{3}-\d{2}\b'
-    'cnpj'  = '\b\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}\b'
+    'cpf'    = '\b\d{3}\.\d{3}\.\d{3}-\d{2}\b'
+    'cnpj'   = '\b\d{2}\.\d{3}\.\d{3}/\d{4}-\d{2}\b'
     'cartao' = '\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b'
 }
 
-# Função: dado um texto, retorna lista de PIIs detectadas (não-whitelisted)
+# Funcao: dado um texto, retorna lista de PIIs detectadas (nao-whitelisted)
 function Find-Pii([string]$text) {
     $found = @()
     foreach ($key in $piiPatterns.Keys) {
@@ -63,40 +74,27 @@ function Find-Pii([string]$text) {
     return $found
 }
 
-# 1) Verifica PII no proprio comando (commit -m, echo, etc.)
-$piiInCmd = @(Find-Pii $cmd)
-if ($piiInCmd.Count -gt 0) {
-    $first = $piiInCmd[0]
+# Monta o corpo a escanear: mensagem do commit (texto do comando) + staged diff.
+$textoAEscanear = $cmd
+try {
+    $stagedDiff = & git diff --staged 2>$null
+    if ($stagedDiff) {
+        $textoAEscanear += "`n" + ($stagedDiff -join "`n")
+    }
+} catch {
+    # git falhou (nao eh repo, sem permissao) - escaneia so a mensagem do commit
+}
+
+$piiFound = @(Find-Pii $textoAEscanear)
+if ($piiFound.Count -gt 0) {
+    $first = $piiFound[0]
     $exemplo = $first.valor.Substring(0, [Math]::Min(6, $first.valor.Length)) + '...'
     @{
         decision      = 'deny'
-        reason        = "[pii-redactor] PII real detectada no comando: $($first.tipo) '$exemplo'"
-        systemMessage = "[pii-redactor] LGPD Art. 7 - comando contem $($piiInCmd.Count) PII real ($(($piiInCmd | ForEach-Object { $_.tipo }) -join ', ')). NUNCA commitar/printar PII real. Substitua por: CPF fake = 123.456.789-09; CNPJ fake = 11.222.333/0001-81; cartao fake = 4111-1111-1111-1111. Se for log de producao, sanitize com sed antes de colar (HOW_TO_ASK_CLAUDE secao 3.4)."
+        reason        = "[pii-redactor] git commit BLOQUEADO: $($first.tipo) '$exemplo' (mensagem ou staged diff)"
+        systemMessage = "[pii-redactor] LGPD Art. 7 - git commit contem $($piiFound.Count) PII real ($(($piiFound | ForEach-Object { $_.tipo }) -join ', ')) na mensagem e/ou no staged diff. Antes de commitar: 1) remova a PII da mensagem do commit; 2) git restore --staged <arquivo> + edite (use [REDACTED] ou fixtures fake) + re-stage. Bypass justificado: adicione --allow-pii ao comando E confirme com Wagner."
     } | ConvertTo-Json -Compress
     exit 0
-}
-
-# 2) Verifica se eh git commit (qualquer flavor) - escanear staged diff
-if ($cmd -match '^\s*git\s+commit\b' -and $cmd -notmatch '--allow-pii') {
-    # Tenta capturar `git diff --staged` no diretorio atual
-    try {
-        $stagedDiff = & git diff --staged 2>$null
-        if ($stagedDiff) {
-            $piiInDiff = @(Find-Pii ($stagedDiff -join "`n"))
-            if ($piiInDiff.Count -gt 0) {
-                $first = $piiInDiff[0]
-                $exemplo = $first.valor.Substring(0, [Math]::Min(6, $first.valor.Length)) + '...'
-                @{
-                    decision      = 'deny'
-                    reason        = "[pii-redactor] git commit BLOQUEADO: $($first.tipo) '$exemplo' no staged diff"
-                    systemMessage = "[pii-redactor] LGPD: git diff --staged contem $($piiInDiff.Count) PII real ($(($piiInDiff | ForEach-Object { $_.tipo }) -join ', ')). Antes de commitar: 1) git restore --staged <arquivo>; 2) edite removendo PII (use [REDACTED] ou fixtures fake); 3) re-stage. Bypass justificado: adicione --allow-pii ao comando E confirme com Wagner."
-                } | ConvertTo-Json -Compress
-                exit 0
-            }
-        }
-    } catch {
-        # git falhou (nao eh repo, sem permissao) - nao bloqueia
-    }
 }
 
 exit 0

--- a/.claude/hooks/test-pii-redactor.ps1
+++ b/.claude/hooks/test-pii-redactor.ps1
@@ -1,20 +1,29 @@
-# Teste do pii-redactor.ps1
+# Teste do pii-redactor.ps1 (opcao B - so inspeciona git commit)
+#
+# Rode de preferencia de um diretorio SEM git (ou sem nada staged) pra que o
+# scan de staged diff fique vazio e o resultado dependa so da mensagem do commit.
 
 $ErrorActionPreference = 'Continue'
 $base = Split-Path -Parent $MyInvocation.MyCommand.Path
 $hook = Join-Path $base 'pii-redactor.ps1'
 
 $cases = @(
-    @{ name='T1 echo CPF real';       cmd='echo "CPF do cliente: 987.654.321-00"';     expectBlock=$true  }
-    @{ name='T2 echo CPF fake';       cmd='echo "CPF: 123.456.789-09"';                expectBlock=$false }
-    @{ name='T3 git commit message OK';cmd='git commit -m "feat: adiciona campo idade"';expectBlock=$false }
-    @{ name='T4 commit -m com CNPJ';  cmd='git commit -m "fix: cliente CNPJ 12.345.678/0001-90 não importa"'; expectBlock=$true }
-    @{ name='T5 grep log com cartão'; cmd='grep "4532-1488-0343-6467" log.txt';        expectBlock=$true  }
-    @{ name='T6 cartão Visa fixture'; cmd='echo "test card 4111-1111-1111-1111"';      expectBlock=$false }
-    @{ name='T7 ls -la';              cmd='ls -la';                                     expectBlock=$false }
-    @{ name='T8 commit + cnpj 0000';  cmd='git commit -m "test 00.000.000/0000-00"';   expectBlock=$false }
-    @{ name='T9 echo email só';       cmd='echo "contato: ana@example.com"';           expectBlock=$false }
-    @{ name='T10 cmd com 4 padrões';  cmd='cat log.txt | grep "098.765.432-11"';       expectBlock=$true  }
+    # Comandos NAO-commit nunca bloqueiam (mudanca da opcao B) ---------------
+    @{ name='T1 echo CPF real (nao-commit)';   cmd='echo "CPF do cliente: 987.654.321-00"';         expectBlock=$false } # pii-allowlist
+    @{ name='T2 echo CPF fake';                cmd='echo "CPF: 123.456.789-09"';                    expectBlock=$false } # pii-allowlist
+    @{ name='T5 grep cartao em log (nao-commit)'; cmd='grep "4532-1488-0343-6467" log.txt';          expectBlock=$false }
+    @{ name='T6 cartao Visa fixture';          cmd='echo "test card 4111-1111-1111-1111"';          expectBlock=$false }
+    @{ name='T7 ls -la';                       cmd='ls -la';                                        expectBlock=$false }
+    @{ name='T9 echo email so';                cmd='echo "contato: ana@example.com"';               expectBlock=$false }
+    @{ name='T10 cat|grep CPF (nao-commit)';   cmd='cat log.txt | grep "098.765.432-11"';           expectBlock=$false } # pii-allowlist
+    @{ name='T13 mysql WHERE cpf (debug ERP)'; cmd="mysql -e ""SELECT * FROM contacts WHERE cpf='987.654.321-00'"""; expectBlock=$false } # pii-allowlist
+
+    # git commit continua protegido (mensagem + staged diff) -----------------
+    @{ name='T3 git commit message OK';        cmd='git commit -m "feat: adiciona campo idade"';    expectBlock=$false }
+    @{ name='T4 commit -m com CNPJ real';      cmd='git commit -m "fix: cliente CNPJ 12.345.678/0001-90 nao importa"'; expectBlock=$true } # pii-allowlist
+    @{ name='T8 commit + cnpj 0000 fake';      cmd='git commit -m "test 00.000.000/0000-00"';       expectBlock=$false } # pii-allowlist
+    @{ name='T11 commit -m com CPF real';      cmd='git commit -m "ajuste do CPF 987.654.321-00"';  expectBlock=$true } # pii-allowlist
+    @{ name='T12 commit --allow-pii bypass';   cmd='git commit --allow-pii -m "CPF 987.654.321-00 autorizado por Wagner"'; expectBlock=$false } # pii-allowlist
 )
 
 $pass = 0; $fail = 0
@@ -35,7 +44,7 @@ foreach ($c in $cases) {
     $sym = if ($ok) { '+' } else { 'X' }
     if ($ok) { $pass++ } else { $fail++ }
 
-    Write-Host ("$sym {0,-32} expected={1,-5} actual={2,-5}" -f $c.name, $expected, $actual)
+    Write-Host ("$sym {0,-34} expected={1,-5} actual={2,-5}" -f $c.name, $expected, $actual)
     if (-not $ok) {
         Write-Host "    cmd: $($c.cmd)"
         Write-Host "    out: $outputStr"


### PR DESCRIPTION
## Problema

O hook `PreToolUse` `pii-redactor.ps1` bloqueava **qualquer** comando Bash com CPF/CNPJ/cartão no texto — sem bypass. Num ERP brasileiro isso quebrava debug legítimo do dia a dia: `mysql ... WHERE cpf=...`, `grep <CNPJ> log`, `ssh` em produção, snapshot Firebird. Fazia mais mal que bem.

## Solução (opção B)

O hook passa a inspecionar **só `git commit`** (mensagem do commit + staged diff) — a real superfície de vazamento pro histórico git / MCP do time. Comandos não-commit passam direto.

- Proteção de commit mantida (mensagem **e** staged diff).
- Bypass `--allow-pii` mantido (fixtures/justificado).
- `cartão` regex inalterada (só pode incomodar em commit, com escape).

## Testes

`test-pii-redactor.ps1` reescrito: **13/13 verdes**. Cobre comandos não-commit (passam), commit com PII real na mensagem (bloqueia), fixtures fake (passam), bypass `--allow-pii`, e debug `mysql WHERE cpf` (passa).

## Nota

Este PR é o único delta real da branch `feat/governance-ds-rollout-ledger` (cherry-pick de `0600bd0ec` a partir do main atual). O resto daquela branch já está no main em versão mais nova — PR #2682 foi fechado como superado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)