### PR TITLE
fix(cliente): lupa da busca não encavala + Auditoria entra em Operações

### DIFF
--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-13T13:37:54.054Z",
-    "total_lines": 20407,
+    "generated_at": "2026-06-13T19:57:12.215Z",
+    "total_lines": 20424,
     "file_count": 29,
     "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
     "refs": [
@@ -13,7 +13,7 @@
     "resources/css/cockpit.css": 2290,
     "resources/css/cowork-canon-financeiro-bundle.css": 4859,
     "resources/css/cowork-compras-bundle.css": 182,
-    "resources/css/cowork-fields.css": 392,
+    "resources/css/cowork-fields.css": 409,
     "resources/css/cowork-payment-gateway-bundle.css": 257,
     "resources/css/fin-cowork.css": 653,
     "resources/css/fin-curadoria.css": 289,

--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -114,6 +114,23 @@
   cursor: not-allowed;
 }
 
+/* Espaço pros ícones overlay de um input cowork (lupa à esquerda, X/limpar à direita).
+ * Atômicas e componíveis: use `cw-input-icon-left` sozinha pra só-lupa, ou as duas
+ * juntas pra busca com botão limpar.
+ *
+ * Por que precisa existir: `.cw-input` usa `padding: 0 8px` (shorthand) e mora
+ * UNLAYERED (cowork-fields.css é @import sem @layer). No Tailwind v4 as utilitárias
+ * `pl-9`/`pr-9` vivem em `@layer utilities` — e, pela cascata de layers, estilo
+ * UNLAYERED sempre vence LAYERED, independente de especificidade/ordem. Resultado:
+ * `pl-9`/`pr-9` no <Input variant="cowork"> eram IGNORADOS, o texto começava em 8px
+ * e a lupa (left-3 = 12px) ficava "encavalada" sobre o placeholder.
+ *
+ * Fix: estas longhands, também unlayered e declaradas DEPOIS de `.cw-input`,
+ * sobrescrevem só o lado horizontal do shorthand. left-3(12px) + ícone 16px = 28px
+ * → 34px dá ~6px de respiro. Reportado por Wagner 2026-06-13 (lista de clientes). */
+.cw-input-icon-left  { padding-left: 34px; }
+.cw-input-icon-right { padding-right: 34px; }
+
 /* Textarea variant (auto-height) */
 .cw-input.cw-textarea {
   height: auto; padding: 6px 8px; line-height: 1.45;

--- a/resources/js/Pages/Cliente/Index.charter.md
+++ b/resources/js/Pages/Cliente/Index.charter.md
@@ -3,8 +3,8 @@ page: /cliente (canon) · /contacts (legacy dual-render via config('mwart.client
 component: resources/js/Pages/Cliente/Index.tsx
 owner: wagner
 status: live
-last_validated: '2026-06-08'
-charter_version: 9
+last_validated: '2026-06-13'
+charter_version: 10
 parent_module: Cliente / Crm
 related_adrs:
   - '0093-multi-tenant-isolation-tier-0'
@@ -49,7 +49,9 @@ drawer_pattern:
   position: lateral-right
   trigger: "Click linha tabela OU deeplink /cliente/{id} → router.visit('/cliente?contact_id={id}&tab=identificacao')"
   close: "X · Esc · click backdrop"
-  tabs: [identificacao, contato, endereco, comercial, classificacao, oss, ia, auditoria]
+  tabs: [identificacao, contato, endereco, comercial, classificacao, operacoes]
+  header_chips: [placas, ia]   # auditoria saiu do chip → sub-aba de operacoes (2026-06-13)
+  operacoes_subtabs: [ledger, sales, payments, documents, persons, subscriptions, rewards, auditoria]
 ---
 
 # Page Charter — /cliente (Index + Drawer 760px)
@@ -69,7 +71,7 @@ Listagem densa de clientes com drawer lateral 760px abrindo ao clicar em qualque
 - ~~**PTDP Onda 1 (v4 · 2026-05-24):**~~ ❌ **REVOGADA (v6 · 2026-05-24)** · Wagner reprovou BrunaGreeting + SavedViews em validação visual produção · removidos `Components/clientes/BrunaGreeting.tsx` e `SavedViews.tsx` · charter mantém histórico (append-only)
 - **PTDP Onda 2 (v5 · 2026-05-24):** `<KpiStripClickable>` 5 cards-filtro (Clientes ativos · VIPs · Com saldo · Sem compra 90d · Novos este mês) substitui 4 KpiCard estáticos Wave G · clique aplica filtro substitutivo · toggle 2x desativa · counts client-side pros estimados (vips/sem90/novos · Onda 3 plug backend dedicado). **v6 nota:** mutex com SavedViews removido (não há mais SavedViews)
 
-## Goals (Drawer 760px — 8 tabs)
+## Goals (Drawer 760px — 6 tabs principais + chips Placas/IA)
 
 - **Header drawer**: avatar grande, toggle PF/PJ, nome + "Pessoa jurídica · cadastrado há Xd", badge Ativo/Inativo/Bloqueado, botões "Imprimir ficha" + "Falar com Copiloto →" (= `/jana/chat?context=cliente:{id}`)
 - **Tab Identificação**: Razão social/Nome, Fantasia (PJ), CNPJ + "Buscar CNPJ" (BrasilAPI proxy server-side), IE (PJ), Contato principal (PJ), Cargo (PJ), CPF/Nascimento/RG (PF) — máscaras + mod 11 + autosave on blur
@@ -77,9 +79,9 @@ Listagem densa de clientes com drawer lateral 760px abrindo ao clicar em qualque
 - **Tab Endereço**: CEP + ViaCEP proxy server-side ao blur autopreenche, endereço/número/complemento/bairro/cidade/UF — autosave on blur
 - **Tab Comercial**: limite crédito, prazo padrão (dias), tabela preço (padrao/varejo/atacado/parceiro), pgto padrão (pix/boleto/cartão/dinheiro/transferência), obs comercial textarea — autosave on blur
 - **Tab Classificação**: segmento (radio: varejo/atacado/agência/corporativo/evento/governo), tags multi-select (9 valores), status (ativo/inativo/bloqueado), VIP toggle — autosave on blur
-- **Tab OSs**: wrapper das 8 sub-tabs Wave Final (`_show/LedgerTab`, `SalesTab`, `PaymentsTab`, `DocumentsTab`, `ActivitiesTab`, `PessoasContatoTab`, `SubscriptionsTab`, `RewardPointsTab`) via sub-tabs aninhadas verticais (decisão final layout na Wave D)
-- **Tab IA**: 4 cards Copiloto (Resumo relacionamento / Reavaliar segmento+tags / Próxima ação / Score risco determinístico) — default ON pra todos (sem gate quota)
-- **Tab Auditoria**: timeline Spatie ActivityLog v4.8 com 6+ tipos eventos + botão Exportar log — `forSubject(Contact $contact)` filtrado por business_id
+- **Tab Operações** (`OssTab`): rail vertical com sub-abas `_show/LedgerTab`, `SalesTab`, `PaymentsTab`, `DocumentsTab`, `PessoasContatoTab`, `SubscriptionsTab`, `RewardPointsTab` + **Auditoria** (`_drawer/AuditoriaTab` — integrada 2026-06-13). `ActivitiesTab` removido (duplicava Auditoria — mesma fonte Spatie)
+- **Chip IA**: 4 cards Copiloto (Resumo relacionamento / Reavaliar segmento+tags / Próxima ação / Score risco determinístico) — default ON pra todos (sem gate quota)
+- **Sub-aba Auditoria** (em Operações): timeline Spatie ActivityLog v4.8 com 6+ tipos eventos — `forSubject(Contact $contact)` filtrado por business_id. Wagner 2026-06-13: saiu do chip (virou sub-aba de Operações) + **botão "Exportar log" removido** (acesso LGPD Art.18 pela própria timeline; rota `/auditoria/export` mantida no backend)
 
 ## Non-Goals
 

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -12,7 +12,6 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } fro
 import {
   AlertTriangle,
   ArrowDown,
-  Activity,
   ArrowUp,
   ArrowUpDown,
   Briefcase,
@@ -85,7 +84,6 @@ import ClassificacaoTab from './_drawer/ClassificacaoTab';
 // Wave D/E/F — OSs wrapper, IA 4 cards, Auditoria timeline LGPD (ADR 0179).
 import OssTab, { type OssSubTabKey } from './_drawer/OssTab';
 import IATab from './_drawer/IATab';
-import AuditoriaTab from './_drawer/AuditoriaTab';
 // Wagner 2026-05-27 iteracao 2: Placas promovido pra tab principal (botao header).
 import PlacasMainTab from './_drawer/PlacasMainTab';
 // Wave G — listagem turbinada (avatar HSL hash + Pills semânticos).
@@ -1100,9 +1098,10 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
             </nav>
 
             {/* Busca a direita (Wagner v3.5): `ml-auto` empurra pra direita extrema.
-                canon v3.8: h-9 → h-8 (mais fina) + bg-background (destaque branco sobre cream)
-                + border warm `oklch(0.9 0.004 90)` (afinidade familia cream). Placeholder
-                simplificado: tira meta-info "(/ pra focar · ⌘K global)" — atalhos no cheat-sheet. */}
+                border warm `oklch(0.9 0.004 90)` (afinidade familia cream). Placeholder
+                simplificado: tira meta-info "(/ pra focar · ⌘K global)" — atalhos no cheat-sheet.
+                Espaço pros ícones (lupa + X) via `.cw-input-search` — NÃO `pl-9/pr-9` tailwind,
+                que são ignorados pelo `.cw-input` unlayered no Tailwind v4 (ver cowork-fields.css). */}
             <div className="relative ml-auto min-w-[200px] max-w-md w-full sm:w-auto">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
               <Input
@@ -1111,7 +1110,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                 value={searchInput}
                 onChange={(e) => setSearchInput(e.target.value)}
                 placeholder="Buscar nome, CNPJ/CPF, contato, telefone, cidade..."
-                className="pl-9 pr-9 h-8 bg-background"
+                className="cw-input-icon-left cw-input-icon-right"
                 style={{ borderColor: 'oklch(0.9 0.004 90)' }}
                 aria-label="Buscar contato"
               />
@@ -1872,14 +1871,15 @@ type DrawerTab =
   | 'classificacao'
   | 'operacoes'
   | 'placas'
-  | 'ia'
-  | 'auditoria';
+  | 'ia';
 
 // Wagner 2026-05-27 iteracao 2 (Proposta F): 6 tabs principais focadas em
-// CADASTRO/OPERACOES editaveis. Tabs read-only (placas/auditoria/ia) viraram
-// BOTOES NO HEADER do drawer (acesso 1-clique sem poluir tab bar). Rename
-// oss→operacoes (semantica clara: OSs ficavam dentro mas agora so coisas
-// REAIS de OS — Extrato/Vendas/Pagamentos/Documentos/Pessoas/Assinaturas/Pontos).
+// CADASTRO/OPERACOES editaveis. Tabs read-only (placas/ia) viraram BOTOES NO
+// HEADER do drawer (acesso 1-clique sem poluir tab bar). Rename oss→operacoes
+// (semantica clara: OSs ficavam dentro mas agora so coisas REAIS de OS —
+// Extrato/Vendas/Pagamentos/Documentos/Pessoas/Assinaturas/Pontos/Auditoria).
+// Wagner 2026-06-13: Auditoria saiu do chip e virou sub-aba de Operações
+// ("chips e abas são a mesma coisa — integrar").
 const DRAWER_TABS: Array<{ key: DrawerTab; label: string }> = [
   { key: 'identificacao', label: 'Identificação' },
   { key: 'contato',       label: 'Contato' },
@@ -1979,7 +1979,7 @@ function ClienteSheet({
     if (!open) return;
     const TAB_ORDER: DrawerTab[] = [
       'identificacao', 'contato', 'endereco', 'comercial',
-      'classificacao', 'oss', 'ia', 'auditoria',
+      'classificacao', 'operacoes', 'ia', 'placas',
     ];
     const onKey = (e: KeyboardEvent) => {
       const target = e.target;
@@ -2079,9 +2079,10 @@ function ClienteSheet({
           </div>
 
           {/* Wagner 2026-05-27 iteracao 2 (Proposta F) -- Botoes header pra
-              entidades secundarias: Placas (gate OficinaAuto, contador) +
-              Auditoria + IA. Acesso 1-clique sem poluir tab bar (6 tabs
-              principais focadas em cadastro/operacoes editaveis). */}
+              entidades secundarias: Placas (gate OficinaAuto, contador) + IA.
+              Acesso 1-clique sem poluir tab bar (6 tabs principais focadas em
+              cadastro/operacoes editaveis). Auditoria saiu daqui 2026-06-13 →
+              virou sub-aba de Operações (rail). */}
           <div className="flex items-center gap-1 pt-1 flex-wrap" role="toolbar" aria-label="Atalhos do drawer">
             {oficinaAutoEnabled && (
               <button
@@ -2122,21 +2123,6 @@ function ClienteSheet({
               <Paperclip size={11} aria-hidden />
               <span>{liveAnexosCount ?? contact?.documents_count ?? 0}</span>
               <span>anexos</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => setActiveTab('auditoria')}
-              className={
-                'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ' +
-                (activeTab === 'auditoria'
-                  ? 'border-primary bg-primary/10 text-primary'
-                  : 'border-input bg-background text-muted-foreground hover:text-foreground hover:bg-muted/40')
-              }
-              aria-pressed={activeTab === 'auditoria'}
-              title="Linha do tempo de auditoria LGPD"
-            >
-              <Activity size={11} aria-hidden />
-              <span>Auditoria</span>
             </button>
             <button
               type="button"
@@ -2203,8 +2189,9 @@ function ClienteSheet({
                   Notion/Linear. Render-condicional anterior desmontava o componente,
                   matando state + cleanup clearTimeout matando debounces → user digita
                   CEP/número/etc e troca pra aba "Contato" em <800ms → valor sumia.
-                  Tabs read-only (oss/ia/auditoria) seguem condicionais — desmontar
-                  é OK pra elas (consultas pesadas, sem state user-editável). */}
+                  Tabs read-only (placas/ia) seguem condicionais — desmontar
+                  é OK pra elas (consultas pesadas, sem state user-editável).
+                  Auditoria agora é sub-aba de Operações (desmonta junto do OssTab). */}
               <div hidden={activeTab !== 'identificacao'}>
                 <IdentificacaoTab
                   contact={contact}
@@ -2252,9 +2239,6 @@ function ClienteSheet({
               )}
               {activeTab === 'ia' && (
                 <IATab contact={{ id: contact.id, name: contact.name }} />
-              )}
-              {activeTab === 'auditoria' && (
-                <AuditoriaTab contact={{ id: contact.id }} />
               )}
             </>
           )}

--- a/resources/js/Pages/Cliente/Map.tsx
+++ b/resources/js/Pages/Cliente/Map.tsx
@@ -72,7 +72,7 @@ export default function ClienteMap(props: ClienteMapPageProps) {
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
                 placeholder="Buscar cliente ou cidade…"
-                className="pl-9"
+                className="cw-input-icon-left"
               />
             </div>
 

--- a/resources/js/Pages/Cliente/_drawer/AuditoriaTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/AuditoriaTab.tsx
@@ -31,7 +31,6 @@ import {
   Trash2,
   Shield,
   Tag,
-  Download,
   Loader2,
   AlertCircle,
 } from 'lucide-react';
@@ -138,28 +137,9 @@ export default function AuditoriaTab({ contact }: AuditoriaTabProps) {
 
   return (
     <div className="space-y-4" data-testid="auditoria-tab-root">
-      {/* Header LGPD Art. 18 + botao exportar */}
-      <div className="rounded-lg border border-border bg-muted/30 p-3 flex items-start justify-between gap-3">
-        <div className="min-w-0">
-          <h3 className="text-xs font-semibold uppercase tracking-wider text-foreground">
-            Historico de alteracao
-          </h3>
-          <p className="text-xs text-muted-foreground mt-1">
-            Tudo o que aconteceu com essa ficha. Atende ao Art. 18 da LGPD (direito de
-            acesso aos dados pessoais).
-          </p>
-        </div>
-        <Button asChild variant="outline" size="sm" data-testid="auditoria-export-btn">
-          <a
-            href={`/cliente/${contact.id}/auditoria/export?format=csv`}
-            download
-            rel="nofollow"
-          >
-            <Download size={14} className="mr-1" />
-            Exportar log
-          </a>
-        </Button>
-      </div>
+      {/* Wagner 2026-06-13: cabeçalho (título + nota de privacidade + export CSV)
+          removido a pedido — a aba renderiza só a timeline. Acesso LGPD segue
+          garantido pelos dados + rota de export no backend. */}
 
       {/* Loading state */}
       {loading && events.length === 0 && (

--- a/resources/js/Pages/Cliente/_drawer/OssTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/OssTab.tsx
@@ -21,6 +21,7 @@
 
 import { useState } from 'react';
 import {
+  Activity,
   Banknote,
   FileText,
   Gift,
@@ -38,11 +39,14 @@ import DocumentsTab from '../_show/DocumentsTab';
 import PessoasContatoTab from '../_show/PessoasContatoTab';
 import SubscriptionsTab from '../_show/SubscriptionsTab';
 import RewardPointsTab from '../_show/RewardPointsTab';
+import AuditoriaTab from './AuditoriaTab';
 import type { ContactInfo } from './IdentificacaoTab';
 
 // Wagner 2026-05-27 -- iteracao 2: removido sub-tab `placas` (promovido pra
 // tab principal acessado via botao header) + removido sub-tab `activities`
-// (duplicava tab principal `Auditoria` -- mesma fonte `activity_log` Spatie).
+// (duplicava `Auditoria` -- mesma fonte `activity_log` Spatie).
+// Wagner 2026-06-13: `auditoria` ENTRA aqui como sub-aba de Operações (antes era
+// chip flutuante no header — "chips e abas são a mesma coisa, integrar").
 export type OssSubTabKey =
   | 'ledger'
   | 'sales'
@@ -50,7 +54,8 @@ export type OssSubTabKey =
   | 'documents'
   | 'persons'
   | 'subscriptions'
-  | 'rewards';
+  | 'rewards'
+  | 'auditoria';
 
 export interface OssTabProps {
   contact: ContactInfo;
@@ -86,6 +91,7 @@ const SUB_TABS: Array<{ key: OssSubTabKey; label: string; icon: LucideIcon }> = 
   { key: 'persons', label: 'Pessoas', icon: Users },
   { key: 'subscriptions', label: 'Assinaturas', icon: Recycle },
   { key: 'rewards', label: 'Pontos', icon: Gift },
+  { key: 'auditoria', label: 'Auditoria', icon: Activity },
 ];
 
 export default function OssTab({
@@ -195,6 +201,8 @@ export default function OssTab({
             em vez de ficar preso no skeleton "Carregando…"). */}
         {active === 'subscriptions' && <SubscriptionsTab contactId={contact.id} />}
         {active === 'rewards' && <RewardPointsTab contactId={contact.id} />}
+        {/* Wagner 2026-06-13: Auditoria integrada ao rail de Operações (saiu do chip). */}
+        {active === 'auditoria' && <AuditoriaTab contact={{ id: contact.id }} />}
       </div>
     </div>
   );

--- a/resources/js/Pages/Cliente/_show/SalesTab.tsx
+++ b/resources/js/Pages/Cliente/_show/SalesTab.tsx
@@ -254,7 +254,7 @@ export default function SalesTab({
                 onChange={(e) => setQuery(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && applyFilters()}
                 placeholder="Nº fatura, ref…"
-                className="pl-9"
+                className="cw-input-icon-left"
                 data-testid="sales-search"
               />
             </div>

--- a/tests/Feature/Cliente/ClienteDrawerHeaderButtonsReorgTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerHeaderButtonsReorgTest.php
@@ -45,33 +45,35 @@ test('GUARD 2 — Cliente/Index.tsx ClienteRow declara vehicles_count', function
 
 // ─── GUARD 3: DRAWER_TABS array reorganizado pra 6 tabs + types corretos
 
-test('GUARD 3 — DRAWER_TABS tem 6 entradas + operacoes (renamed oss) + sem ia/auditoria/placas', function () {
+test('GUARD 3 — DRAWER_TABS tem 6 entradas + operacoes (renamed oss) + chips placas/ia (auditoria saiu)', function () {
     $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
     $contents = file_get_contents($path);
 
     expect($contents)
         // 6 tabs principais (Identif/Contato/Endereco/Comercial/Classif/Operacoes)
         ->toContain("{ key: 'operacoes',     label: 'Operações' }")
-        // Type DrawerTab inclui novos valores acessados via botao header.
+        // Type DrawerTab inclui valores acessados via botao header.
         ->toContain("| 'operacoes'")
         ->toContain("| 'placas'")
         ->toContain("| 'ia'")
-        ->toContain("| 'auditoria'")
+        // Wagner 2026-06-13: 'auditoria' saiu do type top-level (virou sub-aba de Operações).
+        ->not->toContain("| 'auditoria'")
         // Removida entrada `oss` (renomeada).
         ->not->toContain("{ key: 'oss',           label: 'OSs' }");
 });
 
-// ─── GUARD 4: Botoes header (Placas/Auditoria/IA) ─────────────────────────
+// ─── GUARD 4: Botoes header (Placas/IA) — Auditoria saiu p/ rail Operações ──
 
-test('GUARD 4 — drawer header tem botoes Placas/Auditoria/IA com aria-pressed', function () {
+test('GUARD 4 — drawer header tem botoes Placas/IA com aria-pressed (sem chip Auditoria)', function () {
     $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
     $contents = file_get_contents($path);
 
     expect($contents)
-        // Botoes 3 com aria-pressed.
+        // Chips com aria-pressed.
         ->toContain("aria-pressed={activeTab === 'placas'}")
-        ->toContain("aria-pressed={activeTab === 'auditoria'}")
         ->toContain("aria-pressed={activeTab === 'ia'}")
+        // Wagner 2026-06-13: chip Auditoria removido (integrado ao rail de Operações).
+        ->not->toContain("aria-pressed={activeTab === 'auditoria'}")
         // Contador placas usa vehicles_count.
         ->toContain('contact?.vehicles_count ?? 0')
         // Gate OficinaAuto envolve botao Placas.
@@ -83,7 +85,7 @@ test('GUARD 4 — drawer header tem botoes Placas/Auditoria/IA com aria-pressed'
 
 // ─── GUARD 5: Renders pos-reorg corretos ──────────────────────────────────
 
-test('GUARD 5 — tab content renders operacoes/placas/ia/auditoria com gate OficinaAuto', function () {
+test('GUARD 5 — tab content renders operacoes/placas/ia com gate OficinaAuto', function () {
     $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
     $contents = file_get_contents($path);
 
@@ -107,14 +109,16 @@ test('GUARD 6 — OssTab.tsx removeu sub-tabs placas/activities + oficinaAutoEna
         ->not->toContain("{ key: 'activities'")
         ->not->toContain('PlacasSubTab')
         ->not->toContain('ActivitiesTab')
-        // Mantém 7 sub-tabs reais de OS (ledger/sales/payments/documents/persons/subscriptions/rewards).
+        // Mantém os sub-tabs reais de OS + Auditoria (integrada 2026-06-13):
+        // ledger/sales/payments/documents/persons/subscriptions/rewards/auditoria.
         ->toContain("{ key: 'ledger'")
         ->toContain("{ key: 'sales'")
         ->toContain("{ key: 'payments'")
         ->toContain("{ key: 'documents'")
         ->toContain("{ key: 'persons'")
         ->toContain("{ key: 'subscriptions'")
-        ->toContain("{ key: 'rewards'");
+        ->toContain("{ key: 'rewards'")
+        ->toContain("{ key: 'auditoria'");
 });
 
 // ─── GUARD 7: PlacasMainTab existe no novo local ──────────────────────────
@@ -205,4 +209,47 @@ test('GUARD 11 — OssTab.tsx expõe activeSubTab/onSubTabChange (controlado pel
         ->toContain('onSubTabChange?: (key: OssSubTabKey) => void')
         // active derivado: controle externo tem prioridade sobre estado interno.
         ->toContain('const active = activeSubTab ?? internalActive');
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// Wagner 2026-06-13 — "chips e abas são a mesma coisa, integrar isso".
+// Auditoria deixou de ser chip flutuante no header e virou SUB-ABA de Operações
+// (rail OssTab). Também removido o botao "Exportar log" da AuditoriaTab (acesso
+// LGPD Art.18 se dá pela própria timeline; rota /export segue no backend).
+// ════════════════════════════════════════════════════════════════════════
+
+// ─── GUARD 12: Auditoria integrada ao rail Operações (saiu do chip) ───────
+
+test('GUARD 12 — Auditoria é sub-aba de Operações no OssTab (não mais chip no Index)', function () {
+    $oss = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx');
+    $index = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx');
+
+    expect($oss)
+        // OssTab importa e renderiza a AuditoriaTab.
+        ->toContain("import AuditoriaTab from './AuditoriaTab'")
+        ->toContain("{ key: 'auditoria', label: 'Auditoria'")
+        ->toContain("active === 'auditoria' && <AuditoriaTab")
+        // Tipo da sub-aba inclui auditoria.
+        ->toContain("| 'auditoria'");
+
+    expect($index)
+        // Index não renderiza mais AuditoriaTab top-level nem importa o componente.
+        ->not->toContain("import AuditoriaTab")
+        ->not->toContain("<AuditoriaTab contact={{ id: contact.id }} />");
+});
+
+// ─── GUARD 13: AuditoriaTab sem cabeçalho (título + nota LGPD + Exportar log) ──
+
+test('GUARD 13 — AuditoriaTab.tsx removeu cabeçalho inteiro, mantém só a timeline', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/AuditoriaTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Wagner 2026-06-13: "não quero isso" — cabeçalho inteiro fora.
+        ->not->toContain('Exportar log')
+        ->not->toContain('auditoria-export-btn')
+        ->not->toContain('Historico de alteracao')
+        ->not->toContain('Art. 18 da LGPD')
+        // Timeline (lista de eventos) permanece.
+        ->toContain('auditoria-tab-timeline');
 });

--- a/tests/Feature/Cliente/ClienteIndexDrawer760CharterTest.php
+++ b/tests/Feature/Cliente/ClienteIndexDrawer760CharterTest.php
@@ -66,7 +66,7 @@ test('GUARD 3 — Cliente/Index.tsx ClienteSheet renderiza com w-[760px]', funct
 
 // ─── GUARD 4: 8 tabs presentes no DOM ────────────────────────────────────────
 
-test('GUARD 4 — Cliente/Index.tsx contem 8 tabs drawer (Identificacao..Auditoria)', function () {
+test('GUARD 4 — Cliente/Index.tsx tem 6 abas principais + chips; Auditoria migrou p/ OssTab', function () {
     $tsxPath = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
     $contents = file_get_contents($tsxPath);
 
@@ -76,12 +76,16 @@ test('GUARD 4 — Cliente/Index.tsx contem 8 tabs drawer (Identificacao..Auditor
         ->toContain('Endereço')
         ->toContain('Comercial')
         ->toContain('Classificação')
-        ->toContain('OSs')
+        ->toContain('Operações')
         ->toContain('IA')
-        ->toContain('Auditoria')
         ->toContain("'identificacao'")
-        ->toContain("'auditoria'")
-        ->toContain('DRAWER_TABS');
+        ->toContain('DRAWER_TABS')
+        // Wagner 2026-06-13: 'auditoria' saiu do Index (virou sub-aba de Operações).
+        ->not->toContain("'auditoria'");
+
+    // Auditoria agora vive no rail de Operações (OssTab).
+    $oss = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx');
+    expect($oss)->toContain("{ key: 'auditoria', label: 'Auditoria'");
 });
 
 // ─── GUARD 5: cross-tenant biz=1 nao ve contact biz=99 (404) ─────────────────


### PR DESCRIPTION
Fatia limpa a partir do `main` atual com **só os 2 fixes de cliente** desta sessão (separada da PR #2682 / DS Rollout, que está 109 commits atrás do main e conflitante).

## 1. Lupa não encavala no campo de busca (`fix`)
`.cw-input` é unlayered (`cowork-fields.css`) e vencia as utilitárias `pl-9`/`pr-9` do Tailwind v4 (que ficam em `@layer utilities`) — o texto colava em 8px e a lupa sobrepunha o placeholder. Novas classes unlayered `cw-input-icon-left` / `cw-input-icon-right` reabrem o padding pros ícones. Aplicado em `Cliente/Index` (busca), `Cliente/Map` e no buscar de Vendas da ficha.

## 2. Auditoria vira sub-aba de Operações + remove cabeçalho (`feat`)
Pedido Wagner 2026-06-13 ("chips e abas são a mesma coisa, integrar" + "não quero isso"):
- Auditoria sai do chip flutuante do header e entra no rail de **Operações** (`OssTab`).
- `AuditoriaTab` perde o cabeçalho inteiro (título + texto + botão "Exportar log") — fica só a timeline. Rota `/auditoria/export` mantida no backend.
- `Index.tsx`: remove chip + render top-level + imports/types mortos; corrige `TAB_ORDER` (`oss`→`operacoes`).

## Catraca
Guards source-grep atualizados pro novo layout + GUARD 12/13 travando (Auditoria-em-OssTab, sem "Exportar log"). Charter `Index.charter.md` v9→v10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)