### PR TITLE
fix(whatsapp): auditor do flip-flop ACL canal (revoke/reativação) + auditor de corruptores SQLite

### DIFF
--- a/Modules/Whatsapp/Console/Commands/AuditChannelAccessCommand.php
+++ b/Modules/Whatsapp/Console/Commands/AuditChannelAccessCommand.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * Auditor de conflitos em `channel_user_access` — ACL atendente↔canal (US-WA-068, ADR 0135).
+ *
+ * Motivação (Wagner 2026-06-13 "uma hora é removido, uma hora é reativado, por?"):
+ * o acesso de um atendente a um canal fica oscilando entre revogado e ativo.
+ * A causa é DUAS fontes de verdade que se contradizem:
+ *
+ *   1. `DUP_ATIVO` — o `UNIQUE(channel_id, user_id, revoked_at)` original NÃO
+ *      enforça "1 grant ativo por (canal,user)" porque NULLs são DISTINTOS em
+ *      índice UNIQUE (MySQL/MariaDB/SQLite). Logo 2 grants com `revoked_at=NULL`
+ *      (dois ativos do mesmo atendente no mesmo canal) coexistem silenciosamente.
+ *      O enforcement de schema vive na migration 2026_06_13_120000 (coluna gerada
+ *      `revoked_marker`); ESTE auditor é o equivalente runtime/on-demand que acha
+ *      e limpa duplicados mesmo onde a migration ainda não rodou.
+ *
+ *   2. `FLIP_BACKFILL` — `whatsapp:backfill-channel-access` concede grant a TODO
+ *      user com `whatsapp.send/access`, olhando só `whereNull('revoked_at')`. Se um
+ *      admin REVOGOU de propósito (revoked_by_user_id = humano > 0) e o backfill
+ *      roda depois, ele cria um grant novo (`granted_by_user_id = 0` = system) →
+ *      DESFAZ o revoke deliberado. O atendente volta a ver um canal do qual foi
+ *      removido. (A causa-raiz foi corrigida no BackfillChannelAccessCommand, que
+ *      passou a respeitar o tombstone de revoke humano; este auditor limpa o
+ *      passivo já existente em prod.)
+ *
+ * Padrão (espelha `financeiro-bridge-auditor` + `jana:health-check`):
+ *   - READ-ONLY por default. `--fix` (opt-in) é a ÚNICA porta pra DML.
+ *   - Idempotente: re-rodar após `--fix` reporta 0 conflitos.
+ *   - `--strict` faz exit 1 quando há conflito não-corrigido (uso em CI/cron gate).
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - `business_id` explícito em toda query; `--business=X` escopa, `all` = cross-tenant.
+ *   - `withoutGlobalScope` deixa o intent CLI-superadmin explícito (sem auth/sessão).
+ *   - Logs/saída SEM PII: só ids numéricos + contadores. Nunca phone/nome.
+ *
+ * Uso:
+ *   php artisan whatsapp:audit-channel-access --business=1            (relatório biz=1)
+ *   php artisan whatsapp:audit-channel-access                         (relatório todos)
+ *   php artisan whatsapp:audit-channel-access --json                  (saída máquina)
+ *   php artisan whatsapp:audit-channel-access --business=1 --fix      (corrige biz=1)
+ *   php artisan whatsapp:audit-channel-access --strict                (gate CI/cron)
+ *
+ * @see Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand
+ * @see Modules\Whatsapp\Database\Migrations\2026_06_13_120000_enforce_single_active_channel_user_access
+ * @see memory/decisions/0135-omnichannel-inbox-arquitetura.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-068
+ */
+class AuditChannelAccessCommand extends Command
+{
+    protected $signature = 'whatsapp:audit-channel-access
+                            {--business=all : business_id alvo (default: all)}
+                            {--fix : Resolve os conflitos (revoga duplicados/flips). Sem isto = só relatório.}
+                            {--json : Saída JSON (máquina) em vez de tabela.}
+                            {--strict : Exit 1 se houver conflito não-corrigido (gate CI/cron).}';
+
+    protected $description = 'Audita channel_user_access: acha grants em conflito (duplicado-ativo + revogado-por-humano/reativado-pelo-backfill). --fix opcional.';
+
+    /**
+     * Sequência monotônica de revokes do --fix. Garante `revoked_at` GLOBALMENTE
+     * distinto entre TODAS as rows revogadas nesta run (dup + flip), pra não
+     * colidir no UNIQUE antigo `(channel_id,user_id,revoked_at)` onde a migration
+     * corretiva (revoked_marker) ainda não rodou — um par pode aparecer em dup E
+     * flip ao mesmo tempo.
+     */
+    private int $revokeSeq = 0;
+
+    public function handle(): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $fix = (bool) $this->option('fix');
+        $asJson = (bool) $this->option('json');
+        $strict = (bool) $this->option('strict');
+
+        $businessId = null;
+        if ($businessOpt !== 'all') {
+            $businessId = (int) $businessOpt;
+            if ($businessId <= 0) {
+                $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+
+                return self::FAILURE;
+            }
+        }
+
+        $dupGroups = $this->findDuplicateActiveGroups($businessId);
+        $flips = $this->findBackfillFlips($businessId);
+
+        $dupRowsRevoked = 0;
+        $flipRevoked = 0;
+
+        if ($fix) {
+            $dupRowsRevoked = $this->fixDuplicateActiveGroups($dupGroups);
+            $flipRevoked = $this->fixBackfillFlips($flips);
+        }
+
+        $report = [
+            'business_filter' => $businessOpt,
+            'fix' => $fix,
+            'dup_active' => $dupGroups,
+            'flip_backfill' => $flips,
+            'summary' => [
+                'dup_groups' => count($dupGroups),
+                'dup_rows_revoked' => $dupRowsRevoked,
+                'flip_grants' => count($flips),
+                'flip_revoked' => $flipRevoked,
+            ],
+        ];
+
+        Log::info('[whatsapp.audit_channel_access.completed]', array_merge(
+            ['business_filter' => $businessOpt, 'fix' => $fix],
+            $report['summary']
+        ));
+
+        if ($asJson) {
+            $this->line((string) json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->renderHuman($report, $fix);
+        }
+
+        $hasFindings = $report['summary']['dup_groups'] > 0 || $report['summary']['flip_grants'] > 0;
+
+        if ($strict && $hasFindings && ! $fix) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * DUP_ATIVO — pares (business,channel,user) com >1 grant ativo (revoked_at NULL).
+     *
+     * Portável (sem UPDATE..JOIN nem window functions). Retorna, por grupo, o
+     * `keep_id` (maior id = mais recente, preservado) e os `revoke_ids` (revogados
+     * pelo --fix). Tudo só ids — sem PII.
+     *
+     * @return list<array{business_id:int,channel_id:int,user_id:int,active_count:int,keep_id:int,revoke_ids:list<int>}>
+     */
+    private function findDuplicateActiveGroups(?int $businessId): array
+    {
+        $groups = DB::table('channel_user_access')
+            ->select('business_id', 'channel_id', 'user_id', DB::raw('count(*) as active_count'))
+            ->whereNull('revoked_at')
+            ->when($businessId !== null, fn ($q) => $q->where('business_id', $businessId))
+            ->groupBy('business_id', 'channel_id', 'user_id')
+            ->havingRaw('count(*) > 1')
+            ->get();
+
+        $out = [];
+
+        foreach ($groups as $g) {
+            $activeIds = DB::table('channel_user_access')
+                ->where('business_id', $g->business_id)
+                ->where('channel_id', $g->channel_id)
+                ->where('user_id', $g->user_id)
+                ->whereNull('revoked_at')
+                ->orderBy('id')
+                ->pluck('id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
+            $keepId = array_pop($activeIds); // mantém o maior id (mais recente)
+
+            $out[] = [
+                'business_id' => (int) $g->business_id,
+                'channel_id' => (int) $g->channel_id,
+                'user_id' => (int) $g->user_id,
+                'active_count' => (int) $g->active_count,
+                'keep_id' => (int) $keepId,
+                'revoke_ids' => array_values($activeIds),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * FLIP_BACKFILL — grant ATIVO criado pelo system backfill
+     * (`granted_by_user_id = 0`) num par que JÁ teve revoke HUMANO
+     * (`revoked_by_user_id > 0`). Sintoma: o atendente foi removido de propósito
+     * e o backfill o reativou.
+     *
+     * Regra correta porque: se o grant ativo é `granted_by=0` E existe revoke
+     * humano pro mesmo par, o sistema desfez a decisão humana. Se o ativo fosse
+     * `granted_by>0`, seria re-grant humano deliberado (não flip). Backfill
+     * legítimo (sem revoke humano anterior) não é flagado.
+     *
+     * @return list<array{business_id:int,channel_id:int,user_id:int,grant_id:int,human_revokes:int}>
+     */
+    private function findBackfillFlips(?int $businessId): array
+    {
+        $activeSystemGrants = DB::table('channel_user_access')
+            ->whereNull('revoked_at')
+            ->where('granted_by_user_id', 0)
+            ->when($businessId !== null, fn ($q) => $q->where('business_id', $businessId))
+            ->orderBy('id')
+            ->get(['id', 'business_id', 'channel_id', 'user_id']);
+
+        $out = [];
+
+        foreach ($activeSystemGrants as $g) {
+            $humanRevokes = (int) DB::table('channel_user_access')
+                ->where('business_id', $g->business_id)
+                ->where('channel_id', $g->channel_id)
+                ->where('user_id', $g->user_id)
+                ->whereNotNull('revoked_at')
+                ->where('revoked_by_user_id', '>', 0)
+                ->count();
+
+            if ($humanRevokes > 0) {
+                $out[] = [
+                    'business_id' => (int) $g->business_id,
+                    'channel_id' => (int) $g->channel_id,
+                    'user_id' => (int) $g->user_id,
+                    'grant_id' => (int) $g->id,
+                    'human_revokes' => $humanRevokes,
+                ];
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * Soft-revoga os duplicados ativos (mantém `keep_id`). `revoked_by_user_id = 0`
+     * (system). Timestamps ESCALONADOS pra não colidir no UNIQUE antigo
+     * (revoked_at não-NULL iguais colidem onde a migration corretiva não rodou).
+     */
+    private function fixDuplicateActiveGroups(array $dupGroups): int
+    {
+        $revoked = 0;
+        $now = now();
+
+        foreach ($dupGroups as $group) {
+            foreach ($group['revoke_ids'] as $id) {
+                $affected = DB::table('channel_user_access')
+                    ->where('id', $id)
+                    ->whereNull('revoked_at') // defensivo: só se ainda ativo
+                    ->update([
+                        'revoked_at' => $now->copy()->addSeconds($this->revokeSeq++),
+                        'revoked_by_user_id' => 0,
+                        'updated_at' => $now,
+                    ]);
+                $revoked += $affected;
+            }
+        }
+
+        return $revoked;
+    }
+
+    /**
+     * Revoga os grants do system backfill que reativaram um revoke humano —
+     * restaura a intenção do admin. `revoked_by_user_id = 0` (system).
+     */
+    private function fixBackfillFlips(array $flips): int
+    {
+        $revoked = 0;
+        $now = now();
+
+        foreach ($flips as $flip) {
+            $affected = DB::table('channel_user_access')
+                ->where('id', $flip['grant_id'])
+                ->whereNull('revoked_at') // defensivo (dup-fix pode ter pego antes)
+                ->update([
+                    'revoked_at' => $now->copy()->addSeconds($this->revokeSeq++),
+                    'revoked_by_user_id' => 0,
+                    'updated_at' => $now,
+                ]);
+            $revoked += $affected;
+        }
+
+        return $revoked;
+    }
+
+    private function renderHuman(array $report, bool $fix): void
+    {
+        $s = $report['summary'];
+
+        $this->info($fix ? '== Auditoria channel_user_access (modo --fix) ==' : '== Auditoria channel_user_access (relatório) ==');
+        $this->line("business: {$report['business_filter']}");
+        $this->newLine();
+
+        $this->line(sprintf(
+            'DUP_ATIVO   : %d grupo(s) com >1 grant ativo%s',
+            $s['dup_groups'],
+            $fix ? " · {$s['dup_rows_revoked']} row(s) revogada(s)" : ''
+        ));
+        $this->line(sprintf(
+            'FLIP_BACKFILL: %d grant(s) system reativando revoke humano%s',
+            $s['flip_grants'],
+            $fix ? " · {$s['flip_revoked']} revogado(s)" : ''
+        ));
+        $this->newLine();
+
+        if ($s['dup_groups'] > 0) {
+            $this->warn('Duplicados ativos (channel_id/user_id → keep, revoke):');
+            $this->table(
+                ['business_id', 'channel_id', 'user_id', 'ativos', 'mantém id', 'revoga ids'],
+                array_map(fn ($d) => [
+                    $d['business_id'], $d['channel_id'], $d['user_id'],
+                    $d['active_count'], $d['keep_id'], implode(',', $d['revoke_ids']),
+                ], $report['dup_active'])
+            );
+        }
+
+        if ($s['flip_grants'] > 0) {
+            $this->warn('Flips backfill (grant system reativou revoke humano):');
+            $this->table(
+                ['business_id', 'channel_id', 'user_id', 'grant_id', 'revokes humanos'],
+                array_map(fn ($f) => [
+                    $f['business_id'], $f['channel_id'], $f['user_id'],
+                    $f['grant_id'], $f['human_revokes'],
+                ], $report['flip_backfill'])
+            );
+        }
+
+        if ($s['dup_groups'] === 0 && $s['flip_grants'] === 0) {
+            $this->info('✓ Nenhum conflito encontrado.');
+        } elseif (! $fix) {
+            $this->newLine();
+            $this->comment('Rode com --fix pra resolver (revoga duplicados + flips, preserva history).');
+        }
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/BackfillChannelAccessCommand.php
+++ b/Modules/Whatsapp/Console/Commands/BackfillChannelAccessCommand.php
@@ -45,14 +45,16 @@ class BackfillChannelAccessCommand extends Command
 {
     protected $signature = 'whatsapp:backfill-channel-access
                             {--business=all : business_id alvo (default: all)}
-                            {--dry-run : Só conta, não persiste}';
+                            {--dry-run : Só conta, não persiste}
+                            {--force : Re-concede mesmo a quem teve revoke HUMANO (ignora o tombstone). Só pra re-provisionamento intencional.}';
 
-    protected $description = 'Backfill channel_user_access pra users com whatsapp.send/access (idempotente)';
+    protected $description = 'Backfill channel_user_access pra users com whatsapp.send/access (idempotente, respeita revoke humano)';
 
     public function handle(): int
     {
         $businessOpt = (string) $this->option('business');
         $dryRun = (bool) $this->option('dry-run');
+        $force = (bool) $this->option('force');
 
         if ($dryRun) {
             $this->warn('[dry-run] Nenhuma row será persistida.');
@@ -86,16 +88,14 @@ class BackfillChannelAccessCommand extends Command
         $usersPerBusiness = [];
         $totalGranted = 0;
         $totalSkipped = 0;
+        $totalRespected = 0;
         $totalChannelsSkipped = 0;
 
         foreach ($channels as $channel) {
             /** @var Channel $channel */
             $bizId = (int) $channel->business_id;
 
-            if (! isset($usersPerBusiness[$bizId])) {
-                $usersPerBusiness[$bizId] = $this->fetchWhatsappUsers($bizId);
-            }
-
+            $usersPerBusiness[$bizId] ??= $this->fetchWhatsappUsers($bizId);
             $users = $usersPerBusiness[$bizId];
 
             if ($users->isEmpty()) {
@@ -114,6 +114,7 @@ class BackfillChannelAccessCommand extends Command
 
             $grantedNow = 0;
             $skippedNow = 0;
+            $respectedNow = 0;
 
             foreach ($users as $user) {
                 $userId = (int) $user->id;
@@ -133,6 +134,33 @@ class BackfillChannelAccessCommand extends Command
                 if ($existingActive) {
                     $skippedNow++;
                     continue;
+                }
+
+                // Causa-raiz do flip-flop (Wagner 2026-06-13 "removido/reativado por?"):
+                // conceder a TODO user com whatsapp.send/access DESFAZ revokes deliberados.
+                // Respeita o tombstone — se o ÚLTIMO registro do par foi revogado por um
+                // HUMANO (revoked_by_user_id > 0), NÃO re-concede (salvo --force). Sem
+                // active (já filtrado acima), o registro de maior id é o último estado.
+                if (! $force) {
+                    $latest = ChannelUserAccess::query()
+                        ->withoutGlobalScope(ScopeByBusiness::class)
+                        ->where('business_id', $bizId)
+                        ->where('channel_id', $channel->id)
+                        ->where('user_id', $userId)
+                        ->orderByDesc('id')
+                        ->first(['id', 'revoked_at', 'revoked_by_user_id']);
+
+                    if ($latest !== null
+                        && $latest->revoked_at !== null
+                        && (int) $latest->revoked_by_user_id > 0) {
+                        $respectedNow++;
+                        Log::info('[whatsapp.backfill_channel_access.respected_revoke]', [
+                            'business_id' => $bizId,
+                            'channel_id' => $channel->id,
+                            'user_id' => $userId,
+                        ]);
+                        continue;
+                    }
                 }
 
                 if (! $dryRun) {
@@ -155,36 +183,45 @@ class BackfillChannelAccessCommand extends Command
 
             $action = $dryRun ? 'would grant' : 'granted';
             $this->line(sprintf(
-                '  Canal #%d (biz=%d) "%s": %s %d user(s) · skipped %d (já ativos)',
+                '  Canal #%d (biz=%d) "%s": %s %d user(s) · skipped %d (já ativos) · %d respeitando revoke',
                 $channel->id,
                 $bizId,
                 $channel->label,
                 $action,
                 $grantedNow,
-                $skippedNow
+                $skippedNow,
+                $respectedNow
             ));
 
             $totalGranted += $grantedNow;
             $totalSkipped += $skippedNow;
+            $totalRespected += $respectedNow;
         }
 
         $this->newLine();
         $this->info(sprintf(
-            '✓ Resumo: %d canal(is) processado(s), %d canal(is) sem users elegíveis · %s %d grant(s) · %d já ativos',
+            '✓ Resumo: %d canal(is) processado(s), %d canal(is) sem users elegíveis · %s %d grant(s) · %d já ativos · %d respeitando revoke humano',
             $totalChannels - $totalChannelsSkipped,
             $totalChannelsSkipped,
             $dryRun ? 'WOULD grant' : 'granted',
             $totalGranted,
-            $totalSkipped
+            $totalSkipped,
+            $totalRespected
         ));
+
+        if ($totalRespected > 0 && ! $force) {
+            $this->comment("  ({$totalRespected} user(s) não re-grantado(s) por terem revoke humano — use --force pra re-provisionar.)");
+        }
 
         Log::info('[whatsapp.backfill_channel_access.completed]', [
             'business_filter' => $businessOpt,
             'dry_run' => $dryRun,
+            'force' => $force,
             'channels_total' => $totalChannels,
             'channels_skipped' => $totalChannelsSkipped,
             'grants_created' => $totalGranted,
             'grants_skipped_existing' => $totalSkipped,
+            'grants_respected_revoke' => $totalRespected,
         ]);
 
         return self::SUCCESS;

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -8,6 +8,7 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
+use Modules\Whatsapp\Console\Commands\AuditChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\CustomerMemoryBackfillCommand;
@@ -92,6 +93,7 @@ class WhatsappServiceProvider extends ServiceProvider
             $this->commands([
                 DriverHealthCheckAllCommand::class,
                 BackfillChannelAccessCommand::class,
+                AuditChannelAccessCommand::class,       // Wagner 2026-06-13 — auditor flip-flop revoke/reativação ACL canal
                 RegisterWhatsappPermissionsCommand::class,
                 // Guardião 6 camadas anti-mídia-perdida
                 ScanMediaDriftCommand::class,           // Camada 5 — scan drift daily

--- a/Modules/Whatsapp/Tests/Feature/AuditChannelAccessCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AuditChannelAccessCommandTest.php
@@ -1,0 +1,395 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\ChannelUserAccess;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Auditor de conflitos channel_user_access (Wagner 2026-06-13 "removido/reativado por?").
+ *
+ * GUARD tests Tier 0 (ADR 0093 + ADR 0135) do `whatsapp:audit-channel-access`:
+ *
+ *   DUP_ATIVO    : >1 grant ativo no mesmo (canal,user) — detecta + --fix revoga extras.
+ *   FLIP_BACKFILL: grant system (granted_by=0) reativando revoke humano — detecta + --fix.
+ *   Backfill respeita tombstone humano (causa-raiz do flip) salvo --force.
+ *
+ * Pattern espelha BackfillChannelAccessCommandTest (schema sintético manual +
+ * quarentena era-sqlite) — seeds via DB::table (sem activitylog), --fix via raw
+ * update (idem). burn-down SDD converte pra MySQL persistente depois.
+ *
+ * @see Modules\Whatsapp\Console\Commands\AuditChannelAccessCommand
+ * @see Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente — quarentena Onda 2 SDD floor; burn-down converte depois.');
+    }
+
+    foreach ([
+        'model_has_permissions', 'model_has_roles', 'role_has_permissions',
+        'permissions', 'roles',
+        'channel_user_access', 'channels', 'users',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('users', function ($table) {
+        $table->increments('id');
+        $table->string('username', 100)->nullable();
+        $table->string('email', 100)->nullable();
+        $table->unsignedInteger('business_id');
+        $table->string('password')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    // channel_user_access COM o UNIQUE ANTIGO (channel_id,user_id,revoked_at) —
+    // o bug que o auditor caça: NULLs distintos deixam 2 ativos coexistirem.
+    Schema::create('channel_user_access', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('user_id');
+        $table->unsignedInteger('granted_by_user_id');
+        $table->timestamp('granted_at');
+        $table->timestamp('revoked_at')->nullable();
+        $table->unsignedInteger('revoked_by_user_id')->nullable();
+        $table->timestamps();
+        $table->unique(['channel_id', 'user_id', 'revoked_at'], 'cua_channel_user_unq');
+        $table->index(['business_id', 'user_id'], 'cua_biz_user_idx');
+    });
+
+    Schema::create('permissions', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->timestamps();
+        $table->unique(['name', 'guard_name']);
+    });
+
+    Schema::create('roles', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->unsignedInteger('business_id')->nullable();
+        $table->timestamps();
+        $table->unique(['name', 'guard_name']);
+    });
+
+    Schema::create('model_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['permission_id', 'model_id', 'model_type']);
+        $table->index(['model_id', 'model_type']);
+    });
+
+    Schema::create('model_has_roles', function ($table) {
+        $table->unsignedBigInteger('role_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+        $table->primary(['role_id', 'model_id', 'model_type']);
+        $table->index(['model_id', 'model_type']);
+    });
+
+    Schema::create('role_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->unsignedBigInteger('role_id');
+        $table->primary(['permission_id', 'role_id']);
+    });
+
+    app()->forgetInstance(\Spatie\Permission\PermissionRegistrar::class);
+    if (class_exists(\Spatie\Permission\PermissionRegistrar::class)) {
+        try {
+            app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+        } catch (\Throwable $e) {
+            // tolerante a env de teste sem cache
+        }
+    }
+});
+
+function acacChannel(int $businessId, string $label = 'Suporte'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $businessId,
+        'channel_uuid' => 'acac-' . $businessId . '-' . uniqid(),
+        'label' => $label,
+        'type' => Channel::TYPE_WHATSAPP_BAILEYS,
+        'status' => 'active',
+    ]);
+}
+
+/** Insere grant via raw DB (sem disparar activitylog) com defaults seguros. */
+function acacGrant(array $attrs): int
+{
+    return (int) DB::table('channel_user_access')->insertGetId(array_merge([
+        'granted_at' => now(),
+        'granted_by_user_id' => 1,
+        'revoked_at' => null,
+        'revoked_by_user_id' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ], $attrs));
+}
+
+function acacUser(int $businessId, ?string $directPerm = null, ?string $rolePerm = null): \App\User
+{
+    $user = new \App\User();
+    $user->username = 'u' . uniqid();
+    $user->email = $user->username . '@test.local';
+    $user->business_id = $businessId;
+    $user->password = 'x';
+    $user->save();
+
+    if ($directPerm !== null) {
+        $perm = Permission::firstOrCreate(['name' => $directPerm, 'guard_name' => 'web']);
+        $user->givePermissionTo($perm);
+    }
+    if ($rolePerm !== null) {
+        $role = Role::firstOrCreate(['name' => 'Admin#' . $businessId, 'guard_name' => 'web']);
+        $perm = Permission::firstOrCreate(['name' => $rolePerm, 'guard_name' => 'web']);
+        $role->givePermissionTo($perm);
+        $user->assignRole($role);
+    }
+
+    return $user;
+}
+
+function acacActiveCount(int $channelId, int $userId): int
+{
+    return (int) DB::table('channel_user_access')
+        ->where('channel_id', $channelId)
+        ->where('user_id', $userId)
+        ->whereNull('revoked_at')
+        ->count();
+}
+
+// ---------------------------------------------------------------------------
+// DUP_ATIVO
+// ---------------------------------------------------------------------------
+
+it('R-WA-ACAC-001 — relatório detecta duplicado ativo SEM persistir mudança', function () {
+    $ch = acacChannel(1);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]); // 2º ativo (bug)
+
+    expect(acacActiveCount($ch->id, 10))->toBe(2);
+
+    $exit = Artisan::call('whatsapp:audit-channel-access', ['--business' => '1']);
+
+    expect($exit)->toBe(0);
+    // Sem --fix → nada muda
+    expect(acacActiveCount($ch->id, 10))->toBe(2);
+});
+
+it('R-WA-ACAC-002 — --fix revoga o duplicado mantendo o maior id; idempotente', function () {
+    $ch = acacChannel(1);
+    $first = acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+    $second = acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+
+    Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--fix' => true]);
+
+    expect(acacActiveCount($ch->id, 10))->toBe(1);
+    // Mantém o maior id (mais recente)
+    $stillActive = DB::table('channel_user_access')->whereNull('revoked_at')->first();
+    expect((int) $stillActive->id)->toBe($second);
+    // Revogado pelo system (0)
+    $revoked = DB::table('channel_user_access')->where('id', $first)->first();
+    expect((int) $revoked->revoked_by_user_id)->toBe(0);
+    expect($revoked->revoked_at)->not->toBeNull();
+
+    // 2ª run = nada a fazer
+    Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--fix' => true]);
+    expect(acacActiveCount($ch->id, 10))->toBe(1);
+});
+
+// ---------------------------------------------------------------------------
+// FLIP_BACKFILL
+// ---------------------------------------------------------------------------
+
+it('R-WA-ACAC-003 — detecta flip: revoke humano + grant system ativo', function () {
+    $ch = acacChannel(1);
+    // Admin revogou (humano)
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
+        'granted_by_user_id' => 7, 'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(), 'revoked_by_user_id' => 7,
+    ]);
+    // Backfill reativou (system)
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
+        'granted_by_user_id' => 0,
+    ]);
+
+    $exit = Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--json' => true]);
+    $report = json_decode(Artisan::output(), true);
+
+    expect($exit)->toBe(0);
+    expect($report['summary']['flip_grants'])->toBe(1);
+    expect($report['summary']['dup_groups'])->toBe(0);
+});
+
+it('R-WA-ACAC-004 — --fix revoga o grant system do flip (restaura intenção humana)', function () {
+    $ch = acacChannel(1);
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
+        'granted_by_user_id' => 7, 'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(), 'revoked_by_user_id' => 7,
+    ]);
+    $systemGrant = acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
+        'granted_by_user_id' => 0,
+    ]);
+
+    Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--fix' => true]);
+
+    expect(acacActiveCount($ch->id, 10))->toBe(0);
+    $row = DB::table('channel_user_access')->where('id', $systemGrant)->first();
+    expect($row->revoked_at)->not->toBeNull();
+    expect((int) $row->revoked_by_user_id)->toBe(0);
+});
+
+it('R-WA-ACAC-005 — backfill legítimo (system, sem revoke humano) NÃO é flip', function () {
+    $ch = acacChannel(1);
+    // Grant system normal, ninguém revogou antes
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10,
+        'granted_by_user_id' => 0,
+    ]);
+
+    $exit = Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--json' => true]);
+    $report = json_decode(Artisan::output(), true);
+
+    expect($exit)->toBe(0);
+    expect($report['summary']['flip_grants'])->toBe(0);
+});
+
+it('R-WA-ACAC-006 — multi-tenant: --business=1 não toca conflito de biz=99', function () {
+    $ch99 = acacChannel(99);
+    acacGrant(['business_id' => 99, 'channel_id' => $ch99->id, 'user_id' => 20]);
+    acacGrant(['business_id' => 99, 'channel_id' => $ch99->id, 'user_id' => 20]); // dup biz 99
+
+    Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--fix' => true]);
+
+    // biz=99 intacto (escopo --business=1)
+    expect(acacActiveCount($ch99->id, 20))->toBe(2);
+});
+
+it('R-WA-ACAC-007 — --json emite summary estruturado', function () {
+    $ch = acacChannel(1);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+
+    Artisan::call('whatsapp:audit-channel-access', ['--json' => true]);
+    $report = json_decode(Artisan::output(), true);
+
+    expect($report)->toHaveKeys(['business_filter', 'fix', 'dup_active', 'flip_backfill', 'summary']);
+    expect($report['summary']['dup_groups'])->toBe(1);
+    expect($report['dup_active'][0])->toHaveKeys(['channel_id', 'user_id', 'keep_id', 'revoke_ids']);
+});
+
+it('R-WA-ACAC-008 — sem conflitos: exit 0, summary zerado', function () {
+    $ch = acacChannel(1);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]); // 1 só
+
+    $exit = Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--json' => true]);
+    $report = json_decode(Artisan::output(), true);
+
+    expect($exit)->toBe(0);
+    expect($report['summary']['dup_groups'])->toBe(0);
+    expect($report['summary']['flip_grants'])->toBe(0);
+});
+
+it('R-WA-ACAC-009 — --strict com conflito e sem --fix retorna FAILURE', function () {
+    $ch = acacChannel(1);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+    acacGrant(['business_id' => 1, 'channel_id' => $ch->id, 'user_id' => 10]);
+
+    $exit = Artisan::call('whatsapp:audit-channel-access', ['--business' => '1', '--strict' => true]);
+
+    expect($exit)->toBe(1);
+});
+
+// ---------------------------------------------------------------------------
+// Causa-raiz: backfill respeita revoke humano
+// ---------------------------------------------------------------------------
+
+it('R-WA-ACAC-010 — backfill NÃO re-concede a quem teve revoke humano (tombstone)', function () {
+    $ch = acacChannel(1);
+    $u = acacUser(1, 'whatsapp.send');
+
+    // Admin revogou de propósito (humano)
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => $u->id,
+        'granted_by_user_id' => 7, 'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(), 'revoked_by_user_id' => 7,
+    ]);
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    // Continua sem grant ativo — backfill respeitou o tombstone
+    expect(acacActiveCount($ch->id, $u->id))->toBe(0);
+});
+
+it('R-WA-ACAC-011 — backfill --force re-concede mesmo com revoke humano', function () {
+    $ch = acacChannel(1);
+    $u = acacUser(1, 'whatsapp.send');
+
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => $u->id,
+        'granted_by_user_id' => 7, 'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(), 'revoked_by_user_id' => 7,
+    ]);
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1', '--force' => true]);
+
+    expect(acacActiveCount($ch->id, $u->id))->toBe(1);
+});
+
+it('R-WA-ACAC-012 — backfill re-concede quando o revoke foi SYSTEM (não humano)', function () {
+    $ch = acacChannel(1);
+    $u = acacUser(1, 'whatsapp.send');
+
+    // Revoke pelo system (0) — não é tombstone humano
+    acacGrant([
+        'business_id' => 1, 'channel_id' => $ch->id, 'user_id' => $u->id,
+        'granted_by_user_id' => 0, 'granted_at' => now()->subDay(),
+        'revoked_at' => now()->subHour(), 'revoked_by_user_id' => 0,
+    ]);
+
+    Artisan::call('whatsapp:backfill-channel-access', ['--business' => '1']);
+
+    expect(acacActiveCount($ch->id, $u->id))->toBe(1);
+});

--- a/memory/sessions/2026-06-13-audit-sqlite-test-corruptors.md
+++ b/memory/sessions/2026-06-13-audit-sqlite-test-corruptors.md
@@ -1,0 +1,287 @@
+---
+date: "2026-06-13"
+topic: "Auditoria: testes que corrompem SQLite :memory: compartilhado (snapshot ranqueado)"
+authors: [W, C]
+---
+
+# Corruptores SQLite — snapshot 2026-06-13
+
+> Gerado por `node scripts/audit/sqlite-test-corruptors.mjs --json`. **Regenere a qualquer momento** — este arquivo é um retrato datado, não a fonte da verdade.
+
+Motivação: a suíte roda em SQLite `:memory:`. Testes com schema sintético manual (`Schema::create/drop` de tabelas compartilhadas) corrompem o schema pro próximo teste da mesma conexão → cascata de fails. É o "lever real" do floor SDD F2b (~19 corruptores citados nos handoffs → na verdade 237 potenciais).
+
+## Resumo
+
+- Test files escaneados: **1228**
+- Corruptores potenciais: **237**
+- Buckets (raio de cascata): **S=58** crítico · **A=89** alto · **B=64** médio · **C=26** baixo
+
+Ataque por ordem: **S → A**. Cada um: converter pra `RefreshDatabase` (migrations reais) OU quarentenar com `markTestSkipped` não-sqlite (como a família era-sqlite já faz).
+
+Colunas: **tier** | **score** | **arquivo** | **quarentenado** (já tem marcador era-sqlite) | **tabelas de alto raio** | **razões**.
+
+## Bucket S (58)
+
+| tier | score | arquivo | quar. | alto raio | razões |
+|---|---|---|---|---|---|
+| S | 165 | `tests/Feature/Domain/Fsm/ExecuteStageActionServiceTest.php` | não | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | não-quarentenado; alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 165 | `tests/Feature/Jobs/CancelarCobrancaInterJobTest.php` | não | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | não-quarentenado; alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 165 | `tests/Feature/Jobs/RefundCobrancaInterJobTest.php` | não | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | não-quarentenado; alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 155 | `Modules/RecurringBilling/Tests/Feature/Wave21NewSubscriptionTest.php` | não | contacts, activity_log | não-quarentenado; alto-raio[contacts,activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 155 | `Modules/RecurringBilling/Tests/Feature/Wave2Observer3ActionsTest.php` | não | contacts, activity_log | não-quarentenado; alto-raio[contacts,activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 155 | `Modules/RecurringBilling/Tests/Feature/Wave6PlanCrudTest.php` | não | contacts, activity_log | não-quarentenado; alto-raio[contacts,activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 155 | `Modules/RecurringBilling/Tests/Feature/Wave7FaturasIndexTest.php` | não | activity_log, contacts | não-quarentenado; alto-raio[activity_log,contacts]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 155 | `Modules/RecurringBilling/Tests/Feature/Wave9NotesFavoritesTest.php` | não | contacts, activity_log | não-quarentenado; alto-raio[contacts,activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 135 | `tests/Feature/Domain/Inventory/BomResolverTest.php` | não | products, variations | não-quarentenado; alto-raio[products,variations]; writes-sem-isolamento; DDL-manual |
+| S | 135 | `tests/Feature/Domain/Inventory/ReservarEstoqueBomTest.php` | não | products, variations | não-quarentenado; alto-raio[products,variations]; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/Financeiro/Tests/Feature/MultiTenantComprehensiveTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/RecurringBilling/Tests/Feature/AssinaturaServiceWave18Test.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/RecurringBilling/Tests/Feature/BoletoCredentialResolverTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/RecurringBilling/Tests/Feature/CustomerJourneyTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/RecurringBilling/Tests/Feature/InvoiceGeneratorServiceTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/RecurringBilling/Tests/Feature/Wave23EditarAssinaturaTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 125 | `Modules/RecurringBilling/Tests/Feature/Wave8ConfiguracoesIndexTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 110 | `tests/Feature/Console/FsmBulkStartPipelineCommandTest.php` | sim | users, transactions, activity_log | quarentenado(era-sqlite); alto-raio[users,transactions,activity_log]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 110 | `tests/Feature/Modules/Copiloto/TenancyLeakTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 105 | `Modules/Crm/Tests/Feature/Wave27DealPipelineTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| S | 105 | `Modules/Jana/Tests/Feature/Ai/Clarify/ClarifyCascadeServiceTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| S | 105 | `Modules/NfeBrasil/Tests/Feature/CertificadoFallbackLegadoTest.php` | não | business | não-quarentenado; alto-raio[business]; writes-sem-isolamento; DDL-manual |
+| S | 105 | `Modules/NfeBrasil/Tests/Feature/DanfeServiceTest.php` | não | business | não-quarentenado; alto-raio[business]; writes-sem-isolamento; DDL-manual |
+| S | 105 | `Modules/NfeBrasil/Tests/Feature/NfeDomainModelsTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| S | 105 | `Modules/Repair/Tests/Feature/MultiTenantRepairTest.php` | não | activity_log | não-quarentenado; alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| S | 95 | `Modules/Governance/Tests/Feature/CrossTenantPolicyTest.php` | não | — | não-quarentenado; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 95 | `Modules/Governance/Tests/Feature/GovernanceGateTest.php` | não | — | não-quarentenado; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 95 | `Modules/Governance/Tests/Feature/MultiTenantGovernanceTest.php` | não | — | não-quarentenado; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 95 | `Modules/Governance/Tests/Feature/SmokeRoutesTest.php` | não | — | não-quarentenado; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 95 | `Modules/RecurringBilling/Tests/Feature/AtualizarCobrancaAssinaturaTest.php` | não | — | não-quarentenado; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 95 | `Modules/RecurringBilling/Tests/Feature/RepositoryWave18Test.php` | não | — | não-quarentenado; mutação-conexão; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Jana/Tests/Feature/Ai/BriefDiarioAgentTest.php` | sim | transactions, transaction_payments, contacts, channels, products, transaction_sell_lines | quarentenado(era-sqlite); alto-raio[transactions,transaction_payments,contacts,channels,products,transaction_sell_lines]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Jana/Tests/Feature/BriefDiarioServiceTest.php` | sim | transactions, transaction_payments, contacts, channels, products, transaction_sell_lines | quarentenado(era-sqlite); alto-raio[transactions,transaction_payments,contacts,channels,products,transaction_sell_lines]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/NfeBrasil/Tests/Feature/EmitirNFSeJobTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/RecurringBilling/Tests/Feature/CancelarCobrancaAsaasJobTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php` | sim | contacts, permissions, roles, role_has_permissions, model_has_permissions, model_has_roles, users | quarentenado(era-sqlite); alto-raio[contacts,permissions,roles,role_has_permissions,model_has_permissions,model_has_roles,users]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/RecurringBilling/Tests/Feature/RefundCobrancaAsaasJobTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Repair/Tests/Feature/RepairFsmActionControllerTest.php` | sim | activity_log, business, users, model_has_roles, model_has_permissions, role_has_permissions | quarentenado(era-sqlite); alto-raio[activity_log,business,users,model_has_roles,model_has_permissions,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Repair/Tests/Feature/Wave25RepairFsmCanonExpandedTest.php` | sim | users, model_has_roles, model_has_permissions, role_has_permissions, activity_log | quarentenado(era-sqlite); alto-raio[users,model_has_roles,model_has_permissions,role_has_permissions,activity_log]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/AuditChannelAccessCommandTest.php` | sim | users, channels, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,channels,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/AutoLinkContactTest.php` | sim | permissions, roles, role_has_permissions, model_has_permissions, model_has_roles, users, activity_log, contacts, channels | quarentenado(era-sqlite); alto-raio[permissions,roles,role_has_permissions,model_has_permissions,model_has_roles,users,activity_log,contacts,channels]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/BackfillChannelAccessCommandTest.php` | sim | users, channels, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,channels,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php` | sim | contacts, users, channels | quarentenado(era-sqlite); alto-raio[contacts,users,channels]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/LinkContactTest.php` | sim | activity_log, contacts, channels | quarentenado(era-sqlite); alto-raio[activity_log,contacts,channels]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php` | sim | permissions, roles, role_has_permissions, model_has_permissions, model_has_roles, users | quarentenado(era-sqlite); alto-raio[permissions,roles,role_has_permissions,model_has_permissions,model_has_roles,users]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/NotificarClienteCancelamentoJobTest.php` | sim | business, contacts, transactions | quarentenado(era-sqlite); alto-raio[business,contacts,transactions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `Modules/Whatsapp/Tests/Feature/RegisterWhatsappPermissionsCommandTest.php` | sim | business, users, channels, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[business,users,channels,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/CancelarVendaCascadeSideEffectTest.php` | sim | users, model_has_roles, model_has_permissions, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,model_has_roles,model_has_permissions,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/CurrentStageIdBypassObserverTest.php` | sim | users, model_has_roles, model_has_permissions, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,model_has_roles,model_has_permissions,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/EstornarBoletoJobTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/GateEmissaoPorVendaTest.php` | sim | users, business, transactions, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,business,transactions,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/MultiTenantIsolationTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/ProcessoVendaComProducaoTest.php` | sim | users, model_has_roles, model_has_permissions, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,model_has_roles,model_has_permissions,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/SaleHistoryControllerTest.php` | sim | users, model_has_roles, model_has_permissions, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,model_has_roles,model_has_permissions,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/StockReservationsTest.php` | sim | users, products, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,products,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/TransactionDocumentTest.php` | sim | users, permissions, roles, model_has_permissions, model_has_roles, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,permissions,roles,model_has_permissions,model_has_roles,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 90 | `tests/Feature/Domain/Fsm/TransicaoCriticaExigeAutorizacaoTest.php` | sim | users, model_has_roles, model_has_permissions, role_has_permissions | quarentenado(era-sqlite); alto-raio[users,model_has_roles,model_has_permissions,role_has_permissions]; writes-sem-isolamento; DDL-manual |
+| S | 80 | `Modules/RecurringBilling/Tests/Feature/AssinaturaCobrancaServiceTest.php` | não | — | não-quarentenado; mutação-conexão; DDL-manual |
+
+## Bucket A (89)
+
+| tier | score | arquivo | quar. | alto raio | razões |
+|---|---|---|---|---|---|
+| A | 75 | `Modules/ADS/Tests/Unit/ContextForTaskActiveTasksTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Financeiro/Tests/Feature/UnificadoCommentsAuditTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Governance/Tests/Feature/DetectOtelQueryTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/BriefDiarioChatTriggerTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/HealthNarratorServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/HitTrackerServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/AutomationRegistrySyncTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/HandoffDiffToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/HandoffDraftToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/HandoffFetchSummarizedToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/InboxAutoCleanupJobTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/JanaCyclesAutoCloseExpiredCommandTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/JanaWeeklyDigestCommandTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/JanaWeeklyDigestEmailTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/KbAnswerToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/McpTasksHealthCheckCommandTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/MyInboxToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Mcp/WeeklyDigestFetchToolTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Memoria/Freshness/StalenessDetectorTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/NarrarSaudeEcosistemaJobTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Jana/Tests/Feature/Summarizer/AutoSummarizerServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/NfeBrasil/Tests/Feature/CertificadoServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/NfeBrasil/Tests/Feature/DanfeServicePrefersArquivosTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/NfeBrasil/Tests/Feature/ImportRegrasCsvServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/NfeBrasil/Tests/Feature/MotorTributarioServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/NfeBrasil/Tests/Feature/SyncFiscalRuleToTaxRateTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/NfeBrasil/Tests/Feature/TributacaoControllerTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Repair/Tests/Feature/DeviceModelsInertiaSmokeTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/E2EJourneyBiz1Test.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/LidPhoneResolverTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/MetricsSnapshotBuilderTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/ObservabilityTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/OfficeimpressoEnrichServiceTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/ProcessIncomingWebhookJobTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/SendInteractiveJobTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/SendMessageRequestTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/WebhookBackpressureTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/WebhookReplayProtectionTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/WebhookSignatureTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/WhatsappDriverHealthCheckJobTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `Modules/Whatsapp/Tests/Feature/WhatsappTemplateTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `tests/Feature/Cliente/ClienteIndexDrawer760CharterTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `tests/Feature/Modules/Copiloto/ApuracaoIdempotenciaTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `tests/Feature/Modules/Copiloto/Mcp/IndexarMemoryGitParaDbTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `tests/Feature/Modules/Governance/DashboardExtensionTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 75 | `tests/Feature/Modules/Governance/DetectDriftCommandTest.php` | não | — | não-quarentenado; writes-sem-isolamento; DDL-manual |
+| A | 70 | `Modules/Essentials/Tests/Feature/EssentialsBladeT1InertiaSmokeTest.php` | não | — | não-quarentenado; mutação-conexão |
+| A | 70 | `Modules/Financeiro/Tests/Feature/FluxoCaixaServiceTest.php` | não | — | não-quarentenado; mutação-conexão |
+| A | 70 | `tests/Browser/CoreScreens/A11yAxeBrowserTest.php` | não | — | não-quarentenado; mutação-conexão |
+| A | 70 | `tests/Browser/CoreScreens/AuthBridgeSmokeTest.php` | não | — | não-quarentenado; mutação-conexão |
+| A | 70 | `tests/Browser/CoreScreens/ConformanceProbesTest.php` | não | — | não-quarentenado; mutação-conexão |
+| A | 70 | `tests/Browser/CoreScreens/PixelBaselineTest.php` | não | — | não-quarentenado; mutação-conexão |
+| A | 60 | `Modules/Governance/Tests/Feature/ObservabilitySnapshotServiceTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `Modules/Governance/Tests/Feature/ScorecardSnapshotCommandTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `Modules/Governance/Tests/Feature/Wave28InitiativeServiceTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `Modules/Jana/Tests/Feature/Mcp/AutomationRegistryMigrationTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `Modules/Jana/Tests/Feature/RetentionPurgeCommandTest.php` | sim | business, activity_log | quarentenado(era-sqlite); alto-raio[business,activity_log]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/NfeBrasil/Tests/Feature/NfeInutilizacaoServiceTest.php` | sim | activity_log, business | quarentenado(era-sqlite); alto-raio[activity_log,business]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Vestuario/Tests/Feature/Wave28DevolucaoServiceTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/ClientFeedbackDevTaskTest.php` | sim | activity_log, contacts | quarentenado(era-sqlite); alto-raio[activity_log,contacts]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/CustomerMemoryRebuilderTest.php` | sim | business, contacts | quarentenado(era-sqlite); alto-raio[business,contacts]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/EmployeePerformanceRebuilderTest.php` | sim | business, users | quarentenado(era-sqlite); alto-raio[business,users]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/FeedbackReindexCommandTest.php` | sim | activity_log, contacts | quarentenado(era-sqlite); alto-raio[activity_log,contacts]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/FeedbackRelevanceTest.php` | sim | activity_log, contacts | quarentenado(era-sqlite); alto-raio[activity_log,contacts]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/InboxCleanupTest.php` | sim | users, channels | quarentenado(era-sqlite); alto-raio[users,channels]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/IncidentCrossContact20260514E2ERegressionTest.php` | sim | contacts, channels | quarentenado(era-sqlite); alto-raio[contacts,channels]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/LidBackfillObserverTest.php` | sim | contacts, channels | quarentenado(era-sqlite); alto-raio[contacts,channels]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/LidCrossContactIncidentP0Test.php` | sim | contacts, channels | quarentenado(era-sqlite); alto-raio[contacts,channels]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/MediaInboundProcessedTest.php` | sim | contacts, channels | quarentenado(era-sqlite); alto-raio[contacts,channels]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/WhatsmeowBroadcastFilterTest.php` | sim | channels, activity_log | quarentenado(era-sqlite); alto-raio[channels,activity_log]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/WhatsmeowMediaInboundTest.php` | sim | channels, activity_log | quarentenado(era-sqlite); alto-raio[channels,activity_log]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `Modules/Whatsapp/Tests/Feature/WhatsmeowOutboundFromMeRegressionTest.php` | sim | channels, activity_log | quarentenado(era-sqlite); alto-raio[channels,activity_log]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `tests/Feature/Domain/Fsm/SideEffects/EmitirNovaAposCancelamentoTest.php` | sim | transactions, transaction_sell_lines | quarentenado(era-sqlite); alto-raio[transactions,transaction_sell_lines]; writes-sem-isolamento; DDL-manual |
+| A | 60 | `tests/Feature/Modules/Copiloto/MemoriaMetricaTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `tests/Feature/Modules/Copiloto/MetricasApuradorTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 60 | `tests/Feature/Modules/Copiloto/SemanticCacheServiceTest.php` | não | — | não-quarentenado; DDL-manual |
+| A | 50 | `Modules/Whatsapp/Tests/Feature/AutoPrefixSenderNameTest.php` | sim | users | quarentenado(era-sqlite); alto-raio[users]; mutação-conexão; writes-sem-isolamento; DDL-manual |
+
+## Bucket B (64)
+
+<details><summary>64 arquivos (clique)</summary>
+
+| tier | score | arquivo | quar. | alto raio | razões |
+|---|---|---|---|---|---|
+| B | 30 | `Modules/Jana/Tests/Feature/DsrServiceTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Jana/Tests/Feature/LgpdEsquecerTitularToolTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/KB/Tests/Feature/LgpdComplianceTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/KB/Tests/Feature/MultiTenantTraitTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/NfeBrasil/Tests/Feature/NfeEmissaoControllerSerializeUrlsTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/Cnab/Drivers/SicoobCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/CresolCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/EncryptedCredentialCastTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/InterImportarRecebimentosCommandTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/ReconciliarCobrancaServiceTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/PaymentGateway/Tests/Feature/SicrediCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/RecurringBilling/Tests/Feature/SyncBankBalancesJobTest.php` | sim | business | quarentenado(era-sqlite); alto-raio[business]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/RecurringBilling/Tests/Feature/SyncBankStatementsJobTest.php` | sim | business | quarentenado(era-sqlite); alto-raio[business]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/AuthStateDriftCheckTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/Baileys7xPayloadShapeTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/BlockContactTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/CanalFilaIsolationTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelBaileysInstanceIdHelperTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelBaileysWebhookIdempotencyTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelImportHistoryGatingTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelObserverSyncDaemonTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelRequestUniqueIdentifierTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelResetCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelsControllerAutoPurgeBeforeConnectTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelsReconcilerCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ContactObserverCacheInvalidationTest.php` | sim | contacts | quarentenado(era-sqlite); alto-raio[contacts]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ConversationSchemaIdentitiesTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ConversationTagsTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/CsatFlowTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/CustomerMemoryBackfillCommandTest.php` | sim | contacts | quarentenado(era-sqlite); alto-raio[contacts]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/DispatchToJanaBotPiiRedactionTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/GuardiaoMidiaTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/HealthProbeChannelsCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/HistorySyncMetricsTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/HistorySyncQueueArchitectureTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ImportHistoryCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/InboxFiltersTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/InboxMultiPhoneFilterTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/InboxQueueDerivationTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/InboxSendInteractiveTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/InternalNoteTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/LastMessageDenormalizeTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/MacrosCrudTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/MacroVariantPickerTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/MediaMessageTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/MetricsAggregateCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/NotifyRepairCustomerTest.php` | sim | contacts | quarentenado(era-sqlite); alto-raio[contacts]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/OmnichannelIsolationTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/PersistContactsFromHistorySyncJobTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ReconnectAndImportCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/ReparseMediaFromPayloadCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/RetryRecentMediaDownloadsTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/SlaScanCommandTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/SlashConfigTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/SlashCorrigirTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/SlashLembrarTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/SlashLembreteTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/WebhookMediaExtractTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `Modules/Whatsapp/Tests/Feature/WebhookOutboundFromMeRegressionTest.php` | sim | channels | quarentenado(era-sqlite); alto-raio[channels]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `tests/Feature/Domain/Fsm/SequencialNfeAposCancelamentoTest.php` | sim | business | quarentenado(era-sqlite); alto-raio[business]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `tests/Feature/Domain/Fsm/SideEffects/InutilizarFaixaNfeTest.php` | sim | business | quarentenado(era-sqlite); alto-raio[business]; writes-sem-isolamento; DDL-manual |
+| B | 30 | `tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php` | sim | users | quarentenado(era-sqlite); alto-raio[users]; writes-sem-isolamento; DDL-manual |
+
+</details>
+
+## Bucket C (26)
+
+<details><summary>26 arquivos (clique)</summary>
+
+| tier | score | arquivo | quar. | alto raio | razões |
+|---|---|---|---|---|---|
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/AilosCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/BanrisulCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/BBCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/BradescoCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/BtgCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/CaixaCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/CnabBoletoAdapterContractTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/CnabRetornoProcessorTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/ItauCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/RetryOrphanWebhookJobTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/SantanderCnabDriverTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/WebhookEndpointsTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/PaymentGateway/Tests/Feature/WebhookSignatureValidationTest.php` | sim | activity_log | quarentenado(era-sqlite); alto-raio[activity_log]; DDL-manual |
+| C | 15 | `Modules/RecurringBilling/Tests/Feature/DomainModelsTest.php` | sim | contacts | quarentenado(era-sqlite); alto-raio[contacts]; DDL-manual |
+| C | 0 | `Modules/RecurringBilling/Tests/Feature/InterWebhookControllerTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `Modules/RecurringBilling/Tests/Feature/SyncBankBalancesCommandTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `Modules/Whatsapp/Tests/Feature/LidBackfillCommandTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `Modules/Whatsapp/Tests/Feature/SidebarCountsTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `tests/Feature/Domain/Fsm/FsmDriftDetectorTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `tests/Feature/Domain/Fsm/FsmScanDriftCommandTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `tests/Feature/Domain/Fsm/SideEffects/OficinaAutoSideEffectsTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `tests/Feature/Modules/Copiloto/Mcp/McpAuthHealthTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | 0 | `tests/Feature/Modules/Copiloto/Mcp/McpServerTest.php` | sim | — | quarentenado(era-sqlite); writes-sem-isolamento; DDL-manual |
+| C | -15 | `Modules/RecurringBilling/Tests/Feature/AsaasWebhookIdempotencyTest.php` | sim | — | quarentenado(era-sqlite); DDL-manual |
+| C | -15 | `Modules/RecurringBilling/Tests/Feature/BoletoServiceTest.php` | sim | — | quarentenado(era-sqlite); DDL-manual |
+| C | -15 | `tests/Feature/Modules/Copiloto/Mcp/McpSchemaTest.php` | sim | — | quarentenado(era-sqlite); DDL-manual |
+
+</details>
+

--- a/scripts/audit/sqlite-test-corruptors.mjs
+++ b/scripts/audit/sqlite-test-corruptors.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// sqlite-test-corruptors.mjs — auditor READ-ONLY de testes que corrompem o
+// estado SQLite :memory: compartilhado (lever do "floor" SDD F2b).
+//
+// Motivação (Wagner 2026-06-13 "a corrupção sqlite já gastou muito recurso"):
+// a suíte roda contra SQLite :memory: (phpunit.xml DB_CONNECTION=sqlite). Testes
+// que constroem SCHEMA SINTÉTICO MANUAL no beforeEach (Schema::create/drop de
+// tabelas compartilhadas — users/contacts/channels/transactions) deixam o schema
+// num estado que NÃO é o das migrations reais. Quando outro teste roda depois na
+// MESMA conexão, encontra a tabela mutilada → falha em cascata. São re-descobertos
+// um a um em ~19 worktrees `era-sqlite`. Este script ACHA todos de uma vez,
+// rankeados por raio de impacto, SEM rodar a suíte (custo zero de CI).
+//
+// NÃO corrige nada. Só relatório priorizado. A correção (converter pra
+// RefreshDatabase / migrations reais, ou quarentenar com markTestSkipped
+// não-sqlite) é decisão humana — burn-down SDD.
+//
+// Heurística de risco (transparente, ajustável no topo):
+//   +50  não-quarentenado (sem marcador `era-sqlite`)   → ainda no caminho quente
+//   +30  por tabela de ALTO raio dropada/criada manualmente (cap 90)
+//   +25  dropAllTables (nuke geral do schema)
+//   +20  mutação de CONEXÃO (DB::disconnect/purge/reconnect, PRAGMA, config DB,
+//        disableForeignKeyConstraints) — vaza além do schema
+//   +15  faz writes/DDL SEM trait de isolamento (RefreshDatabase/Transactions)
+//   +10  DDL manual presente (Schema::create/drop, DB::statement DDL)
+//   -25  já quarentenado (`era-sqlite`) → conhecido + skip no MySQL nightly
+//
+// Buckets: S(>=80) crítico · A(>=50) alto · B(>=25) médio · C(<25) baixo.
+//
+// Uso:
+//   node scripts/audit/sqlite-test-corruptors.mjs                 (top 30, tabela)
+//   node scripts/audit/sqlite-test-corruptors.mjs --top=50
+//   node scripts/audit/sqlite-test-corruptors.mjs --tier=S        (só críticos)
+//   node scripts/audit/sqlite-test-corruptors.mjs --json          (saída máquina)
+//   node scripts/audit/sqlite-test-corruptors.mjs --strict --tier=S  (exit 1 se houver S)
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const ROOT = process.cwd();
+const SCAN_DIRS = ['Modules', 'tests'];
+
+// Tabelas de ALTO raio — muitos testes dependem delas; dropá-las/recriá-las
+// manualmente corrompe o schema pra todo mundo que roda depois na mesma conexão.
+const HIGH_BLAST = new Set([
+  'users', 'contacts', 'channels', 'transactions', 'business', 'businesses',
+  'products', 'variations', 'roles', 'permissions',
+  'model_has_permissions', 'model_has_roles', 'role_has_permissions',
+  'activity_log', 'transaction_payments', 'transaction_sell_lines',
+]);
+
+const ISOLATION_TRAITS = /\b(RefreshDatabase|LazilyRefreshDatabase|DatabaseTransactions|DatabaseMigrations)\b/;
+const WRITE_HINTS = /->\s*(create|insert|save|update|delete)\s*\(|::create\s*\(|factory\s*\(|DB::table\([^)]*\)->\s*insert/;
+const QUARANTINE = /era-sqlite/;
+
+const RE_SCHEMA_TABLE = /Schema::(create|dropIfExists|drop)\(\s*['"]([a-z0-9_]+)['"]/g;
+const RE_DROP_ALL = /Schema::dropAllTables\(/;
+const RE_RAW_DDL = /DB::(statement|unprepared)\(\s*['"`][^'"`]*\b(create|drop|alter)\s+table\b/i;
+const RE_PRAGMA = /PRAGMA\s+\w+/i;
+const RE_CONN_MUT = /DB::(disconnect|purge|reconnect)\(|disableForeignKeyConstraints\(|->setConnection\(|DB::setDefaultConnection\(|config\(\s*\[?\s*['"]database/;
+
+const args = process.argv.slice(2);
+const opt = (name, def) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.split('=')[1] : def;
+};
+const flag = (name) => args.includes(`--${name}`);
+
+const TOP = parseInt(opt('top', '30'), 10);
+const TIER_FILTER = (opt('tier', '') || '').toUpperCase();
+const AS_JSON = flag('json');
+const STRICT = flag('strict');
+
+function walk(dir, acc) {
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return acc;
+  }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (e.name === 'vendor' || e.name === 'node_modules' || e.name === '.git') continue;
+      walk(full, acc);
+    } else if (e.isFile() && e.name.endsWith('Test.php')) {
+      acc.push(full);
+    }
+  }
+  return acc;
+}
+
+function analyze(file) {
+  let src;
+  try {
+    src = readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+
+  const quarantined = QUARANTINE.test(src);
+  const hasIsolation = ISOLATION_TRAITS.test(src);
+  const dropsAll = RE_DROP_ALL.test(src);
+  const rawDdl = RE_RAW_DDL.test(src) || RE_PRAGMA.test(src);
+  const connMut = RE_CONN_MUT.test(src);
+  const hasWrites = WRITE_HINTS.test(src);
+
+  const tables = new Set();
+  let m;
+  RE_SCHEMA_TABLE.lastIndex = 0;
+  while ((m = RE_SCHEMA_TABLE.exec(src)) !== null) tables.add(m[2]);
+  const highBlast = [...tables].filter((t) => HIGH_BLAST.has(t));
+  const manualDdl = tables.size > 0 || rawDdl || dropsAll;
+
+  // Só interessa quem efetivamente mexe em schema/conexão (corruptor real).
+  if (!manualDdl && !connMut) return null;
+
+  const reasons = [];
+  let score = 0;
+
+  if (!quarantined) { score += 50; reasons.push('não-quarentenado'); }
+  else { score -= 25; reasons.push('quarentenado(era-sqlite)'); }
+
+  if (highBlast.length) {
+    const pts = Math.min(highBlast.length * 30, 90);
+    score += pts;
+    reasons.push(`alto-raio[${highBlast.join(',')}]`);
+  }
+  if (dropsAll) { score += 25; reasons.push('dropAllTables'); }
+  if (connMut) { score += 20; reasons.push('mutação-conexão'); }
+  if (manualDdl && hasWrites && !hasIsolation) { score += 15; reasons.push('writes-sem-isolamento'); }
+  if (manualDdl) { score += 10; reasons.push('DDL-manual'); }
+
+  let tier = 'C';
+  if (score >= 80) tier = 'S';
+  else if (score >= 50) tier = 'A';
+  else if (score >= 25) tier = 'B';
+
+  return {
+    file: relative(ROOT, file).split(sep).join('/'),
+    score,
+    tier,
+    quarantined,
+    hasIsolation,
+    tables: [...tables],
+    highBlast,
+    reasons,
+  };
+}
+
+const files = [];
+for (const d of SCAN_DIRS) walk(join(ROOT, d), files);
+
+let results = files.map(analyze).filter(Boolean).sort((a, b) => b.score - a.score);
+
+const counts = { S: 0, A: 0, B: 0, C: 0 };
+for (const r of results) counts[r.tier]++;
+
+if (TIER_FILTER) results = results.filter((r) => r.tier === TIER_FILTER);
+
+if (AS_JSON) {
+  console.log(JSON.stringify({ scanned: files.length, corruptors: results.length, counts, results }, null, 2));
+} else {
+  console.log('== Auditor SQLite test-corruptors (read-only) ==');
+  console.log(`Test files escaneados : ${files.length}`);
+  console.log(`Corruptores potenciais: ${results.length}`);
+  console.log(`Por bucket            : S=${counts.S} (crítico)  A=${counts.A} (alto)  B=${counts.B} (médio)  C=${counts.C} (baixo)`);
+  console.log('');
+  console.log('Bucket = raio de cascata. S/A = converter pra RefreshDatabase OU quarentenar primeiro.');
+  console.log('');
+  const show = results.slice(0, TOP);
+  for (const r of show) {
+    const q = r.quarantined ? ' (já quarentenado)' : '';
+    console.log(`[${r.tier}] ${String(r.score).padStart(3)}  ${r.file}${q}`);
+    console.log(`        ${r.reasons.join(' · ')}`);
+  }
+  if (results.length > show.length) {
+    console.log('');
+    console.log(`… +${results.length - show.length} (use --top=${results.length} ou --json pra ver todos).`);
+  }
+}
+
+if (STRICT && results.length > 0) process.exit(1);


### PR DESCRIPTION
## Por quê

Wagner (2026-06-13): *"[channel access] está em conflito, uma hora é removido, uma hora é reativado, por? cria um auditor pra resolver. E a corrupção sqlite já gastou muito recurso."* Dois auditores, um PR.

## 1. Flip-flop `channel_user_access` (revoke ↔ reativação)

**Causa-raiz** — duas fontes de verdade que se contradizem:
1. Admin **revoga** o acesso de um atendente a um canal pela UI (`revoked_at` + `revoked_by_user_id` humano).
2. `whatsapp:backfill-channel-access` re-concede a **todo** user com `whatsapp.send/access` olhando só `whereNull('revoked_at')` → recria grant *system* (`granted_by_user_id=0`) e **desfaz o revoke deliberado**. → *"removido pelo admin, reativado pelo backfill."*

**Entregas**
- **`whatsapp:audit-channel-access`** (novo) — read-only; `--fix` opt-in; `--json`; `--strict` (gate CI/cron):
  - `DUP_ATIVO`: >1 grant ativo por (canal,user) — resíduo do `UNIQUE(...,revoked_at)` que não pega `NULL`s.
  - `FLIP_BACKFILL`: grant *system* que reativou um revoke *humano*.
  - `--fix` revoga preservando o histórico, com `revoked_at` globalmente escalonado (não colide no `UNIQUE` antigo onde a migration `revoked_marker` ainda não rodou).
- **`BackfillChannelAccessCommand`** — passa a **respeitar o tombstone**: não re-concede a quem um humano revogou de propósito (salvo `--force`). Corta a causa-raiz; sem isso o auditor acharia o mesmo flip pra sempre.

Complementa a migration `2026_06_13_120000` (enforce 1 ativo via `revoked_marker`, em outra branch) — o auditor limpa o **passivo já existente** em prod; a migration impede dups **novas**.

## 2. Corrupção SQLite nos testes

**`scripts/audit/sqlite-test-corruptors.mjs`** (novo) — read-only, **não roda a suíte** (custo zero de CI). A suíte roda em SQLite `:memory:`; testes com schema sintético manual (`Schema::create/drop` de tabelas compartilhadas) corrompem o schema pro próximo teste da mesma conexão → cascata de fails, re-descobertos em ~19 worktrees `era-sqlite`. O linter acha **todos de uma vez**, ranqueados por raio de cascata.

Run inicial: **1228 escaneados → 237 corruptores** (S=58 crítico · A=89 alto · B=64 · C=26). Snapshot ranqueado em [`memory/sessions/2026-06-13-audit-sqlite-test-corruptors.md`](memory/sessions/2026-06-13-audit-sqlite-test-corruptors.md). Diagnóstico, **não gate** (correção = burn-down humano).

## Tier 0 & verificação
- `business_id` explícito, `withoutGlobalScope` CLI-superadmin, logs/saída sem PII (só ids+contadores), idempotente.
- Guard test `AuditChannelAccessCommandTest` (12 casos) com quarentena `era-sqlite` p/ não quebrar o nightly MySQL.
- ✅ `php -l` limpo · ✅ PHPStan limpo (o `silentFallback` virou `??=`; o aviso `force` ao analisar arquivo de worktree é artefato de autoload stale, resolve no CI) · ✅ linter executado.
- ⏳ Pest funcional roda no CI (worktree não tem `vendor/`; convenção CT 100).

## ⚠️ Operação
Rodar `--fix` contra **produção** é DML em tabela Tier-0 ACL — **Wagner-gated**, não executado neste PR. Sugestão: `--dry-run`/relatório primeiro, depois `--fix` por business.

Refs: US-WA-068, ADR 0135, ADR 0093

🤖 Generated with [Claude Code](https://claude.com/claude-code)
