### PR TITLE
docs(sdd): compliance de frontmatter + anchors em 7 SPECs (frente SA prereq)

### DIFF
--- a/memory/requisitos/Accounting/SPEC.md
+++ b/memory/requisitos/Accounting/SPEC.md
@@ -3,9 +3,18 @@ slug: modules-accounting-spec
 title: "Modules/Accounting — SPEC"
 type: spec
 module: Accounting
-status: legacy
+owner: wagner
+version: "1.0"
+last_updated: "2026-05-16"
+status: arquivado
 authority: canonical
-related_adrs: [0093, 0094, 0104, 0153, 0154, 0156]
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0104-processo-mwart-canonico-unico-caminho
+  - 0153-module-grade-rubrica-v1
+  - 0154-module-grade-v2-na-justificado
+  - 0156-module-grade-v3-errata-otel-helper-na-justified
 na_justified:
   D5: "Módulo herdado UltimatePOS — 12 Controllers Blade legacy compartilhados cross-business sem cliente alvo isolado (Budget/Journal/COA genéricos contabilidade). Sem onboarding Larissa/ROTA LIVRE direto, ferramenta backoffice transversal ([memory/proibicoes.md](../../proibicoes.md) §Multi-tenant Tier 0)."
   D6.a: "Stack legacy UltimatePOS — 12 Controllers Blade puros, ZERO Inertia::render por design. Migração MWART [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md) ainda não iniciada (sem cliente sinal qualificado — [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Inertia::defer N/A enquanto Blade."
@@ -31,7 +40,7 @@ updated_at: 2026-05-16
 **Quero** ver o conjunto de Budget  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -53,7 +62,7 @@ updated_at: 2026-05-16
 **Quero** ver o conjunto de Chart Of Account  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -75,7 +84,7 @@ updated_at: 2026-05-16
 **Quero** criar um novo item em Chart Of Account  
 **Para** alimentar o sistema com os dados operacionais
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -97,7 +106,7 @@ updated_at: 2026-05-16
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -119,7 +128,7 @@ updated_at: 2026-05-16
 **Quero** ver o conjunto de Core  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -141,7 +150,7 @@ updated_at: 2026-05-16
 **Quero** ver o conjunto de Journal Entry  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -163,7 +172,7 @@ updated_at: 2026-05-16
 **Quero** criar um novo item em Journal Entry  
 **Para** alimentar o sistema com os dados operacionais
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -185,7 +194,7 @@ updated_at: 2026-05-16
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -207,7 +216,7 @@ updated_at: 2026-05-16
 **Quero** ver o conjunto de Reconcile  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -229,7 +238,7 @@ updated_at: 2026-05-16
 **Quero** ver o conjunto de Report  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (módulo Blade legacy, ZERO Inertia; migração MWART não iniciada)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)

--- a/memory/requisitos/Crm/SPEC.md
+++ b/memory/requisitos/Crm/SPEC.md
@@ -1,18 +1,30 @@
 ---
 module: Crm
+owner: wagner
 alias: crm
-status: draft-proposal
+version: "1.0"
+last_updated: "2026-06-13"
+status: rascunho
 proposal_date: 2026-05-12
 proposed_by: opus-4.7 (discovery + research)
 needs_wagner_approval: true
 parent_adr_proposal: memory/decisions/proposals/drafts/crm-pre-venda-pipeline.md
-related_adrs: [0093, 0094, 0096, 0105, 0117, 0121, 0143]
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0096-modulo-whatsapp-meta-cloud-api-direto
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0117-multiplos-numeros-whatsapp-por-business
+  - 0121-oimpresso-modular-especializado-por-vertical
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
 related_modules: [Whatsapp, Sells (FSM canon), Jana, Repair, RecurringBilling]
 fsm_handoff: lead_won → transactions.current_stage_id = "quote_draft" (US-SELL-033 processo "Venda Com Produção")
 na_justified:
   D6.a: "Crm é módulo Blade legacy (21 controllers AJAX), sem Inertia::render — Inertia::defer N/A (migração MWART em backlog)."
   D8.b: "Crm Blade tem @csrf padrão preservado — auto-pattern UltimatePOS legacy."
 ---
+
+<!-- schema-allowlist: módulo draft-proposal — US propostas sob "## §6 — User Stories (US-CRM-NNN propostas)"; sem "## US ativas"/"## Backlog ativo" até a ADR-mãe aprovar -->
 
 # Especificação funcional — Crm/Pipeline Pré-venda
 
@@ -358,7 +370,7 @@ Cron diário 08:00 BRT — pra cada user com perm `crm.access_own_leads`:
 **Quero** colunas pipeline em `contacts` (valor_estimado, sla_responder_em, lgpd_consent_at, score, tier, won_transaction_id, lost_motivo_id)
 **Para** habilitar todas US seguintes sem duplicar tabela paralela
 
-**Implementado em:** _Modules/Crm/Database/Migrations/2026_xx_add_pipeline_columns_to_contacts.php_
+**Implementado em:** _pendente_ — migration `2026_xx_add_pipeline_columns_to_contacts.php` não construída (US proposta, aguarda ADR-mãe)
 
 **DoD:**
 - [ ] Migration up/down idempotente

--- a/memory/requisitos/Essentials/SPEC.md
+++ b/memory/requisitos/Essentials/SPEC.md
@@ -3,9 +3,20 @@ slug: modules-essentials-spec
 title: "Modules/Essentials — SPEC"
 type: spec
 module: Essentials
-status: stub
+owner: wagner
+version: "1.0"
+last_updated: "2026-06-13"
+status: rascunho
 authority: canonical
-related_adrs: [0093, 0094, 0105, 0143, 0153, 0154, 0155, 0156]
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+  - 0153-module-grade-rubrica-v1
+  - 0154-module-grade-v2-na-justificado
+  - 0155-module-grade-v3-sub-dimensoes-gate-ci
+  - 0156-module-grade-v3-errata-otel-helper-na-justified
 na_justified:
   D5: "Utilitários backend compartilhados HRM/legado UltimatePOS — sem cliente direto Larissa/biz=4. Módulo transversal cross-business (helpers, traits, mailables compartilhados) seguindo proibições Tier 0 [memory/proibicoes.md](../../proibicoes.md) §Multi-tenant + Constituição v2 [ADR 0094](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md)."
   D4.b: "Essentials é utilitário compartilhado backend HRM/Todo herdado UltimatePOS v6 — usa enum status simples em `essentials_leaves.status` (pending/approved/rejected) e `essentials_to_dos.status` (sem máquina de estados canônica FSM). Pipeline FSM canônico ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)) aplica a Sells/Repair (vendas + OS), não a HRM legacy. Migração futura possível via ADR de feature wish ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) §cliente sinal qualificado: dormente sem dor real)."
@@ -28,7 +39,7 @@ _[TODO — escrever user stories no formato abaixo.]_
 **Quero** [ação]  
 **Para** [objetivo de negócio]
 
-**Implementado em:** _[path]_
+**Implementado em:** _pendente_ — US TODO, tela não construída
 
 **Definition of Done:**
 - [ ] [critério]

--- a/memory/requisitos/Manufacturing/SPEC.md
+++ b/memory/requisitos/Manufacturing/SPEC.md
@@ -1,4 +1,8 @@
 ---
+module: Manufacturing
+owner: wagner
+version: "1.0"
+last_updated: "2026-06-13"
 na_justified:
   D6.a: "Manufacturing usa pattern Blade legacy + 1 página Inertia v2 (Wave J Onda 1) — Inertia::defer aplicado parcialmente."
 ---
@@ -18,7 +22,7 @@ _[TODO — escrever user stories no formato abaixo.]_
 **Quero** [ação]  
 **Para** [objetivo de negócio]
 
-**Implementado em:** _[path]_
+**Implementado em:** _pendente_ — US-MANU-001 não escrita/construída (placeholder TODO)
 
 **Definition of Done:**
 - [ ] [critério]

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -1,4 +1,8 @@
 ---
+module: NfeBrasil
+owner: wagner
+version: "1.0"
+last_updated: "2026-06-13"
 na_justified:
   D7.a: "Fiscal compliance CONFAZ SINIEF 07/2005 — CPF/CNPJ em logs SEFAZ obrigatórios. PiiRedactor NÃO aplica em dados fiscais (XML original preservado). Detalhe em PII-LGPD-FISCAL.md."
 ---
@@ -56,7 +60,7 @@ na_justified:
 **Quero** clicar "Finalizar venda" no POS e o sistema emitir NFC-e em background, retornar DANFE imprimível em até 5s
 **Para** atender exigência fiscal sem fricção no balcão
 
-**Implementado em:** _[TODO — integração `/sells/create` finalizar + `resources/js/Pages/NfeBrasil/Emissao/Sucesso.tsx`]_
+**Implementado em:** _pendente_ — integração `/sells/create` finalizar + tela `Pages/NfeBrasil/Emissao/Sucesso.tsx` não construída
 
 **Definition of Done:**
 - [ ] Listener escuta `App\Events\TransactionCompleted` (core) → dispatch job `EmitirNfceJob` na queue `nfe`
@@ -78,7 +82,7 @@ na_justified:
 **Quero** abrir nota emitida pela chave/número e baixar DANFE + XML
 **Para** reimprimir, enviar pra cliente, anexar em e-mail
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx`]_
+**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Emissoes/Show.tsx` não construída
 
 **Definition of Done:**
 - [ ] Mostra: chave acesso (44 dígitos formatado em 11 grupos), número, série, data emissão, valor, cStat, link DANFE PDF, link XML
@@ -97,7 +101,7 @@ na_justified:
 **Quero** cancelar uma NFC-e em até 24h ou NF-e em até 168h informando justificativa (15-255 chars)
 **Para** corrigir venda errada sem deixar rastro errado pra Receita
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx` (botão Cancelar)]_
+**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Emissoes/Show.tsx` (botão Cancelar) não construída
 
 **Definition of Done:**
 - [ ] Valida prazo legal antes de chamar SEFAZ (NFC-e: 24h; NF-e: 168h)
@@ -118,7 +122,7 @@ na_justified:
 **Quero** enviar CCe pra corrigir erro não-monetário (ex: nome do destinatário errado, transportadora) sem cancelar e re-emitir
 **Para** evitar custo de re-emissão e manter histórico
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx` (botão CCe)]_
+**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Emissoes/Show.tsx` (botão CCe) não construída
 
 **Definition of Done:**
 - [ ] Valida limite legal: máximo 20 CCe por NFe; correção 15-1000 chars; não permite mudar valor/quantidade/CNPJ
@@ -137,7 +141,7 @@ na_justified:
 **Quero** ativar contingência (EPEC pra NF-e, FS-DA pra NFC-e) e seguir vendendo offline
 **Para** não parar caixa quando SEFAZ está com problema
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Contingencia/Index.tsx`]_
+**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Contingencia/Index.tsx` não construída
 
 **Definition of Done:**
 - [ ] Detecção automática: `SefazHealthCheck` ping a cada 30s → se 3 falhas seguidas, sugerir contingência
@@ -158,7 +162,7 @@ na_justified:
 **Quero** dashboard com KPIs (autorizadas hoje, rejeitadas, contingência ativa, cert vencendo) + lista de rejeições com cStat + sugestão de correção
 **Para** atacar rejeições antes de o cliente perceber
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Monitor/Index.tsx`]_
+**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Monitor/Index.tsx` não construída
 
 **Definition of Done:**
 - [ ] KPIs: autorizadas (hoje/semana/mês), rejeitadas, em contingência, cert dias restantes
@@ -179,7 +183,7 @@ na_justified:
 **Quero** manifestar NFe recebida (Confirmação / Ciência / Desconhecimento / Operação não realizada)
 **Para** atender obrigação legal e gerar apropriação correta no DRE
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx`]_
+**Implementado em:** `resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx` · verificado@fd96258 (2026-06-13)
 
 **Definition of Done:**
 - [ ] Lista NFes destinadas (consulta `WS-NFeDistribuicaoDFe` periódica) com status manifestação
@@ -198,7 +202,7 @@ na_justified:
 **Quero** baixar arquivo SPED Fiscal pronto pra ECF do mês de competência
 **Para** entregar obrigação contábil sem ligar pra Larissa
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Sped/Index.tsx`]_
+**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Sped/Index.tsx` não construída
 
 **Definition of Done:**
 - [ ] Geração assíncrona via job (volume grande); progresso via broadcast
@@ -721,7 +725,7 @@ Smoke real em ambiente homologação SEFAZ-SP usando cert + CNPJ Gold. Análogo 
 Bate o **Goal #1 do CYCLE-03** ("smoke fiscal SEFAZ-SC homologação biz=1, 1ª NFC-e real cstat 100"). Pipeline US-NFE-002 server-side já fechado em main; biz=1 (WR2 Sistemas, Tubarão/SC) já está armada — confirmado via SSH 2026-05-09:
 
 **Estado pré-validado (não tocar):**
-- `business.cnpj`=36.613.150/0001-18, `ncm_padrao`=49111090, `ambiente`=2, `ultimo_numero_nfce`=0
+- `business.cnpj`=11.222.333/0001-81, `ncm_padrao`=49111090, `ambiente`=2, `ultimo_numero_nfce`=0 <!-- pii-allowlist: CNPJ fake canônico de fixture, não é PII real -->
 - `nfe_certificados.ativo`=1, `valido_ate`=2026-08-06
 - `nfe_business_configs`: `regime`=simples, `cfop`=5102, `csosn`=102, `auto_emission_enabled`=1
 - `.env` Hostinger: `NFEBRASIL_AUTO_EMISSION_NFCE=true`

--- a/memory/requisitos/PontoWr2/SPEC.md
+++ b/memory/requisitos/PontoWr2/SPEC.md
@@ -1,3 +1,10 @@
+---
+module: PontoWr2
+owner: wagner
+version: "1.0"
+last_updated: "2026-06-13"
+---
+
 # Especificação funcional
 
 ## 3. User stories
@@ -15,7 +22,7 @@
 **Quero** ver o conjunto de Aprovacao  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -37,7 +44,7 @@
 **Quero** ver o conjunto de Banco Horas  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -59,7 +66,7 @@
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -81,7 +88,7 @@
 **Quero** ver o conjunto de Colaborador  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -103,7 +110,7 @@
 **Quero** ver o conjunto de Configuracao  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -125,7 +132,7 @@
 **Quero** ver o conjunto de Core  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -147,7 +154,7 @@
 **Quero** ver o conjunto de Espelho  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -169,7 +176,7 @@
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -191,7 +198,7 @@
 **Quero** ver o conjunto de Importacao  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -213,7 +220,7 @@
 **Quero** criar um novo item em Importacao  
 **Para** alimentar o sistema com os dados operacionais
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -235,7 +242,7 @@
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -257,7 +264,7 @@
 **Quero** ver o conjunto de Relatorio  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
+**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)

--- a/memory/requisitos/Repair/SPEC.md
+++ b/memory/requisitos/Repair/SPEC.md
@@ -1,3 +1,10 @@
+---
+module: Repair
+owner: wagner
+version: "1.0"
+last_updated: "2026-06-13"
+---
+
 # Especificação funcional
 
 ## 3. User stories
@@ -13,7 +20,7 @@ _[TODO — escrever user stories no formato abaixo.]_
 **Quero** [ação]  
 **Para** [objetivo de negócio]
 
-**Implementado em:** _[path]_
+**Implementado em:** _pendente_ — US-REPA-001 não escrita (placeholder TODO)
 
 **Definition of Done:**
 - [ ] [critério]


### PR DESCRIPTION
Desbloqueia o anchor backfill dos 7 SPECs que travaram o #2690 por **débito de frontmatter pré-existente**. Agora passam o `spec.schema.json`:
- required `module`/`version`/`last_updated` preenchidos (datas quoted)
- `status` mapeado pro enum (legacy→arquivado, stub/draft→rascunho)
- `related_adrs` de números crus → slugs reais (resolvidos em memory/decisions/, 0 inventado)
- anchor mecânico ADR 0273 (paths inexistentes → `_pendente_`; NfeBrasil 1 promovido)
- PII: CNPJ real-looking do NfeBrasil → fake canônico + pii-allowlist

Só SPECs (7), 0 ADR/código. Verify adversarial: schema 7/7 + PII clean.

Refs: ADR 0273 · plano SDD 2026-06-12 (SA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)