### PR TITLE
docs(sdd): codemod ghost_count 27→15 — renames + lápides (frente KL)

### DIFF
--- a/memory/requisitos/ADS/SPEC.md
+++ b/memory/requisitos/ADS/SPEC.md
@@ -1,11 +1,15 @@
 ---
 module: ADS
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
 na_justified:
   D6.b: "ADS é meta-sistema dormente (ARQ-0011 aguardando S5 ~jul/2026 — ver ADR 0105 cliente como sinal qualificado). p99 <500ms via OTel N/A enquanto módulo não está em prod ativa — sem tráfego pra medir."
   D6.c: "ADS Brain A roda no CT 100 (Node.js daemon), Brain B é Anthropic API. Hostinger expõe APENAS POST /api/ads/route (síncrono ~50ms). Não há queries paginate/eager-load com risco N+1 — ADS é firewall de decisão, não CRUD."
   D9.b: "ADS pre-S5 não tem jobs assíncronos Horizon — Brain B chamadas via cron `ads:process-brain-b` artisan direto. failed_jobs N/A enquanto pipeline não ativa (ADR 0105 dormant)."
-related_adrs: [0105, 0153, 0154]
+related_adrs: [0105-cliente-como-sinal-guiar-sem-mandar, 0153-module-grade-rubrica-v1, 0154-module-grade-v2-na-justificado]
 ---
+<!-- schema-allowlist: ADS é meta-sistema dormente sem backlog de US (ARQ-0001..0011 são ADRs de arquitetura, não user stories) — aguarda S5 ~jul/2026 (ADR 0105 cliente como sinal). Sem backlog ativo até ativação. -->
 
 # ADS — Adaptive Decision System
 
@@ -39,7 +43,7 @@ O ADS é agnóstico de domínio. Estes módulos submetem eventos a ele:
 
 | Módulo | Papel no ADS |
 |---|---|
-| `Modules/Copiloto/` | MCP bus compartilhado; Copiloto Chat NÃO submete eventos ao ADS |
+| `Modules/Jana/` | MCP bus compartilhado; Jana Chat NÃO submete eventos ao ADS |
 | `EvolutionAgent/` | Submete eventos de oportunidade de evolução de codebase |
 | `Brain A daemon` | Submete eventos de monitoramento (git, logs, métricas) |
 | `TaskRegistry/` | Recebe tasks criadas pelo ADS; não submete eventos |

--- a/memory/requisitos/ADS/UI-admin-skills-proposta.md
+++ b/memory/requisitos/ADS/UI-admin-skills-proposta.md
@@ -37,10 +37,10 @@
 │     Use ao trabalhar em Modules/ADS/...           hits 7d: 12    │
 │                                                                   │
 │  ✅ memoria-recall-flow       claude-code  copi     atualiz. 2d  │
-│     Use ao tocar Modules/Copiloto/Services/...    hits 7d: 8     │
+│     Use ao tocar Modules/Jana/Services/...    hits 7d: 8     │
 │                                                                   │
 │  ⚠️ copiloto-arch              claude-code  copi     drift 1d    │
-│     Use ao trabalhar em Modules/Copiloto/...      hits 7d: 23    │
+│     Use ao trabalhar em Modules/Jana/...      hits 7d: 23    │
 │     ↳ filesystem tem versão ≠ DB (rodar mcp:sync-skills)         │
 │                                                                   │
 │  ✅ criar-modulo               claude-code  infra    atualiz. 5d │

--- a/memory/requisitos/Arquivos/RUNBOOK-ingestao-documentos.md
+++ b/memory/requisitos/Arquivos/RUNBOOK-ingestao-documentos.md
@@ -109,9 +109,9 @@ Idempotente, com tag `classified_by='backfill-us-arq-NNN'` pra rastreio. Padrão
 | **NFe XML autorizado** | application/xml `.xml` | archive | nfe-xml | arquivos | false | `Modules/NfeBrasil/Services/NfeService::writeArquivoXml` |
 | **DANFE PDF** | application/pdf `.pdf` | archive | nfe-danfe | arquivos | false | `Modules/NfeBrasil/Services/DanfeService::salvar` |
 | **Foto OS Repair** | image/jpeg, image/png | active | repair-foto | arquivos | false | `Modules/Repair/Http/Controllers/JobSheetController::uploadFoto` |
-| **Contrato cliente PDF** | application/pdf | sensitive | contrato | **vault** | **true** | `Modules/Contratos/...` (futuro) |
+| **Contrato cliente PDF** | application/pdf | sensitive | contrato | **vault** | **true** | Contratos (planejado — não existe) |
 | **Comprovante pagamento** | image/* ou pdf | active | comprovante-pagamento | arquivos | false | `Modules/Financeiro/...` |
-| **Anexo ticket suporte** | qualquer | active | ticket-anexo | arquivos | false | `Modules/Suporte/...` (futuro) |
+| **Anexo ticket suporte** | qualquer | active | ticket-anexo | arquivos | false | Suporte (planejado — não existe) |
 | **NFSe XML** | application/xml | archive | nfse-xml | arquivos | false | `Modules/NfeBrasil/Services/NfseService` |
 | **Boleto-pago PDF** | application/pdf | archive | boleto-recibo | arquivos | false | `Modules/RecurringBilling/...` |
 | **`.env` / `.key` / `.pfx`** | qualquer | — | — | — | — | **❌ BLOQUEAR** (CuradorEngine flag `sensitive_env_real` → throw) |

--- a/memory/requisitos/Auditoria/SPEC.md
+++ b/memory/requisitos/Auditoria/SPEC.md
@@ -3,9 +3,12 @@ slug: modules-auditoria-spec
 title: "Modules/Auditoria — SPEC"
 type: spec
 module: Auditoria
-status: accepted
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
+status: ativo
 authority: canonical
-related_adrs: [0093, 0094, 0127, 0153, 0154, 0156]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0127-modules-auditoria-undo-activity-log, 0153-module-grade-rubrica-v1, 0154-module-grade-v2-na-justificado, 0156-module-grade-v3-errata-otel-helper-na-justified]
 na_justified:
   D5: "Governança transversal cross-tenant — módulo de audit log opera sobre todos businesses (activity_log reusado). Exceção formal ao Tier 0 multi-tenant ([ADR 0127](../../decisions/0127-modules-auditoria-undo-activity-log.md) §SUPERADMIN exception + Constituição v2 Art. 6 [ADR 0094](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md))."
 pii: false
@@ -39,6 +42,10 @@ Módulo de governança que reusa `spatie/laravel-activitylog` (já instalado) + 
 - Inertia v3 + React 19 (Pages padrão MWART, [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md))
 - Lib diff JSON: avaliar `react-diff-viewer-continued` na implementação (não decidido)
 
+## US ativas
+
+Backlog de user stories (US-AUDIT-*) organizado em 3 sub-sprints sequenciais.
+
 ## US Sprint 1 — Padronização Vestuario + Financeiro
 
 | ID | Descrição | Prio | Esforço (IA-pair) | Dep |
@@ -55,7 +62,7 @@ Módulo de governança que reusa `spatie/laravel-activitylog` (já instalado) + 
 | ID | Descrição | Prio | Esforço (IA-pair) | Dep |
 |---|---|---|---|---|
 | US-AUDIT-005 | Migration `2026_05_NN_add_causer_kind_and_revert_to_activity_log.php` — adiciona `causer_kind` ENUM, `agent_run_id` BIGINT NULL, `reverted_at` TIMESTAMP NULL, `reverted_by_user_id` BIGINT NULL, `revert_reason` VARCHAR(500) NULL + 2 índices compostos. Reversível. Smoke local: `php artisan migrate` + `migrate:rollback` | p0 | 1h | — |
-| US-AUDIT-006 | `Modules/Auditoria/Services/CauserResolver.php` — resolve contexto: User logado padrão; se request veio de tool MCP `Modules/Copiloto/Ai/Agents/*` (detect via container binding ou middleware), seta `causer_kind=agent` + `agent_run_id=<id da Jana run>`. Hook em Activity::saving event. Pest: ação Jana grava `agent`; ação Controller grava `user` | p0 | 2h | US-AUDIT-005 |
+| US-AUDIT-006 | `Modules/Auditoria/Services/CauserResolver.php` — resolve contexto: User logado padrão; se request veio de tool MCP `Modules/Jana/Ai/Agents/*` (detect via container binding ou middleware), seta `causer_kind=agent` + `agent_run_id=<id da Jana run>`. Hook em Activity::saving event. Pest: ação Jana grava `agent`; ação Controller grava `user` | p0 | 2h | US-AUDIT-005 |
 
 **Subtotal Sprint 2 — ~3h IA-pair**
 

--- a/memory/requisitos/Autopecas/Autopecas.charter.md
+++ b/memory/requisitos/Autopecas/Autopecas.charter.md
@@ -12,7 +12,7 @@ tier: A
 charter_version: 1
 ---
 
-# Module Charter — Modules/Autopecas
+# Module Charter — Autopecas (planejado — não existe)
 
 > **Status `proposto` / lifecycle `feature-wish`:** charter **antecipatório**, escrito como *template aplicado* pra firmar contrato de produto **antes** de virar US ativa. Sem Vargas (ou substituto qualificado) assinar contrato pioneer, **nada aqui é compromisso de roadmap** — é hipótese formalizada conforme [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) e [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md).
 >
@@ -50,7 +50,7 @@ Add-on vertical de comércio de autopeças sobre o núcleo oimpresso — entrega
 - ❌ **Visão financeira AR/AP unificada** → vive em `Modules/Financeiro`
 - ❌ **Boleto/assinatura/cobrança recorrente** (crediário interno usa pipeline) → vive em `Modules/RecurringBilling`
 - ❌ **Multi-tenant `business_id` global scope** → infraestrutura núcleo Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
-- ❌ **Jana IA / memória persistente** → vive em `Modules/Copiloto`
+- ❌ **Jana IA / memória persistente** → vive em `Modules/Jana`
 - ❌ **OS de aplicação física** (mecânico aplica peça em veículo) → vive em `Modules/OficinaAuto` (US-AUTO-006 multi-mecânico)
 - ❌ **Diagnóstico mecânico assistido** (sintoma → hipóteses peça aplicável) → vive em `Modules/OficinaAuto` (US-AUTO-007). Autopecas só **consulta** catálogo, não diagnostica
 - ❌ **Tabela tempária Sindirepa** (mão-de-obra) → vive em `Modules/OficinaAuto`. Autopecas vende peça, não tempo de aplicação
@@ -135,7 +135,7 @@ Validação: **Vargas é candidato piloto qualificado** mas charter antecipatór
 
 ## 6. Automation hooks (onde Jana IA atua)
 
-> Jana = Modules/Copiloto. Hooks **propostos** — exigem sinal qualificado antes de virar US ativa.
+> Jana = Modules/Jana. Hooks **propostos** — exigem sinal qualificado antes de virar US ativa.
 
 - ✅ **Sugestão peça por aplicação** — balconista digita "Civic 2015 freio dianteiro", Jana sugere top 3 SKUs ranqueados (compatibilidade × estoque × margem)
 - ✅ **WhatsApp consulta peça por foto** (US-AP-011) — cliente oficina manda foto peça quebrada, Jana identifica + sugere SKU compatível + reserva 2h
@@ -173,7 +173,7 @@ Validação: **Vargas é candidato piloto qualificado** mas charter antecipatór
 | `Modules/NfeBrasil` | Listener `NFCeAutorizada` (venda balcão) + `NFeAutorizada` (transferência multi-depósito + crediário); pipeline TransactionBuilder | consome |
 | `Modules/RecurringBilling` | US-RB-044 boleto pago→NFe automática (crediário + B2B 30/60/90d) | consome |
 | `Modules/Financeiro` | Visão unificada AR/AP de vendas; DRE simplificado | consome |
-| `Modules/Copiloto` (Jana) | Chat contextual + alertas + brief diário + WhatsApp consulta peça (US-AP-011) | consome |
+| `Modules/Jana` (Jana) | Chat contextual + alertas + brief diário + WhatsApp consulta peça (US-AP-011) | consome |
 | `Modules/Whatsapp` | Webhook Meta Cloud API pra US-AP-011 + opt-in cliente | consome |
 | `Modules/OficinaAuto` | **Reuso futuro shared infra** — catálogo `pecas` + `aplicacoes` (chassis/ano/modelo) extraível como pacote shared quando OficinaAuto ativar | consome (futuro) |
 | `Modules/Vestuario` | **Reuso UI/Controller patterns** — venda balcão padrão, variação SKU multi-atributo (~30-40% reuso) | imita (não consome direto) |
@@ -181,7 +181,7 @@ Validação: **Vargas é candidato piloto qualificado** mas charter antecipatór
 | Núcleo UltimatePOS | `business_id`, users, roles, locations, `transactions`, `products`, `contacts` | base |
 | API Bosch / Nakata / Fras-le (catálogo OEM) | Connector — sync periódico catálogo OEM open data ou parceria | externa (opcional fase 2) |
 
-**Inverso:** Modules/Autopecas **não é consumido** por outros módulos verticais (princípio P2 ADR 0121). Excepão: catálogo peças shared (P2 ADR 0125) **será** consumido por Modules/OficinaAuto quando ambos verticais coexistirem.
+**Inverso:** Autopecas (planejado — não existe) **não é consumido** por outros módulos verticais (princípio P2 ADR 0121). Excepão: catálogo peças shared (P2 ADR 0125) **será** consumido por Modules/OficinaAuto quando ambos verticais coexistirem.
 
 ---
 
@@ -222,7 +222,7 @@ Segue lifecycle canon de módulo vertical ([ADR 0121](../../decisions/0121-oimpr
 | `proposto` (`feature-wish`) | ADR feature-wish, sem código | ✅ **AQUI** (sem Vargas assinatura) |
 | `em_construcao` | Vargas (ou substituto qualificado) assinou contrato + 6 features mínimas em desenvolvimento ativo | aguardando gatilho |
 | `piloto` | Vargas em prod pagando, MVP rodando | - |
-| `ativo` | 3+ clientes pagantes, módulo formal `Modules/Autopecas/` | - |
+| `ativo` | 3+ clientes pagantes, módulo formal `Autopecas` (planejado — não existe) | - |
 | `maduro` | 10+ clientes, benchmark setorial via Jana | - |
 | `historical` | <2 clientes ativos / 12m | - |
 

--- a/memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md
+++ b/memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md
@@ -1,8 +1,8 @@
-# Plano Migração Vargas → Modules/Autopecas — 2026-05-10
+# Plano Migração Vargas → Autopecas (planejado — não existe) — 2026-05-10
 
 > **Autor:** Claude (sub-agent migration engineer + customer success) sob direção Wagner [W]
 > **Status:** `draft` — Wagner valida antes de qualquer outreach
-> **Tier:** plano operacional (não ADR), subordinado a [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md) (Modules/Autopecas feature-wish) + [ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md) (Migration Factory) + [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) (modular por vertical) + [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (sinal qualificado)
+> **Tier:** plano operacional (não ADR), subordinado a [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md) (Autopecas (planejado — não existe) feature-wish) + [ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md) (Migration Factory) + [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) (modular por vertical) + [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (sinal qualificado)
 > **Pasta canônica:** `memory/requisitos/Autopecas/` — primeiro doc operacional do módulo (vertical em feature-wish)
 > **Origem:** removido do `PLANO-MIGRACAO-6-SAUDAVEIS.md` (Modules/ComunicacaoVisual) após Wagner confirmar 2026-05-10 que Vargas é **autopeças** (CNAE 4530-X), não comunicação visual
 
@@ -17,7 +17,7 @@
 - **Esforço migração:** ~24h IA-pair Felipe [F] + 12h Wagner [W] (calls + decisão + presencial) + 4h Maiara [M] (suporte L1 + treinamento) = **~40h total** ([ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) recalibração 10x já aplicada)
 - **ROI alvo:** 1 cliente Enterprise R$ [redacted Tier 0]/m × 12 = **R$ [redacted Tier 0]k/ano novo** (cap teórico Enterprise+ R$ [redacted Tier 0]-100k/ano se add-ons + multi-business)
 - **Capacidade time:** ~40h ao longo de 6m = **~7h/m** = sustentável sem comprometer Sprint principal
-- **Gatilho ADR 0125:** Vargas assinatura pioneer **DESBLOQUEIA** Modules/Autopecas `feature-wish` → `em_construcao`. Sem assinatura, módulo permanece dormente
+- **Gatilho ADR 0125:** Vargas assinatura pioneer **DESBLOQUEIA** Autopecas (planejado — não existe) `feature-wish` → `em_construcao`. Sem assinatura, módulo permanece dormente
 
 ### Premissa-chave (declarada — Wagner valida)
 
@@ -54,7 +54,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 
 ## Riscos específicos Vargas
 
-- 🔴 **Maior cliente saudável WR Sistemas — perda massiva.** R$ [redacted Tier 0]M GMV é 30% do agregado. Se migração der ruim, churn de Vargas inviabiliza Modules/Autopecas como vertical comercial + abala 26 anos relação
+- 🔴 **Maior cliente saudável WR Sistemas — perda massiva.** R$ [redacted Tier 0]M GMV é 30% do agregado. Se migração der ruim, churn de Vargas inviabiliza Autopecas (planejado — não existe) como vertical comercial + abala 26 anos relação
 - 🔴 **Build Delphi desatualizado** = cliente conservador, não corre pra novidade. Resistência natural a mudança. Pode interpretar "novo sistema" como "mais um upgrade que não preciso"
 - 🟡 **Vertical confirmado mas detalhe a aprofundar** — "autopeças" é amplo (varejo balcão? atacado? marketplace?). Confirmar via banco antes de positionar produto
 - 🟡 **Concorrência potencial** — Auto Manager / Lokoz / Linx Microvix podem ter mapeado Vargas como prospect (R$ [redacted Tier 0]M GMV é alvo natural mid-market)
@@ -74,7 +74,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 ### Quando
 
 - **Q4/26 outubro-dezembro** — após Modules/ComunicacaoVisual ter Sprint 1 entregue + 1ª piloto comvisual estabilizado em prod (Q3/26)
-- **Não antes** — sem Modules/CV piloto verde, demo Vargas frustra ("você diz que tem ERP mas só ROTA LIVRE vestuário existe")
+- **Não antes** — sem Modules/ComunicacaoVisual piloto verde, demo Vargas frustra ("você diz que tem ERP mas só ROTA LIVRE vestuário existe")
 - **Janela ideal:** **out-nov 2026** — Vargas ainda no clima de planejamento 2027, antes do recesso fim de ano BR
 
 ### Como (tática)
@@ -93,7 +93,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 3. **Follow-up técnico (45min Felipe + Wagner):**
    - Migration Factory demo: como banco Firebird Vargas migra preservando 100% histórico
    - Strangler Fig + parallel run 30d explicado: Delphi continua read-only enquanto oimpresso vira write canônico, rollback grátis 30d
-   - Roadmap Modules/Autopecas Sprint 1 (4 meses) + commitment release date
+   - Roadmap Autopecas (planejado — não existe) Sprint 1 (4 meses) + commitment release date
 
 4. **Decisão (semana +4 a +8):**
    - Vargas decide com cônjuge/sócio (provável) — dar tempo
@@ -112,7 +112,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
   - **Cálculo total ano-2:** R$ [redacted Tier 0]/m × 12m = **R$ [redacted Tier 0] ano-2**
   - **Total 24m grandfathered:** R$ [redacted Tier 0]
 - **Migração full** (Migration Factory pattern Strangler Fig + parallel run 30d Delphi+oimpresso lado a lado)
-- **Modules/Autopecas completo** quando entregue:
+- **Autopecas (planejado — não existe) completo** quando entregue:
   - Catálogo SKU + tabela aplicação por veículo
   - Venda balcão p95<1500ms
   - NFC-e ágil + NFe-de-boleto auto
@@ -140,10 +140,10 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 | **Q3/26 jul-set** | Modules/ComunicacaoVisual Sprint 1 entregue + 1ª piloto comvisual estabilizado | **gate-check** antes outreach Vargas |
 | **Q4/26 out (semana 1-2)** | Snapshot financeiro Vargas + Wagner prepara pitch | 4-8h Felipe + 4h Wagner |
 | **Q4/26 out (semana 3-4)** | Call discovery Wagner direto | 60min sync + 30min preparação Wagner |
-| **Q4/26 nov** | Follow-up técnico + demo Modules/Autopecas roadmap | 45min Felipe + Wagner |
+| **Q4/26 nov** | Follow-up técnico + demo Autopecas (planejado — não existe) roadmap | 45min Felipe + Wagner |
 | **Q4/26 dez** | Decisão Vargas (sim/não/postergar) | Vargas + sócio decidem |
-| **Q1/27 jan** | Se SIM: assinatura contrato + ADR ativação Modules/Autopecas (`feature-wish` → `em_construcao`) | Wagner aprova; Felipe scaffolda módulo |
-| **Q1/27 jan-mar** | Modules/Autopecas Sprint 1 (6 features mínimas US-AP-001..006) | ~10-12 dias úteis Felipe IA-pair + 6h Wagner aprovação |
+| **Q1/27 jan** | Se SIM: assinatura contrato + ADR ativação Autopecas (planejado — não existe) (`feature-wish` → `em_construcao`) | Wagner aprova; Felipe scaffolda módulo |
+| **Q1/27 jan-mar** | Autopecas (planejado — não existe) Sprint 1 (6 features mínimas US-AP-001..006) | ~10-12 dias úteis Felipe IA-pair + 6h Wagner aprovação |
 | **Q1/27 mar** | Snapshot financeiro Vargas re-rodado + Pattern 07 dry-run banco Firebird local | 1-2 dias Felipe |
 | **Q2/27 abr-mai** | Migração Vargas: cutover + parallel run 30d Delphi+oimpresso | 2-4 semanas wallclock + smoke biz Vargas + canary 7d |
 | **Q2/27 jun** | Vargas estabilizado em prod + survey NPS D+30 | 2-4 calls Maiara |
@@ -161,7 +161,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 1. **NÃO churnar Vargas do OfficeImpresso por pressão** — princípio [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) "guiar sem mandar"
 2. **Manter Vargas no OfficeImpresso, sem forçar** — releases manutenção legacy WR Sistemas continuam pago as-is
 3. **Re-tentar em 12-18 meses** com case público de outro cliente migrado já estabilizado (idealmente 2º cliente autopeças OU Vargas vê ROTA LIVRE+ComunicacaoVisual prosperando)
-4. **Modules/Autopecas permanece `feature-wish`** até 2º cliente autopeças saudável sinalizar interesse (ADR 0125 §Trigger Cenário B)
+4. **Autopecas (planejado — não existe) permanece `feature-wish`** até 2º cliente autopeças saudável sinalizar interesse (ADR 0125 §Trigger Cenário B)
 5. **Registrar resposta de Vargas** em `memory/research/vargas-2026-Q4-outreach-resultado.md` pra calibrar abordagens futuras (o quê funcionou? o quê travou?)
 
 ### Cenário: Vargas pede tempo (>3 meses sem decisão)
@@ -175,7 +175,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 1. **Aceitar perda como dado de mercado** — não foi por preço, foi por timing/produto/posicionamento
 2. Solicitar exit interview: "o que faltou no oimpresso pra ganhar você?"
 3. Documentar em post-mortem `memory/research/2026-Q?-post-mortem-vargas.md` (mesmo padrão Gold Comunicação Mubisys)
-4. **Modules/Autopecas vira `historical`** se Vargas era único candidato qualificado (ADR 0125 §review_trigger #5: "12 meses sem sinal Vargas + sem 2º cliente autopeças")
+4. **Autopecas (planejado — não existe) vira `historical`** se Vargas era único candidato qualificado (ADR 0125 §review_trigger #5: "12 meses sem sinal Vargas + sem 2º cliente autopeças")
 
 ---
 
@@ -204,7 +204,7 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
   - aplicação peças: aplicações Delphi → tabela `autopecas_aplicacoes` com integridade referencial
 - [ ] **Pest test multi-tenant verde local** (Felipe roda; Wagner exige conforme [feedback 2026-05-09](../../../C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/feedback_tenancy_changes_require_pest_local.md))
 - [ ] Vargas notificado por escrito (Wagner email + WhatsApp) data exata cutover + comunicação 7d antes ([proibicoes.md](../../proibicoes.md) §F5 CUTOVER sem aviso prévio)
-- [ ] **Treinamento Vargas equipe** agendado D-7 a D-1 (Maiara síncrono 4-8h cobrindo Modules/Autopecas + Jana + NFC-e ágil)
+- [ ] **Treinamento Vargas equipe** agendado D-7 a D-1 (Maiara síncrono 4-8h cobrindo Autopecas (planejado — não existe) + Jana + NFC-e ágil)
 
 ### Cutover (D-Day)
 
@@ -229,14 +229,14 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
   - landing `oimpresso.com/cases/vargas` ([Modules/Cms](../Cms/) cms_pages)
   - autoriza menção em battle card oimpresso vs Auto Manager/Lokoz/Linx Microvix
 - [ ] **Aposentar Delphi WR Sistemas pro Vargas** (status `🔒 retired` em [`_index.md`](../../clientes-legacy/_index.md))
-- [ ] **Modules/Autopecas promovido `em_construcao` → `piloto`** (ADR 0125 lifecycle)
+- [ ] **Autopecas (planejado — não existe) promovido `em_construcao` → `piloto`** (ADR 0125 lifecycle)
 
 ---
 
 ## Riscos sistêmicos específicos Vargas
 
 ### 1. Maior cliente legacy = single point of failure
-- **Impacto:** se Vargas migrar e voltar pro Delphi em <30d, Modules/Autopecas vira módulo morto + 26 anos relação Wagner-Vargas abalada
+- **Impacto:** se Vargas migrar e voltar pro Delphi em <30d, Autopecas (planejado — não existe) vira módulo morto + 26 anos relação Wagner-Vargas abalada
 - **Mitigação:** Migration Factory Pattern Strangler Fig + parallel run 30d garante rollback grátis; Pest validators count/totals match (Pattern 07); Wagner presencial cutover (se viável geo)
 - **Ativação review_trigger ADR 0119 #4** se voltar <30d
 
@@ -250,9 +250,9 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
 - **Mitigação:** **defender pelo vínculo Wagner-Vargas 26y** (intransferível) + diferencial Jana IA + NFe-de-boleto-pago + multi-tenant Tier 0 + stack moderna
 - **Plano B:** se Vargas sinalizar "Auto Manager me ofereceu R$ [redacted Tier 0]/m", Wagner não baixa preço — defende valor Migration Factory + relação
 
-### 4. Modules/Autopecas Sprint 1 atrasado quando Vargas estiver pronto
+### 4. Autopecas (planejado — não existe) Sprint 1 atrasado quando Vargas estiver pronto
 - **Impacto:** Vargas assina out/26 mas Sprint 1 entrega só mar/27 = 5 meses esperando — pode esfriar
-- **Mitigação:** Modules/Autopecas Sprint 1 **só começa após Vargas assinar** (ADR 0125 enforced). Vargas espera 2-3 meses pós-assinatura é normal pra pioneer; comunicar honesto: "você é o primeiro, vamos construir juntos"
+- **Mitigação:** Autopecas (planejado — não existe) Sprint 1 **só começa após Vargas assinar** (ADR 0125 enforced). Vargas espera 2-3 meses pós-assinatura é normal pra pioneer; comunicar honesto: "você é o primeiro, vamos construir juntos"
 - **Plano B:** se atrasar >6 meses pós-assinatura, oferecer compensação (3 meses adicionais grandfathered grátis)
 
 ### 5. Localização Vargas longe Wagner (BR é grande)
@@ -261,7 +261,7 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
 - **Plano B:** se geografia inviabilizar suporte presencial mensal, ajustar pricing? Não — pricing é pricing. Comprometer com suporte remoto premium (SLA 4h vs 24h)
 
 ### 6. Pest local exigência Wagner pode atrasar PRs multi-tenant
-- **Impacto:** [Wagner feedback 2026-05-09](../../../C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/feedback_tenancy_changes_require_pest_local.md) exige Pest verde **rodado localmente pelo dev** antes de PR multi-tenant. Modules/Autopecas tem ~7 Models multi-tenant novos
+- **Impacto:** [Wagner feedback 2026-05-09](../../../C:/Users/wagne/.claude/projects/D--oimpresso-com/memory/feedback_tenancy_changes_require_pest_local.md) exige Pest verde **rodado localmente pelo dev** antes de PR multi-tenant. Autopecas (planejado — não existe) tem ~7 Models multi-tenant novos
 - **Mitigação:** Felipe roda Pest local em cada PR Sprint 1 (não delegar pra CI); inclui no estimate ~2h/PR adicional
 - **Plano B:** se virar gargalo Felipe, Wagner aprova batch parcial em PR menores
 
@@ -288,14 +288,14 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
 
 | Métrica | Alvo | Como medir |
 |---------|------|------------|
-| **Vargas em prod pagando Modules/Autopecas** | ✅ sim | `business[vargas].vertical_id = autopecas` AND `subscription_status = active` |
+| **Vargas em prod pagando Autopecas (planejado — não existe)** | ✅ sim | `business[vargas].vertical_id = autopecas` AND `subscription_status = active` |
 | **ARR Vargas year-1** | R$ [redacted Tier 0] (com 50% off 6m) | sum(monthly_revenue × meses) |
 | **Churn Vargas 90d pós-migração** | 0% (não voltar pro Delphi) | review_trigger ADR 0119 #4 |
 | **NPS Vargas D+90** | ≥40 | survey clássico 0-10 |
 | **Tempo migração (signature → cutover)** | ≤120 dias | `cutover_date - contract_signed_date` |
 | **Case público Vargas autorizado** | ≥1 | `oimpresso.com/cases/vargas` no ar com autorização |
 | **Performance balcão Vargas (US-AP-002)** | p95 <1500ms | Pest browser-test prod biz Vargas |
-| **Modules/Autopecas promovido `piloto`** | ✅ sim D+90 | ADR 0125 lifecycle |
+| **Autopecas (planejado — não existe) promovido `piloto`** | ✅ sim D+90 | ADR 0125 lifecycle |
 
 ### Sinais de alerta (revisão imediata se baterem)
 
@@ -315,8 +315,8 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
 4. **Confirmar localização Vargas** (SC/SP/MG/RJ) via banco — define geografia presencial
 5. **Confirmar vertical autopeças** via sample 100 produtos no banco Firebird Vargas
 6. **Definir gate-check Modules/ComunicacaoVisual Sprint 1** — Felipe + Wagner alinham 4 features mínimas comvisual pra abrir outreach Vargas Q4/26
-7. **Registrar Vargas como candidato piloto Modules/Autopecas** em `memory/clientes-legacy/_index.md` (status `🟡 candidato Modules/Autopecas`)
-8. **NÃO criar tasks MCP Modules/Autopecas ainda** — gatilho Vargas assinatura (ADR 0125) é pré-requisito; criar tasks viola ADR 0105
+7. **Registrar Vargas como candidato piloto Autopecas (planejado — não existe)** em `memory/clientes-legacy/_index.md` (status `🟡 candidato Autopecas (planejado — não existe)`)
+8. **NÃO criar tasks MCP Autopecas (planejado — não existe) ainda** — gatilho Vargas assinatura (ADR 0125) é pré-requisito; criar tasks viola ADR 0105
 
 ---
 
@@ -328,9 +328,9 @@ Por baseado em [`memory/dominios/_patterns/`](../../dominios/_patterns/), execut
 - [ADR 0118](../../decisions/0118-segregacao-dominios-externos-clientes-legacy.md) — Segregação domínios externos
 - [ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md) — Migration Factory (mãe deste plano)
 - [ADR 0121](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md) — Modular especializado por vertical
-- [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md) — Modules/Autopecas feature-wish (mãe deste plano)
-- [SPEC Modules/Autopecas](SPEC.md) — contrato funcional do módulo
-- [Charter Modules/Autopecas](Autopecas.charter.md) — charter v1 antecipatório
+- [ADR 0125](../../decisions/0125-modules-autopecas-feature-wish.md) — Autopecas (planejado — não existe) feature-wish (mãe deste plano)
+- [SPEC Autopecas (planejado — não existe)](SPEC.md) — contrato funcional do módulo
+- [Charter Autopecas (planejado — não existe)](Autopecas.charter.md) — charter v1 antecipatório
 - [PLANO-MIGRACAO-6-SAUDAVEIS.md](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) — Vargas removido pro autopeças, plano comvisual atualizado
 - [memory/clientes-legacy/_index.md](../../clientes-legacy/_index.md) — matriz 49 clientes Delphi
 - [memory/sales/2026-05/06-pricing-tiers.md](../../sales/2026-05/06-pricing-tiers.md) — tiers oficiais (Starter/Pro/Enterprise)

--- a/memory/requisitos/Autopecas/SPEC.md
+++ b/memory/requisitos/Autopecas/SPEC.md
@@ -1,18 +1,20 @@
 ---
 module: Autopecas
-status: feature-wish
+version: "1.0"
+last_updated: "2026-06-13"
+status: rascunho
 lifecycle: aguarda-sinal-qualificado
-piloto: Vargas (candidato — sinal qualificado real, contrato pendente)
-piloto_previsao: depende de Vargas assinar pioneer Q4/26-Q1/27 (ADR 0105 enforcement)
-cnae_principal: "4530-7/03" (comércio a varejo de peças e acessórios novos para veículos automotores)
+piloto: "Vargas (candidato — sinal qualificado real, contrato pendente)"
+piloto_previsao: "depende de Vargas assinar pioneer Q4/26-Q1/27 (ADR 0105 enforcement)"
+cnae_principal: "4530-7/03 (comércio a varejo de peças e acessórios novos para veículos automotores)"
 cnae_secundarios: ["4530-7/01", "4530-7/02", "4530-7/04", "4530-7/05"]
-related_adrs: [0125, 0121, 0094, 0093, 0105, 0106, 0035, 0011, 0089, 0119]
+related_adrs: [0125-modules-autopecas-feature-wish, 0121-oimpresso-modular-especializado-por-vertical, 0094-constituicao-v2-7-camadas-8-principios, 0093-multi-tenant-isolation-tier-0, 0105-cliente-como-sinal-guiar-sem-mandar, 0106-recalibracao-velocidade-fator-10x-ia-pair, 0035-stack-ai-canonica-wagner-2026-04-26, 0011-alinhamento-padrao-jana, 0089-capterra-driven-module-evolution, 0119-migration-factory-capacidade-institucional]
 related_proposals: []
 last_review: 2026-05-10
 owner: [W]
 ---
 
-# Especificação funcional — Modules/Autopecas
+# Especificação funcional — Autopecas (planejado — não existe)
 
 > Convenção do ID: `US-AP-NNN` para user stories, `R-AP-NNN` para regras Gherkin.
 > **Modulo NÃO existe em código.** Este SPEC é **antecipatório** — formaliza o contrato de construção SE/QUANDO Vargas (ou outro candidato autopeças saudável) assinar contrato pioneer ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) gatilho).
@@ -65,7 +67,9 @@ ERP vertical brasileiro pra **autopeças balcão SMB** (1-15 balconistas, 200-30
 
 **Conclusão:** Vargas é piloto realista. Roadmap deste SPEC é **CONDICIONAL** ao gatilho descrito em §9 (Vargas assina contrato).
 
-## 3. Capacidades core (User Stories)
+## 3. User Stories — Capacidades core
+
+> Backlog antecipatório (US-AP-*) — só ativa SE/QUANDO Vargas (ou candidato qualificado) assinar contrato pioneer (ADR 0105). Módulo não existe em código.
 
 Priorização: **P0** = bloqueia 1ª piloto Vargas (paridade competitiva mínima vs Auto Manager/Lokoz) · **P1** = competitivo vs líderes do nicho · **P2** = diferencial de longo prazo · **P3** = backlog/feature-wish.
 
@@ -437,7 +441,7 @@ Priorização: **P0** = bloqueia 1ª piloto Vargas (paridade competitiva mínima
 ### 6.1 Estrutura de diretórios (a criar SE/QUANDO ativado)
 
 ```
-Modules/Autopecas/           ← a criar (status: feature-wish até gatilho)
+Autopecas/                   ← a criar (planejado — não existe; status: feature-wish até gatilho)
 ├── Config/
 │   ├── config.php
 │   └── permissions.php       ← Spatie: autopecas.produto.*, autopecas.balcao.*, autopecas.devolucao.*, autopecas.garantia.*, autopecas.cotacao.*
@@ -522,7 +526,7 @@ Quando OficinaAuto ativar (sinal qualificado pendente), extrair:
 - `pecas` + `peca_aplicacoes` (chassis_ranges, ano, modelo, motor, montadora) → pacote shared `OimpressoCatalogPecas`
 - Ambos módulos consomem o pacote sem duplicação
 
-Por enquanto, Modules/Autopecas implementa standalone com tabelas `autopecas_produtos`, `autopecas_aplicacoes` — refactor pra shared quando OficinaAuto sinalizar piloto.
+Por enquanto, Autopecas (planejado — não existe) implementa standalone com tabelas `autopecas_produtos`, `autopecas_aplicacoes` — refactor pra shared quando OficinaAuto sinalizar piloto.
 
 ### 6.4 Schema essencial (resumo)
 
@@ -669,7 +673,7 @@ Quando os pré-requisitos forem satisfeitos, **abrir ADR canon** "Autopecas-ativ
 
 | Métrica | Baseline (M0 ativação) | M6 | M12 | Crítica |
 |---|---|---|---|---|
-| Clientes pagantes Modules/Autopecas | 1 (Vargas) | 2-3 | **5-10** | <3 = re-avaliar tese |
+| Clientes pagantes Autopecas (planejado — não existe) | 1 (Vargas) | 2-3 | **5-10** | <3 = re-avaliar tese |
 | ARR módulo (R$/ano) | R$ [redacted Tier 0]k (Vargas Enterprise) | R$ [redacted Tier 0]-54k | **R$ [redacted Tier 0]-180k** | <R$ [redacted Tier 0]k = pivotar |
 | US entregues (de 15 totais) | 7 (mínimo P0) | 10 (P0+P1) | **13** | <10 = stack mal calibrado |
 | Cases públicos clicáveis | 0 | 1 (Vargas) | **2** | (transparência radical) |
@@ -677,18 +681,18 @@ Quando os pré-requisitos forem satisfeitos, **abrir ADR canon** "Autopecas-ativ
 | Churn módulo | n/a | <5%/m | <8%/ano | (review trigger ADR 0121) |
 | NFC-e ágil p95 | <1500ms | <1000ms | <800ms | (ux competitivo balcão) |
 
-**Convergência [ADR 0022](../../decisions/0022-meta-5mi-ano-financeira.md):** Modules/Autopecas contribui R$ [redacted Tier 0]-180k ARR de R$ [redacted Tier 0]M total (1.8-3.6% no M12 pós-ativação). Multi-vertical é tese — autopeças é diversificação Vargas-driven, não substituição.
+**Convergência [ADR 0022](../../decisions/0022-meta-5mi-ano-financeira.md):** Autopecas (planejado — não existe) contribui R$ [redacted Tier 0]-180k ARR de R$ [redacted Tier 0]M total (1.8-3.6% no M12 pós-ativação). Multi-vertical é tese — autopeças é diversificação Vargas-driven, não substituição.
 
 ## 11. Anti-padrões — o que NÃO fazer
 
 1. ❌ **Construir SEM Vargas assinatura (ou 2º cliente qualificado)** — viola ADR 0105 explicitamente. Status `feature-wish` é proteção
 2. ❌ **Forçar Vargas a migrar** — princípio ADR 0105 "guiar sem mandar". Plano B mantém Vargas no OfficeImpresso se recusar
 3. ❌ **Copiar feature-set Auto Manager e cobrar 30% menos** — sem diferencial Jana + NFe-boleto + multi-tenant Tier 0, perde por base instalada
-4. ❌ **Hard-code vocabulário autopeças no núcleo UltimatePOS** — quebra ADR 0121 §P1. Tudo "aplicação/montadora/qualidade-peça" vai em `Modules/Autopecas/`
+4. ❌ **Hard-code vocabulário autopeças no núcleo UltimatePOS** — quebra ADR 0121 §P1. Tudo "aplicação/montadora/qualidade-peça" vai em `Autopecas` (planejado — não existe)
 5. ❌ **Esquecer `business_id` global scope em qualquer Model nova** — Tier 0 IRREVOGÁVEL (ADR 0093)
 6. ❌ **Implementar US-AP-011 (WhatsApp consulta) sem opt-in LGPD explícito** — mensagem comercial sem opt-in = TIM-style risco multa Anatel + LGPD Art. 7º
 7. ❌ **PII real (CPF/CNPJ cliente, placa) em PR/commit/log** — skill `commit-discipline` Tier A. `[REDACTED]` ou `PiiRedactor`
-8. ❌ **Fundir Modules/Autopecas com Modules/OficinaAuto** — persona/workflow/concorrência distintos. ADR 0125 §Alternativa B rejeitada
+8. ❌ **Fundir Autopecas (planejado — não existe) com Modules/OficinaAuto** — persona/workflow/concorrência distintos. ADR 0125 §Alternativa B rejeitada
 9. ❌ **Cobrar setup R$ [redacted Tier 0] de Vargas** — pioneer R$ [redacted Tier 0] Setup regular só pra clientes 3+ pós-piloto
 10. ❌ **Smoke test com `business_id=1`** (Wagner WR2) — ADR 0101 manda biz piloto Vargas
 11. ❌ **Migrar Vargas sem dry-run + Pattern 07** — banco Firebird Vargas pode ter quirks não-mapeados (triggers, procedures, customizações)
@@ -707,7 +711,7 @@ Quando os pré-requisitos forem satisfeitos, **abrir ADR canon** "Autopecas-ativ
 
 ## 13. Referências
 
-- ADR 0125 — Modules/Autopecas como feature-wish (mãe deste módulo)
+- ADR 0125 — Autopecas (planejado — não existe) como feature-wish (mãe deste módulo)
 - ADR 0121 — Modular especializado por vertical
 - ADR 0094 — Constituição v2 (princípios duros)
 - ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL

--- a/memory/requisitos/Cms/SiteHome.charter.md
+++ b/memory/requisitos/Cms/SiteHome.charter.md
@@ -26,7 +26,7 @@ Home pública do tenant `oimpresso.com` (e mirrors por business) — landing pag
 ## Non-Goals
 
 - ❌ Catálogo de produtos público (vai virar `/c/produtos` charter separada — Modules/Vestuario/ComunicacaoVisual)
-- ❌ Auth flow (Login/Register são charters próprias em Modules/Auth)
+- ❌ Auth flow (Login/Register são charters próprias em Auth — núcleo UltimatePOS, não é módulo)
 - ❌ Checkout/pricing dinâmico (charter `Site/Pricing` separada — `SitePricingDinamicoTest` cobre)
 - ❌ Hidratar copy de fontes externas (Sanity/Strapi/Contentful) — DB próprio é canon
 

--- a/memory/requisitos/Comissao/MATRIZ-ROI.md
+++ b/memory/requisitos/Comissao/MATRIZ-ROI.md
@@ -78,7 +78,7 @@ Legenda células: ✅ entrega bem · 🟡 entrega parcial · ❌ não entrega ·
 | F | Decisão | Motivo |
 |---|---------|--------|
 | F9 | P2 — quando OficinaAuto entrar em produção (sem cliente Oficina ativo hoje — [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) | Sem sinal qualificado cliente |
-| F10 (marketplace) | P2 — dep externa Modules/Marketplaces ainda em backlog | Bloqueado por outro módulo |
+| F10 (marketplace) | P2 — dep externa módulo Marketplaces (planejado — não existe) ainda em backlog | Bloqueado por outro módulo |
 | F12 (mobile) | P2 — vendedor ROTA LIVRE é Larissa dona (não delegação) | Sem urgência piloto |
 | F13 (per produto) | P2 — schema já comporta (`applies_to_line_filter`); UI completa fica P2 | Schema entregue P0; UI low-prio |
 | F14 (origem) | P3 — backlog ADR feature-wish ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) | Sem sinal cliente |

--- a/memory/requisitos/Comissao/ROADMAP.md
+++ b/memory/requisitos/Comissao/ROADMAP.md
@@ -104,7 +104,7 @@
 | US | Feature | Estimate | Trigger |
 |----|---------|----------|---------|
 | US-COMM-010 | Multi-mecânico Repair/OficinaAuto split apontamentos | 3d | Sinal cliente OficinaAuto chega ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) |
-| US-COMM-011 | Comissão sobre líquido marketplace (após taxa ML/iFood) | 2d | Modules/Marketplaces existir com `marketplace_net_amount` |
+| US-COMM-011 | Comissão sobre líquido marketplace (após taxa ML/iFood) | 2d | módulo Marketplaces (planejado — não existe) com `marketplace_net_amount` |
 | US-COMM-013 | Mobile self-service vendedor (PWA `/comissao/minhas`) | 2d | Vendedor delegado pede (não Larissa-dona) |
 | US-COMM-014 | Migração legacy `users.cmmsn_percent` + `transactions.commission_agent` (backfill 90d) | 2d | Reclamação cliente "perdi histórico" — ainda não houve |
 
@@ -117,7 +117,7 @@
 
 ### Bloqueadores potenciais
 
-- Dependências externas (Modules/Marketplaces backlog)
+- Dependências externas (módulo Marketplaces planejado — não existe, em backlog)
 - Sem sinal cliente → feature fica em backlog ADR feature-wish
 
 ---
@@ -149,7 +149,7 @@ Cycle N+2 (1 cycle + 7d observação)
 Cycle N+3+ (variable, sinal-driven)
 └─ Fase 4 — Extras (2-9d à demanda)
    ├─ US-COMM-010 (Repair/Oficina) - quando sinal
-   ├─ US-COMM-011 (marketplace) - quando Modules/Marketplaces existir
+   ├─ US-COMM-011 (marketplace) - quando módulo Marketplaces (planejado — não existe) for criado
    ├─ US-COMM-013 (mobile) - quando vendedor delegado pedir
    └─ US-COMM-014 (migration) - se reclamarem
 ```

--- a/memory/requisitos/Comissao/SPEC.md
+++ b/memory/requisitos/Comissao/SPEC.md
@@ -1,8 +1,17 @@
+---
+module: Comissao
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
+status: rascunho
+related_adrs: [0151-modules-comissao-feature-wish, 0105-cliente-como-sinal-guiar-sem-mandar, 0143-fsm-pipeline-live-prod-marco-2026-05-12]
+---
+
 # SPEC — Comissão de Vendedores (cross-vertical)
 
 > ## ⛔ DORMENTE — feature-wish ([ADR 0151](../../decisions/0151-modules-comissao-feature-wish.md))
 >
-> **NÃO atribuir owner às US-COMM-* abaixo.** **NÃO scaffoldear código** em `Modules/Comissao/`.
+> **NÃO atribuir owner às US-COMM-* abaixo.** **NÃO scaffoldear código** em `Comissao` (planejado — não existe).
 >
 > Razão (ADR 0151): nenhum dos 5 verticais tem cliente pagante que reporta dor explícita de comissão hoje (Larissa opera com `commission_agent` UPos + planilha Eliana[E], ComVis/OficinaAuto/Autopecas inativos, Marketplaces inexistente). [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — sem sinal qualificado, sem código.
 >
@@ -10,7 +19,7 @@
 >
 > **SPEC abaixo permanece intacto como blueprint pré-pago** — quando trigger ativar, dev abre o SPEC e tem ~2 semanas de design já feito (mapping mercado, 6 schema tables, 5 cenários peculiares, 14 US, riscos catalogados).
 
-> **Módulo proposto:** `Modules/Comissao` (cross-vertical — consumido por Sells, ComVis, OficinaAuto, Autopecas, Marketplaces)
+> **Módulo proposto:** `Comissao` (planejado — não existe) (cross-vertical — consumido por Sells, ComVis, OficinaAuto, Autopecas, Marketplaces)
 > **Status:** **dormente** ([ADR 0151](../../decisions/0151-modules-comissao-feature-wish.md) — feature-wish, aguarda-sinal-qualificado)
 > **Convenção ID:** `US-COMM-NNN`
 > **Owner sugerido (ao ativar):** [W] + [E] (advogada + financeiro — afeta folha/CLT)
@@ -55,7 +64,7 @@
 | Aprovação manual / workflow / audit trail | ❌ | ❌ | 🟡 "reapuração permitida com motivo" | ❌ | ❌ | ❌ | 🟡 | ✅ | **Sim — construir (P1)** |
 | Mobile self-service (vendedor vê próprias comissões) | ❌ | ❌ | ❌ | 🟡 | 🟡 | 🟡 | 🟡 | ✅ "real-time earnings visibility" | **P2 — gap diferencial** |
 
-> **Princípio de não-duplicação:** o módulo `Modules/Comissao` **NÃO substitui** `transactions.commission_agent` nem `users.cmmsn_percent`. Eles continuam sendo os "valores semente" — o módulo novo lê e expande quando a policy exige multi-papel/tier/accelerator. Migração silenciosa: vendas legadas continuam funcionando com cálculo single-tier; vendas novas em verticais que adotam policy avançada usam o módulo novo.
+> **Princípio de não-duplicação:** o módulo `Comissao` (planejado — não existe) **NÃO substitui** `transactions.commission_agent` nem `users.cmmsn_percent`. Eles continuam sendo os "valores semente" — o módulo novo lê e expande quando a policy exige multi-papel/tier/accelerator. Migração silenciosa: vendas legadas continuam funcionando com cálculo single-tier; vendas novas em verticais que adotam policy avançada usam o módulo novo.
 
 ---
 
@@ -273,6 +282,10 @@ Slot pra cada side-effect: `app/Domain/Fsm/SideEffects/{Calcular,Estornar}Comiss
 
 ---
 
+## US ativas
+
+> Backlog dormente (US-COMM-*) — blueprint pré-pago. Só ganha owner quando trigger de ativação do ADR 0151 for satisfeito + Wagner aprovar ADR de promoção. Detalhe das 14 US em §5 abaixo.
+
 ## §5 User Stories — US-COMM-001 a US-COMM-014
 
 ### US-COMM-001 · Schema base + migration + multi-tenant scope — **P0**
@@ -284,7 +297,7 @@ Slot pra cada side-effect: `app/Domain/Fsm/SideEffects/{Calcular,Estornar}Comiss
 **DoD:**
 - [ ] 6 migrations com `business_id` indexado + FK
 - [ ] 6 Eloquent Models com `HasBusinessScope` global scope
-- [ ] `Modules/Comissao/Database/Seeders/CommissionDefaultsSeeder` cria policy default per business existente (preserva backward-compat: rate=`users.cmmsn_percent`, trigger=`on_payment`, base=`gross_total`)
+- [ ] `Comissao/Database/Seeders/CommissionDefaultsSeeder` (módulo planejado — não existe) cria policy default per business existente (preserva backward-compat: rate=`users.cmmsn_percent`, trigger=`on_payment`, base=`gross_total`)
 - [ ] Pest: 1 teste `BusinessIdGuardTest` cross-tenant biz=1 vs biz=99
 - **Estimate:** 3d (recalibrado IA-pair fator 10x — [ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md))
 
@@ -431,7 +444,7 @@ Slot pra cada side-effect: `app/Domain/Fsm/SideEffects/{Calcular,Estornar}Comiss
 ---
 
 ### US-COMM-011 · Comissão sobre líquido (após taxa marketplace) — **P2**
-> **blocked_by:** Modules/Marketplaces existir (não-construído ainda)
+> **blocked_by:** módulo Marketplaces (planejado — não existe)
 
 **Como** dono **quero** que vendas ML/iFood/Shopee usem base líquida (já descontada taxa marketplace) **para** comissão refletir margem real
 

--- a/memory/requisitos/ComunicacaoVisual/ComunicacaoVisual.charter.md
+++ b/memory/requisitos/ComunicacaoVisual/ComunicacaoVisual.charter.md
@@ -46,7 +46,7 @@ Add-on vertical de comunicação visual / gráfica rápida sobre o núcleo oimpr
 - ❌ **Visão financeira AR/AP unificada / DRE** → vive em `Modules/Financeiro`
 - ❌ **Boleto/assinatura/cobrança recorrente** → vive em `Modules/RecurringBilling`
 - ❌ **Multi-tenant `business_id` global scope** → infraestrutura núcleo Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
-- ❌ **Jana IA / memória persistente** → vive em `Modules/Copiloto`
+- ❌ **Jana IA / memória persistente** → vive em `Modules/Jana`
 - ❌ **Cofre de senhas/credenciais (cert digital A1)** → vive em `Modules/MemCofre`
 - ❌ **Estoque por SKU+tamanho+cor / etiqueta de preço de balcão** — isso é de `Modules/Vestuario`
 - ❌ **Kanban genérico drag-drop** — `Modules/Repair` é shared infra ([ADR 0121 §P8](../../decisions/0121-oimpresso-modular-especializado-por-vertical.md)); ComunicacaoVisual consome com vocabulário gráfico (etapa/OS, não placa/veículo)
@@ -113,7 +113,7 @@ Add-on vertical de comunicação visual / gráfica rápida sobre o núcleo oimpr
 
 ## 6. Automation hooks (onde Jana IA atua)
 
-> Jana = Modules/Copiloto. Hooks abaixo são **propostos** — exigem sinal qualificado ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) antes de virar US ativa.
+> Jana = Modules/Jana. Hooks abaixo são **propostos** — exigem sinal qualificado ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) antes de virar US ativa.
 
 - ✅ **Wizard onboarding CNAE 1813** (US-COMVIS-006) — Jana detecta CNAE da empresa e pré-popula NCM/CFOP/CSOSN sem precisar contador
 - ✅ **Bulk update material via chat** (US-COMVIS-013) — "aumenta 5% em todo lona 440g" → preview + confirmação humana + audit log
@@ -150,7 +150,7 @@ Add-on vertical de comunicação visual / gráfica rápida sobre o núcleo oimpr
 | `Modules/NfeBrasil` | Listener `BoletoPago` → `EmitirNfceJob` (US-COMVIS-009 reuso US-RB-044); CFOP/CSOSN/NCM seed CNAE 1813 (US-COMVIS-006) | consome |
 | `Modules/NFSe` (a criar) | NFSe automática pra serviço de instalação (US-COMVIS-008) | consome (dependência futura) |
 | `Modules/Financeiro` | AR/AP boletos, DRE simplificado, comissão folha (US-COMVIS-011) | consome |
-| `Modules/Copiloto` (Jana) | Chat contextual + 3 ângulos faturamento + bulk update materiais + brief diário | consome |
+| `Modules/Jana` (Jana) | Chat contextual + 3 ângulos faturamento + bulk update materiais + brief diário | consome |
 | `Modules/RecurringBilling` | Trigger boleto pago → NFe automática (US-COMVIS-009) | consome |
 | `Modules/Repair` | Kanban drag-drop multi-etapa (US-COMVIS-003) — Repair é shared infra com override de labels gráfico | consome shared infra |
 | `Modules/MemCofre` | Cofre cert digital A1, login fornecedor (Roland/Mimaki SDK futuro), webservice prefeitura NFSe | consome opcional |

--- a/memory/requisitos/ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md
+++ b/memory/requisitos/ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md
@@ -29,7 +29,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 
 > 🚨 **Atualização 2026-05-10**: Wagner confirmou que Vargas é **autopeças** (CNAE 4530-X), não comunicação visual. Vargas portanto NÃO entra no plano migração ComunicacaoVisual.
 >
-> **Vargas vira candidato Modules/Autopecas** — vertical novo a ativar com base em sinal qualificado real (cliente saudável R$ [redacted Tier 0]M GMV, 26 anos relação, Wagner conhece direto). Tratamento separado em `memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md` (a criar).
+> **Vargas vira candidato do módulo Autopecas (planejado — não existe)** — vertical novo a ativar com base em sinal qualificado real (cliente saudável R$ [redacted Tier 0]M GMV, 26 anos relação, Wagner conhece direto). Tratamento separado em `memory/requisitos/Autopecas/PLANO-MIGRACAO-VARGAS.md` (a criar).
 >
 > **Impacto neste plano**: top 1 piloto Modules/ComunicacaoVisual passa a ser **Extreme** (R$ [redacted Tier 0]M GMV, "EXTREMA LED" = com.visual nativo confirmado por nome).
 
@@ -118,7 +118,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 ### 3. Gold (R$ [redacted Tier 0]M GMV/ano) — biz_id legacy mapeado: ? (Gold no registry, versão 1466)
 
 **Status atual:**
-- ⚠️ **AMBIGUIDADE NOMENCLATURA** — *Gold* no registry WR Sistemas (versão 1466, banco "Gold") **pode OU não** ser o **Gold Comunicação** (Três Lagoas/MS, CNPJ 03.348.254/0001-93) que trocou pra Mubisys conforme [post-mortem](../../research/2026-05-prospeccao/07-post-mortem-gold-comunicacao-mubisys.md)
+- ⚠️ **AMBIGUIDADE NOMENCLATURA** — *Gold* no registry WR Sistemas (versão 1466, banco "Gold") **pode OU não** ser o **Gold Comunicação** (Três Lagoas/MS, CNPJ 11.222.333/0001-81) que trocou pra Mubisys conforme [post-mortem](../../research/2026-05-prospeccao/07-post-mortem-gold-comunicacao-mubisys.md) <!-- pii-allowlist: CNPJ real do cliente substituído pelo fake canônico (oimpresso) — LGPD -->
 - 🔴 **Hipótese 1:** mesmo cliente — Gold Comunicação Visual já churned pra Mubisys = perdido
 - 🟡 **Hipótese 2:** Gold no registry é cliente diferente (Goiás? Outra Gold?) — ainda saudável
 - **AÇÃO BLOQUEANTE:** Wagner valida qual Gold é qual antes de qualquer ação
@@ -325,7 +325,7 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 
 | Pessoa | Hora/cliente | × Clientes (5 ativos: Vargas, Extreme, Zoom, Fixar, Mhundo) | Total ano | Mensal |
 |--------|--------------|--------------------------------------------------:|----------:|-------:|
-| **Felipe [F]** dev IA-pair (migração + Modules/CV features sob demanda) | 16h | × 5 | 80h | 6,7h/m |
+| **Felipe [F]** dev IA-pair (migração + Modules/ComunicacaoVisual features sob demanda) | 16h | × 5 | 80h | 6,7h/m |
 | **Wagner [W]** discovery + decisão + go/no-go | 8h | × 5 + 4h Gold validação | 44h | 3,7h/m |
 | **Maiara [M]** suporte L1 + treinamento + migração assistida (Fixar/Mhundo/Produart) | 6h | × 5 | 30h | 2,5h/m |
 | **TOTAL TIME** | — | — | **154h** | **12,8h/m** |
@@ -366,8 +366,8 @@ Receita atual WR Sistemas é **estimativa**, não dado confirmado. Pra fechar es
 - **Pior caso:** confirma Hipótese 1 + zero migração subsequente Gold-style → Modules/ComunicacaoVisual fica com 5 candidatos efetivos
 
 ### 2. Modules/ComunicacaoVisual incompleto na hora da migração 1ª (Vargas Q3/26)
-- **Impacto:** Vargas espera Modules/CV completo (cálculo m² + spool plotter + PCP gráfico + NFe-de-boleto). Se Sprint 1 entregar só 2 de 4 features, piloto frustra
-- **Mitigação:** **gate-check Sprint 1 ANTES de assinar Vargas** — Felipe entrega Modules/CV Sprint 1 em julho/26, Wagner aprova baseado em demo, então abre outreach Vargas. Sem Sprint 1 verde, atrasar outreach
+- **Impacto:** Vargas espera Modules/ComunicacaoVisual completo (cálculo m² + spool plotter + PCP gráfico + NFe-de-boleto). Se Sprint 1 entregar só 2 de 4 features, piloto frustra
+- **Mitigação:** **gate-check Sprint 1 ANTES de assinar Vargas** — Felipe entrega Modules/ComunicacaoVisual Sprint 1 em julho/26, Wagner aprova baseado em demo, então abre outreach Vargas. Sem Sprint 1 verde, atrasar outreach
 - **Plano B:** se Sprint 1 atrasar 60d, postergar Vargas pra Q4/26 inteiro; Extreme passa a ser piloto Q3/26
 
 ### 3. Multi-tenant Tier 0 + Migration Factory cross-business risk
@@ -410,7 +410,7 @@ Por cada cliente migrado, executar checklist baseado em [`memory/dominios/_patte
 ### Cutover (D-Day)
 - [ ] **Parallel run** Delphi + oimpresso 30d pós-cutover (Pattern Strangler Fig — Delphi continua read-only, oimpresso é write canônico)
 - [ ] Smoke test **biz cliente real** (não biz=1, conforme [ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
-- [ ] Treinamento Maiara [M] síncrono 2-8h conforme tier (cobre Modules/CV + Jana + NFe automática)
+- [ ] Treinamento Maiara [M] síncrono 2-8h conforme tier (cobre Modules/ComunicacaoVisual + Jana + NFe automática)
 - [ ] Rollback 30d documentado (cliente sabe pode voltar Delphi sem custo)
 
 ### Pós-migração (D+1 a D+90)

--- a/memory/requisitos/ComunicacaoVisual/QUALIFICACAO-PILOTO-2026-05-16.md
+++ b/memory/requisitos/ComunicacaoVisual/QUALIFICACAO-PILOTO-2026-05-16.md
@@ -72,13 +72,13 @@ related_docs:
 - Maior GMV restante (Vargas removido pra Autopecas)
 - Vertical encaixe nominal: nome registry sugere LED/comunicação visual
 - Build Delphi atualizado (v1472, chama backend Connector) = receptivo a novidade
-- Volume FB alto (~85k vendas histórico) = operação madura testa Modules/CV com carga real
+- Volume FB alto (~85k vendas histórico) = operação madura testa Modules/ComunicacaoVisual com carga real
 
-**Plano discovery:** Wagner [W] + Felipe [F] técnico — call 45min após Sprint 1 Modules/CV verde.
+**Plano discovery:** Wagner [W] + Felipe [F] técnico — call 45min após Sprint 1 Modules/ComunicacaoVisual verde.
 
 **Risco:** concorrência Mubisys/Zênite pode ter mapeado paralelo (AFACOM+ centro-oeste). Acelerar Q3/26.
 
-**Pacote recomendado:** Enterprise R$ [redacted Tier 0]/m grandfathered 24m + setup R$ [redacted Tier 0] + 30% off 6m + Modules/CV completo (cálculo m² + spool plotter + PCP + NFe-de-boleto) + Jana ilimitada. Compromisso: depoimento escrito.
+**Pacote recomendado:** Enterprise R$ [redacted Tier 0]/m grandfathered 24m + setup R$ [redacted Tier 0] + 30% off 6m + Modules/ComunicacaoVisual completo (cálculo m² + spool plotter + PCP + NFe-de-boleto) + Jana ilimitada. Compromisso: depoimento escrito.
 
 ### 🥈 2. Cliente C (Zoom) — score 16/25 (+TBD geo)
 
@@ -92,7 +92,7 @@ related_docs:
 
 **Risco:** pode estar SATISFEITO DEMAIS com OfficeImpresso atual. Diferencial precisa ser CONCRETO (não preço — defender pelo wedge competitivo NFe-de-boleto automática + Jana 22h).
 
-**Pacote recomendado:** Enterprise R$ [redacted Tier 0]/m grandfathered 18m + setup R$ [redacted Tier 0] (50% off Enterprise) + Modules/CV completo. Q4/26 outubro outreach.
+**Pacote recomendado:** Enterprise R$ [redacted Tier 0]/m grandfathered 18m + setup R$ [redacted Tier 0] (50% off Enterprise) + Modules/ComunicacaoVisual completo. Q4/26 outubro outreach.
 
 ### 🥉 3. Cliente E (Mhundo) — score 15/25 (+TBD)
 
@@ -107,7 +107,7 @@ related_docs:
 
 **Risco:** GMV pequeno pode não justificar Pro R$ [redacted Tier 0] (margem cliente apertada). Avaliar tier R$ [redacted Tier 0] em discovery.
 
-**Pacote recomendado:** Pro R$ [redacted Tier 0]/m grandfathered 12m + setup R$ [redacted Tier 0] (entry-level) + Modules/CV lite (essenciais) + NFe + Jana 200 perguntas/m. Q1/27 março outreach.
+**Pacote recomendado:** Pro R$ [redacted Tier 0]/m grandfathered 12m + setup R$ [redacted Tier 0] (entry-level) + Modules/ComunicacaoVisual lite (essenciais) + NFe + Jana 200 perguntas/m. Q1/27 março outreach.
 
 ---
 
@@ -157,14 +157,14 @@ Cliente vira **Tier A** (top prioridade piloto) APENAS se:
 - ❌ Resposta "tá tudo bem, não tenho nenhuma dor" → cliente satisfeito, não vende
 - ❌ "Já fechei com Mubisys/Zênite contrato 24m" → respeitar contrato; outreach D+90 só se Mubisys deteriorar
 - ❌ Cliente menciona preço como ÚNICO critério → não fit (oimpresso vende confiança + diferencial, não preço)
-- ❌ Cliente exige feature que NÃO está no roadmap Modules/CV Sprint 1-4 → não forçar; backlog ADR feature-wish
+- ❌ Cliente exige feature que NÃO está no roadmap Modules/ComunicacaoVisual Sprint 1-4 → não forçar; backlog ADR feature-wish
 
 ---
 
 ## Pré-requisitos antes de qualquer outreach (Wagner aprova)
 
 1. ⏳ **Snapshot financeiro** dos 3 top candidatos via skill [officeimpresso-financial-snapshot](../../../.claude/skills/officeimpresso-financial-snapshot/SKILL.md) — confirma receita real + ticket pago histórico + recência updates Delphi
-2. ⏳ **Sprint 1 Modules/CV verde** (4 features P0: cálculo m² + cadastro substrato + NFe-de-boleto + PCP Kanban CV-vocabulário) — sem isso, demo frustra
+2. ⏳ **Sprint 1 Modules/ComunicacaoVisual verde** (4 features P0: cálculo m² + cadastro substrato + NFe-de-boleto + PCP Kanban CV-vocabulário) — sem isso, demo frustra
 3. ⏳ **Validar identidade Cliente B (Gold)** — registry vs Mubisys post-mortem 2026-05-09 ([04-gold-comvis](../../research/clientes-legacy-officeimpresso/04-gold-comvis/01-perfil.md))
 4. ⏳ **Confirmar vertical real** de cada candidato via Firebird `SELECT * FROM EMPRESA` (cidade/UF/CNAE inferido) — alguns aliases ambíguos
 5. ⏳ **Battle card atualizado** (Mubisys/Zênite/Calcgraf) — defender pelo wedge competitivo, não pelo preço

--- a/memory/requisitos/Copiloto/COBRADORA-PILOTO-TASKS-BATCH.md
+++ b/memory/requisitos/Copiloto/COBRADORA-PILOTO-TASKS-BATCH.md
@@ -164,7 +164,7 @@ Adicionar `cobranca_fatura` em `config/ads.php` com matriz HITL declarativa per-
 
 **Description:**
 
-Criar `Modules/Copiloto/Ai/Agents/CobradoraAgent.php` herdando padrão `LaravelAiSdkDriver` Agent ([ADR 0048](../../decisions/0048-framework-agentes-laravel-ai-vizra-rejeitada.md)). 5 tools internas em `Modules/Copiloto/Ai/Tools/`.
+Criar `Modules/Jana/Ai/Agents/CobradoraAgent.php` herdando padrão `LaravelAiSdkDriver` Agent ([ADR 0048](../../decisions/0048-framework-agentes-laravel-ai-vizra-rejeitada.md)). 5 tools internas em `Modules/Jana/Ai/Tools/`.
 
 **5 tools obrigatórias:**
 
@@ -176,7 +176,7 @@ Criar `Modules/Copiloto/Ai/Agents/CobradoraAgent.php` herdando padrão `LaravelA
 
 **Acceptance criteria:**
 
-- [ ] Charter `Modules/Copiloto/Ai/Agents/CobradoraAgent.charter.md` (Mission/Goals/Non-Goals/UX targets/Anti-hooks) — skill `charter-write`
+- [ ] Charter `Modules/Jana/Ai/Agents/CobradoraAgent.charter.md` (Mission/Goals/Non-Goals/UX targets/Anti-hooks) — skill `charter-write`
 - [ ] Agent registra decisão em `mcp_dual_brain_decisions` com `agent_name='CobradoraAgent'` + `client_visible=true`
 - [ ] Pest cobertura ≥80% per tool + agent
 - [ ] Pest cross-tenant biz=1 vs biz=99 (agent de biz=4 NUNCA enxerga faturas biz=1)
@@ -195,7 +195,7 @@ Criar `Modules/Copiloto/Ai/Agents/CobradoraAgent.php` herdando padrão `LaravelA
 
 **Description:**
 
-Job assíncrono `Modules/Copiloto/Jobs/EnviarCobrancaJob.php` que recebe `business_id`, `contact_id`, `canal`, `mensagem`, `decisao_id` e dispara WhatsappJob OR Mail dispatch conforme `canal`.
+Job assíncrono `Modules/Jana/Jobs/EnviarCobrancaJob.php` que recebe `business_id`, `contact_id`, `canal`, `mensagem`, `decisao_id` e dispara WhatsappJob OR Mail dispatch conforme `canal`.
 
 **Acceptance criteria:**
 

--- a/memory/requisitos/Copiloto/JANA-PRO-PRODUCT-PLAN.md
+++ b/memory/requisitos/Copiloto/JANA-PRO-PRODUCT-PLAN.md
@@ -34,8 +34,8 @@ webhook sincroniza pro DB).
 estruturado.
 
 **AC:**
-- `Modules/Copiloto/Agents/BriefDiarioAgent.php` namespace `agents.brief_diario`
-- 5 PHP tools em `Modules/Copiloto/Services/JanaPro/Tools/`:
+- `Modules/Jana/Agents/BriefDiarioAgent.php` namespace `agents.brief_diario`
+- 5 PHP tools em `Modules/Jana/Services/JanaPro/Tools/`:
   - `VendasPeriodoTool` — transactions sell GROUP BY day vs período anterior + ticket médio
   - `InadimplenciaBucketsTool` — buckets 0-30 / 30-60 / 60-90 / >90d com valores
   - `TicketsPriorizadosTool` — reusa skill ticket-triage, top 5 P1/P2
@@ -54,7 +54,7 @@ estruturado.
 **Owner:** wagner · **Priority:** p1 · **Estimate:** 2h
 
 **AC:**
-- `Modules/Copiloto/Jobs/BriefDiarioJob.php` queue `jana-pro` Horizon CT 100
+- `Modules/Jana/Jobs/BriefDiarioJob.php` queue `jana-pro` Horizon CT 100
 - Schedule `app/Console/Kernel.php` cron 8h BRT segunda-sábado (domingo skip por default)
 - Itera business com flag `jana_pro_active=true` (US-COPI-204)
 - Timeout 60s + retry 3x backoff exponential
@@ -70,7 +70,7 @@ estruturado.
 daemon Baileys CT 100 já conectado.
 
 **AC:**
-- `Modules/Copiloto/Services/JanaPro/Delivery/WhatsappBriefDelivery.php`
+- `Modules/Jana/Services/JanaPro/Delivery/WhatsappBriefDelivery.php`
 - Format markdown → texto Whatsapp formatado (lista bullet + bold via *...*)
 - Reusa `ChannelDriverFactory` + `BaileysDriver::send()`
 - Idempotência: 1 envio por business+date (UNIQUE constraint `mcp_briefs.delivery_key`)
@@ -212,7 +212,7 @@ Escuta eventos críticos via Laravel events + decide se vale alertar/agir.
 **AC:**
 - `App\Events\TransactionPaid` (já pode existir — verificar)
 - `App\Events\NfeRejeitada` (novo — disparado pelo Modules/NfeBrasil)
-- Listeners registrados em `Modules/Copiloto/Providers/JanaProServiceProvider.php`
+- Listeners registrados em `Modules/Jana/Providers/JanaProServiceProvider.php`
 - Multi-tenant Tier 0: listeners propagam `$businessId` async
 
 ---
@@ -371,7 +371,7 @@ não-modificadas, conversations resolvidas). Cache namespace
 - Métrica: % cache hit vs miss (target ≥ 60%)
 - Custo LLM reduz de R$ [redacted Tier 0] → R$ [redacted Tier 0] por brief (margem sobe pra 97%)
 
-**Refs:** Sprint 9 retrieval flow Modules/Copiloto (ADR 0036)
+**Refs:** Sprint 9 retrieval flow Modules/Jana (ADR 0036)
 
 ---
 

--- a/memory/requisitos/Essentials/BRIEFING.md
+++ b/memory/requisitos/Essentials/BRIEFING.md
@@ -29,7 +29,7 @@ Origem: módulo opcional UltimatePOS v6 — preservado intencionalmente como **s
 | Leave Request (ausências) | ✅ em prod | Workflow pending → approved/rejected, ActivityLog Spatie |
 | Documents + Share | ✅ em prod | Upload + share por usuário |
 | Reminder | ✅ em prod | CRUD calendário pessoal |
-| Attendance (ponto) | 🟡 legacy | Coexiste com Modules/PontoWr2 canônico (Portaria 671/2021) — em PontoWr2 fica trabalho novo |
+| Attendance (ponto) | 🟡 legacy | Coexiste com Modules/Ponto canônico (Portaria 671/2021) — em Ponto fica trabalho novo |
 | HRM (allowance/deduction/shift/payroll) | 🟡 legacy | Usado biz=4 minimal; backlog ADR feature-wish para evolução |
 | Sales Target | 🟡 legacy | Pouco uso; possível candidato a desativar |
 | Holiday | ✅ em prod | Gestão de feriados por business |

--- a/memory/requisitos/EvolutionAgent/SPEC.md
+++ b/memory/requisitos/EvolutionAgent/SPEC.md
@@ -1,3 +1,11 @@
+---
+module: EvolutionAgent
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
+status: rascunho
+---
+
 # EvolutionAgent — Especificação
 
 > Status: **spec-ready** (sem código ainda)
@@ -141,7 +149,7 @@ Indexação: `php artisan evolution:index` percorre `memory/`, gera embeddings V
 - [ ] Output: relatório markdown + score 0-100
 - [ ] Salva baseline em `memory/evolution/baseline.json` (commitado)
 - [ ] Falha CI se score cair >5% vs baseline anterior
-- [ ] GH Actions roda em PR que toca `app/Services/Evolution/**` ou `Modules/EvolutionAgent/**`
+- [ ] GH Actions roda em PR que toca `app/Services/Evolution/**` ou os arquivos do módulo EvolutionAgent (planejado — não existe)
 
 ### US-EVOL-005 · Subagent CC `evolucao.md`
 

--- a/memory/requisitos/Financeiro/MAIARA-GUIA-COLETA-CLIENTE.md
+++ b/memory/requisitos/Financeiro/MAIARA-GUIA-COLETA-CLIENTE.md
@@ -162,7 +162,7 @@ Marca call ou email longo com o responsável do cliente. **Não decidir nada soz
 **Bloco E — Dependências:**
 11. "Você usa o sistema pra que vertical? Gráfica / Comércio / Oficina / Outro?"
 12. "Suas NFs de entrada são importantes manter no novo sistema, ou só como referência?"
-13. "Tem mensalidade recorrente (Modules/FinanceiroAvancado) ou só contas pontuais?"
+13. "Tem mensalidade recorrente (módulo FinanceiroAvancado planejado — não existe) ou só contas pontuais?"
 
 **Bloco F — Segurança:**
 14. "Suas senhas de certificado A1, NFe, NFC-e — você prefere recadastrar no novo sistema ou trazer do Delphi?" (Recomendação: recadastrar — mais seguro)

--- a/memory/requisitos/Financeiro/MIGRATION-CHECKLIST-LEGACY.md
+++ b/memory/requisitos/Financeiro/MIGRATION-CHECKLIST-LEGACY.md
@@ -63,7 +63,7 @@ A `FINANCEIRO` Delphi mistura 4 conceitos no mesmo registro. No oimpresso vira *
 | Campo | Vai pra | Dúvida |
 |---|---|---|
 | `CODIGO` | `accounts_legacy_map` | — |
-| `CODMENSALIDADE` | `fin_titulos.metadata.contrato_id` | Modules/FinanceiroAvancado tem contrato recorrente? Confirmar Wagner |
+| `CODMENSALIDADE` | `fin_titulos.metadata.contrato_id` | módulo FinanceiroAvancado (planejado — não existe) tem contrato recorrente? Confirmar Wagner |
 | `VALOR` / `DT_VENCTO` / `DT_EMISSAO` | direto | — |
 | `TIPOPAGTO` (string `'BOLETO'`/`'PIX'`) | `fin_titulo_baixas.meio_pagamento` | Valores que cliente usa? |
 | `PESSOA_RESPONSAVEL_CODIGO` | `fin_titulos.cliente_id` via JOIN | — |
@@ -71,7 +71,7 @@ A `FINANCEIRO` Delphi mistura 4 conceitos no mesmo registro. No oimpresso vira *
 
 ---
 
-## `CONTRATO` → `Modules/FinanceiroAvancado.subscription_contracts`
+## `CONTRATO` → `FinanceiroAvancado.subscription_contracts` (módulo planejado — não existe)
 
 | Campo | Vai pra | Dúvida |
 |---|---|---|
@@ -136,7 +136,7 @@ Mapeamento campo-a-campo já validado em [migracao-officeimpresso-pattern.md](..
 ### Bloco E — Dependências (Wagner+Felipe decidem)
 - [ ] Vertical do cliente: oficina (precisa Fase 2 vehicles), gráfica (skip vehicles), comércio puro?
 - [ ] NFs entrada (`CODNF_ENTRADA`) migram pro `Modules/Compras` ou só referência string?
-- [ ] Cliente usa `Modules/FinanceiroAvancado` (recurring/contratos) ou `Modules/Financeiro` básico?
+- [ ] Cliente usa `FinanceiroAvancado` (planejado — não existe; recurring/contratos) ou `Modules/Financeiro` básico?
 
 ### Bloco F — LGPD / segurança
 - [x] **Autorização LGPD: LIBERADA por Wagner 2026-05-21** — dados PII (CPF/CNPJ/email/HISTORICO) podem migrar do Firebird on-prem pro MySQL Hostinger

--- a/memory/requisitos/FinanceiroAvancado/MATRIZ-ROI.md
+++ b/memory/requisitos/FinanceiroAvancado/MATRIZ-ROI.md
@@ -1,11 +1,11 @@
 ---
-title: MATRIZ-ROI Modules/FinanceiroAvancado
+title: MATRIZ-ROI FinanceiroAvancado (planejado — não existe)
 date: 2026-05-12
 related_spec: SPEC.md
 related_adr_proposal: financeiro-avancado-dre-fluxo-conciliacao.md
 ---
 
-# MATRIZ-ROI — Modules/FinanceiroAvancado vs concorrentes
+# MATRIZ-ROI — FinanceiroAvancado (planejado — não existe) vs concorrentes
 
 > Score 0-10 por feature. **R** = ROI estimado pra ROTA LIVRE + clientes legacy OfficeImpresso (4 candidatos R$ [redacted Tier 0]M receita combinada — ver `_ANALISE-FINANCEIRA-CROSS-CLIENTE.md`).
 > **C** = Custo construção (dias-IA-pair calibrado ADR 0106).

--- a/memory/requisitos/FinanceiroAvancado/ROADMAP.md
+++ b/memory/requisitos/FinanceiroAvancado/ROADMAP.md
@@ -1,11 +1,11 @@
 ---
-title: ROADMAP Modules/FinanceiroAvancado
+title: ROADMAP FinanceiroAvancado (planejado — não existe)
 date: 2026-05-12
 status: draft
 estimate_calibration: ADR 0106 (10x IA-pair + margem 2x)
 ---
 
-# ROADMAP — Modules/FinanceiroAvancado
+# ROADMAP — FinanceiroAvancado (planejado — não existe)
 
 > 5 fases. Estimates **calibrados ADR 0106** — fator 10x IA-pair + margem 2x. Cliente piloto **ROTA LIVRE biz=4** + **canary clientes legacy OfficeImpresso** (Martinho/Vargas/Extreme/Gold).
 > Sinal qualificado (ADR 0105): só ativar feature se cliente paga + reporta OU métrica detecta drift.
@@ -14,7 +14,7 @@ estimate_calibration: ADR 0106 (10x IA-pair + margem 2x)
 
 ## Fase 0 — Foundation (1 sprint = 1 semana)
 
-**Objetivo:** scaffold `Modules/FinanceiroAvancado` + bridge contracts + Pest fixtures.
+**Objetivo:** scaffold `FinanceiroAvancado (planejado — não existe)` + bridge contracts + Pest fixtures.
 
 **Stories:**
 - Scaffold módulo nWidart com 8 peças obrigatórias (skill `criar-modulo`)
@@ -85,7 +85,7 @@ estimate_calibration: ADR 0106 (10x IA-pair + margem 2x)
 
 **Cliente piloto:** ROTA LIVRE biz=4 (Larissa fecha mês com contador).
 
-**Gate:** contador externo Larissa aprova DRE 1 mês completo via token shareable. PDF tem cabeçalho fiscal correto (CNPJ 73.306.573/0001-11). Fluxo projetado 30d bate ±5% com realizado depois.
+**Gate:** contador externo Larissa aprova DRE 1 mês completo via token shareable. PDF tem cabeçalho fiscal correto (CNPJ 11.222.333/0001-81). <!-- pii-allowlist: CNPJ fake canônico de exemplo — substitui CNPJ real-looking de cliente no doc de planejamento --> Fluxo projetado 30d bate ±5% com realizado depois.
 
 **Estimate:** 8 dias-IA-pair (~16 dias calendário margem 2x).
 
@@ -107,7 +107,7 @@ estimate_calibration: ADR 0106 (10x IA-pair + margem 2x)
 - `Modules/Jana/Ai/Agents/CategorizationAgent` calibrado (Fase 1)
 - `InventoryCostResolver` service contract (Fase 0)
 - `RepairLaborResolver` quando OS linkada (Fase 0)
-- `Modules/Comissao` ainda não existe — usar fallback **valor fixo per-venda** (config tenant) até Comissao módulo nascer
+- `Comissao` (planejado — não existe) — usar fallback **valor fixo per-venda** (config tenant) até o módulo Comissao nascer
 
 **Cliente piloto:** ROTA LIVRE biz=4 (50k transactions histórico 24m) + canary Extreme legacy (PCP grafica industrial — margem analítica produto-a-produto fit ideal).
 

--- a/memory/requisitos/FinanceiroAvancado/SPEC.md
+++ b/memory/requisitos/FinanceiroAvancado/SPEC.md
@@ -1,16 +1,18 @@
 ---
-title: SPEC — Modules/FinanceiroAvancado
-status: draft
+title: SPEC — FinanceiroAvancado (planejado — não existe)
+status: rascunho
 date: 2026-05-12
+last_updated: "2026-06-13"
+version: "1.0"
 owner: wagner
 module: FinanceiroAvancado
 parent_modules: [Financeiro, Accounting, RecurringBilling, NfeBrasil, Inventory]
 convention_id: US-FINA-NNN
-related_adrs: [0093, 0094, 0104, 0143]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0104-processo-mwart-canonico-unico-caminho, 0143-fsm-pipeline-live-prod-marco-2026-05-12]
 proposal_adr: financeiro-avancado-dre-fluxo-conciliacao
 ---
 
-# SPEC — Modules/FinanceiroAvancado
+# SPEC — FinanceiroAvancado (planejado — não existe)
 
 > **NÃO** é módulo novo "do zero". É **camada de aprofundamento analítico** sobre `Modules/Financeiro` (operacional) + `Modules/Accounting` (contábil formal) + `Modules/RecurringBilling` (cobrança Asaas/Inter) + `Modules/NfeBrasil` (fiscal). Foco: **DRE realista por competência/caixa**, **fluxo de caixa projetado com IA**, **conciliação bancária automática** (extrato Inter/Asaas/OFX → títulos abertos), **plano de contas configurável BR**, **margem real por venda** e **categorização IA Jana**.
 
@@ -50,7 +52,7 @@ Auditoria executada em `Modules/Financeiro/` (12 controllers, 10 Models, 12 migr
 
 ## §1 — Visão
 
-`Modules/FinanceiroAvancado` adiciona ao stack financeiro existente:
+`FinanceiroAvancado (planejado — não existe)` adiciona ao stack financeiro existente:
 
 1. **Conciliação automática multi-banco** (Inter/Asaas/C6/Sicoob/BTG/Cora/OFX) com match score IA Jana (>95% auto-aceita, 80-95% sugere, <80% rejeita)
 2. **DRE BR estrutura formal completa** (10 linhas) por **regime tenant** (caixa/competência) com **drill-down** + **export PDF/Excel** + **token shareable 7d pro contador**
@@ -73,7 +75,7 @@ Larissa abre `/financeiro-avancado/dre?mes=2026-05&regime=caixa`:
 - (-) CMV: R$ [redacted Tier 0] (somatório `transaction_sell_lines.product.purchase_price` × qty — bridge `Inventory`)
 - (=) Lucro Bruto: R$ [redacted Tier 0] (62%)
 - (-) Despesas operacionais: R$ [redacted Tier 0]k (`fin_titulos tipo=pagar status=quitado` + classificado em plano contas `4.x.x Despesas`)
-- (-) Comissões: R$ [redacted Tier 0]k (bridge `Modules/Comissao` — futuro; hoje manual em plano contas)
+- (-) Comissões: R$ [redacted Tier 0]k (bridge com módulo `Comissao` (planejado — não existe) — futuro; hoje manual em plano contas)
 - (=) EBITDA: R$ [redacted Tier 0] (30%)
 - (-) D&A: R$ [redacted Tier 0] (Larissa não usa Accounting formal)
 - (-) IRPJ/CSLL: R$ [redacted Tier 0] (Simples Nacional — incluso na DAS já deduzida)
@@ -140,10 +142,14 @@ Tabelas novas (todas `business_id` indexado + FK + global scope):
 | **Modules/Accounting** | Read `accounting_account_transactions` quando tenant `accounting_sync_enabled=true`. Write zero (Accounting é autoritário formal). | Bridge listener `SyncDreToAccounting` opt-in (ADR ARQ-0005). |
 | **Modules/RecurringBilling** | Read `Services/Banking/InterBankingClient` extrato; `Services/Boleto/Drivers/AsaasDriver` extrato Asaas. Write zero. | Job diário `SyncBankStatementsJob` (existente) atualiza `extrato_lancamentos`. |
 | **Modules/NfeBrasil** | Listener `NfeEmitida` → cria entry contábil `accounting_account_transactions` (se sync ON) + atualiza projeção. | Event `NfeEmitida(transaction_id, xml, valor)`. |
-| **Modules/Inventory** | Read `products.purchase_price` + `purchase_lines.exp_date`/`lot_number` pra `fina_margin_analysis`. Write zero. | Service contract `InventoryCostResolver::resolveForSell($transactionId)`. |
+| **Inventory** (núcleo UltimatePOS, não é módulo) | Read `products.purchase_price` + `purchase_lines.exp_date`/`lot_number` pra `fina_margin_analysis`. Write zero. | Service contract `InventoryCostResolver::resolveForSell($transactionId)`. |
 | **Modules/Repair** | Read `repair_jobs.total_labor_cost` quando venda tem OS linkada. Write zero. | Service contract `RepairLaborResolver::resolveForSell($transactionId)`. |
 | **Modules/Jana (Copiloto)** | Tool `categorizar_transacao_extrato(extrato_id)` retorna `{plano_conta_id, confidence}`. Tool `sugerir_acao_fluxo_caixa(business_id, horizonte)` retorna cenários ranked. | MCP tool exposed CT 100. |
 | **FSM canônico ADR 0143** | Action `marcar_pago` (transição `aprovado→pago`) dispara `CashMovementCreatedEvent` → invalida projeção + atualiza DRE snapshot. | Event hook em `FsmEngine::transition()`. |
+
+## US ativas
+
+> Backlog de user stories deste SPEC (convenção `US-FINA-NNN`). Detalhamento completo na seção §5 abaixo.
 
 ## §5 — User Stories US-FINA-NNN
 
@@ -206,7 +212,7 @@ Tabelas novas (todas `business_id` indexado + FK + global scope):
 
 ## §6 — Decisões pendentes top 3
 
-1. **Extender Modules/Financeiro vs criar Modules/FinanceiroAvancado separado?** Argumento separar: SoC brutal (ADR 0094 §5); Financeiro = operacional, FinanceiroAvancado = analítico/IA. Argumento juntar: 1 módulo só pra Larissa entender. **Proposta:** separar (ADR D1).
+1. **Extender Modules/Financeiro vs criar FinanceiroAvancado (planejado — não existe) separado?** Argumento separar: SoC brutal (ADR 0094 §5); Financeiro = operacional, FinanceiroAvancado = analítico/IA. Argumento juntar: 1 módulo só pra Larissa entender. **Proposta:** separar (ADR D1).
 2. **DRE realtime calc vs snapshot mensal congelado?** Realtime mais atual; snapshot mais auditável + LGPD-friendly (sem recompute histórico). **Proposta:** híbrido — realtime exibição + snapshot ao fechar mês (ADR D2).
 3. **Auto-aceitar match conciliação threshold?** 95% suficiente? 99%? Trade-off precisão × velocidade. ROTA LIVRE 99% volume — não pode quebrar. **Proposta:** 95% + janela reverter 24h (ADR D6).
 

--- a/memory/requisitos/Fiscal/AUDIT-SENIOR-2026-05-25.md
+++ b/memory/requisitos/Fiscal/AUDIT-SENIOR-2026-05-25.md
@@ -441,7 +441,7 @@ Onda 4 (cert/contingência) e Onda 7 (chaos) ficam pra próximas auditorias.
 
 | # | Gap | Áreas isoladas (paths) | Pré-req | Esforço |
 |---|---|---|---|---|
-| 1 | Habilitar biz=4 + permissões | `Modules/UltimatePos/Database/Seeders/PermissionsTableSeeder.php` + admin UI Spatie | Larissa briefing 30min | 1d |
+| 1 | Habilitar biz=4 + permissões | `Database/Seeders/PermissionsTableSeeder.php` (núcleo UltimatePOS, não é módulo) + admin UI Spatie | Larissa briefing 30min | 1d |
 | 2 | Cache KPIs + palette anti-DOS | `Modules/Fiscal/Http/Controllers/CockpitController.php` + `Modules/Fiscal/Http/Controllers/PaletteSearchController.php` + event listeners NFeAutorizada/NFCeAutorizada | nenhum | 1d |
 | 5 | Onda 3 fixtures cStat (6 testes propostos) | `Modules/NfeBrasil/Tests/Feature/Rejeicao*Test.php` + `Modules/NfeBrasil/Tests/Fixtures/SefazResponses/cstat-*.xml` + `Modules/NfeBrasil/Tests/Helpers/RejeicaoFixture.php` | Wagner aprovar 6 fixtures XML | 2-3d |
 

--- a/memory/requisitos/Garantia/MATRIZ-ROI.md
+++ b/memory/requisitos/Garantia/MATRIZ-ROI.md
@@ -8,7 +8,7 @@ updated_at: 2026-05-12
 related: [SPEC.md, ROADMAP.md, garantia-cross-vertical-workflow]
 ---
 
-# MATRIZ-ROI — Modules/Garantia (cross-vertical workflow)
+# MATRIZ-ROI — Garantia (planejado — não existe) (cross-vertical workflow)
 
 > **Score:** Impacto (1-5) × Esforço inverso (1-5, sendo 5=fácil) = ROI (1-25).
 > Categorização ADR 0106 (estimates IA-pair 10x recalibrados).

--- a/memory/requisitos/Garantia/ROADMAP.md
+++ b/memory/requisitos/Garantia/ROADMAP.md
@@ -8,7 +8,7 @@ updated_at: 2026-05-12
 related: [SPEC.md, MATRIZ-ROI.md, garantia-cross-vertical-workflow]
 ---
 
-# ROADMAP — Modules/Garantia (cross-vertical workflow)
+# ROADMAP — Garantia (planejado — não existe) (cross-vertical workflow)
 
 > **Estimates ADR 0106** (10x IA-pair + 2x margem absoluta).
 > Wallclock humano-limitado (canary, smoke, cliente test) preserva relógio real.

--- a/memory/requisitos/Garantia/SPEC.md
+++ b/memory/requisitos/Garantia/SPEC.md
@@ -2,26 +2,28 @@
 slug: garantia-spec
 module: Garantia
 type: spec
-status: discovery
+status: rascunho
 lifecycle: draft
 owner: [W]
+version: "1.0"
+last_updated: "2026-06-13"
 created_at: 2026-05-12
 updated_at: 2026-05-12
 authority: proposal
-related_adrs: [0143, 0129, 0093, 0094, 0104, 0105, 0106, 0121]
+related_adrs: [0143-fsm-pipeline-live-prod-marco-2026-05-12, 0129-state-machine-canonica-fsm-rbac, 0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0104-processo-mwart-canonico-unico-caminho, 0105-cliente-como-sinal-guiar-sem-mandar, 0106-recalibracao-velocidade-fator-10x-ia-pair, 0121-oimpresso-modular-especializado-por-vertical]
 related_modules: [OficinaAuto, Autopecas, Repair, ComunicacaoVisual, Vestuario, NfeBrasil, RecurringBilling, Financeiro]
 us_prefix: US-WARR
 pii: false
 ---
 
-# SPEC — Modules/Garantia (workflow cross-vertical)
+# SPEC — Garantia (planejado — não existe) (workflow cross-vertical)
 
 > **Status discovery 2026-05-12.** Esta SPEC é PROPOSTA. Wagner aprova → spawn implementador depois.
 > NÃO implementar código produção a partir deste doc — apenas leitura + revisão.
 
 ## §1 Visão
 
-**Modules/Garantia** é o módulo cross-vertical canônico do oimpresso que padroniza o workflow de garantia / warranty claim / RMA pra qualquer vertical (`OficinaAuto`, `Autopecas`, `Repair`, `ComunicacaoVisual`, futuras), integrando com:
+**Garantia (planejado — não existe)** é o módulo cross-vertical canônico do oimpresso que padroniza o workflow de garantia / warranty claim / RMA pra qualquer vertical (`OficinaAuto`, `Autopecas`, `Repair`, `ComunicacaoVisual`, futuras), integrando com:
 
 - **FSM canon LIVE** ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)) — pipeline `garantia_*` em cima do `ExecuteStageActionService`
 - **Multi-tenant Tier 0 IRREVOGÁVEL** ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)) — `business_id` global scope em todas as 4 tabelas centrais + roles Spatie per-business
@@ -37,7 +39,7 @@ OficinaAuto+Autopecas+Repair já têm SPECs com tabelas `oficina_auto_garantias`
 - 3 implementações de "OS-filha sem cobrar cliente" — duplicação
 - ComVis, Vestuario, futuras verticais teriam que reinventar
 
-**Decisão recomendada (D1 ADR draft):** **schema único cross-vertical** `warranty_*` no `Modules/Garantia`, com `morphTo` pro item original (peça/serviço/banner/peça-eletrônica) e `parent_*_id` em cada vertical apontando OS-filha pra OS-pai.
+**Decisão recomendada (D1 ADR draft):** **schema único cross-vertical** `warranty_*` no `Garantia (planejado — não existe)`, com `morphTo` pro item original (peça/serviço/banner/peça-eletrônica) e `parent_*_id` em cada vertical apontando OS-filha pra OS-pai.
 
 ### Antecedentes nos SPECs existentes
 
@@ -47,7 +49,7 @@ OficinaAuto+Autopecas+Repair já têm SPECs com tabelas `oficina_auto_garantias`
 | `Autopecas/SPEC.md` US-AP-006 | `autopecas_garantias` com `tipo enum [loja/fabricante]`, fluxo RMA pendente→enviado→aprovado/rejeitado, `custo_loja_substituicao_pago` | Workflow RMA mais maduro que OficinaAuto → **virar referência** `warranty_reimbursements` |
 | `Repair/SPEC-FSM-WIREUP.md` §2.1 | Stage `garantia_acionada` terminal + action `acionar_garantia` (gerente) cria OS-filha via `parent_job_sheet_id` | Pipeline pioneiro → **manter mecânica** OS-filha (parent FK) |
 | `ComunicacaoVisual/SPEC.md` | NÃO menciona garantia (descoberto no discovery) | **GAP** — adicionar quando workflow estiver canônico (banner descolando = reimpressão) |
-| `Vestuario` | Não usa garantia (vestuário tem troca/devolução, não warranty) | Modules/Garantia é **opt-in per business** — Vestuario simplesmente não ativa |
+| `Vestuario` | Não usa garantia (vestuário tem troca/devolução, não warranty) | Garantia (planejado — não existe) é **opt-in per business** — Vestuario simplesmente não ativa |
 
 ## §2 Cenários de uso (Given/When/Then detalhados)
 
@@ -382,7 +384,7 @@ Refs base legal: [Portal Tributário — substituição em garantia](https://www
 |---|---|---|
 | **OficinaAuto** | Substitui `oa_garantias` por `warranty_claims_eligibility` (gerada no `concluir_producao` Sells FSM). Stage `garantia_acionada` legacy do OficinaAuto FSM **deprecado** — agora claim vive em FSM `warranty_standard` separado. OS-filha continua sendo `service_orders` com `os_pai_id` apontando OS-pai. | `claim.os_filha_id = nova_service_orders.id` |
 | **Autopecas** | Snapshot eligibility no `boleto_pago` venda balcão. Workflow troca-balcão (cenário B) NÃO cria OS-filha — apenas movimentação estoque. | `claim.os_filha_id NULL`, registra em `warranty_resolutions.tipo_resolucao=troca_balcao` |
-| **Repair** | Snapshot no `entregue_completo`. Action legacy `acionar_garantia` (SPEC-FSM-WIREUP §2.2) **redireciona pra Modules/Garantia** — não cria OS-filha direto, cria claim primeiro. | `claim.repair_job_sheet_filha_id = nova_repair_job_sheets.id` |
+| **Repair** | Snapshot no `entregue_completo`. Action legacy `acionar_garantia` (SPEC-FSM-WIREUP §2.2) **redireciona pra Garantia (planejado — não existe)** — não cria OS-filha direto, cria claim primeiro. | `claim.repair_job_sheet_filha_id = nova_repair_job_sheets.id` |
 | **ComVis** | Snapshot no fechamento OS impressão. Reinstalação = OS-filha em Modules/ComunicacaoVisual (a definir) ou Modules/Repair adaptado. | `claim.os_filha_id` apontando JobSheet ComVis |
 | **Vestuario** | NÃO ativa (troca/devolução tem fluxo próprio Modules/Vestuario futuro — não warranty) | N/A |
 | **NfeBrasil** | Emite NFe substituição CFOP 5.949 + entrada CFOP 1.949 quando aplicável. Hook em `MarcarTransactionHadClaim` listener. | — |
@@ -390,6 +392,10 @@ Refs base legal: [Portal Tributário — substituição em garantia](https://www
 | **RecurringBilling/Asaas** | NÃO afeta cobrança original (garantia ≠ estorno). | — |
 | **Whatsapp** | Notificações cliente (claim aberto, aprovado, rejeitado, concluído) + opt-in LGPD (ADR 0143 §LGPD). | — |
 | **Jana** | V4: visão computacional foto-laudo (`AnalisarFotoIa` job) detecta mau uso. V3: tool `buscar_garantias_ativas` MCP pra atendente perguntar via chat. | — |
+
+## US ativas
+
+> Backlog de user stories deste SPEC (convenção `US-WARR-NNN`). Detalhamento completo, fases e estimates na seção §8 abaixo.
 
 ## §8 Lista de US (US-WARR-001..020)
 

--- a/memory/requisitos/Infra/AUTO-MEM-PENDING.md
+++ b/memory/requisitos/Infra/AUTO-MEM-PENDING.md
@@ -53,7 +53,7 @@
 | `reference_rag_estado_arte_2026.md` | 🟡 | `memory/requisitos/Copiloto/RAG-ESTADO-ARTE.md` (pesquisa profunda, citar papers) |
 | ~~`reference_pesquisa_wagner_2026_04_29.md`~~ | ✅ DONE 2026-05-09 | DELETED — virou ADRs 0048/0049/0050/0036 |
 
-**Trigger:** Edit/Read em `Modules/Copiloto/` ou termo "recall"/"hybrid"/"meilisearch hybrid embedder"/"HyDE".
+**Trigger:** Edit/Read em `Modules/Jana/` ou termo "recall"/"hybrid"/"meilisearch hybrid embedder"/"HyDE".
 
 ### A4. Cms
 
@@ -88,7 +88,7 @@
 |---|---|---|
 | `reference_ponto_evolucao_estado_arte.md` | 🟡 | `memory/requisitos/PontoWr2/CAPTERRA-FICHA.md` (apenda 8 capacidades + 10 moves) ou inline em `SPEC.md` |
 
-**Trigger:** Edit/Read em `Modules/PontoWr2/` ou termo "Marcacao"/"Apuracao"/"CLT"/"banco horas".
+**Trigger:** Edit/Read em `Modules/Ponto/` ou termo "Marcacao"/"Apuracao"/"CLT"/"banco horas".
 
 ---
 

--- a/memory/requisitos/Infra/RUNBOOK-audit-datacontroller.md
+++ b/memory/requisitos/Infra/RUNBOOK-audit-datacontroller.md
@@ -40,7 +40,7 @@ Qualquer `-` em `DC` ou `menu` = módulo invisível mesmo se instalado.
 ## Como aplicar
 
 - **Antes de declarar módulo como "instalado/funcionando"**: SEMPRE checar `Modules/<Nome>/Http/Controllers/DataController.php` existe E tem `user_permissions()` E `modifyAdminMenu()`.
-- **Pra criar DataController novo**: usar `Modules/PontoWr2/` ou `Modules/Crm/` como template (foram refatorados em 2026-04-25 e estão limpos).
+- **Pra criar DataController novo**: usar `Modules/Ponto/` ou `Modules/Crm/` como template (foram refatorados em 2026-04-25 e estão limpos).
 - **Permissions Spatie**: `user_permissions()` no DataController só **DECLARA** pro UltimatePOS UI; ainda precisa SEEDER (`Permission::firstOrCreate(['name' => 'x.y.z', 'guard_name' => 'web'])`) pra Spatie reconhecer no `can:'x.y.z'` do Blade/middleware.
 - **Wire seeder no Install**: sobrescrever `postInstallCommand()` no `InstallController` retornando `'<modulo>:seed-permissions'` (Artisan command custom). Pattern do `Modules/Financeiro/`.
 - **Audit periódico**: rodar a receita acima toda vez que adicionar módulo novo, OU integrar em CI como sanity check.

--- a/memory/requisitos/Infra/RUNBOOK-pest-suite.md
+++ b/memory/requisitos/Infra/RUNBOOK-pest-suite.md
@@ -48,10 +48,9 @@ Ou simplesmente: rodar `php artisan test` localmente — se o teste novo não ap
 ## Módulos já na suite (snapshot 2026-05-06)
 
 - ✅ `tests/Unit`, `tests/Feature` (raiz Laravel)
-- ✅ `Modules/PontoWr2/Tests/{Unit,Feature}`
+- ✅ `Modules/Ponto/Tests/{Unit,Feature}`
 - ✅ `Modules/Essentials/Tests/Feature`
 - ✅ `Modules/Cms/Tests/Feature`
-- ✅ `Modules/Copiloto/Tests/Feature`
 - ✅ `Modules/Jana/Tests/Feature` (adicionado 2026-05-06 com fix do MCP)
 - ✅ `Modules/RecurringBilling/Tests/Feature` (adicionado 2026-05-06 com US-RB-040)
 

--- a/memory/requisitos/Inventory/MATRIZ-ROI.md
+++ b/memory/requisitos/Inventory/MATRIZ-ROI.md
@@ -78,7 +78,7 @@ adr_ref: ../../decisions/proposals/drafts/inventory-avancado-kits-batch-dimensio
 | **NetSuite** | ✅ Multi-level assembly | ✅ Lot+serial+bin numbered | ✅ Avançado | ✅ Subledger | ✅ Configurável | ⚠️ Add-on | USD 1k+/mês |
 | **Cin7 Core** | ✅ BOM + auto-kitting | ✅ Batch+serial+recall | ✅ Multi-unit | ✅ Real-time | ✅ Configurável | ✅✅ 700+ integrations | USD 350+/mês |
 | **Odoo Inventory** | ✅ BOM + approval | ✅ Lots+serial+traceability reports | ✅ Multi-unit | ✅ Forte | ✅ FEFO config | ✅ Add-on | EUR 0–24/usr |
-| **oimpresso (proposto V1)** | ✅✅ Multi-level + opcional + substituição | ✅ Lote+serial+defeito+RMA + cor-Pantone | ✅ + custo per unit + alerta % | ✅✅ Append-only triggers SQL | ✅ Per business + per produto override | ✅ Hook ready (Modules/Marketplaces) | R$ ?–? (pricing per ADR 0105) |
+| **oimpresso (proposto V1)** | ✅✅ Multi-level + opcional + substituição | ✅ Lote+serial+defeito+RMA + cor-Pantone | ✅ + custo per unit + alerta % | ✅✅ Append-only triggers SQL | ✅ Per business + per produto override | ✅ Hook ready (módulo Marketplaces planejado — não existe) | R$ ?–? (pricing per ADR 0105) |
 
 **Insight chave:** oimpresso Inventory V1 atinge **paridade SAP B1 / Cin7 Core em capacidades core**, supera Tiny/Bling em multi-level + audit + FEFO, e adiciona **2 features diferenciadas**: (a) cor-Pantone-per-lote ComVis, (b) lookup garantia fornecedor automático AutoPeças. Preço-alvo: 1/5 SAP B1 + paridade Bling Plus.
 

--- a/memory/requisitos/Inventory/SPEC.md
+++ b/memory/requisitos/Inventory/SPEC.md
@@ -1,10 +1,13 @@
 ---
+module: Inventory
 modulo: Inventory
-status: proposed
+status: rascunho
 owner: [W]
+version: "1.0"
+last_updated: "2026-06-13"
 prioridade: P0-P2 (faseado)
 related_modules: [Sells, Repair, OficinaAuto, ComunicacaoVisual, Vestuario, Autopecas, NfeBrasil, Marketplaces]
-related_adrs: [0093, 0094, 0105, 0106, 0121, 0129, 0143]
+related_adrs: [0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0105-cliente-como-sinal-guiar-sem-mandar, 0106-recalibracao-velocidade-fator-10x-ia-pair, 0121-oimpresso-modular-especializado-por-vertical, 0129-state-machine-canonica-fsm-rbac, 0143-fsm-pipeline-live-prod-marco-2026-05-12]
 cnae_relacionados: [todos verticais]
 created_at: 2026-05-12
 ---
@@ -399,7 +402,7 @@ Cruza com agente Marketplaces (sync ML/Shopee/Magalu).
 
 **Fluxo proposto:**
 1. `stock_movements` insertion → event `StockMovedEvent` (já pattern UPos)
-2. Listener `SyncToMarketplacesListener` (futuro Modules/Marketplaces) consome event
+2. Listener `SyncToMarketplacesListener` (futuro módulo Marketplaces — planejado, não existe) consome event
 3. Calcula novo qty_available_consolidated = sum(variation_location_details.qty_available) − sum(stock_reservations.active.qty)
 4. POST API ML/Shopee atualiza listing
 5. Webhook ML PEDIDO criado → cria sell + reserva imediata (idempotente per ext_order_id)
@@ -407,6 +410,10 @@ Cruza com agente Marketplaces (sync ML/Shopee/Magalu).
 **Negative inventory (D6):** se `business.allow_negative_inventory=true`, oversell ML permitido. Stock_movements pode resultar `qty_available < 0` (legítimo — backorder). UI sinaliza vermelho mas NÃO bloqueia.
 
 ---
+
+## US ativas
+
+> Backlog de user stories deste SPEC (convenção `US-INV-NNN`). Detalhamento completo, fases e estimates na seção §7 abaixo.
 
 ## §7 User Stories
 

--- a/memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md
+++ b/memory/requisitos/Jana/ONDA-5-DOSSIER-2026-05-13.md
@@ -53,7 +53,7 @@ Os 5 gaps Onda 5 têm áreas isoladas confirmadas (zero overlap entre paths) →
 ```
 spawn paralelo (1 worktree, 5 agents):
   ├─ agent-K1: Modules/Jana/Services/Memoria/* (driver + score function)
-  ├─ agent-V1: Modules/Copiloto/Http/Controllers/Admin/Roadmap* + resources/js/Pages/Admin/Roadmap/*
+  ├─ agent-V1: Modules/Jana/Http/Controllers/Admin/Roadmap* + resources/js/Pages/Admin/Roadmap/*
   ├─ agent-H1: Modules/Jana/Mcp/Tools/HandoffDraftTool.php + Services/Handoff/HandoffDrafterService.php
   ├─ agent-S1: scripts/validate-frontmatter.* + .github/workflows/memory-schema-lint.yml + memory/decisions/_SCHEMA.md
   └─ agent-A1: Modules/Jana/Mcp/Support/DocSummarizer.php (decorator) + Modules/Jana/Ai/Services/ChunkedSummarizerService.php
@@ -179,13 +179,13 @@ NÃO necessário (refactor interno service, não nova tela). Mas atualizar [RETR
 
 ### Áreas isoladas (paths exatos pra agent V1)
 
-- **Create:** `Modules/Copiloto/Http/Controllers/Admin/RoadmapController.php` — `@index()` lê `mcp_tasks` + `mcp_cycles` + `mcp_task_links` (blocked_by[])
-- **Create:** `Modules/Copiloto/Http/Resources/RoadmapTaskResource.php` — shape compatível com SVAR Gantt task object
+- **Create:** `Modules/Jana/Http/Controllers/Admin/RoadmapController.php` — `@index()` lê `mcp_tasks` + `mcp_cycles` + `mcp_task_links` (blocked_by[])
+- **Create:** `Modules/Jana/Http/Resources/RoadmapTaskResource.php` — shape compatível com SVAR Gantt task object
 - **Create:** `resources/js/Pages/Admin/Roadmap/Index.tsx` — page Inertia consumindo Resource
 - **Create:** `resources/js/Pages/Admin/Roadmap/_components/RoadmapGantt.tsx` — wrapper SVAR
 - **Create:** `resources/js/Pages/Admin/Roadmap/_components/SubIssuesPanel.tsx` — hierarchy view (parent_task_id)
 - **Create:** `resources/js/Pages/Admin/Roadmap/Index.charter.md` — charter MWART canon
-- **Edit:** `Modules/Copiloto/Resources/views/sidebar.blade.php` ou DataController hook — adicionar entry sidebar "Roadmap" ([sidebar-menu-arch](../../../.claude/skills/sidebar-menu-arch/SKILL.md))
+- **Edit:** `Modules/Jana/Resources/views/sidebar.blade.php` ou DataController hook — adicionar entry sidebar "Roadmap" ([sidebar-menu-arch](../../../.claude/skills/sidebar-menu-arch/SKILL.md))
 - **Edit:** `routes/admin.php` (Copiloto) — `Route::get('/copiloto/admin/roadmap', RoadmapController::class)->middleware(['web','auth',...])`
 - **Migration:** `mcp_tasks` JÁ tem `parent_task_id` ou similar? Auditar — se não, ADD COLUMN nullable
 - **Composer/npm:** `npm i @svar-widgets/react-gantt`

--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -439,11 +439,11 @@ Hook PreToolUse em `.claude/settings.json` que bloqueia (exit 2) comandos Bash d
 > owner: wagner · sprint: 2026-W19 · priority: p1 · estimate: 3h · status: done · done_at: 2026-05-04 · tests_passing: 10/10
 > blocked_by: —
 
-Hook PreToolUse em Bash (`git commit`) que escaneia `git diff --staged` por regex PII (CPF, CNPJ, email, cartão) e bloqueia se achar. Avisa ao Claude com mensagem "[PII detectada em path:line] — substitua por [REDACTED] ou fixture fake (ex.: 123.456.789-09)".
+Hook PreToolUse em Bash (`git commit`) que escaneia `git diff --staged` por regex PII (CPF, CNPJ, email, cartão) e bloqueia se achar. Avisa ao Claude com mensagem "[PII detectada em path:line] — substitua por [REDACTED] ou fixture fake (ex.: 123.456.789-09)". <!-- pii-allowlist: CPF fake canônico (fixture de exemplo na doc do hook) -->
 
 **Por quê:** HOW_TO_ASK_CLAUDE §3.4. LGPD Art. 7º (princípio de minimização). Já houve incidente: log de prod com CPF real colado em prompt — risco de vazar em commit/transcript.
 
-**Acceptance:** `.claude/hooks/pii-redactor.ps1` testado · regex BR validados (CPF formato 000.000.000-00 e 00000000000; CNPJ idem; email RFC 5322 simplificado; cartão Luhn) · whitelist pra fixtures conhecidos (123.456.789-09, etc.) · documentação com lista de PIIs cobertos · zero falso-positivo em 50 commits validados.
+**Acceptance:** `.claude/hooks/pii-redactor.ps1` testado · regex BR validados (CPF formato 000.000.000-00 e 00000000000; CNPJ idem; email RFC 5322 simplificado; cartão Luhn) · whitelist pra fixtures conhecidos (123.456.789-09, etc.) · documentação com lista de PIIs cobertos · zero falso-positivo em 50 commits validados. <!-- pii-allowlist: placeholder 000.000.000-00 e CPF fake canônico 123.456.789-09 (fixtures de exemplo na doc do hook PII) -->
 
 ### US-COPI-087 · Sprint 9c — Cross-encoder reranker (qwen3-reranker ou bge-reranker-v2-m3)
 
@@ -1035,7 +1035,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 **Quero** rota `/copiloto/admin/roadmap` com Gantt visual cronológico (SVAR React Gantt MIT) + sub-issues hierarchy view (parent_task_id) + drag-drop datas + filtro current cycle default
 **Para** fechar gap Viz (5%→70%) — listas markdown via tools MCP não mostram cronologia/dependências; Linear/Plane/GitHub Projects vão 5 anos à frente em viz
 
-**Implementado em:** novo `Modules/Copiloto/Http/Controllers/Admin/RoadmapController.php` + `Modules/Copiloto/Http/Resources/RoadmapTaskResource.php` + `resources/js/Pages/Admin/Roadmap/Index.tsx` + `_components/RoadmapGantt.tsx` + `_components/SubIssuesPanel.tsx` + `Index.charter.md`
+**Implementado em:** novo `Modules/Jana/Http/Controllers/Admin/RoadmapController.php` + `Modules/Jana/Http/Resources/RoadmapTaskResource.php` + `resources/js/Pages/Admin/Roadmap/Index.tsx` + `_components/RoadmapGantt.tsx` + `_components/SubIssuesPanel.tsx` + `Index.charter.md`
 
 **Definition of Done:**
 - [ ] npm dep `@svar-widgets/react-gantt` (MIT, ~80KB, React 19 nativo — rejeitado DHTMLX/Bryntum/Frappe por licença ou bundle)

--- a/memory/requisitos/KB/BRIEFING.md
+++ b/memory/requisitos/KB/BRIEFING.md
@@ -50,7 +50,7 @@ Trilha vs Decisão = views diferentes sobre o mesmo grafo. **Decisão pode gerar
 - `business_id` global scope em TODAS as tabelas `kb_*` ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
 - `kb_nodes` bridge canônico (`is_editable=false`) NUNCA tem versionamento local — vem só do git ([ADR 0061](../../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md))
 - ADRs canon append-only via bridge — `kb_nodes.body_blocks IS NULL` pra type ADR; conteúdo vem do JOIN com `mcp_memory_documents.content_md`
-- IA RAG roteia via `Modules/Copiloto/Ai/` ([ADR 0035](../../decisions/0035-stack-ai-canonica-wagner-2026-04-26.md)) — laravel/ai SDK + MeilisearchDriver hybrid embedder. NÃO criar provider novo.
+- IA RAG roteia via `Modules/Jana/Ai/` ([ADR 0035](../../decisions/0035-stack-ai-canonica-wagner-2026-04-26.md)) — laravel/ai SDK + MeilisearchDriver hybrid embedder. NÃO criar provider novo.
 - Pest tests biz=1 + cross-tenant biz=99 obrigatórios ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md))
 - F3 do `Pages/kb/Index.tsx` segue MWART canônico 5 fases ([ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md))
 - Gate visual screenshot Wagner antes de F4 merge ([ADR 0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md))
@@ -75,7 +75,7 @@ ONDA 3 (2-3d, 1 agent)
    ↘ outputs: Composer.tsx + Editor visual KBTroubleEditor
 
 ONDA 4 (2-3d, 1 agent)
-   IA RAG sobre grafo completo (KbRagService → Modules/Copiloto/Ai/)
+   IA RAG sobre grafo completo (KbRagService → Modules/Jana/Ai/)
    ↘ outputs: Modules/KB/Services/KbRagService.php + endpoints /kb/ai/*
 
 ONDA 5 (2-3d, 1 agent)

--- a/memory/requisitos/KB/CAPTERRA-FICHA.md
+++ b/memory/requisitos/KB/CAPTERRA-FICHA.md
@@ -98,7 +98,7 @@ Bench fonte: `prototipo-ui/prototipos/kb/Bench KB v2.html` (Cowork [CC] self-ass
 | Browser de ADRs/sessions com tri-pane Cockpit V2 | 9,0 | 1+2 | — |
 | Bridge `mcp_memory_documents` → `kb_nodes` (read-only) | n/a (infra) | 1 | — |
 | Visualização-grafo dos 143 ADRs + edges supersedes/charter-of/related | 9,5 | 5 | depende kb_edges populado (ONDA 1 bridge) |
-| RAG IA "perguntar ao KB" com citações de fonte | 9,0 | 4 | Modules/Copiloto OK (ADR 0035 ✅) |
+| RAG IA "perguntar ao KB" com citações de fonte | 9,0 | 4 | Modules/Jana OK (ADR 0035 ✅) |
 | Command palette ⌘K + keyboard nav | 9,5 | 2 | — |
 
 ### P1 (após primeiro release Wagner ok, antes da Larissa)
@@ -183,7 +183,7 @@ Detalhes completos do dossier em [`memory/sessions/2026-05-15-agent-d-estado-art
 - US-KB-024 Auto-tag IA no composer (kbSuggestMeta endpoint + UX) — P1, ~4h
 
 **ONDA 4 (IA RAG):**
-- US-KB-030 KbRagService consumindo Modules/Copiloto/Ai/ — P0, ~10h
+- US-KB-030 KbRagService consumindo Modules/Jana/Ai/ — P0, ~10h
 - US-KB-031 Endpoints /kb/ai/{ask,summarize,suggest-meta} — P0, ~6h
 - US-KB-032 UX "Perguntar ao KB" + citações clicáveis — P0, ~5h
 - US-KB-033 Cache de embeddings + cache de respostas curtas — P1, ~4h

--- a/memory/requisitos/KB/SPEC.md
+++ b/memory/requisitos/KB/SPEC.md
@@ -1,3 +1,11 @@
+---
+module: KB
+status: ativo
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
+---
+
 # KB — SPEC canônico (Knowledge Base unificada)
 
 > Especificação técnica do **Módulo IA Central** `Modules/KB/`.
@@ -44,7 +52,7 @@ Critérios:
 **para** descobrir conhecimento sem precisar memorizar 143 slugs ADR.
 
 Critérios:
-- `KbRagService` roteia via `Modules/Copiloto/Ai/` (laravel/ai SDK + MeilisearchDriver hybrid embedder)
+- `KbRagService` roteia via `Modules/Jana/Ai/` (laravel/ai SDK + MeilisearchDriver hybrid embedder)
 - Retorna `RagResult` DTO com summary + array de `CitationResult` (node_id + score)
 - Reranker BGE (`KbBgeRerankerService`) ordena resultados por relevância semântica
 - Cache 5min via `cache()->remember()` reduz custo IA

--- a/memory/requisitos/LaravelAI/SPEC.md
+++ b/memory/requisitos/LaravelAI/SPEC.md
@@ -1,3 +1,11 @@
+---
+module: LaravelAI
+status: rascunho
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
+---
+
 # Especificação funcional — LaravelAI
 
 > Convenção do ID: `US-AI-NNN` para user stories, `R-AI-NNN` para regras Gherkin.
@@ -189,7 +197,7 @@ Quando 31ª chega
 Então retorna 429 com header `Retry-After: 60`
 ```
 **Implementação:** Laravel RateLimiter `ai-chat:user:{id}`.
-**Testado em:** `Modules/LaravelAI/Tests/Feature/RateLimitTest` — 30 queries OK + 31ª retorna 429 com header.
+**Testado em:** `Tests/Feature/RateLimitTest` no módulo LaravelAI (planejado — não existe) — 30 queries OK + 31ª retorna 429 com header.
 
 ### R-AI-010 · Provider fallback (OpenAI down)
 ```gherkin

--- a/memory/requisitos/Marketplaces/MATRIZ-ROI.md
+++ b/memory/requisitos/Marketplaces/MATRIZ-ROI.md
@@ -7,7 +7,7 @@ related_proposal: ../../decisions/proposals/drafts/marketplaces-modulo-cross-ver
 last_review: 2026-05-12
 ---
 
-# MATRIZ-ROI Modules/Marketplaces — 25 features × score competitivo
+# MATRIZ-ROI Marketplaces (planejado — não existe) — 25 features × score competitivo
 
 > **Status:** antecipatório (status SPEC `feature-wish`). ROI calculado contra **Tiny ERP / Bling / Conta Azul / Olist / MagaluHub** ([SPEC §9](SPEC.md#9-concorrentes-research-consolidada-discovery)).
 >

--- a/memory/requisitos/Marketplaces/ROADMAP.md
+++ b/memory/requisitos/Marketplaces/ROADMAP.md
@@ -9,7 +9,7 @@ related_matrix: MATRIZ-ROI.md
 last_review: 2026-05-12
 ---
 
-# ROADMAP Modules/Marketplaces — 5 fases CONDICIONAL
+# ROADMAP Marketplaces (planejado — não existe) — 5 fases CONDICIONAL
 
 > ⚠️ **NÃO IMPLEMENTAR.** Roadmap antecipatório — só vira backlog ativo quando gatilho [SPEC §11.1](SPEC.md#111-sinal-qualificado-de-mercado-adr-0105) for satisfeito (sinal qualificado [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)). Sem cliente piloto pagante, **viola ADR 0105**.
 >

--- a/memory/requisitos/Marketplaces/SPEC.md
+++ b/memory/requisitos/Marketplaces/SPEC.md
@@ -1,17 +1,31 @@
 ---
 module: Marketplaces
-status: feature-wish
+status: rascunho
+version: "1.0"
+last_updated: "2026-06-13"
 lifecycle: aguarda-sinal-qualificado
 piloto: ROTA LIVRE (Modules/Vestuario — sinal natural se Larissa ativar venda ML) OU 1º OfficeImpresso saudável com venda ML ativa (Vargas/Mhundo)
 piloto_previsao: depende de (a) Larissa confirmar interesse ML/Shopee OU (b) 1º cliente OfficeImpresso reportar "vendo em ML, quero integrar"
 cnae_aplicavel: cross-vertical (qualquer cliente que vende online — não tem CNAE próprio)
-related_adrs: [0143, 0121, 0094, 0093, 0105, 0106, 0035, 0011, 0089, 0117, 0119, 0129]
+related_adrs:
+  - "0143-fsm-pipeline-live-prod-marco-2026-05-12"
+  - "0121-oimpresso-modular-especializado-por-vertical"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0105-cliente-como-sinal-guiar-sem-mandar"
+  - "0106-recalibracao-velocidade-fator-10x-ia-pair"
+  - "0035-stack-ai-canonica-wagner-2026-04-26"
+  - "0011-alinhamento-padrao-jana"
+  - "0089-capterra-driven-module-evolution"
+  - "0117-multiplos-numeros-whatsapp-por-business"
+  - "0119-migration-factory-capacidade-institucional"
+  - "0129-state-machine-canonica-fsm-rbac"
 related_proposals: [proposals/drafts/marketplaces-modulo-cross-vertical.md]
 last_review: 2026-05-12
 owner: [W]
 ---
 
-# Especificação funcional — Modules/Marketplaces (cross-vertical)
+# Especificação funcional — Marketplaces (planejado — não existe) (cross-vertical)
 
 > Convenção do ID: `US-MKT-NNN` para user stories, `R-MKT-NNN` para regras Gherkin.
 > **Modulo NÃO existe em código.** SPEC **antecipatório** — formaliza contrato de construção SE/QUANDO (a) Larissa (ROTA LIVRE biz=4 ativa) reportar venda marketplace OU (b) 1+ OfficeImpresso saudável (Vargas/Extreme/Gold/Mhundo) confirmar "vendo em ML/Shopee, preciso integrar com NFe" ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) gatilho).
@@ -19,7 +33,7 @@ owner: [W]
 
 ## 1. Visão
 
-`Modules/Marketplaces` é o módulo **cross-vertical canônico** que permite **qualquer vertical** oimpresso (Vestuario / OficinaAuto / Autopecas / ComunicacaoVisual / futuras) vender via **marketplaces brasileiros** (Mercado Livre, Shopee, Amazon BR, Magalu Hub, Americanas, futuros) com:
+`Marketplaces (planejado — não existe)` é o módulo **cross-vertical canônico** que permite **qualquer vertical** oimpresso (Vestuario / OficinaAuto / Autopecas / ComunicacaoVisual / futuras) vender via **marketplaces brasileiros** (Mercado Livre, Shopee, Amazon BR, Magalu Hub, Americanas, futuros) com:
 
 - **OAuth2 per-business** (cada `business_id` tem credenciais próprias — Tier 0 [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
 - **Webhooks orders → FSM canon stage `pedido_ml_recebido`** ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md))
@@ -30,7 +44,7 @@ owner: [W]
 - **Disputas/claims workflow** (Mercado Livre claims, Shopee returns)
 - **Jana IA** responde "quantos pedidos ML hoje?" / "qual SKU mais vendido ML mês?"
 
-**Tese de entrada:** Brasil tem **gap concreto** entre ERPs especializados por vertical (oimpresso modular) e hubs marketplace generalistas (Tiny/Bling/Olist). Cliente oimpresso vertical (vestuário/auto/comvisual) que também vende ML hoje **sai do oimpresso pra Tiny** pra ter integração. Modules/Marketplaces evita perda + entrega Jana IA + multi-tenant Tier 0 que nenhum hub atual tem.
+**Tese de entrada:** Brasil tem **gap concreto** entre ERPs especializados por vertical (oimpresso modular) e hubs marketplace generalistas (Tiny/Bling/Olist). Cliente oimpresso vertical (vestuário/auto/comvisual) que também vende ML hoje **sai do oimpresso pra Tiny** pra ter integração. Marketplaces (planejado — não existe) evita perda + entrega Jana IA + multi-tenant Tier 0 que nenhum hub atual tem.
 
 **Status atual:** **NÃO em construção.** Sem sinal qualificado (Larissa ou 1º OfficeImpresso saudável), **viola ADR 0105**. Tiny/Bling cobrem ~95% do que o mercado pede — só faz sentido construir se cliente oimpresso reportar dor real.
 
@@ -506,7 +520,7 @@ Sob demanda sinal cliente — driver pattern facilita adição.
 
 ## 10. Riscos top
 
-1. **Tiny/Bling cobrem 95% do que mercado pede** — construir Modules/Marketplaces sem sinal qualificado é desperdício. ADR 0105 enforcement crítico aqui
+1. **Tiny/Bling cobrem 95% do que mercado pede** — construir Marketplaces (planejado — não existe) sem sinal qualificado é desperdício. ADR 0105 enforcement crítico aqui
 2. **API ML mudanças frequentes** — Mercado Livre faz 5-10 breaking changes/ano. Manter driver atualizado tem custo recorrente
 3. **Rate limit 1500/min mais agressivo do que parece** — bulk operations precisam queue + debounce; mass sync 5000 produtos em 1 click = bloqueio app
 4. **Mercado Pago split D+0 a D+60 cria descasamento caixa** — financeiro precisa modelar "recebível futuro garantido" sem inflar AR. Reconciliação errada gera relatório errado
@@ -539,7 +553,7 @@ Sob demanda sinal cliente — driver pattern facilita adição.
 
 ### 11.3 Capacidade time
 
-WIP atual (~Q2/26): 5 pessoas com Vestuario live, ComVis em construção, OficinaAuto V0, MWART Financeiro. Modules/Marketplaces ativa **só após** ComVis ter 1ª piloto verde + sinal Larissa/OfficeImpresso (Q4/26 estimado).
+WIP atual (~Q2/26): 5 pessoas com Vestuario live, ComVis em construção, OficinaAuto V0, MWART Financeiro. Marketplaces (planejado — não existe) ativa **só após** ComVis ter 1ª piloto verde + sinal Larissa/OfficeImpresso (Q4/26 estimado).
 
 ### 11.4 ADR de ativação
 

--- a/memory/requisitos/MemCofre/ARCHITECTURE.md
+++ b/memory/requisitos/MemCofre/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 - **Backend**: Laravel 13.6 · PHP 8.4 (Herd em dev, hospedagem Hostinger em produção)
 - **Banco**: MySQL 8 (Herd MySQL local / Hostinger shared em produção)
 - **Front**: Inertia + React 19 + Tailwind 4 + shadcn/ui
-- **Padrão do módulo**: UltimatePOS via `nwidart/laravel-modules` (igual `Modules/PontoWr2`, `Modules/Officeimpresso`)
+- **Padrão do módulo**: UltimatePOS via `nwidart/laravel-modules` (igual `Modules/Ponto`, `Modules/Officeimpresso`)
 - **Ativação**: `MemCofre: true` em `modules_statuses.json`
 - **Scout driver**: `database` com fulltext MySQL (evita Meilisearch dedicado na Fase 4)
 

--- a/memory/requisitos/Mwart/SPEC.md
+++ b/memory/requisitos/Mwart/SPEC.md
@@ -1,11 +1,14 @@
 ---
 module: Mwart
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
 na_justified:
   D5: "Mwart é meta-processo de governança (enforcement do caminho canônico Blade→Inertia — ADR 0104) — NÃO é módulo de features cliente-facing. Não há biz=4 ROTA LIVRE consumindo features Mwart; consumidores são `Modules/*` que migram para Inertia. D5 cliente real não aplica por design."
   D4.b: "Mwart não tem state machine FSM (ADR 0143). É processo administrativo de gating (skill Tier A + hook PreToolUse + CI workflow), não fluxo de negócio com transições Eloquent. D4.b FSM canônica N/A."
 na_justified_v3:
   D6.a: "Mwart é meta-processo (enforcement skill + hook + CI) — sem Controllers Inertia próprios. Inertia::defer N/A por ausência de telas geradas pelo módulo."
-related_adrs: [0104, 0106, 0153, 0154, 0155, 0156]
+related_adrs: [0104-processo-mwart-canonico-unico-caminho, 0106-recalibracao-velocidade-fator-10x-ia-pair, 0153-module-grade-rubrica-v1, 0154-module-grade-v2-na-justificado, 0155-module-grade-v3-sub-dimensoes-gate-ci, 0156-module-grade-v3-errata-otel-helper-na-justified]
 ---
 
 # Especificação funcional — MWART (processo canônico)
@@ -79,7 +82,7 @@ related_adrs: [0104, 0106, 0153, 0154, 0155, 0156]
 - [ ] Telas <50 score viram tasks p2 explicitamente — Wagner decide ordem do refactor backlog
 - [ ] Próximas migrações já entram com RUNBOOK + SPEC desde o dia 1
 
-**Refs:** [CHECKLIST.md §G — Score 0-100](../../../.claude/skills/cockpit-runbook/CHECKLIST.md), dashboard existente em `Modules/Copiloto/Http/Controllers/Admin/QualidadeController.php`
+**Refs:** [CHECKLIST.md §G — Score 0-100](../../../.claude/skills/cockpit-runbook/CHECKLIST.md), dashboard existente em `Modules/Jana/Http/Controllers/Admin/QualidadeController.php`
 
 ### US-MWART-003 · Métricas de adoção do processo
 

--- a/memory/requisitos/NfeBrasil/CHECKLIST-US-NFE-059-smoke-prod.md
+++ b/memory/requisitos/NfeBrasil/CHECKLIST-US-NFE-059-smoke-prod.md
@@ -11,7 +11,7 @@
 | Candidato | Pros | Contras |
 |---|---|---|
 | **Gold** (Comunicação Visual) | Manifestação Destinatário entregue (US-NFE-049/050/051/052 done); gráfica grande, emite 100% | Precisa explicar mudança pré-execução |
-| **Vargas** (Autopecas) | Sinal qualificado real R$ [redacted Tier 0]M GMV | Modules/Autopecas em construção; arquitetura ainda não cobre OS auto |
+| **Vargas** (Autopecas) | Sinal qualificado real R$ [redacted Tier 0]M GMV | módulo Autopecas (planejado — não existe); arquitetura ainda não cobre OS auto |
 | **Cliente novo CV** (Extreme/Zoom/Fixar/Mhundo/Produart) | Onboarding limpo desde início | Depende adoção pós outreach (sem ETA) |
 
 **Recomendado: Gold** (caminho mais curto pra evidência real).

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -1,8 +1,8 @@
 ---
 module: NfeBrasil
-owner: wagner
 version: "1.0"
 last_updated: "2026-06-13"
+owner: wagner
 na_justified:
   D7.a: "Fiscal compliance CONFAZ SINIEF 07/2005 — CPF/CNPJ em logs SEFAZ obrigatórios. PiiRedactor NÃO aplica em dados fiscais (XML original preservado). Detalhe em PII-LGPD-FISCAL.md."
 ---
@@ -60,7 +60,7 @@ na_justified:
 **Quero** clicar "Finalizar venda" no POS e o sistema emitir NFC-e em background, retornar DANFE imprimível em até 5s
 **Para** atender exigência fiscal sem fricção no balcão
 
-**Implementado em:** _pendente_ — integração `/sells/create` finalizar + tela `Pages/NfeBrasil/Emissao/Sucesso.tsx` não construída
+**Implementado em:** _[TODO — integração `/sells/create` finalizar + `resources/js/Pages/NfeBrasil/Emissao/Sucesso.tsx`]_
 
 **Definition of Done:**
 - [ ] Listener escuta `App\Events\TransactionCompleted` (core) → dispatch job `EmitirNfceJob` na queue `nfe`
@@ -82,7 +82,7 @@ na_justified:
 **Quero** abrir nota emitida pela chave/número e baixar DANFE + XML
 **Para** reimprimir, enviar pra cliente, anexar em e-mail
 
-**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Emissoes/Show.tsx` não construída
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx`]_
 
 **Definition of Done:**
 - [ ] Mostra: chave acesso (44 dígitos formatado em 11 grupos), número, série, data emissão, valor, cStat, link DANFE PDF, link XML
@@ -101,7 +101,7 @@ na_justified:
 **Quero** cancelar uma NFC-e em até 24h ou NF-e em até 168h informando justificativa (15-255 chars)
 **Para** corrigir venda errada sem deixar rastro errado pra Receita
 
-**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Emissoes/Show.tsx` (botão Cancelar) não construída
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx` (botão Cancelar)]_
 
 **Definition of Done:**
 - [ ] Valida prazo legal antes de chamar SEFAZ (NFC-e: 24h; NF-e: 168h)
@@ -122,7 +122,7 @@ na_justified:
 **Quero** enviar CCe pra corrigir erro não-monetário (ex: nome do destinatário errado, transportadora) sem cancelar e re-emitir
 **Para** evitar custo de re-emissão e manter histórico
 
-**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Emissoes/Show.tsx` (botão CCe) não construída
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx` (botão CCe)]_
 
 **Definition of Done:**
 - [ ] Valida limite legal: máximo 20 CCe por NFe; correção 15-1000 chars; não permite mudar valor/quantidade/CNPJ
@@ -141,7 +141,7 @@ na_justified:
 **Quero** ativar contingência (EPEC pra NF-e, FS-DA pra NFC-e) e seguir vendendo offline
 **Para** não parar caixa quando SEFAZ está com problema
 
-**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Contingencia/Index.tsx` não construída
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Contingencia/Index.tsx`]_
 
 **Definition of Done:**
 - [ ] Detecção automática: `SefazHealthCheck` ping a cada 30s → se 3 falhas seguidas, sugerir contingência
@@ -162,7 +162,7 @@ na_justified:
 **Quero** dashboard com KPIs (autorizadas hoje, rejeitadas, contingência ativa, cert vencendo) + lista de rejeições com cStat + sugestão de correção
 **Para** atacar rejeições antes de o cliente perceber
 
-**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Monitor/Index.tsx` não construída
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Monitor/Index.tsx`]_
 
 **Definition of Done:**
 - [ ] KPIs: autorizadas (hoje/semana/mês), rejeitadas, em contingência, cert dias restantes
@@ -183,7 +183,7 @@ na_justified:
 **Quero** manifestar NFe recebida (Confirmação / Ciência / Desconhecimento / Operação não realizada)
 **Para** atender obrigação legal e gerar apropriação correta no DRE
 
-**Implementado em:** `resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx` · verificado@fd96258 (2026-06-13)
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx`]_
 
 **Definition of Done:**
 - [ ] Lista NFes destinadas (consulta `WS-NFeDistribuicaoDFe` periódica) com status manifestação
@@ -202,7 +202,7 @@ na_justified:
 **Quero** baixar arquivo SPED Fiscal pronto pra ECF do mês de competência
 **Para** entregar obrigação contábil sem ligar pra Larissa
 
-**Implementado em:** _pendente_ — tela `Pages/NfeBrasil/Sped/Index.tsx` não construída
+**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Sped/Index.tsx`]_
 
 **Definition of Done:**
 - [ ] Geração assíncrona via job (volume grande); progresso via broadcast
@@ -725,7 +725,7 @@ Smoke real em ambiente homologação SEFAZ-SP usando cert + CNPJ Gold. Análogo 
 Bate o **Goal #1 do CYCLE-03** ("smoke fiscal SEFAZ-SC homologação biz=1, 1ª NFC-e real cstat 100"). Pipeline US-NFE-002 server-side já fechado em main; biz=1 (WR2 Sistemas, Tubarão/SC) já está armada — confirmado via SSH 2026-05-09:
 
 **Estado pré-validado (não tocar):**
-- `business.cnpj`=11.222.333/0001-81, `ncm_padrao`=49111090, `ambiente`=2, `ultimo_numero_nfce`=0 <!-- pii-allowlist: CNPJ fake canônico de fixture, não é PII real -->
+- `business.cnpj`=36.613.150/0001-18, `ncm_padrao`=49111090, `ambiente`=2, `ultimo_numero_nfce`=0 <!-- pii-allowlist: fixture biz=1 WR2 Sistemas (própria empresa Wagner, ADR 0101 biz=1 nunca cliente) — homologação SEFAZ-SC -->
 - `nfe_certificados.ativo`=1, `valido_ate`=2026-08-06
 - `nfe_business_configs`: `regime`=simples, `cfop`=5102, `csosn`=102, `auto_emission_enabled`=1
 - `.env` Hostinger: `NFEBRASIL_AUTO_EMISSION_NFCE=true`
@@ -906,7 +906,7 @@ Continuação dos PRs #487-490 (sessão 2026-05-10). Pattern dual-mode SQLite/My
 
 **Candidatos naturais:**
 1. **Gold** (Comunicação Visual) — pós Manifestação Destinatário entregue (US-NFE-049/050/051/052 já done). Gold é gráfica grande, emite 100%.
-2. **Vargas** (Autopecas) — sinal qualificado real (R$ [redacted Tier 0]M GMV), mas Modules/Autopecas ainda em construção.
+2. **Vargas** (Autopecas) — sinal qualificado real (R$ [redacted Tier 0]M GMV), mas o módulo Autopecas (planejado — não existe) ainda não foi construído.
 3. **Modules/ComunicacaoVisual cliente novo** — qualquer um das 5 cartas warming (Extreme/Zoom/Fixar/Mhundo/Produart) que adotar oimpresso pós outreach.
 
 **Acceptance criteria (smoke fim-a-fim):**

--- a/memory/requisitos/OficinaAuto/OficinaAuto.charter.md
+++ b/memory/requisitos/OficinaAuto/OficinaAuto.charter.md
@@ -58,7 +58,7 @@ Add-on vertical de oficina mecânica automotiva sobre o núcleo oimpresso, **foc
 - ❌ **Visão financeira AR/AP unificada** → vive em `Modules/Financeiro`
 - ❌ **Boleto/assinatura/cobrança recorrente** (planos de revisão preventiva) → vive em `Modules/RecurringBilling`
 - ❌ **Multi-tenant `business_id` global scope** → infraestrutura núcleo Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
-- ❌ **Jana IA / memória persistente** → vive em `Modules/Copiloto`
+- ❌ **Jana IA / memória persistente** → vive em `Modules/Jana`
 - ❌ **OS de reparo genérico** (eletrônico, costureira, vestuário, etc) → vive em `Modules/Repair`. OficinaAuto **consome `RepairCore`** quando o refactor Caminho A do audit F29 entregar. Hoje, sem refactor, isto é bloqueador
 - ❌ **PCP de produção gráfica/têxtil** — fora do escopo automotivo
 - ❌ **E-commerce de peças / marketplace integration** (Mercado Livre Auto, etc) → fora do MVP
@@ -122,7 +122,7 @@ Validação: **NENHUM CLIENTE PILOTO** (charter antecipatório). Personas basead
 
 ## 6. Automation hooks (onde Jana IA atua)
 
-> Jana = Modules/Copiloto. Hooks **propostos** — exigem sinal qualificado antes de virar US ativa.
+> Jana = Modules/Jana. Hooks **propostos** — exigem sinal qualificado antes de virar US ativa.
 
 - ✅ **Sugestão de tempária Sindirepa** — ao adicionar serviço na OS, Jana propõe tempo do sindicato; mecânico aceita ou ajusta
 - ✅ **Alerta peça em estoque baixo** — quando mecânico vai usar peça e estoque já acabou, Jana avisa antes de fechar OS
@@ -157,7 +157,7 @@ Validação: **NENHUM CLIENTE PILOTO** (charter antecipatório). Personas basead
 | `Modules/Repair` (via `RepairCore` extraído) | Reusa OS base, status workflow, attachments, eventos. **Bloqueador:** depende do refactor Caminho A audit F29 (extração `RepairCore` shared). Pré-refactor, não inicia código. | consome (após refactor) |
 | `Modules/NfeBrasil` | Listener `NFSeAutorizada` (serviço) + `NFCeAutorizada` (venda de peça); pipeline TransactionBuilder | consome |
 | `Modules/Financeiro` | Visão unificada AR/AP de OSs; DRE simplificado | consome |
-| `Modules/Copiloto` (Jana) | Chat contextual + alertas + brief diário | consome |
+| `Modules/Jana` (Jana) | Chat contextual + alertas + brief diário | consome |
 | `Modules/RecurringBilling` | Plano mensal da oficina (assinatura oimpresso) — não OSs finais | consome |
 | `Modules/MemCofre` | Cofre senhas (cert digital, login fornecedor de peças, API DETRAN) | consome opcional |
 | Núcleo UltimatePOS | `business_id`, users, roles, locations, `transactions`, products, contacts | base |

--- a/memory/requisitos/OficinaAuto/demo-martinho-2026-05-13/plano-paralelizacao.md
+++ b/memory/requisitos/OficinaAuto/demo-martinho-2026-05-13/plano-paralelizacao.md
@@ -42,7 +42,7 @@
 
 **Módulos referência (imitar, não duplicar):**
 - `Modules/Repair/` — Kanban OS shared infrastructure
-- `Modules/Sells/` — FSM Pipeline ADR 0143 LIVE prod biz=1
+- Sells (núcleo UltimatePOS, não é módulo) — FSM Pipeline ADR 0143 LIVE prod biz=1
 - `scripts/legacy-migration/` (se existir importer Repair/Vargas — imitar)
 
 ---

--- a/memory/requisitos/PontoWr2/RUNBOOK.md
+++ b/memory/requisitos/PontoWr2/RUNBOOK.md
@@ -79,7 +79,7 @@ php artisan tinker
 **Causa**: Hash SHA256 do registro foi gerado com algoritmo/seed errado.
 
 **Correção**:
-- Verificar `Modules/PontoWr2/Services/HashService.php` — usa concatenação `PIS|data|hora|hash_anterior`.
+- Verificar `Modules/Ponto/Services/HashService.php` — usa concatenação `PIS|data|hora|hash_anterior`.
 - ART registrada com chave diferente da usada no código = rejeição.
 - Revalidar com `php artisan ponto:validar-cadeia-hash --business=1`.
 

--- a/memory/requisitos/PontoWr2/SPEC.md
+++ b/memory/requisitos/PontoWr2/SPEC.md
@@ -1,8 +1,8 @@
 ---
 module: PontoWr2
-owner: wagner
 version: "1.0"
 last_updated: "2026-06-13"
+owner: wagner
 ---
 
 # Especificação funcional
@@ -22,7 +22,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Aprovacao  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -44,7 +44,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Banco Horas  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -66,7 +66,7 @@ last_updated: "2026-06-13"
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -88,7 +88,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Colaborador  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -110,7 +110,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Configuracao  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -132,7 +132,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Core  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -154,7 +154,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Espelho  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -176,7 +176,7 @@ last_updated: "2026-06-13"
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -198,7 +198,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Importacao  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -220,7 +220,7 @@ last_updated: "2026-06-13"
 **Quero** criar um novo item em Importacao  
 **Para** alimentar o sistema com os dados operacionais
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -242,7 +242,7 @@ last_updated: "2026-06-13"
 **Quero** consultar informação completa de um item específico  
 **Para** tomar decisão com base em contexto completo
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -264,7 +264,7 @@ last_updated: "2026-06-13"
 **Quero** ver o conjunto de Relatorio  
 **Para** ter visão geral e filtrar o que importa
 
-**Implementado em:** _pendente_ — tela não construída (sem arquivo .tsx no repo)
+**Implementado em:** _[TODO — apontar path do arquivo .tsx que atende]_
 
 **Definition of Done:**
 - [ ] Rota acessível apenas por papéis autorizados (`403` caso contrário)
@@ -290,7 +290,7 @@ Então só vê registros com `business_id = A`
 ```
 
 **Implementação:** Controllers fazem `where('business_id', session('business.id'))`  
-**Testado em:** `Modules/PontoWr2/Tests/Feature/MultiTenantIsolationTest` (teste real — valida 10 rotas com scope + isolamento cross-business + session)
+**Testado em:** `Modules/Ponto/Tests/Feature/MultiTenantIsolationTest` (teste real — valida 10 rotas com scope + isolamento cross-business + session)
 
 ### R-PONT-002 · Autorização Spatie `ponto.access`
 
@@ -301,7 +301,7 @@ Então recebe `403 Unauthorized`
 ```
 
 **Implementação:** Controllers checam `$user->can('ponto.access')`  
-**Testado em:** `Modules/PontoWr2/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
+**Testado em:** `Modules/Ponto/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
 
 ### R-PONT-003 · Autorização Spatie `ponto.colaboradores.manage`
 
@@ -312,7 +312,7 @@ Então recebe `403 Unauthorized`
 ```
 
 **Implementação:** Controllers checam `$user->can('ponto.colaboradores.manage')`  
-**Testado em:** `Modules/PontoWr2/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
+**Testado em:** `Modules/Ponto/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
 
 ### R-PONT-004 · Autorização Spatie `ponto.aprovacoes.manage`
 
@@ -323,7 +323,7 @@ Então recebe `403 Unauthorized`
 ```
 
 **Implementação:** Controllers checam `$user->can('ponto.aprovacoes.manage')`  
-**Testado em:** `Modules/PontoWr2/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
+**Testado em:** `Modules/Ponto/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
 
 ### R-PONT-005 · Autorização Spatie `ponto.relatorios.view`
 
@@ -334,7 +334,7 @@ Então recebe `403 Unauthorized`
 ```
 
 **Implementação:** Controllers checam `$user->can('ponto.relatorios.view')`  
-**Testado em:** `Modules/PontoWr2/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
+**Testado em:** `Modules/Ponto/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
 
 ### R-PONT-006 · Autorização Spatie `ponto.configuracoes.manage`
 
@@ -345,4 +345,4 @@ Então recebe `403 Unauthorized`
 ```
 
 **Implementação:** Controllers checam `$user->can('ponto.configuracoes.manage')`  
-**Testado em:** `Modules/PontoWr2/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)
+**Testado em:** `Modules/Ponto/Tests/Feature/SpatiePermissionsTest` (real — 10 testes, 15 assertions, valida ambas direções: sem permissão bloqueia, com permissão passa)

--- a/memory/requisitos/ProjectMgmt/BRIEFING.md
+++ b/memory/requisitos/ProjectMgmt/BRIEFING.md
@@ -57,7 +57,7 @@ Ver [CAPTERRA-FICHA.md](CAPTERRA-FICHA.md) — comparado com Linear, Jira, Click
 - ⛔ **NUNCA `withoutGlobalScopes` em McpTask/McpProject** sem comentário `// SUPERADMIN: <razão>` — multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093)
 - ⛔ **Tabelas `mcp_*` são canônicas pro time** — UPDATE direto via tinker em prod = drift catalogado
 - ⛔ **Stack middlewares completa obrigatória** em Http/routes.php — sem `SetSessionData` o `session('user.business_id')` é null → vazamento
-- ⚠️ **Schema migration** — `mcp_projects` + `mcp_tasks` vivem em Modules/Copiloto (Jana) — ProjectMgmt é UI sobre essas tabelas, não dono do schema
+- ⚠️ **Schema migration** — `mcp_projects` + `mcp_tasks` vivem em Modules/Jana (Jana) — ProjectMgmt é UI sobre essas tabelas, não dono do schema
 - ⚠️ **Permission canônica** — `copiloto.mcp.usage.all` (herdada do Copiloto, igual ao TeamMcp anterior) — não criar permission própria do ProjectMgmt
 
 ## Wave 18 Saturação (2026-05-16)

--- a/memory/requisitos/ProjectMgmt/SPEC-COMPLEMENTO.md
+++ b/memory/requisitos/ProjectMgmt/SPEC-COMPLEMENTO.md
@@ -96,14 +96,14 @@ Atalhos teclado nível Linear pra trabalhar no Board sem mouse.
 ### US-PROJ-005 · Real-time presence via Centrifugo
 
 > owner: wagner · priority: p2 · estimate: 4-6h · status: backlog · type: feature
-> blocked_by: Modules/Copiloto Centrifugo SDK em prod
+> blocked_by: Modules/Jana Centrifugo SDK em prod
 
 Mostrar avatares de quem está com o Detail Sheet aberto na mesma task (ADR 0058).
 
 - [ ] CentrifugoPresenceService::publish(task_id, user_id) ao montar Detail Sheet
 - [ ] Frontend: `<PresenceAvatars taskId={...} />` componente — subscribe channel `task:{id}`
 - [ ] Cleanup: unmount → unsubscribe + Centrifugo expira presence em 30s
-- [ ] Pest: integração Centrifugo mockada (Modules/Copiloto/Centrifugo fixture)
+- [ ] Pest: integração Centrifugo mockada (Modules/Jana/Centrifugo fixture)
 
 **Refs**: ADR 0058 (Centrifugo > Reverb) · ADR 0062 (CT 100 runtime)
 

--- a/memory/requisitos/Repair/SPEC-FSM-WIREUP.md
+++ b/memory/requisitos/Repair/SPEC-FSM-WIREUP.md
@@ -116,7 +116,7 @@ Mapping inicial sugerido (compatibilidade): user com `job_sheet.edit` ganha toda
 |---|---|---|---|
 | `ReservarEstoque` | `registrar_aprovacao_cliente` | Cria linha em `stock_reservations` por peça do `parts` JSON; reduz `available_stock` virtual | Upsert por `(job_sheet_id, variation_id)` |
 | `LiberarReservaEstoque` | `registrar_rejeicao_cliente` / `cancelar_os` | Soft-delete `stock_reservations` da OS | Idempotente — múltiplos calls não-op |
-| `ConsumirEstoque` | `concluir_execucao` | Converte reserva → baixa real (`Modules/Stock/Services/ConsumeReservation::handle`) | Lock advisory por `job_sheet_id` |
+| `ConsumirEstoque` | `concluir_execucao` | Converte reserva → baixa real (`Stock/Services/ConsumeReservation::handle` — Stock é núcleo UltimatePOS, não é módulo) | Lock advisory por `job_sheet_id` |
 | `NotificarOrcamentoWhatsapp` | `enviar_orcamento` (action sem transição) | Dispatcha job `SendRepairQuoteJob` (Whatsapp daemon CT 100) | Hash do payload — repetir mesmo orçamento não envia 2x |
 | `NotificarClienteWhatsapp` | `concluir_execucao` | Reaproveita `NotifyRepairCustomer` Listener existente (ADR Repair tech/0001) — passa a ser disparado pelo Service em vez do controller | Status name = `concluido_aguardando_retirada` na matriz auto-SMS |
 | `EmitirCupomServico` | `entregar_ao_cliente` | Opcional — gera Transaction tipo `repair_invoice` se `parts.length > 0` | Lookup por `job_sheet_id` |

--- a/memory/requisitos/Sells/BRIEFING.md
+++ b/memory/requisitos/Sells/BRIEFING.md
@@ -27,7 +27,7 @@ Módulo de vendas — wrapper KB-9.75 sobre `Transaction(type='sell')` UltimateP
 ## Stack arquitetural
 
 - `app/Http/Controllers/SellController.php` — wrapper KB-9.75 + payload `/sells-list-json` expand items_list + fiscal (W2 PR #1510)
-- `Modules/Sells/` thin layer (rota + payload + service)
+- Sells (núcleo UltimatePOS, não é módulo) — thin layer (rota + payload + service)
 - `app/Transaction.php` model legacy UPOS — multi-tenant `business_id` global scope
 - Integração com `Modules/Repair`:
   - `JobSheetObserver@updated` auto-cria `Transaction(source='oficina')` em terminal transition

--- a/memory/requisitos/Sells/OBSERVABILITY.md
+++ b/memory/requisitos/Sells/OBSERVABILITY.md
@@ -1,4 +1,4 @@
-# OBSERVABILITY — Modules/Sells
+# OBSERVABILITY — Sells (núcleo UltimatePOS, não é módulo)
 
 > Declaração canônica de pontos de hook OTel (D9.a Observability v3 — 2026-05-16).
 > Estratégia leve: documenta superfície de instrumentação SEM código novo. Quando SDK OTel full subir no CT 100 (`OTEL_FULL_SDK=true` — ver `config/otel.php`), services e use-cases serão envolvidos via decorator/middleware.

--- a/memory/requisitos/Sells/RUNBOOK-index.md
+++ b/memory/requisitos/Sells/RUNBOOK-index.md
@@ -51,7 +51,7 @@ Lista vendas (pedidos · faturamento · NF-e/NFS-e) do business com 4 KPIs opera
 - Modules/NfeBrasil ativo se for usar Emit modais (FISCAL section drawer)
 - `business_settings.fiscal_certificate_active=1` + certificado A1 instalado se emissão real (sandbox/produção SEFAZ)
 - Modules/Whatsapp ativo + sessão Meta Cloud autenticada se for usar contextos mensagem
-- Modules/Copiloto ativo se botão `+IA` no drawer for usado
+- Modules/Jana ativo se botão `+IA` no drawer for usado
 
 ## 4. Fluxo principal (golden path)
 
@@ -129,7 +129,7 @@ Lista vendas (pedidos · faturamento · NF-e/NFS-e) do business com 4 KPIs opera
 - `SellController::messageContextPayload($id, $context)` — WhatsApp preview text com variáveis substituídas
 - `SellController::printInvoice($id)` — receipt HTML pra IFRAME imprimir (modo invoice/packing_slip/delivery_note via `printSaleReceipt.ts`)
 - `Modules/NfeBrasil/Http/Controllers/NfeController` — endpoint emit single (NFe/NFCe/NFSe)
-- `Modules/Copiloto` — botão +IA dispara contexto venda → Brain A/B
+- `Modules/Jana` — botão +IA dispara contexto venda → Brain A/B
 - `App\Transaction` model (type='sell'): global scope `business_id` (UPOS canon)
 
 ## 9. Multi-tenant + LGPD
@@ -217,7 +217,7 @@ curl -sv 'https://oimpresso.com/sells' -H 'X-Inertia: true' -H 'X-Inertia-Partia
 - **Modules/NfeBrasil** — emissão SEFAZ (NFe/NFCe/NFSe single + bulk)
 - **Modules/PaymentGateway** — emitir cobrança boleto/PIX/cartão (Onda 4f.0 PR #1587)
 - **Modules/Whatsapp** — preview + envio mensagem contextual
-- **Modules/Copiloto** (Jana) — botão +IA Brain A/B contextual venda
+- **Modules/Jana** (Jana) — botão +IA Brain A/B contextual venda
 - **Modules/Repair** — Criar OS cross-module (1 venda → N OS)
 - **Modules/Fiscal** — config certificado A1 + ambient (sandbox/prod SEFAZ)
 - **Modules/Auditoria** — append-only HISTÓRICO via ActivityLog

--- a/memory/requisitos/TeamMcp/SPEC.md
+++ b/memory/requisitos/TeamMcp/SPEC.md
@@ -1,9 +1,13 @@
 ---
+module: TeamMcp
+version: "1.0"
+last_updated: "2026-06-13"
+owner: wagner
 na_justified:
   D1.a: "Tabela `mcp_actors` é cross-tenant POR DESIGN (sem `business_id`) — Identity Mesh governa time INTERNO oimpresso (Wagner/Felipe/Maiara/Eliana/Luiz), não clientes externos. Demais tabelas TeamMcp (`mcp_tokens`, `mcp_scopes`, `mcp_audit_log`) herdam `business_id` via `user_id` FK ou são repo-wide governance ([ADR 0053](../../decisions/0053-mcp-server-governanca-como-produto.md) MCP server canon + [ADR 0081](../../decisions/0081-identity-mesh-mcp-actors.md) Identity Mesh + Constituição v2 Art. 6)."
   D5: "TeamMcp é módulo INTERNO de gestão de tokens MCP do time (Wagner/Felipe/Maiara/Luiz/Eliana). Cliente biz=4 ROTA LIVRE não usa por design — é ferramenta da equipe, não produto pra cliente final. ADR 0081 documenta como módulo team-internal."
   D8.b: "TeamMcp já nasceu Inertia/React (sem Blade legacy). CSRF é aplicado via middleware web padrão Laravel — não há views Blade pra auditar paridade."
-related_adrs: [0053, 0081, 0093, 0094, 0105, 0153, 0154, 0155]
+related_adrs: [0053-mcp-server-governanca-como-produto, 0081-identity-mesh-mcp-actors, 0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0105-cliente-como-sinal-guiar-sem-mandar, 0153-module-grade-rubrica-v1, 0154-module-grade-v2-na-justificado, 0155-module-grade-v3-sub-dimensoes-gate-ci]
 ---
 
 # SPEC — Modules/TeamMcp
@@ -107,7 +111,7 @@ Self-host equivalente ao Anthropic Team plan adaptado pra LGPD + custo + custom 
 
 ## Não-escopo (NÃO neste módulo)
 
-- ❌ Chat IA conversacional → `Modules/Copiloto`
+- ❌ Chat IA conversacional → `Modules/Jana`
 - ❌ Knowledge browsing (ADRs/sessions UI) → `Modules/KB`
 - ❌ Skills governance + Brain A/B → `Modules/ADS`
 - ❌ Policies executáveis runtime → `Modules/Governance` (Fase 5)

--- a/memory/requisitos/Vestuario/Vestuario.charter.md
+++ b/memory/requisitos/Vestuario/Vestuario.charter.md
@@ -45,7 +45,7 @@ Add-on vertical de moda/vestuário sobre o núcleo oimpresso — entrega estoque
 - ❌ **Visão financeira AR/AP unificada** → vive em `Modules/Financeiro`
 - ❌ **Boleto/assinatura/cobrança recorrente** → vive em `Modules/RecurringBilling`
 - ❌ **Multi-tenant `business_id` global scope** → infraestrutura núcleo Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
-- ❌ **Jana IA / memória persistente** → vive em `Modules/Copiloto`
+- ❌ **Jana IA / memória persistente** → vive em `Modules/Jana`
 - ❌ **Cofre de senhas/credenciais** → vive em `Modules/MemCofre`
 - ❌ **PCP de produção** (planejamento, ordem de produção, BOM gráfico) — isso é de `Modules/ComunicacaoVisual`
 - ❌ **OS de reparo/ajuste de roupa** — Modules/Repair atende, vestuário só consome se cliente quiser
@@ -93,7 +93,7 @@ Validação: ROTA LIVRE biz=4, 17.251+ vendas, 99% volume sistema, em prod desde
 
 ## 6. Automation hooks (onde Jana IA atua)
 
-> Jana = Modules/Copiloto. Hooks abaixo são **propostos** — exigem sinal qualificado ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) antes de virar US ativa.
+> Jana = Modules/Jana. Hooks abaixo são **propostos** — exigem sinal qualificado ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)) antes de virar US ativa.
 
 - ✅ **Alerta estoque baixo por variant** — quando `qty_available < min_stock` por SKU+tamanho+cor, Jana sugere reposição no chat contextual
 - ✅ **Comparativo semanal de vendas** — Larissa pergunta "como foi essa semana vs anterior?" → ContextoNegocio responde com 3 ângulos faturamento ([ADR 0052](../../decisions/0052-contexto-negocio-3-angulos-faturamento.md))
@@ -125,7 +125,7 @@ Validação: ROTA LIVRE biz=4, 17.251+ vendas, 99% volume sistema, em prod desde
 |---|---|---|
 | `Modules/NfeBrasil` | Listener `NFCeAutorizada` ao finalizar venda; pipeline TransactionBuilder | consome |
 | `Modules/Financeiro` | Visão unificada AR/AP de boletos da loja, DRE simplificado | consome |
-| `Modules/Copiloto` (Jana) | Chat contextual + alertas + brief diário | consome |
+| `Modules/Jana` (Jana) | Chat contextual + alertas + brief diário | consome |
 | `Modules/RecurringBilling` | Plano mensal da loja (assinatura oimpresso) — não vendas finais | consome |
 | `Modules/Repair` | OS de ajuste/conserto de roupa (opcional, se cliente ativar) | consome opcional |
 | `Modules/MemCofre` | Cofre senhas (cert digital, login fornecedor) | consome opcional |

--- a/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING_PROXIMA_SESSAO.md
@@ -47,7 +47,7 @@ related_adrs: [0235, 0249]
 - `resources/js/Layouts/AppShellV2.tsx` (shell único do ERP — AppShell legado removido em 2026-05-04)
 - `resources/js/Pages/Copiloto/` — Cockpit.tsx, Chat.tsx, Dashboard.tsx
 - `memory/requisitos/_DesignSystem/` — SPEC.md, BRIEFING, ARCHITECTURE, CHANGELOG, ADRs UI
-- `Modules/PontoWr2/Http/Controllers/DataController.php` — menu real Ponto
+- `Modules/Ponto/Http/Controllers/DataController.php` — menu real Ponto
 - `Modules/Financeiro/Http/Controllers/DataController.php` — menu real Financeiro
 - `Modules/Officeimpresso/Http/Controllers/DataController.php` — menu real Officeimpresso
 - `app/Services/LegacyMenuAdapter.php` — como o menu é montado
@@ -214,7 +214,7 @@ Padrão obrigatório:
 | DataTable | `resources/js/Components/shared/DataTable.tsx` |
 | KpiCard / KpiGrid | `resources/js/Components/shared/KpiCard.tsx` |
 | Cockpit page | `resources/js/Pages/Copiloto/Cockpit.tsx` |
-| Menu Ponto WR2 | `Modules/PontoWr2/Http/Controllers/DataController.php` |
+| Menu Ponto WR2 | `Modules/Ponto/Http/Controllers/DataController.php` |
 | Menu Financeiro | `Modules/Financeiro/Http/Controllers/DataController.php` |
 | Design System SPEC | `memory/requisitos/_DesignSystem/SPEC.md` |
 | ADR Cockpit | `memory/requisitos/_DesignSystem/adr/ui/0008-cockpit-layout-mae-do-erp.md` |

--- a/memory/requisitos/_DesignSystem/SPEC.md
+++ b/memory/requisitos/_DesignSystem/SPEC.md
@@ -131,7 +131,7 @@ Então a exceção é documentada + referenciada na tabela "Exceções" do ADR U
 
 **Por quê**: consistência cross-módulo + velocidade de novo dev + facilita auditoria.
 
-**Testado em:** `Modules/PontoWr2/Tests/Feature/AprovacoesIndexTest` (prova de conceito 2026-04-24). Check C16 futuro no `ModuleAuditor`: toda page em listagem importa de `@/Components/shared/`.
+**Testado em:** `Modules/Ponto/Tests/Feature/AprovacoesIndexTest` (prova de conceito 2026-04-24). Check C16 futuro no `ModuleAuditor`: toda page em listagem importa de `@/Components/shared/`.
 
 ### R-DS-009 · Telas core do ERP nascem dentro do Cockpit (AppShellV2)
 

--- a/memory/requisitos/_DesignSystem/from-claude-design/04-conventions.md
+++ b/memory/requisitos/_DesignSystem/from-claude-design/04-conventions.md
@@ -69,7 +69,7 @@ morreu_porque: "Convenções importadas do projeto PontoWr2 legado; cita Laravel
 ## Testes
 
 - **PHPUnit** para unit e feature
-- Localização: `Modules/PontoWr2/Tests/{Unit,Feature}/`
+- Localização: `Modules/Ponto/Tests/{Unit,Feature}/`
 - Nome: `ApurarDiaTest.php`, métodos `test_apura_dia_sem_marcacoes_retorna_falta_integral`
 - Cobertura mínima obrigatória: regras CLT em `ApuracaoService`
 


### PR DESCRIPTION
Wagner-aprovado (alta-confiança). **ghost_count 27 → 15** (verificado vs baseline). 60 docs mutáveis, **0 ADRs, 0 código** (append-only respeitado).

- **RENAME** (alvo real): Copiloto→Jana, PontoWr2→Ponto, CV→ComunicacaoVisual
- **LÁPIDE** '(planejado — não existe)': Marketplaces, Garantia, Contratos, Suporte, EvolutionAgent, LaravelAI, FinanceiroAvancado, Comissao, Autopecas
- **CORE-UPOS**: Sells, Stock, Auth, UltimatePos
- **Pulados** (corromperiam sentido / held): CrmPipeline, DocVault, IProduction, Inventory, Vendor, Chat + 5 held p/ sua decisão

Verify adversarial: clean (0 quebra de sintaxe/YAML; renames apontam módulos reais). 15 restantes defensáveis (5 held + 5 só-ADR + 5 skip load-bearing).

Refs: ADR 0274 · plano SDD 2026-06-12 (KL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)