### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — OficinaAuto (US-GOV-019)

### DIFF
--- a/Modules/OficinaAuto/Console/Commands/ImportFirebirdMartinhoCommand.php
+++ b/Modules/OficinaAuto/Console/Commands/ImportFirebirdMartinhoCommand.php
@@ -236,6 +236,8 @@ class ImportFirebirdMartinhoCommand extends Command
         $vehicleType = $this->normalizeVehicleType($ordem['vehicle_type'] ?? null);
 
         // Vehicle: localiza por placa+biz OU cria stub
+        // SUPERADMIN: import CLI roda sem session — bypass do global scope com filtro
+        // explícito por business_id alvo da migração legacy (Tier 0, ADR 0093).
         $vehicle = Vehicle::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('plate', $placa)
@@ -247,6 +249,8 @@ class ImportFirebirdMartinhoCommand extends Command
                     $this->line("  + (dry-run) Vehicle stub: placa={$placa} tipo={$vehicleType}");
                 }
             } else {
+                // SUPERADMIN: import CLI sem session — cria Vehicle com business_id
+                // explícito do alvo da migração legacy (Tier 0, ADR 0093).
                 $vehicle = Vehicle::withoutGlobalScopes()->create([
                     'business_id'  => $businessId,
                     'plate'        => $placa,
@@ -290,6 +294,8 @@ class ImportFirebirdMartinhoCommand extends Command
             &$itensCriados,
             $detail
         ) {
+            // SUPERADMIN: import CLI sem session — cria ServiceOrder com business_id
+            // explícito do alvo da migração legacy (Tier 0, ADR 0093).
             $os = ServiceOrder::withoutGlobalScopes()->create([
                 'business_id'        => $businessId,
                 'vehicle_id'         => $vehicle->id,

--- a/Modules/OficinaAuto/Jobs/EnviarLinkAprovacaoWhatsappJob.php
+++ b/Modules/OficinaAuto/Jobs/EnviarLinkAprovacaoWhatsappJob.php
@@ -85,7 +85,8 @@ class EnviarLinkAprovacaoWhatsappJob implements ShouldQueue
             return;
         }
 
-        // Load ServiceOrder sem global scope (job sem session — Tier 0 guard manual)
+        // SUPERADMIN: job de fila roda sem session — bypass do global scope com filtro
+        // explícito por business_id (Tier 0 guard manual, ADR 0093).
         $so = ServiceOrder::query()
             ->withoutGlobalScopes()
             ->where('id', $this->serviceOrderId)

--- a/Modules/OficinaAuto/Services/DviInspectionService.php
+++ b/Modules/OficinaAuto/Services/DviInspectionService.php
@@ -73,6 +73,8 @@ class DviInspectionService
             );
         }
 
+        // SUPERADMIN: Service não confia em session (defesa em profundidade) — cria com
+        // business_id explícito já validado contra a OS dona (Tier 0, ADR 0093).
         return OaInspectionItem::withoutGlobalScopes()->create([
             'business_id'        => $businessId,
             'service_order_id'   => $serviceOrderId,
@@ -126,6 +128,8 @@ class DviInspectionService
      */
     public function totalRecomendado(int $serviceOrderId): float
     {
+        // SUPERADMIN: agregado controlado por service_order_id (OS já é business-scoped
+        // pelo caller) — Service não depende de session (Tier 0, ADR 0093).
         $total = OaInspectionItem::withoutGlobalScopes()
             ->where('service_order_id', $serviceOrderId)
             ->whereIn('severity', OaInspectionItem::SEVERIDADES_RECOMENDAVEIS)
@@ -142,6 +146,8 @@ class DviInspectionService
      */
     public function listarOrdenado(int $serviceOrderId): Collection
     {
+        // SUPERADMIN: filtro estrito por service_order_id (OS já é business-scoped pelo
+        // caller) — Service não depende de session (Tier 0, ADR 0093).
         return OaInspectionItem::withoutGlobalScopes()
             ->where('service_order_id', $serviceOrderId)
             ->whereNull('deleted_at')

--- a/Modules/OficinaAuto/Services/ServiceOrderItemService.php
+++ b/Modules/OficinaAuto/Services/ServiceOrderItemService.php
@@ -94,6 +94,8 @@ class ServiceOrderItemService
             ? (float) $data['valor_total']
             : round($quantidade * $valorUnitario, 2);
 
+        // SUPERADMIN: Service não confia em session (defesa em profundidade) — cria com
+        // business_id explícito já validado contra a OS dona (Tier 0, ADR 0093).
         return ServiceOrderItem::withoutGlobalScopes()->create([
             'business_id'      => $businessId,
             'service_order_id' => $osId,
@@ -136,6 +138,8 @@ class ServiceOrderItemService
             throw new InvalidArgumentException('business_id obrigatório (Tier 0 ADR 0093)');
         }
 
+        // SUPERADMIN: Service não confia em session — filtro explícito por business_id
+        // + service_order_id antes de mexer estoque (Tier 0, ADR 0093).
         $itens = ServiceOrderItem::withoutGlobalScopes()
             ->where('service_order_id', $osId)
             ->where('business_id', $businessId)
@@ -147,6 +151,8 @@ class ServiceOrderItemService
         $baixados = 0;
 
         foreach ($itens as $item) {
+            // SUPERADMIN: Service sem session — resolve produto com business_id explícito
+            // pra impedir baixar estoque de catálogo de outro tenant (Tier 0, ADR 0093).
             $product = \App\Product::withoutGlobalScopes()
                 ->where('id', $item->product_id)
                 ->where('business_id', $businessId)
@@ -204,6 +210,8 @@ class ServiceOrderItemService
      */
     public function breakdownPorTipo(int $osId): array
     {
+        // SUPERADMIN: agregado controlado por service_order_id (OS já é business-scoped
+        // pelo caller) — Service não depende de session (Tier 0, ADR 0093).
         $rows = ServiceOrderItem::withoutGlobalScopes()
             ->where('service_order_id', $osId)
             ->whereNull('deleted_at')
@@ -233,6 +241,8 @@ class ServiceOrderItemService
             throw new InvalidArgumentException("tipo inválido: '{$tipo}'");
         }
 
+        // SUPERADMIN: filtro estrito por service_order_id (OS já é business-scoped pelo
+        // caller) — Service não depende de session (Tier 0, ADR 0093).
         return ServiceOrderItem::withoutGlobalScopes()
             ->where('service_order_id', $osId)
             ->where('tipo', $tipo)


### PR DESCRIPTION
## O que

Anota com `// SUPERADMIN: <razão>` as **12** chamadas `withoutGlobalScopes()` de **produção** no módulo **OficinaAuto** que ainda não tinham justificativa auditável na mesma linha ou nas 3 linhas acima — satisfazendo o guard estático `tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php`.

Parte da tarefa **US-GOV-019** (governança multi-tenant Tier 0 · ADR 0093 IRREVOGÁVEL). Modelo canônico seguido: `Modules/Vestuario/Services/VestuarioSettingsResolver.php`.

## Por que cada bypass é legítimo

Todos os bypass têm contexto sem `session()` e já filtram explicitamente por `business_id` (ou por `service_order_id` de uma OS já business-scoped pelo caller):

| Arquivo | Calls | Contexto |
|---|---|---|
| `Console/Commands/ImportFirebirdMartinhoCommand.php` | 3 | Import CLI de dados legacy Firebird — sem session, `business_id` alvo explícito |
| `Jobs/EnviarLinkAprovacaoWhatsappJob.php` | 1 | Job de fila — sem session, filtro por `business_id` do constructor (Tier 0 guard manual) |
| `Services/ServiceOrderItemService.php` | 5 | Service não confia em session (defesa em profundidade) — `business_id`/OS business-scoped explícitos |
| `Services/DviInspectionService.php` | 3 | idem — agregados/escritas controlados por OS business-scoped |

## Escopo

- **Apenas comentários** — zero mudança de lógica (diff: 24 inserções, 1 deleção).
- **SUSPECTED LEAKS: nenhum.** Toda chamada de produção é justificável.
- Seeders (`Database/Seeders/`) e Tests são excluídos pelo próprio guard (paths `Database/`, `Tests/`).

## Verificação

Lógica do guard re-executada escopada ao OficinaAuto: **23 chamadas de produção, 0 violações.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)