### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — KB/NFSe/Crm/Arquivos (US-GOV-019)

### DIFF
--- a/Modules/KB/Http/Controllers/KbFavoriteController.php
+++ b/Modules/KB/Http/Controllers/KbFavoriteController.php
@@ -33,6 +33,7 @@ class KbFavoriteController extends Controller
         $node = KbNode::query()->where('slug', $slug)->firstOrFail();
         $userId = Auth::id();
 
+        // SUPERADMIN: lookup limitado por user_id (autenticado) + node_id (já validado ao tenant via firstOrFail acima) — bypass evita depender do scope de business_id em kb_favorites
         $fav = KbFavorite::withoutGlobalScopes()
             ->where('user_id', $userId)
             ->where('node_id', $node->id)

--- a/Modules/KB/Http/Controllers/KbVersionController.php
+++ b/Modules/KB/Http/Controllers/KbVersionController.php
@@ -67,6 +67,7 @@ class KbVersionController extends Controller
             ], 422);
         }
 
+        // SUPERADMIN: lookup limitado por node_id (já validado ao tenant via firstOrFail acima) + version_id — bypass evita depender do scope de business_id em kb_node_versions
         $version = KbNodeVersion::withoutGlobalScopes()
             ->where('id', $data['version_id'])
             ->where('node_id', $node->id)

--- a/Modules/KB/Jobs/KbBridgeFromMcpJob.php
+++ b/Modules/KB/Jobs/KbBridgeFromMcpJob.php
@@ -147,6 +147,7 @@ class KbBridgeFromMcpJob implements ShouldQueue
         //  - senão, usa o business do job (docs globais nascem em cada biz)
         $bizForNode = $doc->business_id ?? $this->businessId;
 
+        // SUPERADMIN: job em fila bridge MCP→KB roda sem sessão — business_id ($bizForNode) explícito na chave
         $node = KbNode::withoutGlobalScopes()
             ->firstOrNew([
                 'business_id'   => $bizForNode,

--- a/Modules/KB/Jobs/KbEdgeAutoDeriverJob.php
+++ b/Modules/KB/Jobs/KbEdgeAutoDeriverJob.php
@@ -48,6 +48,7 @@ class KbEdgeAutoDeriverJob implements ShouldQueue
     {
         $count = 0;
 
+        // SUPERADMIN: job em fila roda sem sessão — business_id explícito abaixo (vem do construtor)
         KbNode::withoutGlobalScopes()
             ->where('business_id', $this->businessId)
             ->whereNull('deleted_at')

--- a/Modules/KB/Services/KbBridgeStateService.php
+++ b/Modules/KB/Services/KbBridgeStateService.php
@@ -21,6 +21,7 @@ class KbBridgeStateService
 {
     public function getLastBridgeAt(int $businessId): ?Carbon
     {
+        // SUPERADMIN: estado do bridge é lido por cron/job sem sessão — business_id explícito no WHERE
         $state = KbBridgeState::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->first();
@@ -39,6 +40,7 @@ class KbBridgeStateService
             'edges_derived'   => $edgesDerived,
             'has_error'       => $error !== null,
         ], function () use ($businessId, $docsProcessed, $edgesDerived, $error) {
+            // SUPERADMIN: estado do bridge é gravado por cron/job sem sessão — business_id explícito na chave
             KbBridgeState::withoutGlobalScopes()->updateOrCreate(
                 ['business_id' => $businessId],
                 [

--- a/Modules/KB/Services/KbEdgeAutoDeriver.php
+++ b/Modules/KB/Services/KbEdgeAutoDeriver.php
@@ -63,6 +63,7 @@ class KbEdgeAutoDeriver
                 }
 
                 // Resolve o slug pra um kb_node já bridgeado.
+                // SUPERADMIN: rodando dentro do bridge job (sem sessão) — business_id explícito no WHERE
                 $targetNode = KbNode::withoutGlobalScopes()
                     ->where('business_id', $node->business_id)
                     ->where('slug', $slug)
@@ -116,6 +117,7 @@ class KbEdgeAutoDeriver
         ], function () use ($node, $tags) {
             // Encontra outros nodes do mesmo business com 2+ tags em comum.
             // SQL: lista nodes que tem JSON_CONTAINS pra qualquer das tags.
+            // SUPERADMIN: rodando dentro do bridge job (sem sessão) — business_id explícito no WHERE
             $candidates = KbNode::withoutGlobalScopes()
                 ->where('business_id', $node->business_id)
                 ->where('id', '<>', $node->id)
@@ -174,6 +176,7 @@ class KbEdgeAutoDeriver
 
         // Busca ADR cujo slug começa com NNNN-
         $padded = str_pad($needle, 4, '0', STR_PAD_LEFT);
+        // SUPERADMIN: rodando dentro do bridge job (sem sessão) — business_id explícito no WHERE
         $targetNode = KbNode::withoutGlobalScopes()
             ->where('business_id', $node->business_id)
             ->where('type', 'adr')
@@ -232,6 +235,7 @@ class KbEdgeAutoDeriver
             'node_id'     => $node->id,
             'refs_count'  => count($ids),
         ], function () use ($node, $ids) {
+            // SUPERADMIN: rodando dentro do bridge job (sem sessão) — business_id explícito no WHERE
             $targets = KbNode::withoutGlobalScopes()
                 ->where('business_id', $node->business_id)
                 ->whereIn('id', $ids)
@@ -275,6 +279,7 @@ class KbEdgeAutoDeriver
         }
 
         try {
+            // SUPERADMIN: upsert idempotente dentro do bridge job (sem sessão) — business_id explícito na chave
             KbEdge::withoutGlobalScopes()->updateOrCreate(
                 [
                     'business_id'  => $businessId,


### PR DESCRIPTION
## O quê

Anota cada chamada `withoutGlobalScopes()` em código de produção dos módulos **KB / NFSe / Crm / Arquivos** com `// SUPERADMIN: <razão verdadeira>`, conforme **ADR 0093** (multi-tenant Tier 0 IRREVOGÁVEL) e o guard estático `tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php` (exige `SUPERADMIN` na mesma linha ou até 3 linhas acima). Tarefa SDD **US-GOV-019**.

## Escopo real por módulo

| Módulo | Call-sites prod | Anotados aqui | Nota |
|---|---|---|---|
| **KB** | 18 | **11 novos** | Jobs/cron sem sessão (business_id explícito) + 2 controllers onde o node já foi validado ao tenant via `firstOrFail()` antes do bypass. KbCorpusBuilder/KbRagService já anotados em #2679. |
| **NFSe** | 4 | 0 | Já 100% coberto por #2679 (EmitirNfseJob + NfseEmissaoService). |
| **Crm** | 0 | 0 | Nenhuma chamada Eloquent `withoutGlobalScopes` em produção — apenas docblocks documentando a política. |
| **Arquivos** | 0 | 0 | Nenhuma chamada Eloquent. `ExportZipCommand` usa `DB::table` direto (CLI com `--business` explícito), fora do escopo do guard. |

## Justificativas adicionadas (KB)

- **Jobs / cron** (`KbEdgeAutoDeriverJob`, `KbBridgeFromMcpJob`, `KbBridgeStateService`, `KbEdgeAutoDeriver` ×5): rodam em fila/cron sem sessão; o `business_id` é sempre passado explicitamente no `WHERE`/chave (vem do construtor do job ou de `$node->business_id`).
- **Controllers** (`KbFavoriteController`, `KbVersionController`): o `KbNode` é carregado via `KbNode::query()->...->firstOrFail()` (scope aplicado, validado ao tenant da sessão) **antes** do bypass; o lookup subsequente é limitado por `node_id` (já-validado) + `user_id`/`version_id`, então não atravessa tenant.

## Verificação

Re-grep nos 4 módulos + replay da lógica exata do guard → **20 call-sites de produção, 0 violações**. Pest completo **não** rodado (guard validado por replay de grep, conforme escopo da tarefa).

## SUSPECTED LEAKs

Nenhum. Todos os bypasses são legítimos (superadmin/CLI/job-sem-sessão/cross-tenant-validado).

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)