### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — PaymentGateway (US-GOV-019)

### DIFF
--- a/Modules/PaymentGateway/Console/Commands/EmitTrialExpiredCobrancasCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/EmitTrialExpiredCobrancasCommand.php
@@ -57,6 +57,7 @@ class EmitTrialExpiredCobrancasCommand extends Command
 
         // 1. Pré-condições Wagner biz=1 — canon Onda 5 (Wagner 2026-05-19):
         // resolve via payment_gateway_credentials.conta_bancaria_id (wizard step 3)
+        // SUPERADMIN: cron diário sem sessão; resolve a credencial BCB de cobrança do operador (biz=1, Wagner) que emite as mensalidades SaaS.
         $credencial = PaymentGatewayCredential::query()
             ->withoutGlobalScopes()
             ->where('business_id', 1)
@@ -96,6 +97,7 @@ class EmitTrialExpiredCobrancasCommand extends Command
         $failed = 0;
 
         foreach ($candidates as $subscription) {
+            // SUPERADMIN: cron sem sessão; checa cobrança ativa da Subscription cross-tenant pela origem (cobrança vive em biz=1, Subscription pertence ao tenant alvo).
             $hasCobrancaAtiva = Cobranca::query()
                 ->withoutGlobalScopes()
                 ->where('origem_type', 'subscription_license')
@@ -119,6 +121,7 @@ class EmitTrialExpiredCobrancasCommand extends Command
 
             try {
                 DB::transaction(function () use ($subscription, $account): void {
+                    // SUPERADMIN: cross-tenant intencional — resolve o Business do tenant alvo (outro business_id) só pra montar o descritivo/payer da cobrança SaaS emitida por biz=1.
                     $tenant = Business::withoutGlobalScopes()->find($subscription->business_id);
                     if (!$tenant) {
                         throw new \RuntimeException('Business tenant #' . $subscription->business_id . ' não encontrado');

--- a/Modules/PaymentGateway/Console/Commands/InterImportarRecebimentosCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/InterImportarRecebimentosCommand.php
@@ -50,6 +50,7 @@ class InterImportarRecebimentosCommand extends Command
             $this->warn('[dry-run] Nada será gravado no Financeiro.');
         }
 
+        // SUPERADMIN: comando CLI sem sessão web; resolve a credencial Inter do business_id passado via --business (default 1 = WR2).
         $cred = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'inter')
@@ -100,6 +101,7 @@ class InterImportarRecebimentosCommand extends Command
                 continue;
             }
 
+            // SUPERADMIN: CLI sem sessão; dedup do título importado filtrando pelo business_id do --business.
             $jaExiste = Titulo::withoutGlobalScopes()
                 ->where('business_id', $businessId)
                 ->where('metadata->inter_ref', $refId)

--- a/Modules/PaymentGateway/Console/Commands/InterReconcilePixCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/InterReconcilePixCommand.php
@@ -63,6 +63,7 @@ class InterReconcilePixCommand extends Command
             $this->warn('[dry-run] Nenhuma cobrança será marcada paga.');
         }
 
+        // SUPERADMIN: cron/CLI sem sessão web; varre credenciais Inter ativas de todos os tenants (ou do --business filtrado) pra polling de reconciliação.
         $credsQuery = PaymentGatewayCredential::query()
             ->withoutGlobalScopes()
             ->where('gateway_key', 'inter')
@@ -85,6 +86,7 @@ class InterReconcilePixCommand extends Command
         $errors = 0;
 
         foreach ($creds as $cred) {
+            // SUPERADMIN: CLI sem sessão; lista cobranças PIX emitidas filtrando pelo business_id da credencial sendo reconciliada.
             $cobrancas = Cobranca::query()
                 ->withoutGlobalScopes()
                 ->where('business_id', $cred->business_id)

--- a/Modules/PaymentGateway/Console/Commands/MigrateCredentialsCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/MigrateCredentialsCommand.php
@@ -82,6 +82,7 @@ class MigrateCredentialsCommand extends Command
             }
 
             // Idempotência: tenta achar PG cred com mesma (business, gateway, ambiente).
+            // SUPERADMIN: comando de backfill CLI sem sessão; itera credenciais legacy de todos os tenants e checa duplicata por business_id de cada linha.
             $existing = PaymentGatewayCredential::query()
                 ->withoutGlobalScopes()
                 ->where('business_id', $row->business_id)

--- a/Modules/PaymentGateway/Console/Commands/RetryOrphanWebhookCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/RetryOrphanWebhookCommand.php
@@ -36,6 +36,7 @@ class RetryOrphanWebhookCommand extends Command
         if ($dryRun) {
             $this->warn('[dry-run] Nenhum CobrancaPaga será dispatchado.');
 
+            // SUPERADMIN: comando CLI roda sem sessão web; --dry-run lista webhook events órfãos de todos os tenants pra Wagner inspecionar antes do cutover.
             $orphans = GatewayWebhookEvent::query()
                 ->withoutGlobalScopes()
                 ->whereNull('processed_at')

--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -174,6 +174,7 @@ class PaymentGatewaysController extends Controller
         }
 
         // Anti-dupla — (business_id, gateway_key, ambiente) é unique no schema
+        // SUPERADMIN: checa a UNIQUE (business_id, gateway_key, ambiente) reaplicando o business_id derivado da sessão (NUNCA do payload), pra a mensagem casar exatamente com a constraint do banco.
         $duplicate = PaymentGatewayCredential::query()
             ->withoutGlobalScopes()
             ->where('business_id', $businessId)

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/AsaasWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/AsaasWebhookController.php
@@ -34,6 +34,7 @@ class AsaasWebhookController extends Controller
 
     public function handle(Request $request, int $businessId): JsonResponse
     {
+        // SUPERADMIN: webhook externo (Asaas) chega sem sessão autenticada; resolve a credencial pelo businessId da rota e valida assinatura antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'asaas')

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/BcbPixWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/BcbPixWebhookController.php
@@ -39,6 +39,7 @@ class BcbPixWebhookController extends Controller
 
     public function handle(Request $request, int $businessId): JsonResponse
     {
+        // SUPERADMIN: webhook externo (BCB/PSP) sem sessão autenticada; resolve a credencial pelo businessId da rota e valida mTLS antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'bcb_pix')

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/C6WebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/C6WebhookController.php
@@ -30,6 +30,7 @@ class C6WebhookController extends Controller
 
     public function handle(Request $request, int $businessId): JsonResponse
     {
+        // SUPERADMIN: webhook externo (C6) sem sessão autenticada; resolve a credencial pelo businessId da rota e valida HMAC antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'c6')

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/InterPixWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/InterPixWebhookController.php
@@ -54,6 +54,7 @@ class InterPixWebhookController extends Controller
     public function handle(Request $request, int $credentialId): JsonResponse
     {
         // 1. Resolve credencial (withoutGlobalScopes — webhook não tem sessão)
+        // SUPERADMIN: webhook externo (Inter PIX) sem sessão autenticada; resolve a credencial pelo credentialId da rota e valida HMAC antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('id', $credentialId)
             ->where('gateway_key', 'inter')

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/InterWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/InterWebhookController.php
@@ -35,6 +35,7 @@ class InterWebhookController extends Controller
 
     public function handle(Request $request, int $businessId): JsonResponse
     {
+        // SUPERADMIN: webhook externo (Inter legacy) sem sessão autenticada; resolve a credencial pelo businessId da rota e valida HMAC antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'inter')

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/PagarmeWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/PagarmeWebhookController.php
@@ -43,6 +43,7 @@ class PagarmeWebhookController extends Controller
     {
         // 1. Resolve credencial Pagar.me ATIVA do business (withoutGlobalScopes —
         //    webhook não tem sessão autenticada).
+        // SUPERADMIN: webhook externo (Pagar.me) sem sessão autenticada; resolve a credencial pelo businessId da rota e valida HMAC antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'pagarme')

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/SicoobApiWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/SicoobApiWebhookController.php
@@ -51,6 +51,7 @@ class SicoobApiWebhookController extends Controller
 
     public function handle(Request $request, int $businessId): JsonResponse
     {
+        // SUPERADMIN: webhook externo (Sicoob API) sem sessão autenticada; resolve a credencial pelo businessId da rota e valida HMAC antes de qualquer write.
         $credential = PaymentGatewayCredential::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('gateway_key', 'sicoob_api')

--- a/Modules/PaymentGateway/Jobs/CnabRetornoProcessor.php
+++ b/Modules/PaymentGateway/Jobs/CnabRetornoProcessor.php
@@ -80,6 +80,7 @@ class CnabRetornoProcessor implements ShouldQueue
         ];
         $erros = [];
 
+        // SUPERADMIN: queue worker sem session(); resolve a credencial pelo credentialId recebido no constructor e deriva business_id dela pra filtrar tudo a seguir.
         $cred = PaymentGatewayCredential::query()
             ->withoutGlobalScopes()
             ->find($this->credentialId);
@@ -189,6 +190,7 @@ class CnabRetornoProcessor implements ShouldQueue
 
         $tipo = (int) $detalhe->getOcorrenciaTipo();
 
+        // SUPERADMIN: job worker sem session(); casa o detalhe CNAB com a Cobranca filtrando pelo business_id da credencial do arquivo de retorno.
         $cobranca = Cobranca::query()
             ->withoutGlobalScopes() // ADR 0093 — Job worker sem session, filtra manualmente
             ->where('business_id', $cred->business_id) // Tier 0 explícito
@@ -336,6 +338,7 @@ class CnabRetornoProcessor implements ShouldQueue
         }
 
         try {
+            // SUPERADMIN: job worker sem session(); atualiza o registro de upload CNAB pelo uploadId recebido no constructor (mesmo tenant do arquivo).
             $upload = CnabRetornoUpload::query()->withoutGlobalScopes()->find($this->uploadId);
             if (! $upload) {
                 return;

--- a/Modules/PaymentGateway/Jobs/ProcessarWebhookPixInterJob.php
+++ b/Modules/PaymentGateway/Jobs/ProcessarWebhookPixInterJob.php
@@ -66,6 +66,7 @@ class ProcessarWebhookPixInterJob implements ShouldQueue
 
     public function handle(ReconciliarCobrancaService $reconciliador): void
     {
+        // SUPERADMIN: queue worker não tem session(); carrega o InterWebhookLog filtrando pelo business_id propagado no constructor (ADR 0093).
         $log = InterWebhookLog::withoutGlobalScopes()
             ->where('id', $this->interWebhookLogId)
             ->where('business_id', $this->businessId)
@@ -86,6 +87,7 @@ class ProcessarWebhookPixInterJob implements ShouldQueue
 
         try {
             // Resolve Cobranca pelo txid + credencial (mesmo gateway_external_id)
+            // SUPERADMIN: queue worker sem session(); resolve a Cobranca pelo business_id propagado no constructor.
             $cobranca = Cobranca::withoutGlobalScopes()
                 ->where('business_id', $this->businessId)
                 ->where('payment_gateway_credential_id', $log->payment_gateway_credential_id)

--- a/Modules/PaymentGateway/Jobs/RetryOrphanWebhookJob.php
+++ b/Modules/PaymentGateway/Jobs/RetryOrphanWebhookJob.php
@@ -91,6 +91,7 @@ class RetryOrphanWebhookJob implements ShouldQueue
     public function handle(): void
     {
         // Janela: órfãos entre 1h e 24h (espera fluxo original + cutoff manual)
+        // SUPERADMIN: cron job worker roda sem sessão web; varre webhook events órfãos de TODOS os tenants e re-dispatcha por business_id explícito de cada linha.
         $orphans = GatewayWebhookEvent::query()
             ->withoutGlobalScopes() // Job sem sessão — ADR 0093 explicit
             ->whereNull('processed_at')
@@ -143,6 +144,7 @@ class RetryOrphanWebhookJob implements ShouldQueue
             return;
         }
 
+        // SUPERADMIN: job worker sem sessão; resolve a Cobranca do evento órfão filtrando pelo business_id derivado da própria linha do webhook.
         $cobranca = Cobranca::withoutGlobalScopes()
             ->where('id', $orphan->cobranca_id)
             ->where('business_id', $businessId)

--- a/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
+++ b/Modules/PaymentGateway/Services/ReconciliarCobrancaService.php
@@ -85,6 +85,7 @@ class ReconciliarCobrancaService
      */
     private function marcarTitulosQuitados(int $businessId, int $cobrancaId): void
     {
+        // SUPERADMIN: chamado por job/command sem sessão (caller passa businessId explícito); quita títulos vinculados filtrando por esse business_id.
         $titulos = Titulo::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('origem', 'manual')


### PR DESCRIPTION
## US-GOV-019 — `// SUPERADMIN:` nos bypass de global scope (PaymentGateway)

Anota **todas** as chamadas `withoutGlobalScopes(` em código de produção do módulo `Modules/PaymentGateway/` com o comentário auditável `// SUPERADMIN: <razão>` exigido pelo guard estático `tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php` (ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL).

Modelo seguido: `Modules/Vestuario/Services/VestuarioSettingsResolver.php`.

### Resumo
- **Chamadas de produção encontradas:** 25 (em 17 arquivos; Tests/ não contam — excluídos pelo guard)
- **Comentários `// SUPERADMIN:` adicionados:** 25
- **SUSPECTED LEAK:** nenhum
- Mudança 100% aditiva — só comentários, zero alteração de lógica (17 files, +25 linhas)

### Arquivos + linhas anotados

**Jobs (queue worker — sem session(), business_id explícito):**
- `Jobs/RetryOrphanWebhookJob.php` — varredura de órfãos (todos tenants) + resolução de Cobranca por business_id da linha
- `Jobs/ProcessarWebhookPixInterJob.php` — InterWebhookLog + Cobranca por business_id propagado no constructor
- `Jobs/CnabRetornoProcessor.php` — credencial por credentialId, Cobranca/Upload por business_id do arquivo (3 calls)

**Console Commands (CLI/cron — sem sessão web):**
- `Console/Commands/RetryOrphanWebhookCommand.php` — `--dry-run` inspeção cross-tenant
- `Console/Commands/MigrateCredentialsCommand.php` — backfill itera credenciais legacy de todos tenants
- `Console/Commands/InterReconcilePixCommand.php` — polling reconciliação por credencial (2 calls)
- `Console/Commands/InterImportarRecebimentosCommand.php` — import biz=1 (--business), dedup por business_id (2 calls)
- `Console/Commands/EmitTrialExpiredCobrancasCommand.php` — cron SaaS: credencial biz=1 + cobrança/Business **cross-tenant intencional** (3 calls)

**Webhooks (chamados externamente pelos gateways — sem sessão; resolvem credencial pelo param da rota antes de validar assinatura):**
- `Http/Controllers/Webhooks/{Asaas,BcbPix,C6,InterPix,Inter,Pagarme,SicoobApi}WebhookController.php` (7 calls)

**Service / Settings:**
- `Services/ReconciliarCobrancaService.php` — caller (job/command) passa businessId explícito
- `Http/Controllers/Settings/PaymentGatewaysController.php` — anti-dupla reaplica business_id **da sessão** (nunca do payload) pra casar com a UNIQUE do banco

### Verificação
Guard é teste estático puro (não toca DB). Replica exata do algoritmo do guard (mesmo regex, mesma janela de 3 linhas acima + mesma linha, mesmas exclusões Tests/Database/Config) sobre o módulo: **25 call sites, 0 violations**. Suíte Pest completa não rodada (exige MySQL) — verificação é o grep estático do guard, conforme escopo da task.

### SUSPECTED LEAK
Nenhum. Todas as 25 chamadas são bypass legítimo (queue worker / CLI / webhook externo / cross-tenant de sistema), sempre com filtro `business_id` explícito derivado de fonte confiável (constructor do job, credencial resolvida, param da rota, ou sessão — nunca do payload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
