### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — NfeBrasil/ComVis (US-GOV-019)

### DIFF
--- a/Modules/ComunicacaoVisual/Console/Commands/DemoSeedCommand.php
+++ b/Modules/ComunicacaoVisual/Console/Commands/DemoSeedCommand.php
@@ -96,6 +96,7 @@ class DemoSeedCommand extends Command
         // ----------------------------------------------------------------
         // 3. Garantir materiais seeded (≥ 5 para este business)
         // ----------------------------------------------------------------
+        // SUPERADMIN: CLI sem session HTTP; $bizId vem de --business validado (linhas 63-92).
         $totalMateriais = Material::withoutGlobalScopes()
             ->where('business_id', $bizId)
             ->count();
@@ -201,6 +202,7 @@ class DemoSeedCommand extends Command
         $calculado = $calc->calcular($payload);
 
         // Criar Orcamento via withoutGlobalScopes (CLI sem session real de HTTP)
+        // SUPERADMIN: CLI sem session; business_id => $bizId explícito (--business validado).
         $orcamento = Orcamento::withoutGlobalScopes()->create([
             'business_id'      => $bizId,
             'numero'           => $numOrc,
@@ -220,6 +222,7 @@ class DemoSeedCommand extends Command
 
         // Criar OrcamentoItens
         foreach ($calculado['itens'] as $ordem => $itemCalc) {
+            // SUPERADMIN: CLI sem session; business_id => $bizId explícito (--business validado).
             OrcamentoItem::withoutGlobalScopes()->create([
                 'orcamento_id'     => $orcamento->id,
                 'business_id'      => $bizId,
@@ -239,6 +242,7 @@ class DemoSeedCommand extends Command
         // ----------------------------------------------------------------
         // 8. Criar OS vinculada ao orçamento
         // ----------------------------------------------------------------
+        // SUPERADMIN: CLI sem session; business_id => $bizId explícito (--business validado).
         $os = Os::withoutGlobalScopes()->create([
             'business_id'  => $bizId,
             'orcamento_id' => $orcamento->id,
@@ -255,6 +259,7 @@ class DemoSeedCommand extends Command
         // 9. Criar Apontamento via ApontamentoTracker (90 min de produção)
         //    m2_produzido=4.5 (banner 3×1.5×1) — drift=0% contra m2_orcado=4.5
         // ----------------------------------------------------------------
+        // SUPERADMIN: CLI sem session; $orcamento já criado neste $bizId acima.
         $primeiroItem = OrcamentoItem::withoutGlobalScopes()
             ->where('orcamento_id', $orcamento->id)
             ->orderBy('ordem')
@@ -385,6 +390,7 @@ class DemoSeedCommand extends Command
      */
     private function buscarMaterial(int $bizId, string $nome): ?int
     {
+        // SUPERADMIN: CLI sem session; filtra por $bizId explícito (--business validado).
         return Material::withoutGlobalScopes()
             ->where('business_id', $bizId)
             ->where('nome', $nome)

--- a/Modules/NfeBrasil/Console/Commands/NfeHealthCommand.php
+++ b/Modules/NfeBrasil/Console/Commands/NfeHealthCommand.php
@@ -193,6 +193,7 @@ class NfeHealthCommand extends Command
     private function checkCertificado(int $bizId): array
     {
         try {
+            // SUPERADMIN: health-check CLI varre todos os businesses; filtra por $bizId explícito (sem session HTTP).
             $cert = NfeCertificado::withoutGlobalScopes()
                 ->where('business_id', $bizId)
                 ->ativos()
@@ -225,6 +226,7 @@ class NfeHealthCommand extends Command
     private function checkUltimaEmissao(int $bizId): array
     {
         try {
+            // SUPERADMIN: health-check CLI varre todos os businesses; filtra por $bizId explícito (sem session HTTP).
             $ultima = NfeEmissao::withoutGlobalScopes()
                 ->where('business_id', $bizId)
                 ->whereNotNull('emitido_em')

--- a/Modules/NfeBrasil/Jobs/CancelarNfeJob.php
+++ b/Modules/NfeBrasil/Jobs/CancelarNfeJob.php
@@ -53,6 +53,7 @@ class CancelarNfeJob implements ShouldQueue
     {
         // ── 1. Carregar TransactionDocument (sem global scope p/ cross-tenant
         //      guard explícito — defesa em profundidade ADR 0093) ────────────
+        // SUPERADMIN: job em fila não tem session; valida business_id explicitamente abaixo (linha ~66).
         $doc = TransactionDocument::withoutGlobalScopes()->find($this->transactionDocumentId);
 
         if (! $doc) {
@@ -105,6 +106,7 @@ class CancelarNfeJob implements ShouldQueue
             return;
         }
 
+        // SUPERADMIN: job em fila sem session; $doc já passou no guard de business_id (linha ~66).
         $emissao = NfeEmissao::withoutGlobalScopes()->find($doc->doc_id);
         if (! $emissao) {
             Log::warning('CancelarNfeJob: NfeEmissao não encontrada', [

--- a/Modules/NfeBrasil/Jobs/CancelarNfseJob.php
+++ b/Modules/NfeBrasil/Jobs/CancelarNfseJob.php
@@ -62,6 +62,7 @@ class CancelarNfseJob implements ShouldQueue
     {
         // ── 1. Carregar TransactionDocument sem global scope p/ cross-tenant
         //      guard explícito (defesa em profundidade ADR 0093) ────────────
+        // SUPERADMIN: job em fila não tem session; valida business_id explicitamente abaixo (linha ~75).
         $doc = TransactionDocument::withoutGlobalScopes()->find($this->transactionDocumentId);
 
         if (! $doc) {
@@ -109,6 +110,7 @@ class CancelarNfseJob implements ShouldQueue
             return;
         }
 
+        // SUPERADMIN: job em fila sem session; $doc já passou no guard de business_id (linha ~75).
         $emissao = NfseEmissao::withoutGlobalScopes()->find($doc->doc_id);
         if (! $emissao) {
             Log::warning('CancelarNfseJob: NfseEmissao não encontrada', [

--- a/Modules/NfeBrasil/Jobs/EmitirNFSeJob.php
+++ b/Modules/NfeBrasil/Jobs/EmitirNFSeJob.php
@@ -71,6 +71,7 @@ class EmitirNFSeJob implements ShouldQueue
         ]);
 
         // STEP 1 · cria registro multi-tenant (scope global garante biz match)
+        // SUPERADMIN: job em fila sem session; business_id => $this->businessId explícito (constructor).
         $emissao = NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)->create([
             'business_id'    => $this->businessId,
             'transaction_id' => $this->transactionId,
@@ -103,6 +104,7 @@ class EmitirNFSeJob implements ShouldQueue
         ]);
 
         if ($this->emissaoId !== null) {
+            // SUPERADMIN: callback failed() em fila sem session; atualiza emissão criada por este próprio job.
             NfseEmissao::withoutGlobalScope(ScopeByBusiness::class)
                 ->where('id', $this->emissaoId)
                 ->update([

--- a/Modules/NfeBrasil/Services/CertificadoService.php
+++ b/Modules/NfeBrasil/Services/CertificadoService.php
@@ -236,6 +236,8 @@ class CertificadoService
         // Único lugar autorizado no codebase a escapar do tenant scope em nfe_certificados.
         // Pest test `CertificadoFallbackInstitucionalTest` valida que não há outras
         // ocorrências de `withoutGlobalScope(ScopeByBusiness::class)` apontando pra esse model.
+        // SUPERADMIN: cross-tenant DELIBERADO — lê cert institucional (biz=$fallbackBusinessId) pra
+        // tenants sem cert próprio; filtra por business_id explícito + audita em mcp_audit_log.
         $certInstitucional = NfeCertificado::withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
             ->where('business_id', $fallbackBusinessId)
             ->where('ativo', true)

--- a/Modules/NfeBrasil/Services/NfeCartaCorrecaoService.php
+++ b/Modules/NfeBrasil/Services/NfeCartaCorrecaoService.php
@@ -70,6 +70,7 @@ class NfeCartaCorrecaoService
     ): NfeEvento {
         $this->validarEntrada($businessId, $textoCorrecao, $nSeqEvento);
 
+        // SUPERADMIN: $businessId vem por parâmetro (não session); cross-tenant guard explícito abaixo (linha ~78).
         $emissao = NfeEmissao::withoutGlobalScopes()->find($nfeEmissaoId);
         if (! $emissao) {
             throw new RuntimeException("NfeEmissao {$nfeEmissaoId} não encontrada.");
@@ -96,6 +97,7 @@ class NfeCartaCorrecaoService
         }
 
         // Idempotência: mesma (emissao_id, n_seq_evento) → retorna evento existente autorizado
+        // SUPERADMIN: filtra por $businessId explícito (param, não session) — defesa em profundidade ADR 0093.
         $eventoExistente = NfeEvento::withoutGlobalScopes()
             ->where('business_id', $businessId)
             ->where('emissao_id', $emissao->id)

--- a/Modules/NfeBrasil/Services/NfseCancelService.php
+++ b/Modules/NfeBrasil/Services/NfseCancelService.php
@@ -75,6 +75,7 @@ class NfseCancelService
 
         // ── 2. Carregar emissão SEM global scope pra fazer cross-tenant guard
         //      explícito (defesa em profundidade ADR 0093) ───────────────────
+        // SUPERADMIN: $businessId vem por parâmetro (não session); cross-tenant guard explícito abaixo (linha ~83).
         $nfse = NfseEmissao::withoutGlobalScopes()->find($nfseEmissaoId);
         if (! $nfse) {
             throw new RuntimeException("NfseEmissao {$nfseEmissaoId} não encontrada.");
@@ -89,6 +90,7 @@ class NfseCancelService
 
         // ── 3. Idempotência — emissão já cancelled retorna evento existente ─
         if ($nfse->status === NfseEmissao::STATUS_CANCELLED) {
+            // SUPERADMIN: $nfse já validado no guard cross-tenant acima; filtra por nfse_emissao_id desse tenant.
             $existente = NfseEventoCancelamento::withoutGlobalScopes()
                 ->where('nfse_emissao_id', $nfse->id)
                 ->where('status', NfseEventoCancelamento::STATUS_AUTORIZADO)


### PR DESCRIPTION
## O quê

Anota **todas** as chamadas `withoutGlobalScopes()` / `withoutGlobalScope()` em código de **produção** dos módulos **NfeBrasil** e **ComunicacaoVisual** com `// SUPERADMIN: <razão>`, satisfazendo o guard estático `tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php` (ADR 0093 multi-tenant Tier 0 IRREVOGÁVEL).

US-GOV-019. Modelo: `Modules/Vestuario/Services/VestuarioSettingsResolver.php`.

## Escopo

- **chamadas_encontradas (produção, excl Tests/Database/Config):** 19 — 16 plural + 3 singular
- **comentários adicionados:** 16 (3 já tinham SUPERADMIN próximo: ApontamentoTracker, OrcamentoController, DemoSeedCommand:279, NfeService #2679)
- **suspected_leaks:** nenhum

## Por que cada bypass é legítimo

| Arquivo | Razão |
|---|---|
| `NfeBrasil/Jobs/CancelarNfeJob` · `CancelarNfseJob` | Job em fila (sem session); `businessId` no constructor + **cross-tenant guard explícito** (aborta em divergência). |
| `NfeBrasil/Jobs/EmitirNFSeJob` | Job em fila; `business_id => $this->businessId` no `create`; `failed()` atualiza emissão criada pelo próprio job. |
| `NfeBrasil/Services/NfeCartaCorrecaoService` · `NfseCancelService` | `businessId` por parâmetro + **cross-tenant guard explícito** (lança `UnauthorizedActionException`). |
| `NfeBrasil/Console/NfeHealthCommand` | Health-check CLI varre todos os businesses; filtra por `$bizId` explícito. |
| `NfeBrasil/Services/CertificadoService` | Cross-tenant **deliberado** — cert institucional fallback (ADR 0186); filtra `business_id` + audita em `mcp_audit_log`. |
| `ComVis/Console/DemoSeedCommand` | CLI demo-seed; `--business` validado; `business_id` explícito em todo create/query. |

Sobre o alerta NfeBrasil (dados fiscais CPF/CNPJ): nenhum bypass aqui fura `business_id` por compliance — cada caso é fila/CLI/cross-tenant deliberado com `business_id` explícito.

## Validação

- Réplica fiel da lógica do guard (coleta + exclusões + janela 3 linhas) → **0 violações** plural; **3/3** singular OK.
- `vendor/` ausente no worktree → suite Pest completa não roda aqui (conforme processo: usar grep, não rodar Pest). CI roda o guard real.
- Diff: **comment-only**, 20 inserções, 0 deleções, 0 mudança de lógica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)