### PR TITLE
docs(prototipo-ui): Thread de Envio handoff artifact (Cowork export)

### DIFF
--- a/prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/Thread de Envio - Protocolo por Etapas.html
+++ b/prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/Thread de Envio - Protocolo por Etapas.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<html lang="pt-BR" data-theme="dark">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Thread de envio · protocolo por etapas</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root{
+  --bg: oklch(0.992 0.0015 95); --sunken: oklch(0.974 0.003 95); --surface: oklch(1 0 0);
+  --hairline: oklch(0.935 0.003 95); --border: oklch(0.905 0.004 95); --border-2: oklch(0.95 0.003 95);
+  --text: oklch(0.205 0.008 90); --text-2: oklch(0.46 0.007 90); --text-3: oklch(0.63 0.006 90); --text-4: oklch(0.74 0.005 90);
+  --accent: oklch(0.55 0.15 295); --accent-hi: oklch(0.50 0.16 295); --accent-soft: oklch(0.965 0.022 295); --accent-fg: #fff;
+  --pos: oklch(0.50 0.12 150); --pos-soft: oklch(0.95 0.075 150);
+  --neg: oklch(0.55 0.18 25);  --neg-soft: oklch(0.955 0.055 25);
+  --warn: oklch(0.62 0.13 65); --warn-soft: oklch(0.955 0.072 75);
+  --info: oklch(0.55 0.13 240); --info-soft: oklch(0.95 0.04 240);
+  --sh-1: 0 1px 1px oklch(0.25 0.02 280/.05), 0 2px 4px -1px oklch(0.25 0.02 280/.07);
+  --sh-2: 0 2px 4px -2px oklch(0.25 0.02 280/.06), 0 6px 16px -5px oklch(0.25 0.02 280/.11);
+  --r-2: 8px; --r-3: 11px; --r-4: 16px;
+  --sans: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif; --mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+}
+[data-theme="dark"]{
+  --bg: oklch(0.165 0.008 282); --sunken: oklch(0.142 0.008 282); --surface: oklch(0.205 0.009 282);
+  --hairline: oklch(0.27 0.010 282); --border: oklch(0.30 0.012 282); --border-2: oklch(0.25 0.010 282);
+  --text: oklch(0.965 0.004 282); --text-2: oklch(0.74 0.008 282); --text-3: oklch(0.58 0.009 282); --text-4: oklch(0.47 0.009 282);
+  --accent: oklch(0.72 0.15 295); --accent-hi: oklch(0.78 0.15 295); --accent-soft: oklch(0.30 0.07 295); --accent-fg: oklch(0.14 0.02 295);
+  --pos: oklch(0.74 0.14 150); --pos-soft: oklch(0.30 0.085 150);
+  --neg: oklch(0.72 0.16 25);  --neg-soft: oklch(0.32 0.09 25);
+  --warn: oklch(0.80 0.13 75); --warn-soft: oklch(0.32 0.085 70);
+  --info: oklch(0.72 0.13 240); --info-soft: oklch(0.30 0.07 240);
+  --sh-1: 0 1px 2px oklch(0 0 0/.3); --sh-2: 0 3px 8px -3px oklch(0 0 0/.42), 0 8px 20px -6px oklch(0 0 0/.4);
+}
+*{ box-sizing: border-box; }
+html,body{ margin: 0; }
+body{ background: var(--bg); color: var(--text); font-family: var(--sans); -webkit-font-smoothing: antialiased; line-height: 1.5; }
+
+.top{ position: sticky; top: 0; z-index: 10; display: flex; align-items: center; gap: 14px; padding: 14px 32px; background: color-mix(in oklch, var(--bg) 86%, transparent); backdrop-filter: blur(10px); border-bottom: 1px solid var(--border); }
+.logo{ width: 30px; height: 30px; border-radius: 8px; background: linear-gradient(135deg, var(--accent), color-mix(in oklch, var(--accent) 60%, var(--text))); display: grid; place-items: center; color: var(--accent-fg); font-weight: 700; font-size: 13px; }
+.top b.tt{ font-size: 15px; font-weight: 600; letter-spacing: -0.01em; }
+.top .stamp{ font-family: var(--mono); font-size: 10.5px; color: var(--accent); background: var(--accent-soft); padding: 3px 9px; border-radius: 999px; font-weight: 600; }
+[data-theme="dark"] .top .stamp{ color: var(--accent-hi); }
+.theme{ margin-left: auto; appearance: none; cursor: pointer; font: inherit; display: inline-flex; align-items: center; gap: 8px; height: 32px; padding: 0 13px; border-radius: 9px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 12px; font-weight: 500; }
+
+.wrap{ max-width: 880px; margin: 0 auto; padding: 36px 32px 90px; }
+.docmeta{ display: flex; flex-wrap: wrap; gap: 8px 18px; font-family: var(--mono); font-size: 10.5px; color: var(--text-4); margin-bottom: 20px; }
+.docmeta b{ color: var(--text-2); }
+h1.title{ font-size: 27px; font-weight: 600; letter-spacing: -0.03em; margin: 0 0 13px; line-height: 1.16; }
+h1.title em{ font-style: normal; color: var(--accent); }
+.lede{ font-size: 14.5px; line-height: 1.6; color: var(--text-2); margin: 0; }
+.lede b{ color: var(--text); font-weight: 600; }
+
+/* thread rail */
+.thread{ position: relative; margin-top: 28px; padding-left: 34px; }
+.thread::before{ content:""; position: absolute; left: 11px; top: 6px; bottom: 30px; width: 2px; background: linear-gradient(180deg, var(--accent), var(--info), var(--pos)); border-radius: 2px; }
+.msg{ position: relative; margin-bottom: 22px; }
+.msg::before{ content: attr(data-n); position: absolute; left: -34px; top: 0; width: 24px; height: 24px; border-radius: 50%; background: var(--surface); border: 2px solid var(--accent); color: var(--accent); display: grid; place-items: center; font: 700 11px/1 var(--mono); }
+[data-theme="dark"] .msg::before{ color: var(--accent-hi); border-color: var(--accent-hi); }
+.msg.gate::before{ border-color: var(--neg); color: var(--neg); content: "🔒"; font-size: 10px; }
+.msg.you::before{ border-color: var(--warn); color: var(--warn); }
+
+.msg-h{ display: flex; align-items: center; gap: 10px; margin-bottom: 8px; flex-wrap: wrap; }
+.msg-h b{ font-size: 14.5px; font-weight: 650; letter-spacing: -0.01em; }
+.who{ font: 700 9px/1 var(--mono); letter-spacing: .04em; text-transform: uppercase; padding: 4px 8px; border-radius: 99px; }
+.who.w{ background: var(--warn-soft); color: var(--warn); }
+.who.cl{ background: var(--info-soft); color: var(--info); }
+[data-theme="dark"] .who.cl{ color: oklch(0.80 0.12 240); }
+.who.par{ background: var(--pos-soft); color: var(--pos); }
+.wait{ font-family: var(--mono); font-size: 10px; color: var(--text-4); }
+
+.block{ background: oklch(0.15 0.01 282); border: 1px solid var(--border); border-radius: var(--r-3); overflow: hidden; box-shadow: var(--sh-1); }
+.block-h{ display: flex; align-items: center; gap: 8px; padding: 9px 13px; border-bottom: 1px solid oklch(0.28 0.01 282); background: oklch(0.18 0.01 282); }
+.block-h .dot{ width: 10px; height: 10px; border-radius: 50%; }
+.block-h .d1{ background: #ff5f57; } .block-h .d2{ background: #febc2e; } .block-h .d3{ background: #28c840; }
+.block-h b{ font-family: var(--mono); font-size: 10.5px; color: oklch(0.68 0.01 282); margin-left: 5px; }
+.block-h .copy{ margin-left: auto; font-family: var(--mono); font-size: 9.5px; color: oklch(0.6 0.02 282); }
+.block pre{ margin: 0; padding: 14px 16px; font-family: var(--mono); font-size: 11px; line-height: 1.65; color: oklch(0.88 0.01 282); white-space: pre-wrap; word-break: break-word; }
+.block pre .c{ color: oklch(0.54 0.02 282); }
+.block pre .k{ color: oklch(0.80 0.13 295); font-weight: 600; }
+.block pre .g{ color: oklch(0.78 0.12 145); }
+.block pre .y{ color: oklch(0.85 0.12 80); }
+.block pre .r{ color: oklch(0.74 0.13 25); }
+
+.note{ font-size: 11.5px; color: var(--text-3); line-height: 1.5; margin: 7px 0 0; padding-left: 2px; }
+.note b{ color: var(--text-2); }
+
+.howto{ background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--accent); border-radius: var(--r-3); padding: 15px 18px; box-shadow: var(--sh-1); margin: 22px 0 0; }
+.howto.pos{ border-left-color: var(--pos); }
+.howto h3{ margin: 0 0 7px; font-size: 13.5px; font-weight: 650; }
+.howto p{ margin: 0 0 6px; font-size: 12px; line-height: 1.55; color: var(--text-2); }
+.howto p:last-child{ margin: 0; }
+.howto b{ color: var(--text); font-weight: 600; }
+
+.foot{ margin-top: 40px; padding-top: 18px; border-top: 1px solid var(--border); font-size: 11px; color: var(--text-4); line-height: 1.65; }
+.foot b{ color: var(--text-3); }
+@media (max-width: 720px){ .wrap{ padding: 28px 18px 70px; } .thread{ padding-left: 28px; } .thread::before{ left: 9px; } .msg::before{ left: -28px; } }
+</style>
+</head>
+<body>
+<div class="top">
+  <div class="logo">Oi</div>
+  <b class="tt">Thread de envio · protocolo por etapas</b>
+  <span class="stamp">cole 1 mensagem por vez</span>
+  <button class="theme" onclick="document.documentElement.dataset.theme=document.documentElement.dataset.theme==='dark'?'light':'dark'">tema</button>
+</div>
+
+<div class="wrap">
+  <div class="docmeta">
+    <span><b>Documento:</b> Thread de envio — handoff por etapas</span>
+    <span><b>Formato:</b> protocolo zero-toque · COWORK_NOTES → F0</span>
+    <span><b>Uso:</b> cola 1 mensagem, espera o portão, cola a próxima</span>
+  </div>
+
+  <h1 class="title">Tudo escrito no protocolo — <em>uma mensagem por etapa</em>.</h1>
+  <p class="lede">A thread completa de despacho, no formato de envio do protocolo. Cada nó é <b>uma mensagem pronta pra colar</b> no Claude Code, na ordem. <b>Você cola a Msg 1, espera o portão fechar, cola a Msg 2</b>, e assim por diante. As mensagens marcadas 🔒 são portões — só avançam com a ação que elas pedem. As marcadas <span class="who par" style="padding:2px 6px">paralelo</span> abrem vários PRs de uma vez.</p>
+
+  <div class="thread">
+
+    <!-- MSG 1 -->
+    <div class="msg gate you" data-n="1">
+      <div class="msg-h"><b>Msg 1 · Portão A — congelar EVAL-001</b><span class="who w">[W] só você</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 0a</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 0a · PORTÃO A — congelar EVAL-001 [Tier-0, soberania W]</span>
+[CL] aplicar 2 edições e abrir PR de congelamento (NÃO mergear — [W] mergeia):
+  GS-01: proibir ⚠inferido em dado crítico (dinheiro/fiscal/estado-de-merge)
+  GS-12: trocar "arquivo .html" por "*V2.tsx / *Alt.tsx" (no-new-root guard)
+Congelar: GOLDEN_SET.md + REPLAY_CASES.md + AUTONOMY_LADDER.md
+<span class="k">SAÍDA:</span> PR draft. O merge de [W] É o ato de congelamento → destrava S4/CX.
+<span class="r"># [CC] propôs; [CL] abre; [W] mergeia. Não afirmar "congelado" antes do merge.</span></pre>
+      </div>
+      <p class="note">🔒 <b>Portão:</b> a thread não avança de verdade até <b>você mergear</b> este PR. Pode colar a Msg 2 em paralelo (domínio diferente), mas S4/CX ficam presos até aqui fechar.</p>
+    </div>
+
+    <!-- MSG 2 -->
+    <div class="msg gate" data-n="2">
+      <div class="msg-h"><b>Msg 2 · Portão B — F1 fundação de token</b><span class="who cl">[CL] Agente F</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 0b</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 0b · PORTÃO B — F1 token (auditar → colapsar)</span>
+[CL] Agente F:
+1. AUDITAR cor no repo real → governance/token-audit.json {papel:[tokens],duplicado}
+2. SE duplicado: colapsar via alias (mesmo valor). SE não: F1 encolhe, reportar.
+3. Dark com identidade: dar hue às superfícies (hsl 222 4.9% → sussurro de cor)
+<span class="k">TESTE:</span> diff computed-style = 0 em todas as telas · dark melhora ou empata
+<span class="r"># Token = Tier-0. PR draft, [W] revisa. Auditar ANTES de colapsar.</span></pre>
+      </div>
+      <p class="note">🔒 <b>Portão:</b> os ports (Msg 4+) <b>não mergeiam</b> antes deste landar — senão colidem no token.</p>
+    </div>
+
+    <!-- MSG 3 -->
+    <div class="msg" data-n="3">
+      <div class="msg-h"><b>Msg 3 · Etapa 1 — destravar (infra + gate)</b><span class="who par">paralelo · 2 agentes</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 1</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 1 · DESTRAVAR — paralelo, domínios disjuntos</span>
+[CL] Agente I (scripts/ + .github):
+  G1 · scripts/ds-critic.mjs — wrapper: compõe score-mechanized + ds-ledger +
+       guards como lentes → 1 critique-score.json/tela. NÃO reimplementa.
+  G2 · ADR severidade 0–4 + veto-P0 — 1 P0 reprova mesmo com nota alta.
+       P0 = guard DETERMINÍSTICO (cor crua/colisão), não juízo de LLM.
+[CL] Agente G (evals/ + .github):
+  US-GOV-013 · gate de regressão visual REAL (troca o stub; tira visual do A3).
+       Tolerância calibrada + fontes pinadas no runner (anti-grito-de-lobo).
+  S3 · licao-rc-guard — L-NN nova sem RC-NN = build falha.
+<span class="k">TESTE:</span> ds:critic roda em 1 tela (σ=0) · P0 injetado trava · 1px muda→gate pega
+<span class="r"># 1 PR por tarefa, draft. Roda 100% ∥ aos ports (arquivos disjuntos).</span></pre>
+      </div>
+      <p class="note"><b>Sem espera:</b> pode colar logo após a Msg 2 — toca <code>scripts/</code>+<code>evals/</code>, nunca <code>Pages/</code>.</p>
+    </div>
+
+    <!-- MSG 4 -->
+    <div class="msg" data-n="4">
+      <div class="msg-h"><b>Msg 4 · Etapa 2a — piloto Clientes</b><span class="who cl">[CL] · após Portão B</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 2a</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 2a · PILOTO — Clientes (prova o ciclo)</span>
+[CL] (após F1 landar):
+  Swap mecânico de paleta (495 cruas) + exceção 1b-B (categorias).
+  Bug PF/PJ + badge 15151 = issue SEPARADA (não trava a célula token).
+<span class="k">TESTE:</span> ds:critic verde · diff Caixa = 0 · screenshot [W] (F2) · Ledger +1
+<span class="r"># 1 PR draft. Mergeia só com "vai" de [W] + screenshot. Prova o método.</span></pre>
+      </div>
+      <p class="note"><b>Gancho:</b> Clientes valida o ciclo antes da enxurrada. Se passar limpo, libera a Msg 5.</p>
+    </div>
+
+    <!-- MSG 5 -->
+    <div class="msg" data-n="5">
+      <div class="msg-h"><b>Msg 5 · Etapa 2b — ports em massa</b><span class="who par">paralelo · N agentes</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 2b</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 2b · PORTS EM MASSA — 1 agente por tela, ∥</span>
+[CL] em paralelo (cada um 1 PR, medido por ds:critic):
+  P2 Compras · P3 Settings · P4 Admin · P5 NF-e+Essentials  (swap simples)
+  P6/P7 Vendas (TSX, depois sells-cowork.css 159KB)  ← exige TESTE E2E do fluxo
+  P8 Financeiro · P9 Oficina · P10 Whatsapp
+<span class="k">REGRAS DURAS (do adversário):</span>
+  - Ports CONSOMEM ui/, NUNCA editam (editar ui/ = vira onda de fundação).
+  - Vendas sub-2 NÃO mergeia sem teste E2E de venda verde (visual não basta).
+  - Financeiro = dinheiro: [W] revisa TODO PR (A0, GS-09). Sem auto-merge.
+<span class="k">TESTE:</span> ds:critic verde por tela · Ledger +1 cada · Caixa diff=0 preservado</pre>
+      </div>
+      <p class="note"><b>Gargalo real:</b> não é o código — é sua revisão (F2). Aprove no ritmo que conseguir olhar.</p>
+    </div>
+
+    <!-- MSG 6 -->
+    <div class="msg" data-n="6">
+      <div class="msg-h"><b>Msg 6 · Etapa 2c — aprendizado + CX</b><span class="who par">paralelo · após Portão A</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 2c</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 2c · SISTEMA QUE APRENDE (só após Portão A fechado)</span>
+[CL] Agente G, ∥ aos ports:
+  S4 · drift-watch + holdout (=EVAL-002): liga dual-brain p/ comparar score vs
+       SINAL OBJETIVO (reabertura de tela + retrabalho em git, não só reclamação).
+       Pool holdout ROTATIVO que o gate não treina.
+  CX · red-team operacional (=EVAL-003): cron mensal injeta defeitos, conta gates
+       que seguram. Roda em MODELO/CONTEXTO SEPARADO das lentes (independência).
+       1º artefato: evals/results/redteam-2026-06.md (vazio = suspeito).
+<span class="k">TESTE:</span> score↑&amp;reabertura↑→alarme · passa gate&amp;falha holdout→flag Goodhart</pre>
+      </div>
+      <p class="note">🔒 <b>Depende do Portão A.</b> Se a EVAL-001 não estiver congelada, esta mensagem espera.</p>
+    </div>
+
+    <!-- MSG 7 -->
+    <div class="msg" data-n="7">
+      <div class="msg-h"><b>Msg 7 · Etapa 3 — Caixa + trava final</b><span class="who cl">[CL] · por último</span></div>
+      <div class="block">
+        <div class="block-h"><span class="dot d1"></span><span class="dot d2"></span><span class="dot d3"></span><b>colar no Code · etapa 3</b><span class="copy">copie</span></div>
+<pre><span class="c"># OIMPRESSO · ETAPA 3 · CAIXA (o ouro) + TRAVA ÚNICA — só no fim</span>
+[CL] depois que os ports fecharem:
+  C1 · migrar a Caixa pra consumir os primitivos provados
+  C2 · tokenizar o verde → --ch-wa governado (412 → 0)
+  TRAVA · 1 job CI único (umbrella) consolida todos os ratchets + ds:critic --meta
+<span class="k">TESTE:</span> diff de pixel = 0 EXATO (mesmo oklch, não aproximação) · CI 100% verde
+<span class="r"># Caixa por último de propósito: era a régua enquanto os outros portavam.</span></pre>
+      </div>
+      <p class="note"><b>Fecha o ciclo:</b> a trava única transforma todo ganho em piso permanente (cataraca).</p>
+    </div>
+
+  </div>
+
+  <!-- HOW TO -->
+  <div class="howto pos">
+    <h3>Como rodar a thread</h3>
+    <p><b>Ordem de colagem:</b> Msg 1 + Msg 2 + Msg 3 podem ir juntas (domínios disjuntos). <b>Espere o Portão B (F1)</b> mergear → cole Msg 4. Clientes passou limpo → cole Msg 5. <b>Portão A congelado</b> → cole Msg 6. Ports fecharam → cole Msg 7.</p>
+    <p><b>Você nunca interpreta nada</b> — cada mensagem é um bloco fechado. O Code abre os PRs; você revisa e mergeia no seu ritmo (o F2 é o gargalo, não o código).</p>
+  </div>
+  <div class="howto">
+    <h3>Limite honesto</h3>
+    <p><b>Eu não escrevo no git.</b> Esta thread é o conteúdo pronto; o transporte é seu (cola no Code). Duas mensagens têm parte que <b>só você faz</b>: Msg 1 (congelar — sua assinatura) e os merges de cada PR (F2). Sem o congelamento da Msg 1, as Msgs 6 ficam presas.</p>
+  </div>
+
+  <div class="foot">
+    <p><b>Base:</b> plano de execução paralela + ficha por onda (detalhe+adversário) + reconciliação [CL] @main. As "regras duras" da Msg 5 vieram das farpas do [CX] (E2E Vendas, A0 Financeiro, ui/ read-only) — o adversário já está dentro das mensagens, não fora.</p>
+    <p><b>Honestidade:</b> formato espelha o protocolo zero-toque (COWORK_NOTES→F0, 1 PR/tarefa, soberania [W]). Não é execução — é o pacote de envio. Nada roda até você colar + congelar.</p>
+    <p style="margin-top:9px;color:var(--text-4)">Oimpresso ERP · [CC] · thread de envio no protocolo, por etapas.</p>
+  </div>
+</div>
+
+<template id="__bundler_thumbnail">
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><rect width="100" height="100" fill="#1a1726"/><g fill="none" stroke="#7c5cff" stroke-width="5" stroke-linecap="round"><circle cx="30" cy="30" r="6"/><circle cx="30" cy="50" r="6"/><circle cx="30" cy="70" r="6"/><path d="M30 36v8M30 56v8M40 30h32M40 50h32M40 70h22"/></g></svg>
+</template>
+</body>
+</html>


### PR DESCRIPTION
## O que é

Recriação **fiel (byte-idêntica)** do export do Claude Design **`Thread de Envio - Protocolo por Etapas.html`** — documento auto-contido (HTML/CSS inline, sem imports) que mostra a *thread de despacho* do protocolo em 7 mensagens prontas-pra-colar (Msg 1–7), com:

- tokens **OKLCH** + temas **claro/escuro** (toggle "tema"),
- thread rail vertical com nós numerados + marcadores 🔒 de portão,
- blocos de código estilo terminal, cards "howto", footer.

Aterrissa na família de artefatos *comunicação-visual* em [`prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/`](../tree/main/prototipo-ui/cowork-2026-05-26-comunicacao-visual/project), ao lado de `Oimpresso ERP - Clientes.html`, `Método KB-9.75.html`, etc.

## Escopo

- **1 arquivo, +266 linhas.** Adição pura (não existia em `main`).
- **`ds-guard.mjs` limpo** (sem L-21 tela-na-raiz; sem paleta inventada — usa tokens canônicos).
- CRLF + `eol=lf` no `.gitattributes` → normaliza igual aos vizinhos.
- **Sem código de produto** — é artefato de design-memory (não toca `Modules/` nem `Pages/`).

## Por que PR isolado

A branch `feat/governance-ds-rollout-ledger` está sendo trabalhada por uma sessão paralela (índice com batch grande de outra feature SDD). Pra manter **1 PR = 1 intent** (commit-discipline), este artefato sai num PR próprio re-parentado em `origin/main`, sem entrelaçar com o trabalho em andamento.

🤖 Generated with [Claude Code](https://claude.com/claude-code)