### PR TITLE
test(fsm): conserta asserção stale da mensagem UnauthorizedActionException — fail-secure já correto (SDD F2b LC-bug-4)

### DIFF
--- a/memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md
+++ b/memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md
@@ -166,14 +166,14 @@ if (! empty($roleNames) && (! $user || ! $user->hasAnyRole($roleNames))) {
 
 **Given**
 - Processo `Venda Padrão` biz=1 com stages [`rascunho` → `orcamento_enviado` → `aprovado_cliente`]
-- Action `voltar_para_orcamento` (de `aprovado_cliente` → `orcamento_enviado`) marcada como `is_critical=true` (campo novo)
+- Action `voltar_para_orcamento` (de `aprovado_cliente` → `orcamento_enviado`) marcada como `is_critical=true` (coluna criada por `2026_05_12_010001_add_is_critical_to_sale_stage_actions`)
 - `sale_stage_action_roles` **sem nenhuma role** cadastrada pra essa action
 
 **When**
 - User `caixa@empresa.com` (sem nenhuma role) chama `ExecuteStageActionService::execute($venda, 'voltar_para_orcamento', $user)`
 
-**Then (esperado, hoje NÃO ocorre)**
-- Lança `UnauthorizedActionException` com mensagem: *"Action 'voltar_para_orcamento' é crítica e exige role explícita — nenhuma role configurada bloqueia execução por segurança"*
+**Then (implementado — US-SELL-031, live prod biz=1)**
+- Lança `UnauthorizedActionException` com mensagem: *"Action crítica 'voltar_para_orcamento' exige role configurada em sale_stage_action_roles. Adicione role no seeder ou via UI antes de executar (fail-secure US-SELL-031)."*
 - Audit log em `sale_stage_history` **não é criado** (transação rollback)
 
 **Caso correlato — action não-crítica continua aberta**
@@ -181,14 +181,15 @@ if (! empty($roleNames) && (! $user || ! $user->hasAnyRole($roleNames))) {
 - When: qualquer user autenticado executa
 - Then: passa (comportamento atual preservado pra actions não-críticas)
 
-### Fix proposto
-1. Migration `add_is_critical_to_sale_stage_actions` (default `false`)
-2. Em `ExecuteStageActionService::execute()`:
+### Fix implementado (US-SELL-031 + short-circuit `grantsByPermission` do ADR 0265)
+1. Migration `2026_05_12_010001_add_is_critical_to_sale_stage_actions` (default `false`)
+2. Em [`ExecuteStageActionService::execute()`](../../../app/Domain/Fsm/Services/ExecuteStageActionService.php#L93):
    ```php
-   if (empty($roleNames) && $action->is_critical) {
+   if (! $grantedByPermission && empty($roleNames) && ($action->is_critical ?? false)) {
        throw new UnauthorizedActionException(
-           "Action '{$actionKey}' é crítica e exige role explícita — " .
-           "nenhuma role configurada bloqueia execução por segurança"
+           "Action crítica '{$actionKey}' exige role configurada em " .
+           "sale_stage_action_roles. Adicione role no seeder ou via UI " .
+           "antes de executar (fail-secure US-SELL-031)."
        );
    }
    ```


### PR DESCRIPTION
## Resultado da investigação SDD F2b Lane C — bug 4

**NÃO é bug de produção.** O FSM fail-secure está **CORRETO**.

### Prova (produção intocada)
[`ExecuteStageActionService::execute()`](../blob/main/app/Domain/Fsm/Services/ExecuteStageActionService.php) — linhas **93-99** — LANÇA `UnauthorizedActionException` quando `action.is_critical=true` SEM role configurada em `sale_stage_action_roles`:

```php
if (! $grantedByPermission && empty($roleNames) && ($action->is_critical ?? false)) {
    throw new UnauthorizedActionException(
        "Action crítica '{$actionKey}' exige role configurada em " .
        "sale_stage_action_roles. Adicione role no seeder ou via UI " .
        "antes de executar (fail-secure US-SELL-031)."
    );
}
```

Controllers (`SaleFsmActionController` / `ServiceOrderFsmActionController`) retornam **403**; a `DB::transaction` garante **rollback** de `current_stage_id`. Nenhum bypass — confirmado por mutation testing e pelo próprio caminho de produção. **Código de produto NÃO foi tocado.**

### O que era stale (asserção do teste) — JÁ resolvido em main
`TransicaoCriticaExigeAutorizacaoTest` spec #1 esperava o substring **antigo** `'crítica e exige role explícita'`. A mensagem de produção mudou (US-SELL-031 + short-circuit `grantsByPermission` do ADR 0265) para `'...exige role configurada em sale_stage_action_roles...'`. **A exceção É lançada corretamente — só a asserção de mensagem estava defasada.**

Essa correção de teste **já foi mergeada em main** pelo **PR #2671** (commit `6885fe07f`, mesma frente LC-bug-4): a asserção virou `'exige role configurada'`, preservando a propriedade de segurança — continua exigindo `toThrow(UnauthorizedActionException::class, ...)` **E** o rollback (`current_stage_id` inalterado, linha 183). Esta branch é baseada em `origin/main`, então **herda esse fix; nada a re-editar no teste** (re-fazer seria redundante e arriscaria enfraquecer o teste).

### Único artefato stale remanescente (este PR)
`memory/requisitos/Sells/CASOS-USO-PIPELINE-VENDAS.md` §CU-02 ainda:
- citava a **mensagem antiga** no GWT "Then" e no snippet "Fix proposto";
- marcava o comportamento como `hoje NÃO ocorre` / `Fix proposto` — quando já está **implementado e live em prod (biz=1)**.

**Atualizado** para a mensagem atual, status "implementado", snippet refletindo o short-circuit `grantsByPermission` (ADR 0265) + nome real da migration `2026_05_12_010001_add_is_critical_to_sale_stage_actions`.

### Escopo
- ✅ Só doc (`CASOS-USO-PIPELINE-VENDAS.md`) — +10 / -9 linhas
- ✅ Produção do FSM **intocada** (está correta)
- ✅ Sem mudança de harness, sem `Modules/Whatsapp`
- ✅ Asserção stale do teste já corrigida upstream (#2671), preservando fail-secure + rollback

Refs: SDD F2b LC-bug-4 (triage Q2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)