### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — Superadmin/Financeiro/app/misc (US-GOV-019)

### DIFF
--- a/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
+++ b/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
@@ -46,6 +46,7 @@ final class OnCobrancaPagaCreateFinanceiroTitulo
             return; // Onda 5 dogfooding processa só o business dono (SaaS)
         }
 
+        // SUPERADMIN: listener SaaS roda sem sessão; resolve a Cobranca pelo id do evento sem depender do scope de tenant
         $cobranca = Cobranca::withoutGlobalScopes()->find($event->cobrancaId);
         if (!$cobranca) {
             Log::error('[onda5][financeiro] CobrancaPaga sem registro Cobranca correspondente', [
@@ -229,6 +230,7 @@ final class OnCobrancaPagaCreateFinanceiroTitulo
     {
         if ($cobranca->payment_gateway_credential_id !== null) {
             // 1. Canon: credencial → conta_bancaria_id (Account UPOS) → fin_contas_bancarias
+            // SUPERADMIN: credencial do gateway pertence a biz=1 (dono SaaS); lookup cross-tenant pra mapear a conta bancária da cobrança
             $accountId = \Modules\PaymentGateway\Models\PaymentGatewayCredential::query()
                 ->withoutGlobalScopes()
                 ->where('id', $cobranca->payment_gateway_credential_id)

--- a/Modules/Financeiro/Services/Integrations/PluggyBankSyncService.php
+++ b/Modules/Financeiro/Services/Integrations/PluggyBankSyncService.php
@@ -127,6 +127,7 @@ class PluggyBankSyncService
         $valor  = abs($amount);
         $data   = isset($tx['date']) ? Carbon::parse($tx['date'])->toDateString() : Carbon::now()->toDateString();
 
+        // SUPERADMIN: sync bancário Pluggy roda sem sessão de tenant; business_id/conta vêm explícitos por argumento e filtram a query
         $existing = ExtratoLancamento::withoutGlobalScopes()
             ->where('conta_bancaria_id', $contaBancariaId)
             ->where('idempotency_key', $idempotencyKey)

--- a/Modules/Jana/Console/Commands/SeedAdrsCommand.php
+++ b/Modules/Jana/Console/Commands/SeedAdrsCommand.php
@@ -175,6 +175,7 @@ class SeedAdrsCommand extends Command
         // do índice). Com SCOUT_DRIVER=null (testes) searchable()/unsearchable() no-opam.
         $reindexados = 0;
         if (! $dryRun) {
+            // SUPERADMIN: comando CLI (schedule diário) roda sem session; business_id/user_id filtrados explicitamente mantêm isolamento Tier 0
             $facts = MemoriaFato::withoutGlobalScopes()
                 ->where('business_id', $businessId)
                 ->where('user_id', $userId)

--- a/Modules/Superadmin/Http/Controllers/BaseController.php
+++ b/Modules/Superadmin/Http/Controllers/BaseController.php
@@ -161,6 +161,7 @@ class BaseController extends Controller
             // Canon Onda 5 (Wagner 2026-05-19) — credencial BCB ativa que TENHA
             // conta_bancaria_id vinculada via wizard step 3. Direção UNIFICADA —
             // não depende mais de FK reverso em fin_contas_bancarias.
+            // SUPERADMIN: credencial BCB da cobrança SaaS vive em biz=1 (Wagner); checagem cross-tenant pra decidir se mostra o gateway
             return \Modules\PaymentGateway\Models\PaymentGatewayCredential::query()
                 ->withoutGlobalScopes()
                 ->where('business_id', 1)

--- a/Modules/Superadmin/Http/Controllers/SubscriptionController.php
+++ b/Modules/Superadmin/Http/Controllers/SubscriptionController.php
@@ -307,6 +307,7 @@ class SubscriptionController extends BaseController
             // 2. Resolve Account Wagner via credencial BCB ativa
             // Canon Onda 5 (Wagner 2026-05-19): direção payment_gateway_credentials.conta_bancaria_id
             // (capturada pelo wizard step 3). Não depende mais de FK reverso em fin_contas_bancarias.
+            // SUPERADMIN: cobrança SaaS é sempre de Wagner (biz=1); resolve credencial BCB cross-tenant a partir do contexto do tenant pagador
             $credBcb = \Modules\PaymentGateway\Models\PaymentGatewayCredential::query()
                 ->withoutGlobalScopes()
                 ->where('business_id', 1)
@@ -372,6 +373,7 @@ class SubscriptionController extends BaseController
      */
     protected function resolveTenantPayerContact(int $tenantBusinessId): ?\App\Contact
     {
+        // SUPERADMIN: Superadmin resolve o Business do tenant pagador cross-tenant pra montar a cobrança SaaS
         $business = \App\Business::withoutGlobalScopes()->find($tenantBusinessId);
         if (!$business) {
             return null;
@@ -382,6 +384,7 @@ class SubscriptionController extends BaseController
             return null;
         }
 
+        // SUPERADMIN: localiza o Contact do tenant dentro da carteira de Wagner (biz=1) cross-tenant pra vincular o pagador
         return \App\Contact::withoutGlobalScopes()
             ->where('business_id', 1)
             ->where('tax_number', $tax)

--- a/Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php
+++ b/Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php
@@ -86,6 +86,7 @@ final class OnCobrancaPagaUpdateSubscription
         $subscription->save();
         // Spatie LogsActivity append-only registra mudança (LGPD D7.b CC Art. 206)
 
+        // SUPERADMIN: listener SaaS roda sem sessão de tenant; desbloqueia o Business do assinante pago cross-tenant
         $business = Business::withoutGlobalScopes()->find($subscription->business_id);
         if ($business && (bool) $business->officeimpresso_bloqueado === true) {
             $business->officeimpresso_bloqueado = false;

--- a/Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php
+++ b/Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php
@@ -63,6 +63,7 @@ final class OnCobrancaVencidaBloqueaSubscription
         $subscription->status = 'declined';
         $subscription->save();
 
+        // SUPERADMIN: listener SaaS roda sem sessão de tenant; bloqueia o Business do assinante inadimplente cross-tenant
         $business = Business::withoutGlobalScopes()->find($subscription->business_id);
         if ($business && (bool) $business->officeimpresso_bloqueado === false) {
             $business->officeimpresso_bloqueado = true;


### PR DESCRIPTION
## US-GOV-019 — anotar bypasses de global scope com `// SUPERADMIN:`

Satisfaz o guard estático `tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php` (ADR 0093 multi-tenant Tier 0 IRREVOGÁVEL): toda chamada `withoutGlobalScopes()` (plural) em código de produção em `app/` + `Modules/<X>/` deve ter `// SUPERADMIN: <razão>` na mesma linha ou nas 3 linhas acima.

### Alvos varridos
Modules/Superadmin · Modules/Financeiro · app/ · Modules/Ponto · Modules/Vestuario · Modules/Jana · Modules/Governance

### Anotadas (10 call sites / 7 arquivos) — todas bypass legítimo
| Arquivo | Razão |
|---|---|
| Superadmin/Http/Controllers/BaseController.php | credencial BCB SaaS vive em biz=1 (Wagner); checagem cross-tenant |
| Superadmin/Http/Controllers/SubscriptionController.php (x3) | cobrança SaaS é de biz=1; resolve credencial/Business/Contact do tenant pagador cross-tenant |
| Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php | listener SaaS sem sessão; desbloqueia Business do assinante pago |
| Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php | listener SaaS sem sessão; bloqueia Business inadimplente |
| Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php (x2) | listener SaaS sem sessão; resolve Cobranca + credencial gateway de biz=1 |
| Financeiro/Services/Integrations/PluggyBankSyncService.php | sync bancário sem sessão; business_id/conta explícitos por argumento |
| Jana/Console/Commands/SeedAdrsCommand.php | comando CLI (schedule diário) sem session; business_id/user_id filtrados explícitos |

### Já conformes (sem mudança neste PR)
- Financeiro/Services/TituloAutoService.php (3 calls — já comentadas)
- app/Services/CriarOsPorVendaService.php (2 calls — comentário inline)
- Ponto/Jobs/ReapurarDiaJob.php (já comentada)
- Vestuario (modelo canônico — já comentado)
- Governance: ocorrências de `withoutGlobalScopes` são só em comentários/strings (sem call real)

### Suspected leaks
Nenhum. Todas as chamadas anotadas são listener/CLI/cross-tenant SaaS sem sessão de tenant, com `business_id` explícito onde aplicável.

### Verificação
Scan estático replicando a lógica exata do guard sobre os 7 alvos no base `origin/main`: **0 violações**. Apenas comentários adicionados — zero mudança de lógica (10 insertions).

Refs: US-GOV-019

🤖 Generated with [Claude Code](https://claude.com/claude-code)