### PR TITLE
fix(cash-register): escopar business_id no fechar-caixa e getRegisterDetails (Tier 0)

### DIFF
--- a/app/Http/Controllers/CashRegisterController.php
+++ b/app/Http/Controllers/CashRegisterController.php
@@ -211,12 +211,17 @@ class CashRegisterController extends Controller
 
             $input = $request->only(['closing_amount', 'total_card_slips', 'total_cheques', 'closing_note']);
             $input['closing_amount'] = $this->cashRegisterUtil->num_uf($input['closing_amount']);
+            $business_id = $request->session()->get('user.business_id');
             $user_id = $request->input('user_id');
             $input['closed_at'] = \Carbon::now()->format('Y-m-d H:i:s');
             $input['status'] = 'close';
             $input['denominations'] = ! empty(request()->input('denominations')) ? json_encode(request()->input('denominations')) : null;
 
-            CashRegister::where('user_id', $user_id)
+            // Tier 0 (ADR 0093): CashRegister não tem global scope e $user_id vem do request.
+            // Sem o filtro business_id, um tenant fecharia o caixa de outro business
+            // passando um user_id alheio. business_id vem SEMPRE da session, nunca do input.
+            CashRegister::where('business_id', $business_id)
+                                ->where('user_id', $user_id)
                                 ->where('status', 'open')
                                 ->update($input);
             $output = ['success' => 1,

--- a/app/Utils/CashRegisterUtil.php
+++ b/app/Utils/CashRegisterUtil.php
@@ -242,6 +242,10 @@ class CashRegisterUtil extends Util
             '=',
             'cash_registers.location_id'
         );
+        // Tier 0 (ADR 0093): CashRegister não tem global scope — escopar business_id
+        // sempre. Sem isto, getRegisterDetails($id) leria o caixa (e os totais
+        // financeiros) de qualquer tenant passando um id alheio.
+        $query->where('cash_registers.business_id', auth()->user()->business_id);
         if (empty($register_id)) {
             $user_id = auth()->user()->id;
             $query->where('user_id', $user_id)

--- a/tests/Feature/Sells/CashRegisterTier0ScopeTest.php
+++ b/tests/Feature/Sells/CashRegisterTier0ScopeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tier 0 (ADR 0093 IRREVOGÁVEL) — escopo business_id no fluxo de caixa.
+ *
+ * Contexto: `App\CashRegister` estende Model SEM global scope (sem
+ * HasBusinessScope / addGlobalScope). Logo, TODA query precisa filtrar
+ * business_id explicitamente, senão vaza entre tenants. Dois vazamentos
+ * reais foram fechados:
+ *
+ *   1. WRITE — CashRegisterController@postCloseRegister fechava o caixa por
+ *      `where('user_id', $request->input('user_id'))` sem business_id. Como o
+ *      user_id vem do REQUEST, um tenant podia fechar o caixa de outro business
+ *      passando um user_id alheio (cross-tenant write).
+ *   2. READ — CashRegisterUtil@getRegisterDetails($id) carregava o caixa (e os
+ *      totais financeiros) por `where('cash_registers.id', $id)` sem business_id
+ *      (cross-tenant read via show()/getCloseRegister()).
+ *
+ * Pattern Pest estrutural (lê source, não roda Eloquent — SQLite incompatível
+ * com schema UltimatePOS MySQL conforme ADR 0101). Mesmo padrão de
+ * SellsCaixaPageTest.php.
+ *
+ * @see app/Http/Controllers/CashRegisterController.php::postCloseRegister()
+ * @see app/Utils/CashRegisterUtil.php::getRegisterDetails()
+ * @see app/CashRegister.php
+ * @see memory/requisitos/Mwart/ONDA-1-CUTOVER-LEDGER.md (§4 — itens Tier 0 flagados)
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+const CRT_CONTROLLER = 'app/Http/Controllers/CashRegisterController.php';
+const CRT_UTIL = 'app/Utils/CashRegisterUtil.php';
+const CRT_MODEL = 'app/CashRegister.php';
+
+function crtRead(string $rel): string
+{
+    return file_get_contents(base_path($rel));
+}
+
+// ─── Premissa: model sem global scope → filtro manual é obrigatório ──────────
+
+it('CashRegister não tem global scope (premissa do filtro manual Tier 0)', function () {
+    $src = crtRead(CRT_MODEL);
+    // Se um dia ganhar global scope, este guard falha e lembra de revisar os filtros manuais.
+    expect($src)->not->toMatch('/addGlobalScope|HasBusinessScope|BusinessScope/');
+});
+
+// ─── WRITE — postCloseRegister ───────────────────────────────────────────────
+
+it('postCloseRegister filtra business_id no update do caixa (Tier 0)', function () {
+    $src = crtRead(CRT_CONTROLLER);
+    expect($src)->toMatch("/postCloseRegister[\s\S]*?CashRegister::where\(\s*'business_id'/");
+    expect($src)->toMatch("/postCloseRegister[\s\S]*?'business_id'[\s\S]*?->update\(/");
+});
+
+it('postCloseRegister deriva business_id da session, nunca do request', function () {
+    $src = crtRead(CRT_CONTROLLER);
+    expect($src)->toMatch("/postCloseRegister[\s\S]*?session\(\)->get\('user\.business_id'\)/");
+});
+
+it('postCloseRegister mantém o gate de permissão close_cash_register', function () {
+    $src = crtRead(CRT_CONTROLLER);
+    expect($src)->toMatch("/postCloseRegister[\s\S]*?close_cash_register[\s\S]*?abort\(403/");
+});
+
+// ─── READ — getRegisterDetails ───────────────────────────────────────────────
+
+it('getRegisterDetails escopa cash_registers.business_id (Tier 0)', function () {
+    $src = crtRead(CRT_UTIL);
+    expect($src)->toMatch("/getRegisterDetails[\s\S]*?cash_registers\.business_id/");
+});
+
+// ─── store() — guard de regressão (já setava business_id da session) ─────────
+
+it('store cria o caixa com business_id da session', function () {
+    $src = crtRead(CRT_CONTROLLER);
+    expect($src)->toMatch("/function store[\s\S]*?'business_id' => \\\$business_id/");
+});


### PR DESCRIPTION
## Severidade: Tier 0 (isolamento multi-tenant) — write + read cross-tenant

`App\CashRegister` estende `Model` **sem global scope** → toda query precisa filtrar `business_id` explícito ([ADR 0093](../blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md), IRREVOGÁVEL). A auditoria da Onda 1 (Cutover Ledger §4) flagou; verifiquei e confirmei **dois vazamentos reais**:

### 1. 🔴 WRITE — `postCloseRegister`
```php
$user_id = $request->input('user_id');           // ← vem do REQUEST
CashRegister::where('user_id', $user_id)          // ← sem business_id
    ->where('status', 'open')->update($input);
```
Um usuário autenticado (com `close_cash_register`) podia **fechar o caixa de outro business** passando um `user_id` alheio (user_ids são sequenciais/adivinháveis) — gravando `status=close`/`closing_amount`/`denominations` no tenant errado **e disparando o bridge `fin_titulo`** ([ADR 0192](../blob/main/memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)) no business errado.
**Fix:** `->where('business_id', session('user.business_id'))` antes do update. `user_id` continua vindo do form (legítimo: gerente fecha caixa de operador do **mesmo** business).

### 2. ⚠️ READ — `CashRegisterUtil::getRegisterDetails($id)`
```php
$query->where('cash_registers.id', $register_id);  // ← sem business_id
```
`show($id)`/`getCloseRegister($id)` liam o caixa e **todos os totais financeiros** (cash/card/cheque/expense…) de qualquer tenant por id.
**Fix:** `->where('cash_registers.business_id', auth user business_id)` sempre. Blast radius confirmado: `getRegisterDetails($id)` só é chamado pelo próprio controller (within-business).

## Teste
`tests/Feature/Sells/CashRegisterTier0ScopeTest.php` — **estrutural source-regex** (mesmo pattern de `SellsCaixaPageTest`; SQLite é incompatível com o schema UltimatePOS MySQL, ADR 0101). 7 asserts: filtros business_id presentes, business_id da session (não do request), gate de permissão preservado, `store()` ok. As 7 regex validadas localmente contra o source (✓).

## Escopo
3 arquivos, sem mudança de comportamento legítimo (gerente fecha caixa do próprio business; relatório do próprio caixa). `store()` já era seguro. **Não fiz deploy** — é Tier 0, você decide o merge/rollout.

Origem: auditoria adversarial da Onda 1 ([PR #2702](https://github.com/wagnerra23/oimpresso.com/pull/2702)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
