### PR TITLE
test(era-sqlite): quarentena Onda 3 — Jobs/Inter corruptores (2 arquivos)

### DIFF
--- a/tests/Feature/Jobs/CancelarCobrancaInterJobTest.php
+++ b/tests/Feature/Jobs/CancelarCobrancaInterJobTest.php
@@ -7,6 +7,7 @@ use App\Jobs\CancelarCobrancaInterJob;
 use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
@@ -44,6 +45,10 @@ class FakeInterCharge extends Model
 }
 
 beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente — quarentena Onda 3 SDD floor; burn-down converte depois.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();
@@ -117,6 +122,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        return;
+    }
+
     foreach (
         [
             'transaction_documents',

--- a/tests/Feature/Jobs/RefundCobrancaInterJobTest.php
+++ b/tests/Feature/Jobs/RefundCobrancaInterJobTest.php
@@ -7,6 +7,7 @@ use App\Jobs\RefundCobrancaInterJob;
 use App\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
@@ -33,6 +34,10 @@ class FakeInterRefundCharge extends Model
 }
 
 beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente — quarentena Onda 3 SDD floor; burn-down converte depois.');
+    }
+
     Schema::create('users', function (Blueprint $t) {
         $t->increments('id');
         $t->string('username')->unique();
@@ -102,6 +107,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        return;
+    }
+
     foreach (['transaction_documents', 'role_has_permissions', 'model_has_roles', 'model_has_permissions', 'roles', 'permissions', 'fake_inter_refund_charges', 'users'] as $tbl) {
         Schema::dropIfExists($tbl);
     }


### PR DESCRIPTION
## Root cause

`CancelarCobrancaInterJobTest` e `RefundCobrancaInterJobTest` faziam `Schema::create('users')` em `beforeEach` + `Schema::dropIfExists('users')` em `afterEach` **sem guard de driver**.

Em MySQL nightly persistente:
1. `beforeEach` tenta criar `users` (que já existe) → QueryException
2. `afterEach` roda mesmo assim (PHPUnit 12.5 issue) → dropa `users`
3. Todos os testes subsequentes falham: `Table 'oimpresso_fullsuite_test.users' doesn't exist`

Evidência: 794 erros com esse padrão no junit.xml do run `20260613-174707` (floor=1570).

## Fix

Quarentena-lite padrão (mesmo pattern Onda 1+2, confirmado em 139 arquivos anteriores):
- `beforeEach`: `markTestSkipped` se driver ≠ sqlite
- `afterEach`: early `return` se driver ≠ sqlite

## Impacto esperado

Floor 1570 → ~776 (-794 cascade victims). Medição confirmada no próximo nightly CT 100.

## Files touched

- `tests/Feature/Jobs/CancelarCobrancaInterJobTest.php`
- `tests/Feature/Jobs/RefundCobrancaInterJobTest.php`

Refs: US-GOV-021 | SDD scorecard anchor_coverage