### PR TITLE
fix(otel): session guard + uses(TestCase) nos Settings tests — RC-4+RC-5 SDD floor

### DIFF
--- a/Modules/Financeiro/Tests/Feature/CobrancaControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/CobrancaControllerTest.php
@@ -10,6 +10,8 @@ use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Spatie\Permission\Models\Permission;
 
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+
 /**
  * Pest GUARDs — /financeiro/cobranca F3 PaymentGateway UI Tela 1.
  *

--- a/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysControllerTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysControllerTest.php
@@ -8,6 +8,8 @@ use App\User;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Spatie\Permission\Models\Permission;
 
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+
 /**
  * Pest GUARDs — /settings/payment-gateways F3 PaymentGateway UI Tela 2.
  *

--- a/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysHistoryTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysHistoryTest.php
@@ -8,6 +8,8 @@ use App\User;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Spatie\Activitylog\Models\Activity;
 
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+
 /**
  * Pest GUARDs — GET /settings/payment-gateways/{id}/history (Onda 4e.UI).
  *

--- a/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysQuotaTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysQuotaTest.php
@@ -9,6 +9,8 @@ use Carbon\CarbonImmutable;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+
 /**
  * Pest GUARDs — GET /settings/payment-gateways/{id}/quota (Onda 4e gap #3).
  *

--- a/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysWebhookEventsTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysWebhookEventsTest.php
@@ -8,6 +8,8 @@ use App\User;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+
 /**
  * Pest GUARDs — GET /settings/payment-gateways/{id}/webhook-events (Onda 4e.UI #2).
  *

--- a/Modules/PaymentGateway/Tests/Feature/Settings/SellsCobrancaChipTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/SellsCobrancaChipTest.php
@@ -10,6 +10,8 @@ use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Spatie\Permission\Models\Permission;
 
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+
 /**
  * Pest GUARDs — Sells drawer chip cobrança F3 PaymentGateway UI Tela 3.
  *

--- a/app/Util/OtelHelper.php
+++ b/app/Util/OtelHelper.php
@@ -126,9 +126,14 @@ class OtelHelper
      */
     public static function spanBiz(string $name, callable $callback, array $extras = [])
     {
-        $bizId = session()->get('user.business_id')
-            ?? optional(auth()->user())->business_id
-            ?? 0;
+        // session() não existe em CLI, queue workers e Unit tests sem TestCase.
+        // try/catch evita "Target class [session] does not exist" nesses contextos.
+        try {
+            $bizId = session()->get('user.business_id');
+        } catch (\Throwable) {
+            $bizId = null;
+        }
+        $bizId ??= optional(auth()->user())->business_id ?? 0;
 
         // Convenção ResourceAttributes canon (config/otel.php): `oimpresso.tenant_id`.
         // Mantém também `business_id` legacy pra compat com call-sites antigos US-WA-083.


### PR DESCRIPTION
## Summary

- **RC-5 (31 erros):** `OtelHelper::spanBiz()` chamava `session()->get()` sem guard — lançava `Target class [session] does not exist` em Unit tests, CLI e queue workers. Fix: `try/catch` preserva semântica HTTP, silencia contextos sem sessão.
- **RC-4 (41 erros):** 6 Feature tests em `PaymentGateway/Settings/` + `Financeiro/CobrancaControllerTest` não tinham `uses(Tests\TestCase::class)` — Spatie Permissions tentava resolver `Illuminate\Cache\CacheManager($app)` sem container completo. Fix: `uses(TestCase::class, DatabaseTransactions::class)` no topo de cada arquivo.

Impacto esperado: **-72 erros** no floor nightly (1570 → ~528 com Onda 1+2+3+RC-3+RC-6+RC-4+RC-5).

## Test plan

- [ ] CI verde (Unit + Financeiro MySQL)
- [ ] Nenhum regressão nas 6 telas Settings/Financeiro (Feature tests agora com TestCase)
- [ ] `OtelHelper::spanBiz` continua funcionando no HTTP path (session existe → mesmo valor)
- [ ] Unit tests ADS (RiskEngineTest, DecisionRouterTest) não lançam mais session error

Refs: US-GOV-021 SDD floor burn-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)