### PR TITLE
test(jana): RefreshDatabase→DatabaseTransactions + uses(TestCase) BrasilApiService — RC-7+RC-8 SDD floor

### DIFF
--- a/Modules/Jana/Tests/Feature/TaskRegistry/GitTaskLinkerServiceTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/GitTaskLinkerServiceTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Modules\Jana\Entities\Mcp\McpProject;
 use Modules\Jana\Entities\Mcp\McpTask;
 use Modules\Jana\Services\TaskRegistry\GitTaskLinkerService;
 
-uses(Tests\TestCase::class, RefreshDatabase::class);
+uses(Tests\TestCase::class, DatabaseTransactions::class);
 
 beforeEach(function () {
     $this->svc = new GitTaskLinkerService();

--- a/Modules/Jana/Tests/Feature/TaskRegistry/JiraStyleSchemaTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/JiraStyleSchemaTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Modules\Jana\Entities\Mcp\McpCycle;
 use Modules\Jana\Entities\Mcp\McpCycleGoal;
 use Modules\Jana\Entities\Mcp\McpEpic;
@@ -23,7 +23,7 @@ use Modules\Jana\Entities\Mcp\McpTaskDependency;
  *   - Cycle.progressPercent calcula
  */
 
-uses(Tests\TestCase::class, RefreshDatabase::class);
+uses(Tests\TestCase::class, DatabaseTransactions::class);
 
 it('cria projeto + alloc identifier sequencial', function () {
     $proj = McpProject::create([

--- a/tests/Unit/Services/BR/BrasilApiServiceTest.php
+++ b/tests/Unit/Services/BR/BrasilApiServiceTest.php
@@ -118,12 +118,12 @@ it('cache hit pula chamada HTTP na segunda vez', function () {
     $service = new BrasilApiService;
 
     // 1ª chamada — hit HTTP, popula cache.
-    $first = $service->lookupCnpj('11.444.777/0001-61');
+    $first = $service->lookupCnpj('11.444.777/0001-61'); // pii-allowlist: fake CNPJ fixture BrasilAPI
     expect($first['razao_social'])->toBe('CACHED LTDA');
     Http::assertSentCount(1);
 
     // 2ª chamada — cache hit, NÃO incrementa HTTP count.
-    $second = $service->lookupCnpj('11.444.777/0001-61');
+    $second = $service->lookupCnpj('11.444.777/0001-61'); // pii-allowlist: fake CNPJ fixture BrasilAPI
     expect($second['razao_social'])->toBe('CACHED LTDA');
     Http::assertSentCount(1); // ainda 1, sem nova chamada
 });

--- a/tests/Unit/Services/BR/BrasilApiServiceTest.php
+++ b/tests/Unit/Services/BR/BrasilApiServiceTest.php
@@ -6,6 +6,8 @@ use App\Services\BR\BrasilApiService;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
+uses(Tests\TestCase::class);
+
 /**
  * Unit — App\Services\BR\BrasilApiService.
  *

--- a/tests/Unit/Services/BR/BrasilApiServiceTest.php
+++ b/tests/Unit/Services/BR/BrasilApiServiceTest.php
@@ -31,7 +31,7 @@ it('retorna null pra CNPJ invalido sem hit HTTP', function () {
     ]);
 
     $service = new BrasilApiService;
-    $result = $service->lookupCnpj('11.111.111/1111-11'); // todos 1, falha mod-11
+    $result = $service->lookupCnpj('11.111.111/1111-11'); // pii-allowlist: fake CNPJ todos-1 que falha mod-11
 
     expect($result)->toBeNull();
     Http::assertNothingSent();
@@ -63,7 +63,7 @@ it('normaliza payload da BrasilAPI quando API retorna 200', function () {
     ]);
 
     $service = new BrasilApiService;
-    $result = $service->lookupCnpj('11.444.777/0001-61');
+    $result = $service->lookupCnpj('11.444.777/0001-61'); // pii-allowlist: fake CNPJ fixture BrasilAPI
 
     expect($result)
         ->toBeArray()
@@ -84,7 +84,7 @@ it('retorna null quando API responde 404', function () {
     ]);
 
     $service = new BrasilApiService;
-    $result = $service->lookupCnpj('11.444.777/0001-61');
+    $result = $service->lookupCnpj('11.444.777/0001-61'); // pii-allowlist: fake CNPJ fixture BrasilAPI
 
     expect($result)->toBeNull();
 });
@@ -95,7 +95,7 @@ it('retorna null quando API responde 5xx (graceful)', function () {
     ]);
 
     $service = new BrasilApiService;
-    $result = $service->lookupCnpj('11.444.777/0001-61');
+    $result = $service->lookupCnpj('11.444.777/0001-61'); // pii-allowlist: fake CNPJ fixture BrasilAPI
 
     expect($result)->toBeNull();
 });
@@ -138,7 +138,7 @@ it('trata payload com campos null/missing da API', function () {
     ]);
 
     $service = new BrasilApiService;
-    $result = $service->lookupCnpj('11.444.777/0001-61');
+    $result = $service->lookupCnpj('11.444.777/0001-61'); // pii-allowlist: fake CNPJ fixture BrasilAPI
 
     expect($result)
         ->toBeArray()


### PR DESCRIPTION
## Summary

- **RC-8 (28 erros):** `JiraStyleSchemaTest` + `GitTaskLinkerServiceTest` usavam `RefreshDatabase` no nightly CT100. O `migrate:fresh` dropa TODAS as tabelas; quando reload do schema dump falha (mysql client/TLS), `mcp_jira_projects`/`roles`/`permissions` somem → 28+ erros em cascata. Fix: `DatabaseTransactions` — mesma proteção de isolamento sem dropar schema.
- **RC-7 (15 erros):** `BrasilApiServiceTest` (em `tests/Unit/`) não tinha `uses(TestCase::class)`. Pest.php só aplica `uses()->in('Feature')`. Sem bootstrap do container, `Log::*` → `LogManager` → `config['logging...']` retorna o objeto Facade em vez do array → `Cannot use object of type Config as array`. Fix: `uses(Tests\TestCase::class)`.

Impacto esperado: **-43 erros** no floor nightly (~528 → ~485).

## Test plan

- [ ] CI verde
- [ ] JiraStyleSchemaTest ainda testa CRUD McpProject/McpTask com transação (não precisa migrate:fresh)
- [ ] GitTaskLinkerServiceTest extrai refs de commit sem precisar de RefreshDatabase
- [ ] BrasilApiServiceTest usa Cache::flush() + Http::fake() com container ativo

Refs: US-GOV-021 SDD floor burn-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)