### PR TITLE
fix(test): PagarmeDriverTest makeCred — Crypt::encryptString pra config_json (RC-9)

### DIFF
--- a/Modules/PaymentGateway/Tests/Feature/PagarmeDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/PagarmeDriverTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Http;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
@@ -22,6 +23,11 @@ uses(Tests\TestCase::class);
  */
 function makeCred(array $configOverride = []): PaymentGatewayCredential
 {
+    $config = array_merge([
+        'secret_key'     => 'sk_test_fake_pagarme_token',
+        'webhook_secret' => 'whsec_fake_pagarme',
+    ], $configOverride);
+
     $cred = new PaymentGatewayCredential();
     $cred->setRawAttributes([
         'id'           => 99,
@@ -30,10 +36,8 @@ function makeCred(array $configOverride = []): PaymentGatewayCredential
         'ambiente'     => 'sandbox',
         'ativo'        => true,
         'nome_display' => 'Pagar.me Test',
-        'config_json'  => json_encode(array_merge([
-            'secret_key'     => 'sk_test_fake_pagarme_token',
-            'webhook_secret' => 'whsec_fake_pagarme',
-        ], $configOverride)),
+        // encrypted:array cast → decryptString(raw) on read; must store encryptString(json)
+        'config_json'  => Crypt::encryptString(json_encode($config)),
     ], true);
     $cred->exists = true;
 


### PR DESCRIPTION
## Root cause

`PaymentGatewayCredential` tem `$casts['config_json'] = 'encrypted:array'`.
Ao **ler** o campo, Eloquent chama `Crypt::decryptString($raw)` → `json_decode`.

O helper `makeCred()` usava `setRawAttributes` com `json_encode($config)` puro
(plaintext) → ao acessar `$cred->config_json`, o cast tentava decriptar JSON
em claro → `DecryptException: The payload is invalid`.

## Fix

```php
'config_json' => Crypt::encryptString(json_encode($config)),
```

Espelha exatamente o que o cast `encrypted:array` produz ao escrever no DB
(`castAttributeAsEncryptedString` → `Crypt::encryptString(json_encode($value))`).

## Impact

~10 erros removidos do floor nightly CT100 (`PagarmeDriverTest` — RC-9).

## Burn-down map até aqui

| RC | Fix | PRs |
|----|-----|-----|
| RC-1 | Era-sqlite corruptors (Jobs tests) | #2709 ✅ |
| RC-3 | PaymentGateway driver tests sem DatabaseTransactions | #2710 ✅ |
| RC-6 | Sells TSX reader file_get_contents em arquivo deletado | #2710 ✅ |
| RC-4 | 6 Settings/Financeiro Feature sem uses(TestCase) | #2711 ✅ |
| RC-5 | OtelHelper::spanBiz session() sem guard | #2711 ✅ |
| RC-8 | Jana RefreshDatabase wipes schema | #2712 ⏳ |
| RC-7 | BrasilApiServiceTest Unit sem uses(TestCase) | #2712 ⏳ |
| RC-9 | PagarmeDriverTest DecryptException config_json | **este PR** |

Floor estimado após merge: ~485 (de 1570 inicial).