### PR TITLE
test: DatabaseTransactions MigrateCredentials + TestCase SddScorecard (RC-10+RC-11)

### DIFF
--- a/Modules/Governance/Tests/Feature/SddScorecardSnapshotCommandTest.php
+++ b/Modules/Governance/Tests/Feature/SddScorecardSnapshotCommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Schema;
  * @see Modules/Governance/Console/Commands/SddScorecardSnapshotCommand.php
  */
 
-uses(RefreshDatabase::class);
+uses(Tests\TestCase::class, DatabaseTransactions::class);
 
 function sddG7ScorecardFixture(float $ghost = 27.0, float $door = 63.9): string
 {

--- a/Modules/PaymentGateway/Tests/Feature/MigrateCredentialsCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/MigrateCredentialsCommandTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 2.5 — ADR 0170.


### PR DESCRIPTION
## RC-10 — 171x `UniqueConstraintViolationException` (`MigrateCredentialsCommandTest`)

**Root cause:** `uses(Tests\TestCase::class)` sem `DatabaseTransactions`.
`beforeEach` insere 2 rows em `rb_boleto_credentials` (UNIQUE: `biz_id + banco`).
Sem rollback, rows acumulam entre testes → duplicate entry `1-inter`.

**Fix:** `uses(Tests\TestCase::class, DatabaseTransactions::class)` — cada teste
rola back o `beforeEach` seed + o que o artisan command escreveu.

## RC-11 — 67x `BindingResolutionException` (`SddScorecardSnapshotCommandTest`)

**Root cause:** `uses(RefreshDatabase::class)` sem `Tests\TestCase::class`.
Dois efeitos cumulativos:
1. `$this->artisan()` não existe (método vem de `TestCase`) → `Error: Call to undefined method ::artisan`
2. `RefreshDatabase` chama `migrate:fresh` → dropa todas as tabelas do schema MySQL nightly → cascade de erros 42S02

**Fix:** `uses(Tests\TestCase::class, DatabaseTransactions::class)`.

## Burn-down acumulado

| RC | Erro | Fix | PRs |
|----|------|-----|-----|
| RC-1 | 794x cascade era-sqlite | quarentena Jobs tests | #2709 ✅ |
| RC-3 | 114x driver sem DatabaseTransactions | PaymentGateway drivers | #2710 ✅ |
| RC-6 | 52x file_get_contents em TSX deletado | guard file_exists Sells | #2710 ✅ |
| RC-4 | 41x Settings sem uses(TestCase) | Settings/Financeiro | #2711 ✅ |
| RC-5 | 31x OtelHelper session() sem guard | try/catch spanBiz | #2711 ✅ |
| RC-8 | 28x Jana RefreshDatabase destroys schema | → DatabaseTransactions | #2712 ⏳ |
| RC-7 | 15x BrasilApiService Unit sem TestCase | uses(TestCase) | #2712 ⏳ |
| RC-9 | 10x PagarmeDriverTest DecryptException | Crypt::encryptString | #2713 ⏳ |
| RC-10 | 171x UniqueConstraint MigrateCredentials | DatabaseTransactions | **este PR** |
| RC-11 | 67x artisan-method SddScorecard | TestCase + DatabaseTransactions | **este PR** |

Floor estimado após merge: ~247 (de 1570 inicial — −84%).