### PR TITLE
fix(nfse): OtelHelper spanBiz extras array + DatabaseTransactions teste RC-16

### DIFF
--- a/Modules/NFSe/Services/NfseEmissaoService.php
+++ b/Modules/NFSe/Services/NfseEmissaoService.php
@@ -104,7 +104,7 @@ class NfseEmissaoService
         // D9.a Wave 14: span por emissão envolve adapter HTTP + idempotência + retries.
         return OtelHelper::spanBiz('nfse.emissao', function () use ($payload) {
             return $this->emitirInterno($payload);
-        }, $payload->businessId);
+        }, ['nfse.business_id' => $payload->businessId]);
     }
 
     private function emitirInterno(NfseEmissaoPayload $payload): NfseEmissao

--- a/tests/Feature/Modules/NFSe/NfseEmissaoServiceTest.php
+++ b/tests/Feature/Modules/NFSe/NfseEmissaoServiceTest.php
@@ -39,7 +39,7 @@ function payload(array $overrides = []): NfseEmissaoPayload
         rpsNumero: $overrides['rpsNumero'] ?? '000001',
         competencia: $overrides['competencia'] ?? Carbon::create(2026, 5, 1),
         tomadorNome: 'ROTA LIVRE LTDA',
-        tomadorCnpj: '12.345.678/0001-90',
+        tomadorCnpj: '12.345.678/0001-90', // pii-allowlist: fake CNPJ fixture de teste NFSe
         tomadorCpf: null,
         tomadorEmail: 'fiscal@rotalivrepress.com.br',
         descricao: 'Licença mensal sistema ERP',
@@ -112,7 +112,7 @@ it('retorna nota existente quando idempotency_key já existe com status emitida'
         'serie'           => 'RPS',
         'competencia'     => '2026-05-01',
         'tomador_nome'    => 'ROTA LIVRE LTDA',
-        'tomador_cnpj'    => '12.345.678/0001-90',
+        'tomador_cnpj'    => '12.345.678/0001-90', // pii-allowlist: fake CNPJ fixture de teste NFSe
         'descricao'       => 'Licença mensal sistema ERP',
         'valor_servicos'  => 1500.00,
         'valor_iss'       => 30.00,

--- a/tests/Feature/Modules/NFSe/NfseEmissaoServiceTest.php
+++ b/tests/Feature/Modules/NFSe/NfseEmissaoServiceTest.php
@@ -23,7 +23,7 @@ use Modules\NFSe\Models\NfseCertificado;
 use Modules\NFSe\Models\NfseProviderConfig;
 use Modules\NFSe\Services\NfseEmissaoService;
 
-uses(RefreshDatabase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Root causes fixed

**RC-16a — TypeError OtelHelper::spanBiz**
NfseEmissaoService::emitir() linha 107 passava $payload->businessId (int) como 3o argumento de OtelHelper::spanBiz() cuja assinatura espera array $extras. Fixed: empacota como array.

**RC-16b — RefreshDatabase era-sqlite corruptor**
NfseEmissaoServiceTest usava RefreshDatabase que chama migrate:fresh -> dropa TODAS as tabelas MySQL nightly -> 21 falhas em cascata (TelasNavegacao 15x, UnificadoController 3x, Wave27Manufacturing 3x).
Fixed: uses(TestCase::class, DatabaseTransactions::class).

Impacto estimado: ~29 failures removidos do floor CT100.
Refs: SDD RC-16