### PR TITLE
fix(test): concede permissões no beforeEach ClienteDrawerAutosaveTest RC-17

### DIFF
--- a/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
@@ -58,6 +58,11 @@ beforeEach(function () {
     // (canon UPOS -- pattern de tests/Feature/Cliente/RedirectLegacyContactsTest).
     $this->actingAs($this->user);
     session(['user.business_id' => $this->business->id]);
+
+    // ClienteAutosaveController::locateContact() verifica customer.update / supplier.update.
+    // Seed não atribui permissões ao user seeded — precisa conceder aqui (RC-17).
+    app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
+    $this->user->givePermissionTo(['customer.update', 'supplier.update']);
 });
 
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

ClienteAutosaveController::locateContact() verifica can('customer.update') / can('supplier.update'). O seed MySQL não atribui permissões ao user seeded de biz=1, causando 25x HTTP 403 em todos os testes PATCH cadastrais.

## Fix

- `givePermissionTo(['customer.update', 'supplier.update'])` no `beforeEach`
- `forgetCachedPermissions()` antes, para evitar cache Spatie stale
- O teste de "403 sem permissão" (linha 415) cria seu próprio `$weakUser` independente — não afetado

## Impacto

25 falhas removidas do floor CT100.

Refs: SDD RC-17