### PR TITLE
chore(routes): remove 9 rotas /sells duplicadas byte-a-byte no web.php

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -445,18 +445,12 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::post('/purchases/check_ref_number', [PurchaseController::class, 'checkRefNumber']);
     Route::resource('purchases', PurchaseController::class)->except(['show']);
 
-    Route::get('/toggle-subscription/{id}', [SellPosController::class, 'toggleRecurringInvoices']);
-    Route::post('/sells/pos/get-types-of-service-details', [SellPosController::class, 'getTypesOfServiceDetails']);
-    Route::get('/sells/subscriptions', [SellPosController::class, 'listSubscriptions']);
-    Route::get('/sells/duplicate/{id}', [SellController::class, 'duplicateSell']);
-    Route::get('/sells/drafts', [SellController::class, 'getDrafts']);
-    Route::get('/sells/convert-to-draft/{id}', [SellPosController::class, 'convertToInvoice']);
-    Route::get('/sells/convert-to-proforma/{id}', [SellPosController::class, 'convertToProforma']);
-    Route::get('/sells/quotations', [SellController::class, 'getQuotations']);
-    Route::get('/sells/draft-dt', [SellController::class, 'getDraftDatables']);
-    // Route::resource('sells', SellController::class)->except(['show']);
-    //   ^ Removido — duplicado com linha 259 acima (Route::resource('sells', 'SellController'))
-    //   route:cache falhava com "Another route has already been assigned name [sells.index]".
+    // As rotas /sells (subscriptions, drafts, quotations, duplicate, convert-to-draft,
+    // convert-to-proforma, draft-dt, get-types-of-service-details, toggle-subscription)
+    // e Route::resource('sells') já estão declaradas ACIMA, antes do resource. O bloco
+    // que existia aqui era duplicata byte-a-byte e, por ficar APÓS o resource, suas rotas
+    // GET eram sombreadas por /sells/{id}; redeclarar o resource aqui quebrava route:cache
+    // ("Another route has already been assigned name [sells.index]"). Bloco removido.
 
     Route::get('/import-sales', [ImportSalesController::class, 'index']);
     Route::post('/import-sales/preview', [ImportSalesController::class, 'preview']);


### PR DESCRIPTION
## O quê
`routes/web.php` declarava **duas vezes** o mesmo bloco de 9 rotas `/sells`:

| | onde | efeito |
|---|---|---|
| Bloco 1 (correto) | **antes** de `Route::resource('sells')` (l.437) | rotas vivas — precisam vir antes pra não serem sombreadas por `/sells/{id}` |
| Bloco 2 (morto) | **depois** do resource (l.448-456) | duplicata **byte-a-byte**; por vir após o resource, as GET ficavam sombreadas por `/sells/{id}` de qualquer jeito |

Removi o bloco 2 + um comentário stale (referenciava "linha 259", que não tem resource — só há **um** `Route::resource('sells')` vivo).

## Por que é seguro
- As 9 rotas continuam servidas pelo **bloco 1** (verifiquei: cada URI aparece exatamente 1× após o diff).
- Rotas sem `->name()` → sem colisão de nome; eram puro ruído.
- `-12/+6` linhas, só `routes/web.php`. FQCN preservado (`[Controller::class, 'method']`).

Achado na auditoria adversarial da Onda 1 ([PR #2702](https://github.com/wagnerra23/oimpresso.com/pull/2702), Cutover Ledger §3.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Infra Contract

**Impacto runtime: NENHUM.** Só remove 9 declarações de rota `/sells` **byte-a-byte duplicadas** (bloco 2, após o `Route::resource('sells')`). As mesmas 9 rotas seguem declaradas no bloco 1 (antes do resource) — que é o que já respondia em prod; o bloco removido vinha após o resource e era sombreado pelo wildcard `/sells/{id}`, nunca atingido. Nenhum endpoint novo/removido/alterado, nenhum middleware mudou. Verificação: cada URI aparece exatamente 1x pós-diff. Sem validação curl pq não há comportamento observável novo.
