### PR TITLE
fix(governance): // SUPERADMIN nos bypass de global scope — Whatsapp (US-GOV-019 · fecha a lane)

### DIFF
--- a/Modules/Whatsapp/Entities/ClientFeedback.php
+++ b/Modules/Whatsapp/Entities/ClientFeedback.php
@@ -224,6 +224,9 @@ class ClientFeedback extends Model
             ];
         }
 
+        // SUPERADMIN: qualificação pode rodar via CLI/job sem session — resolve o
+        // Contact vinculado (relação FK do próprio feedback, mesmo business) pra
+        // checar type. Lookup pela relação contact_id, sem leak cross-tenant. ADR 0093.
         $contact = $this->contact()->withoutGlobalScopes()->first();
         if (! $contact) {
             return [

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -2090,6 +2090,9 @@ class InboxController extends Controller
         }
 
         try {
+            // SUPERADMIN: resolve o próprio operador autenticado ($userId = session
+            // user.id) pra prefixar *FirstName:* no corpo da mensagem. Lookup do
+            // próprio usuário da sessão; sem leak cross-tenant. ADR 0093.
             $user = \App\User::query()->withoutGlobalScopes()->find($userId);
         } catch (\Throwable) {
             return $body;

--- a/Modules/Whatsapp/Http/Requests/ChannelRequest.php
+++ b/Modules/Whatsapp/Http/Requests/ChannelRequest.php
@@ -113,8 +113,11 @@ class ChannelRequest extends FormRequest
             $normalized = $this->normalizeIdentifier($identifier);
             $channelId = $this->route('channel') ?? $this->route('id'); // edit ignora self
 
+            // Uniqueness cross-business de display_identifier — dois channels com
+            // mesmo número em businesses distintos disputam a sessão WhatsApp Web
+            // (incidente 2026-05-13). Check de plataforma sem leak de dados.
             $exists = Channel::query()
-                ->withoutGlobalScopes()
+                ->withoutGlobalScopes() // SUPERADMIN: check de plataforma, só existência por type+identifier (ADR 0093)
                 ->whereIn('type', [
                     Channel::TYPE_WHATSAPP_META,
                     Channel::TYPE_WHATSAPP_ZAPI,

--- a/Modules/Whatsapp/Jobs/ProcessRemindersJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessRemindersJob.php
@@ -62,11 +62,10 @@ class ProcessRemindersJob implements ShouldQueue
         $published = 0;
         $failed = 0;
 
-        // SUPERADMIN: job assíncrono sem session() — bypass global scope
-        // pra varrer reminders de TODOS businesses. Cada row traz seu
-        // próprio business_id; canal Centrifugo é per-user (user:{id}),
-        // sem leak cross-tenant.
-        $query = WhatsappReminder::withoutGlobalScopes()
+        // Job assíncrono sem session() — varre reminders de TODOS businesses.
+        // Cada row traz seu próprio business_id; canal Centrifugo é per-user
+        // (user:{id}), sem leak cross-tenant.
+        $query = WhatsappReminder::withoutGlobalScopes() // SUPERADMIN: cron sem session, cada row escopa seu business_id (ADR 0093)
             ->where('status', WhatsappReminder::STATUS_PENDING)
             ->where('due_at', '<=', now())
             ->whereNull('notified_at')

--- a/Modules/Whatsapp/Services/EmployeePerformance/EmployeePerformanceRebuilder.php
+++ b/Modules/Whatsapp/Services/EmployeePerformance/EmployeePerformanceRebuilder.php
@@ -132,6 +132,9 @@ class EmployeePerformanceRebuilder
     {
         if ($perf->user_id !== null) {
             try {
+                // SUPERADMIN: rebuild roda via CLI/job sem session — resolve o User
+                // (pelo user_id do scorecard já escopado a $businessId) só pra ler
+                // first_name/last_name de exibição. Sem leak cross-tenant. ADR 0093.
                 $user = User::query()->withoutGlobalScopes()->find($perf->user_id);
                 if ($user !== null) {
                     $name = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));

--- a/Modules/Whatsapp/Services/FeedbackIndexGenerator.php
+++ b/Modules/Whatsapp/Services/FeedbackIndexGenerator.php
@@ -49,7 +49,7 @@ class FeedbackIndexGenerator
         $businesses = $businessId
             ? collect([$businessId])
             : ClientFeedback::query()
-                ->withoutGlobalScopes()
+                ->withoutGlobalScopes() // SUPERADMIN: CLI feedback:reindex sem session, enumera businesses pro índice de memória (ADR 0093)
                 ->select('business_id')
                 ->distinct()
                 ->orderBy('business_id')
@@ -60,7 +60,7 @@ class FeedbackIndexGenerator
 
         foreach ($businesses as $bizId) {
             $hot = ClientFeedback::query()
-                ->withoutGlobalScopes()
+                ->withoutGlobalScopes() // SUPERADMIN: CLI feedback:reindex sem session, escopado por business_id explícito (ADR 0093)
                 ->where('business_id', $bizId)
                 ->whereNull('deleted_at')
                 ->hot()
@@ -69,7 +69,7 @@ class FeedbackIndexGenerator
                 ->get();
 
             $active = ClientFeedback::query()
-                ->withoutGlobalScopes()
+                ->withoutGlobalScopes() // SUPERADMIN: CLI feedback:reindex sem session, escopado por business_id explícito (ADR 0093)
                 ->where('business_id', $bizId)
                 ->whereNull('deleted_at')
                 ->whereNotIn('status', [
@@ -163,7 +163,7 @@ class FeedbackIndexGenerator
 
         // Agrupa por (business, persona, modulo) os COLD
         $colds = ClientFeedback::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: CLI feedback:reindex sem session, digest COLD agregado por business_id (ADR 0093)
             ->whereBetween('created_at', [$qStart, $qEnd])
             ->cold()
             ->whereNull('deleted_at')
@@ -215,7 +215,7 @@ class FeedbackIndexGenerator
         $stats = ['processed' => 0, 'rescored' => 0, 'skipped' => 0];
 
         $query = ClientFeedback::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: CLI feedback:reindex sem session, rescore cross-business (filtro business_id opcional abaixo) (ADR 0093)
             ->whereNull('deleted_at');
 
         if ($businessId) {
@@ -248,7 +248,7 @@ class FeedbackIndexGenerator
     protected function emergentPatterns(int $businessId)
     {
         return ClientFeedback::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: CLI feedback:reindex sem session, escopado por business_id explícito (ADR 0093)
             ->where('business_id', $businessId)
             ->whereNotNull('signature')
             ->whereNull('deleted_at')

--- a/Modules/Whatsapp/Services/FeedbackRelevanceService.php
+++ b/Modules/Whatsapp/Services/FeedbackRelevanceService.php
@@ -165,7 +165,9 @@ class FeedbackRelevanceService
         if (! $fb->contact_id) {
             return false;
         }
-        // withoutGlobalScopes pra resilir scope quando rescore via cli sem session
+        // SUPERADMIN: rescore roda via CLI (feedback:reindex) sem session — resolve
+        // o Contact vinculado (FK do próprio feedback, mesmo business) pra checar se
+        // é cliente pagante. Sem leak: lookup por contact_id do feedback. ADR 0093.
         $contact = Contact::withoutGlobalScopes()->find($fb->contact_id);
         if (! $contact) {
             return false;

--- a/Modules/Whatsapp/Services/Sla/SlaEnforcer.php
+++ b/Modules/Whatsapp/Services/Sla/SlaEnforcer.php
@@ -80,6 +80,9 @@ class SlaEnforcer
 
     private function doScanAndAlert(?int $businessId, bool $dryRun): array
     {
+        // SUPERADMIN: scan job de SLA roda sem session ($businessId=null = todos os
+        // businesses no cron). Cada SlaPolicy carrega seu próprio business_id; filtro
+        // opcional por business_id aplicado abaixo. Sem leak cross-tenant. ADR 0093.
         $policyQuery = SlaPolicy::withoutGlobalScopes()->active();
         if ($businessId !== null) {
             $policyQuery->where('business_id', $businessId);

--- a/Modules/Whatsapp/Services/WhatsmeowReconciler.php
+++ b/Modules/Whatsapp/Services/WhatsmeowReconciler.php
@@ -248,8 +248,11 @@ final class WhatsmeowReconciler
      */
     public function resolveChannelByUserName(int $businessId, string $userName): ?Channel
     {
+        // Fluxo de webhook do daemon WuzAPI, que chega sem session de tenant —
+        // $businessId é resolvido pelo middleware e passado explícito; o
+        // where('business_id') abaixo garante isolamento Tier 0.
         return Channel::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: webhook sem session, escopado por business_id explícito (ADR 0093)
             ->where('business_id', $businessId)
             ->where('type', Channel::TYPE_WHATSAPP_WHATSMEOW)
             ->get()
@@ -269,8 +272,11 @@ final class WhatsmeowReconciler
      */
     public function resolveChannelForPendingPair(int $businessId): ?Channel
     {
+        // Fallback de webhook do daemon WuzAPI sem session de tenant — $businessId
+        // vem do middleware; where('business_id') mantém isolamento Tier 0 (nunca
+        // atravessa fronteira business).
         return Channel::query()
-            ->withoutGlobalScopes()
+            ->withoutGlobalScopes() // SUPERADMIN: webhook sem session, escopado por business_id explícito (ADR 0093)
             ->where('business_id', $businessId)
             ->where('type', Channel::TYPE_WHATSAPP_WHATSMEOW)
             ->whereIn('status', ['setup', 'disconnected'])


### PR DESCRIPTION
## US-GOV-019 — fecha a lane WithoutGlobalScopes (último módulo: Whatsapp)

Anota toda chamada `withoutGlobalScopes()` de **produção** em `Modules/Whatsapp/` com `// SUPERADMIN: <razão>` na mesma linha ou até 3 acima, conforme exige o guard estático `tests/Unit/Guards/WithoutGlobalScopesCommentGuardTest.php`. Multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](../blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md)).

**Apenas comentários — zero mudança de lógica.** `php -l` OK nos 9 arquivos. Re-scan com a lógica exata do guard: **0 violações** em `Modules/Whatsapp/`.

Whatsapp era o cluster mais sensível (messaging multi-canal/cross-contact), deixado por último. Cada bypass foi lido método-a-método e classificado como legítimo.

### Anotações adicionadas (14 call sites em 9 arquivos)

| Arquivo:linha | Contexto | Razão (legítima) |
|---|---|---|
| `Entities/ClientFeedback.php:227` | `qualifiesForDevTask()` | CLI/job sem session resolve o Contact vinculado (FK do próprio feedback, mesmo business) pra checar `type` |
| `Http/Controllers/Admin/InboxController.php:2093` | `maybeAutoPrefixSenderName()` | Resolve o **próprio operador autenticado** (`$userId = session('user.id')`) pra prefixar `*Nome:*` |
| `Http/Requests/ChannelRequest.php:117` | `withValidator()` | Uniqueness cross-business de `display_identifier` — check de **plataforma** (só existência), evita conflito de sessão WhatsApp Web (incidente 2026-05-13) |
| `Jobs/ProcessRemindersJob.php:69` | `handle()` | Cron sem session varre reminders de todos businesses; cada row escopa seu `business_id`; Centrifugo per-user |
| `Services/EmployeePerformance/EmployeePerformanceRebuilder.php:135` | `refreshDisplayName()` | Rebuild CLI/job resolve User (id já escopado a `$businessId`) só pra ler `first_name`/`last_name` |
| `Services/FeedbackIndexGenerator.php:52,63,72,166,218,251` | `feedback:reindex` (CLI) | Geração do índice de memória sem session — enumera businesses / agrega digest / escopa por `business_id` explícito |
| `Services/FeedbackRelevanceService.php:169` | `isPayingCustomer()` | Rescore CLI sem session resolve Contact (FK do feedback) pra checar se é pagante |
| `Services/Sla/SlaEnforcer.php:83` | `doScanAndAlert()` | Scan job de SLA sem session (`$businessId=null`=cron todos); cada SlaPolicy carrega seu `business_id`; filtro opcional abaixo |
| `Services/WhatsmeowReconciler.php:252,273` | `resolveChannelByUserName()` / `resolveChannelForPendingPair()` | **Webhook inbound** do daemon WuzAPI chega sem session de tenant; `$businessId` vem do middleware e o `where('business_id')` mantém isolamento Tier 0 |

Observações:
- `EmployeePerformanceRebuilder.php:57` usa `withoutGlobalScope(ScopeByBusiness::class)` (singular) — **não** casa com o pattern do guard (`withoutGlobalScopes(`), portanto não exige anotação. Já escopado por `business_id`.
- Todas as ocorrências em `Tests/` e `Database/Migrations/` ficam fora do escopo do guard (excluídas por path) e **não foram tocadas** (incl. regression-guards R-WA-INCIDENT-CONV-* / AUTH-DRIFT-CONV-*). Harness não tocado.

### suspected_leaks

**Nenhum.** Todos os 14 call sites de produção foram justificados como bypass legítimo (CLI/job/webhook/check-de-plataforma), com isolamento mantido por `where('business_id')` explícito ou lookup do próprio registro/operador. Nada ficou sem justificativa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
