### PR TITLE
test(oficina): RC-20 — forgetCachedPermissions no beforeEach ServiceOrderRichSheetPayload

### DIFF
--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderRichSheetPayloadTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderRichSheetPayloadTest.php
@@ -44,6 +44,8 @@ beforeEach(function () {
     if (! Schema::hasColumn('service_orders', 'box_label')) {
         $this->markTestSkipped('Rode migration 2026_05_26_120001 primeiro (box_label + assigned_user_id)');
     }
+    // Spatie permission cache persiste entre testes — limpar pra givePermissionTo funcionar (RC-20).
+    app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
 });
 
 function rich_criaOs(string $suffix, int $biz = BIZ_RICH): ServiceOrder


### PR DESCRIPTION
## RC-20 — Spatie permission cache flush

### Problema
6 testes em `ServiceOrderRichSheetPayloadTest` retornavam 403 no nightly CT100. Cada teste faz:
```php
$user = User::factory()->create(['business_id' => BIZ_RICH]);
$user->givePermissionTo('superadmin');
```
`ServiceOrderPolicy::before()` chama `$user->can('superadmin')` que lê o cache Spatie stale do teste anterior — retorna `false` → 403.

### Fix
```php
app(\Spatie\Permission\PermissionRegistrar::class)->forgetCachedPermissions();
```
No `beforeEach()`, antes de cada teste. Mesmo padrão do RC-17 (ClienteDrawerCadastroAutosaveTest, PR #2718).

### Impacto
- ✅ 6 testes desbloqueados (GET /oficina-auto/service-orders/{id})
- ✅ Zero mudança de produção
- ✅ Tier 0 não tocado