### PR TITLE
test(payment-gateway): RC-21 — DatabaseTransactions em 28 testes restantes (completa RC-3, ~150 falhas)

### DIFF
--- a/Modules/PaymentGateway/Tests/Feature/AilosCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/AilosCnabDriverTest.php
@@ -13,7 +13,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\AilosCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Bradesco — ADR 0170-bancos-nativos-top5-drivers-separados.

--- a/Modules/PaymentGateway/Tests/Feature/BBCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/BBCnabDriverTest.php
@@ -13,7 +13,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\BBCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Bradesco — ADR 0170-bancos-nativos-top5-drivers-separados.

--- a/Modules/PaymentGateway/Tests/Feature/BanrisulCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/BanrisulCnabDriverTest.php
@@ -14,7 +14,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\BanrisulCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Banrisul — ADR 0170 (driver fino sobre CnabBoletoAdapter).

--- a/Modules/PaymentGateway/Tests/Feature/BradescoCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/BradescoCnabDriverTest.php
@@ -13,7 +13,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\BradescoCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Bradesco — ADR 0170-bancos-nativos-top5-drivers-separados.

--- a/Modules/PaymentGateway/Tests/Feature/BtgCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/BtgCnabDriverTest.php
@@ -12,7 +12,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\BtgCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/BTG — ADR 0170 (drivers separados).

--- a/Modules/PaymentGateway/Tests/Feature/CaixaCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/CaixaCnabDriverTest.php
@@ -13,7 +13,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\CaixaCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Bradesco — ADR 0170-bancos-nativos-top5-drivers-separados.

--- a/Modules/PaymentGateway/Tests/Feature/CnabBoletoAdapterContractTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/CnabBoletoAdapterContractTest.php
@@ -14,7 +14,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\CnabBoletoAdapter;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Schema in-memory per test (não RefreshDatabase — migrations canon usam

--- a/Modules/PaymentGateway/Tests/Feature/CnabRetornoProcessorTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/CnabRetornoProcessorTest.php
@@ -16,7 +16,7 @@ use Modules\PaymentGateway\Models\CnabRetornoUpload;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Schema in-memory per test (pattern canon WebhookEndpointsTest — não usa

--- a/Modules/PaymentGateway/Tests/Feature/CresolCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/CresolCnabDriverTest.php
@@ -13,7 +13,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\CresolCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Cresol — ADR 0170-bancos-nativos-top5-drivers-separados (v3).

--- a/Modules/PaymentGateway/Tests/Feature/EmitTrialExpiredCobrancasCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/EmitTrialExpiredCobrancasCommandTest.php
@@ -8,7 +8,7 @@ use Modules\PaymentGateway\Models\Cobranca;
 use Modules\Superadmin\Entities\Package;
 use Modules\Superadmin\Entities\Subscription;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Pest — paymentgateway:emit-trial-expired (Onda 5.B cron daily).

--- a/Modules/PaymentGateway/Tests/Feature/EncryptedCredentialCastTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/EncryptedCredentialCastTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-PG-001 (Audit Sênior 2026-05-25 — VULN P0-#1 SEC catastrófica).

--- a/Modules/PaymentGateway/Tests/Feature/InterDriverRegisterWebhookTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterDriverRegisterWebhookTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\Http;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Cobertura do gap descoberto 2026-06-03 — `InterDriver` faltava método

--- a/Modules/PaymentGateway/Tests/Feature/InterImportarRecebimentosCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterImportarRecebimentosCommandTest.php
@@ -10,7 +10,7 @@ use Modules\Financeiro\Models\TituloBaixa;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-PG-008 — paymentgateway:inter-importar-recebimentos.

--- a/Modules/PaymentGateway/Tests/Feature/InterPixCobTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterPixCobTest.php
@@ -10,7 +10,7 @@ use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
 use Modules\PaymentGateway\Services\PaymentGatewayService;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4b — ADR 0170.

--- a/Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterReconcilePixCommandTest.php
@@ -10,7 +10,7 @@ use Modules\PaymentGateway\Events\CobrancaPaga;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * paymentgateway:inter-reconcile-pix — polling de reconciliação (fallback do

--- a/Modules/PaymentGateway/Tests/Feature/InterRefundCobvTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterRefundCobvTest.php
@@ -11,7 +11,7 @@ use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
 use Modules\PaymentGateway\Services\PaymentGatewayService;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4c — ADR 0170.

--- a/Modules/PaymentGateway/Tests/Feature/InterWebhookTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterWebhookTest.php
@@ -10,7 +10,7 @@ use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\InterWebhookLog;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-FIN-032 (Onda 26) — Cobertura webhook PIX Inter dedicado.

--- a/Modules/PaymentGateway/Tests/Feature/ItauCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/ItauCnabDriverTest.php
@@ -13,7 +13,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\ItauCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Bradesco — ADR 0170-bancos-nativos-top5-drivers-separados.

--- a/Modules/PaymentGateway/Tests/Feature/OndaDoisSchemaEScopeTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/OndaDoisSchemaEScopeTest.php
@@ -8,7 +8,7 @@ use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 2 — ADR 0170.

--- a/Modules/PaymentGateway/Tests/Feature/PaymentGatewaysControllerStoreTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/PaymentGatewaysControllerStoreTest.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Pest — POST /settings/payment-gateways store endpoint (Onda 5 completar wizard).

--- a/Modules/PaymentGateway/Tests/Feature/ReconciliarCobrancaServiceTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/ReconciliarCobrancaServiceTest.php
@@ -10,7 +10,7 @@ use Modules\PaymentGateway\Events\CobrancaPaga;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Services\ReconciliarCobrancaService;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * ReconciliarCobrancaService::marcarPaga() — lógica canônica "virou paga"

--- a/Modules/PaymentGateway/Tests/Feature/RetryOrphanWebhookJobTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/RetryOrphanWebhookJobTest.php
@@ -11,7 +11,7 @@ use Modules\PaymentGateway\Jobs\RetryOrphanWebhookJob;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Setup: cria SOMENTE `cobrancas` + `gateway_webhook_events` no SQLite in-memory.

--- a/Modules/PaymentGateway/Tests/Feature/SantanderCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SantanderCnabDriverTest.php
@@ -14,7 +14,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\SantanderCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab — ADR 0170-bancos-nativos-top5-drivers-separados (v3).

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverMtlsTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverMtlsTest.php
@@ -8,7 +8,7 @@ use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\SicoobApiDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.sicoob_api US-FIN-046 — mTLS reusa NfeCertificado canon.

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiWebhookTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiWebhookTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-FIN-044 PR4 — Onda 4f.sicoob_api webhook receiver.

--- a/Modules/PaymentGateway/Tests/Feature/SicrediCnabDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicrediCnabDriverTest.php
@@ -12,7 +12,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Cnab\Drivers\SicrediCnabDriver;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 4f.cnab/Sicredi — ADR 0170 (driver fino sobre CnabBoletoAdapter).

--- a/Modules/PaymentGateway/Tests/Feature/WebhookEndpointsTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/WebhookEndpointsTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * Onda 3 — ADR 0170. US-PG-002 audit-senior 2026-05-25 (VULN SEC P0-#2):

--- a/Modules/PaymentGateway/Tests/Feature/WebhookSignatureValidationTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/WebhookSignatureValidationTest.php
@@ -8,7 +8,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-PG-002 (audit-senior 2026-05-25 VULN SEC P0-#2 CATASTRÓFICA).


### PR DESCRIPTION
## RC-21 — fecha o cross-file commit poisoning do PaymentGateway

### Causa-raiz (medida, run `20260614-020001`)
~150 falhas do módulo são `UniqueConstraintViolationException` (1062) no índice `pg_cred_biz_gw_amb_unique` `(business_id, gateway_key, ambiente)`.

**Mecanismo:** testes SEM `DatabaseTransactions` commitam a credencial no `beforeEach`. O nightly recria o DB só **1× por run** (não por teste — `DROP/CREATE DATABASE` no `ct100-fullsuite.sh`), então a linha commitada persiste e colide com o `create()` de **todos os testes seguintes** do mesmo `gateway_key+biz+ambiente` — inclusive os que já tinham DT (ex: `SicoobApiDriverTest` falhava porque `SicoobApiWebhookTest`, sem DT, commitava antes).

### Por que o RC-3 não bastou
RC-3 (#2710) adicionou DT em 5 arquivos — necessário, mas insuficiente enquanto 28 ainda commitavam. Este PR fecha o conjunto.

### Fix
`DatabaseTransactions` nos 28 arquivos restantes que criam linha. Dá o mesmo isolamento per-teste que o sqlite `:memory:` recriado dava — equivalente canônico (ADR 0101). **Zero código de produto.**

### Verificação
Gate = próximo nightly. Esperado: o cluster PaymentGateway (~150) cai junto. Se cair proporcional, escalo o mesmo padrão pros outros módulos com duplicate-key.

28 arquivos · 1 linha cada · 1 intent.