### PR TITLE
test(nfe-brasil): RC-22 — DatabaseTransactions em 4 testes duplicate-key (~17 falhas)

### DIFF
--- a/Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EnviarDanfeNFCePorEmailTest.php
@@ -14,7 +14,7 @@ use Modules\NfeBrasil\Mail\DanfeNotaFiscalMail;
 use Modules\NfeBrasil\Models\NfeEmissao;
 use Modules\NfeBrasil\Services\DanfeService;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-NFE-002 fase 2B · Listener EnviarDanfeNFCePorEmail.

--- a/Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/EnviarDanfePorEmailTest.php
@@ -14,7 +14,7 @@ use Modules\NfeBrasil\Models\NfeEmissao;
 use Modules\NfeBrasil\Services\DanfeService;
 use Modules\RecurringBilling\Models\Invoice;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-NFE-044 fase 2 · Listener EnviarDanfePorEmail.

--- a/Modules/NfeBrasil/Tests/Feature/NfeStatusControllerTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeStatusControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Schema;
 use Modules\NfeBrasil\Models\NfeEmissao;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-NFE-002 fase 2C · Endpoint JSON polling-friendly de status NFC-e.

--- a/Modules/NfeBrasil/Tests/Feature/NfseCancelServiceTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfseCancelServiceTest.php
@@ -9,7 +9,7 @@ use Modules\NfeBrasil\Models\NfseEmissao;
 use Modules\NfeBrasil\Models\NfseEventoCancelamento;
 use Modules\NfeBrasil\Services\NfseCancelService;
 
-uses(Tests\TestCase::class);
+uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 /**
  * US-NFSE-CANCEL-001 — NfseCancelService (Manager pattern + driver registry).


### PR DESCRIPTION
## RC-22 — mesma receita do RC-21, módulo NfeBrasil

4 arquivos commitam `NfeEmissao`/`Invoice`/`transactions` no `beforeEach` sem `DatabaseTransactions` → colidem (1062) com o `create()` dos testes seguintes, porque o nightly recria o DB **1× por run**, não por teste.

- `EnviarDanfePorEmailTest` (6)
- `EnviarDanfeNFCePorEmailTest` (7)
- `NfeStatusControllerTest` (3)
- `NfseCancelServiceTest` (1)

Confirmado **não-era-sqlite** (zero `Schema::create/drop` de CORE) — só row-commit. `DatabaseTransactions` dá isolamento per-teste (ADR 0101). Zero código de produto. Gate = próximo nightly.

Refs: SDD F2b RC-22