### PR TITLE
fix(whatsapp): remove spoofable IP-whitelist fallback from whatsmeow webhook auth

### DIFF
--- a/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
@@ -33,8 +33,16 @@ use Symfony\Component\HttpFoundation\Response;
  * autenticação acontece NESTE middleware via HMAC + token. Após pass, request
  * attributes carregam `whatsapp.config` e `whatsapp.channel` pro controller.
  *
+ * **Fail-closed (2026-06-14):** sem assinatura HMAC válida NEM Token válido →
+ * 401. O antigo fallback de IP whitelist (`177.74.67.30` + `10.0.0.0/8`) foi
+ * REMOVIDO: `$request->ip()` reflete `X-Forwarded-For` sob `TrustProxies = '*'`
+ * (app/Http/Middleware/TrustProxies.php), logo qualquer cliente da Internet
+ * burlava a assinatura só omitindo o header e forjando o IP. IP allowlist do
+ * daemon agora vive no edge (firewall Hostinger / Traefik), não em PHP.
+ *
  * @see memory/decisions/0204-whatsmeow-driver-substituto-baileys.md
  * @see Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php
+ * @see Modules/Whatsapp/daemon-go/docker-compose.yml (WUZAPI_GLOBAL_HMAC_KEY)
  * @see https://github.com/asternic/wuzapi (HMAC global)
  */
 class VerifyWhatsmeowSignature
@@ -66,13 +74,26 @@ class VerifyWhatsmeowSignature
 
         $businessId = (int) $businessRow->id;
 
-        // ─── Verificação HMAC global (defesa primária) ──────────────────
-        // Daemon assina cada POST com HMAC-SHA256(body, WUZAPI_GLOBAL_HMAC_KEY).
-        // Laravel valida com mesma chave (env WHATSMEOW_HMAC_SECRET).
+        // ─── Defesa primária: HMAC global SHA-256 (timing-safe) ─────────
+        // Daemon assina cada POST com HMAC-SHA256(body, WUZAPI_GLOBAL_HMAC_KEY)
+        // — ver daemon-go/docker-compose.yml (WUZAPI_GLOBAL_HMAC_KEY_FILE).
+        // Laravel valida com a mesma chave (env WHATSMEOW_HMAC_SECRET).
         $hmacSecret = (string) config('whatsapp.whatsmeow.hmac_secret', '');
         $providedSignature = (string) $request->header('x-hmac-signature', '');
 
-        if ($hmacSecret !== '' && $providedSignature !== '') {
+        if ($providedSignature !== '') {
+            // Fail-closed: assinatura presente mas secret não configurado NÃO
+            // pode fazer downgrade silencioso pra auth mais fraca — recusa alto
+            // e claro (misconfig vira 401 + log, não bypass).
+            if ($hmacSecret === '') {
+                \Log::warning('[whatsapp.webhook.whatsmeow] x-hmac-signature recebida mas WHATSMEOW_HMAC_SECRET ausente', [
+                    'business_id' => $businessId,
+                    'business_uuid' => $businessUuid,
+                    'ip' => $request->ip(),
+                ]);
+                return response()->json(['error' => 'hmac_not_configured'], 401);
+            }
+
             // Daemon envia formato "sha256=<hex>" ou puro "<hex>" — aceita ambos
             $expectedHash = hash_hmac('sha256', (string) $request->getContent(), $hmacSecret);
             $providedHash = str_starts_with($providedSignature, 'sha256=')
@@ -96,40 +117,25 @@ class VerifyWhatsmeowSignature
             return $next($request);
         }
 
-        // ─── Fallback 1: Token header (sem HMAC global) ─────────────────
-        // Cenário: HMAC global não setado no daemon — valida via user_token
-        // matching algum channel ativo do business. Timing-safe compare.
+        // ─── Defesa secundária: Token header (segredo per-channel) ──────
+        // Daemon configurado pra enviar o user_token no header `Token` em vez
+        // de assinar via HMAC global. Match timing-safe contra
+        // channels.config_json.whatsmeow_user_token — segredo real, não IP.
         $providedToken = (string) $request->header('Token', '');
 
-        // ─── Fallback 2: IP whitelist CT 100 (WuzAPI outbound) ──────────
-        // Quando WuzAPI manda webhook outbound sem HMAC nem Token header
-        // (config padrão atual em /admin/users HasHmac=false), aceita request
-        // se vem do IP whitelist do CT 100 (Tier 1 defesa: rede privada).
-        // Sessão 2026-05-27: business_uuid path já valida tenant; channel
-        // resolvido por payload Username (resolveChannel) ou fallback default
-        // ativo. ADR 0205 Reconciler completo vai substituir esse fallback.
-        $allowedDaemonIps = (array) config('whatsapp.whatsmeow.allowed_daemon_ips', [
-            '177.74.67.30', // CT 100 público (Traefik egress)
-            '10.0.0.0/8',   // Tailscale interno
-        ]);
-        $remoteIp = (string) $request->ip();
-        $ipAllowed = $this->ipMatchesAny($remoteIp, $allowedDaemonIps);
-
-        if ($providedToken === '' && ! $ipAllowed) {
-            \Log::warning('[whatsapp.webhook.whatsmeow] sem HMAC nem Token nem IP whitelist', [
+        if ($providedToken === '') {
+            // Sem HMAC nem Token = recusa (fail-closed).
+            //
+            // O fallback de IP whitelist (177.74.67.30 + 10.0.0.0/8) foi
+            // REMOVIDO 2026-06-14: era spoofável via X-Forwarded-For sob
+            // TrustProxies '*' — qualquer cliente entrava só omitindo a
+            // assinatura. IP allowlist do daemon vive no edge, não em PHP.
+            \Log::warning('[whatsapp.webhook.whatsmeow] sem HMAC nem Token — recusado', [
                 'business_id' => $businessId,
                 'business_uuid' => $businessUuid,
-                'ip' => $remoteIp,
+                'ip' => $request->ip(),
             ]);
             return response()->json(['error' => 'invalid_signature'], 401);
-        }
-
-        if ($providedToken === '' && $ipAllowed) {
-            // IP whitelist OK — resolve channel via payload Username
-            $channel = $this->resolveChannel($request, $businessId);
-            $request->attributes->set('whatsapp.business_id', $businessId);
-            $request->attributes->set('whatsapp.channel', $channel);
-            return $next($request);
         }
 
         // SUPERADMIN: busca channels do business sem global scope (pré-auth)
@@ -157,31 +163,6 @@ class VerifyWhatsmeowSignature
         $request->attributes->set('whatsapp.channel', $channel);
 
         return $next($request);
-    }
-
-    /**
-     * Match IP contra lista de patterns (CIDR ou exato).
-     * Suporta strings simples ("177.74.67.30") + CIDR ("10.0.0.0/8").
-     */
-    private function ipMatchesAny(string $ip, array $patterns): bool
-    {
-        foreach ($patterns as $pattern) {
-            if (str_contains($pattern, '/')) {
-                [$subnet, $bits] = explode('/', $pattern, 2);
-                $ipBin = ip2long($ip);
-                $subnetBin = ip2long($subnet);
-                if ($ipBin === false || $subnetBin === false) {
-                    continue;
-                }
-                $mask = -1 << (32 - (int) $bits);
-                if (($ipBin & $mask) === ($subnetBin & $mask)) {
-                    return true;
-                }
-            } elseif ($ip === $pattern) {
-                return true;
-            }
-        }
-        return false;
     }
 
     /**

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowWebhookAuthTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowWebhookAuthTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Modules\Whatsapp\Http\Controllers\Api\WhatsmeowWebhookController;
+use Modules\Whatsapp\Http\Middleware\VerifyWhatsmeowSignature;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Auth do webhook Whatsmeow (Tier 0 segurança) — guard de regressão da remoção
+ * do fallback de IP whitelist spoofável (fix 2026-06-14, VerifyWhatsmeowSignature).
+ *
+ * red-first: este host de dev NÃO tem PHP/pest (`php: command not found`) — o run
+ * vermelho roda no CI. Contra o `main` atual (que ainda tem o fallback de IP), os
+ * casos "X-Forwarded-For forjado → 401" FALHAM vermelho: o middleware antigo cai na
+ * trilha de IP (`$request->ip()` reflete XFF sob TrustProxies '*') e retorna 200.
+ * Este teste DISCRIMINA o bug — prova que IP não autentica mais. Pós-fix = verde.
+ *
+ * Cobre:
+ *  - HMAC válido = 200
+ *  - HMAC inválido = 401
+ *  - sem HMAC + sem Token, X-Forwarded-For forjado (10.0.0.1) = 401   ← regressão
+ *  - sem HMAC + sem Token, X-Forwarded-For = IP do daemon (177.74.67.30) = 401
+ *  - sem HMAC + sem Token + sem XFF = 401 (fail-closed)
+ *  - HMAC presente mas secret ausente = 401 (fail-closed, sem downgrade)
+ *  - business_uuid inexistente = 404
+ *
+ * Padrão SQLite-friendly (cria `business` em beforeEach), espelha WebhookSignatureTest.
+ */
+
+beforeEach(function () {
+    Schema::dropIfExists('business');
+    Schema::create('business', function ($table) {
+        $table->bigIncrements('id');
+        $table->uuid('uuid')->nullable()->index();
+        $table->string('name')->nullable();
+        $table->timestamps();
+    });
+
+    config(['whatsapp.whatsmeow.hmac_secret' => 'super-secret-hmac-key-0123456789ab']);
+
+    app('router')->aliasMiddleware('whatsapp.whatsmeow.signature', VerifyWhatsmeowSignature::class);
+    Route::post('/api/whatsapp/webhook/whatsmeow/{business_uuid}', [WhatsmeowWebhookController::class, 'handle'])
+        ->middleware('whatsapp.whatsmeow.signature');
+});
+
+function wmAuthSeedBusiness(string $uuid): void
+{
+    DB::table('business')->insert([
+        'uuid' => $uuid,
+        'name' => 'Test Biz',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('HMAC válido retorna 200', function () {
+    $uuid = Str::uuid()->toString();
+    wmAuthSeedBusiness($uuid);
+
+    // Evento desconhecido sem Username/instanceName → controller responde
+    // 200 no_channel sem tocar a tabela `channels`.
+    $body = json_encode(['type' => 'Ping']);
+    $hmac = hash_hmac('sha256', $body, (string) config('whatsapp.whatsmeow.hmac_secret'));
+
+    $response = $this->call(
+        'POST',
+        "/api/whatsapp/webhook/whatsmeow/{$uuid}",
+        [], [], [],
+        ['HTTP_X-HMAC-SIGNATURE' => "sha256={$hmac}", 'CONTENT_TYPE' => 'application/json'],
+        $body
+    );
+
+    $response->assertStatus(200);
+});
+
+it('HMAC inválido retorna 401', function () {
+    $uuid = Str::uuid()->toString();
+    wmAuthSeedBusiness($uuid);
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/whatsmeow/{$uuid}",
+        ['type' => 'Ping'],
+        ['x-hmac-signature' => 'sha256=000000deadbeef000000']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('sem HMAC nem Token, com X-Forwarded-For forjado em 10.0.0.0/8 = 401 (IP não autentica mais)', function () {
+    $uuid = Str::uuid()->toString();
+    wmAuthSeedBusiness($uuid);
+
+    // Sob o fallback antigo, este XFF cairia em `10.0.0.0/8` → 200. Pós-fix → 401.
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/whatsmeow/{$uuid}",
+        ['type' => 'Message'],
+        ['X-Forwarded-For' => '10.0.0.1']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('sem HMAC nem Token, com X-Forwarded-For = IP público do daemon = 401', function () {
+    $uuid = Str::uuid()->toString();
+    wmAuthSeedBusiness($uuid);
+
+    // Mesmo forjando o IP exato que o fallback antigo aceitava (CT 100 egress),
+    // a auth agora exige HMAC/Token — IP é input morto.
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/whatsmeow/{$uuid}",
+        ['type' => 'Message'],
+        ['X-Forwarded-For' => '177.74.67.30']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('sem HMAC nem Token nem XFF = 401 (fail-closed)', function () {
+    $uuid = Str::uuid()->toString();
+    wmAuthSeedBusiness($uuid);
+
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/whatsmeow/{$uuid}",
+        ['type' => 'Message'],
+    );
+
+    $response->assertStatus(401);
+});
+
+it('HMAC presente mas WHATSMEOW_HMAC_SECRET ausente = 401 (fail-closed, sem downgrade)', function () {
+    config(['whatsapp.whatsmeow.hmac_secret' => '']);
+    $uuid = Str::uuid()->toString();
+    wmAuthSeedBusiness($uuid);
+
+    // Secret vazio NÃO pode rebaixar pra trilha mais fraca. Sob o código antigo,
+    // secret vazio pulava o HMAC e caía no IP (XFF forjado) → 200. Pós-fix → 401.
+    $response = $this->postJson(
+        "/api/whatsapp/webhook/whatsmeow/{$uuid}",
+        ['type' => 'Message'],
+        ['x-hmac-signature' => 'sha256=deadbeef', 'X-Forwarded-For' => '10.0.0.1']
+    );
+
+    $response->assertStatus(401);
+});
+
+it('business_uuid inexistente = 404', function () {
+    $response = $this->postJson(
+        '/api/whatsapp/webhook/whatsmeow/00000000-0000-0000-0000-000000000000',
+        ['type' => 'Message'],
+        ['X-Forwarded-For' => '10.0.0.1']
+    );
+
+    $response->assertStatus(404);
+});


### PR DESCRIPTION
## Problema (segurança — Tier 0)

`VerifyWhatsmeowSignature` (webhook WuzAPI inbound) autenticava por **IP de origem sozinho** quando HMAC e Token estavam ausentes. Sob `TrustProxies = '*'` ([app/Http/Middleware/TrustProxies.php](app/Http/Middleware/TrustProxies.php)), `$request->ip()` reflete o header `X-Forwarded-For` enviado pelo cliente. Logo **qualquer cliente da Internet** burlava o HMAC só **omitindo a assinatura e forjando um IP** da whitelist (`10.0.0.0/8` ou `177.74.67.30`).

Como `business_id` vem do `{business_uuid}` da rota e alimenta o `WhatsmeowReconciler`/inbox, um webhook forjado escreve dados de reconciliação/mensagem em **qualquer tenant** cujo UUID o atacante conheça — violação multi-tenant Tier 0 (ADR 0093).

Detalhe importante: o atacante **escolhe** se o HMAC é checado — basta não mandar o header `x-hmac-signature` pra cair na trilha de IP. Ou seja, o fallback **anulava** o HMAC, não só "enfraquecia".

> Pré-existente no `main`. Encontrado em review adversarial do #2721 (não introduzido por ele).

## Capacidade de assinatura do daemon (confirmado)

- O daemon **assina** todo webhook: [daemon-go/docker-compose.yml](Modules/Whatsapp/daemon-go/docker-compose.yml) seta `WUZAPI_GLOBAL_HMAC_KEY_FILE` → WuzAPI emite `x-hmac-signature` em modo global-HMAC.
- Laravel valida com `WHATSMEOW_HMAC_SECRET` ([Config/config.php](Modules/Whatsapp/Config/config.php)).

## Fix

- Remove o fallback de IP whitelist + helper `ipMatchesAny()`.
- Exige **HMAC válido OU Token per-channel válido**; senão **401**.
- **Fail-closed:** `x-hmac-signature` recebida sem `WHATSMEOW_HMAC_SECRET` configurado agora retorna 401 (não faz downgrade silencioso pra trilha mais fraca).
- Mantém a trilha Token (segredo real, `hash_equals`) como secundária.
- Test novo `WhatsmeowWebhookAuthTest`: HMAC válido/inválido, fail-closed, e **X-Forwarded-For forjado** (guard de regressão — vermelho contra o `main` atual).

Allowlist de IP do daemon deve viver no **edge** (firewall Hostinger / Traefik whitelisting o egress do CT 100), não em middleware PHP lendo header spoofável.

## ⚠️ Pré-requisito de DEPLOY (operacional, antes de mergear/deployar)

Confirmar **paridade do segredo em prod** antes de subir, senão todo webhook passa a dar 401 e o inbound WhatsApp quebra (Larissa, biz=4):
1. `WHATSMEOW_HMAC_SECRET` (Hostinger `.env`) **== ** `WUZAPI_GLOBAL_HMAC_KEY` do daemon (Vaultwarden / secret CT 100).
2. Um webhook real chega com `x-hmac-signature` válida (checar `laravel.log`).

## Notas

- Sem PHP neste host de dev (`php: command not found`) → suíte roda no CI. Header `red-first:` no teste documenta o vermelho esperado contra `main`.
- **Não-incluído (já catalogado, P0 separado):** anti-replay `x-ts`/`x-nonce` no whatsmeow (AUDITORIA-WHATSMEOW-DAEMON-2026-05-28).

Refs: ADR 0204, ADR 0206

🤖 Generated with [Claude Code](https://claude.com/claude-code)