### PR TITLE
fix(governance): ghost-fix.mjs pula **/adr/** (append-only) + teste-guard

### DIFF
--- a/scripts/governance/ghost-fix.mjs
+++ b/scripts/governance/ghost-fix.mjs
@@ -7,8 +7,9 @@
 // Nome sem evidência fica em 'excluded' no map e NUNCA é tocado — vai pra fila humana.
 // Plano-mãe: memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md (§1 Classe A).
 //
-// ESCOPO HARDCODED: memory/requisitos/**/*.md — só a forma 'Modules/<Nome>' (mesma
-// token-boundary do knowledge-drift.mjs). Forma namespace 'Modules\<Nome>' fica fora do v1.
+// ESCOPO HARDCODED: memory/requisitos/**/*.md EXCETO **/adr/** (ADRs são append-only,
+// ADR 0094 Art.3 — um ADR de rename CITA o nome antigo como FATO). Só a forma 'Modules/<Nome>'
+// (mesma token-boundary do knowledge-drift.mjs). Forma namespace 'Modules\<Nome>' fica fora do v1.
 //
 // Uso:
 //   node scripts/governance/ghost-fix.mjs            # dry-run (default) — relatório, 0 writes
@@ -49,12 +50,17 @@ for (const [from, r] of Object.entries(renames)) {
 }
 
 // ── varre o escopo ───────────────────────────────────────────────────────────
+// ADRs são append-only (ADR 0094 Art.3): um ADR de rename CITA o nome antigo como FATO
+// (ex: memory/requisitos/MemCofre/adr/0008-rename-docvault-para-memcofre.md). O codemod
+// NUNCA pode reescrevê-lo — pula a subárvore adr/ inteira, em qualquer profundidade.
 function allMd(dir) {
   const out = [];
   for (const e of readdirSync(dir, { withFileTypes: true })) {
     const p = join(dir, e.name);
-    if (e.isDirectory()) out.push(...allMd(p));
-    else if (e.name.endsWith('.md')) out.push(p);
+    if (e.isDirectory()) {
+      if (e.name === 'adr') continue; // hard-skip append-only — ver comentário acima
+      out.push(...allMd(p));
+    } else if (e.name.endsWith('.md')) out.push(p);
   }
   return out;
 }
@@ -105,7 +111,7 @@ const rows = [...perModule.entries()]
 
 const summary = {
   mode: WRITE ? 'WRITE' : 'DRY-RUN',
-  scope: 'memory/requisitos/**/*.md',
+  scope: 'memory/requisitos/**/*.md (exceto **/adr/** — append-only)',
   occurrences_mapped: totalMapped,
   occurrences_excluded_by_map: totalExcluded,
   occurrences_unknown: [...unknownGhosts.values()].reduce((a, b) => a + b, 0),

--- a/scripts/governance/ghost-fix.test.mjs
+++ b/scripts/governance/ghost-fix.test.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// TESTE DE REGRESSÃO — prova que ghost-fix.mjs NUNCA toca **/adr/** (append-only, ADR 0094 Art.3).
+// Monta um repo-fixture temporário e exercita o MESMO code path do codemod real (cwd-based).
+// Origem: um ADR de rename CITA o nome antigo como FATO (ex: MemCofre/adr/0008-rename-docvault…);
+// um --write cego o corromperia. Rodar: node scripts/governance/ghost-fix.test.mjs — exit 0 = passa.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, 'ghost-fix.mjs');
+
+let fails = 0;
+const check = (name, cond) => { console.log(`${cond ? '[OK]' : '[FAIL]'} ${name}`); if (!cond) fails++; };
+
+// ── repo-fixture: Modules/Jana existe (to); Copiloto é ghost (from); um SPEC e dois ADRs citam Copiloto ──
+const root = mkdtempSync(join(tmpdir(), 'ghostfix-'));
+mkdirSync(join(root, 'Modules', 'Jana'), { recursive: true });
+mkdirSync(join(root, 'governance'), { recursive: true });
+mkdirSync(join(root, 'memory', 'requisitos', 'Foo', 'adr', 'sub'), { recursive: true });
+writeFileSync(join(root, 'governance', 'ghost-rename-map.json'),
+  JSON.stringify({ version: 'test', renames: { Copiloto: { to: 'Jana' } }, excluded: {} }));
+const spec = join(root, 'memory', 'requisitos', 'Foo', 'SPEC.md');
+const adr = join(root, 'memory', 'requisitos', 'Foo', 'adr', '0001-rename.md');
+const adrNested = join(root, 'memory', 'requisitos', 'Foo', 'adr', 'sub', '0002.md');
+writeFileSync(spec, 'Ver Modules/Copiloto/Service.\n');
+writeFileSync(adr, 'ADR de rename: Modules/Copiloto virou outra coisa (FATO historico).\n');
+writeFileSync(adrNested, 'Modules/Copiloto citado em adr aninhado.\n');
+
+const run = (extra = []) => spawnSync('node', [SCRIPT, ...extra], { cwd: root, encoding: 'utf8' });
+
+// 1. dry-run --json: conta SÓ o SPEC.md (1 ocorrência), NUNCA os 2 arquivos sob adr/.
+const j = JSON.parse(run(['--json']).stdout);
+check('dry-run conta só fora de adr/ (1 ocorrência)', j.summary.occurrences_mapped === 1);
+check('scope declara a exclusão de adr/', /adr/.test(j.summary.scope));
+
+// 2. --write reescreve o SPEC mas deixa os 2 ADRs byte-idênticos (append-only intacto).
+run(['--write']);
+const specTxt = readFileSync(spec, 'utf8');
+check('SPEC.md reescrito (Copiloto→Jana)', specTxt.includes('Modules/Jana') && !specTxt.includes('Modules/Copiloto'));
+check('ADR intacto (append-only)', readFileSync(adr, 'utf8').includes('Modules/Copiloto'));
+check('ADR aninhado intacto', readFileSync(adrNested, 'utf8').includes('Modules/Copiloto'));
+
+console.log(fails ? `\n${fails} FALHA(S)` : '\nTODOS OS TESTES PASSARAM');
+process.exit(fails ? 1 : 0);


### PR DESCRIPTION
## Problema (verificado em origin/main)
`scripts/governance/ghost-fix.mjs` (codemod de ghost-names, frente KL) varre `memory/requisitos/**/*.md` **sem** excluir os ADRs locais de módulo em `**/adr/**`. Um ADR de rename **cita o nome antigo como FATO** — ex. `memory/requisitos/MemCofre/adr/0008-rename-docvault-para-memcofre.md`. Um `--write` reescreveria **11 ADRs imutáveis**, violando append-only (ADR 0094 Art.3) — o mesmo incidente que o auditor pegou na Fase 1.

## Fix
`allMd()` pula qualquer diretório `adr` em qualquer profundidade (`adr/`, `adr/tech/`, `adr/arq/`).
Dry-run real contra o repo: **0 arquivos sob `adr/`** no output (antes: 11).

## Teste
`scripts/governance/ghost-fix.test.mjs` — repo-fixture (Modules/Jana + 1 SPEC e 2 ADRs citando Copiloto) prova que `--write` reescreve o SPEC mas deixa os ADRs **byte-idênticos**. Estilo `foundation-ratchet.test.mjs` (spawnSync + fixtures, sem rede/DB). `node scripts/governance/ghost-fix.test.mjs` → 5/5 OK.

## Escopo
2 arquivos, ~20 linhas. Não muda o map nem aplica renames — só impede a corrupção de ADRs num `--write` futuro (KL-E2).

Refs: SDD frente KL-A3 · plano `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` §1 Classe A

🤖 Generated with [Claude Code](https://claude.com/claude-code)