### PR TITLE
feat(governance): scorecard mede n_quarantine (FV-Q3) — 27 arquivos

### DIFF
--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -14,7 +14,7 @@
   "metrics": {
     "anchor_coverage": {
       "status": "measured",
-      "value": 2.8,
+      "value": 3.5,
       "unit": "%",
       "direction": "up",
       "target": 100,
@@ -22,11 +22,11 @@
       "detail": {
         "specs_total": 57,
         "specs_with_field": 15,
-        "us_total": 781,
+        "us_total": 799,
         "fields_total": 84,
-        "fields_placeholder": 50,
-        "fields_filled": 34,
-        "fields_anchored_strict": 22
+        "fields_placeholder": 45,
+        "fields_filled": 39,
+        "fields_anchored_strict": 28
       }
     },
     "full_suite_pass_rate": {
@@ -38,12 +38,15 @@
       "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
     },
     "n_quarantine": {
-      "status": "not_yet_measured",
-      "value": null,
+      "status": "measured",
+      "value": 27,
+      "unit": "arquivos de teste",
       "direction": "down",
       "target": 0,
-      "source": "grep @group legacy-quarantine — grupo só passa a existir na quarentena FV-Q3",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "source": "convenção legacy-quarantine (@group | ->group() | skip) em tests/ + Modules/*/Tests (este script)",
+      "detail": {
+        "quarantined_files": 27
+      }
     },
     "coverage_pct": {
       "status": "not_yet_measured",
@@ -55,13 +58,13 @@
     },
     "ghost_count": {
       "status": "measured",
-      "value": 27,
+      "value": 15,
       "unit": "nomes distintos",
       "direction": "down",
       "target": 0,
       "source": "scripts/governance/knowledge-drift.mjs --json (Modules/<X> citado e inexistente no disco; nomes: rodar a fonte direto)",
       "detail": {
-        "citing_modules": 39
+        "citing_modules": 25
       }
     },
     "front_door_coverage": {

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -79,6 +79,30 @@ function measureAnchors() {
     fields_anchored_strict: anchored };
 }
 
+// ── fonte 3: quarentena FV-Q3 (convenção legacy-quarantine nos testes) ───────
+// Conta ARQUIVOS de teste quarentenados (n_quarantine só DESCE no burn-down). A convenção
+// aparece em 3 formas — @group legacy-quarantine (docblock), ->group('legacy-quarantine')
+// (Pest fluent, granular por teste) e skip('legacy-quarantine: ...') — todas cravam o MESMO
+// token. Casar só @group subcontava (14 de 27 reais). Determinístico: contagem por arquivo,
+// independe da ordem do readdir. Escopo = tests/ + Modules/*/Tests (onde vive o marcador).
+const QUARANTINE_RE = /legacy-quarantine/;
+function measureQuarantine() {
+  let files = 0;
+  const walk = (dir) => {
+    if (!existsSync(dir)) return;
+    for (const e of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name.endsWith('.php') && QUARANTINE_RE.test(readFileSync(p, 'utf8'))) files++;
+    }
+  };
+  walk(join(ROOT, 'tests'));
+  const mods = join(ROOT, 'Modules');
+  if (existsSync(mods)) for (const e of readdirSync(mods, { withFileTypes: true }))
+    if (e.isDirectory()) walk(join(mods, e.name, 'Tests'));
+  return { files };
+}
+
 // ── montagem do scorecard (ordem fixa = output determinístico) ──────────────
 function pct(num, den) { return den ? Math.round((1000 * num) / den) / 10 : null; }
 const notYet = (direction, target, source) => ({
@@ -89,6 +113,7 @@ const notYet = (direction, target, source) => ({
 function buildScorecard() {
   const kd = measureKnowledgeDrift();
   const an = measureAnchors();
+  const q = measureQuarantine();
   return {
     _meta: {
       scorecard: 'SDD — sistema spec-anchored + verificação agêntica (plano 2026-06-12 §2)',
@@ -111,8 +136,12 @@ function buildScorecard() {
       },
       full_suite_pass_rate: notYet('up', '100% não-quarentenado',
         'nightly MySQL diagnóstica (FV-F3) — nenhum run full-repo MySQL jamais foi salvo'),
-      n_quarantine: notYet('down', 0,
-        'grep @group legacy-quarantine — grupo só passa a existir na quarentena FV-Q3'),
+      n_quarantine: {
+        status: 'measured', value: q.files, unit: 'arquivos de teste',
+        direction: 'down', target: 0,
+        source: 'convenção legacy-quarantine (@group | ->group() | skip) em tests/ + Modules/*/Tests (este script)',
+        detail: { quarantined_files: q.files },
+      },
       coverage_pct: notYet('up', 'só sobe (catraca C2)',
         'pcov instrumentado em CI (P0-2) — hoje coverage: none'),
       ghost_count: {


### PR DESCRIPTION
## Problema
`scripts/governance/sdd-scorecard.mjs` deixava `n_quarantine` como stub `notYet()` **apesar de 27 arquivos de teste já quarentenados em main** (FV-Q3 começou). A métrica `n_quarantine` (plano §2, "MEDIDA") ficava `not_yet_measured`.

## Armadilha que evitei
A convenção `legacy-quarantine` aparece em **3 formas**: `@group legacy-quarantine` (docblock, 14 arquivos), `->group('legacy-quarantine')` (Pest fluent granular — os testes Sells) e `skip('legacy-quarantine: …')`. Casar só `@group` **subcontava 14 de 27** — uma métrica que sub-reporta quarentena é o tipo de "spec mentindo" que o SDD existe pra matar. O matcher casa o token da convenção.

## Fix
- `measureQuarantine()` conta arquivos com o token em `tests/` + `Modules/*/Tests` (determinístico — só contagem por arquivo). **Confirmado: 27 == `git grep -l legacy-quarantine`.**
- Regenera `governance/sdd-scorecard.json` (a meta-catraca determinística exige committed==fresh).

## Transparência: o regen também refresca métricas stale
O `sdd-scorecard.json` committed estava defasado. O regen atualiza, **além** de n_quarantine, métricas que já melhoraram em main mas não tinham sido re-commitadas (não são mudanças deste PR): `anchor_coverage` 2.8→3.5%, `ghost_count` 27→15, `front_door` (idem).

## Segurança
- Determinismo: 2 runs `--json` byte-idênticos ✓
- Ratchet vs baseline: **sem regressão**, exit 0 — inclusive `SDD_RATCHET_ARM=1 --ratchet`. n_quarantine entra **desarmada** (arma após 3 medições válidas, ADR 0275 §3).
- `gate-selftest` roda em sandbox (sem `tests/`/`Modules/`) → measureQuarantine retorna 0, não afeta o self-test.

Refs: SDD frente FV-Q3 / GT-G2 · plano `memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md` §2 (MEDIDA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)