### PR TITLE
test(ads): RC-23 — uses(TestCase) nos Unit tests (boot container, ~26 falhas)

### DIFF
--- a/Modules/ADS/Tests/Unit/DecisionRouterTest.php
+++ b/Modules/ADS/Tests/Unit/DecisionRouterTest.php
@@ -9,6 +9,8 @@ use Modules\ADS\Services\ConfidenceEngine;
 use Modules\ADS\Services\RoutingInput;
 use Modules\ADS\Services\RoutingDecision;
 
+uses(Tests\TestCase::class);
+
 // ARQ-0003 + ARQ-0010 — DecisionRouter: roteamento + hierarquia
 // Testes sem DB: substitui DecisionRouter por subclasse que não grava no banco
 

--- a/Modules/ADS/Tests/Unit/RiskEngineTest.php
+++ b/Modules/ADS/Tests/Unit/RiskEngineTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Modules\ADS\Services\RiskEngine;
 
+uses(Tests\TestCase::class);
+
 // ARQ-0004 — RiskEngine: fórmula + priors + zonas
 
 it('eventos BLOCK_ALWAYS têm risco >= 0.9', function (string $eventType) {


### PR DESCRIPTION
Triagem workflow: RiskEngineTest + DecisionRouterTest instanciam RiskEngine/DecisionRouter cujo calculate()/route() passa por OtelHelper::spanBiz → auth()->user() sem container bootado → 'Target [Illuminate\Contracts\Auth\Factory] is not instantiable'. Fix: uses(Tests\TestCase::class) (padrão PolicyEngineTest.php:8). Test-only, aprovado por verificação adversarial. Refs: SDD F2b RC-23