### PR TITLE
test(financeiro): RC-24 — corrige import App\Role inexistente (CobrancaControllerTest, ~15 falhas)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/CobrancaControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/CobrancaControllerTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Business;
-use App\Role;
+use Spatie\Permission\Models\Role;
 use App\User;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\PaymentGateway\Models\Cobranca;


### PR DESCRIPTION
Triagem workflow: CobrancaControllerTest importa `use App\Role` (linha 6) que não existe no projeto → beforeEach falha no autoload → ~15 testes erram. Classe Role canônica é Spatie\Permission\Models\Role (mesma usada pelo sibling FinanceiroTestCase.php + seeders + Util.php, todos com business_id). Só o import muda; alias resolve. Test-only, aprovado adversarialmente. Refs: SDD F2b RC-24