### PR TITLE
test(project-mgmt): RC-26 — corrige nome de permission no guard dos helpers (BoardControllerTest, ~25 falhas)

### DIFF
--- a/Modules/ProjectMgmt/Tests/Feature/BoardControllerTest.php
+++ b/Modules/ProjectMgmt/Tests/Feature/BoardControllerTest.php
@@ -55,14 +55,14 @@ function pmgBootstrapUser(): User
 function pmgGivePerm(User $user): void
 {
     Permission::firstOrCreate(['name' => 'copiloto.mcp.usage.all', 'guard_name' => 'web']);
-    if (! $user->hasPermissionTo('jana.mcp.usage.all')) {
+    if (! $user->hasPermissionTo('copiloto.mcp.usage.all')) {
         $user->givePermissionTo('copiloto.mcp.usage.all');
     }
 }
 
 function pmgRevokePerm(User $user): void
 {
-    if ($user->hasPermissionTo('jana.mcp.usage.all')) {
+    if ($user->hasPermissionTo('copiloto.mcp.usage.all')) {
         $user->revokePermissionTo('copiloto.mcp.usage.all');
     }
 }


### PR DESCRIPTION
Triagem workflow: pmgGivePerm/pmgRevokePerm chamavam hasPermissionTo('jana.mcp.usage.all') — permission que NUNCA é criada (só 'copiloto.mcp.usage.all', a que o middleware do BoardController realmente checa). Spatie v6: hasPermissionTo(string) com permission inexistente lança PermissionDoesNotExist → derruba os ~25 testes. Fix: alinhar o predicado à permission real (typo legado TeamMcp/Jana). Aprovado adversarialmente. Refs: SDD F2b RC-26