### PR TITLE
test(nfse): RC-27 — corrige loader-blocker NfseEmissaoServiceTest (TestCase duplicado do RC-16)

### DIFF
--- a/tests/Feature/Modules/NFSe/NfseEmissaoServiceTest.php
+++ b/tests/Feature/Modules/NFSe/NfseEmissaoServiceTest.php
@@ -23,7 +23,10 @@ use Modules\NFSe\Models\NfseCertificado;
 use Modules\NFSe\Models\NfseProviderConfig;
 use Modules\NFSe\Services\NfseEmissaoService;
 
-uses(Tests\TestCase::class, Illuminate\Foundation\Testing\DatabaseTransactions::class);
+// TestCase já é aplicado por tests/Pest.php (uses(TestCase)->in('Feature')) —
+// declarar de novo aqui dispara "already uses the test case" e vira loader-blocker.
+// Só DatabaseTransactions precisa ser anexado (RC-27 corrige RC-16).
+uses(Illuminate\Foundation\Testing\DatabaseTransactions::class);
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## RC-27 — loader-blocker que silenciava o arquivo todo desde RC-16

### Causa-raiz (medida no run.log do nightly)
```
ERROR Test case [Tests\TestCase] can not be used. The folder [...NfseEmissaoServiceTest.php] already uses the test case [Tests\TestCase].
pest exit code: 2 (loader-blockers: 1)
```
Meu RC-16 trocou `uses(RefreshDatabase::class)` por `uses(Tests\TestCase::class, DatabaseTransactions::class)`. Mas `tests/Pest.php` já faz `uses(TestCase::class)->in('Feature')` — e `NfseEmissaoServiceTest` está em `tests/Feature/Modules/NFSe/`, coberto recursivamente. TestCase em duplicata → fatal na coleção → o harness **move o arquivo de lado todo run** (os 16 testes nunca rodaram desde que RC-16 mergeou) + `pest exit code 2`.

### Fix
`uses(Illuminate\Foundation\Testing\DatabaseTransactions::class);` — só anexa DatabaseTransactions; o TestCase vem do Pest.php raiz. Padrão correto pra `tests/Feature/**`.

### Nota de escopo
Confirmei que RC-21/22 (em `Modules/*/Tests/`, FORA do `->in('Feature')`) estão corretos — lá o TestCase explícito é obrigatório. O bug era exclusivo de arquivos em `tests/Feature/`.

Refs: SDD F2b RC-27 (corrige RC-16)