### PR TITLE
test(sells): RC-28 — corrige API de skip em helpers de quarentena (~6 falhas)

### DIFF
--- a/tests/Feature/Sells/SellsBulkActionsTest.php
+++ b/tests/Feature/Sells/SellsBulkActionsTest.php
@@ -60,7 +60,7 @@ function readBulkBar(): string
 {
     $path = base_path(BULK_BAR_PATH);
     if (!file_exists($path)) {
-        test()->skip('SellsBulkActionsBar.tsx não encontrado (legacy-quarantine: componente deletado)');
+        test()->markTestSkipped('SellsBulkActionsBar.tsx não encontrado (legacy-quarantine: componente deletado)');
     }
 
     return (string) file_get_contents($path);
@@ -70,7 +70,7 @@ function readGradeAvancada(): string
 {
     $path = base_path(GRADE_PATH_BULK);
     if (!file_exists($path)) {
-        test()->skip('SellsGradeAvancada.tsx não encontrado (legacy-quarantine: componente deletado)');
+        test()->markTestSkipped('SellsGradeAvancada.tsx não encontrado (legacy-quarantine: componente deletado)');
     }
 
     return (string) file_get_contents($path);

--- a/tests/Feature/Sells/SellsGroupByTest.php
+++ b/tests/Feature/Sells/SellsGroupByTest.php
@@ -44,7 +44,7 @@ function readGroupByDropdown(): string
 {
     $path = base_path(GROUP_BY_DROPDOWN_PATH);
     if (!file_exists($path)) {
-        test()->skip('SellsGroupByDropdown.tsx não encontrado (legacy-quarantine: componente deletado)');
+        test()->markTestSkipped('SellsGroupByDropdown.tsx não encontrado (legacy-quarantine: componente deletado)');
     }
 
     return (string) file_get_contents($path);
@@ -54,7 +54,7 @@ function readGradeGroupBy(): string
 {
     $path = base_path(GRADE_PATH_GROUPBY);
     if (!file_exists($path)) {
-        test()->skip('SellsGradeAvancada.tsx não encontrado (legacy-quarantine: componente deletado)');
+        test()->markTestSkipped('SellsGradeAvancada.tsx não encontrado (legacy-quarantine: componente deletado)');
     }
 
     return (string) file_get_contents($path);
@@ -64,7 +64,7 @@ function readBulkBarGroupBy(): string
 {
     $path = base_path(BULK_BAR_PATH_GROUPBY);
     if (!file_exists($path)) {
-        test()->skip('SellsBulkActionsBar.tsx não encontrado (legacy-quarantine: componente deletado)');
+        test()->markTestSkipped('SellsBulkActionsBar.tsx não encontrado (legacy-quarantine: componente deletado)');
     }
 
     return (string) file_get_contents($path);

--- a/tests/Feature/Sells/SellsTabsViewModeTest.php
+++ b/tests/Feature/Sells/SellsTabsViewModeTest.php
@@ -45,7 +45,7 @@ function tabsReadInsightsView(): string
 {
     $path = base_path(TABS_INSIGHTS_VIEW_PATH);
     if (!file_exists($path)) {
-        test()->skip('SellsInsightsView.tsx não encontrado (legacy-quarantine: componente deletado)');
+        test()->markTestSkipped('SellsInsightsView.tsx não encontrado (legacy-quarantine: componente deletado)');
     }
 
     return (string) file_get_contents($path);


### PR DESCRIPTION
Triagem workflow: 6 helpers em SellsGroupByTest(3)/SellsBulkActionsTest(2)/SellsTabsViewModeTest(1) chamam `test()->skip()` — método inexistente (skip() só existe encadeado no it(), não no TestCase em runtime). Quando o .tsx do componente está ausente (deletado/fundido na refator), o helper dispara 'Call to undefined method'. Fix: `test()->markTestSkipped()` (canon in-body, ex: FsmBulkStartPipelineCommandTest.php:33). Guards Tier-0 em it() separados (que leem arquivos vivos) ficam intactos. Aprovado adversarialmente. Refs: SDD F2b RC-28