### PR TITLE
test(sdd): RC-30 — quarentena cirúrgica de snapshots superseded (Whatsapp/Brief/Financeiro, ~32 falhas)

### DIFF
--- a/Modules/Brief/Tests/Feature/BriefFallbackTest.php
+++ b/Modules/Brief/Tests/Feature/BriefFallbackTest.php
@@ -15,6 +15,19 @@ use Modules\Brief\Services\BriefGeneratorService;
 
 uses(Tests\TestCase::class);
 
+// QUARENTENA CIRÚRGICA (RC-30): generateWithFallback/serveCachedWithStaleFlag são
+// TDD órfão — nunca implementados no BriefGeneratorService (a lógica de fallback vive
+// em BriefFetchTool/BriefFetchController). Pula SÓ os ~10 it() que chamam esses métodos
+// (têm o nome do método na descrição); os 18 it() de FormRequest (Purge/Fetch/Export/
+// Compare — anti-DoS, redact_pii, whitelist) seguem rodando. Remover quando a feature
+// for implementada de fato.
+beforeEach(function () {
+    $name = $this->name();
+    if (str_contains($name, 'generateWithFallback') || str_contains($name, 'serveCachedWithStaleFlag')) {
+        $this->markTestSkipped('TDD órfão — generateWithFallback/serveCachedWithStaleFlag não implementados no BriefGeneratorService.');
+    }
+});
+
 /**
  * BriefFallbackTest — Wave 23 G4 FICHA W22.
  *

--- a/Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php
+++ b/Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php
@@ -82,7 +82,7 @@ describe('Mock Onda Comments DB — Bridge comments (estrutural)', function () {
         $src = file_get_contents(FIN_BRIDGE_COMMENTS);
         expect($src)->toContain('__OIMPRESSO_COMMENTS_DB__');
     });
-});
+})->skip('legacy-quarantine: _oimpresso-bridge-comments.js removido pós-Inertia F3 (snapshot superseded). Backend/HTTP describes seguem vivos.');
 
 describe('Mock Onda Audit DB — Bridge audit (estrutural)', function () {
     it('arquivo _oimpresso-bridge-audit.js existe', function () {
@@ -114,7 +114,7 @@ describe('Mock Onda Audit DB — Bridge audit (estrutural)', function () {
         expect($src)->toContain('__OIMPRESSO_AUDIT_DB__');
         expect($src)->toContain("'oimpresso:fin-audit-loaded'");
     });
-});
+})->skip('legacy-quarantine: _oimpresso-bridge-audit.js removido pós-Inertia F3 (snapshot superseded). Backend/HTTP describes seguem vivos.');
 
 describe('Mock Onda Comments + Audit — JSX dispatch events (modificações mínimas)', function () {
     it('financeiro-curation.jsx FinCommentsThread dispatch oimpresso:fin-comment-add', function () {
@@ -139,7 +139,7 @@ describe('Mock Onda Comments + Audit — JSX dispatch events (modificações mí
         // Nenhuma chamada fetch direta dentro do JSX (bridge faz isso)
         expect($src)->not->toContain('fetch(');
     });
-});
+})->skip('legacy-quarantine: financeiro-curation.jsx/financeiro-app.jsx Cowork removidos pós-Inertia F3 (snapshot superseded). Backend/HTTP describes seguem vivos.');
 
 describe('Mock Onda Comments + Audit — Backend Laravel (endpoints)', function () {
     it('UnificadoController tem 3 métodos novos: comments + addComment + auditTrail', function () {

--- a/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/BusinessSettingsValidationTest.php
@@ -10,6 +10,14 @@ use Modules\Whatsapp\Http\Requests\BusinessSettingsRequest;
 uses(Tests\TestCase::class);
 
 beforeEach(function () {
+    // QUARENTENA (snapshot superseded): a validação de driver/LGPD/fallback migrou
+    // de BusinessSettingsRequest (hoje stub — US-WA-067 + ADR 0135) para
+    // ChannelRequest::withValidator() com contrato incompatível (config.* nesting,
+    // type=whatsapp_zapi/baileys/whatsmeow, lgpd via required_if/accepted_if). As
+    // chaves bypass_business_ids / forbidden_drivers não existem mais.
+    // Cobertura viva: ChannelRequestUniqueIdentifierTest.
+    test()->markTestSkipped('Superseded por ADR 0135 — validação de drivers migrou p/ ChannelRequest; BusinessSettingsRequest é stub (US-WA-067).');
+
     // Reset bypass list — testes Tier 0 dependem de default vazio (gate ativo).
     // Testes de bypass setam [1] explicitamente.
     config()->set('whatsapp.fallback.bypass_business_ids', []);


### PR DESCRIPTION
Triagem workflow + verificação adversarial. O cético reprovou as versões file-wide (mascaravam testes vivos); estas são as **cirúrgicas**:

- **Whatsapp** BusinessSettingsValidationTest: file-wide OK (todos ~10 obsoletos — BusinessSettingsRequest virou stub, validação migrou p/ ChannelRequest, ADR 0135). Corrigido p/ `test()->markTestSkipped` (não bare, que daria 'undefined function').
- **Brief** BriefFallbackTest: skip cirúrgico via beforeEach name-match — pula só os ~10 it() de generateWithFallback/serveCachedWithStaleFlag (TDD órfão); os **18 it() de FormRequest** (anti-DoS/redact_pii/whitelist) seguem rodando.
- **Financeiro** OndaCommentsAuditBridgeTest: skip só os **3 describe de UI morta** (bridges JS + JSX removidos pós-Inertia F3); os **3 describe backend** (UnificadoController/Routes/TituloComment/migration Tier-0 + HTTP smoke) seguem vivos.

Test-only. Refs: SDD F2b RC-30