### PR TITLE
test(whatsapp): RC-31 — updated_at no schema sintético (PhoneResolutionWebhookTest, ~5 falhas)

### DIFF
--- a/Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php
@@ -105,6 +105,9 @@ beforeEach(function () {
         $table->json('payload')->nullable();
         $table->string('status', 20);
         $table->timestamp('created_at')->useCurrent();
+        // WhatsappMessage tem timestamps on (cast updated_at) → create() insere updated_at.
+        // O schema sintético precisa da coluna senão "Unknown column 'updated_at'" (RC-31).
+        $table->timestamp('updated_at')->nullable();
     });
 });
 


### PR DESCRIPTION
Triagem workflow: o beforeEach cria schema sintético de whatsapp_messages só com created_at, mas o model WhatsappMessage tem timestamps habilitados (cast updated_at) → WhatsappMessage::create() insere updated_at → 'Unknown column updated_at'. A tabela REAL tem updated_at. Fix de 1 linha alinha o schema sintético ao model, preservando a cobertura de phone-resolution (meta/zapi/baileys + Tier 0 + idempotência). Refs: SDD F2b RC-31