### PR TITLE
fix(teammcp): McpToken SoftDeletes — corrige crash deleted_at + completa audit LGPD

### DIFF
--- a/Modules/Jana/Database/Migrations/2026_06_14_120000_add_soft_deletes_to_mcp_tokens_table.php
+++ b/Modules/Jana/Database/Migrations/2026_06_14_120000_add_soft_deletes_to_mcp_tokens_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adiciona soft-delete (`deleted_at`) a `mcp_tokens`.
+ *
+ * BUG real (triagem SDD nightly 20260614): McpTokenIssuer::rotate/revoke,
+ * RotateTokenCommand::rotateAllForUser e ScorecardBuilderService::buildFacts
+ * já tratavam `mcp_tokens` como soft-deletable (`delete()`,
+ * `whereNull('deleted_at')`, `withTrashed()`) mas a coluna nunca existiu —
+ * "Unknown column 'deleted_at'" em QUALQUER run MySQL (inclusive prod).
+ *
+ * Tier 0 SEGREDO (ADR 0081): coluna ADITIVA nullable, NÃO-destrutiva. Preserva
+ * o audit trail LGPD — rotate/revoke agora soft-deletam (a row sobrevive) em
+ * vez de hard-delete. Pareado com o trait `SoftDeletes` em McpToken.
+ *
+ * REPO-WIDE: `mcp_tokens` é per-user (sem `business_id` — ADR 0053), exceção
+ * documentada de multi-tenant (token vincula a user, não a business).
+ */
+class AddSoftDeletesToMcpTokensTable extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('mcp_tokens', 'deleted_at')) {
+            Schema::table('mcp_tokens', function (Blueprint $table) {
+                $table->softDeletes(); // deleted_at TIMESTAMP NULL
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('mcp_tokens', 'deleted_at')) {
+            Schema::table('mcp_tokens', function (Blueprint $table) {
+                $table->dropSoftDeletes(); // dropColumn('deleted_at')
+            });
+        }
+    }
+}

--- a/Modules/Jana/Entities/Mcp/McpToken.php
+++ b/Modules/Jana/Entities/Mcp/McpToken.php
@@ -3,6 +3,7 @@
 namespace Modules\Jana\Entities\Mcp;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -21,11 +22,18 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * e expiração — essencial pra responder LGPD Art. 9º (rastreabilidade de
  * tratamento por credenciais).
  *
+ * SOFT-DELETE (2026-06-14): rotate/revoke fazem soft-delete (`deleted_at`) em vez
+ * de hard-delete — a row sobrevive pra forense LGPD e `revoked_at`/`revoked_by`
+ * são gravados junto (quem/quando). O revoke do drill-down admin
+ * (`TeamController::revokeToken`) usa `revogar()` SEM delete: o token permanece
+ * visível como "Revogado" no histórico de governança.
+ *
  * SECURITY: sha256_token NUNCA logado (já marcado em $hidden).
  */
 class McpToken extends Model
 {
     use LogsActivity;
+    use SoftDeletes;
 
     protected $table = 'mcp_tokens';
 
@@ -40,6 +48,7 @@ class McpToken extends Model
         'last_used_at' => 'datetime',
         'expires_at'   => 'datetime',
         'revoked_at'   => 'datetime',
+        'deleted_at'   => 'datetime',
     ];
 
     protected $hidden = ['sha256_token'];

--- a/Modules/TeamMcp/Http/Controllers/TeamController.php
+++ b/Modules/TeamMcp/Http/Controllers/TeamController.php
@@ -327,8 +327,13 @@ JS;
         // de credencial MCP, equivale a operação Tier 0 governança).
         return OtelHelper::spanBiz('teammcp.token.revoke', function () use ($tokenId) {
             $token = McpToken::findOrFail($tokenId);
-            $token->update(['expires_at' => now()]);
-            $token->delete();
+            // Audit LGPD (ADR 0081): grava revoked_at/revoked_by ANTES do soft-delete.
+            $token->update([
+                'expires_at' => now(),
+                'revoked_at' => now(),
+                'revoked_by' => auth()->id() ?? 0,
+            ]);
+            $token->delete(); // soft-delete (SoftDeletes) — a row sobrevive pro audit
 
             return response()->json(['ok' => true]);
         }, ['module' => 'TeamMcp', 'token_id' => $tokenId]);

--- a/Modules/TeamMcp/Services/McpTokenIssuer.php
+++ b/Modules/TeamMcp/Services/McpTokenIssuer.php
@@ -43,19 +43,27 @@ class McpTokenIssuer
     }
 
     /**
-     * Revoga (soft-delete + expires_at=now) um token existente.
+     * Revoga um token: grava `revoked_at`/`revoked_by` (audit LGPD completo) +
+     * `expires_at=now` e soft-delete (SoftDeletes — a row sobrevive pra forense).
      *
+     * @param  int       $tokenId   token a revogar
+     * @param  int|null  $byUserId  actor que revogou (default: o próprio dono — self-revoke)
      * @return bool true se revoke aplicado; false se token não existia.
      */
-    public function revoke(int $tokenId): bool
+    public function revoke(int $tokenId, ?int $byUserId = null): bool
     {
-        return OtelHelper::spanBiz('teammcp.token.revoke', function () use ($tokenId) {
+        return OtelHelper::spanBiz('teammcp.token.revoke', function () use ($tokenId, $byUserId) {
             $token = McpToken::find($tokenId);
             if ($token === null) {
                 return false;
             }
-            $token->update(['expires_at' => now()]);
-            $token->delete();
+            // Audit LGPD (ADR 0081): grava quem/quando ANTES do soft-delete.
+            $token->update([
+                'expires_at' => now(),
+                'revoked_at' => now(),
+                'revoked_by' => $byUserId ?? (int) $token->user_id,
+            ]);
+            $token->delete(); // soft-delete — preserva row pro audit trail
 
             return true;
         }, ['module' => 'TeamMcp', 'token_id' => $tokenId]);
@@ -109,8 +117,13 @@ class McpTokenIssuer
                 $defaultNote = 'Rotated em ' . now()->toDateString();
                 [$new, $raw] = McpToken::gerar($userId, $note ?: $defaultNote);
 
-                // Revoke old (expires_at=now + soft delete)
-                $old->update(['expires_at' => now()]);
+                // Revoke old: audit LGPD (revoked_at/revoked_by) + expires_at=now
+                // + soft-delete (a row sobrevive pra forense — ADR 0081).
+                $old->update([
+                    'expires_at' => now(),
+                    'revoked_at' => now(),
+                    'revoked_by' => $userId, // dono rotaciona o próprio token
+                ]);
                 $old->delete();
 
                 return [

--- a/Modules/TeamMcp/Tests/Feature/Wave23ScorecardRotateTest.php
+++ b/Modules/TeamMcp/Tests/Feature/Wave23ScorecardRotateTest.php
@@ -76,6 +76,9 @@ it('McpTokenIssuer::rotate gera novo token + revoga anterior atomicamente', func
     $oldReloaded = McpToken::withTrashed()->find($old->id);
     expect($oldReloaded->trashed())->toBeTrue();
     expect($oldReloaded->expires_at)->not->toBeNull();
+    // Audit LGPD completo (A+ 2026-06-14): rotate grava revoked_at/revoked_by.
+    expect($oldReloaded->revoked_at)->not->toBeNull('rotate deve gravar revoked_at no token antigo');
+    expect((int) $oldReloaded->revoked_by)->toBe((int) $user->id, 'revoked_by = dono que rotacionou');
 
     // Cleanup
     $result['new_token']->forceDelete();
@@ -433,5 +436,11 @@ it('countActive ignora tokens soft-deleted (consistente com rotate)', function (
     $issuer->revoke((int) $token->id);
     expect($issuer->countActive($user->id))->toBe($countInicial, 'após revoke, count volta ao inicial');
 
-    McpToken::withTrashed()->find($token->id)?->forceDelete();
+    // Audit LGPD completo (A+ 2026-06-14): revoke faz soft-delete + grava revoked_at/by.
+    $revoked = McpToken::withTrashed()->find($token->id);
+    expect($revoked->trashed())->toBeTrue('revoke faz soft-delete, não hard-delete');
+    expect($revoked->revoked_at)->not->toBeNull('revoke grava revoked_at (audit LGPD)');
+    expect((int) $revoked->revoked_by)->toBe((int) $user->id, 'self-revoke → revoked_by = dono');
+
+    $revoked?->forceDelete();
 });

--- a/tests/Feature/Modules/Copiloto/Mcp/McpAuthHealthTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/McpAuthHealthTest.php
@@ -29,6 +29,7 @@ beforeEach(function () {
         $t->timestamp('revoked_at')->nullable();
         $t->unsignedInteger('revoked_by')->nullable();
         $t->timestamps();
+        $t->softDeletes(); // paridade com migration add_soft_deletes_to_mcp_tokens
     });
 
     Schema::create('mcp_audit_log', function (Blueprint $t) {

--- a/tests/Feature/Modules/Copiloto/Mcp/McpSchemaTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/McpSchemaTest.php
@@ -66,6 +66,7 @@ beforeEach(function () {
         $t->timestamp('revoked_at')->nullable();
         $t->unsignedInteger('revoked_by')->nullable();
         $t->timestamps();
+        $t->softDeletes(); // paridade com migration add_soft_deletes_to_mcp_tokens
     });
 
     Schema::create('mcp_quotas', function (Blueprint $t) {


### PR DESCRIPTION
## ⚠️ NÃO MERGEAR sem aprovação Wagner — `mcp_tokens` é tabela Tier 0 SEGREDO

Bug **real de produção** (não só teste) detectado na triagem SDD F2b — nightly `20260614-020001` (~8 falhas em `Wave23ScorecardRotateTest`).

## Causa-raiz
`Modules/Jana/Entities/Mcp/McpToken.php` **não** usava `SoftDeletes` e `mcp_tokens` (migration `2026_04_29_100003`) **não** tinha coluna `deleted_at` — mas 3 caminhos de produção + os testes tratavam o model como soft-deletable:

| Site | Sintoma |
|---|---|
| `McpTokenIssuer::rotate/revoke` | comentário "soft-delete" mas `delete()` = **hard delete** → destrói audit trail LGPD (docblock + ADR 0081) |
| `RotateTokenCommand::rotateAllForUser:147` | `whereNull('deleted_at')` → **"Unknown column 'deleted_at'"** em qualquer run MySQL (inclusive PROD) |
| `ScorecardBuilderService::buildFacts:54` | idem — 2º crash site latente, feed do scorecard do time |
| `Wave23ScorecardRotateTest` | `withTrashed()/trashed()/forceDelete()` ×12 → "Call to undefined method withTrashed()" (~8 falhas) |

## Fix — Caminho A+ (Wagner-aprovado)
1. **McpToken**: trait `SoftDeletes` + cast `deleted_at`.
2. **Migration aditiva** nullable (`$table->softDeletes()`) em `mcp_tokens` — idempotente (`hasColumn`) + reversível (`dropSoftDeletes`).
3. **Audit LGPD completo**: `rotate` + `revoke` (Issuer) + `TeamController::revogarToken` agora gravam `revoked_at`/`revoked_by` **antes** do soft-delete (quem/quando), em vez de hard-delete que destruía a row.
4. **Paridade** `deleted_at` nos 2 schemas sqlite hand-rolled (`McpSchemaTest`, `McpAuthHealthTest`) — senão o global scope do SoftDeletes (`whereNull('deleted_at')`) quebraria `encontrarPorRaw` no sqlite.
5. **Test**: assertions de `revoked_at`/`revoked_by` pós-rotate e pós-revoke (trava o ganho A+).

## Não-objetivos (intocado)
- `TeamController::revokeToken` (drill-down admin) segue usando `revogar()` **sem** delete → token permanece visível como "Revogado" no histórico de governança (ADR 0057 — `TokensListAndRevokeTest` continua verde).
- `RotateTokenCommand` / `ScorecardBuilderService`: `whereNull('deleted_at')` passa a ser válido (coluna existe); não foram tocados (raw query builder em SBS precisa do filtro explícito).

## Multi-tenant
`mcp_tokens` é **repo-wide / per-user** (sem `business_id` — ADR 0053). Migration não adiciona `business_id` (exceção documentada).

## Validação
- ⛔ **Sem PHP local** nesta sessão → não rodei Pest aqui. **Validar no CT100 nightly** (MySQL real) que os ~8 voltam verdes.
- CI MySQL (pest-mysql) deve confirmar no PR.
- Migration em PROD = passo de deploy separado, **requer aprovação Wagner** (Tier 0 segredo).

Refs: triagem SDD F2b (nightly `20260614-020001`) · ADR `0081-identity-mesh-mcp-actors`

🤖 Generated with [Claude Code](https://claude.com/claude-code)