### PR TITLE
fix(financeiro): derivar restante do bridge expense→titulos (coluna total_remaining_amount nunca existiu)

### DIFF
--- a/Modules/Financeiro/Console/Commands/BridgeExpenseToTitulosCommand.php
+++ b/Modules/Financeiro/Console/Commands/BridgeExpenseToTitulosCommand.php
@@ -25,8 +25,12 @@ use Illuminate\Support\Facades\DB;
  *    (business_id, origem, origem_id, parcela_numero) — ADR TECH-0001
  *  - Mapeia payment_status → status fin_titulo:
  *      'paid'    → 'quitado'  (valor_aberto = 0)
- *      'partial' → 'parcial'  (valor_aberto = total_remaining_amount)
+ *      'partial' → 'parcial'  (valor_aberto = final_total − Σ transaction_payments)
  *      'due'     → 'aberto'   (valor_aberto = final_total)
+ *    NOTA: `transactions` NÃO tem coluna total_remaining_amount (nunca existiu no
+ *    UltimatePOS). O restante é DERIVADO igual ao core — SellController calcula
+ *    `final_total - total_paid` (total_paid = Σ pagamentos não-estorno). Ver a
+ *    subquery correlacionada `valor_remaining` na query abaixo.
  *  - plano_conta_id default = '5.1.99.999 Despesas (a classificar)' (mesma
  *    convenção do BackfillPlanoContaCommand). Eliana reatribui via UI depois.
  *  - origem = 'despesa' (já no ENUM da migration)
@@ -110,7 +114,6 @@ class BridgeExpenseToTitulosCommand extends Command
                 't.id',
                 't.business_id',
                 't.final_total',
-                't.total_remaining_amount',
                 't.transaction_date',
                 't.payment_status',
                 't.contact_id',
@@ -118,6 +121,18 @@ class BridgeExpenseToTitulosCommand extends Command
                 't.additional_notes',
                 't.created_by',
                 't.invoice_no',
+            )
+            // Restante derivado: `transactions` não tem total_remaining_amount
+            // (coluna nunca existiu no UltimatePOS). Igual ao core (SellController:
+            // final_total - total_paid), total_paid = Σ pagamentos não-estorno.
+            // Subquery escopada por business_id (Tier 0 ADR 0093, belt-and-suspenders).
+            ->selectRaw(
+                '(t.final_total - COALESCE(('
+                .' SELECT SUM(tp.amount) FROM transaction_payments tp'
+                .' WHERE tp.transaction_id = t.id'
+                .' AND tp.business_id = t.business_id'
+                .' AND tp.is_return = 0'
+                .'), 0)) as valor_remaining'
             );
 
         if ($since) {
@@ -206,7 +221,9 @@ class BridgeExpenseToTitulosCommand extends Command
     private function montarLinha(object $tx, int $businessId, int $planoContaId): array
     {
         $valorTotal = (float) ($tx->final_total ?? 0.0);
-        $valorRemaining = (float) ($tx->total_remaining_amount ?? $tx->final_total ?? 0.0);
+        // valor_remaining vem da subquery (final_total − Σ pagamentos). Clamp >= 0
+        // pra blindar contra over-payment (Σ pagamentos > final_total → negativo).
+        $valorRemaining = max(0.0, (float) ($tx->valor_remaining ?? $tx->final_total ?? 0.0));
         $paymentStatus = (string) ($tx->payment_status ?? 'due');
 
         $status = match ($paymentStatus) {

--- a/Modules/Financeiro/Tests/Feature/BridgeExpenseToTitulosCommandTest.php
+++ b/Modules/Financeiro/Tests/Feature/BridgeExpenseToTitulosCommandTest.php
@@ -66,7 +66,6 @@ it('dry-run não escreve em fin_titulos', function () {
         'business_id' => $business->id,
         'type' => 'expense',
         'final_total' => 100.00,
-        'total_remaining_amount' => 100.00,
         'transaction_date' => '2026-05-20 12:00:00',
         'payment_status' => 'due',
         'created_by' => $userId,
@@ -107,7 +106,6 @@ it('cria fin_titulo pra expense status=due (status=aberto, valor_aberto=valor_to
         'business_id' => $business->id,
         'type' => 'expense',
         'final_total' => 250.50,
-        'total_remaining_amount' => 250.50,
         'transaction_date' => '2026-05-15 10:00:00',
         'payment_status' => 'due',
         'created_by' => $userId,
@@ -148,7 +146,6 @@ it('cria fin_titulo pra expense status=paid (status=quitado, valor_aberto=0)', f
         'business_id' => $business->id,
         'type' => 'expense',
         'final_total' => 99.90,
-        'total_remaining_amount' => 0.00,
         'transaction_date' => '2026-05-10 14:00:00',
         'payment_status' => 'paid',
         'created_by' => $userId,
@@ -174,6 +171,60 @@ it('cria fin_titulo pra expense status=paid (status=quitado, valor_aberto=0)', f
     DB::table('transactions')->where('id', $txId)->delete();
 });
 
+it('cria fin_titulo pra expense status=partial (valor_aberto = final_total − Σ pagamentos)', function () {
+    $business = bridgeExpenseBootstrap();
+    $userId = DB::table('users')->where('business_id', $business->id)->value('id');
+    if (! $userId) {
+        $this->markTestSkipped('Sem user.');
+    }
+
+    // Despesa R$ 500 com R$ 300 já pagos (1 transaction_payment não-estorno).
+    // Restante CANÔNICO = 500 − 300 = 200, derivado da subquery (sem coluna
+    // total_remaining_amount fabricada). Mesma fórmula do core (final_total − total_paid).
+    $txId = DB::table('transactions')->insertGetId([
+        'business_id' => $business->id,
+        'type' => 'expense',
+        'final_total' => 500.00,
+        'transaction_date' => '2026-05-12 11:00:00',
+        'payment_status' => 'partial',
+        'created_by' => $userId,
+        'status' => 'final',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $tpId = DB::table('transaction_payments')->insertGetId([
+        'business_id' => $business->id,
+        'transaction_id' => $txId,
+        'amount' => 300.00,
+        'method' => 'cash',
+        'is_return' => 0,
+        'paid_on' => '2026-05-12 11:00:00',
+        'created_by' => $userId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $this->artisan("financeiro:bridge-expense-to-titulos --business={$business->id}")
+        ->assertExitCode(0);
+
+    $titulo = DB::table('fin_titulos')
+        ->where('business_id', $business->id)
+        ->where('origem', 'despesa')
+        ->where('origem_id', $txId)
+        ->first();
+
+    expect($titulo)->not->toBeNull();
+    expect($titulo->status)->toBe('parcial');
+    expect((float) $titulo->valor_total)->toBe(500.00);
+    expect((float) $titulo->valor_aberto)->toBe(200.00); // 500 − 300 derivado
+
+    // Cleanup
+    DB::table('fin_titulos')->where('id', $titulo->id)->delete();
+    DB::table('transaction_payments')->where('id', $tpId)->delete();
+    DB::table('transactions')->where('id', $txId)->delete();
+});
+
 it('é idempotente — re-rodar não duplica fin_titulos', function () {
     $business = bridgeExpenseBootstrap();
     $userId = DB::table('users')->where('business_id', $business->id)->value('id');
@@ -185,7 +236,6 @@ it('é idempotente — re-rodar não duplica fin_titulos', function () {
         'business_id' => $business->id,
         'type' => 'expense',
         'final_total' => 42.00,
-        'total_remaining_amount' => 42.00,
         'transaction_date' => '2026-04-01 09:00:00',
         'payment_status' => 'due',
         'created_by' => $userId,
@@ -242,7 +292,6 @@ it('não bridja transactions de outro business (Tier 0 multi-tenant)', function 
         'business_id' => $otherBusiness->id,
         'type' => 'expense',
         'final_total' => 999.00,
-        'total_remaining_amount' => 999.00,
         'transaction_date' => '2026-05-01 10:00:00',
         'payment_status' => 'due',
         'created_by' => $userId,


### PR DESCRIPTION
## Bug de produção real (SDD floor burn-down)

Detectado na triagem do SDD floor (nightly `20260614-020001`, ~5 falhas em `BridgeExpenseToTitulosCommandTest`) — um dos "2 bugs reais" do handoff #2741.

### Causa-raiz
`transactions.total_remaining_amount` **nunca existiu** no UltimatePOS — ausente de `database/schema/mysql-schema.sql` e de **todas** as migrations. Só "funcionava" porque o DB de dev antigo tinha uma coluna avulsa; quando o nightly passou a montar MySQL limpo do schema canônico (SDD F2b), explodiu.

- **Produção (latente live):** `BridgeExpenseToTitulosCommand.php:113` fazia `->select('t.total_remaining_amount')` contra query builder cru → `Unknown column 'total_remaining_amount'` (SQLSTATE 42S22) em **qualquer** run real, prod inclusive — não só teste.
- **Teste:** o setup inseria `'total_remaining_amount' => N` em `transactions` (5×) → falha antes mesmo do command rodar.

### Fix — cálculo canônico (igual ao core)
O core calcula o restante como `final_total - total_paid` ([`SellController.php:523`](app/Http/Controllers/SellController.php#L523)). Replico isso no command via subquery correlacionada:

```
valor_remaining = final_total − COALESCE(Σ transaction_payments.amount, 0)
```

- Filtra `is_return = 0` (espelha o `total_paid` do core, ignora linhas de troco/estorno).
- Escopada por `business_id` (Tier 0 ADR 0093, belt-and-suspenders).
- `max(0, …)` contra over-payment.

`TituloAutoService.php:100` (lê o mesmo atributo sobre Model Eloquent) **não** foi tocado: lá o atributo ausente vira `null` e é suprimido por `?? final_total`, então não quebra — está no escopo do follow-up abaixo.

### Teste
- Remove os 5 inserts da coluna fabricada.
- Adiciona caso `partial` com `transaction_payment` real (R$ 500 com R$ 300 pagos) provando `valor_aberto = 200` **derivado** — cobre o caminho que antes dependia da coluna inexistente.

### ⚠️ Validação pendente (não fazer merge sem)
- **CT100:** rodar `php artisan financeiro:bridge-expense-to-titulos --business=4 --dry --detail` + a suíte Pest do Financeiro contra MySQL real. PHP não roda local (Windows) — confiei em review estático + verificação do schema dump (`transaction_payments` tem `business_id`/`amount`/`is_return`).
- **Regra de negócio:** confirmar que para despesa `partial` o restante canônico é `final_total − Σ pagamentos` (Opção 1). Alternativa descartada era tratar `final_total` cheio como restante (Opção 2) — incoerente com o resto do Financeiro (`recalcularTitulo` deriva de baixas).

### Blast radius mais amplo (follow-up, fora deste PR — 1 PR = 1 intent)
A mesma coluna-fantasma aparece em mais arquivos (hoje verdes só porque dão skip): `ResyncFromCoreCommandTest:53`, `BoletoMockEmissaoTest:107`, `TituloAutoServiceTest:79,232`, `TituloAutoServiceExpenseTest:80`, `tests/.../TransactionPaymentObserverTest:78`, e o bug latente de correção em `TituloAutoService:100`. Recomendo purga sistemática em PR separado (toca lógica financeira de produção que a triagem de-escopou e exige confirmação de regra de negócio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
