### PR TITLE
fix(test): guarda sqlite no afterEach de 4 telas Governance (anti-corrupção floor SDD)

### DIFF
--- a/Modules/Governance/Tests/Feature/CrossTenantPolicyTest.php
+++ b/Modules/Governance/Tests/Feature/CrossTenantPolicyTest.php
@@ -90,6 +90,13 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    // mcp_* são tabelas reais-migradas. O afterEach roda MESMO em teste pulado
+    // (PHPUnit 12: tearDown gated só por hasMetRequirements, true antes do
+    // beforeEach/markTestSkipped) — dropá-las no MySQL persistente do nightly
+    // corromperia os testes irmãos (Base table not found). DDL só em sqlite.
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
     Schema::dropIfExists('mcp_actors');
     Schema::dropIfExists('mcp_audit_log');
     Schema::dropIfExists('mcp_skill_versions');

--- a/Modules/Governance/Tests/Feature/GovernanceGateTest.php
+++ b/Modules/Governance/Tests/Feature/GovernanceGateTest.php
@@ -80,6 +80,13 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    // mcp_* são tabelas reais-migradas. O afterEach roda MESMO em teste pulado
+    // (PHPUnit 12: tearDown gated só por hasMetRequirements, true antes do
+    // beforeEach/markTestSkipped) — dropá-las no MySQL persistente do nightly
+    // corromperia os testes irmãos (Base table not found). DDL só em sqlite.
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
     Schema::dropIfExists('mcp_actors');
     Schema::dropIfExists('mcp_audit_log');
     Schema::dropIfExists('mcp_skill_versions');

--- a/Modules/Governance/Tests/Feature/MultiTenantGovernanceTest.php
+++ b/Modules/Governance/Tests/Feature/MultiTenantGovernanceTest.php
@@ -65,6 +65,13 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    // mcp_* são tabelas reais-migradas. O afterEach roda MESMO em teste pulado
+    // (PHPUnit 12: tearDown gated só por hasMetRequirements, true antes do
+    // beforeEach/markTestSkipped) — dropá-las no MySQL persistente do nightly
+    // corromperia os testes irmãos (Base table not found). DDL só em sqlite.
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
     Schema::dropIfExists('mcp_audit_log');
     Schema::dropIfExists('mcp_governance_rules');
 });

--- a/Modules/Governance/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Governance/Tests/Feature/SmokeRoutesTest.php
@@ -80,6 +80,13 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    // mcp_* são tabelas reais-migradas. O afterEach roda MESMO em teste pulado
+    // (PHPUnit 12: tearDown gated só por hasMetRequirements, true antes do
+    // beforeEach/markTestSkipped) — dropá-las no MySQL persistente do nightly
+    // corromperia os testes irmãos (Base table not found). DDL só em sqlite.
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
     Schema::dropIfExists('mcp_actors');
     Schema::dropIfExists('mcp_audit_log');
     Schema::dropIfExists('mcp_skill_versions');

--- a/memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md
+++ b/memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md
@@ -1,0 +1,60 @@
+---
+date: "2026-06-15"
+topic: "Triagem refutada da cauda longa do floor SDD (corruptores era-sqlite): linter mente ~48%, cauda real ~55-60 arquivos; 4 afterEach Governance corrigidos (drops-floor + mantém cobertura)"
+authors: [W, C]
+related_adrs: ["0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes", "0093-multi-tenant-isolation-tier-0"]
+prs: []
+---
+
+# Cauda longa do floor SDD — triagem refutada (2026-06-15)
+
+> **Pedido [W]:** "do plano sdd: Floor ~1308 (de 1928); o mecânico já foi (RC-1..31); sobra a cauda longa (~1078), triagem real por arquivo, não mecânica. **Escolha a melhor resposta, use um refutador e faça.**"
+> **Método:** 4 analistas de cluster (read-only) + 1 refutador adversarial (ADR 0276) sobre `origin/main` (worktree `sdd-triage-main` @ `b23db7193`), + verificação própria do conflito refutador↔analista. Esta sessão NÃO roda Pest (worktree órfão sem vendor) — verificação = leitura de código + `php -l` + cross-check; prova final = CT100.
+
+## TL;DR — a descoberta que reescreve a cauda
+
+1. **O `sqlite-test-corruptors.mjs` MENTE ~48%.** Ele text-match `Schema::create/drop` e marca "quarentenado" só com a string literal `era-sqlite`. Não enxerga: (a) guarda `markTestSkipped` + `config('database.default')!=='sqlite'` com mensagem ≠ "era-sqlite"; (b) DDL dentro de `expect()->toContain('Schema::create(...')` (source-readers); (c) `DB::purge()` dos gates de browser. Dos **99 "floor-droppers abertos"** (29 S + 70 A) → **~51 corruptores reais · ~39 já-guardados/dual-mode · ~9 sem-DDL**.
+2. **A cauda real ≈ 55-60 arquivos**, não 99/237 — dominada por 2 clusters batcháveis (Whatsapp-A ~19, Jana/Mcp-A ~30) + poucos droppers de tabela-CORE de alto raio.
+3. **RC-1..31 quarentenou o B/C tail; o S-tier de maior raio quase não se moveu** (~30→29 não-quarentenados desde 06-13).
+4. **Doutrina correta:** CONVERT (RefreshDatabase/DatabaseTransactions, mantém cobertura) > QUARANTINE (`era-sqlite`, derruba o número mas a suíte mente). Vários "alvos" do linter são Tier-0/segurança — quarentenar = perder a garantia no único lugar que ela roda (MySQL).
+
+## Conflito refutador↔analista — RESOLVIDO (esta é a razão de "use um refutador")
+As 4 telas Governance (`CrossTenantPolicy/GovernanceGate/MultiTenantGovernance/SmokeRoutes`): o refutador disse "já pulam no MySQL → deixar"; o analista disse "corruptor via afterEach". **Vencedor: analista.** `beforeEach` é guardado (L37 etc), **mas `afterEach` dropa `mcp_*` SEM guarda**. Prova no próprio repo: RB/Repair já-corrigidos carregam o comentário *"o afterEach roda MESMO em teste pulado (PHPUnit 12: tearDown gated só por hasMetRequirements, true antes do beforeEach/markTestSkipped)"*. → afterEach sem guarda dropa tabela real no MySQL persistente. O refutador só olhou o `beforeEach`. **Lição: refutar o refutador também.**
+
+## Classificação corrigida (por cluster)
+
+| Cluster | n linter | corruptor REAL | DECISÃO | floor-impact | esforço |
+|---|--:|--:|---|---|---|
+| RecurringBilling S | 14 | **0** | nenhuma (beforeEach+afterEach já guardados) | nenhum | 0 |
+| Governance S (4) | 4 | **4** | CONVERT mínimo: guarda no afterEach (✅ FEITO aqui) | drops-floor + mantém cobertura | ~20min (feito) |
+| Inventory/FSM S | 3 | **2** (BomResolver, ReservarEstoqueBom) | CONVERT→RefreshDatabase | drops-floor | ~1-2h par |
+| Jana ClarifyCascade S | 1 | **1** | CONVERT | drops-floor | ~30-45min |
+| Whatsapp S (WhatsmeowWebhookAuth) | 1 | **1** (dropa `business`!) | CONVERT (NÃO quarentenar — segurança) | drops-floor (pior raio) | ~30min · URGENTE |
+| Whatsapp A | ~20 | **~18** | CONVERT em lote (recipe único) | drops-floor | ~1 sessão |
+| Jana/Mcp/Gov/Copiloto A | ~32 | **~30** | CONVERT em lote (DatabaseTransactions) | drops-floor (7 ERROM já "table exists") | ~1 dia |
+| ADS ContextForTaskActiveTasks | 1 | **1** (dropa `mcp_tasks`!) | CONVERT | drops-floor (core) | ~30min |
+| Vestuario Wave28Devolucao | 1 | **1** | CONVERT | drops-floor | ~30min |
+| NfeBrasil A (6) + Financeiro A (3) + Cliente charter + Browser gates (4) + Essentials/Repair-Device | ~20 | **0** | DON'T-TOUCH / refutado | nenhum | 0 |
+
+## DON'T-TOUCH register (quarentenar = cegar uma garantia, e a suíte mente)
+- **Browser/CoreScreens** (`A11yAxe/AuthBridge/ConformanceProbes/PixelBaseline`) — SÃO os gates Q1/Q4. `DB::purge` é cross-process intencional, zero DDL. Quarentenar desliga o gate.
+- **Tier-0 multi-tenant:** Whatsapp `MultiTenantIsolationTest` (R-WA-005, ADR 0093), Vestuario cenário-7. → CONVERT, nunca quarentenar.
+- **Segurança:** `WhatsmeowWebhookAuthTest` (anti-spoof 06-14), `WebhookSignatureTest`, `WebhookReplayProtectionTest`. → CONVERT.
+- **Source-readers (NÃO são corruptores):** Financeiro `OndaCommentsAuditBridge`/`UnificadoCommentsAudit`, `ClienteIndexDrawer760CharterTest` (confirma "NÃO tocar" anterior), `FluxoCaixaServiceTest` (sem `Schema::`).
+- **Migração-própria:** `AutomationRegistryMigrationTest` — RDB é incompatível (chama `up()` em tabela ausente). → única QUARANTINE-para-sqlite legítima.
+
+## Batches priorizados (para fatiar entre as sessões paralelas)
+1. **Quick wins core-table (maior raio, faça já):** `WhatsmeowWebhookAuth` (business), `ADS/ContextForTaskActiveTasks` (mcp_tasks), Inventory ×2 (products/variations). 4 arquivos, CONVERT.
+2. **Governance afterEach ×4** — ✅ FEITO nesta sessão (PR abaixo).
+3. **Lote Whatsapp-A (~18)** — recipe: `uses(RefreshDatabase::class)` + apagar bloco manual `Schema::dropIfExists/create` de `whatsapp_*`. Ressalvas: `PhonesMigrationDataTest` (replica migração inline → rework), `SendMessageRequest` (precisa 1 row conversation).
+4. **Lote Jana/Mcp-A (~30)** — recipe: `DatabaseTransactions` + apagar DDL manual. Ressalvas: `HandoffDraftTool` precisa NOVA migração `mcp_handoff_drafts`; `KbAnswerTool` mantém macro FULLTEXT→LIKE; `ScorecardSnapshotCommand` só o teste graceful-fail.
+
+## O que ESTA sessão shipou
+- **4 afterEach Governance guardados** (CrossTenantPolicy/GovernanceGate/MultiTenantGovernance/SmokeRoutes) — `php -l` ok. CONVERT mínimo: para a corrupção no MySQL (drops-floor downstream) **mantendo** a cobertura cross-tenant na lane sqlite. Padrão idêntico ao RB/Repair já mergeado. Prova final = CT100.
+- Este doc (registro de honestidade da triagem).
+
+## Follow-up recomendado (NÃO shipado de propósito)
+- **Ensinar o linter** a reconhecer (a) `markTestSkipped`+driver-guard como quarentena-equivalente, (b) DDL em `toContain` como não-DDL, (c) `DB::purge` como não-destrutivo — **mas só com meta-teste 2 lados** (provar que um corruptor real como `WhatsmeowWebhookAuth` CONTINUA flagado e que um guardado vira limpo). Não shipei agora porque um regex apressado pode **sub-contar** (mascarar corruptor real = a suíte mente no sentido perigoso). Spec pronto; precisa de [W]/sessão dona do floor.
+
+## Coordenação (anti-colisão)
+- Trabalho isolado em worktree `sdd-triage-main` (branch `sdd/governance-aftereach-guard`), off `origin/main` fresco. Nenhum PR aberto toca os 4 Governance. Sessões paralelas ("KL-E2/E3", "turbo stages") devem pegar os batches 1/3/4 — este doc é o mapa para fatiar sem refazer.


### PR DESCRIPTION
## O quê
Adiciona a guarda `if (config('database.default') !== 'sqlite') return;` no **afterEach** de 4 telas Governance: `CrossTenantPolicyTest`, `GovernanceGateTest`, `MultiTenantGovernanceTest`, `SmokeRoutesTest`.

## Por quê (corruptor real do floor SDD)
O `beforeEach` dessas telas **já** pula no MySQL (`markTestSkipped` non-sqlite, guard ADR 0101), mas o `afterEach` dropava `mcp_*` **sem guarda**. Em PHPUnit 12 o `afterEach` roda **mesmo em teste pulado** (gated só por `hasMetRequirements`, já `true` antes do `beforeEach`/`markTestSkipped`) — comprovado pelos comentários dos fixes já mergeados em RB/Repair. Logo, no MySQL persistente do nightly o teardown dropava as tabelas `mcp_*` reais-migradas → cascata `Base table not found` nos testes irmãos. É um dos *levers* do floor SDD.

## Doutrina: CONVERT, não QUARANTINE
Fix mínimo que **para a corrupção** (drops-floor downstream) **mantendo 100% da cobertura cross-tenant** na lane sqlite — em vez de quarentenar (que cegaria a garantia Tier-0/governança). Mesmo padrão já mergeado em `MultiTenantRepairTest`/`Wave6PlanCrudTest`.

## Prova
- `php -l` ok nos 4 (Herd 8.4.21). Esta sessão é worktree órfão sem vendor → **prova final = CT100 nightly**.
- Mudança estruturalmente idêntica ao precedente já-verde no main.

## Contexto / triagem da cauda longa
Inclui `memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md` — triagem refutada (4 analistas + refutador adversarial ADR 0276) da cauda longa do floor. Achado-chave: **o `sqlite-test-corruptors.mjs` tem ~48% de falso-positivo** (não enxerga guardas `markTestSkipped`/`toContain`/`DB::purge`); a cauda REAL ≈ 55-60 arquivos, não 99/237. Mapa de batches para as sessões paralelas (Whatsapp-A ~18, Jana/Mcp-A ~30, quick-wins core-table) está no doc.

Refs: US-GOV-021 (floor era-sqlite isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)