### PR TITLE
docs(governance): E1 100% resolvido + emenda TaskRegistry→TeamMcp

### DIFF
--- a/memory/requisitos/_TRIAGEM-IDENTIDADE-2026-06.md
+++ b/memory/requisitos/_TRIAGEM-IDENTIDADE-2026-06.md
@@ -12,19 +12,21 @@
 - Coluna "último commit real" exclui os 2 mass-commits de 2026-06-08 (squash #2413 + restore), que tocaram todas as pastas e mascaram freshness.
 - Pares de identidade re-derivados: **15** (plano citava 7) — ver Tabela B.
 
-> **Preenchimento 2026-06-14 (Claude, por autorização do Wagner "fecho o E1 com os defaults"):** as linhas com `ok` aceitam a proposta fundamentada da coluna anterior. **4 temas de julgamento ficaram PENDENTES (célula vazia) pra decisão explícita do Wagner** — não auto-decididos por serem mudança de identidade canônica de peso:
-> 1. **Atendimento** — fundir em Whatsapp **vs** renomear Whatsapp→Atendimento (P8)
-> 2. **TaskRegistry** — porta própria **vs** fundir em TeamMcp (P9)
-> 3. **Marketplaces** — manter separado do Woocommerce / confirmar (P15)
-> 4. **cluster Estoque** — Inventory/StockAdjustment/StockTransfer/Produto/Purchase → Estoque, repartir 29 docs do Inventory (P5/P6/P7)
+> **Preenchimento concluído (Claude, por autorização do Wagner):**
+> - **2026-06-14** — `ok` nas linhas de evidência dura (FUNDIR / MATAR / GENUÍNO — defaults autorizados).
+> - **2026-06-15** — Wagner decidiu os 4 temas de julgamento que estavam pendentes:
+>   1. **Atendimento** → FUNDIR em Whatsapp (NÃO renomear o módulo — caro/arriscado por ganho cosmético). `ok`
+>   2. **TaskRegistry** → porta própria (não fundir em TeamMcp — mistura 2 sistemas). `ok`
+>   3. **Marketplaces** → manter separado (escopo ≠ Woocommerce). `ok`
+>   4. **cluster Estoque** → criar SÓ a porta `Estoque` agora; a **repartição dos 29 docs do Inventory + consolidação de StockAdjustment/StockTransfer/Produto/Purchase fica `ADIADO`** (puro hygiene, alto custo/risco, sem urgência funcional).
 >
-> Célula vazia = não entra no E2 (semântica original do doc preservada).
+> Semântica: só `ok` (e os verbos FUNDIR/MATAR/GENUÍNO) entram no E2; `ADIADO` e vazio NÃO entram.
 
 ## Tabela A — pastas sem BRIEFING.md (34)
 
 | Pasta | Docs | Últ. commit real | Código existe? | Proposta fundamentada | Decisão Wagner |
 |---|---:|---|---|---|---|
-| Atendimento | 1 | 2026-05-17 | ❌ (telas `Pages/Atendimento` renderizadas por `Modules/Whatsapp`) | FUNDIR em Whatsapp — BRIEFING de lá já se intitula "Whatsapp / Atendimento" | |
+| Atendimento | 1 | 2026-05-17 | ❌ (telas `Pages/Atendimento` renderizadas por `Modules/Whatsapp`) | FUNDIR em Whatsapp — BRIEFING de lá já se intitula "Whatsapp / Atendimento" | ok (FUNDIR→Whatsapp; não renomear módulo) |
 | Autopecas | 3 | 2026-05-10 | ❌ (wish formal `aguarda-sinal-qualificado`, piloto Vargas) | GENUÍNO — manter wish; criar porta mínima `status: wish` | ok |
 | BI | 1 | 2026-04-25 | ❌ (só comparativo Capterra; nunca construído) | MATAR com lápide; comparativo arquiva em `_Ideias/` | ok |
 | Chat | 1 | 2026-04-25 | ❌ (chat real vive em `Modules/Jana`) | FUNDIR em Jana (comparativo de chat) | ok |
@@ -32,14 +34,14 @@
 | ComunicacaoVisual | 10 | 2026-05-17 | ✅ `Modules/ComunicacaoVisual` | GENUÍNO — criar porta (módulo real ativo sem BRIEFING) | ok |
 | ConsultaOs | 4 | 2026-05-17 | ✅ `Modules/ConsultaOs` | GENUÍNO — criar porta | ok |
 | Copiloto | 3 | 2026-05-15 | ❌ (renomeado → `Modules/Jana` em 2026-05-06/09; 3 docs Jana-Pro ficaram pra trás) | FUNDIR em Jana | ok |
-| Estoque | 2 | 2026-06-06 | ❌ como módulo (cross-cutting core: SPEC ativo + DOC-RAIZ 2026-06-04) | GENUÍNO — criar porta cross-cutting; candidata a absorver Inventory/StockAdjustment/StockTransfer (P7) | |
+| Estoque | 2 | 2026-06-06 | ❌ como módulo (cross-cutting core: SPEC ativo + DOC-RAIZ 2026-06-04) | GENUÍNO — criar porta cross-cutting; candidata a absorver Inventory/StockAdjustment/StockTransfer (P7) | ok — só criar porta; absorção P7 ADIADA |
 | EvolutionAgent | 10 | 2026-05-09 | ❌ (spec-ready 2026-04-26, nunca construído; conceito sobreposto por ADS + TaskRegistry/MCP) | MATAR com lápide "(planejado — não existe; absorvido por ADS)" | ok |
 | FinanceiroAvancado | 3 | 2026-05-12 | ❌ (`Modules/Financeiro` existe e tem pasta própria) | FUNDIR em Financeiro (vira ROADMAP-avancado de lá) | ok |
 | Garantia | 3 | 2026-05-12 | ❌ (discovery 2026-05-12, sem sinal desde então) | GENUÍNO — wish; porta mínima `status: wish` | ok |
 | Grow | 1 | 2026-04-25 | ❌ (só comparativo Capterra) | MATAR com lápide; comparativo arquiva em `_Ideias/` | ok |
-| Inventory | 29 | 2026-05-15 | ❌ (26 dos 29 docs são RUNBOOKs/visual-comparisons de telas CORE: Produto/Purchase/Stock*) | FUNDIR — repartir: docs produto→Produto, purchase→Compras, stock\*→Estoque; SPEC wish cross-vertical → Estoque (P6/P7) | |
+| Inventory | 29 | 2026-05-15 | ❌ (26 dos 29 docs são RUNBOOKs/visual-comparisons de telas CORE: Produto/Purchase/Stock*) | FUNDIR — repartir: docs produto→Produto, purchase→Compras, stock\*→Estoque; SPEC wish cross-vertical → Estoque (P6/P7) | ADIADO (repartição dos 29 docs) |
 | LaravelAI | 15 | 2026-05-06 | ❌ (pré-história do que virou `Modules/Jana`) | FUNDIR em Jana marcando HISTORICAL | ok |
-| Marketplaces | 3 | 2026-05-12 | ❌ (wish formal `aguarda-sinal-qualificado` — ML/Shopee ≠ conector Woocommerce) | GENUÍNO — wish; porta mínima; NÃO fundir em Woocommerce (P15) | |
+| Marketplaces | 3 | 2026-05-12 | ❌ (wish formal `aguarda-sinal-qualificado` — ML/Shopee ≠ conector Woocommerce) | GENUÍNO — wish; porta mínima; NÃO fundir em Woocommerce (P15) | ok (manter separado) |
 | MemoriaAutonoma | 2 | 2026-05-10 | ❌ (F1 implementada dentro do então Copiloto = Jana) | FUNDIR em Jana | ok |
 | Modules | 1 | 2026-05-17 | ❌ (tela única `Pages/Modules/Index` = `ModuleManagementController` core) | FUNDIR em Admin — nome "Modules" é isca de ghost-name | ok |
 | Officeimpresso | 9 | 2026-05-27 | ✅ `Modules/Officeimpresso` | GENUÍNO — criar porta (migração Martinho ativa) | ok |
@@ -47,13 +49,13 @@
 | PaymentGateway | 4 | 2026-06-03 | ✅ `Modules/PaymentGateway` | GENUÍNO — criar porta (módulo ativo: PIX Inter, Sicoob) | ok |
 | Pcp | 4 | 2026-05-15 | ❌ (feature-wish dormente — ADR 0152) | GENUÍNO — wish formal; porta mínima `status: wish` | ok |
 | PontoWr2 | 13 | 2026-05-06 | ❌ (renomeado → `Modules/Ponto`; pasta Ponto tem só 4 docs) | FUNDIR em Ponto (13 docs incl. adr/ + audits/) | ok |
-| Produto | 2 | 2026-05-17 | ❌ como módulo (8 telas core `ProductController`; ≠ `Modules/ProductCatalogue`) | GENUÍNO — criar porta; recebe os RUNBOOKs de produto hoje em Inventory (P6) | |
-| Purchase | 3 | 2026-05-17 | ❌ (telas core `PurchaseController`; `Modules/Compras` existe com porta) | FUNDIR em Compras (P5) | |
+| Produto | 2 | 2026-05-17 | ❌ como módulo (8 telas core `ProductController`; ≠ `Modules/ProductCatalogue`) | GENUÍNO — criar porta; recebe os RUNBOOKs de produto hoje em Inventory (P6) | ADIADO (cluster Estoque) |
+| Purchase | 3 | 2026-05-17 | ❌ (telas core `PurchaseController`; `Modules/Compras` existe com porta) | FUNDIR em Compras (P5) | ADIADO (cluster Estoque) |
 | Site | 1 | 2026-05-17 | ❌ (7 telas públicas Login/Register/Blog/Pricing) | FUNDIR em Cms | ok |
-| StockAdjustment | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | |
-| StockTransfer | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | |
+| StockAdjustment | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | ADIADO (cluster Estoque) |
+| StockTransfer | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | ADIADO (cluster Estoque) |
 | Tarefas | 1 | 2026-05-17 | ❌ (`Pages/Tarefas/Index.tsx` é stub sem controller/backend) | MATAR com lápide — tarefas do time = MCP (ADR 0070); de cliente = ProjectMgmt/Essentials | ok |
-| TaskRegistry | 4 | 2026-05-29 | ❌ como `Modules/` (sistema vivo no MCP server — ADR 0070) | GENUÍNO — criar porta (alternativa: FUNDIR em TeamMcp) | |
+| TaskRegistry | 4 | 2026-05-29 | ❌ como `Modules/` (sistema vivo no MCP server — ADR 0070) | GENUÍNO — criar porta (alternativa: FUNDIR em TeamMcp) | ok — porta própria (não TeamMcp) |
 | _DesignSystem | 62 | 2026-06-11 | meta (prefixo `_`) | GENUÍNO — criar porta leve (62 docs, hops=62 no knowledge-drift) | ok |
 | _Ideias | 12 | 2026-04-24 | meta | GENUÍNO — porta leve índice da incubadora | ok |
 | _Showcase | 1 | 2026-05-17 | ❌ (2 telas demo do design system) | FUNDIR em _DesignSystem | ok |
@@ -67,17 +69,17 @@
 | P2 | PontoWr2 ↔ Ponto | rename incompleto; órfã tem 13 docs, porta nova tem 4 | FUNDIR PontoWr2→Ponto | ok |
 | P3 | LaravelAI ↔ Jana | mesmo conceito, fase anterior; 15 docs | FUNDIR→Jana (HISTORICAL) | ok |
 | P4 | MemCofre ↔ SRS | **JÁ RESOLVIDO**: lápide em MemCofre/BRIEFING + DEPRECATION-PLAN aprovado (Caminho 1) | nenhuma ação nova; manter lápide | ok |
-| P5 | Purchase ↔ Compras | 2 pastas pro mesmo domínio (telas core EN + módulo PT scaffold) | FUNDIR Purchase→Compras | |
-| P6 | Produto ↔ ProductCatalogue ↔ Inventory | docs de produto em 3 pastas; ProductCatalogue é módulo DISTINTO (catálogo público QR) | Produto = porta das telas core; ProductCatalogue intocado; Inventory reparte | |
-| P7 | Estoque ↔ Inventory ↔ StockAdjustment ↔ StockTransfer | 4 pastas pro domínio estoque; Estoque tem o DOC-RAIZ canônico (2026-06-04) | consolidar em Estoque | |
-| P8 | Atendimento ↔ Whatsapp ↔ Chat | telas Atendimento são do Whatsapp; chat real é Jana | FUNDIR Atendimento→Whatsapp e Chat→Jana (alt.: RENOMEAR Whatsapp→Atendimento, nome de produto) | |
-| P9 | Tarefas ↔ TaskRegistry ↔ ProjectMgmt | stub UI ≠ sistema MCP ≠ módulo cliente | MATAR stub Tarefas; porta TaskRegistry; ProjectMgmt intocado | |
+| P5 | Purchase ↔ Compras | 2 pastas pro mesmo domínio (telas core EN + módulo PT scaffold) | FUNDIR Purchase→Compras | ADIADO (cluster Estoque) |
+| P6 | Produto ↔ ProductCatalogue ↔ Inventory | docs de produto em 3 pastas; ProductCatalogue é módulo DISTINTO (catálogo público QR) | Produto = porta das telas core; ProductCatalogue intocado; Inventory reparte | ADIADO (cluster Estoque) |
+| P7 | Estoque ↔ Inventory ↔ StockAdjustment ↔ StockTransfer | 4 pastas pro domínio estoque; Estoque tem o DOC-RAIZ canônico (2026-06-04) | consolidar em Estoque | ADIADO — só porta Estoque agora; consolidação adiada |
+| P8 | Atendimento ↔ Whatsapp ↔ Chat | telas Atendimento são do Whatsapp; chat real é Jana | FUNDIR Atendimento→Whatsapp e Chat→Jana (alt.: RENOMEAR Whatsapp→Atendimento, nome de produto) | ok (FUNDIR Atendimento→Whatsapp + Chat→Jana; NÃO renomear módulo) |
+| P9 | Tarefas ↔ TaskRegistry ↔ ProjectMgmt | stub UI ≠ sistema MCP ≠ módulo cliente | MATAR stub Tarefas; porta TaskRegistry; ProjectMgmt intocado | ok (MATAR Tarefas; porta TaskRegistry) |
 | P10 | FinanceiroAvancado ↔ Financeiro | wish avançado duplica pasta do módulo real | FUNDIR→Financeiro | ok |
 | P11 | Orcamento ↔ Sells | quotation = `Transaction type:sell status:draft` (domínio Sells) | FUNDIR→Sells | ok |
 | P12 | Site ↔ Cms | telas públicas vs módulo de conteúdo público | FUNDIR Site→Cms | ok |
 | P13 | Modules ↔ Admin | tela manage-modules é core/Admin; nome colide com `Modules/` do código | FUNDIR→Admin | ok |
 | P14 | EvolutionAgent ↔ ADS | ranqueador-de-ROI nunca construído; ADS é o decisor canônico | MATAR com lápide apontando ADS | ok |
-| P15 | Marketplaces ↔ Woocommerce | escopos distintos (marketplaces ML/Shopee ≠ conector Woo) | MANTER separados (confirmar) | |
+| P15 | Marketplaces ↔ Woocommerce | escopos distintos (marketplaces ML/Shopee ≠ conector Woo) | MANTER separados (confirmar) | ok (manter separado) |
 
 ## Depois da decisão (não é deste PR)
 

--- a/memory/requisitos/_TRIAGEM-IDENTIDADE-2026-06.md
+++ b/memory/requisitos/_TRIAGEM-IDENTIDADE-2026-06.md
@@ -12,63 +12,71 @@
 - Coluna "último commit real" exclui os 2 mass-commits de 2026-06-08 (squash #2413 + restore), que tocaram todas as pastas e mascaram freshness.
 - Pares de identidade re-derivados: **15** (plano citava 7) — ver Tabela B.
 
+> **Preenchimento 2026-06-14 (Claude, por autorização do Wagner "fecho o E1 com os defaults"):** as linhas com `ok` aceitam a proposta fundamentada da coluna anterior. **4 temas de julgamento ficaram PENDENTES (célula vazia) pra decisão explícita do Wagner** — não auto-decididos por serem mudança de identidade canônica de peso:
+> 1. **Atendimento** — fundir em Whatsapp **vs** renomear Whatsapp→Atendimento (P8)
+> 2. **TaskRegistry** — porta própria **vs** fundir em TeamMcp (P9)
+> 3. **Marketplaces** — manter separado do Woocommerce / confirmar (P15)
+> 4. **cluster Estoque** — Inventory/StockAdjustment/StockTransfer/Produto/Purchase → Estoque, repartir 29 docs do Inventory (P5/P6/P7)
+>
+> Célula vazia = não entra no E2 (semântica original do doc preservada).
+
 ## Tabela A — pastas sem BRIEFING.md (34)
 
 | Pasta | Docs | Últ. commit real | Código existe? | Proposta fundamentada | Decisão Wagner |
 |---|---:|---|---|---|---|
 | Atendimento | 1 | 2026-05-17 | ❌ (telas `Pages/Atendimento` renderizadas por `Modules/Whatsapp`) | FUNDIR em Whatsapp — BRIEFING de lá já se intitula "Whatsapp / Atendimento" | |
-| Autopecas | 3 | 2026-05-10 | ❌ (wish formal `aguarda-sinal-qualificado`, piloto Vargas) | GENUÍNO — manter wish; criar porta mínima `status: wish` | |
-| BI | 1 | 2026-04-25 | ❌ (só comparativo Capterra; nunca construído) | MATAR com lápide; comparativo arquiva em `_Ideias/` | |
-| Chat | 1 | 2026-04-25 | ❌ (chat real vive em `Modules/Jana`) | FUNDIR em Jana (comparativo de chat) | |
-| Comissao | 3 | 2026-05-15 | ❌ (feature-wish dormente — ADR 0151) | GENUÍNO — wish formal; porta mínima `status: wish` | |
-| ComunicacaoVisual | 10 | 2026-05-17 | ✅ `Modules/ComunicacaoVisual` | GENUÍNO — criar porta (módulo real ativo sem BRIEFING) | |
-| ConsultaOs | 4 | 2026-05-17 | ✅ `Modules/ConsultaOs` | GENUÍNO — criar porta | |
-| Copiloto | 3 | 2026-05-15 | ❌ (renomeado → `Modules/Jana` em 2026-05-06/09; 3 docs Jana-Pro ficaram pra trás) | FUNDIR em Jana | |
+| Autopecas | 3 | 2026-05-10 | ❌ (wish formal `aguarda-sinal-qualificado`, piloto Vargas) | GENUÍNO — manter wish; criar porta mínima `status: wish` | ok |
+| BI | 1 | 2026-04-25 | ❌ (só comparativo Capterra; nunca construído) | MATAR com lápide; comparativo arquiva em `_Ideias/` | ok |
+| Chat | 1 | 2026-04-25 | ❌ (chat real vive em `Modules/Jana`) | FUNDIR em Jana (comparativo de chat) | ok |
+| Comissao | 3 | 2026-05-15 | ❌ (feature-wish dormente — ADR 0151) | GENUÍNO — wish formal; porta mínima `status: wish` | ok |
+| ComunicacaoVisual | 10 | 2026-05-17 | ✅ `Modules/ComunicacaoVisual` | GENUÍNO — criar porta (módulo real ativo sem BRIEFING) | ok |
+| ConsultaOs | 4 | 2026-05-17 | ✅ `Modules/ConsultaOs` | GENUÍNO — criar porta | ok |
+| Copiloto | 3 | 2026-05-15 | ❌ (renomeado → `Modules/Jana` em 2026-05-06/09; 3 docs Jana-Pro ficaram pra trás) | FUNDIR em Jana | ok |
 | Estoque | 2 | 2026-06-06 | ❌ como módulo (cross-cutting core: SPEC ativo + DOC-RAIZ 2026-06-04) | GENUÍNO — criar porta cross-cutting; candidata a absorver Inventory/StockAdjustment/StockTransfer (P7) | |
-| EvolutionAgent | 10 | 2026-05-09 | ❌ (spec-ready 2026-04-26, nunca construído; conceito sobreposto por ADS + TaskRegistry/MCP) | MATAR com lápide "(planejado — não existe; absorvido por ADS)" | |
-| FinanceiroAvancado | 3 | 2026-05-12 | ❌ (`Modules/Financeiro` existe e tem pasta própria) | FUNDIR em Financeiro (vira ROADMAP-avancado de lá) | |
-| Garantia | 3 | 2026-05-12 | ❌ (discovery 2026-05-12, sem sinal desde então) | GENUÍNO — wish; porta mínima `status: wish` | |
-| Grow | 1 | 2026-04-25 | ❌ (só comparativo Capterra) | MATAR com lápide; comparativo arquiva em `_Ideias/` | |
+| EvolutionAgent | 10 | 2026-05-09 | ❌ (spec-ready 2026-04-26, nunca construído; conceito sobreposto por ADS + TaskRegistry/MCP) | MATAR com lápide "(planejado — não existe; absorvido por ADS)" | ok |
+| FinanceiroAvancado | 3 | 2026-05-12 | ❌ (`Modules/Financeiro` existe e tem pasta própria) | FUNDIR em Financeiro (vira ROADMAP-avancado de lá) | ok |
+| Garantia | 3 | 2026-05-12 | ❌ (discovery 2026-05-12, sem sinal desde então) | GENUÍNO — wish; porta mínima `status: wish` | ok |
+| Grow | 1 | 2026-04-25 | ❌ (só comparativo Capterra) | MATAR com lápide; comparativo arquiva em `_Ideias/` | ok |
 | Inventory | 29 | 2026-05-15 | ❌ (26 dos 29 docs são RUNBOOKs/visual-comparisons de telas CORE: Produto/Purchase/Stock*) | FUNDIR — repartir: docs produto→Produto, purchase→Compras, stock\*→Estoque; SPEC wish cross-vertical → Estoque (P6/P7) | |
-| LaravelAI | 15 | 2026-05-06 | ❌ (pré-história do que virou `Modules/Jana`) | FUNDIR em Jana marcando HISTORICAL | |
+| LaravelAI | 15 | 2026-05-06 | ❌ (pré-história do que virou `Modules/Jana`) | FUNDIR em Jana marcando HISTORICAL | ok |
 | Marketplaces | 3 | 2026-05-12 | ❌ (wish formal `aguarda-sinal-qualificado` — ML/Shopee ≠ conector Woocommerce) | GENUÍNO — wish; porta mínima; NÃO fundir em Woocommerce (P15) | |
-| MemoriaAutonoma | 2 | 2026-05-10 | ❌ (F1 implementada dentro do então Copiloto = Jana) | FUNDIR em Jana | |
-| Modules | 1 | 2026-05-17 | ❌ (tela única `Pages/Modules/Index` = `ModuleManagementController` core) | FUNDIR em Admin — nome "Modules" é isca de ghost-name | |
-| Officeimpresso | 9 | 2026-05-27 | ✅ `Modules/Officeimpresso` | GENUÍNO — criar porta (migração Martinho ativa) | |
-| Orcamento | 1 | 2026-05-17 | ❌ (0 tsx; só charter draft órfão; quotation = domínio Sells) | FUNDIR em Sells | |
-| PaymentGateway | 4 | 2026-06-03 | ✅ `Modules/PaymentGateway` | GENUÍNO — criar porta (módulo ativo: PIX Inter, Sicoob) | |
-| Pcp | 4 | 2026-05-15 | ❌ (feature-wish dormente — ADR 0152) | GENUÍNO — wish formal; porta mínima `status: wish` | |
-| PontoWr2 | 13 | 2026-05-06 | ❌ (renomeado → `Modules/Ponto`; pasta Ponto tem só 4 docs) | FUNDIR em Ponto (13 docs incl. adr/ + audits/) | |
+| MemoriaAutonoma | 2 | 2026-05-10 | ❌ (F1 implementada dentro do então Copiloto = Jana) | FUNDIR em Jana | ok |
+| Modules | 1 | 2026-05-17 | ❌ (tela única `Pages/Modules/Index` = `ModuleManagementController` core) | FUNDIR em Admin — nome "Modules" é isca de ghost-name | ok |
+| Officeimpresso | 9 | 2026-05-27 | ✅ `Modules/Officeimpresso` | GENUÍNO — criar porta (migração Martinho ativa) | ok |
+| Orcamento | 1 | 2026-05-17 | ❌ (0 tsx; só charter draft órfão; quotation = domínio Sells) | FUNDIR em Sells | ok |
+| PaymentGateway | 4 | 2026-06-03 | ✅ `Modules/PaymentGateway` | GENUÍNO — criar porta (módulo ativo: PIX Inter, Sicoob) | ok |
+| Pcp | 4 | 2026-05-15 | ❌ (feature-wish dormente — ADR 0152) | GENUÍNO — wish formal; porta mínima `status: wish` | ok |
+| PontoWr2 | 13 | 2026-05-06 | ❌ (renomeado → `Modules/Ponto`; pasta Ponto tem só 4 docs) | FUNDIR em Ponto (13 docs incl. adr/ + audits/) | ok |
 | Produto | 2 | 2026-05-17 | ❌ como módulo (8 telas core `ProductController`; ≠ `Modules/ProductCatalogue`) | GENUÍNO — criar porta; recebe os RUNBOOKs de produto hoje em Inventory (P6) | |
 | Purchase | 3 | 2026-05-17 | ❌ (telas core `PurchaseController`; `Modules/Compras` existe com porta) | FUNDIR em Compras (P5) | |
-| Site | 1 | 2026-05-17 | ❌ (7 telas públicas Login/Register/Blog/Pricing) | FUNDIR em Cms | |
+| Site | 1 | 2026-05-17 | ❌ (7 telas públicas Login/Register/Blog/Pricing) | FUNDIR em Cms | ok |
 | StockAdjustment | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | |
 | StockTransfer | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | |
-| Tarefas | 1 | 2026-05-17 | ❌ (`Pages/Tarefas/Index.tsx` é stub sem controller/backend) | MATAR com lápide — tarefas do time = MCP (ADR 0070); de cliente = ProjectMgmt/Essentials | |
+| Tarefas | 1 | 2026-05-17 | ❌ (`Pages/Tarefas/Index.tsx` é stub sem controller/backend) | MATAR com lápide — tarefas do time = MCP (ADR 0070); de cliente = ProjectMgmt/Essentials | ok |
 | TaskRegistry | 4 | 2026-05-29 | ❌ como `Modules/` (sistema vivo no MCP server — ADR 0070) | GENUÍNO — criar porta (alternativa: FUNDIR em TeamMcp) | |
-| _DesignSystem | 62 | 2026-06-11 | meta (prefixo `_`) | GENUÍNO — criar porta leve (62 docs, hops=62 no knowledge-drift) | |
-| _Ideias | 12 | 2026-04-24 | meta | GENUÍNO — porta leve índice da incubadora | |
-| _Showcase | 1 | 2026-05-17 | ❌ (2 telas demo do design system) | FUNDIR em _DesignSystem | |
-| _processo | 1 | 2026-05-09 | meta (só MWART-CHECKLIST.md) | FUNDIR em Mwart (pasta Mwart já tem porta) | |
+| _DesignSystem | 62 | 2026-06-11 | meta (prefixo `_`) | GENUÍNO — criar porta leve (62 docs, hops=62 no knowledge-drift) | ok |
+| _Ideias | 12 | 2026-04-24 | meta | GENUÍNO — porta leve índice da incubadora | ok |
+| _Showcase | 1 | 2026-05-17 | ❌ (2 telas demo do design system) | FUNDIR em _DesignSystem | ok |
+| _processo | 1 | 2026-05-09 | meta (só MWART-CHECKLIST.md) | FUNDIR em Mwart (pasta Mwart já tem porta) | ok |
 
 ## Tabela B — pares suspeitos de duplicata/rename (15 decisões de identidade)
 
 | # | Par | Evidência | Proposta | Decisão Wagner |
 |---|---|---|---|---|
-| P1 | Copiloto ↔ Jana | rename 2026-05-06/09 incompleto; 3 docs órfãos | FUNDIR Copiloto→Jana | |
-| P2 | PontoWr2 ↔ Ponto | rename incompleto; órfã tem 13 docs, porta nova tem 4 | FUNDIR PontoWr2→Ponto | |
-| P3 | LaravelAI ↔ Jana | mesmo conceito, fase anterior; 15 docs | FUNDIR→Jana (HISTORICAL) | |
-| P4 | MemCofre ↔ SRS | **JÁ RESOLVIDO**: lápide em MemCofre/BRIEFING + DEPRECATION-PLAN aprovado (Caminho 1) | nenhuma ação nova; manter lápide | |
+| P1 | Copiloto ↔ Jana | rename 2026-05-06/09 incompleto; 3 docs órfãos | FUNDIR Copiloto→Jana | ok |
+| P2 | PontoWr2 ↔ Ponto | rename incompleto; órfã tem 13 docs, porta nova tem 4 | FUNDIR PontoWr2→Ponto | ok |
+| P3 | LaravelAI ↔ Jana | mesmo conceito, fase anterior; 15 docs | FUNDIR→Jana (HISTORICAL) | ok |
+| P4 | MemCofre ↔ SRS | **JÁ RESOLVIDO**: lápide em MemCofre/BRIEFING + DEPRECATION-PLAN aprovado (Caminho 1) | nenhuma ação nova; manter lápide | ok |
 | P5 | Purchase ↔ Compras | 2 pastas pro mesmo domínio (telas core EN + módulo PT scaffold) | FUNDIR Purchase→Compras | |
 | P6 | Produto ↔ ProductCatalogue ↔ Inventory | docs de produto em 3 pastas; ProductCatalogue é módulo DISTINTO (catálogo público QR) | Produto = porta das telas core; ProductCatalogue intocado; Inventory reparte | |
 | P7 | Estoque ↔ Inventory ↔ StockAdjustment ↔ StockTransfer | 4 pastas pro domínio estoque; Estoque tem o DOC-RAIZ canônico (2026-06-04) | consolidar em Estoque | |
 | P8 | Atendimento ↔ Whatsapp ↔ Chat | telas Atendimento são do Whatsapp; chat real é Jana | FUNDIR Atendimento→Whatsapp e Chat→Jana (alt.: RENOMEAR Whatsapp→Atendimento, nome de produto) | |
 | P9 | Tarefas ↔ TaskRegistry ↔ ProjectMgmt | stub UI ≠ sistema MCP ≠ módulo cliente | MATAR stub Tarefas; porta TaskRegistry; ProjectMgmt intocado | |
-| P10 | FinanceiroAvancado ↔ Financeiro | wish avançado duplica pasta do módulo real | FUNDIR→Financeiro | |
-| P11 | Orcamento ↔ Sells | quotation = `Transaction type:sell status:draft` (domínio Sells) | FUNDIR→Sells | |
-| P12 | Site ↔ Cms | telas públicas vs módulo de conteúdo público | FUNDIR Site→Cms | |
-| P13 | Modules ↔ Admin | tela manage-modules é core/Admin; nome colide com `Modules/` do código | FUNDIR→Admin | |
-| P14 | EvolutionAgent ↔ ADS | ranqueador-de-ROI nunca construído; ADS é o decisor canônico | MATAR com lápide apontando ADS | |
+| P10 | FinanceiroAvancado ↔ Financeiro | wish avançado duplica pasta do módulo real | FUNDIR→Financeiro | ok |
+| P11 | Orcamento ↔ Sells | quotation = `Transaction type:sell status:draft` (domínio Sells) | FUNDIR→Sells | ok |
+| P12 | Site ↔ Cms | telas públicas vs módulo de conteúdo público | FUNDIR Site→Cms | ok |
+| P13 | Modules ↔ Admin | tela manage-modules é core/Admin; nome colide com `Modules/` do código | FUNDIR→Admin | ok |
+| P14 | EvolutionAgent ↔ ADS | ranqueador-de-ROI nunca construído; ADS é o decisor canônico | MATAR com lápide apontando ADS | ok |
 | P15 | Marketplaces ↔ Woocommerce | escopos distintos (marketplaces ML/Shopee ≠ conector Woo) | MANTER separados (confirmar) | |
 
 ## Depois da decisão (não é deste PR)
@@ -79,4 +87,4 @@
 4. Meta de scorecard afetada: `front_door_coverage` 62%→100% e `ghost_count` 27→0.
 
 ---
-*Gerado por frente KL-E1 (branch `sdd/kl-identidade`) a partir de origin/main `afecf98f6` em 2026-06-12. Fontes: `node scripts/governance/knowledge-drift.mjs`, `git log` por pasta, grep de `Inertia::render` nos controllers, leitura dos SPEC/BRIEFING citados.*
+*Gerado por frente KL-E1 (branch `sdd/kl-identidade`) a partir de origin/main `afecf98f6` em 2026-06-12. Fontes: `node scripts/governance/knowledge-drift.mjs`, `git log` por pasta, grep de `Inertia::render` nos controllers, leitura dos SPEC/BRIEFING citados. Coluna "Decisão Wagner" preenchida 2026-06-14 (defaults autorizados + 4 pendentes de julgamento).*

--- a/memory/requisitos/_TRIAGEM-IDENTIDADE-2026-06.md
+++ b/memory/requisitos/_TRIAGEM-IDENTIDADE-2026-06.md
@@ -55,7 +55,7 @@
 | StockAdjustment | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | ADIADO (cluster Estoque) |
 | StockTransfer | 1 | 2026-05-17 | ❌ (2 telas core; RUNBOOKs estão em Inventory) | FUNDIR em Estoque (P7) | ADIADO (cluster Estoque) |
 | Tarefas | 1 | 2026-05-17 | ❌ (`Pages/Tarefas/Index.tsx` é stub sem controller/backend) | MATAR com lápide — tarefas do time = MCP (ADR 0070); de cliente = ProjectMgmt/Essentials | ok |
-| TaskRegistry | 4 | 2026-05-29 | ❌ como `Modules/` (sistema vivo no MCP server — ADR 0070) | GENUÍNO — criar porta (alternativa: FUNDIR em TeamMcp) | ok — porta própria (não TeamMcp) |
+| TaskRegistry | 4 | 2026-05-29 | ❌ como `Modules/` (sistema vivo no MCP server — ADR 0070) | GENUÍNO — criar porta (alternativa: FUNDIR em TeamMcp) | EMENDA 2026-06-15 (Wagner): FUNDIR em TeamMcp — reabriu a decisão; TaskRegistry roda DENTRO do MCP server, funde na porta TeamMcp em vez de porta própria |
 | _DesignSystem | 62 | 2026-06-11 | meta (prefixo `_`) | GENUÍNO — criar porta leve (62 docs, hops=62 no knowledge-drift) | ok |
 | _Ideias | 12 | 2026-04-24 | meta | GENUÍNO — porta leve índice da incubadora | ok |
 | _Showcase | 1 | 2026-05-17 | ❌ (2 telas demo do design system) | FUNDIR em _DesignSystem | ok |
@@ -73,7 +73,7 @@
 | P6 | Produto ↔ ProductCatalogue ↔ Inventory | docs de produto em 3 pastas; ProductCatalogue é módulo DISTINTO (catálogo público QR) | Produto = porta das telas core; ProductCatalogue intocado; Inventory reparte | ADIADO (cluster Estoque) |
 | P7 | Estoque ↔ Inventory ↔ StockAdjustment ↔ StockTransfer | 4 pastas pro domínio estoque; Estoque tem o DOC-RAIZ canônico (2026-06-04) | consolidar em Estoque | ADIADO — só porta Estoque agora; consolidação adiada |
 | P8 | Atendimento ↔ Whatsapp ↔ Chat | telas Atendimento são do Whatsapp; chat real é Jana | FUNDIR Atendimento→Whatsapp e Chat→Jana (alt.: RENOMEAR Whatsapp→Atendimento, nome de produto) | ok (FUNDIR Atendimento→Whatsapp + Chat→Jana; NÃO renomear módulo) |
-| P9 | Tarefas ↔ TaskRegistry ↔ ProjectMgmt | stub UI ≠ sistema MCP ≠ módulo cliente | MATAR stub Tarefas; porta TaskRegistry; ProjectMgmt intocado | ok (MATAR Tarefas; porta TaskRegistry) |
+| P9 | Tarefas ↔ TaskRegistry ↔ ProjectMgmt | stub UI ≠ sistema MCP ≠ módulo cliente | MATAR stub Tarefas; porta TaskRegistry; ProjectMgmt intocado | EMENDA 2026-06-15 (Wagner): MATAR Tarefas; TaskRegistry→FUNDIR em TeamMcp; ProjectMgmt intocado |
 | P10 | FinanceiroAvancado ↔ Financeiro | wish avançado duplica pasta do módulo real | FUNDIR→Financeiro | ok |
 | P11 | Orcamento ↔ Sells | quotation = `Transaction type:sell status:draft` (domínio Sells) | FUNDIR→Sells | ok |
 | P12 | Site ↔ Cms | telas públicas vs módulo de conteúdo público | FUNDIR Site→Cms | ok |
@@ -90,3 +90,5 @@
 
 ---
 *Gerado por frente KL-E1 (branch `sdd/kl-identidade`) a partir de origin/main `afecf98f6` em 2026-06-12. Fontes: `node scripts/governance/knowledge-drift.mjs`, `git log` por pasta, grep de `Inertia::render` nos controllers, leitura dos SPEC/BRIEFING citados. Coluna "Decisão Wagner" preenchida 2026-06-14 (defaults autorizados + 4 pendentes de julgamento).*
+
+**Emenda 2026-06-15:** TaskRegistry reclassificado de "porta própria" → **FUNDIR em TeamMcp** (Wagner reabriu a decisão; TaskRegistry vive no MCP server, funde na porta TeamMcp). Atualizadas: Tabela A linha TaskRegistry + Tabela B P9. Downstream: TaskRegistry sai da Lane C e entra no thread B6 (fusão→TeamMcp) do pack KL-E2/E3 ([2026-06-15-sdd-kl-e2-e3-prompts-paralelos](../sessions/2026-06-15-sdd-kl-e2-e3-prompts-paralelos.md)).


### PR DESCRIPTION
Leva pro main o E1 (triagem de identidade das pastas órfãs, frente KL) **resolvido 100%** + a emenda do TaskRegistry. O #2743 só mergeou a versão parcial (defaults + 4 pendentes); os 4 pendentes foram resolvidos por Wagner em 2026-06-15 e ficaram nesta branch sem PR.

## Conteúdo
- 4 pendentes resolvidos (Wagner): Atendimento→Whatsapp (sem renomear módulo), Marketplaces separado de Woocommerce, cluster Estoque (Inventory/Produto/Purchase/Stock*) **ADIADO**, TaskRegistry.
- **Emenda 2026-06-15:** TaskRegistry porta própria → **FUNDIR em TeamMcp** (roda dentro do MCP server).

## Downstream
Destrava as lanes KL-E2 (fusões) + KL-E3 (BRIEFINGs) do pack `memory/sessions/2026-06-15-sdd-kl-e2-e3-prompts-paralelos.md`. Diff = só o doc do E1.

Refs: SDD KL-E1

🤖 Generated with [Claude Code](https://claude.com/claude-code)