### PR TITLE
docs(governance): KL-E2 — portas redirect das 13 fusões (FUNDIR)

### DIFF
--- a/memory/requisitos/Atendimento/BRIEFING.md
+++ b/memory/requisitos/Atendimento/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Atendimento · ⚰️ FUNDIDO em Whatsapp (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Whatsapp`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Whatsapp/`](../Whatsapp/BRIEFING.md)**
+> - Telas `Pages/Atendimento` são renderizadas por `Modules/Whatsapp` (sem renomear o módulo).
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Whatsapp/`.**

--- a/memory/requisitos/Chat/BRIEFING.md
+++ b/memory/requisitos/Chat/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Chat · ⚰️ FUNDIDO em Jana (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Jana`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Jana/`](../Jana/BRIEFING.md)**
+> - Chat real vive em `Modules/Jana`; aqui era só comparativo de chat.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Jana/`.**

--- a/memory/requisitos/Copiloto/BRIEFING.md
+++ b/memory/requisitos/Copiloto/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Copiloto · ⚰️ FUNDIDO em Jana (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Jana`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Jana/`](../Jana/BRIEFING.md)**
+> - Renomeado pra `Modules/Jana` em 2026-05-06/09; 3 docs Jana-Pro ficaram pra trás.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Jana/`.**

--- a/memory/requisitos/FinanceiroAvancado/BRIEFING.md
+++ b/memory/requisitos/FinanceiroAvancado/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — FinanceiroAvancado · ⚰️ FUNDIDO em Financeiro (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Financeiro`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Financeiro/`](../Financeiro/BRIEFING.md)**
+> - Wish avançado do módulo real `Modules/Financeiro` — vira roadmap-avançado de lá.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Financeiro/`.**

--- a/memory/requisitos/LaravelAI/BRIEFING.md
+++ b/memory/requisitos/LaravelAI/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — LaravelAI · ⚰️ FUNDIDO em Jana (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Jana`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Jana/`](../Jana/BRIEFING.md)**
+> - Pré-história do que virou `Modules/Jana` (15 docs) — HISTORICAL.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Jana/`.**

--- a/memory/requisitos/MemoriaAutonoma/BRIEFING.md
+++ b/memory/requisitos/MemoriaAutonoma/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — MemoriaAutonoma · ⚰️ FUNDIDO em Jana (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Jana`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Jana/`](../Jana/BRIEFING.md)**
+> - Memória autônoma (F1) foi implementada dentro do então Copiloto = Jana.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Jana/`.**

--- a/memory/requisitos/Modules/BRIEFING.md
+++ b/memory/requisitos/Modules/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Modules · ⚰️ FUNDIDO em Admin (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Admin`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Admin/`](../Admin/BRIEFING.md)**
+> - Tela única `Pages/Modules/Index` = `ModuleManagementController` core (Admin); nome é isca de ghost.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Admin/`.**

--- a/memory/requisitos/Orcamento/BRIEFING.md
+++ b/memory/requisitos/Orcamento/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Orcamento · ⚰️ FUNDIDO em Sells (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Sells`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Sells/`](../Sells/BRIEFING.md)**
+> - Quotation = `Transaction type:sell status:draft`, domínio do `Modules/Sells`.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Sells/`.**

--- a/memory/requisitos/PontoWr2/BRIEFING.md
+++ b/memory/requisitos/PontoWr2/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — PontoWr2 · ⚰️ FUNDIDO em Ponto (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Ponto`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Ponto/`](../Ponto/BRIEFING.md)**
+> - Renomeado pra `Modules/Ponto`; 13 docs (inclui adr/ + audits/) ficaram pra trás.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Ponto/`.**

--- a/memory/requisitos/Site/BRIEFING.md
+++ b/memory/requisitos/Site/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Site · ⚰️ FUNDIDO em Cms (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Cms`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Cms/`](../Cms/BRIEFING.md)**
+> - 7 telas públicas (Login/Register/Blog/Pricing) — conteúdo público é do `Modules/Cms`.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Cms/`.**

--- a/memory/requisitos/TaskRegistry/BRIEFING.md
+++ b/memory/requisitos/TaskRegistry/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — TaskRegistry · ⚰️ FUNDIDO em TeamMcp (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `TeamMcp`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/TeamMcp/`](../TeamMcp/BRIEFING.md)**
+> - Sistema vivo no MCP server (ADR 0070) — funde na porta `TeamMcp` (emenda E1 #2748).
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/TeamMcp/`.**

--- a/memory/requisitos/_Showcase/BRIEFING.md
+++ b/memory/requisitos/_Showcase/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — _Showcase · ⚰️ FUNDIDO em _DesignSystem (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `_DesignSystem`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/_DesignSystem/`](../_DesignSystem/)**
+> - 2 telas demo do design system — pertencem ao `_DesignSystem`.
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/_DesignSystem/`.**

--- a/memory/requisitos/_processo/BRIEFING.md
+++ b/memory/requisitos/_processo/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — _processo · ⚰️ FUNDIDO em Mwart (2026-06)
+
+> ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Mwart`** (decisão E1 · frente KL · 2026-06-15).
+> - **Verdade viva → [`memory/requisitos/Mwart/`](../Mwart/BRIEFING.md)**
+> - Só `MWART-CHECKLIST.md` — pertence à pasta `Mwart` (que já tem porta).
+> - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
+
+**Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Mwart/`.**


### PR DESCRIPTION
Primeira leva da execução KL-E2 (frente KL do plano SDD). Cria `BRIEFING.md` de **redirect** em cada pasta órfã decidida **FUNDIR** no E1 — padrão MemCofre: a porta aponta pro alvo, os docs ficam como proveniência congelada (sem `git mv` arriscado, sem mexer em ADR/SPEC/RUNBOOK).

**13 fusões:** Copiloto·LaravelAI·MemoriaAutonoma·Chat→Jana · FinanceiroAvancado→Financeiro · Orcamento→Sells · PontoWr2→Ponto · Site→Cms · _Showcase→_DesignSystem · Modules→Admin · Atendimento→Whatsapp · _processo→Mwart · TaskRegistry→TeamMcp (emenda E1 #2748).

**Efeito:** mata 13 ghosts / sobe `front_door_coverage` (toda pasta órfã ganha porta apontando pra verdade viva). Próximas levas: lápides (B8), portas de wish (B9), porta leve do Estoque, e os BRIEFINGs destilados genuínos (Lane C, com refutador G5).

Refs: SDD KL-E2

🤖 Generated with [Claude Code](https://claude.com/claude-code)