### PR TITLE
docs(governance): KL-E2 — lápides (4) + portas de wish (5) + portas leves (3)

### DIFF
--- a/memory/requisitos/Autopecas/BRIEFING.md
+++ b/memory/requisitos/Autopecas/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Autopecas · 🌱 WISH (status: wish)
+
+> **Feature-wish formal — aguarda sinal qualificado** (ADR 0105). Não há código.
+> - Vertical autopeças; piloto Vargas, sem sinal qualificado ativo.
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — manter como wish; porta mínima.
+> - Detalhe (quando houver) → `SPEC.md` desta pasta.
+
+**Tipo:** porta de wish (KL-E2). Backlog só recebe item com sinal de cliente pagante (ADR 0105).

--- a/memory/requisitos/BI/BRIEFING.md
+++ b/memory/requisitos/BI/BRIEFING.md
@@ -1,0 +1,6 @@
+# BRIEFING — BI · ⚰️ LÁPIDE (planejado, não existe)
+
+> ⚠️ **MATAR — módulo nunca construído. Só havia comparativo Capterra; nenhum código. Comparativo arquiva em `_Ideias/`.**
+> - Decisão E1 (frente KL · 2026-06-15): MATAR com lápide.
+
+**Tipo:** lápide (KL-E2). Sem sucessor — não investir.

--- a/memory/requisitos/Comissao/BRIEFING.md
+++ b/memory/requisitos/Comissao/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Comissao · 🌱 WISH (status: wish)
+
+> **Feature-wish formal — aguarda sinal qualificado** (ADR 0105). Não há código.
+> - Comissões de venda; dormente (ADR 0151).
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — manter como wish; porta mínima.
+> - Detalhe (quando houver) → `SPEC.md` desta pasta.
+
+**Tipo:** porta de wish (KL-E2). Backlog só recebe item com sinal de cliente pagante (ADR 0105).

--- a/memory/requisitos/Estoque/BRIEFING.md
+++ b/memory/requisitos/Estoque/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Estoque · 🧭 porta (domínio cross-cutting)
+
+> Domínio **cross-cutting** de estoque (núcleo). Estado: porta leve.
+> - Fonte canônica: `SPEC.md` + DOC-RAIZ (2026-06-04).
+> - Consolidação de `Inventory`/`StockAdjustment`/`StockTransfer` em Estoque está **ADIADA** (E1 P6/P7) — onda futura.
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — porta cross-cutting.
+
+**Tipo:** porta leve (KL-E2). Repartição do cluster Inventory adiada.

--- a/memory/requisitos/EvolutionAgent/BRIEFING.md
+++ b/memory/requisitos/EvolutionAgent/BRIEFING.md
@@ -1,0 +1,6 @@
+# BRIEFING — EvolutionAgent · ⚰️ LÁPIDE (planejado, não existe)
+
+> ⚠️ **MATAR — planejado, nunca construído (ranqueador-de-ROI). Conceito absorvido pelo decisor canônico.**
+> - Decisão E1 (frente KL · 2026-06-15): MATAR com lápide.
+
+**Tipo:** lápide (KL-E2). Verdade viva → `Modules/ADS` (decisor Dual-Brain).

--- a/memory/requisitos/Garantia/BRIEFING.md
+++ b/memory/requisitos/Garantia/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Garantia · 🌱 WISH (status: wish)
+
+> **Feature-wish formal — aguarda sinal qualificado** (ADR 0105). Não há código.
+> - Gestão de garantia; discovery 2026-05-12, sem sinal desde então.
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — manter como wish; porta mínima.
+> - Detalhe (quando houver) → `SPEC.md` desta pasta.
+
+**Tipo:** porta de wish (KL-E2). Backlog só recebe item com sinal de cliente pagante (ADR 0105).

--- a/memory/requisitos/Grow/BRIEFING.md
+++ b/memory/requisitos/Grow/BRIEFING.md
@@ -1,0 +1,6 @@
+# BRIEFING — Grow · ⚰️ LÁPIDE (planejado, não existe)
+
+> ⚠️ **MATAR — módulo nunca construído. Só comparativo Capterra; nenhum código. Comparativo arquiva em `_Ideias/`.**
+> - Decisão E1 (frente KL · 2026-06-15): MATAR com lápide.
+
+**Tipo:** lápide (KL-E2). Sem sucessor — não investir.

--- a/memory/requisitos/Marketplaces/BRIEFING.md
+++ b/memory/requisitos/Marketplaces/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Marketplaces · 🌱 WISH (status: wish)
+
+> **Feature-wish formal — aguarda sinal qualificado** (ADR 0105). Não há código.
+> - Integração marketplaces (ML/Shopee). MANTER separado do `Woocommerce` — escopos distintos (E1 P15).
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — manter como wish; porta mínima.
+> - Detalhe (quando houver) → `SPEC.md` desta pasta.
+
+**Tipo:** porta de wish (KL-E2). Backlog só recebe item com sinal de cliente pagante (ADR 0105).

--- a/memory/requisitos/Pcp/BRIEFING.md
+++ b/memory/requisitos/Pcp/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — Pcp · 🌱 WISH (status: wish)
+
+> **Feature-wish formal — aguarda sinal qualificado** (ADR 0105). Não há código.
+> - Planejamento e controle de produção (PCP); dormente (ADR 0152).
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — manter como wish; porta mínima.
+> - Detalhe (quando houver) → `SPEC.md` desta pasta.
+
+**Tipo:** porta de wish (KL-E2). Backlog só recebe item com sinal de cliente pagante (ADR 0105).

--- a/memory/requisitos/Tarefas/BRIEFING.md
+++ b/memory/requisitos/Tarefas/BRIEFING.md
@@ -1,0 +1,6 @@
+# BRIEFING — Tarefas · ⚰️ LÁPIDE (planejado, não existe)
+
+> ⚠️ **MATAR — `Pages/Tarefas/Index.tsx` é stub sem controller/backend. Tarefas do TIME = MCP/TaskRegistry (ADR 0070); de CLIENTE = `ProjectMgmt`/`Essentials`.**
+> - Decisão E1 (frente KL · 2026-06-15): MATAR com lápide.
+
+**Tipo:** lápide (KL-E2). Não há módulo "Tarefas".

--- a/memory/requisitos/_DesignSystem/BRIEFING.md
+++ b/memory/requisitos/_DesignSystem/BRIEFING.md
@@ -1,0 +1,8 @@
+# BRIEFING — _DesignSystem · 🧭 porta (índice meta)
+
+> Pasta **meta** do Design System (62 docs): tokens de cor/tipo/espaço, ADRs UI, padrões de tela.
+> - Documento mãe: **ADR UI-0013** (Constituição UI v2 · 4 camadas).
+> - É índice/governança de UI, não módulo de código.
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — porta leve.
+
+**Tipo:** porta leve (KL-E2). Hub de design canon.

--- a/memory/requisitos/_Ideias/BRIEFING.md
+++ b/memory/requisitos/_Ideias/BRIEFING.md
@@ -1,0 +1,7 @@
+# BRIEFING — _Ideias · 🧭 porta (índice da incubadora)
+
+> Índice da **incubadora** de ideias/conceitos não-priorizados (12 docs): comparativos, wishes arquivados, hipóteses.
+> - Não é módulo; é onde a ideia espera sinal (ADR 0105) antes de virar wish formal.
+> - Decisão E1 (frente KL · 2026-06-15): GENUÍNO — porta leve índice.
+
+**Tipo:** porta leve (KL-E2).


### PR DESCRIPTION
Segunda leva da execução KL-E2. Cria `BRIEFING.md` por tipo de decisão E1:
- **Lápides (MATAR):** BI · Grow · EvolutionAgent (→ADS) · Tarefas (→MCP/ProjectMgmt).
- **Portas de wish (status: wish):** Autopecas · Comissao · Garantia · Marketplaces (separado de Woo, P15) · Pcp.
- **Portas leves (índice):** _DesignSystem (hub UI-0013) · _Ideias (incubadora) · Estoque (cross-cutting; consolidação Inventory ADIADA).

Os 5 genuínos ativos com corpus (ComunicacaoVisual · ConsultaOs · Officeimpresso · PaymentGateway · Produto) **ficam de fora** — vão via **Lane C** (BRIEFING destilado + refutador G5).

Refs: SDD KL-E2

🤖 Generated with [Claude Code](https://claude.com/claude-code)