### PR TITLE
docs(governance): ledger G5 — lote KL-E2-portas aprovado (25 itens, 0 erros)

### DIFF
--- a/governance/sdd-verification-ledger.json
+++ b/governance/sdd-verification-ledger.json
@@ -20,5 +20,23 @@
       "veredito": "aprovado | reprovado"
     }
   },
-  "entries": []
+  "entries": [
+    {
+      "pr": 2750,
+      "lote_id": "KL-E2-portas",
+      "data": "2026-06-15",
+      "tipo": "prosa",
+      "gerador": "opus-4.8",
+      "refutador": "opus-4.8",
+      "sessao_fresca": true,
+      "amostra_pct": 100,
+      "itens_verificados": 25,
+      "erros_confirmados": 0,
+      "error_rate_pct": 0.0,
+      "pii_scan": true,
+      "pii_hits": 0,
+      "evidencia": "refutador G5 sessao fresca 2026-06-15 — cobre PR #2750 (13 redirects FUNDIR) + PR #2751 (4 lapides + 5 wishes + 3 portas leves). 25/25 conferidos contra E1 + emenda #2748 + existencia das pastas-alvo.",
+      "veredito": "aprovado"
+    }
+  ]
 }


### PR DESCRIPTION
Entry de verificação adversarial (PROTOCOLO-REFUTADOR-BACKFILL · GT-G5) dos 2 lotes de portas KL-E2:
- **#2750** (13 redirect stubs FUNDIR) + **#2751** (4 lápides + 5 wishes + 3 portas leves) = 25 portas.
- Refutador em **sessão fresca**, modelo ≥ gerador (opus/opus), amostra 100%.
- **Resultado:** 25/25 conferidos contra E1 + emenda #2748 + existência das pastas-alvo · error_rate **0.0%** · pii_hits **0** · veredito **aprovado**.

Refs: SDD KL-E2 G5

🤖 Generated with [Claude Code](https://claude.com/claude-code)