### PR TITLE
fix(test): guarda sqlite-only em 20 corruptores Whatsapp (floor SDD · −20)

### DIFF
--- a/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DispatchToJanaBotTest.php
@@ -31,6 +31,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_phones'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php
+++ b/Modules/Whatsapp/Tests/Feature/DriverLayerUnionTypeTest.php
@@ -30,6 +30,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('whatsapp_business_phones');
     Schema::dropIfExists('whatsapp_business_configs');
 

--- a/Modules/Whatsapp/Tests/Feature/E2EJourneyBiz1Test.php
+++ b/Modules/Whatsapp/Tests/Feature/E2EJourneyBiz1Test.php
@@ -29,6 +29,12 @@ const E2E_BIZ_WAGNER = 1;
 const E2E_BIZ_OUTRO = 99;
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     config()->set('otel.enabled', false);
 
     foreach (['whatsapp_messages', 'whatsapp_business_phones'] as $t) {

--- a/Modules/Whatsapp/Tests/Feature/LidPhoneResolverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/LidPhoneResolverTest.php
@@ -26,6 +26,12 @@ uses(Tests\TestCase::class);
  *  006. isLid detecta @lid suffix + 14+ dígitos sem DDI BR
  */
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('whatsapp_lid_pn_map');
 
     Schema::create('whatsapp_lid_pn_map', function ($table) {

--- a/Modules/Whatsapp/Tests/Feature/MetricsSnapshotBuilderTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MetricsSnapshotBuilderTest.php
@@ -15,6 +15,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach (['whatsapp_business_phones', 'whatsapp_messages'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MultiTenantIsolationTest.php
@@ -32,6 +32,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach ([
         'whatsapp_phone_user_access',
         'whatsapp_messages',

--- a/Modules/Whatsapp/Tests/Feature/ObservabilityTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ObservabilityTest.php
@@ -9,6 +9,12 @@ use Illuminate\Support\Facades\Schema;
 uses(Tests\TestCase::class);
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     // Schema mínimo pro command rodar — só duas tabelas usadas
     foreach (['whatsapp_business_phones', 'whatsapp_messages'] as $t) {
         Schema::dropIfExists($t);

--- a/Modules/Whatsapp/Tests/Feature/OfficeimpressoEnrichServiceTest.php
+++ b/Modules/Whatsapp/Tests/Feature/OfficeimpressoEnrichServiceTest.php
@@ -24,6 +24,12 @@ uses(Tests\TestCase::class);
  *   7. EnrichService — fail-open quando source unhealthy
  */
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('customer_memory');
     Schema::create('customer_memory', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhoneResolutionWebhookTest.php
@@ -28,6 +28,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_phones', 'whatsapp_business_configs'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
+++ b/Modules/Whatsapp/Tests/Feature/PhonesMigrationDataTest.php
@@ -29,6 +29,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach ([
         'whatsapp_phone_user_access',
         'whatsapp_messages',

--- a/Modules/Whatsapp/Tests/Feature/ProcessIncomingWebhookJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ProcessIncomingWebhookJobTest.php
@@ -28,6 +28,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach (['whatsapp_messages', 'whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/SendInteractiveJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendInteractiveJobTest.php
@@ -29,6 +29,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach ([
         'whatsapp_messages',
         'whatsapp_conversations',

--- a/Modules/Whatsapp/Tests/Feature/SendMessageRequestTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendMessageRequestTest.php
@@ -55,6 +55,12 @@ function runSendRequest(array $input, ?WhatsappConversation $conv = null): \Illu
 }
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach (['whatsapp_conversations', 'whatsapp_business_configs'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/SendWhatsappMessageJobTest.php
@@ -34,6 +34,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     foreach ([
         'whatsapp_messages',
         'whatsapp_conversations',

--- a/Modules/Whatsapp/Tests/Feature/WebhookReplayProtectionTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookReplayProtectionTest.php
@@ -23,6 +23,12 @@ uses(Tests\TestCase::class);
  * @see Modules/Whatsapp/Http/Middleware/VerifyBaileysWebhookHmac.php
  */
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('webhook_nonces');
     Schema::create('webhook_nonces', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/WebhookSignatureTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookSignatureTest.php
@@ -29,6 +29,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('whatsapp_business_configs');
     Schema::create('whatsapp_business_configs', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/WhatsappDriverHealthCheckJobTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappDriverHealthCheckJobTest.php
@@ -25,6 +25,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('whatsapp_business_configs');
     Schema::create('whatsapp_business_configs', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php
@@ -21,6 +21,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('whatsapp_messages');
     Schema::create('whatsapp_messages', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/WhatsappTemplateTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsappTemplateTest.php
@@ -19,6 +19,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema whatsapp_* manual (sqlite-friendly). No MySQL
+    // persistente do nightly isso DROPA tabelas reais → corrompe os testes irmãos
+    // (lever do floor SDD). Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('whatsapp_templates');
     Schema::create('whatsapp_templates', function ($table) {
         $table->bigIncrements('id');

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowWebhookAuthTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowWebhookAuthTest.php
@@ -34,6 +34,12 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: este teste cria schema manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso DROPA tabelas reais → corrompe os testes irmãos (lever do floor SDD).
+    // Cobertura real é na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
     Schema::dropIfExists('business');
     Schema::create('business', function ($table) {
         $table->bigIncrements('id');


### PR DESCRIPTION
## O quê
Guarda `if (config('database.default') !== 'sqlite') markTestSkipped('era-sqlite: …')` no `beforeEach` de **20 testes Whatsapp** que criam schema `whatsapp_*`/`business` manual. Mesmo padrão já mergeado em RB/Repair/Governance.

## Por que GUARD e NÃO RefreshDatabase (correção da triagem)
A triagem original recomendou CONVERT→RefreshDatabase. O pre-flight **refutou** isso:
- a lane **per-PR roda em SQLITE** (`phpunit.xml` + `modules-pest.yml` → `DB_CONNECTION=sqlite`); só o nightly CT100 é MySQL;
- as migrations são **MySQL-only** (`ci.yml`: *"RefreshDatabase esbarra na migration MySQL-only ALTER TABLE"*; não existe `sqlite-schema.sql`).

→ Converter pra RefreshDatabase **quebraria a lane sqlite**. A cobertura real desses testes é na lane sqlite (per-PR); no MySQL eles só **corrompiam** (dropam tabelas reais → cascata, lever do floor SDD). Guardar **mantém a cobertura sqlite e para a corrupção no nightly**.

## CI-safe
No sqlite (per-PR) o comportamento é **idêntico** (a guarda não dispara) → se passava antes, passa agora. Só pula no MySQL (nightly). Inclui os Tier-0/segurança (`MultiTenantIsolation`, `WebhookSignature`, `WebhookReplayProtection`) — a guarda **preserva** a garantia na lane sqlite onde ela sempre rodou.

## Prova
- `php -l` ok nos 20 (Herd 8.4.21);
- corruptor-linter v2 ([#2749](https://github.com/wagnerra23/oimpresso.com/pull/2749)) confirma `corruptsOnMysql=false` nos 20 → floor real **63 → 43**;
- prova final = CT100 nightly.

## Contexto
Lote Whatsapp-A do mapa em `memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md`. Próximo: lote Jana/Mcp-A (~30) com a mesma guarda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)