### PR TITLE
fix(test): guarda sqlite-only em 28 corruptores Jana/Mcp + Copiloto (floor SDD · −28)

### DIFF
--- a/Modules/Jana/Tests/Feature/Ai/Clarify/ClarifyCascadeServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/Clarify/ClarifyCascadeServiceTest.php
@@ -28,6 +28,13 @@ uses(Tests\TestCase::class);
  *  009. fail-open — exceção no disambiguador → responde (chat nunca quebra)
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     foreach (['jana_conversas', 'jana_mensagens'] as $t) {
         Schema::dropIfExists($t);
     }

--- a/Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php
@@ -24,6 +24,13 @@ uses(Tests\TestCase::class);
  * @see Modules/Jana/Database/Migrations/2026_06_05_120000_create_jana_ui_judge_runs_table.php
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('jana_ui_judge_runs');
     Schema::create('jana_ui_judge_runs', function (Blueprint $t) {
         $t->bigIncrements('id');

--- a/Modules/Jana/Tests/Feature/BriefDiarioChatTriggerTest.php
+++ b/Modules/Jana/Tests/Feature/BriefDiarioChatTriggerTest.php
@@ -26,6 +26,13 @@ uses(Tests\TestCase::class);
  * @see memory/requisitos/Copiloto/JANA-PRO-PRODUCT-PLAN.md
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Setup mínimo de schema pra Conversa
     foreach (['jana_conversas', 'jana_mensagens'] as $t) {
         Schema::dropIfExists($t);

--- a/Modules/Jana/Tests/Feature/HealthNarratorServiceTest.php
+++ b/Modules/Jana/Tests/Feature/HealthNarratorServiceTest.php
@@ -20,6 +20,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     config()->set('copiloto.dry_run', true);
 
     Schema::dropIfExists('jana_health_narratives');
@@ -39,6 +46,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_health_narratives');
 });
 

--- a/Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php
+++ b/Modules/Jana/Tests/Feature/HealthSnapshotServiceTest.php
@@ -20,6 +20,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('failed_jobs');
     Schema::dropIfExists('mcp_audit_log');
     Schema::dropIfExists('jana_mensagens');
@@ -53,6 +60,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_mensagens');
     Schema::dropIfExists('mcp_audit_log');
     Schema::dropIfExists('failed_jobs');

--- a/Modules/Jana/Tests/Feature/HitTrackerServiceTest.php
+++ b/Modules/Jana/Tests/Feature/HitTrackerServiceTest.php
@@ -20,6 +20,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('jana_memoria_facts');
     Schema::create('jana_memoria_facts', function ($t) {
         $t->id();
@@ -34,6 +41,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_memoria_facts');
 });
 

--- a/Modules/Jana/Tests/Feature/Mcp/AutomationRegistryMigrationTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/AutomationRegistryMigrationTest.php
@@ -17,11 +17,22 @@ function loadMigration(string $file)
 }
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_automation_runs');
     Schema::dropIfExists('mcp_automations');
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_automation_runs');
     Schema::dropIfExists('mcp_automations');
 });

--- a/Modules/Jana/Tests/Feature/Mcp/AutomationRegistrySyncTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/AutomationRegistrySyncTest.php
@@ -31,6 +31,13 @@ uses(Tests\TestCase::class);
  * enums viram string (SQLite não suporta ENUM).
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // ── Schema mínimo (replica as migrations; enum→string no SQLite). ──
     Schema::dropIfExists('mcp_automation_runs');
     Schema::dropIfExists('mcp_automations');
@@ -138,6 +145,10 @@ PHP);
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_automation_runs');
     Schema::dropIfExists('mcp_automations');
     Schema::dropIfExists('mcp_alertas_eventos');

--- a/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
@@ -39,6 +39,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Schema minimal pra SQLite (mcp_cycles, mcp_projects, mcp_tasks, events, comments)
     Schema::dropIfExists('mcp_jira_projects');
     Schema::create('mcp_jira_projects', function (Blueprint $t) {
@@ -133,6 +140,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_task_comments');
     Schema::dropIfExists('mcp_task_events');
     Schema::dropIfExists('mcp_tasks');

--- a/Modules/Jana/Tests/Feature/Mcp/HandoffDiffToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/HandoffDiffToolTest.php
@@ -27,6 +27,13 @@ uses(Tests\TestCase::class);
  * Mock: Process::fake() pra `gh` e `git`. Stubs em mcp_tasks/mcp_cycles via DB direto.
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Tabela cache (replica migration em SQLite)
     Schema::dropIfExists('mcp_handoff_diffs');
     Schema::create('mcp_handoff_diffs', function (Blueprint $t) {
@@ -72,6 +79,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     if (isset(test()->tempDir) && File::isDirectory(test()->tempDir)) {
         File::deleteDirectory(test()->tempDir);
     }

--- a/Modules/Jana/Tests/Feature/Mcp/HandoffDraftToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/HandoffDraftToolTest.php
@@ -27,6 +27,13 @@ uses(Tests\TestCase::class);
  *  008. last-handoff sem handoff anterior cai pra default (best-effort, não bloqueia)
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Tabela cache HandoffDiffTool (composição interna)
     Schema::dropIfExists('mcp_handoff_diffs');
     Schema::create('mcp_handoff_diffs', function (Blueprint $t) {
@@ -82,6 +89,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     if (isset(test()->tempDir) && File::isDirectory(test()->tempDir)) {
         File::deleteDirectory(test()->tempDir);
     }

--- a/Modules/Jana/Tests/Feature/Mcp/HandoffFetchSummarizedToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/HandoffFetchSummarizedToolTest.php
@@ -29,6 +29,13 @@ uses(Tests\TestCase::class);
  * Isolamento de prod: usa temp dir via config('jana.handoffs_dir').
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Cria tabela cache (replica migration em SQLite)
     Schema::dropIfExists('mcp_handoff_summaries');
     Schema::create('mcp_handoff_summaries', function (Blueprint $t) {
@@ -69,6 +76,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     if (isset(test()->tempDir) && File::isDirectory(test()->tempDir)) {
         File::deleteDirectory(test()->tempDir);
     }

--- a/Modules/Jana/Tests/Feature/Mcp/InboxAutoCleanupJobTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/InboxAutoCleanupJobTest.php
@@ -16,6 +16,13 @@ uses(Tests\TestCase::class);
  * (migration usa enum, não funciona em SQLite — replicamos com string).
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_inbox_notifications');
     Schema::create('mcp_inbox_notifications', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -31,6 +38,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_inbox_notifications');
 });
 

--- a/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php
@@ -31,6 +31,13 @@ uses(\Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // mcp_memory_documents (mesmo pattern do StalenessDetectorTest — manual create
     // pra rodar em sqlite :memory: do phpunit.xml).
     Schema::create('mcp_memory_documents', function (Blueprint $t) {
@@ -83,6 +90,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_memory_documents_history');
     Schema::dropIfExists('mcp_memory_documents');
 });

--- a/Modules/Jana/Tests/Feature/Mcp/JanaCyclesAutoCloseExpiredCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/JanaCyclesAutoCloseExpiredCommandTest.php
@@ -43,6 +43,13 @@ spl_autoload_register(function (string $class) {
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Worktree fix: registra o command manualmente caso o ServiceProvider em
     // execução (carregado da main repo via vendor symlink) ainda não conheça
     // o arquivo da worktree. Em CI/prod o command é auto-discovered.
@@ -153,6 +160,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_task_comments');
     Schema::dropIfExists('mcp_task_events');
     Schema::dropIfExists('mcp_tasks');

--- a/Modules/Jana/Tests/Feature/Mcp/JanaWeeklyDigestCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/JanaWeeklyDigestCommandTest.php
@@ -28,6 +28,13 @@ uses(Tests\TestCase::class);
  *    então usamos limpeza posterior + filename específico de teste (semana futura).
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_weekly_digests');
     Schema::create('mcp_weekly_digests', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -45,6 +52,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_weekly_digests');
     // Cleanup arquivos teste em memory/sessions/
     foreach (glob(base_path('memory/sessions/WEEKLY-DIGEST-9999-W*.md') ?: []) as $f) {

--- a/Modules/Jana/Tests/Feature/Mcp/JanaWeeklyDigestEmailTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/JanaWeeklyDigestEmailTest.php
@@ -26,6 +26,13 @@ uses(Tests\TestCase::class);
  * (não tocados — esse arquivo aditivo cobre só o gap de envio email D8 #6).
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_weekly_digests');
     Schema::create('mcp_weekly_digests', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -43,6 +50,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_weekly_digests');
     foreach (glob(base_path('memory/sessions/WEEKLY-DIGEST-9999-W*.md') ?: []) as $f) {
         @unlink($f);

--- a/Modules/Jana/Tests/Feature/Mcp/KbAnswerToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/KbAnswerToolTest.php
@@ -31,6 +31,13 @@ uses(Tests\TestCase::class);
  * Dual-mode pattern documentado em reference_tests_pest_canon.md.
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Schema mínimo replicando mcp_memory_documents (sem FULLTEXT).
     Schema::dropIfExists('mcp_memory_documents');
     Schema::create('mcp_memory_documents', function (Blueprint $t) {
@@ -91,6 +98,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_memory_documents');
 });
 

--- a/Modules/Jana/Tests/Feature/Mcp/McpTasksHealthCheckCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/McpTasksHealthCheckCommandTest.php
@@ -27,6 +27,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_tasks');
     Schema::create('mcp_tasks', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -98,6 +105,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_tasks');
     Schema::dropIfExists('mcp_git_links');
     Schema::dropIfExists('mcp_task_comments');

--- a/Modules/Jana/Tests/Feature/Mcp/MyInboxToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/MyInboxToolTest.php
@@ -20,6 +20,13 @@ uses(Tests\TestCase::class);
  * Wagner querer só espiar.
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Schema mínimo da inbox — replica migration (enum em SQLite não rola).
     Schema::dropIfExists('mcp_inbox_notifications');
     Schema::create('mcp_inbox_notifications', function (Blueprint $t) {
@@ -43,6 +50,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_inbox_notifications');
     request()->attributes->remove('mcp_token');
 });

--- a/Modules/Jana/Tests/Feature/Mcp/WeeklyDigestFetchToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/WeeklyDigestFetchToolTest.php
@@ -22,6 +22,13 @@ uses(Tests\TestCase::class);
  *  006. Fallback file lê memory/sessions/WEEKLY-DIGEST-*.md quando DB ausente
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_weekly_digests');
     Schema::create('mcp_weekly_digests', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -39,6 +46,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_weekly_digests');
     foreach (glob(base_path('memory/sessions/WEEKLY-DIGEST-9999-W*.md') ?: []) as $f) {
         @unlink($f);

--- a/Modules/Jana/Tests/Feature/Memoria/Freshness/StalenessDetectorTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/Freshness/StalenessDetectorTest.php
@@ -32,6 +32,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // mcp_memory_documents (mesmo schema da migration canônica, mas sem FULLTEXT
     // pra rodar em sqlite :memory: do phpunit.xml — ADR 0101).
     Schema::create('mcp_memory_documents', function (Blueprint $t) {
@@ -93,6 +100,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_alertas_eventos');
     Schema::dropIfExists('mcp_memory_documents');
 });

--- a/Modules/Jana/Tests/Feature/NarrarSaudeEcosistemaJobTest.php
+++ b/Modules/Jana/Tests/Feature/NarrarSaudeEcosistemaJobTest.php
@@ -20,6 +20,13 @@ uses(Tests\TestCase::class);
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('jana_health_narratives');
     Schema::create('jana_health_narratives', function (Blueprint $t) {
         $t->id();
@@ -37,6 +44,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_health_narratives');
 });
 

--- a/Modules/Jana/Tests/Feature/Summarizer/AutoSummarizerServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Summarizer/AutoSummarizerServiceTest.php
@@ -30,6 +30,13 @@ uses(Tests\TestCase::class);
  * Tabela mcp_doc_summaries criada in-test (SQLite-compat).
  */
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('mcp_doc_summaries');
     Schema::create('mcp_doc_summaries', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -60,6 +67,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_doc_summaries');
 });
 

--- a/tests/Feature/Modules/Copiloto/ApuracaoIdempotenciaTest.php
+++ b/tests/Feature/Modules/Copiloto/ApuracaoIdempotenciaTest.php
@@ -16,6 +16,13 @@ use Modules\Jana\Scopes\ScopeByBusiness;
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::create('jana_meta_apuracoes', function (Blueprint $table) {
         $table->bigIncrements('id');
         $table->unsignedBigInteger('meta_id');
@@ -30,6 +37,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_meta_apuracoes');
 });
 

--- a/tests/Feature/Modules/Copiloto/MemoriaMetricaTest.php
+++ b/tests/Feature/Modules/Copiloto/MemoriaMetricaTest.php
@@ -15,6 +15,13 @@ use Modules\Jana\Entities\MemoriaMetrica;
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::create('jana_memoria_metricas', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->date('apurado_em');
@@ -39,6 +46,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_memoria_metricas');
 });
 

--- a/tests/Feature/Modules/Copiloto/MetricasApuradorTest.php
+++ b/tests/Feature/Modules/Copiloto/MetricasApuradorTest.php
@@ -14,6 +14,13 @@ use Modules\Jana\Services\Metricas\MetricasApurador;
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // copiloto_memoria_metricas
     Schema::create('jana_memoria_metricas', function (Blueprint $t) {
         $t->bigIncrements('id');
@@ -74,6 +81,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_memoria_metricas');
     Schema::dropIfExists('jana_conversas');
     Schema::dropIfExists('jana_mensagens');

--- a/tests/Feature/Modules/Copiloto/SemanticCacheServiceTest.php
+++ b/tests/Feature/Modules/Copiloto/SemanticCacheServiceTest.php
@@ -25,6 +25,13 @@ use Modules\Jana\Services\Cache\SemanticCacheService;
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema mcp_*/jana_* manual (sqlite-friendly). No MySQL persistente
+    // do nightly isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é
+    // na lane sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::create('jana_cache_semantico', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->char('cache_key', 64)->unique();
@@ -46,6 +53,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_cache_semantico');
 });
 


### PR DESCRIPTION
## O quê
Guarda sqlite-only (`markTestSkipped` não-sqlite no `beforeEach` + guarda no `afterEach`) em **28 testes Jana/Mcp + Copiloto** que criam schema `mcp_*`/`jana_*` manual. Mesmo padrão de RB/Repair/Governance ([#2746](https://github.com/wagnerra23/oimpresso.com/pull/2746)) e Whatsapp ([#2753](https://github.com/wagnerra23/oimpresso.com/pull/2753)). 25 levaram beforeEach + afterEach; 3 só beforeEach.

## Por que GUARD e NÃO RefreshDatabase
A lane **per-PR roda em sqlite** e as migrations são **MySQL-only** (`ci.yml`; não há `sqlite-schema.sql`) → converter quebraria a lane sqlite. A cobertura real é na lane sqlite; no MySQL nightly esses testes só **corrompiam** (dropam tabelas reais; 7 "no-drop-guard create" já erravam na hora). Guardar mantém a cobertura sqlite e para a corrupção no nightly.

## CI-safe
No sqlite (per-PR) o comportamento é **idêntico** (guarda não dispara) → passa como antes. Só pula no MySQL (nightly).

## Refutação aplicada
O agente checou cada arquivo contra falsos-positivos (dual-mode `if(sqlite){DDL}`, `RefreshDatabase`, source-reader): **0 exclusões** — todos os 28 eram genuinamente não-guardados. `AutomationRegistryMigrationTest` (teste da própria migração `up()`/`down()`) fica sqlite-only por design.

## Prova
- `php -l` ok nos 28; corruptor-linter v2 ([#2749](https://github.com/wagnerra23/oimpresso.com/pull/2749)) confirma `corruptsOnMysql=false` nos 28;
- floor real (corruptor-linter): main 63 → 35 (este PR) → 15 com #2753 também;
- prova final = CT100 nightly.

## Contexto
Lote Jana/Mcp-A do mapa em `memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md`. Restam ~15 corruptores reais (Governance-A 6, NfeBrasil 5 = falso-positivo dual-mode, FSM/Inv 2, ADS 1, RB 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)