### PR TITLE
fix(governance): KL-E2 — remove 2 ghosts dos stubs (Modules/Index, Modules/Sells)

### DIFF
--- a/memory/requisitos/Modules/BRIEFING.md
+++ b/memory/requisitos/Modules/BRIEFING.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Admin`** (decisão E1 · frente KL · 2026-06-15).
 > - **Verdade viva → [`memory/requisitos/Admin/`](../Admin/BRIEFING.md)**
-> - Tela única `Pages/Modules/Index` = `ModuleManagementController` core (Admin); nome é isca de ghost.
+> - Tela única de gestão de módulos (`ModuleManagementController` core, em Admin); o nome 'Modules' é isca de ghost-name.
 > - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
 
 **Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Admin/`.**

--- a/memory/requisitos/Orcamento/BRIEFING.md
+++ b/memory/requisitos/Orcamento/BRIEFING.md
@@ -2,7 +2,7 @@
 
 > ⚠️ **Pare aqui — esta pasta foi FUNDIDA em `Sells`** (decisão E1 · frente KL · 2026-06-15).
 > - **Verdade viva → [`memory/requisitos/Sells/`](../Sells/BRIEFING.md)**
-> - Quotation = `Transaction type:sell status:draft`, domínio do `Modules/Sells`.
+> - Quotation = `Transaction type:sell status:draft`, domínio de vendas (Sells, core — não há `Modules/` Sells).
 > - Os demais docs aqui são **proveniência congelada** (histórico), não estado vigente.
 
 **Tipo:** redirect/fusão (KL-E2). **Estado vigente → `requisitos/Sells/`.**


### PR DESCRIPTION
O `anti-ghost ratchet` (advisory) pegou 2 ghosts NOVOS introduzidos pelos redirect stubs do #2750:
- `Modules/BRIEFING.md` citava `Pages/Modules/Index` → regex lê `Modules/Index` (falso-ghost, 'Modules é isca').
- `Orcamento/BRIEFING.md` citava `Modules/Sells` → ghost real (Sells é domínio core, não `Modules/`).

Reescritos sem o token. Zera os 2 NOVOS da catraca. (As dezenas de avisos 'X não é mais ghost' = minhas portas resolveram ghosts legados — baseline pode encolher num passo futuro.)

Refs: SDD KL-E2

🤖 Generated with [Claude Code](https://claude.com/claude-code)