### PR TITLE
fix(audit): corruptor-linter v3 — dual-mode if(sqlite){drop} + correção doc (CONVERT→GUARD)

### DIFF
--- a/memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md
+++ b/memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md
@@ -18,6 +18,30 @@ prs: []
 3. **RC-1..31 quarentenou o B/C tail; o S-tier de maior raio quase não se moveu** (~30→29 não-quarentenados desde 06-13).
 4. **Doutrina correta:** CONVERT (RefreshDatabase/DatabaseTransactions, mantém cobertura) > QUARANTINE (`era-sqlite`, derruba o número mas a suíte mente). Vários "alvos" do linter são Tier-0/segurança — quarentenar = perder a garantia no único lugar que ela roda (MySQL).
 
+## ⚠️ CORREÇÃO pós-execução (2026-06-15) — CONVERT estava ERRADO; o certo é GUARD
+
+O item 4 acima (e a tabela "CONVERT" abaixo) foi **refutado na execução** e fica
+SUPERADO. Pré-flight provou:
+- a lane **per-PR roda em SQLITE** (`phpunit.xml` + `modules-pest.yml` → `DB_CONNECTION=sqlite`); só o nightly CT100 é MySQL;
+- as migrations são **MySQL-only** (`ci.yml`: *"RefreshDatabase esbarra na migration MySQL-only ALTER TABLE"*; não existe `sqlite-schema.sql`).
+
+→ CONVERT→RefreshDatabase **quebraria a lane sqlite**. A cobertura real desses testes
+é na lane sqlite (per-PR); no MySQL eles só **corrompiam**. O fix correto é **GUARD
+sqlite-only** (`markTestSkipped` não-sqlite no beforeEach + guarda no teardown) — mantém
+a cobertura sqlite e para a corrupção no nightly. CI-safe (comportamento sqlite inalterado).
+Vale inclusive pros Tier-0/segurança: guardar **preserva** a garantia na lane sqlite.
+
+**Executado (tudo mergeado):** PR #2746 Governance afterEach ×4 · PR #2749 linter v2
+(comportamento-no-MySQL, ~48% FP removido) · PR #2753 Whatsapp-A guard ×20 · PR #2756
+Jana/Mcp+Copiloto guard ×28 · PR linter v3 (dual-mode `if(sqlite){drop}` reconhecido).
+
+**Estado honesto do floor (corruptor-linter v3):** de 67 → **9 corruptores reais**
+(BomResolver, ReservarEstoqueBom [FSM/Inv]; ContextForTaskActiveTasks [ADS]; DetectOtelQuery,
+DashboardExtension, DetectDriftCommand, ObservabilitySnapshot, ScorecardSnapshot, Wave28
+[Governance-A]). Os "fantasmas" (NfeBrasil ×5 + RB RepositoryWave18 + outros dual-mode)
+saíram da conta — eram falso-positivo `if(driver==='sqlite'){DDL}else{row-delete}`.
+Contrato do linter travado em `tests/sqliteCorruptors.spec.ts` (2 lados, com polaridade).
+
 ## Conflito refutador↔analista — RESOLVIDO (esta é a razão de "use um refutador")
 As 4 telas Governance (`CrossTenantPolicy/GovernanceGate/MultiTenantGovernance/SmokeRoutes`): o refutador disse "já pulam no MySQL → deixar"; o analista disse "corruptor via afterEach". **Vencedor: analista.** `beforeEach` é guardado (L37 etc), **mas `afterEach` dropa `mcp_*` SEM guarda**. Prova no próprio repo: RB/Repair já-corrigidos carregam o comentário *"o afterEach roda MESMO em teste pulado (PHPUnit 12: tearDown gated só por hasMetRequirements, true antes do beforeEach/markTestSkipped)"*. → afterEach sem guarda dropa tabela real no MySQL persistente. O refutador só olhou o `beforeEach`. **Lição: refutar o refutador também.**
 

--- a/scripts/audit/sqlite-test-corruptors.mjs
+++ b/scripts/audit/sqlite-test-corruptors.mjs
@@ -188,6 +188,52 @@ function blockRange(src, kw) {
   return [anchor, src.length];
 }
 
+// Condição de `if (...)` que é VERDADEIRA só no sqlite (dual-mode `if(sqlite){drop}else{...}`).
+// POLARIDADE IMPORTA: `=== 'sqlite'` / `:memory:` = positiva (DDL gated, não roda no MySQL);
+// `!== 'sqlite'` = roda no MySQL → NÃO é positiva (continua contando). Sem polaridade o
+// linter sub-contaria `if(!==sqlite){drop}` — travado no meta-teste.
+function isSqlitePositiveCond(cond) {
+  const c = cond.trim();
+  // negativa explícita → o bloco RODA no MySQL (não é gate sqlite)
+  if (/!==?\s*['"]sqlite['"]|['"]sqlite['"]\s*!==?/.test(c)) return false;
+  if (/^!\s*\$?\w*(?:isSqlite|sqliteMemory)\w*$/i.test(c)) return false; // `! $isSqliteMemory`
+  // positiva (literal driver/:memory: OU variável-flag tipo `$isSqliteMemory`)
+  if (/===?\s*['"]sqlite['"]|['"]sqlite['"]\s*===?|getDriverName\(\)\s*===?\s*['"]sqlite|:memory:/.test(c)) return true;
+  if (/^\$?\w*(?:isSqlite|sqliteMemory)\w*$/i.test(c)) return true; // `$isSqliteMemory`
+  return false;
+}
+
+// Ranges [start,end) de blocos `if (<cond sqlite-positiva>) { ... }` em CÓDIGO. DDL aqui
+// dentro só executa no sqlite → não corrompe o MySQL persistente do nightly.
+function sqlitePositiveIfRanges(src, spans) {
+  const ranges = [];
+  const re = /\bif\s*\(/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    if (inNonCode(m.index, spans)) continue;
+    const parenStart = m.index + m[0].length - 1; // posição do '('
+    let depth = 0;
+    let condEnd = -1;
+    for (let j = parenStart; j < src.length; j++) {
+      if (src[j] === '(') depth++;
+      else if (src[j] === ')') { depth--; if (depth === 0) { condEnd = j; break; } }
+    }
+    if (condEnd < 0) continue;
+    if (!isSqlitePositiveCond(src.slice(parenStart + 1, condEnd))) continue;
+    const open = src.indexOf('{', condEnd);
+    if (open < 0 || !/^\s*$/.test(src.slice(condEnd + 1, open))) continue; // `{` logo após a condição
+    let bd = 0;
+    let blockEnd = -1;
+    for (let j = open; j < src.length; j++) {
+      if (src[j] === '{') bd++;
+      else if (src[j] === '}') { bd--; if (bd === 0) { blockEnd = j + 1; break; } }
+    }
+    if (blockEnd < 0) continue;
+    ranges.push([m.index, blockEnd]);
+  }
+  return ranges;
+}
+
 // Classificador puro (testável) — recebe o source + caminho relativo.
 // Retorna null quando o arquivo NÃO faz DDL manual em código (não é corruptor).
 export function classifySource(src, rel = '') {
@@ -222,13 +268,20 @@ export function classifySource(src, rel = '') {
     ...rawDropMatches.map((m) => m.index),
   ];
 
+  // Dual-mode: DDL dentro de `if (sqlite-positiva) { ... }` só roda no sqlite → não corrompe.
+  const sqliteIfRanges = sqlitePositiveIfRanges(src, spans);
+  const inSqliteIf = (idx) => sqliteIfRanges.some(([s, e]) => idx >= s && idx < e);
+
   let teardownUnguardedDrop = false;
   let setupOrBodyDrop = false;
   for (const idx of dropIdxs) {
+    if (inSqliteIf(idx)) continue; // dual-mode — drop só executa no sqlite
     const td = inRanges(idx, teardownRanges);
     if (td) {
       const txt = src.slice(td[0], td[1]);
-      if (!GUARD_TOKEN.test(txt)) teardownUnguardedDrop = true;
+      // teardown guardado = early-return em não-sqlite (`if(!==sqlite){return}`) OU markTestSkipped.
+      const tdGuarded = /(!==?\s*['"]sqlite['"]|['"]sqlite['"]\s*!==?|!\s*\$?\w*(?:isSqlite|sqliteMemory)\w*)[\s\S]{0,40}\breturn\b/i.test(txt) || SKIP_CALL.test(txt);
+      if (!tdGuarded) teardownUnguardedDrop = true;
     } else {
       // está no setup ou no corpo do teste; só roda no MySQL se o setup NÃO guarda.
       setupOrBodyDrop = true;

--- a/tests/sqliteCorruptors.spec.ts
+++ b/tests/sqliteCorruptors.spec.ts
@@ -51,6 +51,20 @@ it('algo', function () { $this->assertTrue(true); });`;
     expect(r.corruptsOnMysql).toBe(true);
   });
 
+  it('POLARIDADE: drop dentro de if(!== sqlite){...} RODA no MySQL → corrompe (não sub-contar)', () => {
+    // O guard de dual-mode NÃO pode confundir polaridade: `!== 'sqlite'` é TRUE no MySQL.
+    const src = `<?php
+beforeEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        Schema::dropIfExists('business');
+    }
+});
+it('algo', function () { $this->assertTrue(true); });`;
+    const r = classifySource(src, 'X/NegIfTest.php');
+    expect(r).not.toBeNull();
+    expect(r.corruptsOnMysql).toBe(true);
+  });
+
   it('CASO CRÍTICO: beforeEach guardado MAS afterEach SEM guarda ainda corrompe (Governance)', () => {
     const src = `<?php
 beforeEach(function () {
@@ -91,6 +105,45 @@ it('algo', function () { $this->assertTrue(true); });`;
     expect(r).not.toBeNull();
     expect(r.corruptsOnMysql).toBe(false);
     expect(r.quarantined).toBe(true);           // efetivamente guardado
+  });
+
+  it('dual-mode if(=== sqlite){DDL} else {row-delete} → seguro (DDL só no sqlite)', () => {
+    const src = `<?php
+beforeEach(function () {
+    if (config('database.default') === 'sqlite') {
+        Schema::dropIfExists('nfe_emissoes');
+        Schema::create('nfe_emissoes', function (Blueprint $t) { $t->id(); });
+    } else {
+        DB::table('nfe_emissoes')->whereIn('business_id', [1, 99])->delete();
+    }
+});
+it('algo', function () { $this->assertTrue(true); });`;
+    const r = classifySource(src, 'X/NfeDualModeTest.php');
+    expect(r).not.toBeNull();
+    expect(r.corruptsOnMysql).toBe(false);
+  });
+
+  it('guarda por variável-flag $isSqliteMemory (skip + afterEach return) → seguro', () => {
+    const src = `<?php
+beforeEach(function () {
+    $isSqliteMemory = config('database.default') === 'sqlite';
+    if (! $isSqliteMemory) {
+        $this->markTestSkipped('só sqlite');
+    }
+    Schema::dropIfExists('fin_titulos');
+    Schema::create('fin_titulos', function (Blueprint $t) { $t->id(); });
+});
+afterEach(function () {
+    $isSqliteMemory = config('database.default') === 'sqlite';
+    if (! $isSqliteMemory) {
+        return;
+    }
+    Schema::dropIfExists('fin_titulos');
+});
+it('algo', function () { $this->assertTrue(true); });`;
+    const r = classifySource(src, 'X/MultiTenantComprehensiveTest.php');
+    expect(r).not.toBeNull();
+    expect(r.corruptsOnMysql).toBe(false);
   });
 
   it('source-reader (DDL dentro de toContain) NÃO é corruptor → null', () => {


### PR DESCRIPTION
## O quê
v3 do `sqlite-test-corruptors.mjs`: reconhece o padrão **dual-mode** `if (config('database.default') === 'sqlite') { ...DDL... } else { ...row-delete... }` — o DDL só roda no sqlite, logo **não corrompe o MySQL**. v2 ainda contava esses como corruptor (falso-positivo).

## Polaridade (trava de sub-contagem)
`sqlitePositiveIfRanges()` só considera gated um `if` **sqlite-positivo** (`=== 'sqlite'` / `:memory:` / flag `$isSqliteMemory`). `if (... !== 'sqlite') { drop }` **continua contando** (roda no MySQL) — senão o linter mentiria pro lado perigoso. Travado no meta-teste.

## Regressão pega no sanity
A 1ª versão do v3 quebrou `MultiTenantComprehensiveTest` (usa flag-var `$isSqliteMemory`). O sanity em arquivos reais pegou; corrigi o reconhecimento da flag-var em ambas as polaridades. (É pra isso que o sanity existe.)

## Floor honesto
**67 → 9 corruptores reais.** Saíram os fantasmas dual-mode: NfeBrasil ×5, RB `RepositoryWave18`, `MultiTenantComprehensive`. Ficam os 9 genuínos (FSM/Inv ×2, ADS ×1, Governance-A ×6) — alvo do próximo PR (GUARD).

## Meta-teste (refutador · 2 lados)
`tests/sqliteCorruptors.spec.ts` +3 casos: `if(!==sqlite){drop}` ainda conta · `if(===sqlite){drop}` seguro · `$isSqliteMemory` seguro. Verificado 8/8 via node + sanity em arquivos reais (BomResolver/ADS ficam flagados; os 3 dual-mode saem). Advisory no umbrella (`continue-on-error`).

## Doc
Correção **CONVERT→GUARD** em `memory/sessions/2026-06-15-sdd-longtail-triage-refuted.md`: a lane per-PR é **sqlite** e as migrations são **MySQL-only** → CONVERT quebraria a lane; GUARD (sqlite-only) é o certo. + estado honesto do floor.

Refs: SDD floor era-sqlite isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)