### PR TITLE
fix(test): guarda os 9 corruptores genuínos restantes (floor SDD → 0)

### DIFF
--- a/Modules/ADS/Tests/Unit/ContextForTaskActiveTasksTest.php
+++ b/Modules/ADS/Tests/Unit/ContextForTaskActiveTasksTest.php
@@ -12,6 +12,15 @@ use Modules\ADS\Services\UserScopeService;
 
 uses(Tests\TestCase::class);
 
+beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+});
+
 // US-COPI-077 — ContextForTaskService consome mcp_tasks no lugar de CURRENT.md.
 // Testes isolam o método novo (buildActiveTasks) via Reflection pra não
 // depender das outras tabelas mcp_* que buildContext() consulta.
@@ -49,6 +58,10 @@ function createMcpTasksSchema(): void
 }
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_tasks');
 });
 

--- a/Modules/Governance/Tests/Feature/DetectOtelQueryTest.php
+++ b/Modules/Governance/Tests/Feature/DetectOtelQueryTest.php
@@ -28,10 +28,21 @@ use Tests\TestCase;
 uses(TestCase::class);
 
 beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     $this->eval = new ScopedScorecardEvaluator();
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     // Limpa tabela de teste se criada (sqlite in-memory normalmente já drop ao fim).
     if (Schema::hasTable('mcp_observability_aggregates_daily')) {
         Schema::drop('mcp_observability_aggregates_daily');

--- a/Modules/Governance/Tests/Feature/ObservabilitySnapshotServiceTest.php
+++ b/Modules/Governance/Tests/Feature/ObservabilitySnapshotServiceTest.php
@@ -36,6 +36,13 @@ use Tests\TestCase;
 uses(TestCase::class);
 
 beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Recria tabelas isoladamente (sem rodar todas as migrations do projeto).
     Schema::dropIfExists('mcp_observability_aggregates_daily');
     Schema::dropIfExists('mcp_observability_spans');
@@ -70,6 +77,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_observability_aggregates_daily');
     Schema::dropIfExists('mcp_observability_spans');
 });

--- a/Modules/Governance/Tests/Feature/ScorecardSnapshotCommandTest.php
+++ b/Modules/Governance/Tests/Feature/ScorecardSnapshotCommandTest.php
@@ -15,6 +15,15 @@ use Illuminate\Support\Facades\Schema;
 
 uses(RefreshDatabase::class);
 
+beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+});
+
 it('governance:scorecard-snapshot persiste rows em mcp_scorecard_runs', function () {
     expect(Schema::hasTable('mcp_scorecard_runs'))->toBeTrue();
 

--- a/Modules/Governance/Tests/Feature/Wave28InitiativeServiceTest.php
+++ b/Modules/Governance/Tests/Feature/Wave28InitiativeServiceTest.php
@@ -33,6 +33,13 @@ use Tests\TestCase;
 uses(TestCase::class);
 
 beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // Tabela canônica do Wave 28 — cria direto pra evitar RefreshDatabase global
     Schema::dropIfExists('mcp_governance_initiatives');
     Schema::create('mcp_governance_initiatives', function (Blueprint $table) {
@@ -83,6 +90,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_governance_initiatives');
     Schema::dropIfExists('mcp_scorecard_runs');
     Schema::dropIfExists('mcp_alertas');

--- a/tests/Feature/Domain/Inventory/BomResolverTest.php
+++ b/tests/Feature/Domain/Inventory/BomResolverTest.php
@@ -22,6 +22,13 @@ use Modules\Jana\Scopes\ScopeByBusiness;
  * colunas necessárias pro resolver).
  */
 beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     // products mínimo
     Schema::create('products', function (Blueprint $t) {
         $t->increments('id');
@@ -48,6 +55,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     (require database_path('migrations/2026_05_12_080001_create_product_bom_table.php'))->down();
     foreach (['variations', 'products'] as $tbl) {
         Schema::dropIfExists($tbl);

--- a/tests/Feature/Domain/Inventory/ReservarEstoqueBomTest.php
+++ b/tests/Feature/Domain/Inventory/ReservarEstoqueBomTest.php
@@ -28,6 +28,13 @@ class InvBomSubject extends Model
 }
 
 beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::create('fsm_inv_bom_subjects', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->unsignedInteger('business_id');
@@ -58,6 +65,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     (require database_path('migrations/2026_05_12_080001_create_product_bom_table.php'))->down();
     (require database_path('migrations/2026_05_11_130001_create_stock_reservations_table.php'))->down();
     foreach (['variations', 'products', 'fsm_inv_bom_subjects'] as $tbl) {

--- a/tests/Feature/Modules/Governance/DashboardExtensionTest.php
+++ b/tests/Feature/Modules/Governance/DashboardExtensionTest.php
@@ -17,6 +17,13 @@ use Illuminate\Support\Facades\Schema;
  */
 
 beforeEach(function () {
+    // era-sqlite: cria schema manual (sqlite-friendly). No MySQL persistente do nightly
+    // isso corrompe os testes irmãos (lever do floor SDD). Cobertura real é na lane
+    // sqlite (per-PR); pula no MySQL.
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: corruptor de schema compartilhado no MySQL — sqlite-only no burn-down do floor SDD.');
+    }
+
     Schema::dropIfExists('jana_health_narratives');
     Schema::dropIfExists('jana_mensagens');
     Schema::dropIfExists('failed_jobs');
@@ -54,6 +61,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('jana_health_narratives');
     Schema::dropIfExists('jana_mensagens');
     Schema::dropIfExists('failed_jobs');

--- a/tests/Feature/Modules/Governance/DetectDriftCommandTest.php
+++ b/tests/Feature/Modules/Governance/DetectDriftCommandTest.php
@@ -26,7 +26,7 @@ use Illuminate\Support\Facades\Schema;
 
 beforeEach(function () {
     if (config('database.default') !== 'sqlite') {
-        test()->skip('era-sqlite: Schema::dropIfExists/create mcp_alertas_eventos corrompe MySQL nightly — teste foi projetado pra SQLite in-memory');
+        $this->markTestSkipped('era-sqlite: Schema::dropIfExists/create mcp_alertas_eventos corrompe MySQL nightly — teste foi projetado pra SQLite in-memory');
     }
 
     // Schema mínimo replicando mcp_alertas_eventos (Modules/Jana/Database/Migrations/2026_04_29_600001_*).
@@ -56,6 +56,10 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        return;
+    }
+
     Schema::dropIfExists('mcp_alertas_eventos');
 
     $fixtureBase = base_path('Modules/__DriftFixture__');


### PR DESCRIPTION
## O quê
Última milha do burn-down: guarda sqlite-only nos **9 corruptores reais restantes** (FSM/Inv ×2, ADS ×1, Governance-A ×6). Mesmo padrão de #2746/#2753/#2756.

## Notas por arquivo
- **BomResolver / ReservarEstoqueBom**: dropam por variável (`foreach … Schema::dropIfExists($tbl)`) no afterEach, sem skip no beforeEach → adicionei beforeEach skip + afterEach return-guard.
- **ContextForTaskActiveTasks / ScorecardSnapshot**: sem beforeEach → hook adicionado. `ScorecardSnapshot` mantém `RefreshDatabase` (o skip pula o teste inteiro no MySQL → neutraliza o `Schema::dropIfExists` que está num corpo de teste).
- **DetectDriftCommand**: usava `test()->skip()` (que o auditor não reconhece) → canonicalizado pra `$this->markTestSkipped()` (mesmo comportamento) + afterEach guard.

## Por que GUARD e não RefreshDatabase
Lane per-PR é **sqlite**; migrations **MySQL-only** → converter quebraria a lane. Guardar mantém a cobertura sqlite e para a corrupção no nightly. CI-safe (sqlite inalterado).

## Prova
- `php -l` ok nos 9; corruptor-linter confirma `corruptsOnMysql=false` nos 9.
- **Com [#2758](https://github.com/wagnerra23/oimpresso.com/pull/2758) (linter v3 dual-mode), o floor de corruptores reais ZERA** (os 6 que sobram no v2 são falso-positivo dual-mode NfeBrasil×5 + RB RepositoryWave18).
- Prova final = CT100 nightly.

## Fecho do burn-down (todos mergeados/armados)
#2746 Governance ×4 · #2749 linter v2 · #2753 Whatsapp ×20 · #2756 Jana/Mcp ×28 · #2758 linter v3 dual-mode + doc · **este: ×9** → **67 → 0 corruptores reais**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)