### PR TITLE
chore(governance): KL-E2 — encolhe baseline anti-ghost (portas mataram ghosts)

### DIFF
--- a/governance/knowledge-ghosts-baseline/ADS.json
+++ b/governance/knowledge-ghosts-baseline/ADS.json
@@ -1,1 +1,0 @@
-{"module":"ADS","ghosts":["Copiloto"]}

--- a/governance/knowledge-ghosts-baseline/Arquivos.json
+++ b/governance/knowledge-ghosts-baseline/Arquivos.json
@@ -1,1 +1,0 @@
-{"module":"Arquivos","ghosts":["Contratos","Suporte"]}

--- a/governance/knowledge-ghosts-baseline/Auditoria.json
+++ b/governance/knowledge-ghosts-baseline/Auditoria.json
@@ -1,1 +1,0 @@
-{"module":"Auditoria","ghosts":["Copiloto"]}

--- a/governance/knowledge-ghosts-baseline/Autopecas.json
+++ b/governance/knowledge-ghosts-baseline/Autopecas.json
@@ -1,1 +1,1 @@
-{"module":"Autopecas","ghosts":["Autopecas","CV","Copiloto","MemCofre"]}
+{"module":"Autopecas","ghosts":["MemCofre"]}

--- a/governance/knowledge-ghosts-baseline/Cms.json
+++ b/governance/knowledge-ghosts-baseline/Cms.json
@@ -1,1 +1,0 @@
-{"module":"Cms","ghosts":["Auth"]}

--- a/governance/knowledge-ghosts-baseline/Comissao.json
+++ b/governance/knowledge-ghosts-baseline/Comissao.json
@@ -1,1 +1,0 @@
-{"module":"Comissao","ghosts":["Comissao","Marketplaces"]}

--- a/governance/knowledge-ghosts-baseline/ComunicacaoVisual.json
+++ b/governance/knowledge-ghosts-baseline/ComunicacaoVisual.json
@@ -1,1 +1,1 @@
-{"module":"ComunicacaoVisual","ghosts":["Autopecas","CV","Copiloto","MemCofre"]}
+{"module":"ComunicacaoVisual","ghosts":["MemCofre"]}

--- a/governance/knowledge-ghosts-baseline/Copiloto.json
+++ b/governance/knowledge-ghosts-baseline/Copiloto.json
@@ -1,1 +1,0 @@
-{"module":"Copiloto","ghosts":["Copiloto"]}

--- a/governance/knowledge-ghosts-baseline/Essentials.json
+++ b/governance/knowledge-ghosts-baseline/Essentials.json
@@ -1,1 +1,1 @@
-{"module":"Essentials","ghosts":["Accounting","PontoWr2"]}
+{"module":"Essentials","ghosts":["Accounting"]}

--- a/governance/knowledge-ghosts-baseline/EvolutionAgent.json
+++ b/governance/knowledge-ghosts-baseline/EvolutionAgent.json
@@ -1,1 +1,0 @@
-{"module":"EvolutionAgent","ghosts":["EvolutionAgent"]}

--- a/governance/knowledge-ghosts-baseline/Financeiro.json
+++ b/governance/knowledge-ghosts-baseline/Financeiro.json
@@ -1,1 +1,1 @@
-{"module":"Financeiro","ghosts":["Accounting","FinanceiroAvancado","PontoWr2"]}
+{"module":"Financeiro","ghosts":["Accounting","PontoWr2"]}

--- a/governance/knowledge-ghosts-baseline/FinanceiroAvancado.json
+++ b/governance/knowledge-ghosts-baseline/FinanceiroAvancado.json
@@ -1,1 +1,1 @@
-{"module":"FinanceiroAvancado","ghosts":["Accounting","Comissao","FinanceiroAvancado","Inventory"]}
+{"module":"FinanceiroAvancado","ghosts":["Accounting"]}

--- a/governance/knowledge-ghosts-baseline/Fiscal.json
+++ b/governance/knowledge-ghosts-baseline/Fiscal.json
@@ -1,1 +1,0 @@
-{"module":"Fiscal","ghosts":["UltimatePos"]}

--- a/governance/knowledge-ghosts-baseline/Garantia.json
+++ b/governance/knowledge-ghosts-baseline/Garantia.json
@@ -1,1 +1,0 @@
-{"module":"Garantia","ghosts":["Garantia"]}

--- a/governance/knowledge-ghosts-baseline/Infra.json
+++ b/governance/knowledge-ghosts-baseline/Infra.json
@@ -1,1 +1,1 @@
-{"module":"Infra","ghosts":["Copiloto","PontoWr2","Project","Vendor"]}
+{"module":"Infra","ghosts":["Project","Vendor"]}

--- a/governance/knowledge-ghosts-baseline/Inventory.json
+++ b/governance/knowledge-ghosts-baseline/Inventory.json
@@ -1,1 +1,1 @@
-{"module":"Inventory","ghosts":["Inventory","Marketplaces"]}
+{"module":"Inventory","ghosts":["Inventory"]}

--- a/governance/knowledge-ghosts-baseline/KB.json
+++ b/governance/knowledge-ghosts-baseline/KB.json
@@ -1,1 +1,0 @@
-{"module":"KB","ghosts":["Copiloto"]}

--- a/governance/knowledge-ghosts-baseline/Marketplaces.json
+++ b/governance/knowledge-ghosts-baseline/Marketplaces.json
@@ -1,1 +1,0 @@
-{"module":"Marketplaces","ghosts":["Marketplaces"]}

--- a/governance/knowledge-ghosts-baseline/Mwart.json
+++ b/governance/knowledge-ghosts-baseline/Mwart.json
@@ -1,1 +1,0 @@
-{"module":"Mwart","ghosts":["Copiloto"]}

--- a/governance/knowledge-ghosts-baseline/NfeBrasil.json
+++ b/governance/knowledge-ghosts-baseline/NfeBrasil.json
@@ -1,1 +1,1 @@
-{"module":"NfeBrasil","ghosts":["Autopecas","PontoWr2"]}
+{"module":"NfeBrasil","ghosts":["PontoWr2"]}

--- a/governance/knowledge-ghosts-baseline/OficinaAuto.json
+++ b/governance/knowledge-ghosts-baseline/OficinaAuto.json
@@ -1,1 +1,1 @@
-{"module":"OficinaAuto","ghosts":["Copiloto","MemCofre","Sells"]}
+{"module":"OficinaAuto","ghosts":["MemCofre"]}

--- a/governance/knowledge-ghosts-baseline/PontoWr2.json
+++ b/governance/knowledge-ghosts-baseline/PontoWr2.json
@@ -1,1 +1,0 @@
-{"module":"PontoWr2","ghosts":["PontoWr2"]}

--- a/governance/knowledge-ghosts-baseline/ProjectMgmt.json
+++ b/governance/knowledge-ghosts-baseline/ProjectMgmt.json
@@ -1,1 +1,1 @@
-{"module":"ProjectMgmt","ghosts":["Copiloto","Project"]}
+{"module":"ProjectMgmt","ghosts":["Project"]}

--- a/governance/knowledge-ghosts-baseline/Repair.json
+++ b/governance/knowledge-ghosts-baseline/Repair.json
@@ -1,1 +1,0 @@
-{"module":"Repair","ghosts":["Stock"]}

--- a/governance/knowledge-ghosts-baseline/Sells.json
+++ b/governance/knowledge-ghosts-baseline/Sells.json
@@ -1,1 +1,1 @@
-{"module":"Sells","ghosts":["Copiloto","NfseBrasil","Project","Sells"]}
+{"module":"Sells","ghosts":["NfseBrasil","Project"]}

--- a/governance/knowledge-ghosts-baseline/TeamMcp.json
+++ b/governance/knowledge-ghosts-baseline/TeamMcp.json
@@ -1,1 +1,1 @@
-{"module":"TeamMcp","ghosts":["Copiloto","MemCofre"]}
+{"module":"TeamMcp","ghosts":["MemCofre"]}

--- a/governance/knowledge-ghosts-baseline/Vestuario.json
+++ b/governance/knowledge-ghosts-baseline/Vestuario.json
@@ -1,1 +1,1 @@
-{"module":"Vestuario","ghosts":["Copiloto","MemCofre"]}
+{"module":"Vestuario","ghosts":["MemCofre"]}

--- a/governance/knowledge-ghosts-baseline/_DesignSystem.json
+++ b/governance/knowledge-ghosts-baseline/_DesignSystem.json
@@ -1,1 +1,1 @@
-{"module":"_DesignSystem","ghosts":["MemCofre","PontoWr2","Sells"]}
+{"module":"_DesignSystem","ghosts":["MemCofre","Sells"]}


### PR DESCRIPTION
Fecha o ciclo das portas KL: registra na catraca anti-ghost que os ghosts foram resolvidos.

- **14 baselines encolhidos** (--write-baseline, interseção — só mantém ghost ainda citado).
- **14 baselines órfãos removidos** (módulos que zeraram citação via portas + codemod #2603/#2693): ADS, Arquivos, Auditoria, Cms, Comissao, Copiloto, EvolutionAgent, Fiscal, Garantia, KB, Marketplaces, Mwart, PontoWr2, Repair.
- **Avisos do `--check` zerados**; catraca verde (0 NOVOS, exit 0); baseline = exatamente os 25 citantes reais.
- Não toca `sdd-scorecard-baseline.json` (ghost_count de citados inalterado — os 34 restantes são citações legadas em docs fora do escopo KL).

Refs: SDD KL-E2

🤖 Generated with [Claude Code](https://claude.com/claude-code)