### PR TITLE
fix(tests): Ponto CLT roda de fato (#[Test] + registra Tests/Unit) + endurece guard @test

### DIFF
--- a/Modules/Ponto/Tests/Unit/ApuracaoServiceTest.php
+++ b/Modules/Ponto/Tests/Unit/ApuracaoServiceTest.php
@@ -33,7 +33,8 @@ class ApuracaoServiceTest extends TestCase
         $this->service = new ApuracaoService(new BancoHorasService());
     }
 
-    /** @test Art. 58 §1º — atraso dentro da tolerância não conta */
+    /** Art. 58 §1º — atraso dentro da tolerância não conta */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function atraso_dentro_da_tolerancia_nao_registra()
     {
         config(['pontowr2.clt.tolerancia_minutos_por_marcacao' => 5]);
@@ -48,7 +49,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(0, $a->atraso_minutos);
     }
 
-    /** @test Art. 58 §1º — atraso além da tolerância registra */
+    /** Art. 58 §1º — atraso além da tolerância registra */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function atraso_alem_da_tolerancia_registra()
     {
         config(['pontowr2.clt.tolerancia_minutos_por_marcacao' => 5]);
@@ -62,7 +64,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(7, $a->atraso_minutos);
     }
 
-    /** @test Art. 71 — intrajornada insuficiente em jornada > 6h registra violação */
+    /** Art. 71 — intrajornada insuficiente em jornada > 6h registra violação */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function intrajornada_insuficiente_em_jornada_longa_registra_violacao()
     {
         config(['pontowr2.clt.intrajornada_minima_minutos' => 60]);
@@ -76,7 +79,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(30, $a->intrajornada_violacao_minutos);
     }
 
-    /** @test Art. 71 — jornada curta não exige intrajornada mínima */
+    /** Art. 71 — jornada curta não exige intrajornada mínima */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function jornada_curta_nao_exige_intrajornada_minima()
     {
         config(['pontowr2.clt.intrajornada_minima_minutos' => 60]);
@@ -90,7 +94,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(0, $a->intrajornada_violacao_minutos);
     }
 
-    /** @test Art. 59 — HE até 2h/dia */
+    /** Art. 59 — HE até 2h/dia */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function he_separa_diurna_e_noturna()
     {
         $a = $this->novaApuracaoBase();
@@ -107,7 +112,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(120, $total);
     }
 
-    /** @test Divisão diurno/noturno com janela inteiramente na madrugada */
+    /** Divisão diurno/noturno com janela inteiramente na madrugada */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function divisao_diurno_noturno_madrugada_inteira()
     {
         $inicio = Carbon::parse('2026-04-15 23:00:00');
@@ -119,7 +125,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(0,   $d['diurno_minutos']);
     }
 
-    /** @test Divisão diurno/noturno com cruzamento das 22h */
+    /** Divisão diurno/noturno com cruzamento das 22h */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function divisao_diurno_noturno_cruza_22h()
     {
         $inicio = Carbon::parse('2026-04-15 20:00:00');
@@ -131,7 +138,8 @@ class ApuracaoServiceTest extends TestCase
         $this->assertEquals(60,  $d['noturno_minutos']);
     }
 
-    /** @test Divisão diurno/noturno inteiramente diurna */
+    /** Divisão diurno/noturno inteiramente diurna */
+    #[\PHPUnit\Framework\Attributes\Test]
     public function divisao_diurno_noturno_inteiramente_diurna()
     {
         $inicio = Carbon::parse('2026-04-15 09:00:00');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -29,6 +29,7 @@
             <directory>./Modules/Admin/Tests/Feature</directory>
             <directory>./Modules/Arquivos/Tests/Feature</directory>
             <directory>./Modules/Ponto/Tests/Feature</directory>
+            <directory>./Modules/Ponto/Tests/Unit</directory>
             <directory>./Modules/ADS/Tests/Feature</directory>
             <directory>./Modules/ADS/Tests/Unit</directory>
             <directory>./Modules/Vestuario/Tests/Feature</directory>

--- a/tests/Unit/Guards/PhpunitTestAnnotationGuardTest.php
+++ b/tests/Unit/Guards/PhpunitTestAnnotationGuardTest.php
@@ -14,6 +14,10 @@ declare(strict_types=1);
  * **Histórico de recidiva:**
  * - PR #393: corrigiu 6 tests com `/** @test *\/`
  * - PR #437: corrigiu mais 35 tests com mesmo padrão
+ * - 2026-06: 39 tests (Ponto CLT + Contact/Cliente/CpfCnpj) escapavam — o regex
+ *   antigo só pegava `/** @test *\/` puro; furava em `/** @test descrição *\/`
+ *   (texto após a tag) e em bloco multi-line com descrição/@dataProvider antes
+ *   do @test. Guard endurecido pra um pattern único robusto (tempered dot).
  * - Sem guard automático, vai voltar.
  *
  * **Regra:** zero ocorrências de `/** @test *\/` em arquivos `*Test.php`
@@ -87,26 +91,22 @@ function phpunitGuardScan(array $files): array
 {
     $violations = [];
 
-    // Pattern 1: doc-comment single-line  /** @test */
-    $patternSingle = '/\/\*\*\s*@test\s*\*\//';
-
-    // Pattern 2: doc-comment multi-line
-    //   /**
-    //    * @test
-    //    */
-    // (qualquer indentação, qualquer linha extra antes/depois do @test no bloco doc)
-    $patternMulti = '/\/\*\*[^*\/]*?\*\s*@test\s*\R[^*]*?\*\//s';
+    // Um único pattern robusto: abre num `/**`, percorre o interior do bloco SEM
+    // cruzar o fechamento `*/` (tempered dot `(?:(?!\*\/).)*?`) e exige a tag
+    // `@test` seguida de espaço ou `*`. Cobre as 4 formas que já furaram o guard:
+    //   /** @test */                        single-line
+    //   /** @test Art. 58 ... */             single-line com texto (furou no Ponto, 2026-06)
+    //   /**\n * @test\n */                   multi-line limpo
+    //   /**\n * desc\n * @test\n */           multi-line com descrição/@dataProvider antes do @test
+    // O lookahead (?=\s|\*) evita falso-positivo em email (foo@test.local) e em
+    // tags vizinhas como @testdox/@testWith.
+    $pattern = '/\/\*\*(?:(?!\*\/).)*?@test(?=\s|\*)/s';
 
     foreach ($files as $file) {
-        $content = $file['content'];
+        $count = preg_match_all($pattern, $file['content']);
 
-        $countSingle = preg_match_all($patternSingle, $content, $mSingle);
-        $countMulti = preg_match_all($patternMulti, $content, $mMulti);
-
-        $total = ($countSingle ?: 0) + ($countMulti ?: 0);
-
-        if ($total > 0) {
-            $violations[] = sprintf('%s: %d ocorrência(s) de /** @test */', $file['relpath'], $total);
+        if ($count) {
+            $violations[] = sprintf('%s: %d ocorrência(s) de tag @test em doc-comment', $file['relpath'], $count);
         }
     }
 


### PR DESCRIPTION
## Problema

`Modules/Ponto/Tests/Unit/ApuracaoServiceTest.php` tem 8 testes das regras CLT
(Art. 58 §1º tolerância, Art. 59 HE, Art. 71 intrajornada, Art. 73 adicional
noturno) que **não rodavam** no PHPUnit 12 — falsa cobertura de regra
trabalhista. Dois motivos somados:

1. Cada método é snake_case sem prefixo `test` e dependia de
   `/** @test <descrição> */`. PHPUnit 10+/12 **ignora silenciosamente**
   doc-comment `@test` (sem erro, sem skip).
2. O `PhpunitTestAnnotationGuardTest` **não pegava** esses casos: o regex exigia
   `@test` colado no `*/`, mas aqui há texto após a tag (`/** @test Art. 58 … */`).
3. O dir `Modules/Ponto/Tests/Unit` **não estava em nenhuma testsuite** do
   `phpunit.xml` — então os testes nunca eram descobertos, nem se corrigidos.

## Mudança (3 arquivos)

- **`ApuracaoServiceTest.php`** — 8 `/** @test … */` → `#[\PHPUnit\Framework\Attributes\Test]`
  (FQ, igual aos testes Feature irmãos do Ponto). Descrições CLT preservadas como docblock.
- **`phpunit.xml`** — registra `./Modules/Ponto/Tests/Unit` na suíte Feature
  (convenção já usada por Financeiro/ADS/KB). Passa a rodar também
  `MarcacaoServiceTest` (2 testes), que estava dormente pelo mesmo motivo de dir não registrado.
- **`PhpunitTestAnnotationGuardTest.php`** — substitui os dois regex frágeis por
  um único pattern robusto (tempered dot `/\/\*\*(?:(?!\*\/).)*?@test(?=\s|\*)/s`)
  que fecha 3 pontos cegos: texto após a tag, multi-line com descrição antes do
  `@test`, e multi-line com `@dataProvider` antes. Lookahead evita falso-positivo
  em email (`foo@test.local`) e em `@testdox`/`@testWith`.

## Validação

PHP/Pest não roda no ambiente local (a prova final é a suíte completa /
nightly CT100). Como prova local, repliquei o regex exato do guard em Node
contra a árvore deste branch:

- **Self-test do pattern:** 5/5 casam (formas que escapavam: pura, com texto,
  multi-line limpa, multi-line com descrição, multi-line com `@dataProvider`),
  4/4 não casam (atributo, email em código, email em docblock, `@testdox`).
- **Scan real:** **0 violações em 1230 `*Test.php`** → guard verde.

## Nota (fora do escopo deste PR)

A branch `feat/governance-ds-rollout-ledger` está **stale** nestes testes: ela
ainda carrega `/** @test */` em 5 arquivos de Contact/Cliente que a `main` **já
corrigiu** (atributos). Ao mergear aquela branch, há risco de **regressão** desses
arquivos — o guard endurecido aqui pegaria isso, mas hoje ele só roda na suíte
completa (nightly), não no CI de PR (`ci.yml` roda um subset escolhido a dedo).
Vale avaliar (a) rebase da branch de governança e (b) rodar este guard no CI de PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
