### PR TITLE
fix(governance): scorecard honesto — anchor_coverage fonte única + re-arma ratchets (ledger §A-C)

### DIFF
--- a/governance/sdd-scorecard-baseline.json
+++ b/governance/sdd-scorecard-baseline.json
@@ -3,6 +3,7 @@
     "baseline": "SDD scorecard baseline v1 — meta-catraca GT-G3 (plano 2026-06-12 §2 GARANTIDA + §4 Semanas 1-2)",
     "adr": "memory/decisions/0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes.md",
     "capturado_de": "medição REAL de scripts/governance/sdd-scorecard.mjs em origin/main 50db89208 (2026-06-12) — nunca copiado de plano/ADR (regra anti-stale)",
+    "re_medido": "anchor_coverage (definição unificada→anchor-lint), ghost_count e front_door_coverage re-medidos live em origin/main 3b281d864 (2026-06-15) no PR do ledger §A/§B — provenance por métrica em nota_armamento",
     "regra_armamento": "ADR 0275 §3 — métrica só ARMA (armed:true ⇒ --ratchet exit 1 na regressão) após 3 medições válidas consecutivas da fonte real (sem erro, não-mock, valor não-nulo); fonte parada >48h desarma até nova sequência de 3",
     "regra_piora": "piorar value, desarmar métrica ou absorver regressão = SÓ via PR editando este arquivo (diff visível) citando ADR 0275 — exceção nunca é invisível",
     "consumidores": [
@@ -13,13 +14,13 @@
   "metrics": {
     "anchor_coverage": {
       "status": "measured",
-      "value": 2.8,
+      "value": 5.4,
       "unit": "%",
       "direction": "up",
       "armed": false,
-      "valid_measurements": 2,
-      "fonte": "grep estrito memory/requisitos/*/SPEC.md (sdd-scorecard.mjs — fonte nasceu no PR #2597)",
-      "nota_armamento": "2 medições válidas (PR #2597 e este PR, ambas 2.8% = 22 anchors estritos / 781 US) — arma na 3ª medição do workflow sdd-scorecard.yml, via PR editando este arquivo com link da run"
+      "valid_measurements": 1,
+      "fonte": "scripts/governance/anchor-lint.mjs --json .summary.anchor_coverage_pct (fonte única — ADR 0273 §2; sdd-scorecard.mjs só transporta)",
+      "nota_armamento": "DEFINIÇÃO UNIFICADA no PR do ledger §A: a série antiga (grep estrito próprio do sdd-scorecard, 2.8% / 2 medições) foi APOSENTADA — número não comparável. 1ª medição da nova fonte = 5.4% (anchor-lint live em origin/main 3b281d864, 2026-06-15). Re-mede 3× consecutivas da nova fonte pra armar (ADR 0275 §3)."
     },
     "full_suite_pass_rate": {
       "status": "not_yet_measured",
@@ -47,23 +48,23 @@
     },
     "ghost_count": {
       "status": "measured",
-      "value": 27,
+      "value": 14,
       "unit": "nomes distintos",
       "direction": "down",
       "armed": true,
       "valid_measurements": 3,
       "fonte": "scripts/governance/knowledge-drift.mjs --json",
-      "nota_armamento": "3 medições válidas consecutivas da fonte: reconhecimento ADR 0275 (27 nomes / 39 citantes) + run do PR #2597 (27) + run deste PR (27)"
+      "nota_armamento": "Re-armado live em origin/main 3b281d864 (2026-06-15): a fonte agora mede 14 (era 27 na captura 2026-06-12 — codemod #2603/#2693 derrubou nomes-fantasma). Catraca DESCE o piso 27→14 (stale absorvido, ADR 0275 §3); regressão >14 = exit 1."
     },
     "front_door_coverage": {
       "status": "measured",
-      "value": 63.9,
+      "value": 100,
       "unit": "%",
       "direction": "up",
       "armed": true,
       "valid_measurements": 3,
       "fonte": "scripts/governance/knowledge-drift.mjs --json (BRIEFING.md presente por módulo)",
-      "nota_armamento": "3 medições válidas consecutivas da fonte: reconhecimento ADR 0275 (64% = 39/61) + run do PR #2597 (63.9) + run deste PR (63.9 = 39/61)"
+      "nota_armamento": "Re-armado live em origin/main 3b281d864 (2026-06-15): a fonte agora mede 100% (69/69; era 63.9% = 39/61 na captura 2026-06-12 — portas BRIEFING criadas nas ondas E2). Catraca SOBE o piso 63.9→100 (stale absorvido, ADR 0275 §3); regressão <100 = exit 1."
     },
     "recall_eval_violations": {
       "status": "not_yet_measured",

--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -5,7 +5,7 @@
     "plan": "memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md",
     "determinismo": "sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio",
     "composta": "v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured",
-    "anchor_coverage_regra": "numerador = campos `**Implementado em:**` sem placeholder (TODO/_[path]_/_pendente_/a criar/_xx_) com ≥1 path existente no disco; denominador = headings `US-XXX-NNN` nos 57 SPECs",
+    "anchor_coverage_regra": "delegado a scripts/governance/anchor-lint.mjs (ADR 0273 §2 — fonte única): (anchored_ok + pendente + parcial) / us_total. Antes era grep estrito próprio (divergia); unificado no PR do ledger §A.",
     "ratchet": {
       "baseline": "governance/sdd-scorecard-baseline.json — armed POR MÉTRICA (ADR 0275 §3: arma após 3 medições válidas consecutivas da fonte real; armar/desarmar/piorar = PR editando o baseline, diff visível)",
       "simulacao": "SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — trata todas as medidas como armadas (selftest local)"
@@ -14,19 +14,30 @@
   "metrics": {
     "anchor_coverage": {
       "status": "measured",
-      "value": 3.5,
+      "value": 5.4,
       "unit": "%",
       "direction": "up",
       "target": 100,
-      "source": "grep estrito memory/requisitos/*/SPEC.md (este script)",
+      "source": "scripts/governance/anchor-lint.mjs --json .summary.anchor_coverage_pct (fonte única — ADR 0273 §2)",
       "detail": {
-        "specs_total": 57,
-        "specs_with_field": 15,
-        "us_total": 799,
+        "coverage_pct": 5.4,
+        "specs_total": 56,
+        "us_total": 775,
+        "anchor_coverage_pct": 5.4,
+        "by_state": {
+          "sem_campo": 696,
+          "placeholder": 22,
+          "pendente": 23,
+          "parcial": 0,
+          "anchored_ok": 19,
+          "anchored_dead": 15
+        },
         "fields_total": 84,
-        "fields_placeholder": 45,
-        "fields_filled": 39,
-        "fields_anchored_strict": 28
+        "fields_placeholder": 22,
+        "fields_grammar_ok": 28,
+        "orphan_fields": 5,
+        "v1_files": 0,
+        "v1_violations": "0"
       }
     },
     "full_suite_pass_rate": {
@@ -58,25 +69,25 @@
     },
     "ghost_count": {
       "status": "measured",
-      "value": 15,
+      "value": 14,
       "unit": "nomes distintos",
       "direction": "down",
       "target": 0,
       "source": "scripts/governance/knowledge-drift.mjs --json (Modules/<X> citado e inexistente no disco; nomes: rodar a fonte direto)",
       "detail": {
-        "citing_modules": 25
+        "citing_modules": 24
       }
     },
     "front_door_coverage": {
       "status": "measured",
-      "value": 63.9,
+      "value": 100,
       "unit": "%",
       "direction": "up",
       "target": 100,
       "source": "scripts/governance/knowledge-drift.mjs --json (BRIEFING.md presente por módulo)",
       "detail": {
-        "with_door": 39,
-        "modules": 61
+        "with_door": 69,
+        "modules": 69
       }
     },
     "recall_eval_violations": {

--- a/scripts/governance/gate-selftest.mjs
+++ b/scripts/governance/gate-selftest.mjs
@@ -56,6 +56,8 @@ function runScorecard(kind) {
     mkdirSync(join(sb, 'scripts', 'governance'), { recursive: true });
     cpSync(script('sdd-scorecard', 'scripts/governance/sdd-scorecard.mjs'), join(sb, 'scripts', 'governance', 'sdd-scorecard.mjs'));
     cpSync(join(ROOT, 'scripts', 'governance', 'knowledge-drift.mjs'), join(sb, 'scripts', 'governance', 'knowledge-drift.mjs'));
+    // sdd-scorecard agora delega anchor_coverage a anchor-lint.mjs (ledger §A · ADR 0273 §2) — copia essa dep tb.
+    cpSync(join(ROOT, 'scripts', 'governance', 'anchor-lint.mjs'), join(sb, 'scripts', 'governance', 'anchor-lint.mjs'));
     return runNode(join(sb, 'scripts', 'governance', 'sdd-scorecard.mjs'), ['--ratchet'], sb, { SDD_RATCHET_ARM: '1' });
   } finally { rmSync(sb, { recursive: true, force: true }); }
 }

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -48,35 +48,16 @@ function measureKnowledgeDrift() {
   return { ghost_count: names.size, ghost_citing_modules: citing, door_num: withDoor, door_den: rows.length };
 }
 
-// ── fonte 2: grep estrito dos SPECs ─────────────────────────────────────────
-const PLACEHOLDER_RE = /TODO|_\[path\]_|_pendente_|a criar|_xx_/i;
-const ANCHOR_PATH_RE = /(?:resources\/js|Modules|app|routes|tests|scripts|database|config|prototipo-ui)\/[A-Za-z0-9_\-./]+/g;
-const US_HEADING_RE = /^#{2,4}\s+.*US-[A-Z][A-Za-z0-9]*-\d/gm;
-const FIELD_RE = /\*\*Implementado em:\*\*[^\n]*/g;
-
+// ── fonte 2: anchor-lint --json (FONTE ÚNICA do anchor_coverage — ADR 0273 §2) ─
+// Antes media com grep estrito próprio (PLACEHOLDER_RE/ANCHOR_PATH_RE/US_HEADING_RE/
+// FIELD_RE) e divergia do anchor-lint: dois números pro mesmo conceito. Agora delega —
+// `summary.anchor_coverage_pct` do anchor-lint é a fonte única; este script só transporta.
 function measureAnchors() {
-  const REQ = join(ROOT, 'memory', 'requisitos');
-  const specs = readdirSync(REQ, { withFileTypes: true })
-    .filter((e) => e.isDirectory() && existsSync(join(REQ, e.name, 'SPEC.md')))
-    .map((e) => join(REQ, e.name, 'SPEC.md'))
-    .sort();
-  let usTotal = 0, fields = 0, placeholder = 0, filled = 0, anchored = 0, specsWithField = 0;
-  for (const f of specs) {
-    const txt = readFileSync(f, 'utf8');
-    usTotal += (txt.match(US_HEADING_RE) || []).length;
-    const fl = txt.match(FIELD_RE) || [];
-    if (fl.length) specsWithField++;
-    for (const field of fl) {
-      fields++;
-      if (PLACEHOLDER_RE.test(field)) { placeholder++; continue; }
-      filled++;
-      const paths = field.match(ANCHOR_PATH_RE) || [];
-      if (paths.some((p) => existsSync(join(ROOT, p.replace(/[.,;:]+$/, ''))))) anchored++;
-    }
-  }
-  return { specs_total: specs.length, specs_with_field: specsWithField, us_total: usTotal,
-    fields_total: fields, fields_placeholder: placeholder, fields_filled: filled,
-    fields_anchored_strict: anchored };
+  const raw = execSync(`"${process.execPath}" scripts/governance/anchor-lint.mjs --json`, {
+    cwd: ROOT, maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'],
+  }).toString();
+  const s = JSON.parse(raw).summary;
+  return { coverage_pct: s.anchor_coverage_pct, ...s };
 }
 
 // ── fonte 3: quarentena FV-Q3 (convenção legacy-quarantine nos testes) ───────
@@ -121,7 +102,7 @@ function buildScorecard() {
       plan: 'memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md',
       determinismo: 'sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio',
       composta: 'v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured',
-      anchor_coverage_regra: 'numerador = campos `**Implementado em:**` sem placeholder (TODO/_[path]_/_pendente_/a criar/_xx_) com ≥1 path existente no disco; denominador = headings `US-XXX-NNN` nos 57 SPECs',
+      anchor_coverage_regra: 'delegado a scripts/governance/anchor-lint.mjs (ADR 0273 §2 — fonte única): (anchored_ok + pendente + parcial) / us_total. Antes era grep estrito próprio (divergia); unificado no PR do ledger §A.',
       ratchet: {
         baseline: 'governance/sdd-scorecard-baseline.json — armed POR MÉTRICA (ADR 0275 §3: arma após 3 medições válidas consecutivas da fonte real; armar/desarmar/piorar = PR editando o baseline, diff visível)',
         simulacao: 'SDD_RATCHET_ARM=1 node scripts/governance/sdd-scorecard.mjs --ratchet — trata todas as medidas como armadas (selftest local)',
@@ -129,9 +110,9 @@ function buildScorecard() {
     },
     metrics: {
       anchor_coverage: {
-        status: 'measured', value: pct(an.fields_anchored_strict, an.us_total), unit: '%',
+        status: 'measured', value: an.coverage_pct, unit: '%',
         direction: 'up', target: 100,
-        source: 'grep estrito memory/requisitos/*/SPEC.md (este script)',
+        source: 'scripts/governance/anchor-lint.mjs --json .summary.anchor_coverage_pct (fonte única — ADR 0273 §2)',
         detail: an,
       },
       full_suite_pass_rate: notYet('up', '100% não-quarentenado',

--- a/tests/governance-fixtures/sdd-scorecard/good/memory/requisitos/DemoMod/SPEC.md
+++ b/tests/governance-fixtures/sdd-scorecard/good/memory/requisitos/DemoMod/SPEC.md
@@ -2,6 +2,7 @@
 
 ### US-DEMO-001 — Tela demo ancorada
 
-**Implementado em:** Modules/RealDemo/README.md
+**Implementado em:** `Modules/RealDemo/README.md`
 
-Anchor estrito: o path existe no sandbox e o campo não tem placeholder.
+Anchor na gramática ADR 0273 (segmento-path em backticks, resolve da raiz e existe no
+sandbox → anchored_ok). Fonte única do anchor_coverage = anchor-lint.mjs (ledger §A).


### PR DESCRIPTION
Aplica os PR-READY **§A+§B+§C** do [ledger firme de conclusão SDD](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-15-sdd-conclusao-ledger-firme.md) (F1-2/F1-3/F1-4). Bundle autorizado pelo próprio ledger ("§C pode ir junto de §A/§B no mesmo PR 'scorecard honesto'").

- **§A (F1-2):** `sdd-scorecard.mjs` `measureAnchors()` agora **delega** a `anchor-lint.mjs --json` (`.summary.anchor_coverage_pct`) — fonte única (ADR 0273 §2). Removidos os 4 consts do grep estrito que divergiam (dois números pro mesmo conceito).
- **§B (F1-3):** baseline re-armado **medido live em `origin/main` 3b281d864** (regra anti-stale): `ghost_count 27→14`, `front_door_coverage 63.9→100` (armed:true mantido). Série antiga do anchor aposentada (definição mudou): `2.8/strict → 5.4/anchor-lint`, armed:false, valid_measurements 2→1.
- **§C (F1-4):** `governance/sdd-scorecard.json` **regenerado rodando o script** (não hand-edit).

### Aceitação (reproduzida)
- `sdd-scorecard.mjs --json .anchor_coverage.value` == `anchor-lint --json .summary.anchor_coverage_pct` → **ambos 5.4** ✓
- `sdd-scorecard.mjs --ratchet` → **exit 0** ✓
- re-run determinístico → diff vazio (json byte-idêntico ao regenerado) ✓

### Anti-stale
O ledger §A-C citava `7.9/15/63.9` (congelados 2026-06-15). A fonte real hoje dá **5.4/14/100** — re-derivado no momento da execução, como o ledger manda. ⚠️ Reviewers: NÃO "corrigir" de volta pros números velhos.

### ⚠️ Pede aval [W]
§A **muda a definição** do `anchor_coverage` (decisão D3 já aprovada por Wagner no handoff #2769, mas a mudança de métrica merece teu olho antes do merge).

Verificado por par adversarial (workflow `verify-sdd-prready-AF`): PASS, deviations justified.

Refs: SDD ledger §A §B §C (F1-2 F1-3 F1-4) · ADR 0273 0275