### PR TITLE
ci(governance): ledger-check advisory (GT-G5) no umbrella (ledger §D)

### DIFF
--- a/.github/workflows/governance-gate-umbrella.yml
+++ b/.github/workflows/governance-gate-umbrella.yml
@@ -41,6 +41,13 @@ jobs:
         run: npm run test:adr-governance
       - name: Meta-teste dos checks G/H/I do memory-health (Onda Q5 — controle-negativo)
         run: npm run test:memory-health
+      # ADVISORY (GT-G5 · ledger §D): refutação adversarial de lote-IA de BRIEFINGs/SPECs
+      # (PROTOCOLO-REFUTADOR-BACKFILL). Sem --enforce → exit 0 sempre nesta fase; promover a
+      # required = adicionar --enforce após o protocolo assentar. Só em PR (precisa nº + base_ref).
+      - name: ledger-check — refutação de lote IA (advisory · GT-G5)
+        if: github.event_name == 'pull_request'
+        run: node scripts/governance/ledger-check.mjs --pr ${{ github.event.pull_request.number }} --base origin/${{ github.base_ref }} --head HEAD
+        continue-on-error: true
       # ADVISORY (nasce sem morder — ONDAS-QUALIDADE regra 2): controle-negativo do
       # auditor de corruptores SQLite (sensibilidade + especificidade). Promover a
       # required = remover continue-on-error após 2 verdes. Ref: sessão 2026-06-15.


### PR DESCRIPTION
Aplica o PR-READY **§D** do [ledger firme SDD](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-15-sdd-conclusao-ledger-firme.md) (F1-5).

Pluga o step `ledger-check` (GT-G5, refutação adversarial de lote-IA — `PROTOCOLO-REFUTADOR-BACKFILL`) no `governance-gate-umbrella.yml`, logo após `test:memory-health`. **Advisory:** `continue-on-error: true`, sem `--enforce` (o script já nasce exit-0 sem `--enforce`). `fetch-depth:0` já existia.

**Desvio do texto literal (justificado):** acrescentei `if: github.event_name == 'pull_request'`. O umbrella também roda em `workflow_dispatch`, onde `pull_request.number`/`base_ref` são vazios → o comando viraria `--pr  --base origin/ …` (run quebrado). O guard roda em todo PR pra main e só pula o dispatch manual.

### Aceitação
- YAML parseia (`yaml.safe_load` OK) ✓
- smoke `ledger-check.mjs` em diff não-de-lote → "nada a exigir", exit 0 ✓

Verificado por par adversarial: PASS, `if`-guard correto e justificado.

Refs: SDD ledger §D (F1-5) · PROTOCOLO-REFUTADOR-BACKFILL · ADR 0275