### PR TITLE
test(utils): restaurar fixtures de moeda NumUf corrompidas pelo redactor (ledger §F)

### DIFF
--- a/tests/Unit/Utils/NumUfHeuristicPtBRTest.php
+++ b/tests/Unit/Utils/NumUfHeuristicPtBRTest.php
@@ -80,9 +80,9 @@ class NumUfHeuristicPtBRTest extends TestCase
             '1329.0567 → 1329.0567'           => ['1329.0567', 1329.0567],
 
             // Símbolo de moeda + espaços (bug secundário antes retornava 0)
-            'R$ [redacted Tier 0] → 80'               => ['R$ [redacted Tier 0]', 80.0],
-            'R$ [redacted Tier 0] → 2500.80'       => ['R$ [redacted Tier 0]', 2500.80],
-            'R$ [redacted Tier 0] → 80'                  => ['R$ [redacted Tier 0]', 80.0],
+            'R$ 80,00 → 80'               => ['R$ 80,00', 80.0],
+            'R$ 2.500,80 → 2500.80'       => ['R$ 2.500,80', 2500.80],
+            'R$ 80 → 80'                  => ['R$ 80', 80.0],
 
             // Negativos (devolução, troco)
             '-80,00 → -80'                => ['-80,00', -80.0],
@@ -149,7 +149,7 @@ class NumUfHeuristicPtBRTest extends TestCase
 
         $this->assertSame(80.0, $this->util->num_uf('80,00'));
         $this->assertSame(80.0, $this->util->num_uf('80.00'));
-        $this->assertSame(2500.80, $this->util->num_uf('R$ [redacted Tier 0]'));
+        $this->assertSame(2500.80, $this->util->num_uf('R$ 2.500,80'));
         $this->assertSame(25000.0, $this->util->num_uf('25.000'));
     }
 }


### PR DESCRIPTION
Aplica o PR-READY **§F** do [ledger firme SDD](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/sessions/2026-06-15-sdd-conclusao-ledger-firme.md) (F2-9 #11).

O redactor antigo (pré-fix #0600bd0ec) trocou 3 inputs `'R$ <valor>'` do data-provider + 1 assertion por `'R$ [redacted Tier 0]'`, criando chave duplicada (PHP sobrescreve → 1 caso silenciosamente perdido). **Git nunca teve versão limpa** (corrompido desde #2224) → inputs **reconstruídos**, não recuperados:

| input | → output (autoritativo, sobreviveu) |
|---|---|
| `R$ 80,00` | 80.0 |
| `R$ 2.500,80` | 2500.80 (exemplo canônico, bate com `num_uf:49`) |
| `R$ 80` | 80.0 |

Outputs são autoritativos. Inputs usam só formatos pt-BR já provados no mesmo provider e foram **verificados traçando + rodando** `app/Utils/Util.php@num_uf` (`preg_replace` tira `R$ `/espaços → heurística pt-BR): os 4 casos batem no esperado sob `assertSame` (===).

Fora de escopo (§F = "1 arq, 3 data-rows + 1 assertion"): 3 comentários em prosa ainda têm `[redacted Tier 0]` — não afetam execução. Restore seguro: o redactor atual só age em CPF/CNPJ (#0600bd0ec).

Verificado por par adversarial: PASS — 4 inputs rodados via php 8.3.30, todos batem; chaves agora distintas.

Refs: SDD ledger §F (F2-9 #11)