### PR TITLE
fix(jana): /ia/dashboard sem encavalamento (cockpit vazava sobre Metas)

### DIFF
--- a/resources/js/Pages/Jana/Dashboard.tsx
+++ b/resources/js/Pages/Jana/Dashboard.tsx
@@ -272,8 +272,13 @@ export default function Dashboard({ metas, sellKpis, insightsAggregates, coworkA
 
       {/* JanaCockpitV2 — conteúdo primário (movido de /sells Onda 2026-05-26).
           Wrapper .sells-cowork porque os tokens .vd-insights-* estão escopados
-          nesse seletor em resources/css/sells-cowork-insights.css. */}
-      <div className="sells-cowork px-6 pt-6">
+          nesse seletor em resources/css/sells-cowork-insights.css.
+          shrink-0: .main-body é flex-column + overflow-y:auto (cockpit.css) e
+          .sells-cowork carrega min-height:100% (sells-cowork.css). Sem shrink-0,
+          o flex encolhia este wrapper até o piso min-height (= altura do viewport)
+          e o conteúdo .vd-insights (mais alto) vazava por cima do bloco Metas
+          irmão — encavalamento reportado 2026-06-15. */}
+      <div className="sells-cowork px-6 pt-6 shrink-0">
         <JanaCockpitV2
           sellKpis={sellKpis}
           insightsAggregates={insightsAggregates}
@@ -285,8 +290,9 @@ export default function Dashboard({ metas, sellKpis, insightsAggregates, coworkA
       </div>
 
       {/* Bloco secundário — Dashboard de Metas (continua acessível, mas não é
-          mais a face primária da /ia/dashboard). */}
-      <div className="space-y-6 p-6">
+          mais a face primária da /ia/dashboard). shrink-0 pelo mesmo motivo do
+          wrapper do cockpit acima (flex-column scroll container). */}
+      <div className="space-y-6 p-6 shrink-0">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## Problema

A tela `/ia/dashboard` (Jana) renderizava o **bloco Metas encavalado sobre os cards do cockpit** (Top 5 clientes / Métodos de pagamento / Ações). Reportado por Wagner 2026-06-15 com screenshot.

## Causa raiz (bug de flexbox em scroll container)

- `.cockpit .main-body` é `display:flex; flex-direction:column; overflow-y:auto` (`resources/css/cockpit.css`).
- O wrapper do `JanaCockpitV2` usa a classe `.sells-cowork`, que carrega `min-height: 100%` (`resources/css/sells-cowork.css:106`).
- A `Dashboard` empilha **3 filhos de bloco** no `.main-body` (JanaAreaHeader + cockpit + Metas). O flex encolhia o wrapper do cockpit até o **piso `min-height` (= altura do viewport, 951px)**, enquanto o conteúdo real `.vd-insights` tinha **1290px** → **363px vazavam** por cima do bloco Metas irmão.

Medido no DOM de **produção**: cockpit travado em 951px, conteúdo até 1365px, Metas começando em 1002px → 363px de sobreposição.

## Correção

`shrink-0` (`flex-shrink: 0`) nos dois filhos de bloco do `.main-body`, pra manterem a altura natural e o container rolar normalmente — padrão canônico de flex-column + overflow-y:auto.

- ✅ Não toca o CSS compartilhado do Sells → zero risco pras telas `/sells/*`.
- ✅ `shrink-0` é utility Tailwind já no bundle (o próprio `JanaAreaHeader` usa).
- ✅ Validado no DOM de produção aplicando `flex-shrink:0`: overflow **363px → 0px**, Metas passa a começar logo após o cockpit, scroll OK.

## Verificação

Validação feita inspecionando o DOM real de `https://oimpresso.com/ia/dashboard` (logado), antes/depois da propriedade `flex-shrink:0`. Gates de CI (visual-regression, ds-guard, etc.) rodam neste PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)