### PR TITLE
chore(gitignore): ignorar artefato transitório violations.json do validador de schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,8 @@ tests/eval/results/*.json
 # Test-results JUnit (Salto #2 / G-7) — efêmero; o manifesto derivado (scripts/casos-test-results.json) é o que se commita
 test-results/
 playwright-report/
+
+# Artefato transitório do validador de schema de memória — escrito no CWD por
+# .github/scripts/validate-memory-schema.sh; o workflow memory-schema-gate.yml
+# também o gera e faz upload como artefato CI-only. Não versionar.
+violations.json


### PR DESCRIPTION
## O quê

Adiciona `violations.json` ao `.gitignore` da raiz.

## Por quê

`violations.json` é um artefato **transitório** do validador de schema de memória:

- [`.github/scripts/validate-memory-schema.sh`](.github/scripts/validate-memory-schema.sh) escreve no CWD (`VIOLATIONS_JSON="${VIOLATIONS_JSON:-violations.json}"`);
- [`.github/workflows/memory-schema-gate.yml`](.github/workflows/memory-schema-gate.yml) também o gera e faz upload como artefato **CI-only**.

Como não estava no `.gitignore`, quem roda o validador localmente e faz `git add -A` acaba commitando o arquivo por acidente — aconteceu no PR #2772, pego na verificação adversarial e removido via amend. O conteúdo costuma vir mojibake (`seÃ§Ã£o`).

## Escopo

- 1 linha de pattern (+ comentário no estilo do arquivo).
- **Não** toca o validador nem o workflow.
- Confirmado que **não há** `violations.json` trackeado no repo (`git ls-files | grep violations.json` → vazio), então não precisou de `git rm --cached`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)