### PR TITLE
chore(governance): refresh screen-coverage baseline (pós-merge #2777)

### DIFF
--- a/memory/governance/screen-coverage-baseline.json
+++ b/memory/governance/screen-coverage-baseline.json
@@ -2,79 +2,79 @@
   "generated_note": "baseline da catraca de cobertura — NÃO editar à mão",
   "aggregates": {
     "total": 275,
-    "charter": 131,
-    "e2e": 4,
+    "charter": 132,
+    "e2e": 110,
     "a11y": 1,
-    "scorecard": 219
+    "scorecard": 218
   },
   "by_module": {
     "Admin": {
       "total": 8,
       "charter": 8,
-      "e2e": 0,
+      "e2e": 2,
       "a11y": 0,
       "scorecard": 8
     },
     "ads": {
       "total": 19,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 19
     },
     "Atendimento": {
       "total": 8,
       "charter": 5,
-      "e2e": 0,
+      "e2e": 5,
       "a11y": 0,
       "scorecard": 8
     },
     "Auditoria": {
       "total": 2,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 2
     },
     "Cliente": {
       "total": 34,
       "charter": 7,
-      "e2e": 0,
+      "e2e": 2,
       "a11y": 0,
       "scorecard": 7
     },
     "Compras": {
       "total": 5,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
     "ComunicacaoVisual": {
       "total": 1,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
     "ConsultaOs": {
       "total": 1,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
     "Essentials": {
       "total": 13,
       "charter": 3,
-      "e2e": 0,
+      "e2e": 9,
       "a11y": 0,
       "scorecard": 13
     },
     "Financeiro": {
       "total": 26,
       "charter": 14,
-      "e2e": 0,
+      "e2e": 15,
       "a11y": 0,
       "scorecard": 19
     },
@@ -86,37 +86,37 @@
       "scorecard": 7
     },
     "governance": {
-      "total": 6,
-      "charter": 6,
-      "e2e": 0,
+      "total": 7,
+      "charter": 7,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 6
     },
     "Home": {
       "total": 1,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
     "Jana": {
-      "total": 17,
+      "total": 16,
       "charter": 8,
-      "e2e": 1,
+      "e2e": 5,
       "a11y": 0,
-      "scorecard": 11
+      "scorecard": 10
     },
     "kb": {
       "total": 3,
       "charter": 3,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 2
     },
     "Manufacturing": {
       "total": 1,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
@@ -130,84 +130,84 @@
     "Modules": {
       "total": 1,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
     "NfeBrasil": {
       "total": 6,
       "charter": 4,
-      "e2e": 1,
+      "e2e": 3,
       "a11y": 1,
       "scorecard": 6
     },
     "Nfse": {
       "total": 3,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 3
     },
     "OficinaAuto": {
       "total": 9,
       "charter": 9,
-      "e2e": 0,
+      "e2e": 3,
       "a11y": 0,
       "scorecard": 8
     },
     "Ponto": {
       "total": 22,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 12,
       "a11y": 0,
       "scorecard": 20
     },
     "Produto": {
       "total": 8,
       "charter": 8,
-      "e2e": 0,
+      "e2e": 3,
       "a11y": 0,
       "scorecard": 8
     },
     "ProjectMgmt": {
       "total": 9,
       "charter": 3,
-      "e2e": 0,
+      "e2e": 8,
       "a11y": 0,
       "scorecard": 8
     },
     "Purchase": {
       "total": 4,
       "charter": 2,
-      "e2e": 0,
+      "e2e": 2,
       "a11y": 0,
       "scorecard": 4
     },
     "RecurringBilling": {
       "total": 6,
       "charter": 6,
-      "e2e": 0,
+      "e2e": 5,
       "a11y": 0,
       "scorecard": 6
     },
     "Repair": {
       "total": 13,
       "charter": 12,
-      "e2e": 0,
+      "e2e": 8,
       "a11y": 0,
       "scorecard": 13
     },
     "Sells": {
       "total": 8,
       "charter": 8,
-      "e2e": 1,
+      "e2e": 3,
       "a11y": 0,
       "scorecard": 8
     },
     "Settings": {
       "total": 2,
       "charter": 2,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 2
     },
@@ -221,56 +221,56 @@
     "StockAdjustment": {
       "total": 2,
       "charter": 2,
-      "e2e": 0,
+      "e2e": 2,
       "a11y": 0,
       "scorecard": 2
     },
     "StockTransfer": {
       "total": 2,
       "charter": 2,
-      "e2e": 0,
+      "e2e": 2,
       "a11y": 0,
       "scorecard": 2
     },
     "superadmin": {
       "total": 2,
       "charter": 2,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 2
     },
     "Tarefas": {
       "total": 1,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 0
     },
     "team-mcp": {
       "total": 3,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 3,
       "a11y": 0,
       "scorecard": 0
     },
     "TransactionPayment": {
       "total": 3,
       "charter": 3,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 3
     },
     "Vestuario": {
       "total": 1,
       "charter": 0,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 1
     },
     "Whatsapp": {
       "total": 2,
       "charter": 1,
-      "e2e": 0,
+      "e2e": 1,
       "a11y": 0,
       "scorecard": 2
     },


### PR DESCRIPTION
## Por quê

[#2777](https://github.com/wagnerra23/oimpresso.com/pull/2777) (remoção do stub `/ia/brief`) mergeou no commit **antes** do que atualizava o baseline da catraca de cobertura. Resultado: `main` ficou com `scorecard: 219` — contando a tela `Jana/Brief/Index.tsx` que **não existe mais**.

**Efeito colateral:** o próximo PR que tocasse qualquer `resources/js/Pages/**/*.tsx` falharia o `screen-coverage-gate` (live 218 < baseline 219) sem ter feito nada de errado.

## O quê

Regenera `memory/governance/screen-coverage-baseline.json` pelo método sancionado pelo próprio gate (`node scripts/qa/screen-coverage-map.mjs --json`).

Os **únicos decréscimos** vs `main` são os 3 da remoção legítima do brief:

```
AGG  scorecard     219 → 218
MOD  Jana.total     17 → 16
MOD  Jana.scorecard 11 → 10
```

Os campos que sobem no diff (`e2e 4→110`, `charter 131→132`) são drift pré-existente do baseline que a regeneração sincroniza — a catraca só bloqueia regressão, então essas subidas nunca tinham forçado um refresh. `--check` passa local (`✓ CATRACA: nenhuma regressão de cobertura`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)