### PR TITLE
feat(mcp): D1 — mcp_work_leases, lease de coordenação anti-vazamento (ADR 0278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML

--- a/Modules/Jana/Database/Migrations/2026_06_15_140000_create_mcp_work_leases_table.php
+++ b/Modules/Jana/Database/Migrations/2026_06_15_140000_create_mcp_work_leases_table.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * mcp_work_leases — lease de coordenação "no máx 1 sessão/agente por task ATIVA".
+ *
+ * D1 da arquitetura durável anti-vazamento (ADR 0278, proposal #2766). Ativa o
+ * Tier 2 do ADR 0119 (lease formal com TTL) que estava dormente: o `whats-active`
+ * (Tier 1) é alerta passivo; este é o compare-and-set real (R3 anti-colisão + R4
+ * estado canônico de quem-faz-o-quê).
+ *
+ * INVARIANTE: no máx 1 lease ATIVO por task_id. Como MySQL/MariaDB/SQLite tratam
+ * NULL como DISTINTO num índice UNIQUE, usa-se coluna gerada VIRTUAL `active_marker`
+ * (1=ativo quando released_at NULL, NULL=liberado) + UNIQUE(task_id, active_marker):
+ *   - ativos    → marker=1    → no máx 1 por task_id [colidem → claim concorrente falha]
+ *   - liberados → marker=NULL → coexistem N (history) + permite re-claim após release
+ *
+ * Por que VIRTUAL e não STORED: SQLite só aceita coluna gerada VIRTUAL via
+ * `ALTER TABLE ADD COLUMN` (STORED proibido em ALTER) — e a lane per-PR roda todas
+ * as migrations contra SQLite :memory: (lição-mãe do floor SDD). VIRTUAL+UNIQUE é
+ * suportado em MySQL 5.7.8+, MariaDB 10.2+ e SQLite 3.31+. Padrão provado em
+ * 2026_06_13_120000_enforce_single_active_channel_user_access (US-WA-068).
+ *
+ * EXPIRAÇÃO (TTL/heartbeat) é responsabilidade do WorkLeaseService (seta released_at
+ * em leases com expires_at<now ANTES de cada claim) — NUNCA do schema: coluna gerada
+ * não pode referenciar now() (função não-determinística).
+ *
+ * SEM business_id: espelha mcp_tasks (cache git-synced de governança global, sem
+ * tenant — coordenação do time é cross-business por natureza). Precedente: mcp_tasks
+ * também não tem business_id. Exceção a .claude/rules/migrations.md justificada aqui.
+ *
+ * SEM FK pra mcp_tasks: aquela tabela é CACHE reconstruído pelo parser idempotente
+ * → uma FK cascatearia/quebraria no re-sync. task_id é validado em RUNTIME pelo
+ * WorkLeaseService (não pelo schema).
+ *
+ * NÃO confundir com mcp_file_locks (Modules/ADS) — aquele é mutex POR-ARQUIVO entre
+ * Brain A/B do daemon ADS; este é lease POR-TASK entre sessões Claude/IA. O
+ * lock-por-path foi conscientemente CORTADO do D1 (proposal #2766, "o que cortar":
+ * overlap de path vira alerta no whats-active, não bloqueio).
+ *
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md
+ * @see memory/decisions/0119-whats-active-tier-1-alerta-passivo.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('mcp_work_leases')) {
+            Schema::create('mcp_work_leases', function (Blueprint $table) {
+                $table->bigIncrements('id');
+
+                $table->string('task_id', 40)
+                    ->comment('US-* canônico (espelha mcp_tasks.task_id; sem FK — cache git-synced)');
+
+                // Ator (R4). human_principal = dono do token MCP (NÃO-spoofável,
+                // resolvido por McpAuthMiddleware). agent_id/session = hints de correlação.
+                $table->string('human_principal', 60)
+                    ->comment('Dono do token MCP (username) — confiável, não auto-declarado');
+                $table->string('agent_id', 80)->nullable()
+                    ->comment('Hint auto-declarado do agente (claude-code/cursor/...) — NÃO-confiável');
+                $table->string('claude_code_session', 64)->nullable()
+                    ->comment('X-Claude-Code-Session — correlaciona com mcp_audit_log/mcp_cc_sessions');
+
+                $table->timestamp('acquired_at')->useCurrent();
+                $table->timestamp('heartbeat_at')->useCurrent()
+                    ->comment('Último heartbeat; Service estende expires_at a partir daqui');
+                $table->timestamp('expires_at')
+                    ->comment('TTL (acquired_at + 30min, ADR 0119); Service expira stale antes do claim');
+                $table->timestamp('released_at')->nullable()
+                    ->comment('NULL=ativo. Setado no release OU pelo Service ao expirar (TTL)');
+
+                $table->timestamps();
+
+                $table->index('task_id', 'mwl_task_idx');
+                $table->index('expires_at', 'mwl_expires_idx');
+            });
+        }
+
+        // Coluna gerada VIRTUAL + UNIQUE via ALTER — padrão provado sqlite+mysql
+        // (US-WA-068). Idempotente: guards hasColumn/hasIndex.
+        if (! Schema::hasColumn('mcp_work_leases', 'active_marker')) {
+            Schema::table('mcp_work_leases', function (Blueprint $table) {
+                $table->integer('active_marker')
+                    ->virtualAs('case when released_at is null then 1 else null end')
+                    ->nullable()
+                    ->comment('GERADA: 1=ativo (released_at NULL), NULL=liberado. Enforce 1 lease ativo/task.');
+            });
+        }
+
+        if (! Schema::hasIndex('mcp_work_leases', 'mwl_active_lease_unq')) {
+            Schema::table('mcp_work_leases', function (Blueprint $table) {
+                $table->unique(['task_id', 'active_marker'], 'mwl_active_lease_unq');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_work_leases');
+    }
+};

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -90,6 +90,13 @@ class OimpressoMcpServer extends Server
         // ADR 0119 Tier 1 — coordenação entre sessões Claude (alerta passivo,
         // não lock). Agregação derivada de mcp_cc_sessions + mcp_cc_messages.
         Tools\WhatsActiveTool::class,
+        // ADR 0278 (D1, proposal #2766) Tier 2 — lease FORMAL de coordenação:
+        // compare-and-set real (no máx 1 por task, TTL 30min + heartbeat). O
+        // whats-active ALERTA; estes RESERVAM (mcp_work_leases). R3 anti-colisão
+        // + R4 estado canônico de quem-faz-o-quê (anti-vazamento).
+        Tools\TasksClaimTool::class,
+        Tools\TasksHeartbeatTool::class,
+        Tools\WhatsLockedTool::class,
         // ADR 0133 — System health audit canônico (5 dimensões: observability/evals/
         // ADR-stale/cost-agg/test-coverage). Wrapper sobre jana:system-audit --json.
         // Princípio 2 (tiered cost): SQL+FS only, ZERO LLM call.

--- a/Modules/Jana/Mcp/Tools/TasksClaimTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksClaimTool.php
@@ -52,7 +52,7 @@ class TasksClaimTool extends Tool
             return Response::text('❌ task_id é obrigatório.');
         }
 
-        $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->id));
+        $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->getAuthIdentifier()));
         $agentId = trim((string) $request->get('agent_id', '')) ?: null;
 
         $svc = app(WorkLeaseService::class);

--- a/Modules/Jana/Mcp/Tools/TasksClaimTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksClaimTool.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+
+/**
+ * D1 (ADR 0278 / proposal #2766) — Tool tasks-claim.
+ *
+ * Compare-and-set: pega um lease ATIVO numa task (no máx 1 por task). É o Tier 2
+ * (lock real) do ADR 0119 — o whats-active (Tier 1) só alerta; este reserva. Sessão
+ * que vai trabalhar uma US dá claim antes; se outro principal segura, recebe quem é
+ * o dono em vez de colidir. Estado vive no Postgres (R1: trabalho-em-voo deixa de ser
+ * invisível). TTL 30min + heartbeat (tasks-heartbeat) renova.
+ *
+ * human_principal = dono do token MCP (não-spoofável). agent_id é hint de correlação.
+ */
+class TasksClaimTool extends Tool
+{
+    protected string $name = 'tasks-claim';
+
+    protected string $title = 'Reservar (claim) uma task — lease de coordenação';
+
+    protected string $description = 'Pega um lease ATIVO numa US-* (no máx 1 por task, TTL 30min). Use ANTES de começar a trabalhar uma task pra evitar que outra sessão/IA pegue a mesma. Se já houver dono ativo, retorna quem é (não bloqueia o resto). Renove com tasks-heartbeat; veja todos com whats-locked. ADR 0278 (Tier 2 do whats-active).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'task_id' => $schema->string()
+                ->description('ID da task, ex: US-GOV-022')
+                ->required(),
+            'agent_id' => $schema->string()
+                ->description('Hint de qual agente (claude-code/cursor/...). Não-confiável (correlação só).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $user = $request->user();
+        if ($user === null) {
+            return Response::error('Autenticação requerida.');
+        }
+
+        $taskId = trim((string) $request->get('task_id', ''));
+        if ($taskId === '') {
+            return Response::text('❌ task_id é obrigatório.');
+        }
+
+        $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->id));
+        $agentId = trim((string) $request->get('agent_id', '')) ?: null;
+
+        $svc = app(WorkLeaseService::class);
+
+        if (! $svc->taskExists($taskId)) {
+            return Response::text("❌ Task `{$taskId}` não existe no cache mcp_tasks. Crie/sincronize a US antes de dar claim.");
+        }
+
+        $res = $svc->claim($taskId, $principal, $agentId);
+
+        if (! $res['ok']) {
+            $h = $res['holder'];
+            $agent = $h->agent_id ? " · agente `{$h->agent_id}`" : '';
+
+            return Response::text(
+                "🔒 Task `{$taskId}` já tem lease ATIVO de **{$h->human_principal}**{$agent} (expira {$h->expires_at}).\n" .
+                '_Coordene antes de pegar — ou veja `whats-locked`. Lease estoura sozinho no TTL se o dono sumir._'
+            );
+        }
+
+        $lease = $res['lease'];
+        $verbo = ($res['renewed'] ?? false) ? 'renovado' : 'adquirido';
+
+        return Response::text(
+            "✅ Lease {$verbo} em `{$taskId}` por **{$principal}** — expira {$lease->expires_at} (TTL 30min).\n" .
+            '_Renove com `tasks-heartbeat task_id:' . $taskId . '` enquanto trabalha; libere ao terminar (release automático no TTL)._'
+        );
+    }
+}

--- a/Modules/Jana/Mcp/Tools/TasksHeartbeatTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksHeartbeatTool.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+
+/**
+ * D1 (ADR 0278 / proposal #2766) — Tool tasks-heartbeat.
+ *
+ * Renova o TTL do lease que VOCÊ segura (estende +30min). Sem heartbeat o lease
+ * estoura sozinho (R2: auto-limpa, sem cron) e a task volta ao pool — o que protege
+ * contra lease órfão de sessão que crashou. Só age se o principal autenticado é o
+ * dono do lease ativo.
+ */
+class TasksHeartbeatTool extends Tool
+{
+    protected string $name = 'tasks-heartbeat';
+
+    protected string $title = 'Renovar (heartbeat) o lease de uma task';
+
+    protected string $description = 'Estende o TTL (+30min) do lease que você segura numa US-*. Use periodicamente enquanto trabalha pra não perder a reserva. Se você não é o dono do lease ativo, é no-op. ADR 0278.';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'task_id' => $schema->string()
+                ->description('ID da task cujo lease renovar, ex: US-GOV-022')
+                ->required(),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $user = $request->user();
+        if ($user === null) {
+            return Response::error('Autenticação requerida.');
+        }
+
+        $taskId = trim((string) $request->get('task_id', ''));
+        if ($taskId === '') {
+            return Response::text('❌ task_id é obrigatório.');
+        }
+
+        $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->id));
+        $svc = app(WorkLeaseService::class);
+
+        if (! $svc->heartbeat($taskId, $principal)) {
+            return Response::text(
+                "⚠️ Você (**{$principal}**) não segura um lease ATIVO de `{$taskId}` — nada a renovar.\n" .
+                '_Talvez expirou ou é de outro. Veja `whats-locked` / dê `tasks-claim` de novo._'
+            );
+        }
+
+        $lease = $svc->activeLeaseFor($taskId);
+
+        return Response::text("✅ Lease de `{$taskId}` renovado — novo TTL expira {$lease->expires_at}.");
+    }
+}

--- a/Modules/Jana/Mcp/Tools/TasksHeartbeatTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksHeartbeatTool.php
@@ -47,7 +47,7 @@ class TasksHeartbeatTool extends Tool
             return Response::text('❌ task_id é obrigatório.');
         }
 
-        $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->id));
+        $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->getAuthIdentifier()));
         $svc = app(WorkLeaseService::class);
 
         if (! $svc->heartbeat($taskId, $principal)) {

--- a/Modules/Jana/Mcp/Tools/WhatsLockedTool.php
+++ b/Modules/Jana/Mcp/Tools/WhatsLockedTool.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+
+/**
+ * D1 (ADR 0278 / proposal #2766) — Tool whats-locked.
+ *
+ * "Quais tasks estão RESERVADAS (lease ativo) agora e por quem?" Complementa o
+ * whats-active (ADR 0119 Tier 1, paths tocados / alerta passivo): este é o estado
+ * canônico de quem-faz-o-quê (R4), derivado do compare-and-set real. Faz sweep de
+ * expirados antes de listar, então só mostra leases dentro do TTL.
+ */
+class WhatsLockedTool extends Tool
+{
+    protected string $name = 'whats-locked';
+
+    protected string $title = 'Tasks reservadas (leases ativos) + por quem';
+
+    protected string $description = 'Lista as US-* com lease ATIVO (reservadas por uma sessão/IA agora) + dono + expiração. Use no início de sessão (depois de whats-active) pra não pegar task que já tem dono. ADR 0278 (Tier 2 do whats-active).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'limit' => $schema->integer()
+                ->min(1)
+                ->max(50)
+                ->default(30)
+                ->description('Máx leases retornados (default 30)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        if ($request->user() === null) {
+            return Response::error('Autenticação requerida.');
+        }
+
+        $limit = max(1, min(50, (int) $request->get('limit', 30)));
+        $leases = app(WorkLeaseService::class)->activeLeases($limit);
+
+        if ($leases->isEmpty()) {
+            return Response::text("✅ Nenhuma task com lease ativo agora.\n_Pode dar `tasks-claim` em qualquer uma sem corrida._");
+        }
+
+        $linhas = $leases->map(function ($l) {
+            $agent = $l->agent_id ? " · `{$l->agent_id}`" : '';
+
+            return "- `{$l->task_id}` → **{$l->human_principal}**{$agent} (expira {$l->expires_at})";
+        })->implode("\n");
+
+        return Response::text(
+            "🔒 **{$leases->count()} task(s) reservada(s)** (lease ativo):\n\n{$linhas}\n\n" .
+            '_Lease estoura sozinho no TTL (30min sem heartbeat) → volta ao pool._'
+        );
+    }
+}

--- a/Modules/Jana/Services/WorkLease/WorkLeaseService.php
+++ b/Modules/Jana/Services/WorkLease/WorkLeaseService.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\WorkLease;
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * WorkLeaseService — lógica do lease de coordenação (D1, ADR 0278 / proposal #2766).
+ *
+ * SoC brutal (Princípio 5): toda a regra de TTL/expiração/compare-and-set vive AQUI,
+ * não no schema (coluna gerada não pode usar now()) nem nas tools (que só adaptam
+ * o protocolo MCP). O invariante "1 lease ativo por task" é enforçado pelo UNIQUE
+ * (task_id, active_marker) da tabela — este service o respeita e o expõe.
+ *
+ * Lease "ativo" = released_at IS NULL AND expires_at > now. A coluna gerada só
+ * conhece released_at (determinística); a janela de TTL é checada em runtime aqui.
+ */
+class WorkLeaseService
+{
+    /** TTL do lease em minutos (ADR 0119 — alinhado à janela do whats-active). */
+    public const TTL_MINUTES = 30;
+
+    /**
+     * Expira (seta released_at) leases ainda-ativos cujo expires_at já passou.
+     * Idempotente. Chamado antes de cada claim/listagem pra que o UNIQUE não barre
+     * um re-claim legítimo de task cujo dono anterior sumiu (crash/timeout).
+     */
+    public function sweepExpired(): int
+    {
+        return DB::table('mcp_work_leases')
+            ->whereNull('released_at')
+            ->where('expires_at', '<', now())
+            ->update(['released_at' => now(), 'updated_at' => now()]);
+    }
+
+    /** Lease ATIVO de uma task (released_at NULL e dentro do TTL), ou null. */
+    public function activeLeaseFor(string $taskId): ?object
+    {
+        return DB::table('mcp_work_leases')
+            ->where('task_id', $taskId)
+            ->whereNull('released_at')
+            ->where('expires_at', '>', now())
+            ->first();
+    }
+
+    /**
+     * task_id existe no cache mcp_tasks? Validação de runtime (não há FK — mcp_tasks
+     * é cache git-synced). Em ambiente sem o cache migrado, não bloqueia (degrada
+     * gracioso, como WhatsActiveTool faz com mcp_cc_sessions).
+     */
+    public function taskExists(string $taskId): bool
+    {
+        if (! Schema::hasTable('mcp_tasks')) {
+            return true;
+        }
+
+        return DB::table('mcp_tasks')->where('task_id', $taskId)->exists();
+    }
+
+    /**
+     * Claim compare-and-set de uma task.
+     *
+     * @return array{ok: bool, lease?: object|null, holder?: object|null, reason?: string, renewed?: bool}
+     *   ok=true  → lease adquirido (ou renovado, se já era do mesmo principal)
+     *   ok=false → reason 'held' (outro dono ativo) | 'race' (perdeu corrida pro UNIQUE)
+     */
+    public function claim(string $taskId, string $humanPrincipal, ?string $agentId = null, ?string $session = null): array
+    {
+        $this->sweepExpired();
+
+        $existing = $this->activeLeaseFor($taskId);
+        if ($existing !== null) {
+            // Mesmo dono pega de novo → trata como heartbeat (renova), não conflito.
+            if ($existing->human_principal === $humanPrincipal) {
+                $this->heartbeat($taskId, $humanPrincipal);
+
+                return ['ok' => true, 'lease' => $this->activeLeaseFor($taskId), 'renewed' => true];
+            }
+
+            return ['ok' => false, 'reason' => 'held', 'holder' => $existing];
+        }
+
+        try {
+            DB::table('mcp_work_leases')->insert([
+                'task_id' => $taskId,
+                'human_principal' => $humanPrincipal,
+                'agent_id' => $agentId,
+                'claude_code_session' => $session,
+                'acquired_at' => now(),
+                'heartbeat_at' => now(),
+                'expires_at' => now()->addMinutes(self::TTL_MINUTES),
+                'released_at' => null,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } catch (QueryException $e) {
+            // Corrida concorrente perdida pro UNIQUE(task_id, active_marker) — re-lê
+            // o vencedor pra reportar quem segura (em vez de estourar exceção).
+            $holder = $this->activeLeaseFor($taskId);
+            if ($holder === null) {
+                throw $e; // não foi colisão de invariante — propaga
+            }
+
+            return ['ok' => false, 'reason' => 'race', 'holder' => $holder];
+        }
+
+        return ['ok' => true, 'lease' => $this->activeLeaseFor($taskId)];
+    }
+
+    /** Estende o TTL (heartbeat). Só age se o principal segura o lease ativo. */
+    public function heartbeat(string $taskId, string $humanPrincipal): bool
+    {
+        $affected = DB::table('mcp_work_leases')
+            ->where('task_id', $taskId)
+            ->where('human_principal', $humanPrincipal)
+            ->whereNull('released_at')
+            ->update([
+                'heartbeat_at' => now(),
+                'expires_at' => now()->addMinutes(self::TTL_MINUTES),
+                'updated_at' => now(),
+            ]);
+
+        return $affected > 0;
+    }
+
+    /** Libera o lease (release explícito). Só o próprio principal libera. */
+    public function release(string $taskId, string $humanPrincipal): bool
+    {
+        $affected = DB::table('mcp_work_leases')
+            ->where('task_id', $taskId)
+            ->where('human_principal', $humanPrincipal)
+            ->whereNull('released_at')
+            ->update(['released_at' => now(), 'updated_at' => now()]);
+
+        return $affected > 0;
+    }
+
+    /** Leases ATIVOS no momento (não-liberados, dentro do TTL). */
+    public function activeLeases(int $limit = 30): Collection
+    {
+        $this->sweepExpired();
+
+        return DB::table('mcp_work_leases')
+            ->whereNull('released_at')
+            ->where('expires_at', '>', now())
+            ->orderBy('acquired_at')
+            ->limit($limit)
+            ->get();
+    }
+}

--- a/Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
@@ -155,3 +155,19 @@ it('sweepExpired devolve lease estourado ao pool (TTL vive no Service)', functio
     expect($res['ok'])->toBeTrue()
         ->and($res['lease']->human_principal)->toBe('eliana');
 })->group('work-lease', 'ci');
+
+it('heartbeat de NÃO-dono é no-op (guard de posse anti-spoof)', function () {
+    $svc = app(WorkLeaseService::class);
+    $svc->claim('US-GOV-022', 'wagner');
+
+    expect($svc->heartbeat('US-GOV-022', 'intruso'))->toBeFalse()
+        ->and($svc->activeLeaseFor('US-GOV-022')->human_principal)->toBe('wagner');
+})->group('work-lease', 'ci');
+
+it('release de NÃO-dono é no-op (guard de posse anti-spoof)', function () {
+    $svc = app(WorkLeaseService::class);
+    $svc->claim('US-GOV-022', 'wagner');
+
+    expect($svc->release('US-GOV-022', 'intruso'))->toBeFalse()
+        ->and($svc->activeLeaseFor('US-GOV-022'))->not->toBeNull();
+})->group('work-lease', 'ci');

--- a/Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * D1 (ADR 0278 / proposal #2766) — mcp_work_leases + WorkLeaseService.
+ *
+ * GUARD tests do invariante de coordenação anti-vazamento:
+ *   1. Schema: UNIQUE(task_id, active_marker) enforça 1 lease ATIVO por task
+ *   2. claim() adquire lease quando livre
+ *   3. claim() por OUTRO principal numa task ativa → conflito 'held' (não estoura)
+ *   4. claim() pelo MESMO principal → renova (heartbeat), não conflito
+ *   5. release() libera → re-claim por outro funciona
+ *   6. sweepExpired() devolve lease estourado ao pool (TTL é do Service, não do schema)
+ *
+ * Padrão era-sqlite (schema sintético inline + skip não-sqlite), igual a
+ * ChannelUserAccessTest: a lane per-PR roda sqlite :memory:, e RefreshDatabase
+ * (suite inteira) inclui migrations MySQL-only — então monta-se só a tabela do D1.
+ *
+ * @see Modules/Jana/Database/Migrations/2026_06_15_140000_create_mcp_work_leases_table.php
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente (floor SDD).');
+    }
+
+    Schema::dropIfExists('mcp_work_leases');
+
+    Schema::create('mcp_work_leases', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('task_id', 40);
+        $table->string('human_principal', 60);
+        $table->string('agent_id', 80)->nullable();
+        $table->string('claude_code_session', 64)->nullable();
+        $table->timestamp('acquired_at')->useCurrent();
+        $table->timestamp('heartbeat_at')->useCurrent();
+        $table->timestamp('expires_at');
+        $table->timestamp('released_at')->nullable();
+        $table->timestamps();
+        $table->index('task_id', 'mwl_task_idx');
+        $table->index('expires_at', 'mwl_expires_idx');
+    });
+    Schema::table('mcp_work_leases', function ($table) {
+        $table->integer('active_marker')
+            ->virtualAs('case when released_at is null then 1 else null end')
+            ->nullable();
+    });
+    Schema::table('mcp_work_leases', function ($table) {
+        $table->unique(['task_id', 'active_marker'], 'mwl_active_lease_unq');
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_work_leases');
+});
+
+function insertActiveLease(string $taskId, string $principal): void
+{
+    DB::table('mcp_work_leases')->insert([
+        'task_id' => $taskId,
+        'human_principal' => $principal,
+        'acquired_at' => now(),
+        'heartbeat_at' => now(),
+        'expires_at' => now()->addMinutes(30),
+        'released_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('schema enforça no máx 1 lease ativo por task (UNIQUE active_marker)', function () {
+    insertActiveLease('US-GOV-022', 'wagner');
+
+    expect(fn () => insertActiveLease('US-GOV-022', 'eliana'))
+        ->toThrow(QueryException::class);
+})->group('work-lease', 'ci');
+
+it('liberados coexistem e permitem re-claim (NULLs distintos no UNIQUE)', function () {
+    insertActiveLease('US-GOV-022', 'wagner');
+    DB::table('mcp_work_leases')->where('task_id', 'US-GOV-022')->update(['released_at' => now()]);
+
+    // Segundo lease ativo após release NÃO colide (marker do liberado = NULL).
+    insertActiveLease('US-GOV-022', 'eliana');
+
+    expect(DB::table('mcp_work_leases')->where('task_id', 'US-GOV-022')->count())->toBe(2);
+})->group('work-lease', 'ci');
+
+it('claim adquire lease quando a task está livre', function () {
+    $svc = app(WorkLeaseService::class);
+    $res = $svc->claim('US-GOV-022', 'wagner', 'claude-code');
+
+    expect($res['ok'])->toBeTrue()
+        ->and($res['lease']->human_principal)->toBe('wagner')
+        ->and($res['lease']->agent_id)->toBe('claude-code');
+})->group('work-lease', 'ci');
+
+it('claim por outro principal numa task ativa retorna conflito held (não estoura)', function () {
+    $svc = app(WorkLeaseService::class);
+    $svc->claim('US-GOV-022', 'wagner');
+
+    $res = $svc->claim('US-GOV-022', 'eliana');
+
+    expect($res['ok'])->toBeFalse()
+        ->and($res['reason'])->toBe('held')
+        ->and($res['holder']->human_principal)->toBe('wagner');
+})->group('work-lease', 'ci');
+
+it('claim pelo mesmo principal renova o lease (heartbeat, não conflito)', function () {
+    $svc = app(WorkLeaseService::class);
+    $svc->claim('US-GOV-022', 'wagner');
+
+    $res = $svc->claim('US-GOV-022', 'wagner');
+
+    expect($res['ok'])->toBeTrue()
+        ->and($res['renewed'] ?? false)->toBeTrue()
+        ->and(DB::table('mcp_work_leases')->where('task_id', 'US-GOV-022')->whereNull('released_at')->count())->toBe(1);
+})->group('work-lease', 'ci');
+
+it('release libera e permite re-claim por outro', function () {
+    $svc = app(WorkLeaseService::class);
+    $svc->claim('US-GOV-022', 'wagner');
+
+    expect($svc->release('US-GOV-022', 'wagner'))->toBeTrue();
+
+    $res = $svc->claim('US-GOV-022', 'eliana');
+    expect($res['ok'])->toBeTrue()
+        ->and($res['lease']->human_principal)->toBe('eliana');
+})->group('work-lease', 'ci');
+
+it('sweepExpired devolve lease estourado ao pool (TTL vive no Service)', function () {
+    DB::table('mcp_work_leases')->insert([
+        'task_id' => 'US-GOV-022',
+        'human_principal' => 'wagner',
+        'acquired_at' => now()->subHour(),
+        'heartbeat_at' => now()->subHour(),
+        'expires_at' => now()->subMinutes(5), // já estourou
+        'released_at' => null,
+        'created_at' => now()->subHour(),
+        'updated_at' => now()->subHour(),
+    ]);
+
+    $svc = app(WorkLeaseService::class);
+
+    expect($svc->activeLeaseFor('US-GOV-022'))->toBeNull(); // fora do TTL = não-ativo
+
+    $res = $svc->claim('US-GOV-022', 'eliana'); // sweep + re-claim
+    expect($res['ok'])->toBeTrue()
+        ->and($res['lease']->human_principal)->toBe('eliana');
+})->group('work-lease', 'ci');


### PR DESCRIPTION
## O quê
**D1** da arquitetura durável anti-vazamento (proposal #2766). Ativa o **Tier 2** (lease formal com TTL) do [ADR 0119](memory/decisions/0119-whats-active-tier-1-alerta-passivo.md) que estava dormente. O `whats-active` **alerta**; estes **reservam** (compare-and-set real) → R3 anti-colisão + R4 estado canônico de quem-faz-o-quê.

## Conteúdo (1 intent, Tier-0 MCP canônico)
- `mcp_work_leases` — `UNIQUE(task_id, active_marker)` via **coluna gerada VIRTUAL** (padrão provado US-WA-068 `enforce_single_active_channel_user_access`): no máx 1 lease ativo/task; liberados coexistem (NULLs distintos) → re-claim + history.
- `WorkLeaseService` — TTL 30min + heartbeat + sweep de expirados vivem no **Service** (coluna gerada não pode usar `now()`). compare-and-set com fallback de corrida.
- 3 tools MCP: `tasks-claim` / `tasks-heartbeat` / `whats-locked` (cluster coordenação, page 2 ao lado de `whats-active`).

## Refutador adversarial (ADR 0276) — correções aplicadas ANTES de codar
- ❌→✅ **marker determinístico** (`released_at`), nunca TTL na coluna gerada — era **fatal** (derrubaria a lane sqlite).
- ✂️ check **"estou-ingerido?" CORTADO** — falso-negativo permanente sob a cadência real do watcher (cron 1×/dia, não real-time) = fadiga de alerta. Vira **known-gap**, não gate.
- 🔒 `agent_id` = hint **não-confiável**; `human_principal` = dono do token MCP (não-spoofável, `McpAuthMiddleware`).
- ♻️ carimbo já vem de graça do `mcp_audit_log` (imutável) — **não tocado**.
- 🔗 **sem FK** pra `mcp_tasks` (cache git-synced) — `task_id` validado em runtime.

## Decisões Tier-0 justificadas
- **Sem `business_id`**: espelha `mcp_tasks` (governança global cross-business). Exceção a `.claude/rules/migrations.md` documentada na migration.
- **Não duplica `mcp_file_locks`** (Modules/ADS): aquele é mutex por-arquivo entre Brains do daemon; este é lease por-task entre sessões. lock-por-path foi conscientemente cortado (#2766 "o que cortar").

## Verificação
- ✅ `php -l` limpo nos 7 arquivos.
- ✅ **Invariante provado em PDO sqlite 3.51**: 2º ativo barrado pelo UNIQUE; re-claim pós-release ok.
- ⚠️ `WorkLeaseServiceTest` (Pest, sqlite sintético padrão era-sqlite, 7 casos) **NÃO roda local** (CT100/CI). **Por isso DRAFT.**

## Fora de escopo (deferido, honesto)
- **Wire `whats-active` no SessionStart** (Fase 0): o adversário mostrou que a skill `session-start-check` **já** cobre a camada agente; um hook seria redundância determinística, não "ligar algo desligado" → PR separado se Wagner quiser.
- Fechar o **SPOF do watcher** exige mudá-lo pra `--watch` real-time — fora do mínimo.

Refs: SDD D1 · proposal #2766 · ADR 0278
🤖 Generated with [Claude Code](https://claude.com/claude-code)