### PR TITLE
fix(governance): e2e screen-coverage conta só caminho exato (remove 106 falsos-positivos)

### DIFF
--- a/memory/governance/screen-coverage-baseline.json
+++ b/memory/governance/screen-coverage-baseline.json
@@ -3,7 +3,7 @@
   "aggregates": {
     "total": 275,
     "charter": 132,
-    "e2e": 110,
+    "e2e": 4,
     "a11y": 1,
     "scorecard": 218
   },
@@ -11,70 +11,70 @@
     "Admin": {
       "total": 8,
       "charter": 8,
-      "e2e": 2,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 8
     },
     "ads": {
       "total": 19,
       "charter": 0,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 19
     },
     "Atendimento": {
       "total": 8,
       "charter": 5,
-      "e2e": 5,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 8
     },
     "Auditoria": {
       "total": 2,
       "charter": 1,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },
     "Cliente": {
       "total": 34,
       "charter": 7,
-      "e2e": 2,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 7
     },
     "Compras": {
       "total": 5,
       "charter": 1,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
     "ComunicacaoVisual": {
       "total": 1,
       "charter": 1,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
     "ConsultaOs": {
       "total": 1,
       "charter": 0,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
     "Essentials": {
       "total": 13,
       "charter": 3,
-      "e2e": 9,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 13
     },
     "Financeiro": {
       "total": 26,
       "charter": 14,
-      "e2e": 15,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 19
     },
@@ -88,35 +88,35 @@
     "governance": {
       "total": 7,
       "charter": 7,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 6
     },
     "Home": {
       "total": 1,
       "charter": 1,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
     "Jana": {
       "total": 16,
       "charter": 8,
-      "e2e": 5,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 10
     },
     "kb": {
       "total": 3,
       "charter": 3,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },
     "Manufacturing": {
       "total": 1,
       "charter": 1,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
@@ -130,84 +130,84 @@
     "Modules": {
       "total": 1,
       "charter": 0,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
     "NfeBrasil": {
       "total": 6,
       "charter": 4,
-      "e2e": 3,
+      "e2e": 1,
       "a11y": 1,
       "scorecard": 6
     },
     "Nfse": {
       "total": 3,
       "charter": 0,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 3
     },
     "OficinaAuto": {
       "total": 9,
       "charter": 9,
-      "e2e": 3,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 8
     },
     "Ponto": {
       "total": 22,
       "charter": 0,
-      "e2e": 12,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 20
     },
     "Produto": {
       "total": 8,
       "charter": 8,
-      "e2e": 3,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 8
     },
     "ProjectMgmt": {
       "total": 9,
       "charter": 3,
-      "e2e": 8,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 8
     },
     "Purchase": {
       "total": 4,
       "charter": 2,
-      "e2e": 2,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 4
     },
     "RecurringBilling": {
       "total": 6,
       "charter": 6,
-      "e2e": 5,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 6
     },
     "Repair": {
       "total": 13,
       "charter": 12,
-      "e2e": 8,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 13
     },
     "Sells": {
       "total": 8,
       "charter": 8,
-      "e2e": 3,
+      "e2e": 2,
       "a11y": 0,
       "scorecard": 8
     },
     "Settings": {
       "total": 2,
       "charter": 2,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },
@@ -221,56 +221,56 @@
     "StockAdjustment": {
       "total": 2,
       "charter": 2,
-      "e2e": 2,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },
     "StockTransfer": {
       "total": 2,
       "charter": 2,
-      "e2e": 2,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },
     "superadmin": {
       "total": 2,
       "charter": 2,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },
     "Tarefas": {
       "total": 1,
       "charter": 0,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 0
     },
     "team-mcp": {
       "total": 3,
       "charter": 1,
-      "e2e": 3,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 0
     },
     "TransactionPayment": {
       "total": 3,
       "charter": 3,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 3
     },
     "Vestuario": {
       "total": 1,
       "charter": 0,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 1
     },
     "Whatsapp": {
       "total": 2,
       "charter": 1,
-      "e2e": 1,
+      "e2e": 0,
       "a11y": 0,
       "scorecard": 2
     },

--- a/scripts/qa/screen-coverage-map.mjs
+++ b/scripts/qa/screen-coverage-map.mjs
@@ -68,14 +68,17 @@ const scorecards = new Set(
   ),
 );
 
-/** Uma tela é "referenciada" por um E2E se o caminho relativo do Page (Mod/Tela) aparece no body. */
+/**
+ * Uma tela é "referenciada" por um E2E se o caminho relativo do Page (Mod/Tela)
+ * aparece LITERALMENTE no body do teste — ex: `'Sells/Create'` no mapa do Pest Browser.
+ * NÃO casamos por basename solto ('Index', 'Create', 'Cockpit'): um único teste citando
+ * '/Index' creditaria todas as ~90 telas homônimas. Esse termo gerava 106 falsos-positivos
+ * (e2e inflado de 4 → 110); a contagem honesta é só quem cita o caminho exato. Ver ADR 0249.
+ */
 function e2eFor(relTsx) {
   const key = relTsx.replace(/\.tsx$/, ''); // ex: Sells/Create
-  const keyAlt = key.replace(/\//g, '\\');
-  const name = basename(key); // ex: Create
-  return browserCorpus.filter(
-    (b) => b.body.includes(key) || b.body.includes(keyAlt) || new RegExp(`['"\`/]${name}['"\`]`).test(b.body),
-  );
+  const keyAlt = key.replace(/\//g, '\\');  // idem em refs com separador Windows
+  return browserCorpus.filter((b) => b.body.includes(key) || b.body.includes(keyAlt));
 }
 
 const rows = screens.map((abs) => {


### PR DESCRIPTION
A métrica `e2e` da catraca de cobertura (`screen-coverage-gate`, ADR 0249 anel 2) estava **96% ruído**.

## Causa

A função `e2eFor()` em `scripts/qa/screen-coverage-map.mjs` casava uma tela com um teste Browser por **três** condições: caminho do componente (`Mod/Tela`), o mesmo com separador Windows, **e basename solto** (um nome curto entre aspas/barra, ex.: `'Index'`, `/Index`). Esse terceiro termo é o problema: um único teste citando `/Index` ou `'Create'` creditava **todas** as telas homônimas.

Medição no `origin/main` (8 arquivos em `tests/Browser/`):

| matching | telas cobertas |
|---|---|
| **frouxo** (atual, qualquer termo) | **110/275** |
| **preciso** (só caminho do componente) | **4/275** |
| falsos-positivos por basename | **106** |

Quebra dos 106 falsos: **91** telas `*/Index` (qualquer teste citando `/Index`), **14** `*/Create`, **1** `Jana/Cockpit` (creditada porque `Fiscal/Cockpit` cita "Cockpit").

O #2780 regenerou o baseline via `--json` e **cristalizou os 110 como piso** da catraca — número que é ruído, não cobertura. O docstring da própria função já dizia que cobertura = *"o caminho relativo do Page (Mod/Tela) aparece no body"*; o termo basename contradizia isso.

## Mudança

- `e2eFor()` casa **só** pelo caminho do componente Inertia (`Mod/Tela` + variante Windows). 3 linhas de lógica + docstring.
- Re-baselina via `node scripts/qa/screen-coverage-map.mjs --json`.

`git diff` do baseline = **só linhas `e2e`** (36+/36-). Nenhum outro agregado muda:

```
e2e: 110 → 4        scorecard: 218 (=)   charter: 132 (=)   a11y: 1 (=)   total: 275 (=)
```

Cobertura E2E real = **4 telas**, todas confirmadas por referência ao caminho exato no teste:

| tela | teste |
|---|---|
| `Sells/Index` | `CoreScreens/PixelBaselineTest.php` |
| `Sells/Create` | `CoreScreens/PixelBaselineTest.php` · `Sells/CreateScreenshotTest.php` |
| `Fiscal/Cockpit` | `CoreScreens/{AuthBridgeSmoke,Smoke}Test.php` |
| `NfeBrasil/Transactions/NfceStatus` | `NfeBrasil/NfceStatusTest.php` |

## Por que NÃO é gaming da catraca

A catraca diz "telas cobertas só sobem". Baixar `e2e` de 110 → 4 **não** baixa cobertura real — corrige a **medição**, que contava 106 falsos-positivos. A cobertura E2E real sempre foi 4 (era exatamente o valor do baseline antes do #2780). O gate fica **verde** (`--check` exit 0) porque live e baseline são recomputados pelo script novo e batem.

## Limitação conhecida (follow-up, não mascarado aqui)

Smokes que referenciam telas por **label de rota** (`'Oficina/OS'`, `'Venda/Lista'`, `'Financeiro/Unificado'`) não são creditados — esses labels não correspondem ao caminho real do `.tsx`. Pra contar, os mapas dos testes precisam usar o caminho do componente. Higiene de teste, fora do escopo deste PR (1 PR = 1 intent).

## Verificação

```
node scripts/qa/screen-coverage-map.mjs --check   →  ✓ CATRACA: nenhuma regressão · EXIT 0
```

Refs: ADR 0249 · segue #2780 / #2777

🤖 Generated with [Claude Code](https://claude.com/claude-code)
