### PR TITLE
feat(jana): acceptance_ref em mcp_tasks — Fase 2 ADR 0278 (estado explícito, soft consumer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML

--- a/Modules/Jana/Database/Migrations/2026_06_15_150000_add_acceptance_ref_to_mcp_tasks.php
+++ b/Modules/Jana/Database/Migrations/2026_06_15_150000_add_acceptance_ref_to_mcp_tasks.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * mcp_tasks.acceptance_ref — prova de DoD pra fechar uma task (Fase 2, ADR 0278).
+ *
+ * R1 (estado explícito, anti-vazamento): "done" passa a poder carregar a evidência
+ * que a satisfez (URL do PR / commit SHA / path de teste Pest / smoke). O consumer
+ * SOFT no TaskCrudService registra um evento de AVISO quando uma task vira `done`
+ * SEM esta referência — auditável/ruidoso, **não bloqueante**. O hard-gate (throw)
+ * é a Fase 3, sequenciada para DEPOIS do lease (D1) provar valor (ADR 0105).
+ *
+ * SEM business_id: mcp_tasks é cache git-synced repo-wide (ADR 0070, sem tenant) —
+ * a coluna nova espelha a tabela. String simples (não-gerada, sem now()).
+ * Idempotente (hasColumn guard) porque a lane per-PR roda contra sqlite :memory:.
+ *
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md (Fase 2)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('mcp_tasks') && ! Schema::hasColumn('mcp_tasks', 'acceptance_ref')) {
+            Schema::table('mcp_tasks', function (Blueprint $table) {
+                $table->string('acceptance_ref', 500)->nullable()->after('blocked_by')
+                    ->comment('Prova de DoD pra fechar (PR url / commit sha / test path / smoke). Fase 2 ADR 0278 — R1. Hard-gate = Fase 3.');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('mcp_tasks') && Schema::hasColumn('mcp_tasks', 'acceptance_ref')) {
+            Schema::table('mcp_tasks', function (Blueprint $table) {
+                $table->dropColumn('acceptance_ref');
+            });
+        }
+    }
+};

--- a/Modules/Jana/Entities/Mcp/McpTask.php
+++ b/Modules/Jana/Entities/Mcp/McpTask.php
@@ -24,6 +24,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * REPO-WIDE: ADR 0070 jira-style cross-tenant intencional — planejamento é da
  * plataforma. Sem `business_id` by design. Wave 25 SATURATION marker explícito
  * pra rubrica D1.c v3.2 hardened.
+ *
+ * @property string|null $acceptance_ref Prova de DoD pra fechar (Fase 2, ADR 0278).
+ *           Coluna adicionada via ALTER — declarada aqui pro Larastan reconhecer.
  */
 class McpTask extends Model
 {

--- a/Modules/Jana/Entities/Mcp/McpTask.php
+++ b/Modules/Jana/Entities/Mcp/McpTask.php
@@ -57,6 +57,7 @@ class McpTask extends Model
         'labels',
         'custom_fields',
         'blocked_by',
+        'acceptance_ref',
         'source_path',
         'source_git_sha',
         'parsed_at',

--- a/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
@@ -45,6 +45,8 @@ class TasksUpdateTool extends Tool
                 ->description('Nova prioridade: p0|p1|p2|p3'),
             'module' => $schema->string()
                 ->description('Mover task pra outro módulo (ex: COPI→JANA pós-rename ADR 0088). Use uppercase.'),
+            'acceptance_ref' => $schema->string()
+                ->description('Prova de DoD pra fechar a task (URL do PR / commit SHA / path de teste Pest / evidência smoke). Recomendado ao mover pra done — Fase 2 ADR 0278. Use "—" pra limpar.'),
             'author' => $schema->string()
                 ->description('Quem está fazendo a mudança (para audit log). Default: wagner.'),
         ];
@@ -60,7 +62,7 @@ class TasksUpdateTool extends Tool
         $author = trim((string) $request->get('author', 'wagner')) ?: 'wagner';
 
         $campos = [];
-        foreach (['status', 'owner', 'sprint', 'priority', 'module'] as $field) {
+        foreach (['status', 'owner', 'sprint', 'priority', 'module', 'acceptance_ref'] as $field) {
             $val = $request->get($field);
             if ($val !== null) {
                 $v = trim((string) $val);

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -98,7 +98,7 @@ class TaskCrudService
                 // (deferida até o lease provar valor, ADR 0105).
                 if ($newVal === 'done'
                     && empty($fields['acceptance_ref'])
-                    && empty($task->acceptance_ref)) {
+                    && empty($task->getAttribute('acceptance_ref'))) {
                     $events[] = McpTaskEvent::log(
                         taskId: $task->task_id,
                         eventType: 'field_updated',

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -62,6 +62,7 @@ class TaskCrudService
             'type', 'story_points', 'estimate_unit', 'estimate_value',
             'estimate_h', 'due_date', 'labels', 'custom_fields',
             'title', 'description', 'module',
+            'acceptance_ref',
         ];
         $events = [];
 
@@ -90,6 +91,20 @@ class TaskCrudService
                 }
                 if (in_array($newVal, ['done', 'cancelled'], true) && ! $task->completed_at) {
                     $task->completed_at = now();
+                }
+
+                // Fase 2 (ADR 0278) — consumer SOFT: fechar (done) sem prova de DoD
+                // vira evento de AVISO auditável. NÃO throw — o hard-gate é a Fase 3
+                // (deferida até o lease provar valor, ADR 0105).
+                if ($newVal === 'done'
+                    && empty($fields['acceptance_ref'])
+                    && empty($task->acceptance_ref)) {
+                    $events[] = McpTaskEvent::log(
+                        taskId: $task->task_id,
+                        eventType: 'field_updated',
+                        author: $author,
+                        note: 'AVISO Fase 2 (ADR 0278): movida pra done SEM acceptance_ref — DoD não comprovado. Hard-gate (Fase 3) vai barrar.',
+                    );
                 }
             }
 

--- a/Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Fase 2 (ADR 0278) — acceptance_ref em mcp_tasks + consumer SOFT no TaskCrudService.
+ *
+ * GUARD tests:
+ *   1. acceptance_ref persiste via service
+ *   2. acceptance_ref + status=done juntos → grava ref + carimba completed_at
+ *   3. done SEM acceptance_ref → evento de AVISO (soft, NÃO throw)
+ *   4. done COM acceptance_ref preexistente → nenhum aviso
+ *   5. campo não-whitelisted continua bloqueado (whitelist não virou wildcard)
+ *
+ * Padrão era-sqlite (schema sintético inline + activitylog OFF): a lane per-PR roda
+ * sqlite :memory:; RefreshDatabase puxaria a migration MySQL-only do extend de
+ * mcp_tasks (ALTER ... MODIFY ENUM) e quebraria. McpTask usa LogsActivity → desligo
+ * o activitylog pra não exigir a tabela activity_log.
+ *
+ * @see Modules/Jana/Database/Migrations/2026_06_15_150000_add_acceptance_ref_to_mcp_tasks.php
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético incompatível com MySQL persistente (floor SDD).');
+    }
+
+    config(['activitylog.enabled' => false]); // McpTask usa LogsActivity
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->json('blocked_by')->nullable();
+        $t->string('acceptance_ref', 500)->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('mcp_task_events', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('updated_at')->nullable();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+});
+
+function seedTask(string $id, string $status = 'todo', ?string $ref = null): void
+{
+    DB::table('mcp_tasks')->insert([
+        'task_id' => $id,
+        'module' => 'Governance',
+        'title' => 'T',
+        'status' => $status,
+        'acceptance_ref' => $ref,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('aceita acceptance_ref no update via service', function () {
+    seedTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['acceptance_ref' => 'PR #9999'], 'wagner');
+
+    expect(DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->value('acceptance_ref'))->toBe('PR #9999');
+})->group('acceptance-ref', 'ci');
+
+it('grava acceptance_ref junto com status done + carimba completed_at', function () {
+    seedTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done', 'acceptance_ref' => 'commit abc123'], 'wagner');
+
+    $row = DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->first();
+    expect($row->acceptance_ref)->toBe('commit abc123')
+        ->and($row->completed_at)->not->toBeNull();
+})->group('acceptance-ref', 'ci');
+
+it('done SEM acceptance_ref registra evento de aviso (soft, nao throw)', function () {
+    seedTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done'], 'wagner'); // não lança
+
+    $avisos = McpTaskEvent::where('task_id', 'US-GOV-099')
+        ->where('note', 'like', '%SEM acceptance_ref%')->count();
+    expect($avisos)->toBe(1);
+})->group('acceptance-ref', 'ci');
+
+it('done COM acceptance_ref preexistente nao gera aviso', function () {
+    seedTask('US-GOV-099', 'todo', 'PR #1');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done'], 'wagner');
+
+    $avisos = McpTaskEvent::where('task_id', 'US-GOV-099')
+        ->where('note', 'like', '%SEM acceptance_ref%')->count();
+    expect($avisos)->toBe(0);
+})->group('acceptance-ref', 'ci');
+
+it('campo nao-whitelisted continua bloqueado (whitelist nao virou wildcard)', function () {
+    seedTask('US-GOV-099');
+
+    expect(fn () => app(TaskCrudService::class)->update('US-GOV-099', ['foo' => 'x'], 'wagner'))
+        ->toThrow(RuntimeException::class);
+})->group('acceptance-ref', 'ci');


### PR DESCRIPTION
## O quê
**Fase 2** da arquitetura durável anti-vazamento ([ADR 0278](memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md)) — **vencedor de um painel adversarial** (5 opções avaliadas + refutador, sobreviveu a 5 vetores de refutação). Continuação do D1 ([#2781](https://github.com/wagnerra23/oimpresso.com/pull/2781)).

Ataca **R1 (não-vaza)**: `done` passa a poder carregar a **prova de DoD** (PR/commit/test path/smoke).

## Conteúdo (6 arquivos, 1 intent)
- **migration** — `acceptance_ref` (string 500, nullable) em `mcp_tasks`. Idempotente (`hasColumn`), sem `now()`, **sem `business_id`** (espelha mcp_tasks repo-wide, ADR 0070).
- **McpTask** `$fillable` + **TaskCrudService** whitelist + **consumer SOFT**: fechar (done) sem `acceptance_ref` registra um `McpTaskEvent` de **AVISO** — auditável/ruidoso, **não throw**.
- **TasksUpdateTool** — param no schema + forward no `foreach` (pegadinha: sem o forward o param é silenciosamente ignorado).
- **AcceptanceRefTest** (5 casos, era-sqlite sintético + `activitylog` OFF) **plugado na lane sqlite da ci.yml** — lição B2 do D1 (teste que não roda em CI = teatro).

## ⚠️ Escopo honesto (NÃO é o gate final)
- Isto é **estado + aviso soft**, **não** o hard-gate. Uma IA ainda consegue marcar `done` com `acceptance_ref` vazio — só fica **auditável** (evento). O **hard-gate** (throw) é a **Fase 3**, deliberadamente sequenciada para **depois do lease (D1) provar valor** (sinal qualificado, ADR 0105).
- Entrega só a metade `acceptance_ref` da Fase 2; a outra metade (`blocked_by`) já existe na migration base.

## Verificação
- ✅ `php -l` limpo nos 5 PHP.
- ⚠️ `AcceptanceRefTest` roda no CI (lane sqlite) — **não local** (sem vendor no worktree). **Por isso DRAFT.**

Refs: SDD Fase 2 · ADR 0278
🤖 Generated with [Claude Code](https://claude.com/claude-code)