### PR TITLE
feat(jana): updateInner ATÔMICO — DB::transaction + lockForUpdate (Fase 2b, ADR 0278)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML

--- a/Modules/Jana/Database/Migrations/2026_06_15_150000_add_acceptance_ref_to_mcp_tasks.php
+++ b/Modules/Jana/Database/Migrations/2026_06_15_150000_add_acceptance_ref_to_mcp_tasks.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * mcp_tasks.acceptance_ref — prova de DoD pra fechar uma task (Fase 2, ADR 0278).
+ *
+ * R1 (estado explícito, anti-vazamento): "done" passa a poder carregar a evidência
+ * que a satisfez (URL do PR / commit SHA / path de teste Pest / smoke). O consumer
+ * SOFT no TaskCrudService registra um evento de AVISO quando uma task vira `done`
+ * SEM esta referência — auditável/ruidoso, **não bloqueante**. O hard-gate (throw)
+ * é a Fase 3, sequenciada para DEPOIS do lease (D1) provar valor (ADR 0105).
+ *
+ * SEM business_id: mcp_tasks é cache git-synced repo-wide (ADR 0070, sem tenant) —
+ * a coluna nova espelha a tabela. String simples (não-gerada, sem now()).
+ * Idempotente (hasColumn guard) porque a lane per-PR roda contra sqlite :memory:.
+ *
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md (Fase 2)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('mcp_tasks') && ! Schema::hasColumn('mcp_tasks', 'acceptance_ref')) {
+            Schema::table('mcp_tasks', function (Blueprint $table) {
+                $table->string('acceptance_ref', 500)->nullable()->after('blocked_by')
+                    ->comment('Prova de DoD pra fechar (PR url / commit sha / test path / smoke). Fase 2 ADR 0278 — R1. Hard-gate = Fase 3.');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasTable('mcp_tasks') && Schema::hasColumn('mcp_tasks', 'acceptance_ref')) {
+            Schema::table('mcp_tasks', function (Blueprint $table) {
+                $table->dropColumn('acceptance_ref');
+            });
+        }
+    }
+};

--- a/Modules/Jana/Entities/Mcp/McpTask.php
+++ b/Modules/Jana/Entities/Mcp/McpTask.php
@@ -24,6 +24,9 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * REPO-WIDE: ADR 0070 jira-style cross-tenant intencional — planejamento é da
  * plataforma. Sem `business_id` by design. Wave 25 SATURATION marker explícito
  * pra rubrica D1.c v3.2 hardened.
+ *
+ * @property string|null $acceptance_ref Prova de DoD pra fechar (Fase 2, ADR 0278).
+ *           Coluna adicionada via ALTER — declarada aqui pro Larastan reconhecer.
  */
 class McpTask extends Model
 {

--- a/Modules/Jana/Entities/Mcp/McpTask.php
+++ b/Modules/Jana/Entities/Mcp/McpTask.php
@@ -57,6 +57,7 @@ class McpTask extends Model
         'labels',
         'custom_fields',
         'blocked_by',
+        'acceptance_ref',
         'source_path',
         'source_git_sha',
         'parsed_at',

--- a/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
@@ -45,6 +45,8 @@ class TasksUpdateTool extends Tool
                 ->description('Nova prioridade: p0|p1|p2|p3'),
             'module' => $schema->string()
                 ->description('Mover task pra outro módulo (ex: COPI→JANA pós-rename ADR 0088). Use uppercase.'),
+            'acceptance_ref' => $schema->string()
+                ->description('Prova de DoD pra fechar a task (URL do PR / commit SHA / path de teste Pest / evidência smoke). Recomendado ao mover pra done — Fase 2 ADR 0278. Use "—" pra limpar.'),
             'author' => $schema->string()
                 ->description('Quem está fazendo a mudança (para audit log). Default: wagner.'),
         ];
@@ -60,7 +62,7 @@ class TasksUpdateTool extends Tool
         $author = trim((string) $request->get('author', 'wagner')) ?: 'wagner';
 
         $campos = [];
-        foreach (['status', 'owner', 'sprint', 'priority', 'module'] as $field) {
+        foreach (['status', 'owner', 'sprint', 'priority', 'module', 'acceptance_ref'] as $field) {
             $val = $request->get($field);
             if ($val !== null) {
                 $v = trim((string) $val);

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -54,7 +54,23 @@ class TaskCrudService
      */
     protected function updateInner(string $taskId, array $fields, string $author = 'system'): array
     {
-        $task = $this->findTaskOrFail($taskId);
+        // Fase 2b (ADR 0278) — mutação ATÔMICA: transação + lock de linha fecham o
+        // lost-update (2 agentes na mesma task → last-write-wins silencioso = a causa
+        // literal do "a lista fura"). lockForUpdate serializa writers no MySQL; no
+        // sqlite da lane per-PR é no-op seguro (writes já são serializados).
+        return DB::transaction(fn (): array => $this->applyLockedUpdate($taskId, $fields, $author));
+    }
+
+    /**
+     * Corpo do update sob lock pessimista — chamado SEMPRE dentro de DB::transaction
+     * (por updateInner). O lockForUpdate de findTaskOrFail só tem efeito aqui dentro.
+     *
+     * @param  array<string,mixed> $fields
+     * @return array{task: McpTask, events: list<McpTaskEvent>}
+     */
+    protected function applyLockedUpdate(string $taskId, array $fields, string $author): array
+    {
+        $task = $this->findTaskOrFail($taskId, forUpdate: true);
 
         $allowed = [
             'status', 'owner', 'sprint', 'priority',
@@ -342,11 +358,15 @@ class TaskCrudService
 
     // ---------- helpers ----------
 
-    protected function findTaskOrFail(string $taskId): McpTask
+    protected function findTaskOrFail(string $taskId, bool $forUpdate = false): McpTask
     {
-        $task = McpTask::where('task_id', strtoupper($taskId))->first()
-            ?? McpTask::where('task_id', $taskId)->first()
-            ?? McpTask::where('identifier', strtoupper($taskId))->first();
+        // forUpdate=true só dentro de DB::transaction (applyLockedUpdate) — pega lock
+        // pessimista de linha pra fechar o lost-update. Builder novo por tentativa.
+        $q = fn () => $forUpdate ? McpTask::query()->lockForUpdate() : McpTask::query();
+
+        $task = $q()->where('task_id', strtoupper($taskId))->first()
+            ?? $q()->where('task_id', $taskId)->first()
+            ?? $q()->where('identifier', strtoupper($taskId))->first();
 
         if (! $task) {
             throw new \RuntimeException("Task '{$taskId}' não encontrada.");

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -98,7 +98,7 @@ class TaskCrudService
                 // (deferida até o lease provar valor, ADR 0105).
                 if ($newVal === 'done'
                     && empty($fields['acceptance_ref'])
-                    && empty($task->acceptance_ref)) {
+                    && empty($task->getAttribute('acceptance_ref'))) {
                     $events[] = McpTaskEvent::log(
                         taskId: $task->task_id,
                         eventType: 'field_updated',

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -62,6 +62,7 @@ class TaskCrudService
             'type', 'story_points', 'estimate_unit', 'estimate_value',
             'estimate_h', 'due_date', 'labels', 'custom_fields',
             'title', 'description', 'module',
+            'acceptance_ref',
         ];
         $events = [];
 
@@ -90,6 +91,20 @@ class TaskCrudService
                 }
                 if (in_array($newVal, ['done', 'cancelled'], true) && ! $task->completed_at) {
                     $task->completed_at = now();
+                }
+
+                // Fase 2 (ADR 0278) — consumer SOFT: fechar (done) sem prova de DoD
+                // vira evento de AVISO auditável. NÃO throw — o hard-gate é a Fase 3
+                // (deferida até o lease provar valor, ADR 0105).
+                if ($newVal === 'done'
+                    && empty($fields['acceptance_ref'])
+                    && empty($task->acceptance_ref)) {
+                    $events[] = McpTaskEvent::log(
+                        taskId: $task->task_id,
+                        eventType: 'field_updated',
+                        author: $author,
+                        note: 'AVISO Fase 2 (ADR 0278): movida pra done SEM acceptance_ref — DoD não comprovado. Hard-gate (Fase 3) vai barrar.',
+                    );
                 }
             }
 

--- a/Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Fase 2 (ADR 0278) — acceptance_ref em mcp_tasks + consumer SOFT no TaskCrudService.
+ *
+ * GUARD tests:
+ *   1. acceptance_ref persiste via service
+ *   2. acceptance_ref + status=done juntos → grava ref + carimba completed_at
+ *   3. done SEM acceptance_ref → evento de AVISO (soft, NÃO throw)
+ *   4. done COM acceptance_ref preexistente → nenhum aviso
+ *   5. campo não-whitelisted continua bloqueado (whitelist não virou wildcard)
+ *
+ * Padrão era-sqlite (schema sintético inline + activitylog OFF): a lane per-PR roda
+ * sqlite :memory:; RefreshDatabase puxaria a migration MySQL-only do extend de
+ * mcp_tasks (ALTER ... MODIFY ENUM) e quebraria. McpTask usa LogsActivity → desligo
+ * o activitylog pra não exigir a tabela activity_log.
+ *
+ * @see Modules/Jana/Database/Migrations/2026_06_15_150000_add_acceptance_ref_to_mcp_tasks.php
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético incompatível com MySQL persistente (floor SDD).');
+    }
+
+    config(['activitylog.enabled' => false]); // McpTask usa LogsActivity
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->json('blocked_by')->nullable();
+        $t->string('acceptance_ref', 500)->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('mcp_task_events', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('updated_at')->nullable();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+});
+
+function seedTask(string $id, string $status = 'todo', ?string $ref = null): void
+{
+    DB::table('mcp_tasks')->insert([
+        'task_id' => $id,
+        'module' => 'Governance',
+        'title' => 'T',
+        'status' => $status,
+        'acceptance_ref' => $ref,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('aceita acceptance_ref no update via service', function () {
+    seedTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['acceptance_ref' => 'PR #9999'], 'wagner');
+
+    expect(DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->value('acceptance_ref'))->toBe('PR #9999');
+})->group('acceptance-ref', 'ci');
+
+it('grava acceptance_ref junto com status done + carimba completed_at', function () {
+    seedTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done', 'acceptance_ref' => 'commit abc123'], 'wagner');
+
+    $row = DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->first();
+    expect($row->acceptance_ref)->toBe('commit abc123')
+        ->and($row->completed_at)->not->toBeNull();
+})->group('acceptance-ref', 'ci');
+
+it('done SEM acceptance_ref registra evento de aviso (soft, nao throw)', function () {
+    seedTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done'], 'wagner'); // não lança
+
+    $avisos = McpTaskEvent::where('task_id', 'US-GOV-099')
+        ->where('note', 'like', '%SEM acceptance_ref%')->count();
+    expect($avisos)->toBe(1);
+})->group('acceptance-ref', 'ci');
+
+it('done COM acceptance_ref preexistente nao gera aviso', function () {
+    seedTask('US-GOV-099', 'todo', 'PR #1');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done'], 'wagner');
+
+    $avisos = McpTaskEvent::where('task_id', 'US-GOV-099')
+        ->where('note', 'like', '%SEM acceptance_ref%')->count();
+    expect($avisos)->toBe(0);
+})->group('acceptance-ref', 'ci');
+
+it('campo nao-whitelisted continua bloqueado (whitelist nao virou wildcard)', function () {
+    seedTask('US-GOV-099');
+
+    expect(fn () => app(TaskCrudService::class)->update('US-GOV-099', ['foo' => 'x'], 'wagner'))
+        ->toThrow(RuntimeException::class);
+})->group('acceptance-ref', 'ci');

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
@@ -87,12 +87,15 @@ it('update sob transação+lock persiste e loga (sqlite-safe — lockForUpdate n
 it('update multi-campo commita o conjunto inteiro (atomicidade da transação)', function () {
     seedAtomicTask('US-GOV-099');
 
-    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'doing', 'owner' => 'eliana', 'priority' => 'p1'], 'wagner');
+    // 3 campos sem side-effect externo (owner dispararia maybeNotifyAssignment →
+    // query em `users`, ausente do schema sintético). status/priority/sprint provam
+    // a atomicidade do commit do conjunto sem dependência de outras tabelas.
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'doing', 'priority' => 'p1', 'sprint' => 'S1'], 'wagner');
 
     $row = DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->first();
     expect($row->status)->toBe('doing')
-        ->and($row->owner)->toBe('eliana')
-        ->and($row->priority)->toBe('p1');
+        ->and($row->priority)->toBe('p1')
+        ->and($row->sprint)->toBe('S1');
 })->group('atomic-update', 'ci');
 
 it('campo inválido reverte a transação inteira — sem escrita parcial (rollback real)', function () {

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Fase 2b (ADR 0278) — updateInner ATÔMICO (DB::transaction + lockForUpdate).
+ *
+ * Fecha o lost-update — a causa-raiz literal do "a lista fura": 2 agentes escrevendo
+ * a mesma task com last-write-wins silencioso. lockForUpdate serializa writers no
+ * MySQL; aqui (sqlite :memory:, single-thread) o valor do teste é provar (a) que o
+ * caminho atômico é SQLITE-SAFE e funcional, e (b) que a transação REVERTE escritas
+ * parciais. A prevenção de corrida concorrente é propriedade do MySQL, garantida por
+ * construção (transação + lock pessimista) — não unit-testável em sqlite single-thread.
+ *
+ * era-sqlite sintético + activitylog OFF (McpTask usa LogsActivity).
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético (floor SDD).');
+    }
+    config(['activitylog.enabled' => false]);
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('mcp_task_events', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('updated_at')->nullable();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+});
+
+function seedAtomicTask(string $id): void
+{
+    DB::table('mcp_tasks')->insert([
+        'task_id' => $id,
+        'module' => 'Governance',
+        'title' => 'T',
+        'status' => 'todo',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('update sob transação+lock persiste e loga (sqlite-safe — lockForUpdate não quebra a lane)', function () {
+    seedAtomicTask('US-GOV-099');
+
+    $r = app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'doing'], 'wagner');
+
+    expect($r['task']->status)->toBe('doing')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->value('status'))->toBe('doing')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->value('started_at'))->not->toBeNull()
+        ->and(McpTaskEvent::where('task_id', 'US-GOV-099')->where('event_type', 'status_changed')->count())->toBe(1);
+})->group('atomic-update', 'ci');
+
+it('update multi-campo commita o conjunto inteiro (atomicidade da transação)', function () {
+    seedAtomicTask('US-GOV-099');
+
+    app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'doing', 'owner' => 'eliana', 'priority' => 'p1'], 'wagner');
+
+    $row = DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->first();
+    expect($row->status)->toBe('doing')
+        ->and($row->owner)->toBe('eliana')
+        ->and($row->priority)->toBe('p1');
+})->group('atomic-update', 'ci');
+
+it('campo inválido reverte a transação inteira — sem escrita parcial (rollback real)', function () {
+    seedAtomicTask('US-GOV-099');
+
+    // Ordem: 'status' é processado (loga evento status_changed em mcp_task_events
+    // ANTES do save) e então 'xpto' lança RuntimeException (fora da whitelist).
+    expect(fn () => app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'doing', 'xpto' => 'y'], 'wagner'))
+        ->toThrow(RuntimeException::class);
+
+    // SEM a transação, o evento status_changed teria persistido (escrita parcial).
+    // COM a transação, ele reverte junto — ESTA é a prova do wrapper atômico.
+    expect(McpTaskEvent::where('task_id', 'US-GOV-099')->where('event_type', 'status_changed')->count())->toBe(0)
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-099')->value('status'))->toBe('todo');
+})->group('atomic-update', 'ci');


### PR DESCRIPTION
## A "1 coisa" que move a agulha
O painel adversarial + refutador apontaram: o gap #1 (concorrência, nota 18) tem uma causa-raiz LITERAL — `TaskCrudService::updateInner` era read-modify-write **sem transação, sem lock, sem versão** → **lost-update silencioso** quando 2 agentes tocam a mesma task. É o "a lista fura" no nível do banco.

## Fix (mínimo, sem migration)
- `updateInner` agora envolve a mutação em **`DB::transaction` + lock pessimista de linha** (`findTaskOrFail(forUpdate: true)` → `lockForUpdate`). Corpo extraído pra `applyLockedUpdate` (sem re-indent).
- `lockForUpdate` **serializa writers no MySQL**; no **sqlite** da lane per-PR é **no-op seguro** (writes já serializados) — portável.
- **3 testes** plugados na lane: sqlite-safe + atomicidade multi-campo + **rollback real** (o evento `status_changed` logado antes de um campo inválido reverte junto — só acontece COM a transação; é a prova do wrapper).

## Escopo honesto
- Torna a escrita **atômica**; **não** bloqueia por lease ainda (isso é a **Fase 3** — gate no barramento MCP). Aqui só fecha a corrida.
- A prevenção de corrida concorrente é propriedade do MySQL (lock+transação por construção) — não unit-testável em sqlite single-thread; os testes provam sqlite-safety + rollback.

## ⚠️ Stacked PR
Ramificado de `sdd/fase2-acceptance-ref` (#2784, auto-merge pendente) porque ambos tocam `updateInner`. O diff limpa quando #2784 mergear. Mergear DEPOIS de #2784.

Refs: SDD Fase 2b · ADR 0278
🤖 Generated with [Claude Code](https://claude.com/claude-code)