### PR TITLE
docs(governance): ADR 0280 — postura multi-tenant das tabelas mcp_* (repo-wide by-design)

### DIFF
--- a/memory/decisions/0280-postura-multi-tenant-tabelas-mcp-governanca.md
+++ b/memory/decisions/0280-postura-multi-tenant-tabelas-mcp-governanca.md
@@ -1,0 +1,106 @@
+---
+slug: 0280-postura-multi-tenant-tabelas-mcp-governanca
+number: 280
+title: "Postura multi-tenant das tabelas mcp_* — governança de plataforma é repo-wide (sem business_id) by-design; não é vazamento"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+kind: meta
+decided_by: [W]
+decided_at: "2026-06-15"
+module: governance
+tags: [governanca, multi-tenant, business_id, mcp, plataforma, tier-0, schema]
+supersedes: []
+superseded_by: []
+related:
+  - 0070-jira-style-task-management-current-md-removed
+  - 0093-multi-tenant-isolation-tier-0
+  - 0144-tasks-db-canonico-spec-template
+---
+
+# ADR 0280 — Postura multi-tenant das tabelas `mcp_*`: governança é repo-wide by-design
+
+## Contexto
+
+A regra Tier 0 do projeto é absoluta: **toda tabela de negócio** tem `business_id` com
+global scope ([ADR 0093](0093-multi-tenant-isolation-tier-0.md) · vazar dado entre tenants
+é o pior bug possível). A `.claude/rules/migrations.md` repete isso e prevê uma **exceção
+repo-wide** (ex: `users`, `permissions`) que "vira ADR".
+
+O módulo Jana criou ~45 tabelas `mcp_*`. Parte é dado **do cliente** (uso por business,
+alertas por business, sessões Claude Code por business). Outra parte é dado **da
+plataforma** — o backlog Jira-style, os eventos de task, os leases de coordenação do time.
+Essas últimas **não têm** `business_id` e isso é **proposital**, não esquecimento.
+
+O gatilho desta ADR foi a tabela nova `mcp_work_leases` ([ADR 0278](0278-arquitetura-rede-ia-duravel-anti-vazamento.md),
+migration `2026_06_15_140000`): ela espelha `mcp_tasks` (sem `business_id`) e justifica a
+exceção no próprio docblock. Um auditor de schema repo-wide ("toda tabela precisa de
+`business_id`") sinalizaria isso como vazamento Tier 0 — **falso positivo**. Faltava a ADR
+canônica que documenta a postura, pra que o gate (e o time MCP entrando: Felipe/Maiara/
+Eliana/Luiz) saiba distinguir os dois grupos sem reabrir a discussão a cada migration.
+
+## Decisão
+
+As tabelas `mcp_*` se dividem em **dois grupos**, e a ausência de `business_id` no grupo de
+governança é **invariante by-design**, não uma falha de isolamento:
+
+### Grupo A — Governança de plataforma (REPO-WIDE, SEM `business_id`)
+
+São o estado vivo do desenvolvimento de uma **única organização** (oimpresso). Coordenação
+de time é cross-business por natureza — uma US, um cycle, um lease pertencem ao **projeto**,
+não a um cliente. Citadas no spec, mais o conjunto Jira-style ([ADR 0070](0070-jira-style-task-management-current-md-removed.md) ·
+[ADR 0144](0144-tasks-db-canonico-spec-template.md): o DB é canon do estado vivo):
+
+- **`mcp_tasks`** — backlog canônico (US/subtask). Precedente raiz.
+- **`mcp_task_events`** — timeline append-only por task.
+- **`mcp_work_leases`** — lease "no máx 1 sessão/agente por task ativa" ([ADR 0278](0278-arquitetura-rede-ia-duravel-anti-vazamento.md)).
+- Demais do estado Jira-style: `mcp_task_comments`, `mcp_jira_projects`, `mcp_epics`,
+  `mcp_cycles`, `mcp_cycle_goals`, `mcp_components`, `mcp_workflows`, `mcp_issue_templates`,
+  `mcp_views`, `mcp_inbox_notifications`, `mcp_task_dependencies`, `mcp_task_watchers`,
+  `mcp_task_attachments`, `mcp_task_memory_links`, `mcp_git_links`, `mcp_automation_runs`,
+  `mcp_memory_documents` / `_history` (cache git-synced do conhecimento canônico),
+  `mcp_tokens` / `mcp_quotas` / `mcp_cc_blobs`, `mcp_skill_versions` / `_labels` /
+  `_approvals`.
+
+### Grupo B — Dado de cliente / por-tenant (TEM `business_id`, global scope)
+
+Onde existe sinal real de tenant (uso, custo, alertas, sessões e mensagens do cliente),
+a regra Tier 0 vale integralmente — `business_id` NOT NULL + index + FK + global scope:
+
+- **`mcp_audit_log`** — TEM `business_id` (coluna + `mcp_al_biz_ts_idx` + FK→`business`).
+  É o caso canônico do grupo B: auditoria é segregada por tenant.
+- `mcp_scopes`, `mcp_user_scopes`, `mcp_usage_diaria`, `mcp_alertas`, `mcp_alertas_eventos`,
+  `mcp_cc_sessions`, `mcp_cc_messages`, `mcp_skills`, `mcp_skill_test_runs`,
+  `mcp_handoff_summaries`, `mcp_handoff_diffs`, `mcp_weekly_digests`, `mcp_doc_summaries`,
+  `mcp_scorecard_ai_suggestions`, `mcp_automations`.
+
+## Invariante
+
+> **Ausência de `business_id` numa tabela `mcp_*` de governança NÃO é vazamento de tenant** —
+> porque (1) é dado de **plataforma** (estado de desenvolvimento), não dado de **cliente**, e
+> (2) o MCP serve **1 organização**, então não há fronteira de tenant a cruzar. A fronteira
+> Tier 0 existe entre os clientes do ERP (Grupo B), não dentro da governança do próprio
+> projeto (Grupo A).
+
+Regras complementares:
+
+1. **O default permanece Grupo B.** Toda tabela `mcp_*` nova nasce tenant-scoped salvo prova
+   de que é puramente governança de plataforma. Na dúvida → `business_id` (lado seguro).
+2. **A exceção precisa estar escrita no docblock da migration** (precedente `mcp_work_leases`:
+   "SEM business_id: espelha mcp_tasks... Exceção a `.claude/rules/migrations.md` justificada
+   aqui") **e** referenciar esta ADR — assim o gate de schema não acusa falso positivo.
+3. **Esta ADR não cria nem altera coluna alguma** — é puramente declaratória da postura já
+   implementada. ADR é append-only ([ADR 0093](0093-multi-tenant-isolation-tier-0.md) §lifecycle).
+
+## Consequências
+
+- O auditor de schema repo-wide pode usar a lista acima como allowlist do Grupo A (ou checar
+  a referência a esta ADR no docblock) — para de gerar falso positivo de "tabela sem
+  `business_id`" no backlog/leases/eventos.
+- Time MCP entrando (Felipe/Maiara/Eliana/Luiz) tem a regra explícita: governança = repo-wide,
+  cliente = por-tenant — sem reabrir a discussão por migration.
+- Risco: alguém classificar como Grupo A uma tabela que de fato carrega dado de cliente. Mitigado
+  pelo default (regra 1: na dúvida é Grupo B) e pela exigência de justificativa escrita + ref ADR
+  na migration (regra 2), que vira artefato revisável no PR.
+- Esta ADR é D2 (postura de governança Tier 0 multi-tenant) — aceita por Wagner em 2026-06-15.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **284** arquivos · **269** números únicos · máx **0279**
-- **ADRs ATIVOS (lifecycle ativo): 244** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 222 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 244 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **285** arquivos · **270** números únicos · máx **0280**
+- **ADRs ATIVOS (lifecycle ativo): 245** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 223 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 245 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (284)
+## Todas as ADRs (285)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -316,3 +316,4 @@ _(íntegra)_
 | 0277 | aceito | ativo | meta | Rota de migração do backbone Blade (UltimatePOS) — contrato de completude por ro |
 | 0278 | aceito | ativo | meta | Arquitetura durável de automação multi-IA (anti-vazamento, thread-aware, em rede |
 | 0279 | aceito | ativo | meta | Fechar o elo MEDIR→GOVERNAR do floor (transporte CT100 → scorecard, Opção A) |
+| 0280 | aceito | ativo | meta | Postura multi-tenant das tabelas mcp_* — governança de plataforma é repo-wide (s |


### PR DESCRIPTION
## O quê

ADR-only (zero código). Cria `memory/decisions/0280-postura-multi-tenant-tabelas-mcp-governanca.md` documentando a **postura multi-tenant** das tabelas `mcp_*`:

- **Grupo A (REPO-WIDE, sem `business_id`):** `mcp_tasks`, `mcp_task_events`, `mcp_work_leases` + todo o estado Jira-style. Governança de plataforma de **1 organização** — coordenação de time é cross-business por natureza.
- **Grupo B (tenant-scoped, TEM `business_id`):** `mcp_audit_log` (coluna + `mcp_al_biz_ts_idx` + FK→business) e demais dados de cliente (uso, alertas, sessões CC, skills).
- **Invariante:** ausência de `business_id` na governança **não é vazamento** — é dado de plataforma (não de cliente) + MCP serve 1 org (não há fronteira de tenant a cruzar).

Gatilho: `mcp_work_leases` ([ADR 0278](memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md), migration 2026_06_15_140000) que espelha `mcp_tasks` sem `business_id` — faltava a ADR canônica pra que o gate de schema não acuse falso positivo Tier 0.

Frontmatter espelha exatamente ADR 0276 (Nygard, kind meta, module governance). Related: 0070/0093/0144.

## Acceptance

- [x] `0280` livre antes do commit (max era 0279)
- [x] Frontmatter valida contra `scripts/memory-schemas/adr.schema.json` (AJV 2020, `VALID: true`)
- [x] `node scripts/governance/adr-index-generate.mjs --write` rodado; `_INDEX-GENERATED.md` no commit (285 ADRs, máx 0280, 0 alertas de supersessão)
- [x] `--check` passa (índice em dia → gate "índice de ADR em dia" verde)
- [x] ADR append-only — não duplica/altera canon, ESTENDE a postura já implementada nas migrations
- [x] Grounded no código real (verificado business_id em cada migration `mcp_*`)

## Teste

Sem teste de código (ADR-only). N/A — _teste NÃO plugado na lane ainda (centralizado)_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)