### PR TITLE
feat(jana): detecta divergencia descritiva SPEC<->DB no sync (SDD C4)

### DIFF
--- a/Modules/Jana/Console/Commands/McpTasksSyncCommand.php
+++ b/Modules/Jana/Console/Commands/McpTasksSyncCommand.php
@@ -47,6 +47,15 @@ class McpTasksSyncCommand extends Command
         $this->line("  Inseridas:    {$relatorio['inseridas']}");
         $this->line("  Atualizadas:  {$relatorio['atualizadas']}");
         $this->line("  Canceladas:   {$relatorio['canceladas']} (US sumiu do SPEC)");
+        // SDD C4 — visibilidade de drift descritivo (title/description) DB↔SPEC.
+        // git venceu o update (não muda quem é canon); só reportamos a divergência.
+        $divergentes = $relatorio['descritivos_divergentes'] ?? 0;
+        $linhaDivergentes = "  Divergências descritivas: {$divergentes} (title/description DB↔SPEC — git venceu)";
+        if ($divergentes > 0) {
+            $this->warn($linhaDivergentes);
+        } else {
+            $this->line($linhaDivergentes);
+        }
         if (! empty($relatorio['modulos'])) {
             $this->line('');
             $this->line('Módulos:');

--- a/Modules/Jana/Services/TaskRegistry/TaskParserService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskParserService.php
@@ -59,9 +59,17 @@ class TaskParserService
     public const LIVE_STATE_FIELDS = ['status', 'owner', 'sprint', 'priority'];
 
     /**
+     * Campos descritivos onde o git é canon (SPEC sobrescreve o DB no update).
+     * Divergência DB↔SPEC nestes campos é APENAS detectada e contabilizada
+     * (SDD C4) — git continua ganhando, sem mudar quem é canon. NÃO confundir
+     * com LIVE_STATE_FIELDS (DB canon, nunca sobrescrito — ADR 0144).
+     */
+    public const DESCRITIVOS_DETECTAVEIS = ['title', 'description'];
+
+    /**
      * Parser SPEC + sync DB. Retorna relatório por módulo.
      *
-     * @return array{tasks_processadas:int, inseridas:int, atualizadas:int, canceladas:int, modulos:array<string,int>}
+     * @return array{tasks_processadas:int, inseridas:int, atualizadas:int, canceladas:int, descritivos_divergentes:int, modulos:array<string,int>}
      */
     public function syncAll(?string $apenasModulo = null): array
     {
@@ -75,12 +83,13 @@ class TaskParserService
     {
         $base = base_path('memory/requisitos');
         if (! is_dir($base)) {
-            return $this->relatorio(0, 0, 0, 0, []);
+            return $this->relatorio(0, 0, 0, 0, 0, []);
         }
 
         $reportadasNoSync = [];
         $inseridas = 0;
         $atualizadas = 0;
+        $descritivosDivergentes = 0;
         $modulos = [];
 
         $iterator = new \DirectoryIterator($base);
@@ -109,6 +118,14 @@ class TaskParserService
                     McpTask::create($cand);
                     $inseridas++;
                 } elseif ($this->precisaAtualizar($existente, $cand)) {
+                    // SDD C4 — detectar (não resolver) divergência SPEC↔DB em
+                    // campos descritivos (title/description). git continua canon
+                    // (preserva ADR 0144 zero-regressão de estado vivo); aqui só
+                    // contabilizamos + logamos pra dar visibilidade ao drift.
+                    if ($this->detectarDivergenciaDescritiva($existente, $cand)) {
+                        $descritivosDivergentes++;
+                    }
+
                     // Task existente — ADR 0144 — só atualiza campos descritivos.
                     // Estado vivo (status/owner/sprint/priority) é canônico no DB,
                     // mudança via `tasks-update`. SPEC vira template descritivo.
@@ -148,9 +165,10 @@ class TaskParserService
             'inseridas' => $inseridas,
             'atualizadas' => $atualizadas,
             'canceladas' => $canceladas,
+            'descritivos_divergentes' => $descritivosDivergentes,
         ]);
 
-        return $this->relatorio(count($reportadasNoSync), $inseridas, $atualizadas, $canceladas, $modulos);
+        return $this->relatorio(count($reportadasNoSync), $inseridas, $atualizadas, $canceladas, $descritivosDivergentes, $modulos);
     }
 
     /**
@@ -467,6 +485,45 @@ class TaskParserService
         }
     }
 
+    /**
+     * Detecta (NÃO resolve) divergência DB↔SPEC em campos descritivos
+     * (title/description) — SDD C4.
+     *
+     * git continua canon: o update logo a seguir vai sobrescrever o DB com o
+     * valor do SPEC normalmente (não muda quem ganha, preserva ADR 0144 que só
+     * blinda estado vivo status/owner/sprint/priority). Esta verificação só dá
+     * VISIBILIDADE ao drift — loga + alimenta o contador `descritivos_divergentes`.
+     *
+     * @return bool true se title OU description divergem
+     */
+    protected function detectarDivergenciaDescritiva(McpTask $existente, array $cand): bool
+    {
+        $divergencias = [];
+        foreach (self::DESCRITIVOS_DETECTAVEIS as $field) {
+            $vDb = (string) ($existente->{$field} ?? '');
+            $vSpec = (string) ($cand[$field] ?? '');
+            if ($vDb !== $vSpec) {
+                $divergencias[$field] = [
+                    'db' => mb_substr($vDb, 0, 120),
+                    'spec' => mb_substr($vSpec, 0, 120),
+                ];
+            }
+        }
+
+        if (empty($divergencias)) {
+            return false;
+        }
+
+        Log::channel('copiloto-ai')->info('TaskParser detectou divergência descritiva SPEC↔DB (SDD C4)', [
+            'task_id' => $existente->task_id,
+            'campos' => array_keys($divergencias),
+            'divergencias' => $divergencias,
+            'canon' => 'git', // git vence o update — só registramos o drift
+        ]);
+
+        return true;
+    }
+
     /** Cache em-memória pra evitar query repetida no mesmo sync. */
     protected array $cacheProjetos = [];
     protected array $cacheEpics = [];
@@ -533,13 +590,14 @@ class TaskParserService
         return $head !== '' ? substr($head, 0, 40) : null;
     }
 
-    protected function relatorio(int $processadas, int $ins, int $upd, int $can, array $modulos): array
+    protected function relatorio(int $processadas, int $ins, int $upd, int $can, int $descritivosDivergentes, array $modulos): array
     {
         return [
             'tasks_processadas' => $processadas,
             'inseridas' => $ins,
             'atualizadas' => $upd,
             'canceladas' => $can,
+            'descritivos_divergentes' => $descritivosDivergentes,
             'modulos' => $modulos,
         ];
     }

--- a/Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Services\TaskRegistry\TaskParserService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * SDD C4 — detectar (NÃO resolver) divergência SPEC↔DB em campos descritivos.
+ *
+ * Quando o sync git→DB atualiza uma task existente, se title OU description do
+ * DB divergirem do SPEC, o TaskParserService:
+ *   1. loga a divergência (canal copiloto-ai), e
+ *   2. incrementa o contador `descritivos_divergentes` no relatório de retorno.
+ *
+ * NÃO muda quem ganha: git continua canon nos campos descritivos (o update
+ * sobrescreve o DB com o SPEC normalmente). Estado vivo (status/owner/sprint/
+ * priority) permanece blindado pelo ADR 0144 — zero-regressão.
+ *
+ * Cobertura em 2 modos (espelha TaskParserPreservaEstadoVivoTest):
+ *  - Testes unit (sem DB) que travam o contrato do helper + contador
+ *  - Teste integração (skip local — roda em CT 100/MySQL) porque
+ *    RefreshDatabase com SQLite quebra na migration legacy UltimatePOS
+ *    `ALTER TABLE transactions MODIFY COLUMN type ENUM(...)` (MySQL-only).
+ */
+
+// ─── Testes unit (rodam local na lane sqlite — sem DB) ──────────────────
+
+it('expõe DESCRITIVOS_DETECTAVEIS = title + description', function () {
+    expect(TaskParserService::DESCRITIVOS_DETECTAVEIS)
+        ->toBe(['title', 'description']);
+});
+
+it('detectarDivergenciaDescritiva retorna false quando title e description batem', function () {
+    $svc = new TaskParserService();
+    $reflect = (new ReflectionClass(TaskParserService::class))
+        ->getMethod('detectarDivergenciaDescritiva');
+    $reflect->setAccessible(true);
+
+    // Log não deve ser chamado quando não há divergência.
+    Log::shouldReceive('channel')->never();
+
+    $existente = new McpTask([
+        'task_id' => 'US-X-1',
+        'title' => 'Mesmo título',
+        'description' => 'Mesma descrição',
+    ]);
+
+    $cand = [
+        'title' => 'Mesmo título',
+        'description' => 'Mesma descrição',
+    ];
+
+    expect($reflect->invoke($svc, $existente, $cand))->toBeFalse();
+});
+
+it('detectarDivergenciaDescritiva retorna true quando description diverge e loga drift', function () {
+    $svc = new TaskParserService();
+    $reflect = (new ReflectionClass(TaskParserService::class))
+        ->getMethod('detectarDivergenciaDescritiva');
+    $reflect->setAccessible(true);
+
+    $existente = new McpTask([
+        'task_id' => 'US-X-2',
+        'title' => 'Título igual',
+        'description' => 'Descrição ANTIGA no DB',
+    ]);
+
+    $cand = [
+        'title' => 'Título igual',
+        'description' => 'Descrição NOVA vinda do git/SPEC',
+    ];
+
+    Log::shouldReceive('channel')
+        ->with('copiloto-ai')
+        ->andReturnSelf();
+    Log::shouldReceive('info')
+        ->with(
+            'TaskParser detectou divergência descritiva SPEC↔DB (SDD C4)',
+            \Mockery::on(function ($ctx) {
+                return $ctx['task_id'] === 'US-X-2'
+                    && $ctx['campos'] === ['description']
+                    && $ctx['canon'] === 'git'
+                    && str_contains($ctx['divergencias']['description']['db'], 'ANTIGA')
+                    && str_contains($ctx['divergencias']['description']['spec'], 'NOVA')
+                    && ! isset($ctx['divergencias']['title']);
+            })
+        )
+        ->once();
+
+    expect($reflect->invoke($svc, $existente, $cand))->toBeTrue();
+});
+
+it('detectarDivergenciaDescritiva pega divergência só no title também', function () {
+    $svc = new TaskParserService();
+    $reflect = (new ReflectionClass(TaskParserService::class))
+        ->getMethod('detectarDivergenciaDescritiva');
+    $reflect->setAccessible(true);
+
+    $existente = new McpTask([
+        'task_id' => 'US-X-3',
+        'title' => 'Título velho',
+        'description' => 'desc igual',
+    ]);
+    $cand = [
+        'title' => 'Título renomeado no SPEC',
+        'description' => 'desc igual',
+    ];
+
+    Log::shouldReceive('channel')->with('copiloto-ai')->andReturnSelf();
+    Log::shouldReceive('info')->once();
+
+    expect($reflect->invoke($svc, $existente, $cand))->toBeTrue();
+});
+
+it('relatorio inclui chave descritivos_divergentes', function () {
+    $svc = new TaskParserService();
+    $reflect = (new ReflectionClass(TaskParserService::class))
+        ->getMethod('relatorio');
+    $reflect->setAccessible(true);
+
+    $rel = $reflect->invoke($svc, 5, 1, 2, 0, 3, ['X' => 5]);
+
+    expect($rel)->toHaveKey('descritivos_divergentes')
+        ->and($rel['descritivos_divergentes'])->toBe(3)
+        ->and($rel)->toHaveKey('atualizadas')
+        ->and($rel['atualizadas'])->toBe(2);
+});
+
+// ─── Teste integração (skip local — roda em CT 100/MySQL) ───────────────
+
+function tpDivMod(string $mod): string
+{
+    return '__TestSddC4_' . $mod;
+}
+
+function tpDivWriteSpec(string $module, string $body): string
+{
+    $dir = base_path("memory/requisitos/{$module}");
+    if (! is_dir($dir)) {
+        File::makeDirectory($dir, 0755, true);
+    }
+    $path = $dir . '/SPEC.md';
+    file_put_contents($path, $body);
+    return $path;
+}
+
+function tpDivCleanup(): void
+{
+    foreach (['DIVA'] as $m) {
+        $dir = base_path('memory/requisitos/' . tpDivMod($m));
+        if (is_dir($dir)) {
+            File::deleteDirectory($dir);
+        }
+    }
+}
+
+it('integração: description divergente → contador ≥1 + estado vivo preservado', function () {
+    afterEach(fn () => tpDivCleanup());
+
+    $module = tpDivMod('DIVA');
+
+    // 1) Cria a task a partir do SPEC.
+    tpDivWriteSpec($module, <<<MD
+    ### US-SDDC4DIVA-1 · Título inicial
+
+    > owner: wagner · status: todo · priority: p2
+
+    Descrição original vinda do SPEC.
+    MD);
+
+    $svc = new TaskParserService();
+    $svc->syncAll($module);
+
+    $task = McpTask::where('task_id', 'US-SDDC4DIVA-1')->first();
+    expect($task)->not->toBeNull()
+        ->and($task->description)->toContain('Descrição original');
+
+    // 2) Simula estado vivo evoluindo no DB (tasks-update) + description
+    //    editada no DB divergindo do que ainda está no SPEC.
+    $task->update([
+        'status' => 'doing',
+        'owner' => 'felipe',
+        'priority' => 'p0',
+        'sprint' => 'CYCLE-08',
+        'description' => 'Descrição EDITADA direto no DB (drift).',
+    ]);
+
+    // 3) SPEC muda a description (git canon) — deve detectar divergência.
+    tpDivWriteSpec($module, <<<MD
+    ### US-SDDC4DIVA-1 · Título inicial
+
+    > owner: wagner · status: todo · priority: p2
+
+    Descrição NOVA no SPEC depois de discussão.
+    MD);
+
+    $rel = $svc->syncAll($module);
+
+    // Contador detectou o drift descritivo.
+    expect($rel['descritivos_divergentes'])->toBeGreaterThanOrEqual(1);
+
+    $task->refresh();
+
+    // git venceu o update descritivo (não mudou quem é canon).
+    expect($task->description)->toContain('Descrição NOVA no SPEC');
+
+    // Estado vivo preservado (ADR 0144 — zero regressão).
+    expect($task->status)->toBe('doing')
+        ->and($task->owner)->toBe('felipe')
+        ->and($task->priority)->toBe('p0')
+        ->and($task->sprint)->toBe('CYCLE-08');
+})->skip('requer MySQL — RefreshDatabase com SQLite quebra na migration legacy UltimatePOS ALTER TABLE MODIFY ENUM. Rodar em CT 100 (Tailscale) ou Laragon com MYSQL_TESTING. Cobertura unit acima trava o contrato do helper + contador na lane sqlite.');


### PR DESCRIPTION
## O quê

Detecta (NÃO resolve) divergência SPEC↔DB em campos descritivos (`title`/`description`) durante o sync git→DB do TaskRegistry.

- `TaskParserService::syncAll` compara o valor do DB vs o do SPEC **antes** do update de cada task existente.
- Se `title` OU `description` divergirem: loga no canal `copiloto-ai` (`TaskParser detectou divergência descritiva SPEC↔DB (SDD C4)`) + incrementa o contador `descritivos_divergentes` no relatório de retorno.
- **Não muda quem ganha:** git continua canon nos campos descritivos (o update sobrescreve o DB com o SPEC normalmente). Estado vivo (`status/owner/sprint/priority`) segue blindado pelo **ADR 0144** (zero-regressão).
- `McpTasksSyncCommand` expõe o contador no output (linha "Divergências descritivas: N", `warn` quando > 0).

## Acceptance

- [x] Counter `descritivos_divergentes` no relatório de `syncAll`.
- [x] Log de visibilidade do drift (sem alterar canon).
- [x] Estado vivo preservado (ADR 0144) — git só vence campos descritivos como já era.
- [x] Counter exposto no `mcp:tasks:sync`.
- [x] Teste Pest: description divergente DB↔SPEC → contador ≥1 + estado vivo preservado.

## Teste

`Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php`
- Unit (rodam na lane sqlite): contrato do helper `detectarDivergenciaDescritiva`, constante `DESCRITIVOS_DETECTAVEIS`, chave `descritivos_divergentes` no relatório, log do drift.
- Integração (MySQL-only via `->skip()`, espelha `TaskParserPreservaEstadoVivoTest`): description divergente → contador ≥1 + estado vivo preservado.

**Teste NÃO plugado na lane ainda (centralizado depois).**

Refs: SDD C4 · ADR 0278

🤖 Generated with [Claude Code](https://claude.com/claude-code)