### PR TITLE
feat(jana): TasksClaimTool propaga X-Claude-Code-Session pro lease (LEASE-HABITO)

### DIFF
--- a/Modules/Jana/Mcp/Tools/TasksClaimTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksClaimTool.php
@@ -55,13 +55,20 @@ class TasksClaimTool extends Tool
         $principal = (string) ($user->username ?? $user->email ?? ('user#' . $user->getAuthIdentifier()));
         $agentId = trim((string) $request->get('agent_id', '')) ?: null;
 
+        // Sessão Claude Code (R4: correlaciona lease ↔ mcp_audit_log/mcp_cc_sessions).
+        // Lida da HTTP Request via global helper — mesmo header que o McpAuthMiddleware
+        // consome (X-Claude-Code-Session, ~linha 126). $request aqui é o Laravel\Mcp\Request
+        // (protocolo MCP/args), não a HTTP Request — por isso o helper request().
+        // NÃO muda a chave de conflito (C1, signal-gated): só propaga o dado.
+        $session = trim((string) (request()->header('X-Claude-Code-Session') ?? '')) ?: null;
+
         $svc = app(WorkLeaseService::class);
 
         if (! $svc->taskExists($taskId)) {
             return Response::text("❌ Task `{$taskId}` não existe no cache mcp_tasks. Crie/sincronize a US antes de dar claim.");
         }
 
-        $res = $svc->claim($taskId, $principal, $agentId);
+        $res = $svc->claim($taskId, $principal, $agentId, $session);
 
         if (! $res['ok']) {
             $h = $res['holder'];

--- a/Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
@@ -102,6 +102,29 @@ it('claim adquire lease quando a task está livre', function () {
         ->and($res['lease']->agent_id)->toBe('claude-code');
 })->group('work-lease', 'ci');
 
+it('claim com sessão setada grava claude_code_session (LEASE-HABITO — TasksClaimTool propaga)', function () {
+    // dim 4 (prep): a TasksClaimTool agora lê X-Claude-Code-Session da HTTP Request
+    // e propaga como 4º arg do claim(). Este guard prova o contrato do Service que a
+    // tool usa: $session → coluna claude_code_session (gera o PRIMEIRO sinal real da
+    // Raia C/reconciler). Não muda a chave de conflito (C1, signal-gated).
+    $svc = app(WorkLeaseService::class);
+    $res = $svc->claim('US-GOV-022', 'wagner', 'claude-code', 'sess-abc123');
+
+    expect($res['ok'])->toBeTrue()
+        ->and($res['lease']->claude_code_session)->toBe('sess-abc123')
+        ->and(DB::table('mcp_work_leases')
+            ->where('task_id', 'US-GOV-022')
+            ->value('claude_code_session'))->toBe('sess-abc123');
+})->group('work-lease', 'ci');
+
+it('claim sem sessão deixa claude_code_session NULL (default, retrocompat)', function () {
+    $svc = app(WorkLeaseService::class);
+    $res = $svc->claim('US-GOV-022', 'wagner', 'claude-code');
+
+    expect($res['ok'])->toBeTrue()
+        ->and($res['lease']->claude_code_session)->toBeNull();
+})->group('work-lease', 'ci');
+
 it('claim por outro principal numa task ativa retorna conflito held (não estoura)', function () {
     $svc = app(WorkLeaseService::class);
     $svc->claim('US-GOV-022', 'wagner');


### PR DESCRIPTION
## O quê

`Modules/Jana/Mcp/Tools/TasksClaimTool.php` chamava `$svc->claim($taskId, $principal, $agentId)` — o 4º arg `$session` virava `null`, então o lease nunca distinguia sessão.

Esta mudança lê o header `X-Claude-Code-Session` (o mesmo que `McpAuthMiddleware` já consome, ~linha 126) via `request()->header()` dentro do Tool e o propaga como `$session` pro `WorkLeaseService::claim()`, que **já** aceita o 4º arg e grava na coluna `claude_code_session` (confirmado em `WorkLeaseService.php:72,93` e na migration `2026_06_15_140000_create_mcp_work_leases_table.php:66`).

É o pré-req de toda a Raia C/reconciler: gera o **primeiro sinal real** (qual sessão segura qual lease). **Não muda a chave de conflito** — isso é C1, signal-gated. Só propaga o dado pra começar a gerá-lo. dim 4 (prep).

## Por que `request()` e não `$request`

O `$request` injetado no `handle()` é `Laravel\Mcp\Request` (args do protocolo MCP), não a `Illuminate\Http\Request`. O header HTTP é lido via o helper global `request()` — a mesma instância que o middleware processou.

## Acceptance

- [x] `TasksClaimTool` lê `X-Claude-Code-Session` e passa como 4º arg do `claim()`
- [x] Sem sessão → `null` (retrocompat, coluna nullable)
- [x] Chave de conflito `UNIQUE(task_id, active_marker)` **inalterada** (C1 fora de escopo)
- [x] Teste Pest era-sqlite (padrão `WorkLeaseServiceTest`): claim com sessão → coluna `claude_code_session` preenchida; sem sessão → NULL
- [x] `php -l` limpo nos 2 arquivos

## Teste

`Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php` (2 casos novos, grupo `work-lease`/`ci`, padrão era-sqlite com `markTestSkipped` em não-sqlite).

⚠️ Teste **NÃO plugado na lane ainda** (centralizado depois). `ci.yml` e `financeiro-pest.yml` intocados.

Refs: SDD LEASE-HABITO · ADR 0278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
