### PR TITLE
feat(teammcp): heartbeat do ingest pra matar SPOF do watcher

### DIFF
--- a/Modules/TeamMcp/Database/Migrations/2026_06_15_100000_create_mcp_ingest_heartbeat_table.php
+++ b/Modules/TeamMcp/Database/Migrations/2026_06_15_100000_create_mcp_ingest_heartbeat_table.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * B-LIVE-HB (SDD · ADR 0278) — Heartbeat do ingest (núcleo do fim do SPOF).
+ *
+ * 1 linha por `host` (máquina/cwd do watcher local de cada dev). Toda vez que
+ * POST /api/cc/ingest grava com sucesso, o controller do TeamMcp faz UPSERT
+ * idempotente bumpando `last_ingest_at`, `last_session_uuid` e somando `msgs_acc`.
+ * Um reader/liveness service (tarefa SEPARADA) lê essa tabela pra detectar SPOF
+ * (nenhum ingest recente = watcher caído).
+ *
+ * FRONTEIRA (refutador): tabela + writer vivem em Modules/TeamMcp (dono do
+ * ingest), NÃO em Jana.
+ *
+ * Tier 0 ({@see ADR 0093}): SEM `business_id` — espelha `mcp_cc_sessions`
+ * cross-tenant by design (heartbeat é de infra/máquina, não de tenant).
+ * UNIQUE em `host` garante 1 linha por máquina pra upsert.
+ *
+ * Idempotente (hasTable) + reversível (down dropIfExists).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('mcp_ingest_heartbeat')) {
+            return;
+        }
+
+        Schema::create('mcp_ingest_heartbeat', function (Blueprint $t) {
+            $t->bigIncrements('id');
+
+            // Chave de upsert — máquina/cwd do watcher (espelha project_path do session).
+            // SEM business_id (cross-tenant, igual mcp_cc_sessions).
+            $t->string('host', 500)->unique()
+                ->comment('Host/cwd do watcher local (chave de upsert idempotente)');
+
+            $t->timestamp('last_ingest_at')->nullable()
+                ->comment('Quando o último POST /api/cc/ingest gravou com sucesso');
+            $t->string('last_session_uuid', 36)->nullable()
+                ->comment('UUID da última session ingerida por este host');
+            $t->unsignedBigInteger('msgs_acc')->default(0)
+                ->comment('Acumulador de mensagens ingeridas (msgs_acc += N por POST)');
+
+            $t->timestamps();
+
+            $t->index('last_ingest_at', 'mcp_ingest_hb_last_ingest_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('mcp_ingest_heartbeat');
+    }
+};

--- a/Modules/TeamMcp/Entities/McpIngestHeartbeat.php
+++ b/Modules/TeamMcp/Entities/McpIngestHeartbeat.php
@@ -19,6 +19,11 @@ use Illuminate\Database\Eloquent\Model;
  * scope de business aqui.
  *
  * @see Modules\TeamMcp\Http\Controllers\Mcp\CcIngestController (writer)
+ *
+ * @property string $host
+ * @property \Illuminate\Support\Carbon|null $last_ingest_at
+ * @property string|null $last_session_uuid
+ * @property int $msgs_acc
  */
 class McpIngestHeartbeat extends Model
 {

--- a/Modules/TeamMcp/Entities/McpIngestHeartbeat.php
+++ b/Modules/TeamMcp/Entities/McpIngestHeartbeat.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * B-LIVE-HB (SDD · ADR 0278) — Heartbeat do ingest.
+ *
+ * 1 linha por `host`. Escrita (upsert) no caminho de sucesso de
+ * POST /api/cc/ingest pelo CcIngestController do TeamMcp. Reader/liveness
+ * service é tarefa SEPARADA (não cria aqui).
+ *
+ * Tier 0 ({@see ADR 0093}): SEM `business_id` e SEM `HasBusinessScope` —
+ * cross-tenant by design, espelha {@see \Modules\Jana\Entities\Mcp\McpCcSession}
+ * (heartbeat é sinal de infra/máquina, não de tenant). NUNCA adicionar global
+ * scope de business aqui.
+ *
+ * @see Modules\TeamMcp\Http\Controllers\Mcp\CcIngestController (writer)
+ */
+class McpIngestHeartbeat extends Model
+{
+    protected $table = 'mcp_ingest_heartbeat';
+
+    protected $fillable = [
+        'host',
+        'last_ingest_at',
+        'last_session_uuid',
+        'msgs_acc',
+    ];
+
+    protected $casts = [
+        'last_ingest_at' => 'datetime',
+        'msgs_acc'       => 'integer',
+    ];
+}

--- a/Modules/TeamMcp/Http/Controllers/Mcp/CcIngestController.php
+++ b/Modules/TeamMcp/Http/Controllers/Mcp/CcIngestController.php
@@ -12,6 +12,7 @@ use Modules\Jana\Entities\Mcp\McpCcBlob;
 use Modules\Jana\Entities\Mcp\McpCcMessage;
 use Modules\Jana\Entities\Mcp\McpCcSession;
 use Modules\Jana\Services\Privacy\PiiRedactor;
+use Modules\TeamMcp\Entities\McpIngestHeartbeat;
 
 /**
  * MEM-CC-1 — Endpoint POST /api/cc/ingest pra watcher local de cada dev
@@ -104,6 +105,13 @@ class CcIngestController extends Controller
                 'total_cost_usd' => (float) $session->messages()->sum('cost_usd'),
             ]);
 
+            // B-LIVE-HB (SDD · ADR 0278) — heartbeat do ingest (fim do SPOF).
+            // Upsert idempotente por host: bump last_ingest_at + last_session_uuid
+            // e acumula msgs_acc com o nº de mensagens efetivamente inseridas neste
+            // POST. NÃO conta duplicadas (re-envio idempotente não infla acumulador).
+            // Falha aqui NÃO derruba o ingest (heartbeat é sinal best-effort de infra).
+            $this->bumpHeartbeat($session->project_path ?? '', $session->session_uuid, $inserted);
+
             return response()->json([
                 'ok' => true,
                 'session_id' => $session->id,
@@ -126,6 +134,38 @@ class CcIngestController extends Controller
                 'error' => 'Internal',
                 'message' => $redactor->redact($e->getMessage()),
             ], 500);
+        }
+    }
+
+    /**
+     * B-LIVE-HB — Upsert idempotente do heartbeat de ingest por `host`.
+     *
+     * Cross-tenant (sem business_id — espelha mcp_cc_sessions). Chave de upsert é
+     * `host` (cwd/project_path do watcher). Re-envio do mesmo host atualiza a
+     * MESMA linha (UNIQUE host): 1 host = 1 linha. `msgs_acc` SOMA apenas as
+     * mensagens recém-inseridas ($inserted) — duplicadas não inflam o acumulador.
+     *
+     * Best-effort: erro aqui é logado mas NÃO falha o ingest (o reader/liveness
+     * — tarefa separada — apenas verá um heartbeat um pouco mais antigo).
+     */
+    protected function bumpHeartbeat(string $host, string $sessionUuid, int $inserted): void
+    {
+        if ($host === '') {
+            return;
+        }
+
+        try {
+            $hb = McpIngestHeartbeat::firstOrNew(['host' => $host]);
+            $hb->last_ingest_at = now();
+            $hb->last_session_uuid = $sessionUuid;
+            $hb->msgs_acc = (int) ($hb->msgs_acc ?? 0) + max(0, $inserted);
+            $hb->save();
+        } catch (\Throwable $e) {
+            $redactor = app(PiiRedactor::class);
+            Log::channel('copiloto-ai')->warning('CcIngest heartbeat falhou', [
+                'host_redacted' => $redactor->redact($host),
+                'error' => $redactor->redact($e->getMessage()),
+            ]);
         }
     }
 

--- a/Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php
+++ b/Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Entities\McpIngestHeartbeat;
+use Modules\TeamMcp\Http\Controllers\Mcp\CcIngestController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * B-LIVE-HB (SDD · ADR 0278) — Heartbeat do ingest (núcleo do fim do SPOF).
+ *
+ * Testa o WRITER do heartbeat (CcIngestController::bumpHeartbeat), que vive em
+ * Modules/TeamMcp (dono do ingest, NÃO Jana). O reader/liveness service é tarefa
+ * SEPARADA e não é coberto aqui.
+ *
+ * Estratégia era-sqlite sintética: a tabela real `mcp_ingest_heartbeat` é criada
+ * sob demanda (Blueprint compatível sqlite) e o método protegido `bumpHeartbeat`
+ * é invocado via reflection — sem depender da stack HTTP/middleware MySQL do
+ * UltimatePOS (mcp.auth + SetSessionData etc.), que exige schema completo.
+ *
+ * Contratos:
+ *   1. 1 POST (1 bump) → heartbeat com last_ingest_at recente.
+ *   2. 2 POSTs do MESMO host → 1 ÚNICA linha (upsert idempotente por host) +
+ *      msgs_acc acumulado.
+ *
+ * Tier 0 ({@see ADR 0093}): tabela SEM business_id (cross-tenant, espelha
+ * mcp_cc_sessions). last_ingest_at gravado via now() em runtime (NUNCA coluna
+ * gerada).
+ *
+ * @see Modules\TeamMcp\Http\Controllers\Mcp\CcIngestController::bumpHeartbeat
+ * @see Modules\TeamMcp\Database\Migrations\2026_06_15_100000_create_mcp_ingest_heartbeat_table.php
+ */
+
+/**
+ * Cria a tabela sintética (Blueprint sqlite-friendly — sem fullText/MySQL-only).
+ * Espelha as colunas da migration canônica.
+ */
+function ensureHeartbeatTable(): void
+{
+    if (Schema::hasTable('mcp_ingest_heartbeat')) {
+        Schema::drop('mcp_ingest_heartbeat');
+    }
+
+    Schema::create('mcp_ingest_heartbeat', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('host', 500)->unique();
+        $t->timestamp('last_ingest_at')->nullable();
+        $t->string('last_session_uuid', 36)->nullable();
+        $t->unsignedBigInteger('msgs_acc')->default(0);
+        $t->timestamps();
+    });
+}
+
+/**
+ * Invoca o método protegido CcIngestController::bumpHeartbeat via reflection.
+ */
+function bumpHeartbeatViaController(string $host, string $sessionUuid, int $inserted): void
+{
+    $controller = app(CcIngestController::class);
+    $ref = new ReflectionMethod($controller, 'bumpHeartbeat');
+    $ref->setAccessible(true);
+    $ref->invoke($controller, $host, $sessionUuid, $inserted);
+}
+
+beforeEach(function () {
+    ensureHeartbeatTable();
+});
+
+afterEach(function () {
+    if (Schema::hasTable('mcp_ingest_heartbeat')) {
+        Schema::drop('mcp_ingest_heartbeat');
+    }
+});
+
+it('1 POST → cria heartbeat com last_ingest_at recente', function () {
+    bumpHeartbeatViaController('D:\\oimpresso.com', 'uuid-aaa-111', 5);
+
+    $hb = McpIngestHeartbeat::where('host', 'D:\\oimpresso.com')->first();
+
+    expect($hb)->not->toBeNull();
+    expect($hb->last_session_uuid)->toBe('uuid-aaa-111');
+    expect((int) $hb->msgs_acc)->toBe(5);
+    // last_ingest_at recente (escrito via now() em runtime, não coluna gerada).
+    expect($hb->last_ingest_at)->not->toBeNull();
+    expect($hb->last_ingest_at->diffInSeconds(now()))->toBeLessThan(10);
+});
+
+it('2 POSTs do mesmo host → 1 ÚNICA linha (upsert idempotente) + msgs_acc acumulado', function () {
+    bumpHeartbeatViaController('D:\\oimpresso.com', 'uuid-aaa-111', 5);
+    bumpHeartbeatViaController('D:\\oimpresso.com', 'uuid-bbb-222', 3);
+
+    // Upsert por host: continua 1 linha.
+    expect(DB::table('mcp_ingest_heartbeat')->count())->toBe(1);
+
+    $hb = McpIngestHeartbeat::where('host', 'D:\\oimpresso.com')->first();
+    expect($hb)->not->toBeNull();
+    // last_session_uuid reflete o ÚLTIMO POST.
+    expect($hb->last_session_uuid)->toBe('uuid-bbb-222');
+    // msgs_acc somou 5 + 3.
+    expect((int) $hb->msgs_acc)->toBe(8);
+});
+
+it('hosts distintos → linhas distintas (cross-tenant, sem colisão)', function () {
+    bumpHeartbeatViaController('D:\\oimpresso.com', 'uuid-a', 2);
+    bumpHeartbeatViaController('/home/felipe/oimpresso', 'uuid-b', 4);
+
+    expect(DB::table('mcp_ingest_heartbeat')->count())->toBe(2);
+});
+
+it('host vazio é ignorado (no-op seguro)', function () {
+    bumpHeartbeatViaController('', 'uuid-empty', 9);
+
+    expect(DB::table('mcp_ingest_heartbeat')->count())->toBe(0);
+});


### PR DESCRIPTION
## O quê

Núcleo do fim do SPOF do ingest: um **heartbeat** escrito toda vez que `POST /api/cc/ingest` grava com sucesso, pra um reader/liveness service (tarefa SEPARADA) detectar watcher caído.

**Fronteira (refutador):** tabela + writer vivem em `Modules/TeamMcp` (dono do ingest), **NÃO** em Jana.

### Mudanças
- **Migration** `2026_06_15_100000_create_mcp_ingest_heartbeat_table.php` — tabela `mcp_ingest_heartbeat`:
  - `host` (UNIQUE, chave de upsert), `last_ingest_at`, `last_session_uuid` (nullable), `msgs_acc` (default 0), `timestamps`.
  - **SEM `business_id`** — cross-tenant by design, espelha `mcp_cc_sessions` (Tier 0 · ADR 0093).
  - Idempotente (`hasTable`) + reversível (`down` = `dropIfExists`).
- **Entity** `McpIngestHeartbeat` — sem `HasBusinessScope` (cross-tenant).
- **Controller** `CcIngestController::bumpHeartbeat` — no caminho de sucesso do ingest, upsert idempotente por `host` (= `project_path` do watcher): `last_ingest_at = now()`, `last_session_uuid`, `msgs_acc += N` (só mensagens **recém-inseridas**, duplicadas não inflam). Best-effort: falha do heartbeat **não** derruba o ingest.

> Reader/liveness service **NÃO** criado aqui (é tarefa separada).

## Acceptance
- 1 POST → heartbeat com `last_ingest_at` recente. ✅
- 2 POSTs do mesmo host → **1 linha** (upsert) + `msgs_acc` acumulado. ✅
- Hosts distintos → linhas distintas. ✅
- `host` vazio → no-op seguro. ✅

## Teste
`Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php` — Pest era-sqlite sintético (invoca `bumpHeartbeat` via reflection contra tabela sqlite-friendly; evita stack HTTP/middleware MySQL do UltimatePOS).

**Teste NÃO plugado na lane ainda (centralizado depois).**

Refs: SDD B-LIVE-HB · ADR 0278