### PR TITLE
ci(jana): pluga 3 testes da Leva 1 na lane (loop-closer)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML


### PR DESCRIPTION
Pluga na lane sqlite do `ci.yml` os 3 testes da Leva 1 que mergearam sem rodar (McpAuthCost, TaskParserDivergência, IngestHeartbeat). **O CI desta PR os executa de verdade** — se verde, prova que as features (D-COST-FIX/C4/B-LIVE-HB) estão cobertas, não só 'verde de teatro'.

Pendente (task à parte): `ImmutabilityTriggersTest` (D-EVT-TRIG) é MySQL-only → precisa de lane Jana-MySQL per-PR (que hoje não existe; mesmo gap do trigger de `mcp_audit_log`).

Refs: SDD · ADR 0278
🤖 Generated with [Claude Code](https://claude.com/claude-code)