### PR TITLE
chore(governance): aceita TeamMcp 82→81 no baseline (furo #2 SDD Leva 1)

### DIFF
--- a/governance/module-grades-baseline.json
+++ b/governance/module-grades-baseline.json
@@ -1,10 +1,10 @@
 {
   "generated_at": "2026-05-27T16:30:00-03:00",
-  "baseline_version": "v3.5.0",
+  "baseline_version": "v3.5.1",
   "rubric_adr": "0155",
   "reconciled_at": "2026-05-28T00:00:00-03:00",
   "reconciliation_pr": "fix(ci) gates secrets/governance OTel+boot (PR #1888) — reconcilia Governance 89→88: drift natural pós-merge #1885 (ADR 0222 Renovate) + #1887 (ADR 0223 NpmAuditChecker, código novo sem teste pareado). PR #1888 NÃO toca Modules/Governance.",
-  "last_update_pr": "v3.5.0 (#2303 fix model_used OpenAI): Jana 72→71 — drift natural da rubrica entre runs CI/local (mesmo padrão -1pp sistêmico ja documentado em v3.4.7); PR #2303 NÃO toca Modules/Jana (só Modules/ADS, que ficou 83→83 estável). Baixa o floor do Jana em 1pp pra destravar o gate; OficinaAuto/ProjectMgmt/Superadmin subiram (+1/+1/+2) e nao bloqueiam (floor < atual). · v3.4.9 US-CRM-078 backend (#2095/#2100): Crm 88→87 — controller multi-tenant novo, Pest validado no CT-100 MySQL (tests/Feature/Contact, não Modules/Crm/Tests) + drift natural rubrica; sem regressão funcional. · v3.4.6 fix-whatsapp-settings — Whatsapp +2pp, NfeBrasil +2pp, demais drift natural · v3.4.7 fix-sells-v2-agrupar-variacoes-popover: 26 módulos com -1pp sistêmico vs baseline v3.4.6 (drift natural rubrica entre execuções CI/local — não há mudança funcional nesses módulos no PR). ComunicacaoVisual +1pp (72→73 natural). PaymentRow.amount convertido pra NumericInputPtBR completando fix Bug R$ [redacted Tier 0]k Larissa.",
+  "last_update_pr": "v3.5.1 (furo #2 SDD Leva 1 — aceite consciente): TeamMcp 82→81 — a feature heartbeat (#2791 B-LIVE-HB, mata o SPOF do watcher de ingest) diluiu ~1pp da nota; aceito no baseline conscientemente per handoff 2026-06-15-2000-sdd-leva1-coordenacao-duravel. Esta PR só toca o baseline (NÃO toca Modules/TeamMcp). · v3.5.0 (#2303 fix model_used OpenAI): Jana 72→71 — drift natural da rubrica entre runs CI/local (mesmo padrão -1pp sistêmico ja documentado em v3.4.7); PR #2303 NÃO toca Modules/Jana (só Modules/ADS, que ficou 83→83 estável). Baixa o floor do Jana em 1pp pra destravar o gate; OficinaAuto/ProjectMgmt/Superadmin subiram (+1/+1/+2) e nao bloqueiam (floor < atual). · v3.4.9 US-CRM-078 backend (#2095/#2100): Crm 88→87 — controller multi-tenant novo, Pest validado no CT-100 MySQL (tests/Feature/Contact, não Modules/Crm/Tests) + drift natural rubrica; sem regressão funcional. · v3.4.6 fix-whatsapp-settings — Whatsapp +2pp, NfeBrasil +2pp, demais drift natural · v3.4.7 fix-sells-v2-agrupar-variacoes-popover: 26 módulos com -1pp sistêmico vs baseline v3.4.6 (drift natural rubrica entre execuções CI/local — não há mudança funcional nesses módulos no PR). ComunicacaoVisual +1pp (72→73 natural). PaymentRow.amount convertido pra NumericInputPtBR completando fix Bug R$ [redacted Tier 0]k Larissa.",
   "notes": "Atualizado 2026-05-27 (PR #1778 popover variações + PaymentRow.amount fix): snapshot CI rodado pós-merge #1779 (parser pt-BR) + #1780 (cliente drawer). 26 módulos com -1pp sistêmico vs v3.4.6 — drift natural rubrica entre runs CI/local (mesma rodada em local main devolve nota X-1 vs snapshot anterior). Sem mudança funcional nos 26. ComunicacaoVisual +1pp natural. Esta PR só toca Sells V2 — Sells não está no gate (entry deprecated_pending_decision).",
   "modules": {
     "Governance": 88,
@@ -15,7 +15,7 @@
     "ADS": 83,
     "Brief": 83,
     "Financeiro": 82,
-    "TeamMcp": 82,
+    "TeamMcp": 81,
     "Auditoria": 81,
     "RecurringBilling": 81,
     "Woocommerce": 81,


### PR DESCRIPTION
## Furo #2 do handoff SDD Leva 1 (#2793)

> Handoff `memory/handoffs/2026-06-15-2000-sdd-leva1-coordenacao-duravel.md`, item **#2 "fechar primeiro"**: _"Débito advisory: TeamMcp module-grade 82→81 (advisory, não bloqueou — a feature heartbeat diluiu ~1pt)... OU aceitar no baseline conscientemente."_

## O que / por quê
- `governance/module-grades-baseline.json`: `TeamMcp` **82 → 81** (+ bump `baseline_version` v3.5.0→v3.5.1 com rationale no `last_update_pr`, seguindo a convenção do arquivo).
- A queda veio por **diluição de dimensão** quando a feature heartbeat (#2791 — B-LIVE-HB, mata o SPOF do watcher de ingest) entrou no main: código novo legítimo sem cobertura pareada na mesma proporção. **Não é regressão funcional.**
- Escolho o caminho **"aceitar no baseline conscientemente"** (esforço S do handoff) em vez de recuperar a dimensão agora — recuperar (observabilidade/cobertura do TeamMcp) fica como item próprio de evolução, não de furo.

## Impacto
O `module-grades-gate` está enforced e barrava **todo PR off main** (baseline 82 vs computado 81). Esta PR destrava o gate repo-wide — incluindo o furo #1 ([#2794](https://github.com/wagnerra23/oimpresso.com/pull/2794)), que após o merge desta rebaseia e fica verde no module-grades.

Esta PR toca **só o baseline** — zero código, zero `Modules/TeamMcp`.

Refs: SDD furo #2 · ADR 0155 · #2791 · handoff 2026-06-15-2000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)