### PR TITLE
feat(teammcp): IngestLivenessService — heartbeat fresh/stale/dead (B-LIVE-CHECK, Leva 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML

--- a/Modules/TeamMcp/Services/IngestLivenessService.php
+++ b/Modules/TeamMcp/Services/IngestLivenessService.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Services;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Entities\McpIngestHeartbeat;
+
+/**
+ * IngestLivenessService — reader de liveness do ingest (B-LIVE-CHECK, SDD · ADR 0278).
+ *
+ * Lê `mcp_ingest_heartbeat` (escrito por B-LIVE-HB / #2791 — CcIngestController) e
+ * classifica cada host (máquina/cwd do watcher local) em fresh/stale/dead pela idade
+ * do `last_ingest_at`. É a metade-leitora que faltava pra detectar o SPOF do watcher
+ * (nenhum ingest recente = pipeline cego). O consumidor (B-SPOF-WA: whats-active deixa
+ * de dar "tudo livre" falso quando o pipeline está morto) é tarefa SEPARADA.
+ *
+ * SoC (Princípio 5, espelha {@see \Modules\Jana\Services\WorkLease\WorkLeaseService}):
+ * a JANELA de frescor vive AQUI (runtime now()), NUNCA no schema (coluna gerada não
+ * pode usar now()). Degrada gracioso se a tabela ainda não migrou — e enviesa pra
+ * INCERTEZA (host desconhecido = 'dead'), nunca pra falso "tudo bem" (blind ≠ safe).
+ *
+ * Tier 0 ({@see ADR 0093}/{@see ADR 0280}): heartbeat é sinal de infra/máquina, SEM
+ * business_id (cross-tenant by design — Grupo A). Este reader não filtra por tenant.
+ *
+ * @see \Modules\TeamMcp\Entities\McpIngestHeartbeat
+ * @see \Modules\TeamMcp\Http\Controllers\Mcp\CcIngestController (writer, B-LIVE-HB)
+ */
+class IngestLivenessService
+{
+    /** Ingeriu nos últimos FRESH_MINUTES → watcher vivo. */
+    public const FRESH_MINUTES = 15;
+
+    /** Sem ingest há mais de STALE_MINUTES (ou nunca) → watcher morto (SPOF). */
+    public const STALE_MINUTES = 60;
+
+    private const TABLE = 'mcp_ingest_heartbeat';
+
+    /**
+     * Classifica uma marca de último ingest em fresh/stale/dead.
+     * null (host que nunca ingeriu) → 'dead' (enviesa pra incerteza, blind ≠ safe).
+     */
+    public function classify(?Carbon $lastIngestAt): string
+    {
+        if ($lastIngestAt === null) {
+            return 'dead';
+        }
+
+        $now = now();
+
+        if ($lastIngestAt->greaterThanOrEqualTo($now->copy()->subMinutes(self::FRESH_MINUTES))) {
+            return 'fresh';
+        }
+
+        if ($lastIngestAt->greaterThan($now->copy()->subMinutes(self::STALE_MINUTES))) {
+            return 'stale';
+        }
+
+        return 'dead';
+    }
+
+    /**
+     * Status de um host específico. Tabela ausente OU host desconhecido → 'dead'
+     * (incerteza, não falso-OK).
+     */
+    public function classifyHost(string $host): string
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            return 'dead';
+        }
+
+        $hb = McpIngestHeartbeat::query()->where('host', $host)->first();
+
+        return $hb ? $this->classify($hb->last_ingest_at) : 'dead';
+    }
+
+    /**
+     * Todos os hosts com status + idade. Degrada gracioso (coleção vazia) se a tabela
+     * ainda não migrou — nunca estoura.
+     *
+     * @return Collection<int, object{host: string, last_ingest_at: Carbon|null, status: string, age_minutes: int|null}>
+     */
+    public function all(): Collection
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            return collect();
+        }
+
+        return McpIngestHeartbeat::query()->get()->map(function (McpIngestHeartbeat $hb): object {
+            $last = $hb->last_ingest_at;
+
+            return (object) [
+                'host'           => $hb->host,
+                'last_ingest_at' => $last,
+                'status'         => $this->classify($last),
+                'age_minutes'    => $last ? (int) $last->diffInMinutes(now()) : null,
+            ];
+        });
+    }
+
+    /**
+     * Contagem por status. Tabela ausente → tudo zero (sem hosts conhecidos = cego).
+     *
+     * @return array{fresh: int, stale: int, dead: int}
+     */
+    public function summary(): array
+    {
+        $all = $this->all();
+
+        return [
+            'fresh' => $all->where('status', 'fresh')->count(),
+            'stale' => $all->where('status', 'stale')->count(),
+            'dead'  => $all->where('status', 'dead')->count(),
+        ];
+    }
+}

--- a/Modules/TeamMcp/Services/IngestLivenessService.php
+++ b/Modules/TeamMcp/Services/IngestLivenessService.php
@@ -78,10 +78,11 @@ class IngestLivenessService
     }
 
     /**
-     * Todos os hosts com status + idade. Degrada gracioso (coleção vazia) se a tabela
-     * ainda não migrou — nunca estoura.
+     * Todos os hosts com status + idade. Cada item é um stdClass com:
+     * host (string), last_ingest_at (Carbon|null), status (string), age_minutes (int|null).
+     * Degrada gracioso (coleção vazia) se a tabela ainda não migrou — nunca estoura.
      *
-     * @return Collection<int, object{host: string, last_ingest_at: Carbon|null, status: string, age_minutes: int|null}>
+     * @return Collection<int, \stdClass>
      */
     public function all(): Collection
     {

--- a/Modules/TeamMcp/Services/IngestLivenessService.php
+++ b/Modules/TeamMcp/Services/IngestLivenessService.php
@@ -78,11 +78,10 @@ class IngestLivenessService
     }
 
     /**
-     * Todos os hosts com status + idade. Cada item é um stdClass com:
-     * host (string), last_ingest_at (Carbon|null), status (string), age_minutes (int|null).
+     * Todos os hosts com status + idade (DTO tipado IngestLivenessStatus).
      * Degrada gracioso (coleção vazia) se a tabela ainda não migrou — nunca estoura.
      *
-     * @return Collection<int, \stdClass>
+     * @return Collection<int, IngestLivenessStatus>
      */
     public function all(): Collection
     {
@@ -90,15 +89,15 @@ class IngestLivenessService
             return collect();
         }
 
-        return McpIngestHeartbeat::query()->get()->map(function (McpIngestHeartbeat $hb): object {
+        return McpIngestHeartbeat::query()->get()->map(function (McpIngestHeartbeat $hb): IngestLivenessStatus {
             $last = $hb->last_ingest_at;
 
-            return (object) [
-                'host'           => $hb->host,
-                'last_ingest_at' => $last,
-                'status'         => $this->classify($last),
-                'age_minutes'    => $last ? (int) $last->diffInMinutes(now()) : null,
-            ];
+            return new IngestLivenessStatus(
+                host: $hb->host,
+                lastIngestAt: $last,
+                status: $this->classify($last),
+                ageMinutes: $last ? (int) $last->diffInMinutes(now()) : null,
+            );
         });
     }
 
@@ -112,9 +111,9 @@ class IngestLivenessService
         $all = $this->all();
 
         return [
-            'fresh' => $all->where('status', 'fresh')->count(),
-            'stale' => $all->where('status', 'stale')->count(),
-            'dead'  => $all->where('status', 'dead')->count(),
+            'fresh' => $all->filter(fn (IngestLivenessStatus $r): bool => $r->status === 'fresh')->count(),
+            'stale' => $all->filter(fn (IngestLivenessStatus $r): bool => $r->status === 'stale')->count(),
+            'dead'  => $all->filter(fn (IngestLivenessStatus $r): bool => $r->status === 'dead')->count(),
         ];
     }
 }

--- a/Modules/TeamMcp/Services/IngestLivenessStatus.php
+++ b/Modules/TeamMcp/Services/IngestLivenessStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Services;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * Status de liveness de um host do watcher de ingest (B-LIVE-CHECK, SDD · ADR 0278).
+ *
+ * DTO tipado (em vez de stdClass) pra ser PHPStan-clean sob Collection invariante e
+ * dar ao consumidor (B-SPOF-WA) propriedades tipadas (->status, ->host) sem acesso
+ * dinâmico.
+ *
+ * @see \Modules\TeamMcp\Services\IngestLivenessService
+ */
+final class IngestLivenessStatus
+{
+    public function __construct(
+        public readonly string $host,
+        public readonly ?Carbon $lastIngestAt,
+        /** fresh | stale | dead */
+        public readonly string $status,
+        public readonly ?int $ageMinutes,
+    ) {
+    }
+}

--- a/Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
+++ b/Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Entities\McpIngestHeartbeat;
+use Modules\TeamMcp\Services\IngestLivenessService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * B-LIVE-CHECK (SDD · ADR 0278) — reader de liveness do ingest.
+ *
+ * Cobre IngestLivenessService: classificação fresh/stale/dead por idade de
+ * last_ingest_at + graceful-degrade quando a tabela não existe. Complementa o
+ * teste do WRITER (IngestHeartbeatTest, B-LIVE-HB).
+ *
+ * Estratégia era-sqlite sintética (espelha IngestHeartbeatTest::ensureHeartbeatTable):
+ * monta só mcp_ingest_heartbeat sob demanda; sem RefreshDatabase/migrate:fresh.
+ * Carbon::setTestNow crava os limiares (sem flake de relógio). 100% sqlite — fica na
+ * lane rápida do ci.yml (NÃO jana-pest.yml: nenhuma feature MySQL-only).
+ *
+ * @see \Modules\TeamMcp\Services\IngestLivenessService
+ */
+function ensureLivenessTable(): void
+{
+    if (Schema::hasTable('mcp_ingest_heartbeat')) {
+        Schema::drop('mcp_ingest_heartbeat');
+    }
+
+    Schema::create('mcp_ingest_heartbeat', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('host', 500)->unique();
+        $t->timestamp('last_ingest_at')->nullable();
+        $t->string('last_session_uuid', 36)->nullable();
+        $t->unsignedBigInteger('msgs_acc')->default(0);
+        $t->timestamps();
+    });
+}
+
+function seedHeartbeat(string $host, ?Carbon $lastIngestAt): void
+{
+    McpIngestHeartbeat::query()->create([
+        'host'           => $host,
+        'last_ingest_at' => $lastIngestAt,
+        'last_session_uuid' => 'uuid-'.$host,
+        'msgs_acc'       => 1,
+    ]);
+}
+
+beforeEach(function () {
+    Carbon::setTestNow(Carbon::parse('2026-06-15 12:00:00'));
+    ensureLivenessTable();
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+    if (Schema::hasTable('mcp_ingest_heartbeat')) {
+        Schema::drop('mcp_ingest_heartbeat');
+    }
+});
+
+// ─── classify() — limiares determinísticos (não toca DB) ────────────────────────
+
+it('classify: ingest recente (5min) é fresh', function () {
+    expect(app(IngestLivenessService::class)->classify(now()->subMinutes(5)))->toBe('fresh');
+});
+
+it('classify: borda 15min ainda é fresh, 16min vira stale', function () {
+    $svc = app(IngestLivenessService::class);
+    // BITE: trocar >= por > na borda FRESH viraria o caso de 15min pra stale.
+    expect($svc->classify(now()->subMinutes(15)))->toBe('fresh');
+    expect($svc->classify(now()->subMinutes(16)))->toBe('stale');
+});
+
+it('classify: além do STALE_MINUTES (61min) é dead', function () {
+    expect(app(IngestLivenessService::class)->classify(now()->subMinutes(61)))->toBe('dead');
+});
+
+it('classify: nunca ingeriu (null) é dead — incerteza, não falso-OK', function () {
+    // BITE: enviesar null pra 'fresh'/'stale' (blind=safe) quebra aqui.
+    expect(app(IngestLivenessService::class)->classify(null))->toBe('dead');
+});
+
+// ─── all() / summary() — agregação + graceful-degrade ───────────────────────────
+
+it('summary: conta fresh/stale/dead corretos num mix de hosts', function () {
+    seedHeartbeat('host-fresh', now()->subMinutes(3));
+    seedHeartbeat('host-stale', now()->subMinutes(40));
+    seedHeartbeat('host-dead', now()->subMinutes(120));
+    seedHeartbeat('host-never', null);
+
+    expect(app(IngestLivenessService::class)->summary())
+        ->toBe(['fresh' => 1, 'stale' => 1, 'dead' => 2]);
+});
+
+it('classifyHost: host conhecido fresco é fresh; desconhecido é dead', function () {
+    seedHeartbeat('host-a', now()->subMinutes(2));
+    $svc = app(IngestLivenessService::class);
+
+    expect($svc->classifyHost('host-a'))->toBe('fresh');
+    expect($svc->classifyHost('host-inexistente'))->toBe('dead');
+});
+
+it('graceful-degrade: tabela ausente não estoura — all() vazio, summary zerado', function () {
+    Schema::dropIfExists('mcp_ingest_heartbeat');
+    $svc = app(IngestLivenessService::class);
+
+    // BITE: remover o guard Schema::hasTable faria isto lançar QueryException.
+    expect($svc->all())->toHaveCount(0);
+    expect($svc->summary())->toBe(['fresh' => 0, 'stale' => 0, 'dead' => 0]);
+    expect($svc->classifyHost('qualquer'))->toBe('dead');
+});


### PR DESCRIPTION
## Leva 2 · Raia B — B-LIVE-CHECK

A metade-**leitora** que faltava do heartbeat do ingest: #2791 (B-LIVE-HB) escreve `mcp_ingest_heartbeat`, mas **ninguém lia**. `IngestLivenessService` classifica cada host do watcher em **fresh** (<15min) / **stale** / **dead** (>60min ou nunca) pela idade de `last_ingest_at`.

É a base do próximo item **B-SPOF-WA** (fazer `whats-active` parar de dar 'tudo livre' falso quando o pipeline está cego — bug central da dim 10 no ADR 0278).

### Decisões
- **SoC**: janela de frescor no Service (runtime `now()`), não no schema — espelha `WorkLeaseService`.
- **blind ≠ safe**: degrada gracioso se a tabela não migrou **e enviesa pra incerteza** (host desconhecido/sem dado = `dead`), nunca pra falso-OK.
- **Tier 0**: sem `business_id` (heartbeat é infra/máquina — Grupo A, ADR 0280). Reader não filtra tenant.

### Teste que morde
`IngestLivenessTest` (era-sqlite, `setTestNow` determinístico): crava limiares (15min=fresh, 16min=stale, 61min/null=dead), `summary()` num mix de hosts, e o guard graceful-degrade (drop da tabela não estoura). Ancorado no `ci.yml` L101 (lane sqlite) pra rodar em todo PR — sem MySQL-only.

### CI esperado
`module-grades-gate` vermelho aqui é o **mesmo débito pré-existente** TeamMcp 82→81 que [#2795](https://github.com/wagnerra23/oimpresso.com/pull/2795) resolve (ainda não mergeado) — não é deste PR. `foundation-ratchet` é advisory. Sinais reais: **PHP/Pest (Unit)** + **PHPStan**.

Refs: SDD Leva 2 (raia B) · ADR 0278 · #2791.

🤖 Generated with [Claude Code](https://claude.com/claude-code)