### PR TITLE
feat(jana): enforce mcp_tasks FSM transition matrix (proíbe todo→done teleporte) — A1+A8 Leva 2

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -27,3 +27,4 @@ Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php
 Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
 tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
+Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php

--- a/Modules/Jana/Entities/Mcp/McpTask.php
+++ b/Modules/Jana/Entities/Mcp/McpTask.php
@@ -87,6 +87,36 @@ class McpTask extends Model
     /** Status canônicos (ADR 0070 — backlog adicionado). */
     public const STATUSES = ['backlog', 'todo', 'doing', 'review', 'done', 'blocked', 'cancelled'];
 
+    /**
+     * FSM mcp_tasks — matriz de transições permitidas (single source-of-truth em código).
+     *
+     * Espelha EXATAMENTE o workflow default semeado em McpDefaultsSeeder::$defaultWorkflow
+     * ('transitions'). Antes a matriz só existia como dado de seed e tinha ZERO leitores —
+     * todo→done (teleport) passava silencioso. Agora o chokepoint applyLockedUpdate consulta
+     * esta const e rejeita transição ilegal (rollback automático dentro da DB::transaction).
+     *
+     * @var array<string, list<string>>
+     */
+    public const TRANSITIONS = [
+        'backlog'   => ['todo', 'cancelled'],
+        'todo'      => ['doing', 'blocked', 'cancelled'],
+        'doing'     => ['review', 'blocked', 'todo', 'cancelled'],
+        'review'    => ['done', 'doing', 'blocked'],
+        'blocked'   => ['todo', 'doing', 'cancelled'],
+        'done'      => ['review'],   // reabrir
+        'cancelled' => ['todo'],     // reabrir
+    ];
+
+    /**
+     * A transição $from → $to é permitida pela FSM?
+     *
+     * Estado desconhecido (fora de TRANSITIONS) => nenhuma transição permitida (fail-closed).
+     */
+    public static function canTransition(string $from, string $to): bool
+    {
+        return in_array($to, self::TRANSITIONS[$from] ?? [], true);
+    }
+
     /** Priorities canônicas. */
     public const PRIORITIES = ['p0', 'p1', 'p2', 'p3'];
 

--- a/Modules/Jana/Services/TaskRegistry/GitTaskLinkerService.php
+++ b/Modules/Jana/Services/TaskRegistry/GitTaskLinkerService.php
@@ -123,6 +123,11 @@ class GitTaskLinkerService
                         ]);
 
                         // Status auto se for fixes/closes/resolves
+                        // NOTA FSM (ADR 0070): este write DIRETO é um caminho de transição
+                        // de SISTEMA (PR-merge → done/review) intencionalmente FORA do guard
+                        // FSM de applyLockedUpdate — pode forçar done a partir de não-review e
+                        // passar pelo guard quebraria o git linking. Follow-up: modelar como
+                        // transição de sistema explícita em vez de bypass.
                         if ($linkAction === 'fixes') {
                             $newStatus = $isMain ? 'done' : 'review';
                             if (in_array($task->status, ['todo', 'doing', 'review', 'blocked'], true) && $task->status !== $newStatus) {

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -102,6 +102,18 @@ class TaskCrudService
 
             // Side-effects: started_at / completed_at autopopulate
             if ($field === 'status') {
+                // FSM mcp_tasks (ADR 0070) — barra transição ilegal ANTES de qualquer
+                // side-effect/assignment. Fecha o "teleport" todo→done (matriz tinha 0
+                // leitores). Throw dentro da DB::transaction => rollback automático.
+                $fromStatus = (string) $task->status;
+                $toStatus = (string) $newVal;
+                if (! McpTask::canTransition($fromStatus, $toStatus)) {
+                    throw new \RuntimeException(
+                        "Transição ilegal {$fromStatus} → {$toStatus} (FSM mcp_tasks). Permitidas: "
+                        . implode(', ', McpTask::TRANSITIONS[$fromStatus] ?? [])
+                    );
+                }
+
                 if ($newVal === 'doing' && ! $task->started_at) {
                     $task->started_at = now();
                 }

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -110,7 +110,7 @@ class TaskCrudService
                 if (! McpTask::canTransition($fromStatus, $toStatus)) {
                     throw new \RuntimeException(
                         "Transição ilegal {$fromStatus} → {$toStatus} (FSM mcp_tasks). Permitidas: "
-                        . implode(', ', McpTask::TRANSITIONS[$fromStatus] ?? [])
+                        . implode(', ', McpTask::TRANSITIONS[$fromStatus])
                     );
                 }
 

--- a/Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
@@ -90,7 +90,7 @@ it('aceita acceptance_ref no update via service', function () {
 })->group('acceptance-ref', 'ci');
 
 it('grava acceptance_ref junto com status done + carimba completed_at', function () {
-    seedTask('US-GOV-099');
+    seedTask('US-GOV-099', 'review'); // review→done é legal na FSM (A1+A8); todo→done agora é barrado
 
     app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done', 'acceptance_ref' => 'commit abc123'], 'wagner');
 
@@ -100,7 +100,7 @@ it('grava acceptance_ref junto com status done + carimba completed_at', function
 })->group('acceptance-ref', 'ci');
 
 it('done SEM acceptance_ref registra evento de aviso (soft, nao throw)', function () {
-    seedTask('US-GOV-099');
+    seedTask('US-GOV-099', 'review'); // review→done é legal na FSM (A1+A8); todo→done agora é barrado
 
     app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done'], 'wagner'); // não lança
 
@@ -110,7 +110,7 @@ it('done SEM acceptance_ref registra evento de aviso (soft, nao throw)', functio
 })->group('acceptance-ref', 'ci');
 
 it('done COM acceptance_ref preexistente nao gera aviso', function () {
-    seedTask('US-GOV-099', 'todo', 'PR #1');
+    seedTask('US-GOV-099', 'review', 'PR #1'); // review→done é legal na FSM (A1+A8)
 
     app(TaskCrudService::class)->update('US-GOV-099', ['status' => 'done'], 'wagner');
 

--- a/Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Item A1+A8 (SDD Leva 2) — FSM mcp_tasks: barra o teleport todo→done.
+ *
+ * A matriz de transições (McpTask::TRANSITIONS) espelha o workflow default semeado
+ * em McpDefaultsSeeder e ANTES tinha ZERO leitores — qualquer salto era aceito. O
+ * chokepoint applyLockedUpdate agora chama McpTask::canTransition() e lança
+ * RuntimeException numa transição ilegal; como roda dentro de DB::transaction, a
+ * escrita parcial (status + evento status_changed) REVERTE — esta é a mordida.
+ *
+ * era-sqlite sintético (mcp_tasks + mcp_task_events) + activitylog OFF (McpTask usa
+ * LogsActivity). Mesmo molde de TaskUpdateAtomicTest. markTestSkipped se driver !=
+ * sqlite (a matriz é unit-pura, mas o teste de rollback depende da lane sqlite).
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético (floor SDD).');
+    }
+    config(['activitylog.enabled' => false]);
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('mcp_task_events', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('updated_at')->nullable();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+});
+
+function seedFsmTask(string $id, string $status): void
+{
+    DB::table('mcp_tasks')->insert([
+        'task_id' => $id,
+        'module' => 'Governance',
+        'title' => 'T',
+        'status' => $status,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('todo→done (teleport) lança RuntimeException E reverte — status fica todo, 0 evento status_changed', function () {
+    seedFsmTask('US-GOV-A1', 'todo');
+
+    expect(fn () => app(TaskCrudService::class)->update('US-GOV-A1', ['status' => 'done'], 'wagner'))
+        ->toThrow(RuntimeException::class);
+
+    // SEM o guard, o teleport persistiria status='done' + evento status_changed.
+    // COM o guard, o throw dentro da DB::transaction reverte tudo — esta é a mordida.
+    expect(DB::table('mcp_tasks')->where('task_id', 'US-GOV-A1')->value('status'))->toBe('todo')
+        ->and(McpTaskEvent::where('task_id', 'US-GOV-A1')->where('event_type', 'status_changed')->count())->toBe(0);
+})->group('atomic-update', 'ci');
+
+it('todo→doing é transição legal — persiste e popula started_at', function () {
+    seedFsmTask('US-GOV-A2', 'todo');
+
+    $r = app(TaskCrudService::class)->update('US-GOV-A2', ['status' => 'doing'], 'wagner');
+
+    expect($r['task']->status)->toBe('doing')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-A2')->value('status'))->toBe('doing')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-A2')->value('started_at'))->not->toBeNull();
+})->group('atomic-update', 'ci');
+
+it('review→done é transição legal — o caminho canônico de fechamento passa', function () {
+    seedFsmTask('US-GOV-A3', 'review');
+
+    $r = app(TaskCrudService::class)->update('US-GOV-A3', ['status' => 'done'], 'wagner');
+
+    expect($r['task']->status)->toBe('done')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-A3')->value('status'))->toBe('done')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-A3')->value('completed_at'))->not->toBeNull();
+})->group('atomic-update', 'ci');
+
+it('done→review é transição legal — reabrir uma task concluída passa', function () {
+    seedFsmTask('US-GOV-A4', 'done');
+
+    $r = app(TaskCrudService::class)->update('US-GOV-A4', ['status' => 'review'], 'wagner');
+
+    expect($r['task']->status)->toBe('review')
+        ->and(DB::table('mcp_tasks')->where('task_id', 'US-GOV-A4')->value('status'))->toBe('review');
+})->group('atomic-update', 'ci');


### PR DESCRIPTION
## Leva 2 · Raia A — A1+A8

Liga a matriz FSM que já existia como dado morto (`McpDefaultsSeeder` transitions, **zero leitores**) e a **enforça no chokepoint** `TaskCrudService::applyLockedUpdate()` — por onde TODO update/bulkUpdate/move passa. Transição ilegal (ex `todo→done`) lança antes de qualquer side-effect; como roda dentro do `DB::transaction` do A0 (#2785), o rollback é de graça.

- `McpTask::TRANSITIONS` const (espelha o seeder linha-a-linha) + `canTransition()` fail-closed.
- **Não quebra git auto-transitions**: `GitTaskLinkerService` escreve status direto (fora do chokepoint) — intacto, com comentário NOTA-FSM marcando o follow-up.
- Teste que morde (`FsmTransitionGuardTest`, sqlite na lane ci.yml): `todo→done` lança + status fica `todo` + 0 eventos; transições legais (incl. `review→done`) passam.

Revisão adversarial (workflow): **ready**, 6 eixos verificados contra código real, matriz idêntica ao seeder, invariante git intacta.

⚠️ Nova rigidez (intencional): transições ilegais via MCP-API que antes gravavam em silêncio agora erram (ex `backlog→doing`, `todo→review`). `TasksUpdateTool` devolve msg amigável (sem fatal).

Refs: SDD Leva 2 (A1+A8) · ADR 0278 · #2785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)