### PR TITLE
feat(jana): TasksReconciler detect-only (R-A/R-B/R-E) em jana:reconcile — B-R0 Leva 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php --no-coverage --log-junit test-results/junit.xml
+          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php Modules/Jana/Tests/Feature/Reconcile/TasksReconcilerTest.php Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -322,6 +322,7 @@ return [
         \Modules\Jana\Services\Reconcile\Reconcilers\ContentReconciler::class,  // git→DB mcp_memory_documents
         \Modules\Jana\Services\Reconcile\Reconcilers\DeployReconciler::class,   // SHA deployado vs main
         \Modules\Jana\Services\Reconcile\Reconcilers\EvalReconciler::class,     // RAGAS pass-rate threshold
+        \Modules\Jana\Services\Reconcile\Reconcilers\TasksReconciler::class,    // detect-only: doing órfã / done sem acceptance_ref / blocked_by resolvido (ADR 0237 + 0278)
     ],
 
     'reranker' => [

--- a/Modules/Jana/Services/Reconcile/Reconcilers/TasksReconciler.php
+++ b/Modules/Jana/Services/Reconcile/Reconcilers/TasksReconciler.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Reconcile\Reconcilers;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Contracts\Reconciler;
+use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Services\Reconcile\ReconcileDrift;
+use Modules\Jana\Services\Reconcile\ReconcileResult;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+
+/**
+ * TasksReconciler — faceta 'tasks' do loop `jana:reconcile` (ADR 0237).
+ *
+ * Garante que o estado vivo das tasks (`mcp_tasks`, cache Jira-style ADR 0070) é
+ * COERENTE com os invariantes de governança do backlog. NÃO compara git × DB de
+ * conteúdo (isso é a faceta 'content'); compara o estado declarado de cada task
+ * com os sinais de coordenação/aceitação que DEVERIAM acompanhá-lo.
+ *
+ * ── DETECT-ONLY (alerta-only) — todos os drifts healable=false ──────────────
+ * Cada faceta aponta uma INCOERÊNCIA cuja resolução é decisão humana (R10): mexer
+ * em status/owner/blocked_by de uma task é ato de planejamento, não cura mecânica
+ * segura. Logo a faceta DETECTA + ALERTA; humano (ou um workflow gated) decide.
+ * Espelha a postura `healable=false` do {@see ContentReconciler} (delete inseguro)
+ * — aqui o motivo é semântico: não há fonte-de-verdade única pra auto-corrigir.
+ *
+ * ── 3 facetas (observed = `mcp_tasks` + leases ativos) ──────────────────────
+ *   R-A  doing-órfã          : task status='doing' SEM lease ativo correspondente
+ *                              (mcp_work_leases). Quem está fazendo? Coordenação
+ *                              perdida (crash/timeout que não renovou heartbeat, ou
+ *                              status movido à mão sem claim). ADR 0278 (work-lease).
+ *   R-B  done-sem-acceptance : task status='done' com `acceptance_ref` NULL ou ''.
+ *                              Fechou sem prova de DoD (ADR 0278 Fase 2). Furo de
+ *                              rastreabilidade (RTM) — done sem evidência.
+ *   R-E  blocked_by-resolvido: task cujo `blocked_by[]` referencia uma task que JÁ
+ *                              está fechada (status done/cancelled, {@see McpTask::isClosed}).
+ *                              O bloqueio "venceu" mas a referência ficou stale — a
+ *                              task pode estar represada sem motivo.
+ *
+ * ── Núcleo PURO injetável ────────────────────────────────────────────────────
+ * {@see analisar()} recebe as linhas de tasks JÁ materializadas + a lista de
+ * task_ids com lease ativo e devolve os drifts SEM tocar DB — determinístico,
+ * testável sem I/O (mesmo padrão de IndexReconciler::analisar / DeployDriftChecker).
+ * `reconcile()` faz a coleta de I/O (DB::table('mcp_tasks') + WorkLeaseService) e
+ * delega ao núcleo puro.
+ *
+ * ── Multi-tenant Tier 0 (ADR 0093 / 0280) ───────────────────────────────────
+ * As tabelas `mcp_tasks` / `mcp_work_leases` são Grupo A (governança da
+ * PLATAFORMA, ADR 0280) — SEM `business_id` por design (planejamento Jira-style é
+ * cross-tenant intencional, ADR 0070). Esta faceta NÃO aplica escopo de business.
+ *
+ * Refs:
+ *   - ADR 0237 (jana:reconcile loop único — contrato Reconciler)
+ *   - ADR 0070 (mcp_tasks Jira-style — repo-wide, sem business_id)
+ *   - ADR 0278 (acceptance_ref Fase 2 + work-lease D1)
+ *   - ADR 0280 (tabelas mcp_* Grupo A — sem business_id by design)
+ */
+final class TasksReconciler implements Reconciler
+{
+    // ── Chaves canônicas dos drifts (target prefix) ──────────────────────────
+    private const T_DOING_ORFA = 'tasks.doing_orfa';
+    private const T_DONE_SEM_ACCEPTANCE = 'tasks.done_sem_acceptance';
+    private const T_BLOCKED_BY_RESOLVIDO = 'tasks.blocked_by_resolvido';
+
+    /** Status que contam como "fechado" pra R-E (espelha McpTask::isClosed()). */
+    private const CLOSED_STATUSES = ['done', 'cancelled'];
+
+    private readonly WorkLeaseService $leases;
+
+    public function __construct(?WorkLeaseService $leases = null)
+    {
+        // WorkLeaseService injetável pra teste; resolve via app() no caminho real.
+        $this->leases = $leases ?? app(WorkLeaseService::class);
+    }
+
+    public function name(): string
+    {
+        return 'tasks';
+    }
+
+    public function description(): string
+    {
+        return 'Detecta incoerências de governança em mcp_tasks (doing órfã sem lease, done sem acceptance_ref, blocked_by já resolvido) — alerta-only';
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function tags(): array
+    {
+        return ['tier_0', 'governance', 'tasks'];
+    }
+
+    public function reconcile(array $opts = []): ReconcileResult
+    {
+        $start = microtime(true);
+
+        $heal = ($opts['heal'] ?? false) === true;
+        $dryRun = ($opts['dry_run'] ?? false) === true;
+
+        // Sem o cache de tasks migrado não há o que reconciliar — synced honesto
+        // (degrada gracioso, como WorkLeaseService::taskExists faz).
+        if (! Schema::hasTable('mcp_tasks')) {
+            return ReconcileResult::synced(
+                $this->name(),
+                (int) ((microtime(true) - $start) * 1000),
+                ['heal' => $heal, 'dry_run' => $dryRun, 'reason' => 'mcp_tasks ausente'],
+            );
+        }
+
+        $tasksRows = $this->coletarTasks();
+        $activeLeaseTaskIds = $this->coletarActiveLeaseTaskIds();
+
+        $drifts = $this->analisar($tasksRows, $activeLeaseTaskIds);
+
+        $durationMs = (int) ((microtime(true) - $start) * 1000);
+
+        return ReconcileResult::from(
+            name: $this->name(),
+            drifts: $drifts,
+            durationMs: $durationMs,
+            metadata: [
+                'heal' => $heal,
+                'dry_run' => $dryRun,
+                'detect_only' => true,
+                'tasks_observed' => count($tasksRows),
+                'active_leases' => count($activeLeaseTaskIds),
+            ],
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // NÚCLEO PURO — sem I/O. Recebe tasks + leases ativos e devolve os drifts.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Compara o estado das tasks com os invariantes de governança e devolve os
+     * drifts. PURO + determinístico: nada de DB/clock aqui — tudo injetado.
+     *
+     * Forma esperada de cada item de $tasksRows (chaves toleradas; ausência = vazio):
+     *   - task_id:        string  identificador da task (chave do drift).
+     *   - status:         string  status canônico (doing/done/cancelled/...).
+     *   - acceptance_ref: ?string prova de DoD (R-B: NULL/'' = furo).
+     *   - blocked_by:     list<string>  task_ids que bloqueiam esta (R-E).
+     *
+     * @param array<int, array{
+     *     task_id?: string,
+     *     status?: string,
+     *     acceptance_ref?: ?string,
+     *     blocked_by?: list<string>
+     * }> $tasksRows
+     * @param list<string> $activeLeaseTaskIds task_ids com lease ATIVO agora.
+     * @return array<int, ReconcileDrift>
+     */
+    public function analisar(array $tasksRows, array $activeLeaseTaskIds): array
+    {
+        $leaseSet = array_fill_keys($activeLeaseTaskIds, true);
+
+        // Mapa task_id → status pra resolver R-E (a task referenciada está fechada?).
+        $statusPorTask = [];
+        foreach ($tasksRows as $row) {
+            $tid = (string) ($row['task_id'] ?? '');
+            if ($tid === '') {
+                continue;
+            }
+            $statusPorTask[$tid] = (string) ($row['status'] ?? '');
+        }
+
+        $drifts = [];
+
+        foreach ($tasksRows as $row) {
+            $taskId = (string) ($row['task_id'] ?? '');
+            if ($taskId === '') {
+                continue;
+            }
+            $status = (string) ($row['status'] ?? '');
+
+            // ── R-A: doing SEM lease ativo ────────────────────────────────────
+            if ($status === 'doing' && ! isset($leaseSet[$taskId])) {
+                $drifts[] = new ReconcileDrift(
+                    target: self::T_DOING_ORFA.':'.$taskId,
+                    detail: "Task '{$taskId}' está em 'doing' SEM lease ativo (mcp_work_leases). "
+                        .'Coordenação perdida — quem está executando? (ADR 0278 work-lease). '
+                        .'Resolver (re-claim ou mover status) é decisão humana.',
+                    desired: "doing ⇒ lease ativo pra '{$taskId}'",
+                    observed: 'doing sem lease ativo',
+                    healable: false,
+                );
+            }
+
+            // ── R-B: done SEM acceptance_ref ──────────────────────────────────
+            if ($status === 'done') {
+                $ref = $row['acceptance_ref'] ?? null;
+                $refStr = is_string($ref) ? trim($ref) : '';
+                if ($refStr === '') {
+                    $drifts[] = new ReconcileDrift(
+                        target: self::T_DONE_SEM_ACCEPTANCE.':'.$taskId,
+                        detail: "Task '{$taskId}' está 'done' sem `acceptance_ref` (prova de DoD, ADR 0278 Fase 2). "
+                            .'Furo de rastreabilidade — done sem evidência. Preencher é decisão humana.',
+                        desired: 'done ⇒ acceptance_ref preenchido',
+                        observed: $ref === null ? 'acceptance_ref NULL' : "acceptance_ref vazio ('')",
+                        healable: false,
+                    );
+                }
+            }
+
+            // ── R-E: blocked_by referencia task JÁ fechada ────────────────────
+            foreach ($this->normalizarBlockedBy($row['blocked_by'] ?? []) as $bloqueador) {
+                $statusBloqueador = $statusPorTask[$bloqueador] ?? null;
+                if ($statusBloqueador !== null && in_array($statusBloqueador, self::CLOSED_STATUSES, true)) {
+                    $drifts[] = new ReconcileDrift(
+                        target: self::T_BLOCKED_BY_RESOLVIDO.':'.$taskId.':'.$bloqueador,
+                        detail: "Task '{$taskId}' está bloqueada por '{$bloqueador}', que já está "
+                            ."'{$statusBloqueador}' (fechada). O bloqueio venceu mas a referência ficou stale — "
+                            .'task pode estar represada sem motivo. Desbloquear é decisão humana.',
+                        desired: "blocked_by['{$bloqueador}'] removido (bloqueador fechado)",
+                        observed: "blocked_by ainda referencia '{$bloqueador}' ({$statusBloqueador})",
+                        healable: false,
+                    );
+                }
+            }
+        }
+
+        return $drifts;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // COLETA DE ESTADO (I/O) — observed do DB + leases ativos do Service.
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Materializa as tasks relevantes (status que importa pras 3 facetas) em linhas
+     * normalizadas pro núcleo puro. `blocked_by` é coluna JSON (cast array em
+     * {@see McpTask}); aqui decodificamos do raw string da query builder.
+     *
+     * @return array<int, array{task_id: string, status: string, acceptance_ref: ?string, blocked_by: list<string>}>
+     */
+    private function coletarTasks(): array
+    {
+        // Só precisamos de tasks que possam disparar alguma faceta: 'doing'/'done'
+        // (R-A/R-B) + qualquer uma com blocked_by não-nulo (R-E). Mas pra resolver
+        // R-E precisamos do status do BLOQUEADOR também → trazemos o conjunto que
+        // cobre tudo: status em doing/done OU blocked_by preenchido. Pra o mapa de
+        // status do bloqueador ser completo, trazemos também as fechadas referenciadas;
+        // o jeito honesto e simples é trazer todas as linhas com os 4 campos (a tabela
+        // é cache de planejamento, não tem volume de tabela transacional).
+        $rows = DB::table('mcp_tasks')
+            ->select(['task_id', 'status', 'acceptance_ref', 'blocked_by'])
+            ->get();
+
+        $out = [];
+        foreach ($rows as $row) {
+            $taskId = is_string($row->task_id ?? null) ? $row->task_id : '';
+            if ($taskId === '') {
+                continue;
+            }
+
+            $out[] = [
+                'task_id' => $taskId,
+                'status' => is_string($row->status ?? null) ? $row->status : '',
+                'acceptance_ref' => is_string($row->acceptance_ref ?? null) ? $row->acceptance_ref : null,
+                'blocked_by' => $this->decodificarBlockedBy($row->blocked_by ?? null),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * task_ids com lease ATIVO agora (released_at NULL + dentro do TTL). Espelha
+     * {@see WorkLeaseService::activeLeases}.
+     *
+     * @return list<string>
+     */
+    private function coletarActiveLeaseTaskIds(): array
+    {
+        $out = [];
+        foreach ($this->leases->activeLeases(PHP_INT_MAX) as $lease) {
+            $tid = is_object($lease) && isset($lease->task_id) && is_string($lease->task_id) ? $lease->task_id : '';
+            if ($tid !== '') {
+                $out[] = $tid;
+            }
+        }
+
+        return array_values(array_unique($out));
+    }
+
+    /**
+     * Decodifica a coluna JSON `blocked_by` (raw da query builder pode vir string
+     * JSON, array já-decodificado, ou null) numa list<string> de task_ids.
+     *
+     * @return list<string>
+     */
+    private function decodificarBlockedBy(mixed $raw): array
+    {
+        if (is_string($raw) && $raw !== '') {
+            $decoded = json_decode($raw, true);
+            $raw = $decoded;
+        }
+
+        return $this->normalizarBlockedBy(is_array($raw) ? $raw : []);
+    }
+
+    /**
+     * Normaliza uma lista de bloqueadores pra list<string> (só task_ids não-vazios,
+     * deduplicada, ordem preservada). PURO.
+     *
+     * @param array<int|string, mixed> $valores
+     * @return list<string>
+     */
+    private function normalizarBlockedBy(array $valores): array
+    {
+        $out = [];
+        foreach ($valores as $valor) {
+            if (! is_scalar($valor)) {
+                continue;
+            }
+            $tid = trim((string) $valor);
+            if ($tid !== '' && ! in_array($tid, $out, true)) {
+                $out[] = $tid;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/Modules/Jana/Tests/Feature/Reconcile/TasksReconcilerTest.php
+++ b/Modules/Jana/Tests/Feature/Reconcile/TasksReconcilerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Reconcile\Reconcilers\TasksReconciler;
+use Modules\Jana\Services\Reconcile\ReconcileDrift;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * TasksReconciler — cobre o NÚCLEO PURO `analisar()` com tasks + leases ativos
+ * INJETADOS (sem DB, determinístico). Espelha o BLOCO A puro do IndexReconcilerTest.
+ *
+ * Mapa pra ITEM B-R0 (ADR 0237 detect-only + ADR 0278):
+ *   - R-A doing-órfã          → 'doing' SEM lease ativo = 1 drift; com lease = 0.
+ *   - R-B done-sem-acceptance  → 'done' com acceptance_ref NULL ou '' = drift cada;
+ *                                com ref preenchido = 0.
+ *   - R-E blocked_by-resolvido → blocked_by=[Y] com Y done/cancelled = drift;
+ *                                Y ainda doing = 0.
+ *   - todos os drifts são detect-only → healable=false (alerta humano, R10).
+ *
+ * Cada `it` MORDE: se o reconciler parar de detectar (ou marcar healable=true), o
+ * teste falha (assert de presença/ausência + flag healable, não tautologia).
+ */
+
+/** Reconciler PURO: WorkLeaseService nunca é tocado por analisar() (sem DB). */
+function novoTasksRec(): TasksReconciler
+{
+    return new TasksReconciler(new WorkLeaseService());
+}
+
+/**
+ * @param array<int, ReconcileDrift> $drifts
+ */
+function tasksDriftPorTarget(array $drifts, string $prefixo): ?ReconcileDrift
+{
+    foreach ($drifts as $d) {
+        if ($d->target === $prefixo || str_starts_with($d->target, $prefixo)) {
+            return $d;
+        }
+    }
+
+    return null;
+}
+
+// ─── R-A: doing-órfã ──────────────────────────────────────────────────────────
+
+it('R-A: doing SEM lease ativo → 1 drift doing_orfa (detect-only)', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-1', 'status' => 'doing', 'acceptance_ref' => null, 'blocked_by' => []],
+    ];
+    $drifts = $rec->analisar($tasks, []); // NENHUM lease ativo
+
+    $drift = tasksDriftPorTarget($drifts, 'tasks.doing_orfa:COPI-1');
+
+    expect($drifts)->toHaveCount(1)
+        ->and($drift)->not->toBeNull()
+        ->and($drift->healable)->toBeFalse()   // detect-only → alerta humano
+        ->and($drift->healed)->toBeFalse()
+        ->and($drift->detail)->toContain('COPI-1');
+});
+
+it('R-A: doing COM lease ativo → 0 drift (coordenação ok)', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-1', 'status' => 'doing', 'acceptance_ref' => null, 'blocked_by' => []],
+    ];
+    $drifts = $rec->analisar($tasks, ['COPI-1']); // lease ativo cobre a task
+
+    expect(tasksDriftPorTarget($drifts, 'tasks.doing_orfa'))->toBeNull();
+});
+
+// ─── R-B: done-sem-acceptance_ref ───────────────────────────────────────────────
+
+it('R-B: done com acceptance_ref NULL → 1 drift done_sem_acceptance', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-2', 'status' => 'done', 'acceptance_ref' => null, 'blocked_by' => []],
+    ];
+    $drift = tasksDriftPorTarget($rec->analisar($tasks, []), 'tasks.done_sem_acceptance:COPI-2');
+
+    expect($drift)->not->toBeNull()
+        ->and($drift->healable)->toBeFalse()
+        ->and($drift->observed)->toContain('NULL');
+});
+
+it('R-B: done com acceptance_ref vazio ("") → 1 drift done_sem_acceptance', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-3', 'status' => 'done', 'acceptance_ref' => '', 'blocked_by' => []],
+    ];
+    $drift = tasksDriftPorTarget($rec->analisar($tasks, []), 'tasks.done_sem_acceptance:COPI-3');
+
+    expect($drift)->not->toBeNull()
+        ->and($drift->healable)->toBeFalse()
+        ->and($drift->observed)->toContain('vazio');
+});
+
+it('R-B: done com acceptance_ref preenchido → 0 drift', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-4', 'status' => 'done', 'acceptance_ref' => 'PR #2795', 'blocked_by' => []],
+    ];
+    $drifts = $rec->analisar($tasks, []);
+
+    expect(tasksDriftPorTarget($drifts, 'tasks.done_sem_acceptance'))->toBeNull();
+});
+
+// ─── R-E: blocked_by-resolvido ──────────────────────────────────────────────────
+
+it('R-E: blocked_by referencia task DONE → 1 drift blocked_by_resolvido', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-5', 'status' => 'todo', 'acceptance_ref' => null, 'blocked_by' => ['COPI-9']],
+        ['task_id' => 'COPI-9', 'status' => 'done', 'acceptance_ref' => 'x', 'blocked_by' => []],
+    ];
+    $drift = tasksDriftPorTarget($rec->analisar($tasks, []), 'tasks.blocked_by_resolvido:COPI-5');
+
+    expect($drift)->not->toBeNull()
+        ->and($drift->healable)->toBeFalse()
+        ->and($drift->detail)->toContain('COPI-9');
+});
+
+it('R-E: blocked_by referencia task CANCELLED → 1 drift blocked_by_resolvido', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-6', 'status' => 'blocked', 'acceptance_ref' => null, 'blocked_by' => ['COPI-9']],
+        ['task_id' => 'COPI-9', 'status' => 'cancelled', 'acceptance_ref' => null, 'blocked_by' => []],
+    ];
+    $drift = tasksDriftPorTarget($rec->analisar($tasks, []), 'tasks.blocked_by_resolvido:COPI-6');
+
+    expect($drift)->not->toBeNull()
+        ->and($drift->healable)->toBeFalse();
+});
+
+it('R-E: blocked_by referencia task ainda DOING → 0 drift (bloqueio legítimo)', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-7', 'status' => 'blocked', 'acceptance_ref' => null, 'blocked_by' => ['COPI-9']],
+        ['task_id' => 'COPI-9', 'status' => 'doing', 'acceptance_ref' => null, 'blocked_by' => []],
+    ];
+    $drifts = $rec->analisar($tasks, ['COPI-9']); // COPI-9 doing com lease → não dispara R-A nele tampouco
+
+    expect(tasksDriftPorTarget($drifts, 'tasks.blocked_by_resolvido'))->toBeNull();
+});
+
+// ─── Sanidade + contrato ────────────────────────────────────────────────────────
+
+it('analisar: backlog todo em sincronia → nenhum drift', function () {
+    $rec = novoTasksRec();
+
+    $tasks = [
+        ['task_id' => 'COPI-1', 'status' => 'doing', 'acceptance_ref' => null, 'blocked_by' => []],
+        ['task_id' => 'COPI-2', 'status' => 'done', 'acceptance_ref' => 'PR #1', 'blocked_by' => []],
+        ['task_id' => 'COPI-3', 'status' => 'blocked', 'acceptance_ref' => null, 'blocked_by' => ['COPI-1']],
+        ['task_id' => 'COPI-4', 'status' => 'todo', 'acceptance_ref' => null, 'blocked_by' => []],
+    ];
+    // COPI-1 doing tem lease; COPI-2 done tem ref; COPI-3 bloqueada por COPI-1 (doing, não fechada).
+    $drifts = $rec->analisar($tasks, ['COPI-1']);
+
+    expect($drifts)->toBe([]);
+});
+
+it('reconcile: name e tags canônicos', function () {
+    $rec = novoTasksRec();
+
+    expect($rec->name())->toBe('tasks')
+        ->and($rec->tags())->toContain('tasks')
+        ->and($rec->tags())->toContain('tier_0')
+        ->and($rec->tags())->toContain('governance');
+});


### PR DESCRIPTION
## Leva 2 · Raia B — B-R0

Adiciona a faceta `tasks` ao reconciler canônico **existente** (`jana:reconcile`, ADR 0237) — **sem** criar comando novo. Detect-only (todos os drifts `healable=false` → só alerta, decisão humana R10):
- **R-A** doing-órfã: task `doing` sem lease ativo (`mcp_work_leases`, #2781).
- **R-B** done-sem-acceptance_ref: task `done` com `acceptance_ref` null/vazio (#2785).
- **R-E** blocked_by-resolvido: `blocked_by[]` aponta pra task já fechada (done/cancelled).

Registrado no array `reconcilers` do `config.php`; núcleo `analisar()` puro (testável sem DB). Teste mirror do `IndexReconcilerTest` (sqlite, lane ci.yml) cobrindo as 3 facetas + caso são.

Revisão adversarial (workflow): **ready**, `php -l` limpo, fiel ao contrato Reconciler, deps (#2781/#2785/ADR 0237) já no main.

Refs: SDD Leva 2 (B-R0) · ADR 0237 · ADR 0278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)