### PR TITLE
feat(brief): leases ativos + nudge 'claim antes de pegar' no Daily Brief — C2+C3 Leva 2

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -29,3 +29,4 @@ tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
 Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
+Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php

--- a/Modules/Brief/Config/retention.php
+++ b/Modules/Brief/Config/retention.php
@@ -112,4 +112,17 @@ return [
     | aplicável (time interno, ciência implícita via Termo de Uso).
     */
     'notice_period_days' => 0,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Kill-switch C2+C3 (default ON) — bloco de leases ATIVOS no Daily Brief
+    |--------------------------------------------------------------------------
+    | SDD Leva 2 (ADR 0278). Quando true, LeaseBriefSectionService injeta sob
+    | `## EM VOO AGORA` a lista de leases de coordenação ativos + o nudge
+    | "claim antes de pegar". `BRIEF_LEASE_SECTION=false` no .env desliga o
+    | inject() sem deploy — o service devolve o brief intacto (zero bloco,
+    | zero query). Mesmo idioma do kill-switch GT-G8 (governance.sdd_brief_line).
+    | @see Modules\Brief\Services\LeaseBriefSectionService
+    */
+    'lease_section' => env('BRIEF_LEASE_SECTION', true),
 ];

--- a/Modules/Brief/Config/retention.php
+++ b/Modules/Brief/Config/retention.php
@@ -119,10 +119,11 @@ return [
     |--------------------------------------------------------------------------
     | SDD Leva 2 (ADR 0278). Quando true, LeaseBriefSectionService injeta sob
     | `## EM VOO AGORA` a lista de leases de coordenação ativos + o nudge
-    | "claim antes de pegar". `BRIEF_LEASE_SECTION=false` no .env desliga o
-    | inject() sem deploy — o service devolve o brief intacto (zero bloco,
-    | zero query). Mesmo idioma do kill-switch GT-G8 (governance.sdd_brief_line).
+    | "claim antes de pegar". Desligar = override de config (runtime/deploy) pra
+    | false → o service devolve o brief intacto (zero bloco, zero query). SEM env()
+    | aqui: Larastan barra env() fora do config/ root (NoEnvCallsOutsideOfConfig);
+    | o toggle vive em config('brief.lease_section') com default ON.
     | @see Modules\Brief\Services\LeaseBriefSectionService
     */
-    'lease_section' => env('BRIEF_LEASE_SECTION', true),
+    'lease_section' => true,
 ];

--- a/Modules/Brief/Console/Commands/GenerateBriefCommand.php
+++ b/Modules/Brief/Console/Commands/GenerateBriefCommand.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Modules\Brief\Services\BriefGeneratorService;
 use Modules\Brief\Services\BriefValidator;
+use Modules\Brief\Services\LeaseBriefSectionService;
 use Modules\Governance\Services\SddBriefLineService;
 use Throwable;
 
@@ -49,6 +50,12 @@ final class GenerateBriefCommand extends Command
         // mcp_sdd_scorecard_history OU há alerta (armada regrediu/fonte
         // vermelha). inject() é best-effort — brief nunca falha por causa dela.
         $content = app(SddBriefLineService::class)->inject($content);
+
+        // C2+C3 (SDD Leva 2, ADR 0278) — bloco de leases ATIVOS + nudge "claim
+        // antes de pegar", injetado sob `## EM VOO AGORA`. Best-effort (pós-LLM):
+        // sem leases / tabela ausente / qualquer erro → brief intacto. Roteia por
+        // WorkLeaseService::activeLeases() (varre expirados antes de listar).
+        $content = app(LeaseBriefSectionService::class)->inject($content);
 
         $aggregatedHash = hash('sha256', $content);
 

--- a/Modules/Brief/Services/LeaseBriefSectionService.php
+++ b/Modules/Brief/Services/LeaseBriefSectionService.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Brief\Services;
+
+use Illuminate\Support\Collection;
+use Modules\Jana\Services\WorkLease\WorkLeaseService;
+use Throwable;
+
+/**
+ * Item C2+C3 (SDD Leva 2) — bloco de leases ATIVOS no Daily Brief (ADR 0091).
+ *
+ * Superfície determinística (pós-LLM) que injeta, sob a seção `## EM VOO AGORA`,
+ * a lista de leases de coordenação ativos (D1, ADR 0278) + um nudge "claim antes
+ * de pegar" (ADR 0278) pra que o agente não colida com trabalho já reivindicado.
+ *
+ * Por que pós-LLM (e não no stored proc / num novo header):
+ *  - O corpo do brief é gerado pelo Brain B; leases vivem em runtime (TTL no
+ *    Service, não no schema) — o modelo nunca poderia inventar esse estado.
+ *  - BriefValidator exige EXATAMENTE 7 headers ordenados; criar um header novo
+ *    quebraria a validação. Por isso o bloco entra SOB um header existente
+ *    (`## EM VOO AGORA`), exatamente como SddBriefLineService faz com `## FLAGS`.
+ *
+ * Best-effort: tabela ausente, zero leases, ou qualquer exceção → devolve o
+ * conteúdo intacto. O brief NUNCA quebra por causa deste bloco.
+ * Kill-switch: `brief.lease_section` false → no-op (default ON).
+ *
+ * @see Modules\Governance\Services\SddBriefLineService (idiom espelhado)
+ * @see Modules\Jana\Services\WorkLease\WorkLeaseService::activeLeases()
+ * @see Modules\Brief\Console\Commands\GenerateBriefCommand (plug-point inject)
+ * @see memory/decisions/0278-arquitetura-rede-ia-duravel-anti-vazamento.md
+ */
+final class LeaseBriefSectionService
+{
+    /** Teto de leases listados — alinhado ao default de WorkLeaseService::activeLeases(). */
+    private const MAX_LEASES = 15;
+
+    /**
+     * Injeta o bloco de leases ativos sob `## EM VOO AGORA`. Best-effort:
+     * sem leases (ou qualquer falha) devolve o conteúdo intacto.
+     * Kill-switch: `brief.lease_section` false → no-op (default ON).
+     */
+    public function inject(string $content): string
+    {
+        if (! (bool) config('brief.lease_section', true)) {
+            return $content;
+        }
+
+        try {
+            $block = $this->block();
+        } catch (Throwable) {
+            return $content;
+        }
+
+        if ($block === null) {
+            return $content;
+        }
+
+        $injected = preg_replace(
+            '/^## EM VOO AGORA$/m',
+            "## EM VOO AGORA\n{$block}",
+            $content,
+            1,
+            $count
+        );
+
+        return ($count === 1 && is_string($injected)) ? $injected : $content;
+    }
+
+    /**
+     * Bloco markdown dos leases ativos, ou null quando não há nenhum
+     * (ou a fonte está indisponível). Roteia por WorkLeaseService::activeLeases(),
+     * que já varre os expirados (sweepExpired) — leases vencidos NÃO aparecem.
+     */
+    public function block(): ?string
+    {
+        /** @var Collection<int, \stdClass> $leases */
+        $leases = app(WorkLeaseService::class)->activeLeases(self::MAX_LEASES);
+
+        if ($leases->isEmpty()) {
+            return null;
+        }
+
+        $bullets = $leases
+            ->map(fn (object $lease): string => sprintf(
+                '- 🔒 `%s` → %s (expira %s)',
+                (string) ($lease->task_id ?? '—'),
+                (string) ($lease->human_principal ?? '—'),
+                (string) ($lease->expires_at ?? '—'),
+            ))
+            ->implode("\n");
+
+        $nudge = '↳ claim antes de pegar: rode tasks-claim pra não colidir (ADR 0278)';
+
+        return "{$bullets}\n{$nudge}";
+    }
+}

--- a/Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
+++ b/Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Brief\Services\BriefValidator;
+use Modules\Brief\Services\LeaseBriefSectionService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Item C2+C3 (SDD Leva 2, ADR 0278) — bloco de leases ATIVOS no Daily Brief.
+ *
+ * GUARDA o contrato do injetor pós-LLM:
+ *   1. Leases ativos → bullet 🔒 + nudge literal "claim antes de pegar" SOB
+ *      `## EM VOO AGORA`; resto do markdown intacto; ainda termina em ---END---.
+ *   2. Zero leases → conteúdo byte-idêntico (best-effort silencioso).
+ *   3. Lease EXPIRADO não vaza (roteia por activeLeases → sweepExpired).
+ *   4. Kill-switch `brief.lease_section` false → no-op (mesmo com lease ativo).
+ *   5. Pós-injeção, o brief AINDA passa BriefValidator::validate() (7 headers).
+ *
+ * Padrão era-sqlite (schema sintético inline + skip não-sqlite), igual a
+ * WorkLeaseServiceTest: a lane per-PR roda sqlite :memory: e RefreshDatabase da
+ * suite inteira inclui migrations MySQL-only — então monta-se só a tabela do D1.
+ *
+ * @see Modules/Brief/Services/LeaseBriefSectionService.php
+ * @see Modules/Brief/Console/Commands/GenerateBriefCommand.php (plug-point inject)
+ * @see Modules/Jana/Services/WorkLease/WorkLeaseService.php (activeLeases)
+ * @see Modules/Governance/Tests/Feature/SddBriefLineServiceTest.php (idiom espelhado)
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente (floor SDD).');
+    }
+
+    Schema::dropIfExists('mcp_work_leases');
+
+    Schema::create('mcp_work_leases', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('task_id', 40);
+        $table->string('human_principal', 60);
+        $table->string('agent_id', 80)->nullable();
+        $table->string('claude_code_session', 64)->nullable();
+        $table->timestamp('acquired_at')->useCurrent();
+        $table->timestamp('heartbeat_at')->useCurrent();
+        $table->timestamp('expires_at');
+        $table->timestamp('released_at')->nullable();
+        $table->timestamps();
+        $table->index('task_id', 'mwl_task_idx');
+        $table->index('expires_at', 'mwl_expires_idx');
+    });
+    Schema::table('mcp_work_leases', function ($table) {
+        $table->integer('active_marker')
+            ->virtualAs('case when released_at is null then 1 else null end')
+            ->nullable();
+    });
+    Schema::table('mcp_work_leases', function ($table) {
+        $table->unique(['task_id', 'active_marker'], 'mwl_active_lease_unq');
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_work_leases');
+});
+
+function leaseC2Insert(string $taskId, string $principal, int $expiresInMinutes = 30): void
+{
+    DB::table('mcp_work_leases')->insert([
+        'task_id' => $taskId,
+        'human_principal' => $principal,
+        'acquired_at' => now(),
+        'heartbeat_at' => now(),
+        'expires_at' => now()->addMinutes($expiresInMinutes),
+        'released_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+/** Brief sintético com os 7 headers ordenados, terminando em ---END--- (passa BriefValidator). */
+function leaseC2Brief(): string
+{
+    return "## ESTADO MACRO\n- x\n\n## EM VOO AGORA\n- US-GOV-099: trabalho narrado\n\n"
+        ."## DECISÕES RECENTES (24h)\n- x\n\n## SKILLS USO 7d\n- x\n\n"
+        ."## CHARTERS APODRECENDO\n—\n\n## FLAGS\n- 🟢 Migration aging: ok\n\n"
+        ."## METADATA\n- Gerado: hoje\n---END---";
+}
+
+it('lease ativo → bullet 🔒 + nudge literal injetado sob EM VOO AGORA (resto intacto, termina ---END---)', function () {
+    leaseC2Insert('US-GOV-022', 'wagner');
+
+    $out = (new LeaseBriefSectionService())->inject(leaseC2Brief());
+
+    expect($out)->toContain("## EM VOO AGORA\n- 🔒 `US-GOV-022` → wagner (expira ")
+        ->and($out)->toContain('↳ claim antes de pegar: rode tasks-claim pra não colidir (ADR 0278)')
+        // bullet narrado original da seção preservado (não foi sobrescrito)
+        ->and($out)->toContain('- US-GOV-099: trabalho narrado')
+        // headers vizinhos intactos
+        ->and($out)->toContain('## DECISÕES RECENTES (24h)')
+        ->and($out)->toContain('- 🟢 Migration aging: ok')
+        ->and(trim($out))->toEndWith('---END---');
+})->group('brief', 'work-lease', 'ci');
+
+it('zero leases → conteúdo byte-idêntico (best-effort silencioso)', function () {
+    expect((new LeaseBriefSectionService())->inject(leaseC2Brief()))
+        ->toBe(leaseC2Brief());
+})->group('brief', 'work-lease', 'ci');
+
+it('lease EXPIRADO NÃO é surfaceado (roteia por activeLeases → sweepExpired)', function () {
+    leaseC2Insert('US-GOV-022', 'wagner', expiresInMinutes: -5); // já estourou o TTL
+
+    $out = (new LeaseBriefSectionService())->inject(leaseC2Brief());
+
+    expect($out)->toBe(leaseC2Brief())              // nenhum bloco injetado
+        ->and($out)->not->toContain('🔒')
+        ->and($out)->not->toContain('claim antes de pegar');
+})->group('brief', 'work-lease', 'ci');
+
+it('kill-switch brief.lease_section false → inject vira no-op mesmo com lease ativo', function () {
+    config(['brief.lease_section' => false]);
+    leaseC2Insert('US-GOV-022', 'wagner');
+
+    expect((new LeaseBriefSectionService())->inject(leaseC2Brief()))
+        ->toBe(leaseC2Brief());
+})->group('brief', 'work-lease', 'ci');
+
+it('brief pós-injeção AINDA passa BriefValidator (7 headers ordenados, ---END--- intacto)', function () {
+    leaseC2Insert('US-GOV-022', 'wagner');
+    leaseC2Insert('US-GOV-031', 'eliana');
+
+    $out = (new LeaseBriefSectionService())->inject(leaseC2Brief());
+
+    // 2 leases + nudge presentes (injeção real aconteceu)…
+    expect($out)->toContain('`US-GOV-022` → wagner')
+        ->and($out)->toContain('`US-GOV-031` → eliana')
+        ->and($out)->toContain('claim antes de pegar');
+
+    // …e o validador canônico continua aceitando (nenhum header novo criado).
+    expect((new BriefValidator())->validate($out)->isOk())->toBeTrue();
+})->group('brief', 'work-lease', 'ci');


### PR DESCRIPTION
## Leva 2 · Raia C — C2+C3

Mostra os work-leases ativos (`mcp_work_leases`, #2781) + nudge **'claim antes de pegar'** no Daily Brief (ADR 0091), pra coordenação multi-IA não colidir.

Como o corpo do brief é **gerado por LLM**, usa um **injetor pós-LLM determinístico** (`LeaseBriefSectionService`, espelha o `SddBriefLineService` provado): injeta bullets sob a seção **'## EM VOO AGORA'** existente via `preg_replace` — **não cria header novo** (preserva o invariante das 7 seções do `BriefValidator`). Best-effort (config kill-switch + try/catch → nunca derruba o brief). Leases expirados não aparecem (`activeLeases()` faz `sweepExpired()`).

Teste (sqlite, lane ci.yml): injeta bullet+nudge sob EM VOO AGORA; zero leases → no-op byte-idêntico; lease expirado não some... não surge; kill-switch; e o brief pós-injeção **ainda passa no BriefValidator** (7 headers).

Revisão adversarial (workflow): **ready**, idioma fiel ao SddBriefLineService, 7-header intacto.

Refs: SDD Leva 2 (C2+C3) · ADR 0091 · ADR 0278 · #2781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)