### PR TITLE
feat(jana-mcp): server-side scope gate via AuthorizesMcpMutation trait — A4 Leva 2

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -28,3 +28,4 @@ Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
 tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
+Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php

--- a/Modules/Jana/Http/Middleware/McpAuthMiddleware.php
+++ b/Modules/Jana/Http/Middleware/McpAuthMiddleware.php
@@ -49,15 +49,20 @@ class McpAuthMiddleware
         }
 
         // RBAC gate — MEM-MCP-1.d (ADR 0053): user precisa da permission
-        // `copiloto.mcp.use` mesmo com token válido. Sem isso → 403 + audit.
-        // Granularidade fina (decisions.read, governanca.financeiro, etc.)
-        // fica nos Tools individuais (cada Tool checa o scope via $user->can).
+        // `jana.mcp.use` mesmo com token válido. Sem isso → 403 + audit.
+        // Este é o gate GROSSO (acesso ao server). A granularidade fina por
+        // scope (jana.mcp.tasks.write, jana.mcp.cycles.manage, jana.mcp.memory.manage,
+        // etc.) é enforced nas tools que MUTAM estado via o trait
+        // AuthorizesMcpMutation (SDD Leva 2 · A4) — chamado como primeiro
+        // statement do handle() de cada tool mutadora. Tools de leitura só
+        // exigem este gate básico (e filtram resultado por scope quando aplicável,
+        // ex: CcSearchTool com jana.cc.read.all).
         if (method_exists($user, 'can') && ! $user->can('jana.mcp.use')) {
             return $this->denied(
                 $request,
                 $startedAt,
                 'no_permission',
-                "User não tem permission `copiloto.mcp.use`. Atribua via Spatie role/permission."
+                "User não tem permission `jana.mcp.use`. Atribua via Spatie role/permission."
             );
         }
 

--- a/Modules/Jana/Mcp/Tools/Concerns/AuthorizesMcpMutation.php
+++ b/Modules/Jana/Mcp/Tools/Concerns/AuthorizesMcpMutation.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools\Concerns;
+
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+
+/**
+ * SDD Leva 2 · A4 (RBAC server-side mutation gate) — fecha o furo deixado pelo
+ * comentário mentiroso do McpAuthMiddleware (L51-54), que afirmava "cada Tool
+ * checa o scope via $user->can". Na prática só o gate grosso `jana.mcp.use`
+ * existia; tools que MUTAM (criam/atualizam/fecham/esquecem) não checavam scope
+ * fino nenhum. Este trait dá o gate de escopo por-tool, chamado como PRIMEIRO
+ * statement do handle().
+ *
+ * Resolução de user idêntica ao resto do codebase: $request->user() (que o
+ * McpAuthMiddleware povoa via auth userResolver, L88) + guarda method_exists
+ * pra users não-Spatie/de teste (espelha McpAuthMiddleware.php:55 e
+ * CcSearchTool.php:86). Idioma de negação = Response::error() (laravel/mcp
+ * v0.7.0 não tem ->asError(); error() já marca isError:true — mesmo idioma
+ * usado em CcSearchTool, TasksClaimTool e LgpdEsquecerTitularTool).
+ *
+ * Uso:
+ *   if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.tasks.write')) {
+ *       return $deny;
+ *   }
+ */
+trait AuthorizesMcpMutation
+{
+    /**
+     * Gate de escopo pra tools que mutam estado.
+     *
+     * @param  Request  $request  Request MCP (protocolo) — user resolve via auth.
+     * @param  string  $scope  Slug Spatie do scope exigido (ex: jana.mcp.tasks.write).
+     * @return Response|null  Response de erro quando NEGADO; null quando autorizado.
+     */
+    protected function authorizeMcpMutation(Request $request, string $scope): ?Response
+    {
+        $user = $request->user();
+
+        // Sem user autenticado → nega. O McpAuthMiddleware já barraria antes,
+        // mas a tool não pode confiar nisso (defesa em profundidade).
+        if ($user === null) {
+            return Response::error("⛔ Sem permissão: requer scope {$scope} (autenticação ausente).");
+        }
+
+        // Guarda method_exists pra users sem Spatie HasRoles (test stubs,
+        // contas legadas) — mesma defesa do middleware/CcSearchTool. Se o user
+        // não sabe responder can(), tratamos como SEM o scope (fail-closed).
+        if (! method_exists($user, 'can') || ! $user->can($scope)) {
+            return Response::error("⛔ Sem permissão: requer scope {$scope}.");
+        }
+
+        return null;
+    }
+}

--- a/Modules/Jana/Mcp/Tools/CyclesCloseTool.php
+++ b/Modules/Jana/Mcp/Tools/CyclesCloseTool.php
@@ -14,6 +14,7 @@ use Modules\Jana\Entities\Mcp\McpProject;
 use Modules\Jana\Entities\Mcp\McpTask;
 use Modules\Jana\Entities\Mcp\McpTaskEvent;
 use Modules\Jana\Entities\Mcp\McpTaskComment;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
 
 /**
  * ADR 0070 — fecha cycle ativo. Por DEFAULT faz rollover Linear-style de
@@ -31,6 +32,8 @@ use Modules\Jana\Entities\Mcp\McpTaskComment;
  */
 class CyclesCloseTool extends Tool
 {
+    use AuthorizesMcpMutation;
+
     protected string $name = 'cycles-close';
 
     protected string $title = 'Fechar cycle ativo';
@@ -53,6 +56,10 @@ class CyclesCloseTool extends Tool
 
     public function handle(Request $request): Response
     {
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.cycles.manage')) {
+            return $deny;
+        }
+
         $key = strtoupper((string) $request->get('project', 'COPI'));
         $project = McpProject::where('key', $key)->first();
         if (! $project) {

--- a/Modules/Jana/Mcp/Tools/CyclesCreateTool.php
+++ b/Modules/Jana/Mcp/Tools/CyclesCreateTool.php
@@ -12,6 +12,7 @@ use Laravel\Mcp\Server\Tool;
 use Modules\Jana\Entities\Mcp\McpCycle;
 use Modules\Jana\Entities\Mcp\McpCycleGoal;
 use Modules\Jana\Entities\Mcp\McpProject;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
 
 /**
  * ADR 0070 — cria cycle novo (Linear-style) com goals opcionais em batch.
@@ -22,6 +23,8 @@ use Modules\Jana\Entities\Mcp\McpProject;
  */
 class CyclesCreateTool extends Tool
 {
+    use AuthorizesMcpMutation;
+
     protected string $name = 'cycles-create';
 
     protected string $title = 'Criar cycle (sprint)';
@@ -44,6 +47,10 @@ class CyclesCreateTool extends Tool
 
     public function handle(Request $request): Response
     {
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.cycles.manage')) {
+            return $deny;
+        }
+
         $projectKey = strtoupper((string) $request->get('project', 'COPI'));
         $project = McpProject::where('key', $projectKey)->first();
         if (! $project) {

--- a/Modules/Jana/Mcp/Tools/LgpdEsquecerTitularTool.php
+++ b/Modules/Jana/Mcp/Tools/LgpdEsquecerTitularTool.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Log;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
 use Modules\Jana\Services\Lgpd\DsrService;
 use Throwable;
 
@@ -36,6 +37,8 @@ use Throwable;
  */
 class LgpdEsquecerTitularTool extends Tool
 {
+    use AuthorizesMcpMutation;
+
     protected string $name = 'lgpd-esquecer-titular';
 
     protected string $title = 'LGPD Art. 18 §VI — direito de eliminação do titular';
@@ -63,6 +66,10 @@ class LgpdEsquecerTitularTool extends Tool
 
     public function handle(Request $request): Response
     {
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.memory.manage')) {
+            return $deny;
+        }
+
         $doc = trim((string) $request->get('cpf_or_cnpj', ''));
         $businessId = (int) $request->get('business_id', 0);
         $mode = (string) $request->get('mode', 'anonymize');

--- a/Modules/Jana/Mcp/Tools/LgpdEsquecerTitularTool.php
+++ b/Modules/Jana/Mcp/Tools/LgpdEsquecerTitularTool.php
@@ -50,7 +50,7 @@ class LgpdEsquecerTitularTool extends Tool
         return [
             'cpf_or_cnpj' => $schema->string()
                 ->required()
-                ->description('CPF (11 dígitos) ou CNPJ (14 dígitos). Aceita formatado (123.456.789-00) ou só dígitos.'),
+                ->description('CPF (11 dígitos) ou CNPJ (14 dígitos). Aceita formatado (123.456.789-00) ou só dígitos.'), // pii-allowlist (CPF de exemplo na doc do schema, não é dado real)
             'business_id' => $schema->integer()
                 ->required()
                 ->description('Tenant scope (Tier 0 IRREVOGÁVEL — explicit, não usa session).'),

--- a/Modules/Jana/Mcp/Tools/TasksCommentTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksCommentTool.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
 use Modules\Jana\Services\TaskRegistry\TaskCrudService;
 
 /**
@@ -18,6 +19,8 @@ use Modules\Jana\Services\TaskRegistry\TaskCrudService;
  */
 class TasksCommentTool extends Tool
 {
+    use AuthorizesMcpMutation;
+
     protected string $name = 'tasks-comment';
 
     protected string $title = 'Comentar numa task';
@@ -40,6 +43,10 @@ class TasksCommentTool extends Tool
 
     public function handle(Request $request): Response
     {
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.tasks.write')) {
+            return $deny;
+        }
+
         $taskId  = trim((string) $request->get('task_id', ''));
         $comment = trim((string) $request->get('comment', ''));
         $author  = trim((string) $request->get('author', 'wagner')) ?: 'wagner';

--- a/Modules/Jana/Mcp/Tools/TasksCreateTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksCreateTool.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
 use Modules\Jana\Services\TaskRegistry\TaskCrudService;
 
 /**
@@ -21,6 +22,8 @@ use Modules\Jana\Services\TaskRegistry\TaskCrudService;
  */
 class TasksCreateTool extends Tool
 {
+    use AuthorizesMcpMutation;
+
     protected string $name = 'tasks-create';
 
     protected string $title = 'Criar nova task (US-*) no SPEC.md';
@@ -55,6 +58,10 @@ class TasksCreateTool extends Tool
 
     public function handle(Request $request): Response
     {
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.tasks.write')) {
+            return $deny;
+        }
+
         $module = trim((string) $request->get('module', ''));
         $title  = trim((string) $request->get('title', ''));
 

--- a/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
 use Modules\Jana\Services\TaskRegistry\TaskCrudService;
 
 /**
@@ -23,6 +24,8 @@ use Modules\Jana\Services\TaskRegistry\TaskCrudService;
  */
 class TasksUpdateTool extends Tool
 {
+    use AuthorizesMcpMutation;
+
     protected string $name = 'tasks-update';
 
     protected string $title = 'Atualizar task (status/owner/sprint/priority)';
@@ -54,6 +57,10 @@ class TasksUpdateTool extends Tool
 
     public function handle(Request $request): Response
     {
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.tasks.write')) {
+            return $deny;
+        }
+
         $taskId = trim((string) $request->get('task_id', ''));
         if ($taskId === '') {
             return Response::text('❌ task_id é obrigatório.');

--- a/Modules/Jana/Tests/Feature/LgpdEsquecerTitularToolTest.php
+++ b/Modules/Jana/Tests/Feature/LgpdEsquecerTitularToolTest.php
@@ -100,10 +100,45 @@ beforeEach(function () {
     // injetam um user AUTORIZADO no auth userResolver (mesmo canal que
     // Laravel\Mcp\Request::user() lê). A negação por scope vive em
     // AuthorizesMcpMutationTest.
-    app('auth')->resolveUsersUsing(fn ($guard = null) => new class {
+    app('auth')->resolveUsersUsing(fn ($guard = null) => new class implements \Illuminate\Contracts\Auth\Authenticatable {
         public function can($abilities, $arguments = []): bool
         {
             return true;
+        }
+
+        public function getAuthIdentifierName()
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier()
+        {
+            return 42;
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword()
+        {
+            return '';
+        }
+
+        public function getRememberToken()
+        {
+            return '';
+        }
+
+        public function setRememberToken($value)
+        {
+            // no-op (stub)
+        }
+
+        public function getRememberTokenName()
+        {
+            return 'remember_token';
         }
     });
 });

--- a/Modules/Jana/Tests/Feature/LgpdEsquecerTitularToolTest.php
+++ b/Modules/Jana/Tests/Feature/LgpdEsquecerTitularToolTest.php
@@ -94,6 +94,18 @@ beforeEach(function () {
         $t->uuid('batch_uuid')->nullable();
         $t->timestamps();
     });
+
+    // A4 (SDD Leva 2): a tool agora exige scope jana.mcp.memory.manage via
+    // AuthorizesMcpMutation. Estes cenários cobrem validações/happy-path, então
+    // injetam um user AUTORIZADO no auth userResolver (mesmo canal que
+    // Laravel\Mcp\Request::user() lê). A negação por scope vive em
+    // AuthorizesMcpMutationTest.
+    app('auth')->resolveUsersUsing(fn ($guard = null) => new class {
+        public function can($abilities, $arguments = []): bool
+        {
+            return true;
+        }
+    });
 });
 
 afterEach(function () {

--- a/Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+// Local-dev worktree autoload fix: require_once ANTES de qualquer `use` pra
+// garantir que a versão da worktree das tools/trait seja a carregada (vendor é
+// symlink pra main repo em dev local; em CI/prod o autoload do worktree resolve
+// nativo). Mesmo padrão de CyclesCloseToolTest.
+(function () {
+    $base = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'Mcp' . DIRECTORY_SEPARATOR . 'Tools' . DIRECTORY_SEPARATOR;
+    $map = [
+        'Modules\\Jana\\Mcp\\Tools\\Concerns\\AuthorizesMcpMutation' => $base . 'Concerns' . DIRECTORY_SEPARATOR . 'AuthorizesMcpMutation.php',
+        'Modules\\Jana\\Mcp\\Tools\\TasksCreateTool' => $base . 'TasksCreateTool.php',
+        'Modules\\Jana\\Mcp\\Tools\\LgpdEsquecerTitularTool' => $base . 'LgpdEsquecerTitularTool.php',
+    ];
+    foreach ($map as $class => $file) {
+        if (is_file($file) && ! class_exists($class, false) && ! trait_exists($class, false)) {
+            require_once $file;
+        }
+    }
+})();
+
+use Illuminate\Contracts\Auth\Access\Authorizable;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Laravel\Mcp\Request as McpRequest;
+use Laravel\Mcp\Response as McpResponse;
+use Modules\Jana\Mcp\Tools\LgpdEsquecerTitularTool;
+use Modules\Jana\Mcp\Tools\TasksCreateTool;
+use Modules\Jana\Services\Lgpd\DsrEsquecimentoResult;
+use Modules\Jana\Services\Lgpd\DsrService;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * SDD Leva 2 · A4 — gate de escopo server-side em tools que MUTAM via trait
+ * AuthorizesMcpMutation.
+ *
+ * BITE: a versão anterior (comentário mentiroso no McpAuthMiddleware: "cada Tool
+ * checa o scope via $user->can") deixava tools mutadoras SEM checagem fina. Este
+ * teste prova que:
+ *   (a) caller SEM o scope recebe Response::error() mencionando o scope/'permiss'
+ *       E a mutação NÃO acontece (o service nunca é invocado);
+ *   (b) caller COM o scope segue adiante (o service É invocado).
+ *
+ * Se o gate regredir (for removido / não rodar como primeiro statement), o caller
+ * negado alcançaria o service → o spy registraria a chamada → o teste FALHA.
+ * Não é tautologia: a asserção é sobre o efeito colateral (service chamado ou não),
+ * não só sobre a string da Response.
+ *
+ * Cobre TasksCreateTool (jana.mcp.tasks.write) + LgpdEsquecerTitularTool
+ * (jana.mcp.memory.manage — o de maior risco).
+ *
+ * sqlite-only: a resolução de user é via auth userResolver (não toca schema),
+ * mas mantemos o guard de driver pra consistência com a lane sqlite per-PR.
+ *
+ * @see Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation
+ */
+beforeEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('era-sqlite: sqlite-only no burn-down do floor SDD (consistência com tools irmãs).');
+    }
+});
+
+afterEach(function () {
+    // Restaura o resolver pra closure neutra — evita vazar o stub pros testes
+    // irmãos no mesmo processo Pest.
+    app('auth')->resolveUsersUsing(fn ($guard = null) => null);
+});
+
+/**
+ * Stub de user que implementa só o necessário: Authenticatable (contrato que
+ * Laravel\Mcp\Request::user() devolve) + Authorizable (provê can()). A decisão
+ * de can() é injetada via $granted.
+ */
+function makeMcpUser(bool $granted): Authenticatable
+{
+    return new class($granted) implements Authenticatable, Authorizable
+    {
+        public function __construct(private bool $granted) {}
+
+        public function can($abilities, $arguments = []): bool
+        {
+            return $this->granted;
+        }
+
+        public function getAuthIdentifierName()
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier()
+        {
+            return 42;
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword()
+        {
+            return '';
+        }
+
+        public function getRememberToken()
+        {
+            return '';
+        }
+
+        public function setRememberToken($value)
+        {
+            // no-op (stub)
+        }
+
+        public function getRememberTokenName()
+        {
+            return 'remember_token';
+        }
+    };
+}
+
+/** Injeta (ou limpa) o user resolvido por Laravel\Mcp\Request::user(). */
+function actAsMcpUser(?Authenticatable $user): void
+{
+    app('auth')->resolveUsersUsing(fn ($guard = null) => $user);
+}
+
+/** Extrai o texto de uma Response MCP (Text::__toString). */
+function mcpResponseText(McpResponse $response): string
+{
+    return (string) $response->content();
+}
+
+/**
+ * Spy de TaskCrudService: registra se create() foi chamado e devolve um result
+ * válido pra tool renderizar sucesso no caminho autorizado.
+ */
+function bindTaskCrudSpy(): object
+{
+    $spy = new class extends TaskCrudService
+    {
+        public bool $createCalled = false;
+
+        public function __construct()
+        {
+            // não chama parent::__construct — TaskCrudService não tem ctor com deps,
+            // mas explicitamos pra deixar o spy auto-contido.
+        }
+
+        public function create(array $data): array
+        {
+            $this->createCalled = true;
+
+            return [
+                'task_id'   => 'US-TEST-999',
+                'written'   => true,
+                'spec_path' => 'memory/requisitos/Test/SPEC.md',
+                'markdown'  => "\n### US-TEST-999 — spy\n",
+            ];
+        }
+    };
+
+    app()->instance(TaskCrudService::class, $spy);
+
+    return $spy;
+}
+
+/**
+ * Spy de DsrService: registra se esquecerTitular() foi chamado. Override do ctor
+ * pra não precisar das deps (PiiRedactor + JanaAuditService).
+ */
+function bindDsrSpy(): object
+{
+    $spy = new class extends DsrService
+    {
+        public bool $esquecerCalled = false;
+
+        public function __construct()
+        {
+            // sem deps — override do ctor de DsrService.
+        }
+
+        public function esquecerTitular(string $cpfOuCnpj, int $businessId, string $mode = 'anonymize'): DsrEsquecimentoResult
+        {
+            $this->esquecerCalled = true;
+
+            return new DsrEsquecimentoResult(
+                cpfOuCnpj: preg_replace('/\D+/', '', $cpfOuCnpj) ?? '',
+                businessId: $businessId,
+                refsByEntity: [],
+                auditTrailId: 'spy-batch',
+                startedAt: now()->toIso8601String(),
+                finishedAt: now()->toIso8601String(),
+                durationMs: 1,
+                status: 'ok',
+            );
+        }
+    };
+
+    app()->instance(DsrService::class, $spy);
+
+    return $spy;
+}
+
+// ─── TasksCreateTool (jana.mcp.tasks.write) ───────────────────────────────────
+
+it('TasksCreateTool NEGA caller sem jana.mcp.tasks.write e NÃO muta', function () {
+    $spy = bindTaskCrudSpy();
+    actAsMcpUser(makeMcpUser(granted: false));
+
+    $params = ['module' => 'Test', 'title' => 'tentativa sem scope'];
+    request()->replace($params);
+
+    $response = (new TasksCreateTool())->handle(new McpRequest($params));
+
+    // Response é de erro e menciona o scope exigido.
+    expect($response->isError())->toBeTrue();
+    expect(mcpResponseText($response))
+        ->toContain('jana.mcp.tasks.write')
+        ->toContain('permiss');
+
+    // BITE: o service de mutação NUNCA foi invocado.
+    expect($spy->createCalled)->toBeFalse();
+});
+
+it('TasksCreateTool PERMITE caller com jana.mcp.tasks.write e segue pro service', function () {
+    $spy = bindTaskCrudSpy();
+    actAsMcpUser(makeMcpUser(granted: true));
+
+    $params = ['module' => 'Test', 'title' => 'criação autorizada'];
+    request()->replace($params);
+
+    $response = (new TasksCreateTool())->handle(new McpRequest($params));
+
+    // Passou do gate — o service foi chamado e a Response não é de negação.
+    expect($spy->createCalled)->toBeTrue();
+    expect(mcpResponseText($response))->toContain('US-TEST-999');
+});
+
+it('TasksCreateTool NEGA quando não há user autenticado (defesa em profundidade)', function () {
+    $spy = bindTaskCrudSpy();
+    actAsMcpUser(null);
+
+    $params = ['module' => 'Test', 'title' => 'sem user'];
+    request()->replace($params);
+
+    $response = (new TasksCreateTool())->handle(new McpRequest($params));
+
+    expect($response->isError())->toBeTrue()
+        ->and(mcpResponseText($response))->toContain('jana.mcp.tasks.write')
+        ->and($spy->createCalled)->toBeFalse();
+});
+
+// ─── LgpdEsquecerTitularTool (jana.mcp.memory.manage — maior risco) ────────────
+
+it('LgpdEsquecerTitularTool NEGA caller sem jana.mcp.memory.manage e NÃO esquece', function () {
+    $spy = bindDsrSpy();
+    actAsMcpUser(makeMcpUser(granted: false));
+
+    // confirm=true seria o caminho destrutivo — o gate (1º statement) tem que
+    // barrar ANTES de tocar o DsrService.
+    $params = [
+        'cpf_or_cnpj' => '123.456.789-00', // pii-allowlist
+        'business_id' => 1,
+        'mode'        => 'anonymize',
+        'confirm'     => true,
+    ];
+    request()->replace($params);
+
+    $response = (new LgpdEsquecerTitularTool())->handle(new McpRequest($params));
+
+    expect($response->isError())->toBeTrue();
+    expect(mcpResponseText($response))
+        ->toContain('jana.mcp.memory.manage')
+        ->toContain('permiss');
+
+    // BITE: o esquecimento LGPD (destrutivo) NUNCA rodou.
+    expect($spy->esquecerCalled)->toBeFalse();
+});
+
+it('LgpdEsquecerTitularTool PERMITE caller com jana.mcp.memory.manage (confirm=true executa)', function () {
+    $spy = bindDsrSpy();
+    actAsMcpUser(makeMcpUser(granted: true));
+
+    $params = [
+        'cpf_or_cnpj' => '123.456.789-00', // pii-allowlist
+        'business_id' => 1,
+        'mode'        => 'anonymize',
+        'confirm'     => true,
+    ];
+    request()->replace($params);
+
+    $response = (new LgpdEsquecerTitularTool())->handle(new McpRequest($params));
+
+    // Passou do gate → o service destrutivo foi de fato invocado.
+    expect($spy->esquecerCalled)->toBeTrue();
+    expect($response->isError())->toBeFalse();
+});

--- a/Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
@@ -20,7 +20,6 @@ declare(strict_types=1);
     }
 })();
 
-use Illuminate\Contracts\Auth\Access\Authorizable;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Laravel\Mcp\Request as McpRequest;
 use Laravel\Mcp\Response as McpResponse;
@@ -70,12 +69,13 @@ afterEach(function () {
 
 /**
  * Stub de user que implementa só o necessário: Authenticatable (contrato que
- * Laravel\Mcp\Request::user() devolve) + Authorizable (provê can()). A decisão
- * de can() é injetada via $granted.
+ * Laravel\Mcp\Request::user() devolve) + um método can() (a trait chama via
+ * method_exists, NÃO pelo contrato Authorizable). A decisão de can() é injetada
+ * via $granted.
  */
 function makeMcpUser(bool $granted): Authenticatable
 {
-    return new class($granted) implements Authenticatable, Authorizable
+    return new class($granted) implements Authenticatable
     {
         public function __construct(private bool $granted) {}
 

--- a/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
@@ -143,10 +143,45 @@ beforeEach(function () {
     // injeta um user autorizado no auth userResolver (mesmo canal que o
     // McpAuthMiddleware povoa + que Laravel\Mcp\Request::user() lê). A cobertura
     // da NEGAÇÃO vive em AuthorizesMcpMutationTest.
-    app('auth')->resolveUsersUsing(fn ($guard = null) => new class {
+    app('auth')->resolveUsersUsing(fn ($guard = null) => new class implements \Illuminate\Contracts\Auth\Authenticatable {
         public function can($abilities, $arguments = []): bool
         {
             return true;
+        }
+
+        public function getAuthIdentifierName()
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier()
+        {
+            return 42;
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword()
+        {
+            return '';
+        }
+
+        public function getRememberToken()
+        {
+            return '';
+        }
+
+        public function setRememberToken($value)
+        {
+            // no-op (stub)
+        }
+
+        public function getRememberTokenName()
+        {
+            return 'remember_token';
         }
     });
 });

--- a/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/CyclesCloseToolTest.php
@@ -137,6 +137,18 @@ beforeEach(function () {
         $t->text('body');
         $t->timestamps();
     });
+
+    // A4 (SDD Leva 2): CyclesCloseTool agora exige scope jana.mcp.cycles.manage
+    // via trait AuthorizesMcpMutation. Os cenários abaixo são do caminho FELIZ —
+    // injeta um user autorizado no auth userResolver (mesmo canal que o
+    // McpAuthMiddleware povoa + que Laravel\Mcp\Request::user() lê). A cobertura
+    // da NEGAÇÃO vive em AuthorizesMcpMutationTest.
+    app('auth')->resolveUsersUsing(fn ($guard = null) => new class {
+        public function can($abilities, $arguments = []): bool
+        {
+            return true;
+        }
+    });
 });
 
 afterEach(function () {


### PR DESCRIPTION
## Leva 2 · Raia A — A4

Fecha o buraco que o comentário **mentiroso** do `McpAuthMiddleware` ('cada Tool checa o scope via $user->can') escondia: hoje **só** `CcSearchTool` chamava `->can()`, e era um read-filter — toda tool **mutadora** rodava sem checagem fina (só o `jana.mcp.use` coarse). Qualquer token válido podia chamar `tasks-create`, `cycles-close`, e até `lgpd-esquecer-titular` (delete destrutivo LGPD).

- **Trait `AuthorizesMcpMutation`** — gate no barramento (primeiro statement do `handle()`): resolve user via `$request->user()`, nega com `Response::error()` se `! ->can($scope)`, guard `method_exists`/null. Aplicado em TasksCreate/Update/Comment (`tasks.write`), CyclesCreate/Close (`cycles.manage`), **LgpdEsquecerTitular** (`memory.manage` — o de maior risco).
- **Corrige o comentário** do middleware + `copiloto.mcp.use`→`jana.mcp.use`.
- **Teste que morde** (`AuthorizesMcpMutationTest`, lane ci.yml): spies de TaskCrudService/DsrService provam que o caller **negado não muta** (service nunca invocado) e o autorizado segue.

### Pós-revisão adversarial (workflow) — 2 blockers corrigidos antes do PR
A revisão pegou que os stubs de user dos testes irmãos (CyclesClose/Lgpd) eram `new class { can() }` **sem implementar `Authenticatable`** → `Request::user()` (tipado `?Authenticatable`) daria TypeError. Corrigido: todos os stubs (incl. `makeMcpUser`, o único na lane CI) agora implementam `Authenticatable` + método `can()`; tirei o contrato `Authorizable` (a trait chama `can()` via `method_exists`, não pelo contrato — evita incerteza de `canAny/cant/cannot`).

Refs: SDD Leva 2 (A4) · ADR 0278 · ADR 0079 (Artigo 9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)