### PR TITLE
ci: lane sqlite lê allowlist merge=union (mata o conflito de 1 linha do ci.yml)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 "* text=auto eol=lf" 
+.github/ci-sqlite-pest.list merge=union

--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -1,0 +1,29 @@
+# Allowlist da lane sqlite per-PR — lida pelo job "PHP / Pest (Unit)" do
+# .github/workflows/ci.yml. 1 path por linha (arquivo OU diretório de teste).
+#
+# POR QUE UM ARQUIVO (e não a linha única do pest dentro do ci.yml): a linha
+# única era editada por TODO PR que adiciona um teste → todo par de PRs conflitava
+# (o "conflito de ci.yml lane de 1 linha" do handoff SDD Leva 1). Este arquivo é
+# marcado `merge=union` em .gitattributes → PRs concorrentes que adicionam linhas
+# são UNIDOS automaticamente pelo git, sem conflito. O runner faz `sort -u`, então
+# ordem e duplicatas não importam.
+#
+# REGRA: só testes SQLITE-SAFE (rodam em :memory: sem migrate completo). NÃO
+# adicionar testes com RefreshDatabase/migrate:fresh que puxem migration MySQL-only
+# (ex ALTER TABLE ... ENUM) — esses pertencem à lane MySQL (financeiro-pest /
+# jana-pest), não aqui. Testes MySQL-only que dão markTestSkipped em sqlite podem
+# ficar (viram skip-as-pass), mas o lar deles é a lane MySQL.
+#
+# Comentários começam com # e linhas em branco são ignoradas.
+Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
+Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php
+Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php
+Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php
+Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
+Modules/Jana/Tests/Feature/Reconcile/TasksReconcilerTest.php
+Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
+Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
+Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php
+Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
+tests/Feature/Form
+tests/Feature/Services/FeatureFlagServiceTest.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,16 @@ jobs:
         # FV-F1: --log-junit adicionado SEM mudar o subset de testes acima.
         run: |
           mkdir -p test-results
-          vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php Modules/Jana/Tests/Feature/Reconcile/TasksReconcilerTest.php Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php --no-coverage --log-junit test-results/junit.xml
+          # Alvos vêm de .github/ci-sqlite-pest.list (1 path/linha, merge=union via
+          # .gitattributes → PRs concorrentes que adicionam testes NÃO conflitam).
+          # sort -u torna ordem/duplicata irrelevantes. Adicionar teste = 1 linha
+          # naquele arquivo (NÃO editar este ci.yml).
+          mapfile -t PEST_TARGETS < <(grep -vE '^[[:space:]]*(#|$)' .github/ci-sqlite-pest.list | sort -u)
+          if [ "${#PEST_TARGETS[@]}" -eq 0 ]; then
+            echo "::error::.github/ci-sqlite-pest.list vazio — nenhum alvo de teste"; exit 1
+          fi
+          echo "Lane sqlite — ${#PEST_TARGETS[@]} alvos:"; printf '  %s\n' "${PEST_TARGETS[@]}"
+          vendor/bin/pest "${PEST_TARGETS[@]}" --no-coverage --log-junit test-results/junit.xml
 
       # FV-F1 (plano SDD 2026-06-12): coleta JUnit que SOBREVIVE a falha de teste.
       # A tentativa anterior rendeu artefato 0 bytes porque nada validava o XML


### PR DESCRIPTION
## Conserta o gargalo do `ci.yml` (escolha do Wagner: "conserta o gargalo primeiro")

A lane `PHP / Pest (Unit)` lia os testes de **uma única linha** no `ci.yml`. Toda PR que adiciona um teste edita essa linha → **todo par de PRs conflita** (o *"conflito de ci.yml lane de 1 linha"* do handoff, que forçou um trem de rebase manual na Leva 2).

### Fix
- Alvos movidos pra **`.github/ci-sqlite-pest.list`** (1 path/linha).
- **`.gitattributes`: `merge=union`** → git **une** adições concorrentes, **sem conflito**.
- `ci.yml` lê o arquivo (`grep` comentários/vazias + `sort -u` + guard anti-vazio).
- **Conjunto de testes idêntico** — só relocado. Zero mudança de comportamento (a lane roda exatamente os mesmos 12 alvos).

### Efeito
Adicionar teste à lane sqlite = **1 linha no `.list`**, sem tocar `ci.yml`, **sem rebase-train**. As PRs restantes da Leva 2 (FSM/C2+C3/A4 + Wave 2) passam a só apendar no manifesto.

Refs: SDD Leva 2 (gargalo) · handoff 2026-06-15-2000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)