### PR TITLE
feat(jana): whats-active injeta liveness — pipeline cego vira 'NÃO SEI' (B-SPOF-WA, Leva 2)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -30,3 +30,4 @@ tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
 Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
 Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
+tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php

--- a/Modules/Jana/Mcp/Tools/WhatsActiveTool.php
+++ b/Modules/Jana/Mcp/Tools/WhatsActiveTool.php
@@ -86,6 +86,22 @@ class WhatsActiveTool extends Tool
             ->pluck('last_activity_at', 'session_id');
 
         if ($sessionIds->isEmpty()) {
+            // B-SPOF-WA (ADR 0278 dim 10): "nenhuma msg recente" só é all-clear CONFIÁVEL
+            // se o pipeline de ingest estiver VIVO. Se o heartbeat existe E nenhum host
+            // está fresco (fresh=0), estamos CEGOS (watcher de ingest caído) — blind ≠ safe.
+            // Se a tabela de heartbeat nem existe (feature não-deployada), não cria lobo:
+            // mantém o all-clear original (sem sinal de liveness pra contradizê-lo).
+            if (Schema::hasTable('mcp_ingest_heartbeat')) {
+                $ingest = app(\Modules\TeamMcp\Services\IngestLivenessService::class)->summary();
+                if ($ingest['fresh'] === 0) {
+                    return Response::text(
+                        "⚠️ Nenhuma sessão Claude Code vista nas últimas {$hours}h — MAS o pipeline de "
+                        . "ingest está SEM heartbeat fresco (fresh=0 · stale={$ingest['stale']} · dead={$ingest['dead']}).\n"
+                        . '_Posso estar CEGO (watcher de ingest caído): NÃO assuma escopo livre — confirme antes de pegar._'
+                    );
+                }
+            }
+
             return Response::text(
                 "✅ Nenhuma sessão Claude Code ativa nas últimas {$hours}h.\n" .
                 '_Pode pegar qualquer escopo sem risco de overlap._'

--- a/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
+++ b/tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
@@ -18,6 +18,13 @@ beforeEach(function () {
         test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente — quarentena Onda 2 SDD floor; burn-down converte depois.');
     }
 
+    // Idempotente: este teste agora roda na lane sqlite compartilhada (:memory:) ao
+    // lado de outros — limpa antes de criar pra não estourar "table already exists".
+    Schema::dropIfExists('mcp_cc_messages');
+    Schema::dropIfExists('mcp_cc_sessions');
+    Schema::dropIfExists('users');
+    Schema::dropIfExists('mcp_ingest_heartbeat');
+
     Schema::create('mcp_cc_sessions', function (Blueprint $t) {
         $t->bigIncrements('id');
         $t->string('session_uuid', 36)->unique();
@@ -79,6 +86,7 @@ afterEach(function () {
         Schema::dropIfExists('mcp_cc_messages');
         Schema::dropIfExists('mcp_cc_sessions');
         Schema::dropIfExists('users');
+        Schema::dropIfExists('mcp_ingest_heartbeat'); // B-SPOF-WA: criada só no teste de liveness
     }
 });
 
@@ -146,6 +154,37 @@ it('WhatsActiveTool retorna mensagem amigável quando ninguém ativo', function 
         ->assertOk()
         ->assertSee('Nenhuma sessão Claude Code ativa');
 });
+
+it('WhatsActiveTool NÃO dá all-clear falso quando o pipeline de ingest está cego (B-SPOF-WA)', function () {
+    // Heartbeat EXISTE mas o último ingest foi há 3h (> STALE_MINUTES=60) → fresh=0:
+    // o watcher de ingest está caído, então "nenhuma sessão" pode ser CEGUEIRA, não calmaria.
+    Schema::create('mcp_ingest_heartbeat', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('host', 500)->unique();
+        $t->timestamp('last_ingest_at')->nullable();
+        $t->string('last_session_uuid', 36)->nullable();
+        $t->unsignedBigInteger('msgs_acc')->default(0);
+        $t->timestamps();
+    });
+    DB::table('mcp_ingest_heartbeat')->insert([
+        'host' => 'D:\\oimpresso.com',
+        'last_ingest_at' => now()->subHours(3)->toDateTimeString(),
+        'msgs_acc' => 5,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $user = makeUser();
+
+    // Sem mensagens recentes (isEmpty) MAS pipeline cego → resposta de INCERTEZA.
+    // BITE: se a guarda B-SPOF-WA regredir, volta o all-clear ("Pode pegar qualquer
+    // escopo") que NÃO contém estas frases → assertSee falha.
+    OimpressoMcpServer::actingAs($user)
+        ->tool(WhatsActiveTool::class)
+        ->assertOk()
+        ->assertSee('NÃO assuma escopo livre')
+        ->assertSee('fresh=0');
+})->group('ci');
 
 it('WhatsActiveTool lista 2 sessões ativas com paths overlapping', function () {
     $wagner = makeUser(['id' => 1, 'username' => 'wagner', 'first_name' => 'Wagner']);


### PR DESCRIPTION
## Leva 2 · Raia B — B-SPOF-WA (bug central da dim 10, ADR 0278)

`whats-active` respondia **"Pode pegar qualquer escopo sem risco de overlap"** sempre que não havia mensagens recentes — **mesmo quando o pipeline de ingest estava morto** (watcher caído = a tool está CEGA, não vendo as sessões que existem). All-clear falso.

### Fix
Antes do all-clear (`$sessionIds->isEmpty()`), consulta `IngestLivenessService` (B-LIVE-CHECK, já no main):
- **Heartbeat existe + `fresh==0`** (nenhum host ingeriu recente → watcher caído) → resposta de **INCERTEZA**: _"posso estar CEGO, NÃO assuma escopo livre"_ com `fresh/stale/dead`. **blind ≠ safe.**
- **Heartbeat fresco** → all-clear normal.
- **Tabela de heartbeat ausente** (feature não-deployada) → mantém o all-clear original (não cria lobo).

### Teste que morde
`WhatsActiveToolTest` ganhou um caso: heartbeat de 3h atrás (dead) + zero msgs → assert vê `'NÃO assuma escopo livre'` + `'fresh=0'` (se a guarda regredir, volta o all-clear → assertSee falha). **Importante:** esse arquivo de teste não rodava em lane nenhuma — agora ancorado no manifesto sqlite (`ci-sqlite-pest.list`), então toda a suíte do `whats-active` passa a rodar em CI. `beforeEach` idempotente pra coexistir na lane `:memory:`.

Refs: SDD Leva 2 (B-SPOF-WA) · ADR 0278 dim 10 · #2791 / B-LIVE-CHECK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)