### PR TITLE
feat(jana): A5 — aviso SOFT de mutação claim-less (instrumenta sinal pré-A7, Leva 2)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -31,3 +31,4 @@ Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
 Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
 Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
 tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
+Modules/Jana/Tests/Feature/TaskRegistry/ClaimlessMutationWarningTest.php

--- a/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
+++ b/Modules/Jana/Mcp/Tools/TasksUpdateTool.php
@@ -68,6 +68,14 @@ class TasksUpdateTool extends Tool
 
         $author = trim((string) $request->get('author', 'wagner')) ?: 'wagner';
 
+        // A5 (ADR 0278): principal CONFIÁVEL = dono do token MCP (não o $author
+        // auto-declarado/spoofável). Alimenta o sinal de mutação claim-less no
+        // TaskCrudService. Mesmo idiom do TasksClaimTool (human_principal do lease).
+        $user = $request->user();
+        $principal = $user !== null
+            ? (string) ($user->username ?? $user->email ?? ('user#' . $user->getAuthIdentifier()))
+            : null;
+
         $campos = [];
         foreach (['status', 'owner', 'sprint', 'priority', 'module', 'acceptance_ref'] as $field) {
             $val = $request->get($field);
@@ -98,7 +106,7 @@ class TasksUpdateTool extends Tool
         }
 
         try {
-            $result = app(TaskCrudService::class)->update($taskId, $campos, $author);
+            $result = app(TaskCrudService::class)->update($taskId, $campos, $author, $principal);
         } catch (\Throwable $e) {
             return Response::text('❌ ' . $e->getMessage());
         }

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -34,10 +34,10 @@ class TaskCrudService
      * @param  array<string,mixed> $fields
      * @return array{task: McpTask, events: list<McpTaskEvent>}
      */
-    public function update(string $taskId, array $fields, string $author = 'system'): array
+    public function update(string $taskId, array $fields, string $author = 'system', ?string $principal = null): array
     {
-        return OtelHelper::spanBiz('project_mgmt.task_crud.update', function () use ($taskId, $fields, $author): array {
-            return $this->updateInner($taskId, $fields, $author);
+        return OtelHelper::spanBiz('project_mgmt.task_crud.update', function () use ($taskId, $fields, $author, $principal): array {
+            return $this->updateInner($taskId, $fields, $author, $principal);
         }, [
             'module'      => 'ProjectMgmt',
             'task_id'     => $taskId,
@@ -52,13 +52,13 @@ class TaskCrudService
      * @param  array<string,mixed> $fields
      * @return array{task: McpTask, events: list<McpTaskEvent>}
      */
-    protected function updateInner(string $taskId, array $fields, string $author = 'system'): array
+    protected function updateInner(string $taskId, array $fields, string $author = 'system', ?string $principal = null): array
     {
         // Fase 2b (ADR 0278) — mutação ATÔMICA: transação + lock de linha fecham o
         // lost-update (2 agentes na mesma task → last-write-wins silencioso = a causa
         // literal do "a lista fura"). lockForUpdate serializa writers no MySQL; no
         // sqlite da lane per-PR é no-op seguro (writes já são serializados).
-        return DB::transaction(fn (): array => $this->applyLockedUpdate($taskId, $fields, $author));
+        return DB::transaction(fn (): array => $this->applyLockedUpdate($taskId, $fields, $author, $principal));
     }
 
     /**
@@ -68,7 +68,7 @@ class TaskCrudService
      * @param  array<string,mixed> $fields
      * @return array{task: McpTask, events: list<McpTaskEvent>}
      */
-    protected function applyLockedUpdate(string $taskId, array $fields, string $author): array
+    protected function applyLockedUpdate(string $taskId, array $fields, string $author, ?string $principal = null): array
     {
         $task = $this->findTaskOrFail($taskId, forUpdate: true);
 
@@ -81,6 +81,24 @@ class TaskCrudService
             'acceptance_ref',
         ];
         $events = [];
+
+        // A5 (ADR 0278 Fase 2) — instrumenta o SINAL de mutação CLAIM-LESS: o mutador
+        // (principal do TOKEN, não o $author auto-declarado/spoofável) não segura o lease
+        // ativo da task. SOFT — só evento de AVISO, sem throw. O hard-gate (A7) é
+        // signal-gated (espera o sinal acumular, ADR 0105). $principal null = caller de
+        // sistema/bulk → sem sinal. Degrada gracioso se mcp_work_leases não migrou.
+        if ($principal !== null && \Illuminate\Support\Facades\Schema::hasTable('mcp_work_leases')) {
+            $lease = app(\Modules\Jana\Services\WorkLease\WorkLeaseService::class)->activeLeaseFor($taskId);
+            $leaseHolder = $lease ? data_get($lease, 'human_principal') : null;
+            if ($leaseHolder !== $principal) {
+                $events[] = McpTaskEvent::log(
+                    taskId: $task->task_id,
+                    eventType: 'field_updated',
+                    author: $author,
+                    note: "AVISO Fase 2 (ADR 0278): mutação SEM lease ativo do mutador ({$principal}) — claim antes de pegar (tasks-claim). Hard-gate A7 é signal-gated.",
+                );
+            }
+        }
 
         foreach ($fields as $field => $newVal) {
             if (! in_array($field, $allowed, true)) {

--- a/Modules/Jana/Tests/Feature/TaskRegistry/ClaimlessMutationWarningTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/ClaimlessMutationWarningTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * A5 (ADR 0278 Fase 2) — sinal SOFT de mutação CLAIM-LESS.
+ *
+ * Quando o principal do TOKEN (não o $author auto-declarado) muta uma task SEM
+ * segurar o lease ativo dela, o TaskCrudService emite um McpTaskEvent de AVISO
+ * (sem throw). Esse sinal acumula pro hard-gate A7 (signal-gated, ADR 0105) decidir
+ * depois entre hard-block e auto-claim.
+ *
+ * Padrão era-sqlite (schema sintético inline + activitylog OFF), espelha
+ * AcceptanceRefTest. Roda na lane sqlite per-PR.
+ *
+ * @see Modules/Jana/Services/TaskRegistry/TaskCrudService::applyLockedUpdate
+ * @see Modules/Jana/Services/WorkLease/WorkLeaseService::activeLeaseFor
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético incompatível com MySQL persistente (floor SDD).');
+    }
+
+    config(['activitylog.enabled' => false]); // McpTask usa LogsActivity
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+    Schema::dropIfExists('mcp_work_leases');
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->json('blocked_by')->nullable();
+        $t->string('acceptance_ref', 500)->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->timestamp('completed_at')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('mcp_task_events', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('event_type', 40);
+        $t->string('from_value', 255)->nullable();
+        $t->string('to_value', 255)->nullable();
+        $t->string('author', 60)->nullable();
+        $t->text('note')->nullable();
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('updated_at')->nullable();
+    });
+    // Lease mínimo sqlite-friendly (sem a coluna gerada active_marker do MySQL —
+    // activeLeaseFor só usa task_id + released_at + expires_at + human_principal).
+    Schema::create('mcp_work_leases', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40);
+        $t->string('human_principal', 100);
+        $t->string('agent_id', 100)->nullable();
+        $t->timestamp('expires_at')->nullable();
+        $t->timestamp('released_at')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_task_events');
+    Schema::dropIfExists('mcp_work_leases');
+});
+
+function seedClaimTask(string $id): void
+{
+    DB::table('mcp_tasks')->insert([
+        'task_id' => $id,
+        'module' => 'Governance',
+        'title' => 'T',
+        'status' => 'todo',
+        'priority' => 'p2',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+function avisosClaimless(string $taskId): int
+{
+    return McpTaskEvent::where('task_id', $taskId)
+        ->where('note', 'like', '%SEM lease ativo%')->count();
+}
+
+it('mutação SEM lease ativo do mutador emite AVISO claim-less', function () {
+    seedClaimTask('US-CLM-001');
+
+    // wagner muta sem ter feito claim (nenhum lease) → sinal.
+    app(TaskCrudService::class)->update('US-CLM-001', ['priority' => 'p1'], 'wagner', 'wagner');
+
+    // BITE: se a guarda A5 regredir (não emitir), vira 0 e falha.
+    expect(avisosClaimless('US-CLM-001'))->toBe(1);
+})->group('claim-less', 'ci');
+
+it('mutação COM lease ativo do mutador NÃO emite aviso', function () {
+    seedClaimTask('US-CLM-002');
+    DB::table('mcp_work_leases')->insert([
+        'task_id' => 'US-CLM-002',
+        'human_principal' => 'wagner',
+        'expires_at' => now()->addMinutes(30),
+        'released_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    app(TaskCrudService::class)->update('US-CLM-002', ['priority' => 'p1'], 'wagner', 'wagner');
+
+    // BITE: se A5 ignorar o lease do dono e avisar à toa, vira 1 e falha.
+    expect(avisosClaimless('US-CLM-002'))->toBe(0);
+})->group('claim-less', 'ci');
+
+it('lease de OUTRO principal ainda conta como claim-less (avisa)', function () {
+    seedClaimTask('US-CLM-004');
+    DB::table('mcp_work_leases')->insert([
+        'task_id' => 'US-CLM-004',
+        'human_principal' => 'felipe', // lease é do felipe; quem muta é o wagner
+        'expires_at' => now()->addMinutes(30),
+        'released_at' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    app(TaskCrudService::class)->update('US-CLM-004', ['priority' => 'p1'], 'wagner', 'wagner');
+
+    expect(avisosClaimless('US-CLM-004'))->toBe(1);
+})->group('claim-less', 'ci');
+
+it('caller de sistema (principal null) NÃO emite aviso claim-less', function () {
+    seedClaimTask('US-CLM-003');
+
+    // 3 args (sem principal) = caller de sistema/bulk → sem sinal.
+    app(TaskCrudService::class)->update('US-CLM-003', ['priority' => 'p1'], 'system');
+
+    expect(avisosClaimless('US-CLM-003'))->toBe(0);
+})->group('claim-less', 'ci');


### PR DESCRIPTION
## Leva 2 · Raia A — A5

Instrumenta o **sinal** que os hard-gates signal-gated (A6/A7) vão ler: quando alguém muta uma task **sem segurar o lease ativo dela**, registra um `McpTaskEvent` de **AVISO** — SOFT, sem throw (o hard-gate A7 é deferido até o sinal acumular, ADR 0105).

### Como
- `TaskCrudService::update()` ganha um `?string $principal` (threaded por `updateInner→applyLockedUpdate`). `$principal` = dono do **token** (não o `$author` auto-declarado/spoofável).
- Se `$principal` não bate com o `human_principal` do lease ativo (`WorkLeaseService::activeLeaseFor`) → evento de aviso. Degrada gracioso se `mcp_work_leases` não migrou (`hasTable` guard).
- `$principal` null (sistema/bulk) = sem sinal → **callers 3-args existentes não mudam** (AcceptanceRef/FSM/TaskUpdateAtomic intactos).
- `TasksUpdateTool` resolve o principal via `$request->user()` (mesmo idiom do `TasksClaimTool`).

### Teste que morde (era-sqlite, lane sqlite)
claim-less → avisa (1) · lease do próprio mutador → silêncio (0) · lease de **outro** principal → avisa (1) · caller de sistema (principal null) → silêncio (0). Regressão da guarda vira os contadores.

Refs: SDD Leva 2 (A5) · ADR 0278 Fase 2 · ADR 0105 (signal-gated) · #2781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)