### PR TITLE
fix(repair): resolve conflito de merge commitado no CHANGELOG.md

### DIFF
--- a/Modules/Repair/CHANGELOG.md
+++ b/Modules/Repair/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Repair — Changelog
 
-<<<<<<< HEAD
 ## [Wave 28 — 2026-05-17] POLISH ≥95 (80-95 → 96)
 
 ### D2 Pest +2 sentry FSM canon ADR 0143
@@ -12,7 +11,7 @@
     + motivo obrigatório (LGPD audit trail).
 - Tier 0 IRREVOGÁVEL ADR 0143: FSM canon SEMPRE via `ExecuteStageActionService`,
   NUNCA UPDATE direto. Multi-tenant ADR 0093 + biz=4 intocado (ADR 0101).
-=======
+
 ## [Wave 27 — 2026-05-17] POLISH FINAL ≥95 (90 → 95, +5pp)
 
 ### D8 Security (8 → 12) — FormRequests FSM canon completos
@@ -64,7 +63,6 @@
 - ADR 0093 multi-tenant Tier 0 IRREVOGÁVEL
 - ADR 0143 FSM Pipeline LIVE prod biz=1
 - CDC Art. 26 (garantia produto durável 90d)
->>>>>>> origin/main
 
 ## [Wave 25 — 2026-05-16] POLISH ≥90 (80 → 90, +10pp)
 


### PR DESCRIPTION
`Modules/Repair/CHANGELOG.md` tinha **marcadores de conflito de merge** (`<<<<<<<` / `=======` / `>>>>>>>`) **commitados no main** — duas entradas append-only (Wave 28 no HEAD + Wave 27 no origin/main) adicionadas no topo por branches diferentes nunca foram reconciliadas.

Resolvido **mantendo as duas**, em ordem reversa-cronológica (Wave 28 → Wave 27 → Wave 25). Zero perda de conteúdo. Achado pelo painel adversarial do plano de backlog/changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
