### PR TITLE
feat(governance): gerador de backlog indexado read-only (US dos SPEC.md)

### DIFF
--- a/memory/requisitos/_BACKLOG-GENERATED.md
+++ b/memory/requisitos/_BACKLOG-GENERATED.md
@@ -1,0 +1,1066 @@
+<!-- GERADO por scripts/governance/tasks-index-generate.mjs — NÃO editar à mão (regenera). -->
+# Backlog indexado (gerado)
+
+> Fonte: as US-* dos `memory/requisitos/<Mod>/SPEC.md` (canon, ADR 0070). US abertas (status ∉ done/cancelled).
+> **696 tarefas abertas** em **44 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
+
+## Índice por módulo
+
+| Módulo | Abertas | doing | review | blocked | todo/backlog |
+|---|---:|---:|---:|---:|---:|
+| [`Jana`](#jana) | 53 | 2 | 0 | 0 | 50 |
+| [`Financeiro`](#financeiro) | 47 | 0 | 1 | 0 | 45 |
+| [`OficinaAuto`](#oficinaauto) | 47 | 0 | 5 | 0 | 41 |
+| [`Whatsapp`](#whatsapp) | 43 | 1 | 2 | 0 | 40 |
+| [`Sells`](#sells) | 37 | 0 | 0 | 0 | 37 |
+| [`Infra`](#infra) | 33 | 0 | 0 | 0 | 31 |
+| [`RecurringBilling`](#recurringbilling) | 33 | 0 | 0 | 0 | 33 |
+| [`NfeBrasil`](#nfebrasil) | 28 | 0 | 0 | 6 | 22 |
+| [`Marketplaces`](#marketplaces) | 25 | 0 | 0 | 0 | 25 |
+| [`Crm`](#crm) | 23 | 0 | 0 | 0 | 23 |
+| [`Pcp`](#pcp) | 20 | 0 | 0 | 0 | 20 |
+| [`Vestuario`](#vestuario) | 20 | 0 | 0 | 0 | 20 |
+| [`Fiscal`](#fiscal) | 19 | 0 | 0 | 0 | 17 |
+| [`Governance`](#governance) | 19 | 0 | 2 | 0 | 17 |
+| [`ComunicacaoVisual`](#comunicacaovisual) | 18 | 0 | 0 | 0 | 18 |
+| [`Accounting`](#accounting) | 16 | 0 | 0 | 0 | 16 |
+| [`Autopecas`](#autopecas) | 15 | 0 | 0 | 0 | 15 |
+| [`Comissao`](#comissao) | 14 | 0 | 0 | 0 | 14 |
+| [`Mwart`](#mwart) | 13 | 0 | 0 | 0 | 13 |
+| [`Connector`](#connector) | 12 | 0 | 0 | 0 | 12 |
+| [`PontoWr2`](#pontowr2) | 12 | 0 | 0 | 0 | 12 |
+| [`Essentials`](#essentials) | 11 | 0 | 0 | 0 | 11 |
+| [`MemCofre`](#memcofre) | 11 | 0 | 0 | 0 | 11 |
+| [`NFSe`](#nfse) | 11 | 0 | 0 | 0 | 11 |
+| [`Cms`](#cms) | 10 | 0 | 0 | 0 | 10 |
+| [`Compras`](#compras) | 10 | 0 | 0 | 0 | 10 |
+| [`Ponto`](#ponto) | 10 | 0 | 0 | 0 | 10 |
+| [`Superadmin`](#superadmin) | 10 | 0 | 0 | 0 | 10 |
+| [`TaskRegistry`](#taskregistry) | 9 | 0 | 0 | 0 | 9 |
+| [`ProjectMgmt`](#projectmgmt) | 8 | 0 | 7 | 0 | 1 |
+| [`EvolutionAgent`](#evolutionagent) | 7 | 0 | 0 | 0 | 7 |
+| [`KB`](#kb) | 7 | 0 | 0 | 0 | 7 |
+| [`PaymentGateway`](#paymentgateway) | 7 | 0 | 0 | 0 | 7 |
+| [`TeamMcp`](#teammcp) | 7 | 0 | 0 | 0 | 7 |
+| [`SRS`](#srs) | 6 | 0 | 0 | 0 | 6 |
+| [`Woocommerce`](#woocommerce) | 6 | 0 | 0 | 0 | 6 |
+| [`LaravelAI`](#laravelai) | 5 | 0 | 0 | 0 | 5 |
+| [`Spreadsheet`](#spreadsheet) | 5 | 0 | 0 | 0 | 5 |
+| [`Dashboard`](#dashboard) | 3 | 0 | 0 | 0 | 3 |
+| [`MemoriaAutonoma`](#memoriaautonoma) | 2 | 0 | 0 | 0 | 2 |
+| [`Admin`](#admin) | 1 | 0 | 0 | 0 | 1 |
+| [`Manufacturing`](#manufacturing) | 1 | 0 | 0 | 0 | 1 |
+| [`Mcp`](#mcp) | 1 | 0 | 0 | 0 | 1 |
+| [`Repair`](#repair) | 1 | 0 | 0 | 0 | 1 |
+
+
+## Jana
+
+
+### doing
+
+- **US-COPI-096** — Setup Horizon — provider + auth gate superadmin + flag CT-only _(`p2` · @wagner · sprint 2026-W20)_
+- **US-COPI-100** — NarrarSaudeEcosistemaJob — Job hourly + schedule + escalation HITL _(`p2` · @wagner · sprint 2026-W20)_
+
+### todo
+
+- **US-COPI-106** — Jana V2 demo — tela navegável apresentável a 1 cliente piloto _(`p0` · @wagner)_
+- **US-COPI-107** — Onda 4 R1 — Reranker BGE-v2-m3 self-host CT 100 _(`p0` · @wagner · sprint CYCLE-06)_
+- **US-COPI-108** — Onda 4 L1 — Langfuse v3 self-host CT 100 (MULTIPLICADOR) _(`p0` · @wagner · sprint CYCLE-06)_
+- **US-COPI-115** — LGPD jana:retention-purge artisan + DSR Art. 18 §VI + tool MCP lgpd-esquecer-titular _(`p0`)_
+- **US-COPI-116** — RAGAS canary CI daily 06:00 UTC + 30 golden questions gate _(`p0`)_
+- **US-COPI-117** — Deploy Langfuse self-host CT 100 (ADR 0132) _(`p0`)_
+- **US-COPI-079** — Demo Maiara real — Claude Code + /team-mcp + tela 360° _(`p1` · @wagner · sprint 2026-W19)_
+- **US-COPI-087** — Sprint 9c — Cross-encoder reranker (qwen3-reranker ou bge-reranker-v2-m3) _(`p1` · @wagner · sprint 2026-W20)_
+- **US-COPI-092** — GUARD-01 — Schema snapshot Pest test + procedure_drift health-check _(`p1` · @wagner · sprint 2026-W20)_
+- **US-COPI-094** — BRIEF-A2 follow-up — Remover brief-fetch do Hostinger MCP server _(`p1` · @wagner · sprint 2026-W20)_
+- **US-COPI-101** — Pages/Jana/Admin/Permissions — UI dedicada CRUD roles+scopes _(`p1` · sprint cycle-04)_
+- **US-COPI-105** — Jana Chat V2 — block renderer (4 kinds) + streaming + citations + atalhos _(`p1` · @wagner)_
+- **US-COPI-110** — Onda 5 K1 — Time-decay weighting recall (boost recente + decay historical) _(`p1` · @wagner · sprint pós-Onda 4 (gate Langfuse))_
+- **US-COPI-111** — Onda 5 V1 — Roadmap timeline UI (SVAR Gantt MIT + sub-issues) _(`p1` · @wagner · sprint pós-Onda 4)_
+- **US-COPI-112** — Onda 5 H1 — Auto-skeleton handoff-draft (tool MCP) _(`p1` · @wagner · sprint pós-Onda 4)_
+- **US-COPI-113** — Onda 5 S1 — Schema rígido CI validation (SPEC/RUNBOOK/Session/Handoff/Charter) _(`p1` · @wagner · sprint pós-Onda 4)_
+- **US-COPI-118** — Tokenizar cores cruas do card-de-prova Pro.tsx (fix ui:lint R1 pré-existente) _(`p1`)_
+- **US-COPI-080** — Buffer fix — corrigir o que demo Maiara encontrar _(`p2` · @wagner · sprint 2026-W19)_
+- **US-COPI-090** — BRIEF-A3 — ADR 0096 superseding parcial 0091 (model real gpt-4o-mini) _(`p2` · @wagner · sprint 2026-W20)_
+- **US-COPI-091** — BRIEF-A4 — Investigar baixa adoção brief-first (2 triggers em 7d) _(`p2` · @wagner · sprint 2026-W20)_
+- **US-COPI-095** — EPIC — Cockpit Saúde do Ecossistema _(`p2` · @wagner · sprint 2026-W21)_
+- **US-COPI-102** — Business switcher na sidebar do Chat (UI mid-conversa) _(`p2` · sprint cycle-04)_
+- **US-COPI-103** — Pest cross-tenant biz=99 hardcoded em HitTrackerServiceTest _(`p2` · sprint cycle-04)_
+- **US-COPI-104** — Smoke Browser MCP fresh (screenshot+console) para Chat Jana _(`p2` · sprint cycle-04)_
+- **US-COPI-119** — design:review Fase 2 — juiz LLM (R5/R8/R10 + nota holística + best_of_class) _(`p2`)_
+- **US-COPI-001** — Iniciar conversa com a Jana
+- **US-COPI-002** — Enviar mensagem à Jana
+- **US-COPI-003** — Receber propostas estruturadas
+- **US-COPI-004** — Escolher proposta
+- **US-COPI-005** — Arquivar conversa
+- **US-COPI-010** — Listar metas ativas
+- **US-COPI-011** — Ver detalhe de meta + série temporal
+- **US-COPI-012** — Criar meta manualmente (sem chat)
+- **US-COPI-013** — Editar meta
+- **US-COPI-014** — Arquivar meta (soft delete)
+- **US-COPI-020** — Adicionar período a uma meta
+- **US-COPI-021** — Editar alvo de período
+- **US-COPI-030** — Apuração automática por job
+- **US-COPI-031** — Forçar reapuração manual
+- **US-COPI-040** — Ver/editar fonte da meta
+- **US-COPI-050** — Dashboard consolidado
+- **US-COPI-060** — Listar alertas pendentes
+- **US-COPI-061** — Configurar thresholds
+- **US-COPI-070** — Dashboard de custo IA
+- **US-COPI-071** — Definir orçamento mensal de IA
+- **US-COPI-072** — Bloquear chamada IA quando orçamento estourar
+- **US-COPI-073** — Listar conversas do business (admin)
+- **US-COPI-074** — Visualizar conversa em modo read-only (admin)
+- **US-COPI-075** — Card "Status do orçamento" no chat
+- **US-COPI-076** — ..081 · Cronograma Cycle 01 (semanas W19+W20)
+
+### **em-implementacao 75%**
+
+- **US-COPI-109** — Onda 4 C1 — Charters S4 ativos (charter-fetch tool + Tier A) _(`p0` · @wagner · sprint CYCLE-06)_
+
+## Financeiro
+
+
+### review
+
+- **US-FIN-046** — Sicoob mTLS reusa NfeCertificado (single source of truth) _(`p0` · @wagner)_
+
+### todo
+
+- **US-FIN-015** — Fix BUG-3 — Listener cria titulo_pagar pra purchase com payment_status=due _(`p0` · @wagner)_
+- **US-FIN-026** — UI lista anexos GET no drawer Unificado + thumbnail PDF + delete _(`p0` · sprint Onda 22)_
+- **US-FIN-027** — Pill aprovacao_status na tabela Unificado + filtro workflow _(`p0` · sprint Onda 22)_
+- **US-FIN-028** — Spatie permission financeiro.titulo.aprovar + gate UI _(`p0` · sprint Onda 22)_
+- **US-FIN-014** — Imprimir 2ª via boleto Inter pelo título financeiro (botão na tela /boletos) _(`p1` · @wagner)_
+- **US-FIN-016** — Auto-emite boleto Inter ao criar titulo_receber (Observer + Job idempotente) _(`p1` · @wagner)_
+- **US-FIN-017** — Boletos — Sheet Emitir multi-título (bulk emission) _(`p1` · @wagner)_
+- **US-FIN-029** — OCR boleto upload — OpenAI Vision API extrai linha digitável + valor + vencimento _(`p1` · sprint Onda 23)_
+- **US-FIN-030** — Aging buckets <30/30-60/60-90/90+ no header Unificado + filtro _(`p1` · sprint Onda 24)_
+- **US-FIN-031** — Bulk actions tabela Unificado — checkbox + select-all + ações em lote _(`p1` · sprint Onda 25)_
+- **US-FIN-032** — Inter API webhook PIX recebido → titulo auto-pago (auto-conciliação) _(`p1` · sprint Onda 26)_
+- **US-FIN-038** — UI label 'Conta indefinida' + CTA 'vincular conta' nas linhas com conta_bancaria_id NULL _(`p1`)_
+- **US-FIN-043** — Coleta pre-migracao Financeiro Delphi cliente piloto (Maiara) _(`p1` · @maiara)_
+- **US-FIN-045** — Wizard bank-first 2-step (banco → modo conexão) _(`p1`)_
+- **US-FIN-055** — Purgar coluna-fantasma transactions.total_remaining_amount (resto Financeiro + TituloAutoService) _(`p1`)_
+- **US-FIN-018** — Boletos — Sheet Remessa/Retorno CNAB upload + processing _(`p2` · @wagner)_
+- **US-FIN-019** — Boletos — Drawer timeline cronológica rica via activity_log Spatie _(`p2` · @wagner)_
+- **US-FIN-020** — Boletos — Jobs automáticos cobrança (lembrete + ativa + protesto) _(`p2` · @wagner)_
+- **US-FIN-021** — Fluxo de caixa — Margem mínima configurável via business_settings _(`p2` · @wagner)_
+- **US-FIN-022** — Onda 4d.6.1 — Widget Asaas JS tokenização cartão (PCI-DSS) _(`p2` · @wagner)_
+- **US-FIN-023** — Onda 4d.6.2 — SheetNovaCobranca UI tipo=card (campos cartão) _(`p2` · @wagner)_
+- **US-FIN-024** — Onda 5 — Dogfooding Superadmin (Plan SaaS Oimpresso Premium biz=1) _(`p2` · @wagner)_
+- **US-FIN-033** — Notificações vencimento próximo (e-mail + WhatsApp X dias antes) _(`p2` · sprint Onda 27)_
+- **US-FIN-034** — Importação massiva CSV/Excel — mapping wizard + dry-run + commit _(`p2` · sprint Onda 28)_
+- **US-FIN-035** — Repetir lançamento próximo mês + Combobox autocomplete contraparte _(`p2` · sprint Onda 29)_
+- **US-FIN-036** — PWA básico Financeiro — manifest + service worker + offline cache + install prompt _(`p2` · sprint Onda 30)_
+- **US-FIN-037** — Customer service network — Portal Advisor Contadores parceiros (referral + acesso compartilhado) _(`p2` · sprint Onda 31)_
+- **US-FIN-039** — Artisan command financeiro:vincular-baixas-sem-conta - reconciliacao posterior _(`p2`)_
+- **US-FIN-040** — Artisan command financeiro:health-check cron daily 06:00 BRT - detecta gaps bridge _(`p2`)_
+- **US-FIN-041** — Onda 6 Accounting DROP TABLE - 6 vazias + ARCHIVE 2 seed + DELETE permissions _(`p2`)_
+- **US-FIN-025** — Onda 6 — Cleanup colunas legacy + remover redirects 301 _(`p3` · @wagner)_
+- **US-FIN-042** — Backfill cliente_descricao biz=1 - 52 fin_titulos pre-Onda-Edit NULL _(`p3`)_
+- **US-FIN-001** — Listar Contas a Receber em aberto
+- **US-FIN-002** — Lançar título a receber manual
+- **US-FIN-003** — Baixar título (parcial ou total)
+- **US-FIN-004** — Listar Contas a Pagar com vencimento próximo
+- **US-FIN-005** — Cadastrar título a pagar com upload de boleto OCR
+- **US-FIN-006** — Pagar título (registrar saída do caixa)
+- **US-FIN-007** — Visualizar fluxo de caixa projetado
+- **US-FIN-008** — Cadastrar conta bancária
+- **US-FIN-009** — Importar extrato OFX e conciliar
+- **US-FIN-010** — Emitir boleto bancário (CNAB ou via gateway)
+- **US-FIN-011** — DRE (Demonstração de Resultado)
+- **US-FIN-012** — Aging de inadimplência
+- **US-FIN-013** — Dashboard unificado de títulos (4 estados na mesma tela)
+
+### in_progress
+
+- **US-FIN-044** — SicoobApiDriver nativo (OAuth2 + mTLS + webhook real-time) _(`p1` · @wagner)_
+
+## OficinaAuto
+
+
+### review
+
+- **US-OFICINA-038** — Check-in de entrada — avarias na entrada da OS _(`p1`)_
+- **US-OFICINA-039** — Check-in de entrada — nível de combustível _(`p1`)_
+- **US-OFICINA-040** — Vistoria DVI → orçamento na OS _(`p2`)_
+- **US-OFICINA-041** — Gate de aprovação do cliente in-screen _(`p2`)_
+- **US-OFICINA-042** — Painel fiscal NF-e/NFS-e na OS _(`p3`)_
+
+### todo
+
+- **US-OFICINA-002** — Importer Firebird `EQUIPAMENTO_VEICULO` → `vehicles` Laravel — **P0** _(`p0`)_
+- **US-OFICINA-003** — FSM canônica OS (3 estados Simples + 5 Complexa) — **P0** _(`p0`)_
+- **US-OFICINA-005** — Cleanup tools pra cliente legacy migrado — **P0 (emergente PR #555)** _(`p0`)_
+- **US-OFICINA-006** — FSM wire-up canônico `ServiceOrder` (espelha Sells/Repair ADR 0143) — **P0** _(`p0`)_
+- **US-OFICINA-007** — Importer Vargas (1.064 veículos multi-placa) — **P0** _(`p0`)_
+- **US-OFICINA-014** — Aprovação OS via WhatsApp (link público + PIN) — **P0** _(`p0`)_
+- **US-OFICINA-026** — Outreach Martinho Caçambas + cutover discovery — fechar contrato pioneer _(`p0` · @wagner)_
+- **US-OFICINA-004** — UI Kanban OS (V1 — multi-item + multi-mecânico) — **P1** _(`p1`)_
+- **US-OFICINA-008** — Schema garantia granular per-item (`oa_pecas_utilizadas`+`oa_servicos_executados`+`oa_garantias`) — **P1** _(`p1`)_
+- **US-OFICINA-009** — Defeitos múltiplos por OS (JSON array) — **P1** _(`p1`)_
+- **US-OFICINA-010** — Stages oficina-específicos `teste_estrada` + `ajuste_final` + loop — **P1** _(`p1`)_
+- **US-OFICINA-011** — Re-orçamento (action `escalar_supervisor` + flag `aprovado_apos_aumento`) — **P1** _(`p1`)_
+- **US-OFICINA-012** — Consulta CRLV/placa (cache 30d + adapter pluggable) — **P1** _(`p1`)_
+- **US-OFICINA-013** — Tabela tempária seed (100 serviços comuns BR) — **P1** _(`p1`)_
+- **US-OFICINA-017** — Histórico veículo (timeline OS + KPIs km/manutenção) — **P1** _(`p1`)_
+- **US-OFICINA-018** — NFSe modelo 56 split documentos fiscais — **P1** _(`p1`)_
+- **US-OFICINA-015** — App PWA mecânico campo (V0 — minhas OS + foto + clock-in) — **P2** _(`p2`)_
+- **US-OFICINA-016** — Garantia lembrete cron (pré-vencimento WhatsApp) — **P2** _(`p2`)_
+- **US-OFICINA-019** — Comissão por OS (mecânico + atendente, % escalonado) — **P2** _(`p2`)_
+- **US-OFICINA-020** — Importer Firebird `WR_KANBAN` → `oa_kanban_state` (pré-arte Vargas/Martinho) — **P2** _(`p2`)_
+- **US-OFICINA-021** — Integração FIPE veículo (valor mercado + filtro garantia) — **P2** _(`p2`)_
+- **US-OFICINA-046** — Dívida F3: repontuar kanban Caçambas overdue→expected_completion + remover UI "Locações ativas" _(`p2`)_
+- **US-AUTO-001** — Cadastro veículo persistente (placa + chassi + km + ano + modelo + cor) — **P0**
+- **US-AUTO-002** — Consulta CRLV/Renavam por placa (DETRAN/SerPro) — **P0**
+- **US-AUTO-003** — Histórico do veículo (todas OS passadas) — **P0**
+- **US-AUTO-004** — Tabela tempária (preço hora-homem por tipo serviço) — **P0**
+- **US-AUTO-005** — OS com pipeline (recepção → diagnóstico → orçamento → aprovação → peças → execução → teste → entrega) — **P0**
+- **US-AUTO-006** — OS multi-mecânico (1 OS, N mecânicos com peças/horas distintas) — **P0**
+- **US-AUTO-007** — Diagnóstico assistido por Jana IA (sintoma → hipóteses + tempário sugerido) — **P1**
+- **US-AUTO-008** — Catálogo peças OEM + similares (cód fabricante + equivalentes) — **P1**
+- **US-AUTO-009** — Aprovação OS via WhatsApp (link + PIN) — **P0**
+- **US-AUTO-010** — NFC-e (peça) + NFS-e (serviço) automática a partir de boleto pago — **P0**
+- **US-AUTO-011** — Comissão por OS (vendedor + mecânico, % escalonado) — **P1**
+- **US-AUTO-012** — App mobile mecânico (PWA — vê OS, marca status, sobe foto) — **P0**
+- **US-AUTO-013** — Garantia serviço (registro + lembrete pós-X dias) — **P1**
+- **US-AUTO-014** — Lembrete revisão (km/tempo) — **P1**
+- **US-AUTO-015** — Pré-cadastro fornecedores + cotação (RFQ) — **P2**
+- **US-AUTO-016** — Apontamento horas mecânico (clock-in/out por OS) — **P2**
+- **US-AUTO-017** — Painel cliente público (status OS online) — **P1**
+- **US-AUTO-018** — CT-e/MDF-e quando entrega de veículo — **P3**
+- **US-OFICINA-022** — Cleanup tools cliente legacy migrado (continua US-OFICINA-005) — **P0 já existe**
+
+### in-progress (backend done)
+
+- **US-OFICINA-035** — DVI (Vistoria Digital · Digital Vehicle Inspection) schema + API — **P1** _(`p1`)_
+
+## Whatsapp
+
+
+### doing
+
+- **US-WA-040** — Múltiplos números por business — driver + escopo de atendimento per-phone (Sprint 4) _(`p2` · @wagner · sprint 4)_
+
+### review
+
+- **US-WA-002** — Driver Interface + ZapiDriver + MetaCloudDriver + NullDriver _(`p2` · @wagner · sprint 1)_
+- **US-WA-010** — Receber webhook Meta + assinatura HMAC _(`p2` · @wagner · sprint 2)_
+
+### todo
+
+- **US-WA-051** — FICHA v2 — Wagner-curate ux_heuristics + automation_targets _(`p0` · @wagner)_
+- **US-WA-052** — AUDIT-LOG.md shell + 1ª entrada audit 2026-05-10 _(`p0` · @wagner)_
+- **US-WA-056** — Omnichannel Fase 0 — schema polimórfico (channels + conversations + messages) _(`p0` · @wagner · sprint CYCLE-06)_
+- **US-WA-066** — Polling fallback 5s SEMPRE + bloquear contato _(`p0` · @wagner · sprint CYCLE-06)_
+- **US-WA-094** — Anti-cross-contact P0 (incident 2026-05-14) _(`p0` · @wagner)_
+- **US-WA-041** — Métricas conversation (custo/deflection/tempo) — acelerar US-WA-021 _(`p1` · @wagner)_
+- **US-WA-042** — Mídia outbound — anexar imagem/PDF na conversa (UI upload) _(`p1` · @wagner)_
+- **US-WA-043** — Mídia inbound — processar foto/PDF/audio recebido do cliente _(`p1` · @wagner)_
+- **US-WA-044** — Permissions UI per-phone (multi-select atendentes em Settings/Edit) _(`p1` · @wagner)_
+- **US-WA-053** — UX /whatsapp/conversations — composer no rodapé + sidebar colapsável + responsivo monitor pequeno _(`p1` · @wagner · sprint CYCLE-05)_
+- **US-WA-058** — Inbox omnichannel — envio outbound via Channel (shim Phone, drivers intactos) _(`p1` · @wagner · sprint CYCLE-05)_
+- **US-WA-059** — Inbox omnichannel — real-time via Centrifugo (novo schema) _(`p1` · @wagner · sprint CYCLE-05)_
+- **US-WA-063** — Tags classificadoras com seed defaults + catálogo per-business _(`p1` · @wagner · sprint CYCLE-06)_
+- **US-WA-064** — Vincular Contact UltimatePOS a conversa + resolver @lid JID _(`p1` · @wagner · sprint CYCLE-06)_
+- **US-WA-078** — Fix banDetector falso positivo loggedOut/forbidden vira 'session_expired' _(`p1`)_
+- **US-WA-079** — Fix daemon SIGTERM revoga session (sock.logout → sock.end) preserva pareamento em restart _(`p1`)_
+- **US-WA-093** — LID resolution custom + backfill (workaround pré-Baileys 7.x) _(`p1` · @wagner · sprint CYCLE-07)_
+- **US-WA-021** — Métricas conversation (custo, deflection, tempo resposta) _(`p2` · @wagner · sprint 3)_
+- **US-WA-045** — Botões interativos (HSM com CTAs) _(`p2` · @wagner)_
+- **US-WA-046** — List messages (cardápio: orçar / acompanhar OS / segunda via) _(`p2` · @wagner)_
+- **US-WA-047** — Tags / labels em conversa (classificar por dept/etapa) _(`p2` · @wagner)_
+- **US-WA-048** — Quick replies / atalhos atendente (respostas pré-definidas) _(`p2` · @wagner)_
+- **US-WA-055** — UX polish round 2 + skill `wagner-request-refiner` _(`p2` · @wagner · sprint CYCLE-06)_
+- **US-WA-060** — Sync daemon-node source do CT 100 pra Modules/Whatsapp/daemon-node/ _(`p2` · @wagner · sprint CYCLE-05)_
+- **US-WA-062** — Busca local na conversa (Ctrl+F dentro da thread) _(`p2` · @wagner · sprint CYCLE-06)_
+- **US-WA-089** — Re-parear channels Baileys Jana (id=8) + Suporte (id=10) após purge auth_state _(`p2` · @wagner)_
+- **US-WA-091** — Remover legacy /whatsapp/conversations (URL deprecation) _(`p2` · @wagner · sprint CYCLE-06)_
+- **US-WA-095** — Caixa Unificada v4 redesign (em F1 PLAN) _(`p2` · @wagner · sprint CYCLE-08)_
+- **US-WA-049** — A/B testing templates (variantes A/B com tracking deflection) _(`p3` · @wagner)_
+- **US-WA-050** — Voice transcription inbound (whisper.cpp local CT 100) _(`p3` · @wagner)_
+- **US-WA-057** — Mover conversa pra outro número/canal (admin reclassifica) _(`p3`)_
+- **US-WA-061** — Drift webhook legacy Z-API/Meta — observability + cutover plan _(`p3` · @wagner · sprint CYCLE-05)_
+- **US-WA-022** — ~~UX simplificada onboarding Baileys~~ [DEPRECATED 2026-05-27]
+
+### backlog
+
+- **US-WA-301** — Filas DB + drawer config (label/hue/sla/dist/members/trigger_tags) _(`p1` · @wagner · sprint TBD)_
+- **US-WA-302** — Assignee picker no Contexto (select operators ativos) _(`p1` · @wagner · sprint TBD)_
+- **US-WA-303** — Slash macros inline + Templates picker inline no composer _(`p1` · @wagner · sprint TBD)_
+- **US-WA-304** — Drawer "Canais e contas" agrupado por type (vs link /canais) _(`p2` · @wagner · sprint TBD)_
+- **US-WA-305** — Mover conversa entre filas (override manual da heurística tag→fila) _(`p2` · @wagner · sprint TBD)_
+- **US-WA-306** — Broadcast cross-canal real (janela 24h Meta + opt-in LGPD) _(`p2` · @wagner · sprint TBD)_
+- **US-WA-307** — + Nova conversa (ContactPickerModal + template inicial + novo channel) _(`p2` · @wagner · sprint TBD)_
+
+## Sells
+
+
+### todo
+
+- **US-SELL-008** — QA: audit + smoke biz=1 + canary Wagner 7d + rollback plan _(`p0` · @wagner)_
+- **US-SELL-009** — Cutover ROTA LIVRE + remover Blade após 30d _(`p0` · @wagner)_
+- **US-SELL-015** — Modo "Grade Avançada" — toggle + layout densa base · **P0** _(`p0`)_
+- **US-SELL-016** — Multiseleção + ações em lote (imprimir/exportar/agrupar) · **P0** _(`p0`)_
+- **US-SELL-017** — Totalizador rodapé (Qtd vendas + Σ R$ filtrado) · **P0** _(`p0`)_
+- **US-SELL-021** — Especificação campo "Data" (qual data: emissão / NF / faturamento / competência / prometido) · **P0 (subido!)** _(`p0`)_
+- **US-SELL-027** — Schema discovery dinâmico Grade Avançada · **P0 (subida v2!)** _(`p0`)_
+- **US-SELL-029** — NFe cancelada via SEFAZ não sofre forceDelete (preserva sequencial) · **P0 fiscal** _(`p0`)_
+- **US-SELL-030** — NfeInutilizacaoService — chama SEFAZ + persiste em `nfe_inutilizacoes` · **P0 fiscal** _(`p0`)_
+- **US-SELL-033** — Processo seed "Venda Com Produção" canônico (9 stages + 12 actions + roles) · **P0 negócio** _(`p0`)_
+- **US-SELL-036** — FSM rollout — migrar 14 vendas legadas biz=1 via bulk-start-pipeline + canary 7d _(`p0` · @wagner)_
+- **US-SELL-001** — Epic — Migrar /sells/create pra MWART _(`p1` · @wagner)_
+- **US-SELL-002** — Backend dual Inertia/Blade + feature flag + Pest _(`p1` · @wagner)_
+- **US-SELL-003** — Frontend skeleton + AppShellV2 + props contract _(`p1` · @wagner)_
+- **US-SELL-004** — Triagem visibilidade campos (18 → 8 visíveis + 10 colapsáveis) _(`p1` · @wagner)_
+- **US-SELL-010** — Investigar State Machines existentes (Repair, Project, mcp_tasks) + propor ADR padrão FSM canônico _(`p1` · @wagner)_
+- **US-SELL-018** — Filtros multi-data com presets Dia/Semana/Mês/Ano + custom · **P1 confirmado** _(`p1`)_
+- **US-SELL-019** — Agrupamento drag-to-group por campo do grid · **P1 confirmado** _(`p1`)_
+- **US-SELL-023** — Status produção visível na lista (badge separado) · **P1 (subido!)** _(`p1`)_
+- **US-SELL-024** — Campo "venda agrupada" explícito · **P1 (subido!)** _(`p1`)_
+- **US-SELL-028** — Modules/OficinaAuto — schema com multi-placa (cavalo+reboque) · **P1 (emergente v3 — recalibrada)** _(`p1`)_
+- **US-SELL-031** — Action FSM crítica (is_critical) exige role explícita (fail-secure) · **P1 governança** _(`p1`)_
+- **US-SELL-032** — Observer bloqueia UPDATE direto em current_stage_id (gateway obrigatório) · **P1 governança** _(`p1`)_
+- **US-SELL-034** — Side-effect `CancelarVendaCascade` orquestra NFe + boleto + reserva + notificação · **P1 negócio** _(`p1`)_
+- **US-SELL-041** — NFC-e "emitir agora" no fim do Create (paridade Bling) _(`p1` · @wagner)_
+- **US-SELL-042** — Batch no handlePriceGroupChange — elimina N+1 em /products/list _(`p1` · @wagner)_
+- **US-SELL-043** — Migrar CSS Cowork (.sells-cowork / vd-*) → tokens DS no Sells/Index _(`p1` · @wagner)_
+- **US-SELL-047** — Teste de isolamento multi-tenant REAL da tela Sells (ADR 0093) — gap mascarado por grep _(`p1`)_
+- **US-SELL-020** — Especificação campo "Status" (financeiro vs produção vs fiscal — badges separados) · **P2 (rebaixado)** _(`p2`)_
+- **US-SELL-022** — Sub-linha de produtos por venda (expandir linha) · **P2 confirmado** _(`p2`)_
+- **US-SELL-026** — Impressão batch de vendas selecionadas (PDF consolidado) · **P2 (subido)** _(`p2`)_
+- **US-SELL-035** — UI timeline de transições FSM (drawer + page) · **P2 UX/auditoria** _(`p2`)_
+- **US-SELL-040** — Pest integration HTTP full do `SellPosController@store` (caminho B) _(`p2` · @wagner)_
+- **US-SELL-045** — Bug: payload `totals` morto na rede — backend calcula/envia, frontend nunca lê _(`p2`)_
+- **US-SELL-046** — Bug: viewMode `grade-avancada` órfão — middleware roteia 6 clientes legacy pra UI deletada _(`p2`)_
+- **US-SELL-048** — Higiene dos snapshots-grep Sells: DELETE/REWRITE por it() (não quarentena) — gated no nº do nightly C1 _(`p2`)_
+- **US-SELL-025** — Botões agrupamento rápido (1-click) · **P3 confirmado** _(`p3`)_
+
+## Infra
+
+
+### todo
+
+- **US-INFRA-001** — GrowthBook self-hosted (feature flag system) _(`p0` · @wagner)_
+- **US-INFRA-014** — Install Larastan + phpstan.neon.dist nível 5 baseline _(`p0`)_
+- **US-INFRA-015** — Workflow phpstan-gate.yml — CI ratchet contra baseline _(`p0`)_
+- **US-INFRA-016** — LogContextMiddleware global — business_id/user_id/request_id em todo log _(`p0`)_
+- **US-INFRA-017** — PHPStan custom rule NoMissingTenantScope (T-AP-2 Tier 0) _(`p0`)_
+- **US-INFRA-020** — PHPStan custom rule NoSilentFallbackRule (R9 raiz) _(`p0`)_
+- **US-INFRA-022** — Install Laravel Wayfinder + Vite plugin + watch types _(`p0`)_
+- **US-INFRA-026** — Convenção markdown TASK[owner](Px) em audits _(`p0`)_
+- **US-INFRA-027** — Hook audit-creates-tasks.ps1 (PostToolUse Write) _(`p0`)_
+- **US-INFRA-002** — Client Signal — entidade + canal estruturado _(`p1` · @wagner)_
+- **US-INFRA-003** — APM full-stack — captura "lento aqui" automaticamente _(`p1` · @wagner)_
+- **US-INFRA-005** — S5 ADS adiantado (Risk + Confidence + Policy core) _(`p1` · @wagner)_
+- **US-INFRA-011** — Rotacionar senha MySQL Hostinger u906587222_oimpresso - exposicao sessao 2026-05-20 _(`p1` · @wagner)_
+- **US-INFRA-013** — Implementar contract-test-gate GH Action (ADR 0207) _(`p1` · sprint 2026-W22)_
+- **US-INFRA-018** — PHPStan custom rule NoInventedModel (T-AP-1) _(`p1`)_
+- **US-INFRA-019** — PHPStan custom rule NoNopMutationController (T-AP-13) _(`p1`)_
+- **US-INFRA-023** — Zod schemas em endpoints JSON não-Inertia _(`p1`)_
+- **US-INFRA-028** — Skill audit-to-backlog Tier B _(`p1`)_
+- **US-INFRA-029** — Workflow CI audit-orphan-check.yml — warning PR órfãos _(`p1`)_
+- **US-INFRA-031** — Resolver colisões de const/function globais em tests/Feature (bloqueia suíte Pest completa) _(`p1`)_
+- **US-INFRA-033** — Suíte Pest no staging falha em massa por testes fazerem Schema::create/dropIfExists cru em tabelas compartilhadas (vs clone MySQL) _(`p1`)_
+- **US-INFRA-004** — Detecção automática de desvio (cron diário) _(`p2` · @wagner)_
+- **US-INFRA-006** — Tool MCP `whats-active` — agregar sessões doing + paths tocados (Tier 1 ADR 0119) _(`p2` · @wagner)_
+- **US-INFRA-007** — Skill Tier A `session-start-check` — alertar paths overlapping (ADR 0119) _(`p2` · @wagner)_
+- **US-INFRA-012** — Resolver migration order legacy pra visual-regression.yml sair de INFRA-ONLY (ADR 0108) _(`p2` · @wagner)_
+- **US-INFRA-021** — Catalogar AP-18 "Fallback default sem Log::warning" no LICOES_F3 _(`p2`)_
+- **US-INFRA-024** — PHPStan custom rule NoUntypedInertiaProps (R8 gate final) _(`p2`)_
+- **US-INFRA-025** — Catalogar AP-17 "Inertia props não tipadas" no LICOES_F3 _(`p2`)_
+- **US-INFRA-030** — health-check audits_with_orphan_findings — auditoria periódica _(`p2`)_
+- **US-INFRA-032** — Triar 11 hardcodes $businessId === N flagados pelo NoHardcodeBusinessIdInModulesTest (guard Tier 0 agora ativo) _(`p2`)_
+- **US-INFRA-035** — Item 7 ADR 0271 — fusão 4 gates de cor → 1 (executar ≥2026-06-18) _(`p2` · @claude)_
+
+### in-progress
+
+- **US-INFRA-008** — Feature Flag Control (3 canais: Artisan/MCP/Painel) _(`p1` · @wagner)_
+
+### superseded
+
+- **US-INFRA-009** — Artisan command `feature:activate` via GrowthBook API ⚠️ **SUPERSEDED por US-INFRA-008** _(`p2` · @wagner)_
+
+## RecurringBilling
+
+
+### todo
+
+- **US-RB-040** — Cobertura Pest dos 3 drivers de boleto (Inter/C6/Asaas) _(`p0`)_
+- **US-RB-041** — Test de retry idempotente do ProcessAsaasWebhookJob _(`p0`)_
+- **US-RB-042** — Completar cancelar() C6/Asaas + UI Cancelar título + audit log _(`p0`)_
+- **US-RB-048** — RUNBOOK operacional antes do Inter PJ Banking API ir pra prod _(`p0` · @wagner · sprint cycle-04)_
+- **US-RB-050** — Inter PJ — PIX cobrança imediata (CYCLE-06 G1 wiring Martinho) _(`p0` · @wagner · sprint cycle-06)_
+- **US-RB-051** — Inter PJ — webhook PIX receiver (CYCLE-06 G1 wiring Martinho) _(`p0` · @wagner · sprint cycle-06)_
+- **US-RECURRINGBILLING-001** — Escopo 0 — PaymentGateway + adapter Asaas (pré-requisito cobrança) _(`p0` · @wagner)_
+- **US-RECURRINGBILLING-001** — Escopo 1 — Motor de cobrança recorrente (plans + contracts + invoices + job) _(`p0` · @wagner)_
+- **US-RECURRINGBILLING-001** — Escopo 2 — Boleto impresso via Asaas _(`p0` · @wagner)_
+- **US-RECURRINGBILLING-001** — Cobertura Pest dos 3 drivers de boleto (Inter/C6/Asaas) _(`p0`)_
+- **US-RECURRINGBILLING-001** — Test de retry idempotente do ProcessAsaasWebhookJob _(`p0`)_
+- **US-RECURRINGBILLING-001** — Completar cancelar() C6/Asaas + UI Cancelar título + audit log _(`p0`)_
+- **US-RB-043** — [Epic] Models Subscription/Plan/Invoice/ChargeAttempt + migrations _(`p1`)_
+- **US-RB-046** — Inter PJ — extrato sync diário + tela /financeiro/extrato (Fase 2) _(`p1` · @wagner)_
+- **US-RB-047** — Inter PJ — PIX cob imediata + webhook receiver (Fase 3) _(`p1` · @wagner)_
+- **US-RB-049** — Permissions UI: plans.manage, contracts.manage, webhooks.view (US-RB-001..005) _(`p1` · sprint cycle-04)_
+- **US-RECURRINGBILLING-001** — Escopo 3 — NFSe assíncrona ao pagar (Focus/PlugNotas adapter) _(`p1` · @wagner)_
+- **US-RECURRINGBILLING-001** — [Epic] Models Subscription/Plan/Invoice/ChargeAttempt + migrations _(`p1`)_
+- **US-RECURRINGBILLING-001** — Listener InvoicePaid em NfeBrasil — emissão automática de NFe55 + DANFE + e-mail _(`p1`)_
+- **US-RB-001** — Cadastrar plano de assinatura
+- **US-RB-002** — Criar contrato (subscription)
+- **US-RB-003** — Gerar faturas em ciclo (job)
+- **US-RB-004** — Cobrar fatura (charge attempt)
+- **US-RB-005** — Cancelar contrato
+- **US-RB-006** — Proração em upgrade/downgrade mid-cycle
+- **US-RB-010** — Cadastrar credencial de gateway
+- **US-RB-011** — Salvar cartão tokenizado de cliente
+- **US-RB-012** — Receber webhook de gateway
+- **US-RB-013** — Smart retry em soft decline
+- **US-RB-020** — Solicitar autorização Pix Automático
+- **US-RB-021** — Cobrar via Pix Automático autorizado
+- **US-RB-030** — Configurar régua de inadimplência
+- **US-RB-031** — Disparar régua quando cobrança falha
+
+## NfeBrasil
+
+
+### blocked
+
+- **US-NFE-043** — Proposta comercial Gold — diferenciais vs Mubsys + pricing on-prem · 🔒 DORMENTE _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-044** — Upgrade plataforma on-prem Gold pra versão atual com NfeBrasil · 🔒 DORMENTE _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-045** — Configuração fiscal NfeBrasil Gold (cert + IE + regime + template SP) · 🔒 DORMENTE _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-046** — Smoke fiscal homologação SEFAZ-SP biz=Gold (1ª NF-e 55 cstat 100) · 🔒 DORMENTE _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-047** — Treinamento operadora Gold + cutover NF-e produção + canary 7d · 🔒 DORMENTE _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-048** — Refinar runbook on-prem reutilizável pós-Gold (Trilha 1 dormentes) · 🔒 DORMENTE _(`p2` · @wagner · sprint Gold-Reativacao)_
+
+### todo
+
+- **US-NFE-040** — [Epic] Foundation domínio NFe — migrations + models + composer _(`p0`)_
+- **US-NFE-041** — CertificadoService + storage encrypted + UI admin _(`p0`)_
+- **US-NFE-042** — Discovery técnico instalação Gold Comunicação Visual _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-053** — Smoke homologação SEFAZ-SP eventos 210/220 biz=Gold _(`p1` · @wagner · sprint Gold-Reativacao)_
+- **US-NFE-054** — Smoke real homologação SEFAZ-SC biz=1 — 1ª NFC-e cstat 100 (Goal #1 CYCLE-03) _(`p1` · @wagner)_
+- **US-NFE-062** — AuditLog em mutações fiscais NFe (Tributacao, Certificado, Manifestacao) _(`p1` · sprint cycle-04)_
+- **US-NFE-055** — Estabilizar 107 tests broken Modules/NfeBrasil aplicando dual-mode SQLite/MySQL _(`p2`)_
+- **US-NFE-056** — Continuação PR #453 — migrar configBusiness(4) → configBusiness(1) em MotorTributarioServiceTest _(`p2`)_
+- **US-NFE-057** — Schema drift — atualizar fixtures DanfeServicePrefersArquivosTest pós-remoção `arquivos.filename` _(`p2`)_
+- **US-NFE-058** — Aplicar pattern dual-mode em batch restante — Emitir* + NfeEmissaoController + DistribuicaoDfe (4 files, ~15 fails) _(`p2`)_
+- **US-NFE-059** — Smoke prod end-to-end auto-emissão NFe55 com cliente real que opt-in _(`p2` · @wagner)_
+- **US-NFE-063** — Smoke Browser MCP fresh (screenshot+console) para fluxos Certificado/Auto-emission/Manifestacao _(`p2` · sprint cycle-04)_
+- **US-NFE-001** — Configurar certificado digital A1
+- **US-NFE-002** — Emitir NFC-e a partir de venda finalizada
+- **US-NFE-003** — Visualizar e reimprimir NFCe/NFe emitida
+- **US-NFE-004** — Cancelar NFe/NFC-e dentro do prazo legal
+- **US-NFE-005** — Carta de Correção Eletrônica (CCe)
+- **US-NFE-006** — Modo contingência (EPEC ou FS-DA)
+- **US-NFE-007** — Monitor de rejeições + status SEFAZ
+- **US-NFE-008** — Manifestar NF-e recebida (destinatário)
+- **US-NFE-009** — Gerar SPED Fiscal/EFD ICMS-IPI mensal
+- **US-NFE-010** — Cadastrar regra tributária por NCM (motor)
+
+## Marketplaces
+
+
+### todo
+
+- **US-MKT-001** — Schema fundação 9 tabelas + Models global scope — **P0** · 4h
+- **US-MKT-002** — Catálogo `mkt_marketplaces` seed 3 drivers — **P0** · 2h
+- **US-MKT-003** — OAuth2 Mercado Livre — authorization code flow + refresh token — **P0** · 6h
+- **US-MKT-004** — OAuth2 Shopee + Amazon BR — **P1** · 6h
+- **US-MKT-005** — Importar 1 anúncio manual ML (proof of concept) — **P0** · 5h
+- **US-MKT-006** — Webhook receiver ML orders_v2 + idempotency-key — **P0** · 5h
+- **US-MKT-007** — Pedido ML → cria `mkt_orders` + transaction UltimatePOS + FSM stage initial — **P0** · 8h
+- **US-MKT-008** — UI Page `Marketplaces/Orders/Index.tsx` (Cockpit V2) — **P0** · 6h
+- **US-MKT-009** — NFe automática ao emitir → CFOP marketplace resolver + dispatch SEFAZ — **P0** · 7h
+- **US-MKT-010** — Sync rastreamento Correios + auto-fechamento — **P0** · 6h
+- **US-MKT-011** — Sync estoque oimpresso → ML (one-way push) — **P1** · 8h
+- **US-MKT-012** — Sync estoque ML → oimpresso (one-way pull via webhook) — **P1** · 4h
+- **US-MKT-013** — Anúncio em lote (bulk create) — **P1** · 10h
+- **US-MKT-014** — Disputa workflow completo — **P1** · 12h
+- **US-MKT-015** — Reconciliação financeira Mercado Pago split D+X — **P1** · 8h
+- **US-MKT-016** — Reputação ML monitoring + alerta SLA — **P1** · 5h
+- **US-MKT-017** — Pricing rules per marketplace (markup diferenciado) — **P1** · 6h
+- **US-MKT-018** — Jana tool `marketplaces.consulta` (relatórios IA) — **P2** · 4h
+- **US-MKT-019** — Etiquetas envio ML Coletas + integração Correios — **P2** · 6h
+- **US-MKT-020** — Pipeline produção sob demanda marketplace (ComVis) — **P2** · 8h
+- **US-MKT-021** — Shopee orders webhook + NFe (mesmo pattern ML) — **P2** · 10h
+- **US-MKT-022** — Amazon BR orders webhook + NFe (SP-API) — **P2** · 12h
+- **US-MKT-023** — Pricing dinâmico copilot competitor watch — **P3** · 14h
+- **US-MKT-024** — Analytics avançado margem real (CMV + frete + taxa + tributos) — **P3** · 10h
+- **US-MKT-025** — Magalu Hub + Americanas drivers (4º + 5º marketplaces) — **P3** · 16h
+
+## Crm
+
+
+### todo
+
+- **US-CRM-001** — Migration estender `contacts` com colunas pipeline · **P0** · 2H
+- **US-CRM-002** — `crm_motivos_perda` catálogo + seeder padrão · **P0** · 2H
+- **US-CRM-003** — `crm_lead_interactions` timeline append-only + observers · **P0** · 4H
+- **US-CRM-004** — `crm_lead_tags` + pivot · **P1** · 2H
+- **US-CRM-010** — Listener `WhatsappMessageReceived` cria/resolve lead · **P0** · 4H
+- **US-CRM-011** — `JanaIntencaoAgent` classifica intenção mensagem entrante · **P0** · 6H
+- **US-CRM-012** — `CrmLeadFromWhatsappService.createOrUpdate` + round-robin · **P0** · 4H
+- **US-CRM-013** — Auto-resposta template WhatsApp ao criar lead · **P1** · 2H
+- **US-CRM-014** — Vincular `whatsapp_conversations.contact_id` ao Lead criado · **P0** · 2H
+- **US-CRM-020** — `ConvertLeadToSaleService` cria Transaction + inicia FSM `quote_draft` · **P0** · 6H
+- **US-CRM-021** — UI kanban "Ganho" dispara ConvertLeadToSale + redireciona SaleSheet · **P0** · 4H
+- **US-CRM-022** — UI kanban "Perdido" modal obrigatório motivo + data reabordagem · **P0** · 4H
+- **US-CRM-023** — Cron `lead:reactivate-cold` reabre leads "perdido_timing" com data atingida · **P1** · 2H
+- **US-CRM-030** — `crm_lead_scoring_log` + cron `lead:rescore` regras simples · **P1** · 6H
+- **US-CRM-031** — SLA novo lead → alerta vendedor superior se sla_responder_em vencido · **P1** · 4H
+- **US-CRM-032** — Dashboard pipeline com forecast (sum valor_estimado per stage) · **P2** · 6H
+- **US-CRM-040** — API REST pública `/api/v1/crm/leads` (token `business_uuid` + reCAPTCHA + rate-limit) · **P1** · 6H
+- **US-CRM-041** — Form embed JS oimpresso.com captura → POST API · **P2** · 4H
+- **US-CRM-050** — `lgpd_consent_at` + opt-in/opt-out + endpoint direito esquecimento · **P0** · 6H
+- **US-CRM-060** — MWART tela Lead Kanban (atual `crm::lead.index lead_view=kanban`) · **P1** · 12H
+- **US-CRM-061** — MWART tela Lead Show (drawer cockpit pattern V2 ADR 0110) · **P2** · 12H
+- **US-CRM-062** — MWART CrmDashboard com Recharts · **P2** · 10H
+- **US-CRM-077** — Pattern canon `officeimpresso_codigo` nos 3 importers de contacts (gap ADR 0200) · **P1** · 6H _(@felipe)_
+
+## Pcp
+
+
+### todo
+
+- **US-PCP-001** — Schema base + migrations (4 tabelas + triggers append-only) — **P0** _(`p0`)_
+- **US-PCP-002** — DECISÃO D1 — Pcp vs IProduction (renomeação ou módulo novo) — **P0 BLOCKER** _(`p0` · @[W])_
+- **US-PCP-003** — Models + global scopes `HasBusinessScope` — **P0** _(`p0`)_
+- **US-PCP-004** — CRUD `pcp_workstations` Inertia (Index/Create/Edit) — **P0** _(`p0`)_
+- **US-PCP-005** — CRUD `pcp_operations` Inertia — **P0** _(`p0`)_
+- **US-PCP-006** — FSM actions intermediárias (5 actions seed) — **P0** _(`p0`)_
+- **US-PCP-007** — Service `RegisterAppointment` (idempotent) — **P0** _(`p0`)_
+- **US-PCP-008** — Endpoint API JWT `POST /api/pcp/scan` — **P0** _(`p0`)_
+- **US-PCP-009** — PWA mobile shell + scanner QR (camera API) — **P0** _(`p0`)_
+- **US-PCP-010** — QR token na label OS + endpoint print extended — **P0** _(`p0`)_
+- **US-PCP-011** — Kanban shared infra adicionar agrupador configurável (8 agrupadores Delphi) — **P0** _(`p0`)_
+- **US-PCP-020** — Documentação RUNBOOK + Charter páginas — **P0** _(`p0`)_
+- **US-PCP-012** — Detect bottleneck (cron 15min) + alerta UI + Jana RAG context — **P1** _(`p1`)_
+- **US-PCP-013** — Capacidade dia/semana view agregada + dashboard card — **P1** _(`p1`)_
+- **US-PCP-014** — Performance operador (view + dashboard table com permission guard) — **P1** _(`p1`)_
+- **US-PCP-017** — Dashboard PCP Inertia (4 cards KPI + Kanban embed + heatmap) — **P1** _(`p1`)_
+- **US-PCP-015** — `pcp_schedules` agendamento drag-drop calendário — **P2** _(`p2`)_
+- **US-PCP-016** — Integração BoM `MfgRecipe` (consumo automático ao concluir operação) — **P2** _(`p2`)_
+- **US-PCP-018** — Broadcast Centrifugo (Kanban realtime + fila workstation) — **P2** _(`p2`)_
+- **US-PCP-019** — Smoke biz=4 ROTA LIVRE (canary 7d + cutover) — **P2** _(`p2`)_
+
+## Vestuario
+
+
+### todo
+
+- **US-VEST-020** — Etiqueta/código de barras com tamanho+cor (impressão térmica) `p0` _(`p0`)_
+- **US-VEST-021** — Devolução/troca com prazo CDC + crédito em conta-cliente `p0` _(`p0`)_
+- **US-VEST-022** — Comissão de vendedor (% sobre venda + meta) `p1` _(`p1`)_
+- **US-VEST-023** — Liquidação por categoria/marca/estação (desconto em massa) `p1` _(`p1`)_
+- **US-VEST-024** — Programa fidelidade (R$ [redacted Tier 0] = 1 ponto) com resgate em desconto `p1` _(`p1`)_
+- **US-VEST-029** — Atributo "estação" (verão/inverno/meia-estação/atemporal) `p1` _(`p1`)_
+- **US-VEST-025** — Vale-presente / cartão presente (gift card) `p2` _(`p2`)_
+- **US-VEST-026** — Crediário próprio (layaway / parcelado loja) `p2` _(`p2`)_
+- **US-VEST-027** — Provador / fila / pré-venda (separação reserva 24h) `p3` _(`p3`)_
+- **US-VEST-028** — Vendas externas (sacoleira / venda direta) `p3` _(`p3`)_
+- **US-VEST-030** — Ecommerce (loja virtual / WhatsApp catálogo) `p3` _(`p3`)_
+- **US-VEST-001** — Cadastro de produto com variações tamanho + cor `live`
+- **US-VEST-002** — Venda balcão (PDV) com leitor de código de barras `live`
+- **US-VEST-003** — Emissão de NFC-e modelo 65 a partir do POS `live (parcial — biz=4 não usa hoje, mas infra existe)`
+- **US-VEST-004** — Histórico de vendas com filtros (cliente, período, vendedor) `live`
+- **US-VEST-005** — Estoque por localização (matriz tamanho × cor × loja) `live`
+- **US-VEST-006** — Compra (purchase) com fornecedor + recebimento `live`
+- **US-VEST-007** — Conta a receber (boleto Asaas) e a pagar `live`
+- **US-VEST-008** — Múltiplos schemes de invoice convivendo (`2026/NNNN` + `17NNN`) `live`
+- **US-VEST-009** — Sidebar/topnav adaptado por monitor 1280px `live`
+
+## Fiscal
+
+
+### todo
+
+- **US-FISCAL-001** — Cockpit NF-e · NFC-e (sub-página 2)
+- **US-FISCAL-002** — Cockpit (sub-página 1) — ✅ PR #2 Wave
+- **US-FISCAL-003** — ⌘K palette cross-fiscal — **backlog PR #3**
+- **US-FISCAL-004** — Ações de mutação — **backlog PR #4**
+- **US-FISCAL-005** — NFS-e (sub-página 3) — ✅ PR #2 Wave
+- **US-FISCAL-006** — Manifesto DF-e (sub-página 4) — **backlog PR #6**
+- **US-FISCAL-007** — Eventos (sub-página 5) — ✅ PR #2 Wave
+- **US-FISCAL-008** — DF-e manifesto (sub-página 4) — ✅ PR #3 Wave
+- **US-FISCAL-009** — Cert/Cfg fiscal (sub-página 6) — ✅ PR #3 Wave
+- **US-FISCAL-010** — SPED & Livros (sub-página 7) — ✅ PR #3 Wave (placeholder)
+- **US-FISCAL-011** — SPED Fiscal complete + PIS/COFINS — **backlog PR #10**
+- **US-FISCAL-012** — Ações mutação NFe + DF-e — ✅ PR #4 Wave
+- **US-FISCAL-013** — CC-e (Carta de Correção) + Inutilização faixa — ✅ PR #5 Wave
+- **US-FISCAL-014** — Retransmitir NFe rejeitada/denegada — ✅ PR #6 Wave
+- **US-FISCAL-015** — ⌘K palette cross-fiscal — ✅ PR #7 Wave
+- **US-FISCAL-016** — Gerador SPED EFD-ICMS/IPI MVP — ✅ PR #8 Wave
+- **US-FISCAL-017** — SPED EFD-ICMS/IPI Bloco E + Bloco H — ✅ PR #9 Wave
+
+### in_progress (provisionamento técnico ✅
+
+- **US-FISCAL-018** — Habilitar cockpit Fiscal Larissa biz=4 + canary 7d smoke _(`p0` · @wagner)_
+
+### done (fase 1 — fallback safe entregue
+
+- **US-FISCAL-020** — Integrar MotorTributarioService NfeBrasil — elimina 6 hardcodes Tier-0 SPED — ✅ Onda CONSOLIDAR _(`p0` · @wagner)_
+
+## Governance
+
+
+### review
+
+- **US-GOV-018** — P0 Fase 2b: consertar harness de DB de teste do nightly (3 frentes) — não é "completar schema" _(`p0`)_
+- **US-GOV-020** — Frente C: migrate:fresh do nightly carrega dump incompleto (trigger DEFINER prod / privilégio) _(`p0`)_
+
+### todo
+
+- **US-GOV-011** — [ROI alto] Carregar extension OTel no Herd dev (+2-3pp em 36 módulos D9) _(`p0`)_
+- **US-GOV-012** — Investigar ScopedScorecardEvaluator não captura SATURATION markers Jana (gap 25pp grade real) _(`p1`)_
+- **US-GOV-015** — Zelador diário — piloto 14d (reconciliação + triagem por âncora + subtração de ruído) _(`p1` · @claude)_
+- **US-GOV-016** — Reestruturação SDD — Semana 0 (12 frentes paralelas) _(`p1` · @wagner)_
+- **US-GOV-017** — Reestruturação SDD — Fase 1+2 (medição real, backfill, burn-down) _(`p1` · @wagner)_
+- **US-GOV-019** — Re-triage eixo-FAILURE: 7 bugs (design) + 91 quarentena + 11 unclear _(`p1`)_
+- **US-GOV-013** — Tornar o gate visual ADR 0108 (visual-regression) REAL — sair do stub _(`p2`)_
+- **US-GOV-001** — Dashboard consolidado `/governance` ✅ DONE
+- **US-GOV-002** — Policies listagem + toggle ativo/inativo 🟡 PARCIAL
+- **US-GOV-003** — Audit log drill-down filtrável 🟡 PARCIAL
+- **US-GOV-004** — Drift alerts (Module Charter Art. 7) 🟡 PARCIAL
+- **US-GOV-005** — ActionGate middleware (modo warn/strict) ✅ DONE (warn)
+- **US-GOV-006** — Module Grade Dashboard `/governance/module-grades` ✅ DONE
+- **US-GOV-007** — Module Grade Drill-down + botão Evoluir ✅ DONE
+- **US-GOV-008** — CLI `php artisan module:grade` (machine-readable JSON) ✅ DONE
+- **US-GOV-009** — Cron daily snapshot histórico 90d ❌ BACKLOG
+- **US-GOV-010** — Integração ADS Brain B disparar agents auto ❌ BACKLOG
+
+## ComunicacaoVisual
+
+
+### todo
+
+- **US-COMVIS-001** — Cálculo automático por m² (lona, vinil, banner, fachada) — **P0**
+- **US-COMVIS-002** — Cadastro de material com preço por gramatura — **P0**
+- **US-COMVIS-003** — PCP gráfico — fluxo OS multi-etapa com responsável + prazo + custo — **P0**
+- **US-COMVIS-004** — Apontamento de máquina (Roland/Mimaki/Mutoh/HP Latex) — **P1**
+- **US-COMVIS-005** — Pós-cálculo (orçado vs realizado) — **P1**
+- **US-COMVIS-006** — Tabela tributária CNAE 1813-0/01 (CFOP/CSOSN/NCM padrão) — **P0**
+- **US-COMVIS-007** — Gestão de fachada/instalação (agenda + equipe + EPI) — **P1**
+- **US-COMVIS-008** — NFSe automática pra serviço de instalação — **P1**
+- **US-COMVIS-009** — NFe automática a partir de boleto pago — **P0** (já entregue no núcleo)
+- **US-COMVIS-010** — Provador de orçamento online (formulário web público) — **P2**
+- **US-COMVIS-011** — Comissão por OS (vendedor + instalador) — **P1**
+- **US-COMVIS-012** — DAM básico — cliente envia arquivo print-ready — **P2**
+- **US-COMVIS-013** — Bulk update preço material via Jana — **P2**
+- **US-COMVIS-014** — Dashboard "Larissa pergunta no chat às 22h" — **P2**
+- **US-COMVIS-015** — Cadastro de máquina com tinta/CMYK consumption tracking — **P2**
+- **US-COMVIS-016** — CT-e/MDF-e pra entrega — **P3**
+- **US-COMVIS-017** — Importação massiva de clientes/produtos do legacy OfficeImpresso — **P0**
+- **US-COMVIS-018** — Loja whitelabel pra catálogo público — **P3**
+
+## Accounting
+
+
+### todo
+
+- **US-ACCO-012** — DEPRECATION Onda 2: UI freeze (sidebar hide + routes 410 Gone) _(`p0` · @claude)_
+- **US-ACCO-015** — DEPRECATION Onda 5: Drop Modules/Accounting/ + modules_statuses=false _(`p0` · @claude)_
+- **US-ACCO-011** — DEPRECATION Onda 1.3: Errata BRIEFING Accounting (claims falsos linhas 21+25) _(`p1` · @claude)_
+- **US-ACCO-013** — DEPRECATION Onda 3: Migration accounts_legacy_map → fin_planos_conta (idempotente) _(`p1` · @claude)_
+- **US-ACCO-014** — DEPRECATION Onda 4: View bridge tabelas (60d rollback window) _(`p1` · @claude)_
+- **US-ACCO-016** — DEPRECATION Onda 6: Drop tabelas (90d após Onda 5) — IRREVERSÍVEL _(`p2` · @wagner)_
+- **US-ACCO-001** — Listar Budget
+- **US-ACCO-002** — Listar Chart Of Account
+- **US-ACCO-003** — Criar Chart Of Account
+- **US-ACCO-004** — Ver detalhe de Chart Of Account
+- **US-ACCO-005** — Listar Core
+- **US-ACCO-006** — Listar Journal Entry
+- **US-ACCO-007** — Criar Journal Entry
+- **US-ACCO-008** — Ver detalhe de Journal Entry
+- **US-ACCO-009** — Listar Reconcile
+- **US-ACCO-010** — Listar Report
+
+## Autopecas
+
+
+### todo
+
+- **US-AP-001** — Catálogo SKU + tabela aplicação por veículo (chassis/ano/modelo/montadora) — **P0**
+- **US-AP-002** — Venda balcão rápida (p95<1500ms, 1 tela 1 atalho) — **P0**
+- **US-AP-003** — Tabela preço por categoria/montadora (markup configurável) — **P0**
+- **US-AP-004** — Controle estoque mínimo + alertas reposição — **P0**
+- **US-AP-005** — Devolução com motivo + impacto em estoque — **P0**
+- **US-AP-006** — Garantia loja vs fabricante (registro + lookup + RMA) — **P0**
+- **US-AP-007** — NFC-e ágil (modelo 65) + NFe-de-boleto-pago automática — **P1**
+- **US-AP-008** — Cotação fornecedores (RFQ multi-fornecedor) — **P1**
+- **US-AP-009** — Multi-depósito (loja matriz + filial + estoque consignado) — **P1**
+- **US-AP-010** — Crediário interno (limite cliente + parcelamento + boleto) — **P1**
+- **US-AP-011** — WhatsApp consulta peça (Jana bot consulta catálogo) — **P1**
+- **US-AP-012** — App balconista mobile (PWA — busca peça + reserva) — **P1**
+- **US-AP-013** — Diagnóstico assistido Jana IA ("qual peça pra Civic 2015 freio dianteiro?") — **P1**
+- **US-AP-014** — Cupom fiscal SAT (SP) — **P2**
+- **US-AP-015** — E-commerce mini-loja (catálogo digital + pedido online) — **P2**
+
+## Comissao
+
+
+### todo
+
+- **US-COMM-001** — Schema base + migration + multi-tenant scope — **P0**
+- **US-COMM-002** — Side-effect `CalcularComissaoSells` no `marcar_pago` — **P0**
+- **US-COMM-003** — Side-effect `EstornarComissao` no `cancelar_venda` (clawback) — **P0**
+- **US-COMM-004** — UI cadastro de policy + role distributions — **P0**
+- **US-COMM-005** — Tiers escalonados (3 faixas R$/% per user OU policy) — **P1**
+- **US-COMM-006** — Metas mensais + accelerator — **P1**
+- **US-COMM-007** — Comando `commission:close --month=YYYY-MM` (fechamento) — **P0**
+- **US-COMM-008** — UI relatório mensal per-vendedor (substitui ReportController legacy) — **P1**
+- **US-COMM-009** — Multi-papel split ComVis (vendedor+designer+instalador) — **P1**
+- **US-COMM-010** — Multi-mecânico split OficinaAuto (apontamentos por % mão-de-obra) — **P2**
+- **US-COMM-011** — Comissão sobre líquido (após taxa marketplace) — **P2**
+- **US-COMM-012** — Aprovação workflow + audit trail (manager review) — **P1**
+- **US-COMM-013** — Mobile self-service vendedor — **P2**
+- **US-COMM-014** — Migração legacy `users.cmmsn_percent` + `transactions.commission_agent` — **P3**
+
+## Mwart
+
+
+### todo
+
+- **US-MWART-001** — Camada 2+3 enforcement — Hook + CI workflow _(`p0` · @wagner)_
+- **US-MWART-002** — Backfill — audit das 78 telas Inertia já existentes _(`p1` · @wagner)_
+- **US-MWART-004** — Onda 1 — migrar Vendas, PDV & Caixa e desligar Blade _(`p1`)_
+- **US-MWART-003** — Métricas de adoção do processo _(`p2` · @wagner)_
+- **US-MWART-005** — Onda 2 — migrar Clientes & contatos e desligar /contacts _(`p2`)_
+- **US-MWART-006** — Onda 3 — migrar Produtos & catálogo e desligar Blade _(`p2`)_
+- **US-MWART-007** — Onda 4 — migrar Estoque & inventário e desligar Blade _(`p2`)_
+- **US-MWART-008** — Onda 5 — migrar Compras & suprimentos e desligar Blade _(`p2`)_
+- **US-MWART-009** — Onda 6 — migrar Contábil & tesouraria (camada Account) e desligar Blade _(`p2`)_
+- **US-MWART-011** — Onda 8 — migrar Relatórios (a represa) e desligar Blade _(`p2`)_
+- **US-MWART-013** — Onda 10 — gate de zero-Blade (prova de honestidade [CX]) _(`p2`)_
+- **US-MWART-010** — Onda 7 — migrar Configurações, admin & documentos e desligar Blade _(`p3`)_
+- **US-MWART-012** — Onda 9 — migrar Acesso & onboarding e remover /login/old _(`p3`)_
+
+## Connector
+
+
+### todo
+
+- **US-CONN-001** — Auth Passport `auth:api` bloqueia anônimo
+- **US-CONN-002** — Sync Delphi via `/processa-dados-cliente`
+- **US-CONN-003** — Registrar WR Comercial via `/oimpresso/registrar`
+- **US-CONN-004** — Check-update via `/check-update`
+- **US-CONN-005** — REST CRUD `/contactapi`
+- **US-CONN-006** — REST CRUD `/product`
+- **US-CONN-007** — REST CRUD `/sell` (vendas)
+- **US-CONN-008** — REST `/business-location` (filiais)
+- **US-CONN-009** — REST `/taxonomy` + `/brand`
+- **US-CONN-010** — REST `/user`
+- **US-CONN-011** — Sync `salvar-cliente` + `salvar-equipamento/{business_id}`
+- **US-CONN-012** — CRM API (`crm/follow-ups`, `crm/leads`)
+
+## PontoWr2
+
+
+### todo
+
+- **US-PONT-001** — Listar Aprovacao
+- **US-PONT-002** — Listar Banco Horas
+- **US-PONT-003** — Ver detalhe de Banco Horas
+- **US-PONT-004** — Listar Colaborador
+- **US-PONT-005** — Listar Configuracao
+- **US-PONT-006** — Listar Core
+- **US-PONT-007** — Listar Espelho
+- **US-PONT-008** — Ver detalhe de Espelho
+- **US-PONT-009** — Listar Importacao
+- **US-PONT-010** — Criar Importacao
+- **US-PONT-011** — Ver detalhe de Importacao
+- **US-PONT-012** — Listar Relatorio
+
+## Essentials
+
+
+### todo
+
+- **US-ESS-001** — Listar tarefas (Todo) por business
+- **US-ESS-002** — Criar tarefa Todo
+- **US-ESS-003** — Editar tarefa (status/priority)
+- **US-ESS-004** — Deletar tarefa
+- **US-ESS-005** — Solicitação de Leave (ausência)
+- **US-ESS-006** — Aprovar/Rejeitar Leave
+- **US-ESS-007** — Compartilhar documentos via DocumentShare
+- **US-ESS-008** — Calendário Reminder
+- **US-ESS-009** — Module install/uninstall por business
+- **US-ESS-010** — Isolamento multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+- **US-ESSE-001** — [TODO — título]
+
+## MemCofre
+
+
+### todo
+
+- **US-DOCVAULT-001** — Ver dashboard com cobertura por módulo
+- **US-DOCVAULT-002** — Adicionar evidência
+- **US-DOCVAULT-003** — Triar evidências pendentes
+- **US-DOCVAULT-004** — Ver detalhes de um módulo
+- **US-DOCVAULT-005** — Chat com o conhecimento
+- **US-DOCVAULT-006** — Navegar memória unificada
+- **US-DOCVAULT-007** — Migrar módulo plano → pasta
+- **US-DOCVAULT-008** — Declarar stories/regras na tela via `@docvault`
+- **US-DOCVAULT-009** — Auditar qualidade de um módulo
+- **US-DOCVAULT-010** — Validar integridade global da documentação
+- **US-DOCVAULT-011** — Gerar stub de teste a partir de regra Gherkin
+
+## NFSe
+
+
+### todo
+
+- **US-NFSE-013** — Deploy produção real _(`p0` · @eliana · sprint D)_
+- **US-NFSE-005** — Job assíncrono _(`p1` · @eliana · sprint B)_
+- **US-NFSE-006** — HTTP Controller + rotas _(`p1` · @eliana · sprint B)_
+- **US-NFSE-008** — Pages/Nfse/Index.tsx _(`p1` · @eliana · sprint C)_
+- **US-NFSE-009** — Pages/Nfse/Emitir.tsx _(`p1` · @eliana · sprint C)_
+- **US-NFSE-011** — Testes Pest end-to-end _(`p1` · @eliana · sprint D)_
+- **US-NFSE-012** — Deploy sandbox _(`p1` · @eliana · sprint D)_
+- **US-NFSE-007** — Bridge recurring nativo UPOS _(`p2` · @eliana · sprint B)_
+- **US-NFSE-010** — Action "Imprimir DANFSE" _(`p2` · @eliana · sprint C)_
+- **US-NFSE-014** — Rollout pros clientes oimpresso _(`p2` · @eliana · sprint D)_
+- **US-NFSE-015** — Ambiente per-business em consultar()/cancelar() do SnNfseAdapter _(`p2` · @eliana)_
+
+## Cms
+
+
+### todo
+
+- **US-CMS-001** — Site home pública oimpresso.com renderiza Inertia/React sem auth
+- **US-CMS-002** — Adicionar `business_id` em `cms_pages` (multi-tenant CMS)
+- **US-CMS-003** — Adicionar `business_id` em `cms_site_details`
+- **US-CMS-004** — CRUD CmsPage migrado Blade→Inertia/React (MWART)
+- **US-CMS-005** — Páginas dinâmicas (`/p/{slug}` ou `/c/page/{slug}`)
+- **US-CMS-006** — Site Home dinâmico por tenant
+- **US-CMS-007** — Pricing dinâmico por tenant (planos custom)
+- **US-CMS-008** — Autenticação social no landing
+- **US-CMS-009** — Importer WordPress (XML/REST API)
+- **US-CMS-010** — Editor visual drag-drop (page builder)
+
+## Compras
+
+
+### todo
+
+- **US-COM-006** — Pest cross-tenant biz=1 vs biz=99 (4 testes) _(`p0`)_
+- **US-COM-007** — Fix business_id source: auth() em vez de session() + abort_if _(`p0`)_
+- **US-COM-008** — Throttle 60/1 em /compras + FormRequest ListarComprasRequest _(`p0`)_
+- **US-COM-009** — Validar JOIN scope contacts.business_id em TransactionUtil::getListPurchases (R1 leak) _(`p0`)_
+- **US-COM-010** — Adicionar Compras em config/governance/module_clients.yaml (Larissa biz=4 piloto reportando) _(`p1`)_
+- **US-COM-001** — Cockpit `/compras` (lista paginada + 4 KPIs + drawer)
+- **US-COM-002** — Criar compra manual
+- **US-COM-003** — Importar XML DF-e como compra (GAP NOVO)
+- **US-COM-004** — Deprecar `/purchases` legacy
+- **US-COM-005** — Entrada matricial tam×cor (GradeMatrixInput)
+
+## Ponto
+
+
+### todo
+
+- **US-PONTO-001** — Relogio web pra registrar entrada/saida (REP-P)
+- **US-PONTO-002** — Marcacao via REP-A (importacao AFD)
+- **US-PONTO-003** — Workflow de intercorrencia (atestado/abono/falta)
+- **US-PONTO-004** — Banco de horas com saldo + creditos/debitos
+- **US-PONTO-005** — Apuracao automatica de jornada (Art. 66 + 71 CLT)
+- **US-PONTO-006** — Geracao AFD legacy pra fiscalizacao MTE (REP-A INMETRO)
+- **US-PONTO-007** — Multi-tenant isolation (Tier 0 IRREVOGAVEL)
+- **US-PONTO-008** — Imutabilidade append-only (Portaria 671/2021)
+- **US-PONTO-009** — Geracao AEJ canon Portaria 671/2021 Anexo VI (CRITICO REGULATORIO)
+- **US-PONTO-010** — Comprovante PDF QR Code (Anexo I §5.5 Portaria 671)
+
+## Superadmin
+
+
+### todo
+
+- **US-SUPER-001** — Listagem e CRUD de Businesses
+- **US-SUPER-002** — Gestão de Packages (planos comerciais)
+- **US-SUPER-003** — Subscriptions (cobrança recorrente)
+- **US-SUPER-004** — Communicator (mensagens cross-tenant)
+- **US-SUPER-005** — Frontend Pages (site público)
+- **US-SUPER-006** — Manage Modules (instalar/desinstalar)
+- **US-SUPER-007** — System Info (saúde do sistema)
+- **US-SUPER-008** — Settings globais (SMTP/Pusher/Cron/Backup/Gateways)
+- **US-SUPER-009** — Pricing público (`/pricing`)
+- **US-SUPER-010** — Usuario 360 (visão consolidada do cliente)
+
+## TaskRegistry
+
+
+### todo
+
+- **US-NFSE-001** — Pesquisa fiscal Tubarão _(`p0` · @eliana · sprint A)_
+- **US-TR-303** — Fase 3.8 — Deletar Modules/Project legacy (UltimatePOS Project queue-for-delete) _(`p1` · @wagner)_
+
+### backlog
+
+- **US-TR-201** — Page /copiloto/admin/board (Kanban) _(`p1` · @wagner)_
+- **US-TR-202** — Backlog view (lista filtrável + bulk edit) _(`p1` · @wagner)_
+- **US-TR-204** — My Work + Inbox homepage _(`p1` · @wagner)_
+- **US-TR-203** — Roadmap view (epics em quarters) _(`p2` · @wagner)_
+- **US-TR-205** — Activity feed timeline _(`p2` · @wagner)_
+- **US-TR-206** — Burndown chart _(`p2` · @wagner)_
+- **US-TR-302** — tasks-suggest-* (D2 AI-native) _(`p2` · @wagner)_
+
+## ProjectMgmt
+
+
+### review
+
+- **US-TR-301** — Triage — lista de tasks órfãs _(`p1` · @wagner)_
+- **US-TR-302** — Triage — atribuir owner + prioridade inline _(`p1` · @wagner)_
+- **US-TR-304** — Inbox — lista de não-lidas _(`p1` · @wagner)_
+- **US-TR-305** — Inbox — marcar lido (individual + todas) _(`p1` · @wagner)_
+- **US-TR-306** — Inbox — deep-link pra task/DetailSheet _(`p1` · @wagner)_
+- **US-TR-303** — Triage — mover cycle/epic _(`p2` · @wagner)_
+- **US-TR-307** — Operador não-técnico usa sem treino _(`p2` · @wagner)_
+
+### todo
+
+- **US-TR-308** — Chips de ADRs/SPECs relacionados (memory-linked) _(`p2` · @wagner)_
+
+## EvolutionAgent
+
+
+### todo
+
+- **US-EVOL-001** — Indexar `memory/` em vetor
+- **US-EVOL-002** — Consultar memória via Artisan (chamado pelo CC)
+- **US-EVOL-003** — Ranquear oportunidades por ROI
+- **US-EVOL-004** — Eval golden set
+- **US-EVOL-005** — Subagent CC `evolucao.md`
+- **US-EVOL-006** — Tier-2 autonomia: comentar PR
+- **US-EVOL-007** — Tier-3 autonomia: PR-draft autônomo
+
+## KB
+
+
+### todo
+
+- **US-KB-001** — Bridge canon dos 143 ADRs (ONDA 1, ✅ LIVE)
+- **US-KB-002** — Artigo editável (Larissa Cowork, ONDA 3 parcial)
+- **US-KB-003** — Pergunta IA RAG sobre grafo (ONDA 4, ✅ LIVE)
+- **US-KB-004** — Trilha de aprendizado Larissa (ONDA 3+5)
+- **US-KB-005** — Troubleshooter Q→Sim/Não→Fix (ONDA 3)
+- **US-KB-006** — Visualização-grafo Cytoscape (ONDA 5)
+- **US-KB-007** — Imprimir SOP balcão físico (ONDA 5)
+
+## PaymentGateway
+
+
+### todo
+
+- **US-PG-001** — [SEC P0] Encrypted cast config_json (drift ADR 0170 §G) + rewrap command + 3 Pest _(`p0`)_
+- **US-PG-002** — [SEC P0] HMAC validation 4 webhooks legacy (espelhar Pagarme/InterPix) + WebhookProcessor refactor + 8 Pest _(`p0`)_
+- **US-PG-003** — [SEC P0] Throttle 120/min webhooks + timestamp window 5min + nonce-cache _(`p0`)_
+- **US-PG-004** — Doc mínimo: BRIEFING + CAPTERRA-FICHA + RUNBOOK-integrar-provider _(`p1`)_
+- **US-PG-005** — Registrar URL de webhook PIX no Inter (PUT /pix/v2/webhook) _(`p2` · @eliana)_
+- **US-PG-006** — Corrigir autenticação do webhook Inter (mTLS em vez de HMAC x-inter-signature) _(`p2` · @eliana)_
+- **US-PG-007** — Expor URL pública HTTPS do webhook Inter (deploy/proxy CT100) _(`p2` · @eliana)_
+
+## TeamMcp
+
+
+### todo
+
+- **US-TEAM-001** — Actor onboarding (cadastro humano novo no time)
+- **US-TEAM-002** — Token MCP issue (gerar token pra dev/IA)
+- **US-TEAM-003** — Token MCP revoke (revogar token comprometido)
+- **US-TEAM-004** — Isolamento token A vs token B
+- **US-TEAM-005** — Permission per tool/módulo (gates execução)
+- **US-TEAM-006** — IA pareada → audit trail no humano parent
+- **US-TEAM-007** — Audit log MCP append-only (Tier 0)
+
+## SRS
+
+
+### todo
+
+- **US-SRS-001** — Cadastrar fonte de documentação (Doc Source)
+- **US-SRS-002** — Cadastrar requisito (Requirement) e linkar evidências
+- **US-SRS-003** — Ingest job (process source → evidences)
+- **US-SRS-004** — Search hybrid (FULLTEXT + chat)
+- **US-SRS-005** — Audit log SRS (validation runs)
+- **US-SRS-006** — Memcofre legacy prefix (compat layer)
+
+## Woocommerce
+
+
+### todo
+
+- **US-WOO-001** — Configurar credenciais API (consumer key/secret + URL)
+- **US-WOO-002** — Sync de produtos (oimpresso → WooCommerce)
+- **US-WOO-003** — Sync de categorias e tax rates
+- **US-WOO-004** — Visualizar sync log + diagnóstico
+- **US-WOO-005** — Webhook: pedido criado na Woo → venda no oimpresso
+- **US-WOO-006** — Webhook: pedido atualizado na Woo → atualizar no oimpresso
+
+## LaravelAI
+
+
+### todo
+
+- **US-AI-001** — Perguntar em PT-BR sobre permissões
+- **US-AI-002** — Buscar ADRs por similaridade semântica
+- **US-AI-003** — Visualizar grafo de permissões
+- **US-AI-004** — Auditoria temporal por subject
+- **US-AI-005** — Chat IA contextual nas telas (rota corrente)
+
+## Spreadsheet
+
+
+### todo
+
+- **US-SHEET-001** — Criar planilha nova
+- **US-SHEET-002** — Listar e editar planilhas do business
+- **US-SHEET-003** — Share via link (público read-only)
+- **US-SHEET-004** — Post-share (revogar / listar shares ativos)
+- **US-SHEET-005** — Embed view (iframe-friendly)
+
+## Dashboard
+
+
+### todo
+
+- **US-DASH-001** — Soft wrapper Inertia `/home` (F6 entrega 2026-05-21)
+- **US-DASH-002** — Charts ECharts em Inertia (backlog F1→F4 wave)
+- **US-DASH-003** — Widget registry pluggable em React (backlog ADR nova)
+
+## MemoriaAutonoma
+
+
+### todo
+
+- **US-MEMORIAAUTONOMA-001** — MEM-MIGRACAO Auto-mem → git/MCP (22 candidatos pós-consolidação 2026-05-10) _(`p2` · @wagner)_
+- **US-MEMORIAAUTONOMA-002** — MEM-VERIFICAR 8 pendências stale detectadas pós-consolidação 2026-05-10 _(`p3` · @wagner)_
+
+## Admin
+
+
+### todo
+
+- **US-ADM-001** — ..010
+
+## Manufacturing
+
+
+### todo
+
+- **US-MANU-001** — [TODO — título]
+
+## Mcp
+
+
+### todo
+
+- **US-MCP-017** — Tool `module-state <modulo>` (CQRS projection per bounded context) _(`p1` · @wagner)_
+
+## Repair
+
+
+### todo
+
+- **US-REPA-001** — [TODO — título]

--- a/scripts/governance/tasks-index-generate.mjs
+++ b/scripts/governance/tasks-index-generate.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * tasks-index-generate.mjs — GERADOR determinístico de BACKLOG + CHANGELOG indexados.
+ *
+ * Mesmo princípio do adr-index-generate.mjs (Log4brains): índice GERADO da fonte de
+ * verdade, nunca mantido à mão. Fonte = as US-* dos SPEC.md (canon dos US-XXX-NNN por
+ * ADR 0070; o mcp_tasks é o cache de estado vivo). Lê todo memory/requisitos/<Mod>/SPEC.md,
+ * extrai cada bloco `### US-XXX-NNN · título` + a linha de metadados `> owner: … · status:
+ * … · priority: … · done_at: … · commit: …`, e emite:
+ *
+ *   - memory/requisitos/_BACKLOG-GENERATED.md   — US ABERTAS (status ∉ done|cancelled),
+ *       indexadas por módulo → status → owner. É a "lista indexada de tarefas" por
+ *       módulo/identidade.
+ *   - CHANGELOG gerado: DESLIGADO por ora (veredito adversarial 2026-06-16). done_at/commit
+ *       só existem em ~1/44 SPECs → sairia stale/vazio. O changelog REAL são os
+ *       Modules/<X>/CHANGELOG.md curados. Reabilitar quando done_at for materializado.
+ *
+ * Determinístico (mesmo input → mesmo output). Sem DB, sem rede — git-native, reproduzível.
+ *
+ * Uso:
+ *   node scripts/governance/tasks-index-generate.mjs           (dry: imprime resumo)
+ *   node scripts/governance/tasks-index-generate.mjs --write   (grava os 2 _*-GENERATED.md)
+ *   node scripts/governance/tasks-index-generate.mjs --check   (CI: exit 1 se gerado ≠ commitado = drift)
+ *
+ * Refs: ADR 0070 (Jira-style task mgmt; SPEC=canon US, mcp_tasks=estado) · ADR 0256
+ *       (survival, fonte única gerada) · adr-index-generate.mjs (mesmo padrão).
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SPEC_DIR = 'memory/requisitos';
+const OUT_BACKLOG = 'memory/requisitos/_BACKLOG-GENERATED.md';
+const OUT_CHANGELOG = 'memory/requisitos/_CHANGELOG-GENERATED.md';
+const MODE = process.argv.includes('--write') ? 'write' : process.argv.includes('--check') ? 'check' : 'dry';
+
+const DONE = new Set(['done', 'cancelled', 'canceled']);
+const CLOSED_OK = 'done';
+
+/** Lê a linha `> key: v · key: v` que segue uma US e devolve o mapa de metadados. */
+function parseMeta(line) {
+  /** @type {Record<string,string>} */
+  const meta = {};
+  const body = line.replace(/^>\s*/, '');
+  for (const part of body.split('·')) {
+    const m = part.match(/^\s*([a-z_]+)\s*:\s*(.+?)\s*$/i);
+    if (m) meta[m[1].toLowerCase()] = m[2].trim();
+  }
+  return meta;
+}
+
+/** @type {Array<{module:string,id:string,title:string,status:string,owner:string,priority:string,sprint:string,done_at:string,commit:string,progress:string}>} */
+const tasks = [];
+
+for (const mod of readdirSync(join(ROOT, SPEC_DIR)).sort()) {
+  const specPath = join(ROOT, SPEC_DIR, mod, 'SPEC.md');
+  if (!existsSync(specPath) || !statSync(specPath).isFile()) continue;
+  const lines = readFileSync(specPath, 'utf8').split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    // Heading de US: "### US-XXX-NNN · título"  (aceita ·, : ou — como separador)
+    const h = lines[i].match(/^#{2,4}\s+(US-[A-Za-z0-9]+-\d+)\b\s*[·:—-]?\s*(.*)$/);
+    if (!h) continue;
+    const id = h[1];
+    const title = (h[2] || '').trim() || '(sem título)';
+
+    // Procura a linha de metadados `> …` nas próximas 4 linhas (pula vazias).
+    let meta = {};
+    for (let j = i + 1; j < Math.min(i + 5, lines.length); j++) {
+      if (lines[j].trim() === '') continue;
+      if (lines[j].startsWith('>')) meta = parseMeta(lines[j]);
+      break; // primeira não-vazia decide
+    }
+
+    tasks.push({
+      module: mod,
+      id,
+      title,
+      status: (meta.status || 'todo').toLowerCase(),
+      owner: meta.owner || '—',
+      priority: (meta.priority || '').toLowerCase(),
+      sprint: meta.sprint || '',
+      done_at: meta.done_at || '',
+      commit: meta.commit || '',
+      progress: meta.progress || '',
+    });
+  }
+}
+
+const open = tasks.filter((t) => !DONE.has(t.status));
+const done = tasks.filter((t) => t.status === CLOSED_OK);
+
+// ─── BACKLOG (aberto) — por módulo → status → owner ─────────────────────────────
+const STATUS_ORDER = ['blocked', 'doing', 'review', 'todo', 'backlog'];
+function statusRank(s) {
+  const i = STATUS_ORDER.indexOf(s);
+  return i === -1 ? STATUS_ORDER.length : i;
+}
+function prioRank(p) {
+  const m = p.match(/p(\d)/);
+  return m ? Number(m[1]) : 9;
+}
+
+function renderBacklog() {
+  const byModule = new Map();
+  for (const t of open) {
+    if (!byModule.has(t.module)) byModule.set(t.module, []);
+    byModule.get(t.module).push(t);
+  }
+  const modules = [...byModule.keys()].sort((a, b) => byModule.get(b).length - byModule.get(a).length || a.localeCompare(b));
+
+  let out = '<!-- GERADO por scripts/governance/tasks-index-generate.mjs — NÃO editar à mão (regenera). -->\n';
+  out += '# Backlog indexado (gerado)\n\n';
+  out += `> Fonte: as US-* dos \`memory/requisitos/<Mod>/SPEC.md\` (canon, ADR 0070). US abertas (status ∉ done/cancelled).\n`;
+  out += `> **${open.length} tarefas abertas** em **${modules.length} módulos**. Regenera com \`node scripts/governance/tasks-index-generate.mjs --write\`.\n\n`;
+
+  // Índice (TOC) por módulo
+  out += '## Índice por módulo\n\n';
+  out += '| Módulo | Abertas | doing | review | blocked | todo/backlog |\n|---|---:|---:|---:|---:|---:|\n';
+  for (const mod of modules) {
+    const ts = byModule.get(mod);
+    const c = (s) => ts.filter((t) => t.status === s).length;
+    out += `| [\`${mod}\`](#${mod.toLowerCase()}) | ${ts.length} | ${c('doing')} | ${c('review')} | ${c('blocked')} | ${c('todo') + c('backlog')} |\n`;
+  }
+  out += '\n';
+
+  // Detalhe por módulo → status → tarefas (ordenadas por prioridade)
+  for (const mod of modules) {
+    const ts = byModule.get(mod).sort((a, b) => statusRank(a.status) - statusRank(b.status) || prioRank(a.priority) - prioRank(b.priority) || a.id.localeCompare(b.id));
+    out += `\n## ${mod}\n\n`;
+    let curStatus = null;
+    for (const t of ts) {
+      if (t.status !== curStatus) {
+        curStatus = t.status;
+        out += `\n### ${curStatus}\n\n`;
+      }
+      const tags = [t.priority && `\`${t.priority}\``, t.owner !== '—' && `@${t.owner}`, t.sprint && `sprint ${t.sprint}`, t.progress && `${t.progress}`].filter(Boolean).join(' · ');
+      out += `- **${t.id}** — ${t.title}${tags ? ` _(${tags})_` : ''}\n`;
+    }
+  }
+  return out;
+}
+
+// ─── CHANGELOG (done) — por data (desc) → módulo ────────────────────────────────
+function renderChangelog() {
+  const dated = done.filter((t) => t.done_at).sort((a, b) => b.done_at.localeCompare(a.done_at) || a.module.localeCompare(b.module));
+  const undated = done.filter((t) => !t.done_at);
+
+  let out = '<!-- GERADO por scripts/governance/tasks-index-generate.mjs — NÃO editar à mão (regenera). -->\n';
+  out += '# Changelog indexado (gerado)\n\n';
+  out += `> Fonte: US-* com \`status: done\` nos SPEC.md. **${done.length} entregues** (${dated.length} com data). Mais recentes primeiro.\n\n`;
+
+  let curDate = null;
+  for (const t of dated) {
+    if (t.done_at !== curDate) {
+      curDate = t.done_at;
+      out += `\n## ${curDate}\n\n`;
+    }
+    const ref = [t.commit && `\`${t.commit}\``, t.sprint && `sprint ${t.sprint}`, t.owner !== '—' && `@${t.owner}`].filter(Boolean).join(' · ');
+    out += `- **[${t.module}]** ${t.id} — ${t.title}${ref ? ` _(${ref})_` : ''}\n`;
+  }
+  if (undated.length) {
+    out += `\n## (done sem done_at)\n\n`;
+    for (const t of undated.sort((a, b) => a.module.localeCompare(b.module) || a.id.localeCompare(b.id))) {
+      out += `- **[${t.module}]** ${t.id} — ${t.title}\n`;
+    }
+  }
+  return out;
+}
+
+const backlogMd = renderBacklog();
+const changelogMd = renderChangelog();
+
+console.log(`tasks-index: ${tasks.length} US lidas · ${open.length} abertas · ${done.length} done`);
+
+if (MODE === 'dry') {
+  console.log(`\n[dry-run] BACKLOG (${OUT_BACKLOG}) + CHANGELOG (${OUT_CHANGELOG}) NÃO gravados.`);
+  console.log(backlogMd.split('\n').slice(0, 22).join('\n'));
+} else if (MODE === 'write') {
+  writeFileSync(join(ROOT, OUT_BACKLOG), backlogMd);
+  console.log(`\n✅ gravado: ${OUT_BACKLOG}`);
+  // CHANGELOG gerado DESLIGADO de propósito (veredito adversarial 2026-06-16): done_at/commit
+  // só existem em ~1/44 SPECs (sai stale/vazio). O changelog REAL são os Modules/<X>/CHANGELOG.md
+  // curados (prosa semver). Reabilitar só quando done_at for materializado nos SPECs.
+} else if (MODE === 'check') {
+  let drift = false;
+  for (const [path, gen] of [[OUT_BACKLOG, backlogMd]]) {
+    const cur = existsSync(join(ROOT, path)) ? readFileSync(join(ROOT, path), 'utf8') : '';
+    if (cur !== gen) {
+      console.error(`❌ drift: ${path} difere do gerado — rode --write e commit.`);
+      drift = true;
+    }
+  }
+  process.exit(drift ? 1 : 0);
+}


### PR DESCRIPTION
@
## O quê

`scripts/governance/tasks-index-generate.mjs` — gerador determinístico que lê as `US-*` de todos os `memory/requisitos/<Mod>/SPEC.md` (canon ADR 0070) e emite **`memory/requisitos/_BACKLOG-GENERATED.md`**: a "lista indexada de tarefas por módulo/identidade" pedida — **696 US abertas** indexadas por módulo → status → owner, com TOC e contadores.

Mesmo princípio do `adr-index-generate.mjs` (Log4brains): índice **gerado** da fonte de verdade, nunca mantido à mão. Git-native, sem DB, sem rede, reproduzível. Modes: `dry` / `--write` / `--check`.

## Por que read-only (veredito adversarial 2026-06-16)

O plano original era gerar **também** um changelog e migrar estado pro banco. O adversário matou os 5 pontos sérios — premissas factualmente erradas:

- **CHANGELOG gerado DESLIGADO**: `done_at`/`commit` só existem em ~1/44 SPECs → sairia stale/vazio. O changelog REAL são os `Modules/<X>/CHANGELOG.md` curados (prosa semver). Não os toco nem apago.
- **ADR 0144 intocado**: o DB segue canon de estado vivo (status/owner/sprint/priority via `tasks-update`). Isto aqui é só um **agregador read-only** — não compete com o banco, não reescreve nada.
- **Sem gate CI bloqueante**: evita a fricção de exigir regen a cada PR que toca SPEC. Quem quiser atualizar roda `--write` e commita.

## Como usar

```bash
node scripts/governance/tasks-index-generate.mjs            # dry: resumo
node scripts/governance/tasks-index-generate.mjs --write    # grava _BACKLOG-GENERATED.md
node scripts/governance/tasks-index-generate.mjs --check    # drift check (exit 1 se ≠ commitado)
```

Refs: ADR 0070 (Jira-style: SPEC=canon US, mcp_tasks=estado vivo) · ADR 0256 (fonte única gerada) · ADR 0144 (DB canon de estado — preservado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@