### PR TITLE
fix(governance): foundation-ratchet conta uso real de RefreshDatabase, não menção

### DIFF
--- a/scripts/tests/baselines/foundation-ratchet-baseline.json
+++ b/scripts/tests/baselines/foundation-ratchet-baseline.json
@@ -2,7 +2,7 @@
   "generated_by": "scripts/tests/foundation-ratchet.mjs --write",
   "counters": {
     "n_quarantine": 127,
-    "n_refresh_database": 71,
+    "n_refresh_database": 15,
     "n_business_first": 75
   }
 }

--- a/scripts/tests/fixtures/foundation-ratchet/comment-vs-uso/baseline.json
+++ b/scripts/tests/fixtures/foundation-ratchet/comment-vs-uso/baseline.json
@@ -1,0 +1,8 @@
+{
+  "nota": "fixture comment-vs-uso (FV-Q1, ADR 0275): 2 arquivos contêm a palavra RefreshDatabase, mas só 1 APLICA o trait (uses(...::class)) — o outro só MENCIONA (docblock + string de skip). A contagem honesta é 1.",
+  "counters": {
+    "n_quarantine": 0,
+    "n_refresh_database": 1,
+    "n_business_first": 0
+  }
+}

--- a/scripts/tests/fixtures/foundation-ratchet/comment-vs-uso/tests/Feature/SoMencionaTest.php
+++ b/scripts/tests/fixtures/foundation-ratchet/comment-vs-uso/tests/Feature/SoMencionaTest.php
@@ -1,0 +1,25 @@
+<?php
+
+// FIXTURE (comment-vs-uso) do foundation-ratchet selftest — MENÇÃO sem USO.
+// Espelha o padrão era-sqlite REAL: monta schema à mão e EXPLICA por que EVITA o
+// trait. A palavra RefreshDatabase aparece só em docblock e em string literal —
+// o detector corrigido (FV-Q1, ADR 0275) NÃO pode contar isto.
+// Vive fora dos roots reais (tests/ · Modules/*/Tests/) de propósito.
+
+namespace FoundationRatchetFixtures\CommentVsUso;
+
+/**
+ * Este teste NÃO usa RefreshDatabase: a suite inteira com RefreshDatabase puxaria
+ * migrations MySQL-only que quebram no sqlite :memory: da lane per-PR — por isso
+ * monta-se o schema sintético na mão.
+ */
+class SoMencionaTest
+{
+    public function test_skip_menciona_a_palavra_em_string(): void
+    {
+        // string de skip do mundo real — a palavra sobrevive ao strip de comentário
+        // mas não casa `uses(`/`use …;`, então continua não contando:
+        $motivoSkip = 'requer MySQL — RefreshDatabase quebra com sqlite na migration legacy';
+        $this->assertNotEmpty($motivoSkip);
+    }
+}

--- a/scripts/tests/fixtures/foundation-ratchet/comment-vs-uso/tests/Feature/UsaDeVerdadeViaPestTest.php
+++ b/scripts/tests/fixtures/foundation-ratchet/comment-vs-uso/tests/Feature/UsaDeVerdadeViaPestTest.php
@@ -1,0 +1,13 @@
+<?php
+
+// FIXTURE (comment-vs-uso) do foundation-ratchet selftest — USO REAL via Pest `uses()`.
+// Cobre o 2º padrão de detecção (o good/bad cobre `use RefreshDatabase;` clássico).
+// DEVE contar: aplica o trait de fato. Nunca é executado — só lido como texto pelo ratchet.
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('exemplo que aplica o trait pesado de verdade', function () {
+    expect(true)->toBeTrue();
+});

--- a/scripts/tests/foundation-ratchet.mjs
+++ b/scripts/tests/foundation-ratchet.mjs
@@ -5,7 +5,9 @@
 // a full-suite nunca rodou verde em DB real. Antes da nightly diagnóstica medir, congelamos
 // 3 contadores REAIS (medidos no repo, não no plano — regra anti-stale) pra nenhum PR piorar:
 //   n_quarantine        — marcadores `legacy-quarantine` (burn-down: subir = regressão)
-//   n_refresh_database  — ARQUIVOS de teste com RefreshDatabase (alvo: DatabaseTransactions)
+//   n_refresh_database  — ARQUIVOS que APLICAM o trait RefreshDatabase — `uses(...RefreshDatabase::class)`
+//                         ou `use [...\]RefreshDatabase;` (alvo: DatabaseTransactions). MENÇÃO da palavra
+//                         em comentário/docstring/string de skip NÃO conta (conserto raiz FV-Q1, ADR 0275).
 //   n_business_first    — ocorrências de Business::first() cru em teste (alvo: trait WithSeededTenant)
 //
 // CONVENÇÃO QUARENTENA (hard-fail, independe de baseline): todo marcador exige
@@ -30,6 +32,18 @@ const BASELINE = opt('--baseline') || join(ROOT, 'scripts/tests/baselines/founda
 
 const MARKER = /@group\s+legacy-quarantine\b|#\[Group\(['"]legacy-quarantine['"]\)\]|->group\(['"]legacy-quarantine['"]/;
 const REASON = /quarantine-reason:\s*\S/;
+
+// USO REAL do trait RefreshDatabase (≠ MENÇÃO). Conta só quem APLICA o trait:
+//   `uses(...RefreshDatabase::class...)` (Pest) ou `use [...\]RefreshDatabase;` (import/trait-use).
+// Remove comentários antes (docblock /* */ + linha //) pra não casar a docstring que explica POR QUE o
+// teste EVITA o trait (padrão era-sqlite). String literal sobrevive ao strip (ex.: `->skip('… RefreshDatabase …')`)
+// mas não casa `uses(`/`use …;`, então não conta. Conserta a raiz do FV-Q1: o `\bRefreshDatabase\b` cru
+// contava ~50 falsos positivos (menção em comentário), medindo FORMA e não USO real (ADR 0275 — métrica honesta).
+function refreshDatabaseTraitUsed(src) {
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+  return /\buses\s*\([^)]*\bRefreshDatabase\b/.test(code)
+    || /^\s*use\s+[\w\\]*\bRefreshDatabase\b/m.test(code);
+}
 
 // Roots canônicos: tests/ + Modules/<X>/Tests/. Comparação case-insensitive + readdir
 // (cada dir REAL visitado 1×) — imune ao alias NTFS Tests/tests que duplicaria contagem.
@@ -57,7 +71,7 @@ function measure(root) {
   const semRazao = [];
   for (const tr of testRoots(root)) for (const f of phpFiles(tr)) {
     const src = readFileSync(f, 'utf8');
-    if (/\bRefreshDatabase\b/.test(src)) counters.n_refresh_database++;
+    if (refreshDatabaseTraitUsed(src)) counters.n_refresh_database++;
     counters.n_business_first += (src.match(/\bBusiness::first\s*\(/g) || []).length;
     if (!MARKER.test(src)) continue;
     const lines = src.split('\n');

--- a/scripts/tests/foundation-ratchet.test.mjs
+++ b/scripts/tests/foundation-ratchet.test.mjs
@@ -14,7 +14,8 @@ const SCRIPT = join(__dirname, 'foundation-ratchet.mjs');
 const FIX = join(__dirname, 'fixtures', 'foundation-ratchet');
 
 let fails = 0;
-const check = (name, cond) => { console.log(`${cond ? '[OK]' : '[FAIL]'} ${name}`); if (!cond) fails++; };
+let ran = 0;
+const check = (name, cond) => { ran++; console.log(`${cond ? '[OK]' : '[FAIL]'} ${name}`); if (!cond) fails++; };
 const exec = (a, env = {}) => spawnSync('node', [SCRIPT, ...a], { encoding: 'utf8', env: { ...process.env, GITHUB_STEP_SUMMARY: '', ...env } });
 const run = (root, extra = [], env = {}) => exec(['--root', join(FIX, root), '--baseline', join(FIX, root, 'baseline.json'), ...extra], env);
 
@@ -56,7 +57,15 @@ run('bad', [], { GITHUB_STEP_SUMMARY: sum });
 const md = readFileSync(sum, 'utf8');
 check('summary → tabela com contadores + sem-razão', /n_quarantine/.test(md) && /quarantine-reason/.test(md));
 
+// 7. Conserto raiz FV-Q1 (ADR 0275): MENÇÃO da palavra (comentário/docstring/string de skip)
+//    NÃO conta; só USO real do trait conta. A fixture tem 2 arquivos com a palavra, 1 aplica o
+//    trait via `uses(RefreshDatabase::class)` e o outro só menciona → contagem honesta = 1.
+const cvu = run('comment-vs-uso');
+check('comment-vs-uso → exit 0 (uso real == baseline == 1)', cvu.status === 0);
+const jc = JSON.parse(run('comment-vs-uso', ['--json']).stdout);
+check('comment-vs-uso → mede 1 (ignora a menção, conta o uso Pest)', jc.counters.n_refresh_database === 1);
+
 console.log('');
-if (fails === 0) { console.log('[PASS] catraca MORDE — subir = vermelho, sem razão = vermelho, --write só desce. (10/10)'); process.exit(0); }
+if (fails === 0) { console.log(`[PASS] catraca MORDE — subir = vermelho, sem razão = vermelho, --write só desce, menção ≠ uso. (${ran}/${ran})`); process.exit(0); }
 console.log(`[FAIL] ${fails} caso(s) — a catraca NÃO está garantida. NÃO mergear.`);
 process.exit(1);


### PR DESCRIPTION
## Problema

A catraca `foundation-ratchet` (FV-Q1, advisory) pinta **vermelho em toda PR**: o contador `n_refresh_database` está em drift `71→74` no `main`.

## Raiz (não é o que parecia)

O detector casava `\bRefreshDatabase\b` **cru** — contava a palavra em **comentário / docstring / string de `->skip()`** como se fosse uso do trait. Medi no `main` inteiro:

| | arquivos |
|---|---:|
| Contados (menção à palavra) | **71** |
| **Uso real do trait** | **15** |
| **Falsos positivos** (só menção) | **56** |

Os ~5 testes da Leva 2 que "subiram" o número (`LeaseBriefSectionServiceTest`, `WorkLeaseServiceTest`, `AcceptanceRefTest`, `IngestLivenessTest`, `TaskParserDetectaDivergenciaDescritivaTest`) **não usam** o trait — montam schema sqlite sintético e **mencionam** `RefreshDatabase` só pra explicar por que o **evitam** (padrão era-sqlite). A métrica media **forma, não correção** — exatamente o que o avaliador adversarial do SDD existe pra caçar.

**Converter teste pra `DatabaseTransactions` não resolve** — não há o que converter.

## Conserto de raiz

- **Detector** (`foundation-ratchet.mjs`): conta só **uso real** — `uses(...RefreshDatabase::class)` (Pest) ou `use [...\]RefreshDatabase;` (import/trait), removendo comentários antes do match. String de `skip()` sobrevive ao strip mas não casa os padrões de uso.
- **Baseline re-armado** pro número honesto: `n_refresh_database 71 → 15` (burn-down acionável de verdade — os 15 reais).
- **Travado com teste**: nova fixture `comment-vs-uso` (2 arquivos com a palavra, 1 usa o trait + 1 só menciona) + 2 asserts no selftest → **13/13**. A CI roda o selftest antes do gate, então a discriminação morde em CI.

`n_quarantine` e `n_business_first` **intactos**.

## Por que é seguro

- Re-definição de métrica **visível no diff** (ADR 0275; precedente direto: `anchor_coverage` teve a série antiga aposentada do mesmo jeito).
- Catraca segue **advisory** (não bloqueia merge).
- Node puro, sem MySQL. Selftest local **13/13**, gate **verde**, PII diff-only **0 hits**.

Refs: SDD FV-Q1 · ADR 0275

🤖 Generated with [Claude Code](https://claude.com/claude-code)