### PR TITLE
fix(whatsapp): religa recebimento — segredo na URL do webhook whatsmeow (incidente 2026-06-16, pós-#2726)

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -70,6 +70,10 @@ return [
         'daemon_url' => env('WHATSMEOW_DAEMON_URL', 'https://whatsapp-whatsmeow.oimpresso.com'),
         'api_key' => env('WHATSMEOW_API_KEY'),
         'hmac_secret' => env('WHATSMEOW_HMAC_SECRET'),
+        // Segredo compartilhado na URL do webhook (`?wh=`) — autentica o daemon
+        // WuzAPI que não consegue assinar HMAC nem mandar header. Hotfix incidente
+        // 2026-06-16 (recebimento parado pós-#2726). Não-spoofável (TLS-only).
+        'webhook_url_secret' => env('WHATSMEOW_WEBHOOK_URL_SECRET'),
         'request_timeout' => (int) env('WHATSMEOW_TIMEOUT', 15),
     ],
 

--- a/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
@@ -85,7 +85,7 @@ class VerifyWhatsmeowSignature
         // sem downgrade silencioso). Substituível por HMAC quando/se o daemon
         // ganhar suporte a assinatura.
         $urlSecret = (string) config('whatsapp.whatsmeow.webhook_url_secret', '');
-        $providedUrlSecret = (string) $request->query('wh', '');
+        $providedUrlSecret = is_string($wh = $request->query('wh')) ? $wh : '';
         if ($urlSecret !== '' && hash_equals($urlSecret, $providedUrlSecret)) {
             $channel = $this->resolveChannel($request, $businessId);
             $request->attributes->set('whatsapp.business_id', $businessId);

--- a/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
@@ -74,6 +74,26 @@ class VerifyWhatsmeowSignature
 
         $businessId = (int) $businessRow->id;
 
+        // ─── Defesa por segredo na URL (hotfix incidente 2026-06-16) ────
+        // O daemon WuzAPI (asternic/wuzapi) NÃO assina HMAC nem manda header
+        // de auth — a única coisa configurável nele é a URL do webhook. Um
+        // segredo compartilhado no query string `?wh=` trafega apenas via TLS
+        // daemon→app e NÃO é spoofável como o antigo IP-whitelist removido em
+        // #2726 (não depende de `X-Forwarded-For` sob `TrustProxies = '*'`).
+        // Restaura o recebimento preservando Tier 0 (ADR 0093). Inerte quando
+        // `WHATSMEOW_WEBHOOK_URL_SECRET` não está setado (fail-safe, timing-safe,
+        // sem downgrade silencioso). Substituível por HMAC quando/se o daemon
+        // ganhar suporte a assinatura.
+        $urlSecret = (string) config('whatsapp.whatsmeow.webhook_url_secret', '');
+        $providedUrlSecret = (string) $request->query('wh', '');
+        if ($urlSecret !== '' && hash_equals($urlSecret, $providedUrlSecret)) {
+            $channel = $this->resolveChannel($request, $businessId);
+            $request->attributes->set('whatsapp.business_id', $businessId);
+            $request->attributes->set('whatsapp.channel', $channel);
+
+            return $next($request);
+        }
+
         // ─── Defesa primária: HMAC global SHA-256 (timing-safe) ─────────
         // Daemon assina cada POST com HMAC-SHA256(body, WUZAPI_GLOBAL_HMAC_KEY)
         // — ver daemon-go/docker-compose.yml (WUZAPI_GLOBAL_HMAC_KEY_FILE).

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13016,7 +13016,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 49
+			count: 50
 			path: Modules/Whatsapp/Config/config.php
 
 		-


### PR DESCRIPTION
## Incidente 2026-06-16 — Caixa Unificada parou de receber WhatsApp

**Sintoma (relato Wagner):** "não está recebendo mensagem". Recebimento parado desde **13/jun 19:27** (3 dias, 0 inbound) nas 2 linhas (Suporte +554896486699 · Jana +554888782087, biz=1).

**Causa raiz:** PR #2726 removeu o fallback de IP-whitelist (spoofável via X-Forwarded-For sob TrustProxies=*) e tornou o `VerifyWhatsmeowSignature` *fail-closed* (exige HMAC ou Token). Mas o daemon **WuzAPI (asternic/wuzapi) não assina HMAC nem manda header de auth** — sempre dependeu do IP. Resultado: todo webhook tomava **401 "sem HMAC nem Token"** (confirmado no log do daemon: `status=401`, e no laravel.log). Nenhum `failed_job` porque o job nem era despachado.

**Por que não foi HMAC:** o binário do daemon não tem suporte a assinatura; a única coisa configurável nele é a URL do webhook.

## Fix
Aceitar um **segredo compartilhado na URL** do webhook (`?wh=<segredo>`):
- Trafega só por TLS daemon→app, **não-spoofável** (independe de X-Forwarded-For) → **não reabre o buraco Tier 0** que o #2726 fechou (ADR 0093).
- `hash_equals` timing-safe; **inerte** quando `WHATSMEOW_WEBHOOK_URL_SECRET` está vazio (fail-safe, sem downgrade).
- Substituível por HMAC se/quando o daemon ganhar suporte.

## Já aplicado em produção (este PR torna durável)
- ✅ App (Hostinger): patch + `WHATSMEOW_WEBHOOK_URL_SECRET` no `.env` + config:cache (o `.env` persiste; o **código** revertia a cada deploy — daí este PR).
- ✅ Daemon (CT 100 WuzAPI): URL do webhook das 2 sessões atualizada pra incluir `?wh=` (persistente na db do WuzAPI). Eventos preservados.
- ✅ Verificado: POST com segredo certo → **200**, errado → **401**. Mensagens reais voltaram a cair no banco (último inbound 13/jun 19:27 → 16/jun 08:48).

## Requisito de deploy
`WHATSMEOW_WEBHOOK_URL_SECRET` precisa existir no `.env` de produção (já está). 

## Follow-ups
- [ ] Rotacionar o segredo (apareceu em logs/sessão durante o incidente).
- [ ] Avaliar trocar a imagem do daemon por uma com HMAC nativo (fix definitivo de assinatura).
- [ ] Considerar mover o segredo pro header se o WuzAPI passar a suportar headers custom (URL pode vazar em access logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)