### PR TITLE
feat(jana): sentinela de fluxo de inbound WhatsApp — detecta recebimento parado (nunca mais #2726)

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -25,6 +25,9 @@ use Modules\Jana\Services\CharterHealthChecker;
  *   6. Procedure drift (US-COPI-092) — hash deployed vs migration canônica
  *   7. Spec ID drift (ADR 0134) — colisão DB↔SPEC.md (mesmo ID, title diferente)
  *   8. Whatsapp media pending 1h (Guardião 6 Camada 6) — mídia órfã > 1h
+ *   8b. Whatsapp inbound flow (sentinela de fluxo real · incidente 2026-06-16
+ *       #2726) — por canal ativo com histórico, último inbound > Nh em horário
+ *       comercial = ALERTA. Pega QUALQUER causa de silêncio no recebimento.
  *   9. MCP webhook 5xx 2h (US-FIN-043 incident 2026-05-21) — webhook GitHub
  *      retornando 5xx nas últimas 2h indica drift no DB sync (tasks/memory)
  *  10. Memoria recall backend (resiliência Meilisearch) — MCP/Meilisearch
@@ -55,7 +58,7 @@ class HealthCheckCommand extends Command
                             {--json : Output JSON em vez de tabela}
                             {--notify : Loga ALERT em jana-health channel se algo falhou}';
 
-    protected $description = 'Health check diário Jana + Constituição v2 (10 checks SQL + ledger de lições + charter/loop advisory)';
+    protected $description = 'Health check diário Jana + Constituição v2 (11 checks SQL + ledger de lições + charter/loop advisory)';
 
     public function handle(): int
     {
@@ -68,6 +71,7 @@ class HealthCheckCommand extends Command
             $this->checkProcedureDrift(),
             $this->checkSpecIdDrift(),
             $this->checkWhatsappMediaPending1h(),
+            $this->checkWhatsappInboundFlow(),
             $this->checkMcpWebhookHealth2h(),
             $this->checkMemoriaRecallBackend(),
             $this->checkLessonLedgerGraduation(),
@@ -488,6 +492,128 @@ class HealthCheckCommand extends Command
                 'message' => 'ERRO: ' . $e->getMessage(),
             ];
         }
+    }
+
+    /**
+     * Check 8b — Whatsapp INBOUND FLOW (sentinela de fluxo real · incidente 2026-06-16 #2726).
+     *
+     * O #2726 (hardening de auth do webhook) deixou o recebimento de WhatsApp MORTO
+     * por 3 dias SEM ninguém ver: todo monitor media degradação DENTRO de um fluxo
+     * vivo (mídia órfã, SLA, custo), nunca a AUSÊNCIA do fluxo. Com 401 antes do
+     * dispatch, zero rows nasciam → zero órfãs → tudo "verde"; channel_health dizia
+     * "paired" (proxy de conexão, não de recebimento).
+     *
+     * Este check mede o que importa e é DRIVER-AGNÓSTICO: por canal ATIVO com
+     * histórico de inbound, a última mensagem recebida não pode ser mais velha que
+     * o threshold em horário comercial. Pega QUALQUER causa de silêncio
+     * (auth/rota/worker/firewall/daemon/UUID), sem depender de saber a causa. Hard
+     * check — derruba o exit code + dispara o ALERT do cron.
+     *
+     * Baseline por canal: só vigia quem JÁ recebeu inbound algum dia (evita
+     * falso-positivo em linha quieta/recém-criada). Fora do horário comercial BRT
+     * não acende (canal quieto à noite/domingo é normal).
+     */
+    protected function checkWhatsappInboundFlow(): array
+    {
+        $name = 'whatsapp_inbound_flow';
+        $thresholdHours = (int) config('whatsapp.inbound_silence_alert_hours', 6);
+
+        try {
+            if (! \Illuminate\Support\Facades\Schema::hasTable('channels')
+                || ! \Illuminate\Support\Facades\Schema::hasTable('conversations')
+                || ! \Illuminate\Support\Facades\Schema::hasTable('messages')) {
+                return [
+                    'name' => $name,
+                    'ok' => true,
+                    'value' => 'n/a',
+                    'threshold' => "<= {$thresholdHours}h",
+                    'message' => 'Tabelas de canal ausentes — módulo Whatsapp não instalado',
+                ];
+            }
+
+            $channels = DB::table('channels')
+                ->where('status', 'active')
+                ->get(['id', 'label', 'business_id'])
+                ->map(fn ($ch) => [
+                    'label' => $ch->label ?? "canal {$ch->id}",
+                    'business_id' => (int) $ch->business_id,
+                    'last_inbound' => DB::table('messages')
+                        ->join('conversations', 'conversations.id', '=', 'messages.conversation_id')
+                        ->where('conversations.channel_id', $ch->id)
+                        ->where('messages.direction', 'inbound')
+                        ->max('messages.created_at'),
+                ])
+                ->all();
+
+            $r = self::evaluateInboundFlow($channels, now()->setTimezone('America/Sao_Paulo'), $thresholdHours);
+
+            if ($r['fora_horario']) {
+                return [
+                    'name' => $name,
+                    'ok' => true,
+                    'value' => 'fora-horário',
+                    'threshold' => "<= {$thresholdHours}h",
+                    'message' => 'Fora do horário comercial BRT — silêncio de inbound não alarma agora',
+                ];
+            }
+
+            $count = count($r['mudos']);
+
+            return [
+                'name' => $name,
+                'ok' => $count === 0,
+                'value' => $count === 0 ? "{$r['vigiados']} canal(is) com fluxo" : $count,
+                'threshold' => "<= {$thresholdHours}h",
+                'message' => $count === 0
+                    ? "Todos os {$r['vigiados']} canais ativos receberam inbound nas últimas {$thresholdHours}h"
+                    : 'ALERTA recebimento parado: ' . implode(' · ', $r['mudos'])
+                        . ' — checar webhook/daemon/auth (classe do incidente #2726)',
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'name' => $name,
+                'ok' => false,
+                'value' => null,
+                'threshold' => "<= {$thresholdHours}h",
+                'message' => 'ERRO: ' . $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Lógica pura da sentinela de inbound — pública e estática pra ser testável sem
+     * tocar DB nem o relógio real (mesmo padrão de parseLessonLedger).
+     *
+     * @param  array<int, array{label: string, business_id: int, last_inbound: ?string}>  $channels
+     * @return array{ok: bool, vigiados: int, mudos: list<string>, fora_horario: bool}
+     */
+    public static function evaluateInboundFlow(array $channels, \Illuminate\Support\Carbon $nowBrt, int $thresholdHours): array
+    {
+        // Janela comercial BRT (08–20, seg–sáb). Fora dela, silêncio é normal.
+        $horaComercial = $nowBrt->hour >= 8 && $nowBrt->hour < 20 && $nowBrt->dayOfWeek !== \Carbon\Carbon::SUNDAY;
+        if (! $horaComercial) {
+            return ['ok' => true, 'vigiados' => 0, 'mudos' => [], 'fora_horario' => true];
+        }
+
+        $mudos = [];
+        $vigiados = 0;
+        foreach ($channels as $ch) {
+            $last = $ch['last_inbound'] ?? null;
+            if ($last === null || $last === '') {
+                continue; // sem histórico → sem baseline, não vigia
+            }
+            $vigiados++;
+            $lastBrt = \Illuminate\Support\Carbon::parse((string) $last, 'America/Sao_Paulo');
+            if ($lastBrt->greaterThanOrEqualTo($nowBrt)) {
+                continue; // timestamp futuro (clock skew) → trata como fresco
+            }
+            $idade = (int) $lastBrt->diffInHours($nowBrt);
+            if ($idade > $thresholdHours) {
+                $mudos[] = "{$ch['label']} (biz {$ch['business_id']}): {$idade}h sem inbound";
+            }
+        }
+
+        return ['ok' => $mudos === [], 'vigiados' => $vigiados, 'mudos' => $mudos, 'fora_horario' => false];
     }
 
     /**

--- a/Modules/Jana/Tests/Feature/Smoke/WhatsappInboundFlowCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/WhatsappInboundFlowCheckTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Sentinela de fluxo de inbound WhatsApp (incidente 2026-06-16 #2726).
+ *
+ * A lógica vive no método estático evaluateInboundFlow (mesmo padrão de
+ * parseLessonLedger): testável sem DB nem relógio real. O último teste prova que
+ * o check está registrado no jana:health-check e é HARD (derruba o exit code).
+ *
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php::checkWhatsappInboundFlow
+ */
+$comercial = fn (): Carbon => Carbon::parse('2026-06-16 10:00:00', 'America/Sao_Paulo'); // terça 10h BRT
+
+test('acende quando canal ativo com histórico fica mudo além do threshold em horário comercial', function () use ($comercial) {
+    $r = HealthCheckCommand::evaluateInboundFlow([
+        ['label' => 'Suporte', 'business_id' => 1, 'last_inbound' => '2026-06-16 09:30:00'], // 30min — fresco
+        ['label' => 'Jana', 'business_id' => 1, 'last_inbound' => '2026-06-15 20:00:00'],    // ~14h — mudo
+    ], $comercial(), 6);
+
+    expect($r['ok'])->toBeFalse();
+    expect($r['mudos'])->toHaveCount(1);
+    expect($r['mudos'][0])->toContain('Jana');
+    expect($r['vigiados'])->toBe(2);
+});
+
+test('ignora canal sem histórico de inbound (sem baseline pra vigiar)', function () use ($comercial) {
+    $r = HealthCheckCommand::evaluateInboundFlow([
+        ['label' => 'NovoCanal', 'business_id' => 1, 'last_inbound' => null],
+    ], $comercial(), 6);
+
+    expect($r['ok'])->toBeTrue();
+    expect($r['vigiados'])->toBe(0);
+});
+
+test('não alarma fora do horário comercial BRT (canal quieto à noite é normal)', function () {
+    $noite = Carbon::parse('2026-06-16 23:00:00', 'America/Sao_Paulo');
+    $r = HealthCheckCommand::evaluateInboundFlow([
+        ['label' => 'Suporte', 'business_id' => 1, 'last_inbound' => '2026-06-14 10:00:00'], // 2+ dias mudo
+    ], $noite, 6);
+
+    expect($r['ok'])->toBeTrue();
+    expect($r['fora_horario'])->toBeTrue();
+});
+
+test('ok quando todos os canais ativos receberam dentro do threshold', function () use ($comercial) {
+    $r = HealthCheckCommand::evaluateInboundFlow([
+        ['label' => 'Suporte', 'business_id' => 1, 'last_inbound' => '2026-06-16 08:00:00'], // 2h
+    ], $comercial(), 6);
+
+    expect($r['ok'])->toBeTrue();
+    expect($r['mudos'])->toBe([]);
+});
+
+test('whatsapp_inbound_flow está registrado no jana:health-check e é hard (não-advisory)', function () {
+    Artisan::call('jana:health-check', ['--json' => true]);
+    $out = Artisan::output();
+    $start = strpos($out, '{');
+    $json = $start === false ? [] : json_decode(substr($out, (int) $start), true);
+
+    $check = collect($json['checks'] ?? [])->firstWhere('name', 'whatsapp_inbound_flow');
+    expect($check)->not->toBeNull('check whatsapp_inbound_flow ausente do jana:health-check');
+    expect($check['advisory'] ?? false)->toBeFalse(); // hard check — derruba exit + ALERT
+    expect($check)->toHaveKeys(['name', 'ok', 'value', 'threshold', 'message']);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -161,6 +161,23 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Sentinela de FLUXO de inbound WhatsApp — cadência HORÁRIA em horário
+        // comercial BRT (incidente 2026-06-16 #2726: recebimento morto 3 dias sem
+        // ninguém ver; o cron diário 06:00 só detectaria ~22h depois). Reusa o
+        // mesmo --notify/ALERT; o check whatsapp_inbound_flow só acende em horário
+        // comercial e ignora canal sem histórico de inbound (baseline por canal).
+        $schedule->command('jana:health-check --notify')
+            ->hourlyAt(7)
+            ->timezone('America/Sao_Paulo')
+            ->between('8:00', '20:00')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule jana:health-check (horário · sentinela inbound) FALHOU'
+                );
+            });
+
         // US-SELL-COWORK-R6-SMOKE — smoke automatizado Sells/Index Cowork.
         // 5 sinais críticos: schema essencial + multi-tenant biz=1/biz=4 com vendas 30d
         // + Vite manifest contém chunks Cowork (Sale*.tsx) + CSS scoped imports


### PR DESCRIPTION
## Peça-mestra do "nunca mais" (incidente 2026-06-16, pós-#2726)

O #2726 deixou o recebimento de WhatsApp **morto por 3 dias sem ninguém ver**. Causa-classe (review adversarial de processos): **todo monitor media degradação DENTRO de um fluxo vivo, nunca a AUSÊNCIA do fluxo** — com 401 antes do dispatch, zero rows nasciam → zero órfãs → tudo "verde"; `channel_health` dizia "paired" (proxy de conexão, não de recebimento). O detector certo existia só como comentário "## Cron de detecção (proposta)" numa skill, nunca foi pro Kernel.

## O que faz
Adiciona o check **`whatsapp_inbound_flow`** (HARD — derruba exit + dispara ALERT) no `jana:health-check`:
- **Driver-agnóstico:** por canal ATIVO com histórico de inbound, alerta se `MAX(inbound.created_at) > N horas` (default 6h). Pega QUALQUER causa de silêncio (auth/rota/worker/firewall/daemon/UUID) — não depende de saber a causa. **Teria disparado no 1º dia do #2726.**
- **Baseline por canal:** só vigia quem já recebeu inbound algum dia (não grita em linha nova/quieta).
- **Horário comercial BRT** (08–20, seg–sáb): canal quieto à noite/domingo não é alarme.
- **Cadência horária** (08:07–20:07 BRT) além do run diário 06:00 — detecta em ~1h, não em ~22h.
- **Lógica pura testável** (`evaluateInboundFlow`, estática, padrão `parseLessonLedger`) + 5 testes.

Threshold tunável via `config('whatsapp.inbound_silence_alert_hours', 6)` (default, sem exigir env).

Refs: incidente 2026-06-16 (#2726) · review adversarial de processos (risco #1 / peça-mestra)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
