### PR TITLE
ci(gates): infra-contract + multi-tenant enxergam Modules/**/Http/Middleware (classe #2726)

### DIFF
--- a/.github/workflows/infra-contract-required.yml
+++ b/.github/workflows/infra-contract-required.yml
@@ -19,6 +19,14 @@ on:
       - 'routes/**'
       - 'app/Providers/*ServiceProvider.php'
       - 'bootstrap/app.php'
+      # Runtime crítico vive MAJORITARIAMENTE em Modules/ (incidente 2026-06-16
+      # #2726: middleware de auth do webhook em Modules/Whatsapp/Http/Middleware/
+      # ficou FORA deste gate — passou sem Infra Contract). ~90% dos middlewares
+      # e TODOS os webhooks são de módulo.
+      - 'Modules/**/Http/Middleware/**'
+      - 'Modules/**/Routes/**'
+      - 'Modules/**/Providers/*ServiceProvider.php'
+      - 'Modules/**/Http/Controllers/**/*Webhook*.php'
 
 permissions:
   contents: read

--- a/.github/workflows/multi-tenant-gate.yml
+++ b/.github/workflows/multi-tenant-gate.yml
@@ -54,7 +54,7 @@ jobs:
           echo "Base do diff: ${base}"
           changed="$(git diff --name-only "${base}" HEAD || true)"
           echo "Arquivos mudados:"; echo "${changed:-<nenhum>}"
-          if echo "${changed}" | grep -Eq '^(Modules/.*/Http/Controllers/|app/Http/Middleware/AdminSidebarMenu\.php|app/Http/Middleware/HandleInertiaRequests\.php|tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest\.php|\.github/workflows/multi-tenant-gate\.yml)'; then
+          if echo "${changed}" | grep -Eq '^(Modules/.*/Http/Controllers/|Modules/.*/Http/Middleware/|app/Http/Middleware/AdminSidebarMenu\.php|app/Http/Middleware/HandleInertiaRequests\.php|tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest\.php|\.github/workflows/multi-tenant-gate\.yml)'; then
             echo "relevant=true" >> "${GITHUB_OUTPUT}"
             echo "→ arquivo Tier 0 mudou: RODA o teste."
           else


### PR DESCRIPTION
## Gates de Tier-0 enxergam o que mora em Modules/ (incidente 2026-06-16 #2726)

Review adversarial (risco #4): `infra-contract-required` e `multi-tenant-gate` só cobriam `app/Http/Middleware/**` — mas **~90% dos middlewares e TODOS os webhooks vivem em `Modules/**/Http/Middleware/`**. O middleware de auth do #2726 (`Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php`) caiu FORA dos dois → nenhum disparou. Ironia: o autor classificou o #2726 como violação Tier 0 e o gate criado pra Tier 0 nem olhou o arquivo.

## O que faz
- **`infra-contract-required`** (advisory): adiciona `Modules/**/Http/Middleware/**`, `Modules/**/Routes/**`, `Modules/**/Providers/*ServiceProvider.php`, `Modules/**/Http/Controllers/**/*Webhook*.php` aos paths. PR que toca runtime crítico de módulo passa a exigir a seção `## Infra Contract` (nudge, não bloqueia — gate advisory).
- **`multi-tenant-gate`** (required, skip-as-pass): adiciona `Modules/.*/Http/Middleware/` ao regex de detecção → roda o `NoHardcodeBusinessIdInModulesTest` quando middleware de módulo muda. O teste já varre a árvore inteira, então fica verde se limpo (sem novo risco de bloqueio).

Pega os outros 4 middlewares de webhook (Meta/Z-API/Baileys/Backpressure) + middleware/rotas de ~34 módulos.

Refs: incidente 2026-06-16 (#2726) · review adversarial (risco #4) · US-GOV-027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
