### PR TITLE
docs(whatsapp): HMAC do daemon é INERTE + pin do SHA WuzAPI (risco #5 do #2726)

### DIFF
--- a/Modules/Whatsapp/daemon-go/.env.example
+++ b/Modules/Whatsapp/daemon-go/.env.example
@@ -22,9 +22,10 @@ WUZAPI_PORT=8080
 # Salvar em Vaultwarden (entry: "WhatsApp Whatsmeow Admin Token")
 WUZAPI_ADMIN_TOKEN=__GERAR_32_BYTES_HEX__
 
-# HMAC global pra assinar webhooks (daemon → Laravel). Backend valida
-# header `x-hmac-signature` via middleware VerifyWhatsmeowSignature.
-# Gerar com: openssl rand -hex 32
+# ⚠️ INERTE (2026-06-16, incidente #2726): o build asternic/wuzapi em uso NÃO
+# implementa assinatura de webhook — esta env é IGNORADA pelo binário. A auth
+# EFETIVA é o segredo na URL (?wh=, WHATSMEOW_WEBHOOK_URL_SECRET no app) + IP
+# allowlist no edge. Só volta a valer com um build que implemente HMAC (+ SHA pinado).
 WUZAPI_GLOBAL_HMAC_KEY=__GERAR_32_BYTES_HEX__
 
 # ─── Configuração runtime ─────────────────────────────────────────────

--- a/Modules/Whatsapp/daemon-go/docker-compose.yml
+++ b/Modules/Whatsapp/daemon-go/docker-compose.yml
@@ -30,7 +30,9 @@ services:
     # Imagem oficial mantida por asternic — REST API Go wrapping tulir/whatsmeow
     # Pin em SHA digest exato pra reprodutibilidade (NÃO usar `:latest` em prod).
     # Atualizar via PR explícita pós smoke test em staging.
-    image: asternic/wuzapi:latest
+    # Pinado 2026-06-16 (incidente #2726): `:latest` mascarava QUAL build rodava —
+    # e este build NÃO implementa assinatura HMAC (ver WUZAPI_GLOBAL_HMAC_KEY abaixo).
+    image: asternic/wuzapi@sha256:86b0b26c6b778ed6805a254c023ea368d46fa8bcab615d1ee3d0343d021ee1c3
     container_name: whatsapp-whatsmeow
     restart: unless-stopped
 
@@ -59,9 +61,15 @@ services:
       # Timezone consistente com app Laravel (ADR 0035 baseline America/Sao_Paulo)
       - TZ=America/Sao_Paulo
 
-      # HMAC global signature pra todos webhooks (defesa em profundidade
-      # contra spoof — daemon assina cada POST com SHA-256 do payload).
-      # Backend valida via middleware VerifyWhatsmeowSignature.
+      # ⚠️ INERTE (verificado 2026-06-16, incidente #2726): este build do
+      # asternic/wuzapi NÃO implementa assinatura de webhook — esta env é
+      # IGNORADA pelo binário (não emite header x-hmac-signature). A doc anterior
+      # afirmava "daemon assina cada POST" como FATO; era ASPIRACIONAL e foi citada
+      # como "confirmação" pra remover a única auth em uso (IP) → 3 dias mudo.
+      # Auth EFETIVA hoje: segredo na URL do webhook (?wh=, ver
+      # VerifyWhatsmeowSignature + WHATSMEOW_WEBHOOK_URL_SECRET) + IP allowlist no
+      # edge (Traefik). Mantida só pra quando/se um build com HMAC for adotado
+      # (aí pinar o SHA novo + religar via teste de contrato real).
       - WUZAPI_GLOBAL_HMAC_KEY_FILE=/run/secrets/whatsmeow_hmac_secret
 
     # Health check interno — daemon healthy se /health responde 200


### PR DESCRIPTION
## Para de tratar config aspiracional como ativa (incidente 2026-06-16 #2726)

Review adversarial (risco #5 — a MENTIRA que deu confiança pra remover a única auth em uso): `docker-compose.yml` afirmava "daemon assina cada POST com SHA-256" como FATO, mas o binário `asternic/wuzapi` **não implementa assinatura** — a env `WUZAPI_GLOBAL_HMAC_KEY` é inerte. Essa doc foi citada como "confirmação" no #2726 pra remover o IP-whitelist → 3 dias mudo.

## O que faz
- Marca `WUZAPI_GLOBAL_HMAC_KEY` como **INERTE** no `docker-compose.yml` e `.env.example`, com o estado REAL: auth efetiva = segredo na URL (`?wh=`, `WHATSMEOW_WEBHOOK_URL_SECRET`) + IP allowlist no edge.
- **Pina o SHA** do WuzAPI (`@sha256:86b0b26…`) em vez de `:latest` — cumprindo o próprio comentário do compose que mandava pinar. Protege contra um `:latest` surpresa mudar o comportamento.

Nota operacional: o daemon rodando no CT 100 ainda usa `:latest` (== este digest hoje); pega o pin no próximo redeploy do compose.

Refs: incidente 2026-06-16 (#2726) · review adversarial (risco #5) · US-WA-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
