### PR TITLE
docs(rules): checklist de mudança de auth-boundary (processo anti-#2726)

### DIFF
--- a/.claude/rules/auth-boundary.md
+++ b/.claude/rules/auth-boundary.md
@@ -1,0 +1,33 @@
+---
+paths:
+  - "Modules/**/Http/Middleware/Verify*.php"
+  - "app/Http/Middleware/TrustProxies.php"
+---
+
+# Mudar auth de fronteira de integração (webhook/callback externo)
+
+> Origem: incidente 2026-06-16 (#2726). Um hardening de segurança removeu a ÚNICA
+> auth em uso (IP-whitelist) assumindo um substituto (HMAC) que **nunca esteve
+> ativo** → recebimento de WhatsApp morto 3 dias. A análise da vulnerabilidade
+> estava certa; o erro foi "confirmar" o substituto lendo um **comentário de
+> config** (aspiracional/inerte), não observando o emissor real.
+
+**ANTES de remover, trocar ou endurecer o mecanismo de auth de um webhook/callback
+externo, responda no corpo do PR (checklist bloqueante — pareia com `## Infra Contract`):**
+
+1. **Qual auth autentica HOJE em produção?** Por **evidência observada** (log de uma
+   entrega real, `docker logs` do emissor, header capturado) — NUNCA por doc/comentário.
+   Comentários mentem: `WUZAPI_GLOBAL_HMAC_KEY` estava setada mas o binário a ignora.
+2. **O substituto já foi observado funcionando com o PRODUTOR REAL?** Um contract-test
+   com o payload+headers que o emissor manda de verdade (não credencial auto-forjada)
+   passa VERDE? Ver `WhatsmeowWebhookAuthTest` (caso "contrato REAL do daemon").
+3. **Ordem de deploy + paridade de segredos:** app e emissor têm o mesmo segredo? Quem
+   deploya primeiro? `.env` de prod tem a chave? (config cacheado + opcache → rebuildar.)
+4. **Qual monitor detecta `inbound==0` pós-mudança e em quanto tempo?** Sentinela de
+   fluxo `whatsapp_inbound_flow` (`jana:health-check`, horária) cobre este canal?
+
+> Não derrube a viga antes de confirmar que a nova está segurando — com o **cliente
+> real**, não com a doc. Os 5 webhooks vivem em `Modules/Whatsapp/Http/Middleware/Verify*.php`.
+> `TrustProxies='*'` torna `$request->ip()` spoofável: auth por IP em PHP é proibida
+> (use segredo na URL/HMAC verificado, ou allowlist no edge Traefik/firewall). Ver
+> ADR 0093 (Tier 0) · `memory/proibicoes.md`.


### PR DESCRIPTION
## Dono de processo pra mudança de auth-boundary (incidente 2026-06-16 #2726)

Tema sistêmico do review adversarial: **"remover a viga sem confirmar a nova segurando"** — não existia skill/rule/gate governando "remover ou trocar mecanismo de auth de integração externa". O #2726 removeu a única auth em uso assumindo um substituto inerte.

## O que faz
Adiciona `.claude/rules/auth-boundary.md` (path-scoped, carrega ao tocar `Modules/**/Http/Middleware/Verify*.php` ou `TrustProxies.php`): checklist bloqueante de 4 perguntas antes de mexer em auth de webhook/callback — (1) qual auth autentica HOJE por evidência observada, não doc; (2) substituto observado com o produtor real (contract-test); (3) ordem de deploy + paridade de segredos; (4) qual monitor pega inbound==0 e em quanto tempo.

Passivo (contexto pro agente/dev), não muda CI. Amarra os outros fixes (#2813 sentinela, #2814 contract-test) num processo.

Refs: incidente 2026-06-16 (#2726) · review adversarial (tema "remover a viga") · US-GOV-027

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
