### PR TITLE
fix(caixa-unificada): modo escuro legível + colapsa Customer 360 vazio

### DIFF
--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -452,3 +452,20 @@ Mandato [W] "vamos aplicar todas" executado fim-a-fim no dia. Gate §10.4 contra
 Extra (incidente prod ~16:50 BRT, [W] "carregando canais erro 500"): deploy parcial deixou codigo pos-PR-3 sem migrate → queuesAdmin sem guard derrubava o grupo Inertia::defer inteiro. Hotfix #2515 (degrade gracioso, principio duro 8) + #2516 (workflow one-shot debug-caixa-logs.yml read-only). Diagnostico pos-fix: prod trackeia main com migrations aplicadas (whatsapp_queues [176] Ran, tabelas 1/1/1), ZERO production.ERROR no log. LICAO: payload deferred novo SEMPRE nasce com guard (deploy-ordering).
 
 Charter CaixaUnificada/Index.charter.md → v10 (historico PR-a-PR + metricas vivas R-WA-CAIXA-UNIF-001..012). Fase 2 do broadcast (Job rate-limited) e extensao do cmd-K global = proximas US com gate [W].
+
+---
+
+## 2026-06-16 [CL] · PROCESSED PROMPT_PARA_CODE_CAIXA-UNIFICADA-DARK-MODE — placar 4 partes
+
+Brief [CC]: tela aberta no tema escuro → painel da conversa branco + elementos do Contexto sem contraste (mesma classe de bug ja erradicada em Produtos/Oficina/Financeiro: cor clara crua que nao flipa no escuro; a Caixa Unificada foi portada antes da auditoria de escuro). Gate §10.4 contra main (origin/main `5253a776c`, alem do `dd09f96` que o [CC] leu — o repo venceu).
+
+Descoberta-chave que mudou a abordagem do brief: o repo ativa dark via **`<html class="dark">` (Tailwind `.dark`), NAO `[data-theme=dark]`** (inertia.css L97 confirma que data-theme nunca e ativado). Logo a correcao usa os pares de **token semantico que ja flipam** (`warning-soft`/`warning-fg`/`warning`, `card`, `info`) — **ZERO override CSS, ZERO token novo** (conformance/foundation intactos). A propagacao de tema NAO era o furo (o `bg-muted/15` da thread flipa OK no probe); o bug estava so nas FOLHAS com cor clara hardcoded.
+
+| Parte | Entrega | Status |
+|---|---|---|
+| 1 | `ConversationThreadV4`: bolha inbound `bg-white`→`bg-card` · read-tick `text-blue-600`→`oklch(0.55 0.18 250)` inline (passa R1) · nota interna + banner "em homologacao" + SLA-pill amber → `warning-soft`/`warning-fg`/`warning` · corpo da nota `text-foreground` (contraste nos 2 temas) · bolha verde-WA mantida (proposital) | feito — este PR |
+| 2 | `ContextSidebarV4`: chip de Tag aplicada (oklch claro cru) → `bg-warning-soft border-warning/30 text-foreground` (flipa; antes claro-no-claro no escuro) | feito — este PR |
+| 3 | `CustomerMemoryBlock` (compartilhado c/ Inbox legacy `ConversationSidebar`): sem Contact CRM **e** sem enriquecimento (reclamacoes/temas/fontes/notas/flags) → colapsa o card grande vazio numa linha ("Sem cadastro de cliente vinculado."), **sem prop nova** (nao regride o legacy) | feito — este PR |
+| 4 | Chips todos "em breve": o catalogo do `CaixaUnificadaController::buildAvailableChannelsPayload` so tem `whatsapp_baileys`; o canal LIVE e `whatsapp_whatsmeow` (WuzAPI, substituiu Baileys ADR 0202) → o type ATIVO nunca casa com row do catalogo. Fix = adicionar/mapear `whatsapp_whatsmeow` no catalogo (+ Pest) | **ABERTO** — PR separado (backend/config, nao bloqueia o dark) |
+
+Verificacao: probe token-flip standalone (tokens REAIS do inertia.css inlinados + markup pos-fix → headless-chrome screenshot LIGHT|DARK lado-a-lado) confirma flip correto e light intacto; ds-canon/conformance/foundation locais PASS; DS-GUARD limpo. Pest de unidade novo dispensado (dark e CSS/visual — guidance do proprio brief). Smoke vivo em prod fica pro pos-merge (`tela-smoke-pos-merge`).

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -3,7 +3,7 @@ page: /atendimento/caixa-unificada
 component: resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
 owner: wagner
 status: live
-last_validated: "2026-06-10"
+last_validated: "2026-06-16"
 cutover_at: "2026-05-15"
 supersedes: resources/js/Pages/Atendimento/Inbox/Index.charter.md
 parent_module: Whatsapp
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 10
+charter_version: 11
 permissao: whatsapp.access
 ---
 
@@ -320,6 +320,7 @@ Após Wagner aprovar canary 7d:
 
 | Data | Autor | Mudança |
 |---|---|---|
+| 2026-06-16 | Claude Code (brief [CC] dark-mode) | **Fix MODO ESCURO + empty-state Customer 360.** Tokenização dark-aware das folhas que usavam cor clara crua (a tela foi portada antes da auditoria de escuro): bolha inbound `bg-white`→`bg-card`; nota interna, banner "em homologação", SLA-pill e chip de Tag → `warning-soft`/`warning-fg`/`warning` (flipam no `.dark`), corpo da nota `text-foreground` (contraste nos 2 temas); read-tick `text-blue-600`→`oklch` inline (passa R1). `CustomerMemoryBlock` colapsa o card vazio (sem Contact CRM **e** sem enriquecimento) numa linha — compartilhado com o Inbox legacy, sem prop nova (não regride). Repo ativa dark via `.dark` (não `[data-theme]`) → **zero token novo, zero override CSS**. Verificado por probe token-flip nos 2 temas. PARTE 4 (chips "em breve" — catálogo sem `whatsapp_whatsmeow`) fica em PR backend separado. Charter v11. |
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **IA na thread** (PR-9/10): validação pré-PR confirmou infra Jana (laravel/ai + Agents) → IA REAL. `InboxAssistAgent` + `InboxAiController` (summarize/ask/suggest-reply) com PII redigida (PiiRedactor), dry_run gateando custo, 503 gracioso. UI: header Resumir/Perguntar + composer ✦ Sugerir (humano revisa). Charter v10. Pest R-WA-CAIXA-UNIF-012. |
 | 2026-06-10 | Claude (mandato [W] "aplicar todas") | **Polish V2** (PR-8/10): SLA pill lista+thread (slaState 75%/estourado) · cheat-sheet `?` · lightbox MediaFullscreenModal reusado · mobile tabs <lg (InboxMobileTabs) · favoritos localStorage (useInboxFavs, sem DB) · transcript imprimível (notas fora por default) · modo apresentação (Esc). ⌘K = TODO honesto (palette global PMG-002 já existe; estender = US cross-módulo). 100% frontend — payloads cobertos por R-WA-CAIXA-UNIF-001/002. Charter v9. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -418,14 +418,12 @@ export default function ContextSidebarV4({ thread, channels, queues, availableTa
           {thread.tags.length > 0 ? (
             <div className="flex flex-wrap gap-1">
               {thread.tags.map(t => (
-                // Cowork .om-tag — padding 1px 8px, font 10px mono, OKLCH §710
+                // Cowork .om-tag — âmbar-pastel. Dark-aware via warning-soft/warning
+                // (flipam no .dark); texto foreground mantém contraste nos 2 temas
+                // (antes: oklch claro cru → chip claro-no-claro no escuro).
                 <span
                   key={t.id}
-                  className="inline-block px-2 py-px text-[10px] font-mono rounded-full text-foreground"
-                  style={{
-                    background: 'oklch(0.94 0.03 80)',
-                    border: '1px solid oklch(0.86 0.06 80)',
-                  }}
+                  className="inline-block px-2 py-px text-[10px] font-mono rounded-full text-foreground bg-warning-soft border border-warning/30"
                   data-testid={`caixa-unif-ctx-tag-${t.slug}`}
                 >
                   {t.label}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -175,8 +175,7 @@ export default function ConversationThreadV4({
         )}
         {headerSla === 'warning' && (
           <span
-            className="ml-auto font-mono text-[9.5px] font-bold px-2 py-px rounded-full flex-shrink-0"
-            style={{ background: 'oklch(0.95 0.06 80)', color: 'oklch(0.40 0.12 80)', border: '1px solid oklch(0.82 0.10 80)' }}
+            className="ml-auto font-mono text-[9.5px] font-bold px-2 py-px rounded-full flex-shrink-0 bg-warning/15 text-warning-fg border border-warning/30"
             title={`SLA ${thread.queue.sla} da fila ${thread.queue.label} perto de estourar`}
             data-testid="caixa-unif-thread-sla"
           >
@@ -239,27 +238,18 @@ export default function ConversationThreadV4({
       {/* Banner "em homologação" pra canal preview (Cowork .om-preview-banner — tokens OKLCH §467) */}
       {isPreview && channel && (
         <div
-          className="mx-4 mt-2.5 px-3.5 py-2.5 rounded-lg text-[11.5px] flex flex-col gap-0.5"
-          style={{
-            background: 'oklch(0.97 0.013 80)',
-            border: '1px solid oklch(0.88 0.04 80)',
-            color: 'oklch(0.32 0.06 80)',
-          }}
+          className="mx-4 mt-2.5 px-3.5 py-2.5 rounded-lg text-[11.5px] flex flex-col gap-0.5 bg-warning-soft border border-warning/25"
           role="status"
           data-testid="caixa-unif-preview-banner"
         >
-          <b
-            className="block text-[12.5px] font-semibold"
-            style={{ color: 'oklch(0.28 0.10 80)' }}
-          >
+          <b className="block text-[12.5px] font-semibold text-warning-fg">
             {channel.label} · em homologação.
           </b>
           <span>
             Conexão deste canal ainda não foi ativada. Esta conversa é uma prévia.{' '}
             <a
               href={route('atendimento.channels.index')}
-              className="underline"
-              style={{ color: 'oklch(0.40 0.13 250)' }}
+              className="underline text-info"
             >
               Ativar canal
             </a>
@@ -304,37 +294,22 @@ export default function ConversationThreadV4({
                   </div>
                 )}
                 {m.is_internal_note ? (
-                  // Cowork .om-internal — tokens OKLCH §525 (amarelo-pastel + dashed)
-                  <div
-                    className="self-center w-[92%] max-w-[560px] mx-auto my-1 rounded-lg px-3 py-2"
-                    style={{
-                      background: 'oklch(0.97 0.03 80)',
-                      border: '1px dashed oklch(0.78 0.10 80)',
-                    }}
-                  >
+                  // Cowork .om-internal — âmbar-pastel + dashed. Dark-aware via tokens
+                  // semânticos warning-soft/warning-fg (flipam no .dark); o corpo usa
+                  // text-foreground pra manter contraste nos 2 temas (erradicado o
+                  // "miolo branco no escuro" — mesma disciplina Produtos/Oficina/Fin).
+                  <div className="self-center w-[92%] max-w-[560px] mx-auto my-1 rounded-lg px-3 py-2 bg-warning-soft border border-dashed border-warning/40">
                     <div className="flex items-center gap-2 mb-1">
-                      <span
-                        className="text-[9.5px] uppercase tracking-[0.06em] font-semibold px-1.5 py-px rounded-full"
-                        style={{
-                          color: 'oklch(0.28 0.12 80)',
-                          background: 'oklch(0.90 0.08 80)',
-                        }}
-                      >
+                      <span className="text-[9.5px] uppercase tracking-[0.06em] font-semibold px-1.5 py-px rounded-full text-warning-fg bg-warning/20">
                         Nota interna
                       </span>
-                      <small
-                        className="text-[10px] font-mono"
-                        style={{ color: 'oklch(0.45 0.06 80)' }}
-                      >
+                      <small className="text-[10px] font-mono text-warning-fg/70">
                         {new Date(m.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })} ·
                         {m.sender_user_name ? ` ${m.sender_user_name} · ` : ' '}
                         só a equipe vê
                       </small>
                     </div>
-                    <div
-                      className="text-[12.5px] whitespace-pre-wrap leading-[1.45]"
-                      style={{ color: 'oklch(0.22 0.10 80)' }}
-                    >
+                    <div className="text-[12.5px] whitespace-pre-wrap leading-[1.45] text-foreground">
                       {m.body}
                     </div>
                   </div>
@@ -364,7 +339,7 @@ export default function ConversationThreadV4({
                       // Tokens Cowork canon (inbox-page.css §498): max-w 75%, padding 7px 11px, radius 10px, font 12.5px, line-height 1.45
                       'px-[11px] py-[7px] rounded-[10px] text-[12.5px] leading-[1.45] whitespace-pre-wrap break-words flex flex-col flex-1 min-w-0',
                       m.direction === 'inbound'
-                        ? 'bg-white border border-border rounded-bl-[3px]'
+                        ? 'bg-card border border-border rounded-bl-[3px]'
                         : 'rounded-br-[3px]',
                     )}
                     style={
@@ -436,7 +411,9 @@ export default function ConversationThreadV4({
                       {new Date(m.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
                       {m.direction === 'outbound' && (
                         m.status === 'read' ? (
-                          <CheckCheck size={10} className="text-blue-600" aria-label="Lida" />
+                          // azul-tick WA — oklch fixo (passa R1, sem família -NNN);
+                          // fica sobre a bolha verde-WA que não flipa, legível nos 2 temas.
+                          <CheckCheck size={10} style={{ color: 'oklch(0.55 0.18 250)' }} aria-label="Lida" />
                         ) : m.status === 'delivered' ? (
                           <CheckCheck size={10} aria-label="Entregue" />
                         ) : m.status === 'sent' ? (

--- a/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
@@ -187,6 +187,26 @@ export default function CustomerMemoryBlock({ customerExternalId }: Props) {
   const m = data.memory!;
   const c = data.contact;
 
+  // Empty-state enxuto — sem Contact CRM vinculado E sem nenhum enriquecimento
+  // (reclamações/temas/fontes externas/notas/flags), o card grande fica "vazio" e
+  // redundante com o header da thread (que já mostra nome/telefone). Colapsa numa
+  // linha em vez do card. Compartilhado com o Inbox legacy (ConversationSidebar) —
+  // mesma colapsagem nos dois consumidores, sem prop nova (não regride o legacy).
+  const hasEnrichment =
+    (m.total_reclamacoes ?? 0) > 0 ||
+    !!m.inferences?.temas_recorrentes?.length ||
+    !!m.external_sources?.length ||
+    !!m.notes?.notas_jana ||
+    !!m.flags?.length;
+  if (!c && !hasEnrichment) {
+    return (
+      <div className="px-1 py-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+        <User className="size-3.5 shrink-0" />
+        <span>Sem cadastro de cliente vinculado.</span>
+      </div>
+    );
+  }
+
   const severityBadge = (sev: Reclamacao['severity']) => {
     const map = {
       critica: 'bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/30',

--- a/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
@@ -33,6 +33,7 @@ import {
 import { Card } from '@/Components/ui/card';
 import { Badge } from '@/Components/ui/badge';
 import { Separator } from '@/Components/ui/separator';
+import { Inline } from '@/Components/layout';
 
 interface Reclamacao {
   date: string;
@@ -200,10 +201,10 @@ export default function CustomerMemoryBlock({ customerExternalId }: Props) {
     !!m.flags?.length;
   if (!c && !hasEnrichment) {
     return (
-      <div className="px-1 py-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+      <Inline gap={1} className="px-1 py-1 text-xs text-muted-foreground">
         <User className="size-3.5 shrink-0" />
         <span>Sem cadastro de cliente vinculado.</span>
-      </div>
+      </Inline>
     );
   }
 


### PR DESCRIPTION
## Contexto

Brief [CC] (`PROMPT_PARA_CODE_CAIXA-UNIFICADA-DARK-MODE`): a Caixa Unificada aberta no **tema escuro** mostrava o painel da conversa branco + elementos do Contexto sem contraste. É a **mesma classe de bug já erradicada em Produtos/Oficina/Financeiro** ("cor clara crua não flipa no escuro") — a tela foi portada **antes** dessa auditoria.

Validado contra `origin/main` (`5253a776c`, à frente do `dd09f96` que o [CC] leu — §10.4, o repo venceu).

**Descoberta-chave:** o repo ativa dark via **`<html class="dark">` (Tailwind `.dark`), não `[data-theme=dark]`** (`inertia.css` L97 confirma que `data-theme` nunca é ativado). Então a correção usa os **pares de token semântico que já flipam** — **zero token novo, zero override CSS** (`conformance`/`foundation` intactos). O probe também confirmou que a **propagação de tema não era o furo** (o `bg-muted/15` da thread flipa OK); o bug estava só nas **folhas** com cor clara hardcoded.

## O que muda (PARTES 1–3 do brief)

| Parte | Arquivo | Mudança |
|---|---|---|
| 1 | `ConversationThreadV4.tsx` | bolha inbound `bg-white`→`bg-card`; nota interna + banner "em homologação" + SLA-pill âmbar → `warning-soft`/`warning-fg`/`warning` (flipam); **corpo da nota `text-foreground`** (contraste nos 2 temas); read-tick `text-blue-600`→`oklch(0.55 0.18 250)` inline (**passa R1**). Bolha verde-WA **mantida** (proposital). |
| 2 | `ContextSidebarV4.tsx` | chip de Tag aplicada (oklch claro cru → claro-no-claro no escuro) → `bg-warning-soft border-warning/30 text-foreground`. |
| 3 | `CustomerMemoryBlock.tsx` | sem Contact CRM **e** sem enriquecimento → colapsa o card grande vazio numa linha. **Sem prop nova** — compartilhado com o Inbox legacy (`ConversationSidebar`), não regride. |

## Fora deste PR

- **PARTE 4** (chips todos "em breve"): o catálogo do `CaixaUnificadaController::buildAvailableChannelsPayload` só tem `whatsapp_baileys`; o canal **live** é `whatsapp_whatsmeow` (WuzAPI, substituiu Baileys — ADR 0202) → o type ativo nunca casa com row do catálogo. **Fix backend separado** (não bloqueia o dark, conforme o brief).

## Verificação

- **Probe token-flip** (tokens reais do `inertia.css` + markup pós-fix → screenshot headless-chrome LIGHT|DARK lado-a-lado): flip correto no escuro, light **intacto**, verde-WA + read-tick legíveis nos 2 temas.
- `ds:canon` (R1), `conformance`, `foundation` locais **PASS**; DS-GUARD limpo; `integrity-check` (§15) PASS.
- Pest de unidade novo **dispensado** (dark é CSS/visual — guidance do próprio brief). Smoke vivo fica pro pós-merge (`tela-smoke-pos-merge`).

Charter `Index.charter.md` → **v11** + `COWORK_NOTES.md` com placar das 4 partes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
