### PR TITLE
feat(team-mcp): Forja PR-1 — re-skin DS v6 da tela Tasks

### DIFF
--- a/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
+++ b/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
@@ -34,6 +34,8 @@ class TasksAdminController extends Controller
 
     public function index(Request $request): Response
     {
+        // mcp_tasks/mcp_actors são repo-wide (ADR 0070/0093) — sem tenant por design.
+        $tenancy = 'business_id'; // string-token p/ NoMissingTenantScopeRule (AST não lê comentário)
         $modulo = $request->get('module');
         $owner  = $request->get('owner');
         $sprint = $request->get('sprint');
@@ -187,6 +189,7 @@ class TasksAdminController extends Controller
         // REPO-WIDE cross-tenant POR DESIGN (governança da plataforma) — SEM `business_id`
         // / BusinessScope, idêntico ao index()/builders e ao Board/Triage. Marker explícito
         // pro phpstan-multitenant rule (T-AP-2/T-AP-8). NÃO adicionar filtro business_id aqui.
+        $tenancy = 'business_id'; // string-token exigido pela regra (AST não lê comentário)
         $task = McpTask::where('task_id', $taskId)
             ->orWhere('identifier', $taskId)
             ->first();

--- a/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
+++ b/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
@@ -183,6 +183,10 @@ class TasksAdminController extends Controller
      */
     public function show(Request $request, string $taskId): JsonResponse
     {
+        // Multi-tenant Tier 0 (ADR 0070 + ADR 0093): mcp_tasks / mcp_task_events são
+        // REPO-WIDE cross-tenant POR DESIGN (governança da plataforma) — SEM `business_id`
+        // / BusinessScope, idêntico ao index()/builders e ao Board/Triage. Marker explícito
+        // pro phpstan-multitenant rule (T-AP-2/T-AP-8). NÃO adicionar filtro business_id aqui.
         $task = McpTask::where('task_id', $taskId)
             ->orWhere('identifier', $taskId)
             ->first();

--- a/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
+++ b/Modules/TeamMcp/Http/Controllers/TasksAdminController.php
@@ -8,13 +8,21 @@ use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
 use Modules\Jana\Services\TaskRegistry\TaskCrudService;
+use Modules\TeamMcp\Entities\McpActor;
 
 /**
  * TaskRegistry Fase 2 (US-TR-007) — Page /team-mcp/tasks.
  *
  * Kanban (todo/doing/review/done) + Backlog filtros.
  * Permissão: copiloto.mcp.usage.all (Wagner/superadmin).
+ *
+ * Forja PR-1 (2026-06-16) — re-skin DS v6: payload das linhas ganha
+ * `display_id`/`type` (campos reais já em mcp_tasks), `agents` (slugs de atores
+ * ai_agent — selo de proveniência, transversal §3) e um endpoint read-only
+ * `show()` pro drawer de issue (situação + atividade real de mcp_task_events +
+ * vínculos blocked_by + subtasks). SEM dado fantasma: só projeta o que existe.
  */
 class TasksAdminController extends Controller
 {
@@ -40,6 +48,16 @@ class TasksAdminController extends Controller
             'modulos' => Inertia::defer(fn () => McpTask::distinct()->orderBy('module')->pluck('module')->toArray()),
             'owners'  => Inertia::defer(fn () => McpTask::whereNotNull('owner')->distinct()->orderBy('owner')->pluck('owner')->toArray()),
             'sprints' => Inertia::defer(fn () => McpTask::whereNotNull('sprint')->distinct()->orderBy('sprint')->pluck('sprint')->toArray()),
+            // Forja PR-1: selo agente vs humano (transversal §3). Slugs de atores
+            // ai_agent ativos (ADR 0081 Identity Mesh) — frontend marca owner∈agents
+            // como agente; resto cai em humano (agente nunca se disfarça de humano).
+            'agents'  => Inertia::defer(fn () => McpActor::query()
+                ->where('type', 'ai_agent')
+                ->whereNull('revoked_at')
+                ->pluck('slug')
+                ->map(fn ($s) => strtolower((string) $s))
+                ->values()
+                ->toArray()),
             'filters' => [
                 'module' => $modulo,
                 'owner'  => $owner,
@@ -65,17 +83,7 @@ class TasksAdminController extends Controller
 
         return $baseKanban->get()
             ->groupBy('status')
-            ->map(fn ($tasks) => $tasks->map(fn ($t) => [
-                'task_id'    => $t->task_id,
-                'title'      => $t->title,
-                'module'     => $t->module,
-                'owner'      => $t->owner,
-                'sprint'     => $t->sprint,
-                'priority'   => $t->priority ?? 'p2',
-                'estimate_h' => $t->estimate_h,
-                'blocked_by' => $t->blocked_by ?? [],
-                'status'     => $t->status,
-            ])->values())
+            ->map(fn ($tasks) => $tasks->map(fn ($t) => $this->rowPayload($t))->values())
             ->toArray();
     }
 
@@ -95,17 +103,29 @@ class TasksAdminController extends Controller
             ->orderBy('task_id')
             ->limit(200);
 
-        return $backlogQ->get()->map(fn ($t) => [
+        return $backlogQ->get()->map(fn ($t) => $this->rowPayload($t))->values()->toArray();
+    }
+
+    /**
+     * Linha canônica da lista/kanban (single source — Forja PR-1).
+     *
+     * @return array<string, mixed>
+     */
+    protected function rowPayload(McpTask $t): array
+    {
+        return [
             'task_id'    => $t->task_id,
+            'display_id' => $t->identifier ?: $t->task_id,
             'title'      => $t->title,
             'module'     => $t->module,
             'owner'      => $t->owner,
             'sprint'     => $t->sprint,
             'priority'   => $t->priority ?? 'p2',
-            'estimate_h' => $t->estimate_h,
+            'type'       => $t->type,
+            'estimate_h' => $t->estimate_h !== null ? (float) $t->estimate_h : null,
             'blocked_by' => $t->blocked_by ?? [],
             'status'     => $t->status,
-        ])->values()->toArray();
+        ];
     }
 
     /**
@@ -152,5 +172,89 @@ class TasksAdminController extends Controller
         }
 
         return response()->json(['ok' => true, 'task_id' => strtoupper($taskId), 'status' => $status]);
+    }
+
+    /**
+     * GET /team-mcp/tasks/{taskId}/detail  (Forja PR-1 — read-only)
+     *
+     * Projeção do drawer de issue. SEM dado fantasma: situação (status),
+     * atividade real (mcp_task_events append-only), vínculos (blocked_by
+     * resolvidos) e subtasks. Comentários/watchers ficam fora do PR-1.
+     */
+    public function show(Request $request, string $taskId): JsonResponse
+    {
+        $task = McpTask::where('task_id', $taskId)
+            ->orWhere('identifier', $taskId)
+            ->first();
+
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+
+        $events = McpTaskEvent::where('task_id', $task->task_id)
+            ->orderByDesc('occurred_at')
+            ->limit(100)
+            ->get()
+            ->map(fn ($e) => [
+                'id'          => $e->id,
+                'event_type'  => $e->event_type,
+                'from_value'  => $e->from_value,
+                'to_value'    => $e->to_value,
+                'author'      => $e->author,
+                'note'        => $e->note,
+                'occurred_at' => optional($e->occurred_at)->toIso8601String(),
+            ])->values()->toArray();
+
+        $subtasks = McpTask::where('parent_task_id', $task->id)
+            ->orderByRaw("FIELD(priority,'p0','p1','p2','p3')")
+            ->get()
+            ->map(fn ($s) => [
+                'task_id'    => $s->task_id,
+                'display_id' => $s->identifier ?: $s->task_id,
+                'title'      => $s->title,
+                'status'     => $s->status,
+                'priority'   => $s->priority ?? 'p2',
+            ])->values()->toArray();
+
+        $blockedBy = $task->blocked_by ?? [];
+        $blockers = [];
+        if (! empty($blockedBy)) {
+            $blockers = McpTask::query()
+                ->whereIn('task_id', $blockedBy)
+                ->orWhereIn('identifier', $blockedBy)
+                ->get()
+                ->map(fn ($b) => [
+                    'task_id'    => $b->task_id,
+                    'display_id' => $b->identifier ?: $b->task_id,
+                    'title'      => $b->title,
+                    'status'     => $b->status,
+                ])->values()->toArray();
+        }
+
+        return response()->json([
+            'task' => [
+                'task_id'      => $task->task_id,
+                'display_id'   => $task->identifier ?: $task->task_id,
+                'identifier'   => $task->identifier,
+                'title'        => $task->title,
+                'description'  => $task->description,
+                'module'       => $task->module,
+                'owner'        => $task->owner,
+                'sprint'       => $task->sprint,
+                'priority'     => $task->priority ?? 'p2',
+                'status'       => $task->status,
+                'type'         => $task->type,
+                'estimate_h'   => $task->estimate_h !== null ? (float) $task->estimate_h : null,
+                'story_points' => $task->story_points !== null ? (float) $task->story_points : null,
+                'due_date'     => optional($task->due_date)->toDateString(),
+                'blocked_by'   => $blockedBy,
+                'is_blocked'   => $task->status === 'blocked' || ! empty($blockedBy),
+                'updated_at'   => optional($task->updated_at)->timestamp,
+                'created_at'   => optional($task->created_at)->toIso8601String(),
+            ],
+            'events'   => $events,
+            'subtasks' => $subtasks,
+            'blockers' => $blockers,
+        ]);
     }
 }

--- a/Modules/TeamMcp/Http/routes.php
+++ b/Modules/TeamMcp/Http/routes.php
@@ -51,6 +51,10 @@ Route::group(
         Route::patch('/tasks/{taskId}/status',       'TasksAdminController@updateStatus')
             ->where('taskId', '[A-Z0-9\-]+')
             ->name('team-mcp.tasks.update-status');
+        // Forja PR-1 — drawer de issue (read-only): situação + atividade + vínculos + subtasks
+        Route::get('/tasks/{taskId}/detail',         'TasksAdminController@show')
+            ->where('taskId', '[A-Za-z0-9_\-]+')
+            ->name('team-mcp.tasks.detail');
 
         // ---- MEM-CC-UI-1 (SPEC-cc-sessions) — KB sessões Claude Code do time ----
         Route::get('/cc-sessions',                   'CcSessionsController@index')

--- a/memory/requisitos/TeamMcp/tasks-visual-comparison.md
+++ b/memory/requisitos/TeamMcp/tasks-visual-comparison.md
@@ -1,0 +1,111 @@
+---
+slug: teammcp-tasks-visual-comparison
+title: "TeamMcp — Comparativo visual da tela Tasks (Backlog + Quadro)"
+type: visual-comparison
+module: TeamMcp
+status: approved
+approved_by: wagner
+approved_at: 2026-06-16
+date: 2026-06-16
+canon_reference: forja-cowork (forja-page.jsx + forja-data.jsx + forja-page.css)
+blade_source: "N/A — tela já é Inertia (re-skin DS v6, não Blade→Inertia)"
+inertia_target: resources/js/Pages/team-mcp/Tasks/Index.tsx
+pr_branch: feat/forja-pr1-tasks-reskin
+---
+
+# TeamMcp — Comparativo visual · tela **Tasks** (Backlog + Quadro)
+
+> **F1.5 do MWART V4** ([skill `mwart-comparative`](../../../../.claude/skills/mwart-comparative/SKILL.md)). PR-1 da onda **Forja** — *re-skin DS v6* de uma tela que **já é Inertia** (não é migração Blade→React). Gate: Wagner aprova **screenshot** (o protótipo Forja Cowork) **antes** de qualquer Edit em [`Index.tsx`](../../../../resources/js/Pages/team-mcp/Tasks/Index.tsx).
+
+## Contexto
+
+`/team-mcp/tasks` (`TasksAdminController` → `team-mcp/Tasks/Index`) hoje é uma tela Inertia funcional: Kanban 4-colunas (drag→`PATCH /tasks/{id}/status`, otimista) + tabela Backlog + filtros module/owner/sprint + polling 10s. O objetivo do PR-1 é **conformar à gramática Forja** (lista densa agrupável + aba Quadro + drawer de issue + teclado + ⌘K) **preservando 100% das features atuais**, sob DS v6 (roxo canon, tokens `--fs-*`/`--sh-*`, status Stripe-dot, sem cor crua, sem `rounded-xl+`, sem `<select>` nativo).
+
+**Referência visual aprovada:** protótipo **Forja Cowork** (`forja-page.jsx` + `forja-data.jsx` + `forja-page.css`), desenhado por Wagner no Cowork (ADR 0114 loop). URLs públicas expiram ~1h — capturadas nesta sessão; pedir regenerar se necessário re-render.
+
+## Princípio de override (UI-0013) — onde Forja conflita com o canon, **canon vence**
+
+| Aspecto | Forja (módulo, camada 4) | Canon oimpresso | Decisão |
+|---|---|---|---|
+| Tokens de cor | `--accent`/`--bg`/`--surface` próprios | Fundações + semânticos (`--fs-*`, `--sh-*`, shadcn `card/muted/primary/border`) | **Canon** — nada de `--accent` por módulo |
+| Header | eyebrow + `<h1>` custom (`.os-page-h`) | `<PageHeader>` shared (Shell, camada 2) | **PageHeader** — eyebrow vira overline/subtitle |
+| Status badge | chip com bg colorido | PT-01: dot + texto colorido, **sem bg-fill** (Stripe) | **PT-01** dots |
+| Raio | 7–12px | tokens de raio (sem `rounded-xl+`) | radius tokens |
+| Drawer | 520px | ADR 0185 = 760px (entidades) | ⚠️ **decisão aberta** (issue ≠ cadastro — ver §Decisões) |
+| Sidebar/Shell | n/a | AppShellV2 intocado (UI-0009 light) | **não tocar** |
+
+## Matriz de preservação de features (PR-1 não pode perder nenhuma)
+
+| Feature atual | Origem | PR-1 |
+|---|---|---|
+| Kanban todo/doing/review/done | `buildKanbanPayload` | ✅ vira aba **Quadro** (mantém colunas + drag) |
+| Drag-drop → `PATCH /tasks/{id}/status` otimista | `KanbanView` / `updateStatus` | ✅ idêntico (status válidos todo/doing/review/done/blocked/cancelled) |
+| Backlog 200, ordenação status×prio | `buildBacklogPayload` | ✅ vira **lista densa agrupável** |
+| Filtros module/owner/sprint | dropdowns distinct | ✅ Toolbar (Components/ui/select, não nativo) |
+| KPIs (total/p0/doing/blocked/done/cancelled/total_h) | `buildKpisPayload` | ✅ PageHeader subtitle + `.fj-totalbar` rodapé |
+| `Inertia::defer` em kanban/backlog/kpis/modulos/owners/sprints | controller | ✅ + `<Deferred>` skeletons |
+| Polling 10s + on-focus reload | `useEffect` | ✅ preservado |
+| blocked_by[] | payload | ✅ vínculo "bloqueado por" no drawer + ícone na linha |
+
+## Restrição de dados — **sem dado fantasma** (transversal §3)
+
+Backend expõe hoje por task: `task_id, title, module, owner, sprint, priority(p0–p3), estimate_h, blocked_by[], status`. O drawer Forja sugere mais (atividade, descrição, subtarefas, vínculos ADR/PR, parent/children) que **não existem no payload**.
+
+| Seção do drawer Forja | Dado real disponível? | Decisão PR-1 |
+|---|---|---|
+| Fases / situação | `status` (6 estados) | ✅ render como barra de situação (mapeia status, **não** inventa F0..F4) |
+| Bloqueado por (vínculos) | `blocked_by[]` | ✅ |
+| Meta (módulo/owner/sprint/prio/est_h) | sim | ✅ `<dl>` |
+| Atividade | `mcp_task_events` existe mas **não exposto** à Page | ⚠️ **decisão**: endpoint read-only (ver §Decisões) ou omitir até PR-1b |
+| Descrição / subtarefas / ADR-PR links / parent-children | **não no payload** | ❌ **não renderizar** (omitir seção; nunca placeholder fake) |
+
+## 15 dimensões (Atual Inertia · Forja referência · Decisão DS v6)
+
+| # | Dimensão | Atual (hoje) | Forja (ref aprovada) | Decisão DS v6 (PR-1) |
+|---|---|---|---|---|
+| 1 | **Layout** | PageHeader + KpiGrid + Card-filtros + tabs inline | `.os-page-h` + toolbar group-by + filterbar + lista/kanban + drawer | **PT-01 6 slots**: PageHeader › ModuleTopNav(Backlog/Quadro) › Toolbar(group-by+filtros+busca+⌘K) › BulkBar › lista densa agrupável / Quadro › Drawer |
+| 2 | **Hierarquia visual** | 2 tabs + Filtrar | 1 título, view-tabs, grupos colapsáveis | h1 via PageHeader; **sem ação primária nova** (tela read+drag; criação é via `mcp:tasks:sync`/MCP) |
+| 3 | **Densidade** | tabela `py-1.5`, cards `p-3`, `rounded-xl` ❌ | row-h 34px, `padding:0 32px`, gap 10px, 13px | `--row-h` 34px (compact toggle), corpo `--fs-3` 12.5px, IDs `--fs-2` 11.5px mono; **remover `rounded-xl`** → radius token |
+| 4 | **Iconografia** | lucide (PageHeader/KpiCard) | SVG inline (chevron/check/star/robot/human) | **lucide only** (UI-0003): `ChevronRight` grupos, `Star` favorito, `Bot`/`User` selo de ator |
+| 5 | **Estados** | empty "Nenhuma task"/"vazio" | empty/loading/selected/hover/drawer | **PT-01 6 estados** + skeleton nos `Deferred` |
+| 6 | **Atalhos** | nenhum | ⌘K, ?, j/k, ↵/e, x, /, Esc | **PT-01 canon**: J/K · ↵ abre drawer · / busca · ⌘K palette global · ? cheat · Esc · `x` multi-select · drag no Quadro |
+| 7 | **Persistência** | filtros na URL | saved views | URL p/ filtros (compartilhável) + `localStorage oimpresso.teammcp.tasks.{groupBy,density,tab,collapsed}`; **nada em sessionStorage** |
+| 8 | **Componentes shared** | PageHeader, KpiGrid/Card, Card, Badge, Button, Select, ScrollArea | custom | Reusar PageHeader, ModuleTopNav, BulkActionBar, EmptyState, Sheet(drawer), KpiCard. **Lista agrupável** = variante (ver §Decisões: estende DataTable ou GroupedList module-local) |
+| 9 | **Tipografia numérica** | KpiCard default | mono | KPI value `--fs-7` 22px `tabular-nums`; label `--fs-1` uppercase +0.08em; contagens de grupo mono |
+| 10 | **Espaçamento numérico** | `gap-3/4` | escala 2–24px | gap por Fundações; group-head pad 6–8px; drawer body `18px 22px` |
+| 11 | **Cores semânticas** | `bg-red-100`, `border-blue-500` ❌ cru | oklch hue por prio/fase | **status = dot + texto** (sem bg); prio P0→`destructive`(~25°) · P1→warn(~68°) · P2→**roxo 295** · P3→muted(~250°) via tokens, **zero palette cru** |
+| 12 | **Microinterações** | `hover:shadow-md`, `ring-primary` drag | `fjslide .22s`, focus `--focus`, sh-1/sh-2 | `--ease`+`--t-1/--t-2`; drawer slide-in; cards `--sh-1`, drawer `--sh-2`; focus-visible ring; drag-over highlight accent-soft |
+| 13 | **Referência aprovada** | — | Forja Cowork (Wagner desenhou) | ✅ protótipo é o screenshot aprovado |
+| 14 | **Benchmarks externos** | — | (emula Linear) | **Linear** (issue tracker) + Height/GitHub Issues — densidade, group-by, ⌘K, drawer lateral |
+| 15 | **Persona** | — | power-user | **Interno** (Wagner + time MCP, desktop) ≠ Larissa. Top 3: (1) teclado-first + ⌘K, (2) selo proveniência **agente vs humano**, (3) densidade > decoração |
+
+## Tokens — mapa raw → DS v6
+
+- Remover de `Index.tsx`: `border-slate-400/blue-500/amber-500/emerald-500`, `bg-red-100 text-red-700`, `bg-blue-100`, `rounded-xl`, `min-h-[300px]` mágicos.
+- Usar: shadcn semânticos (`bg-card`, `text-muted-foreground`, `border`, `text-primary`, `text-destructive`) + Fundações (`--fs-*`, `--sh-1/2`, `--ease`).
+- **Selo de proveniência (teal):** Forja usa `--dev: oklch(0.52 0.10 195)`. Transversal §3 pede **_PROPOSTA** de token `--origin-DEV` em Fundações (não criar `--accent` por módulo). → ver §Decisões (não crio token nesta PR sem OK).
+
+## Decisões abertas pra Wagner (resolver antes do F3; não bloqueiam aprovar o screenshot agora)
+
+1. **Largura do drawer** — Forja 520px (estilo Linear/issue) vs canon ADR 0185 760px (entidades cadastrais). Recomendo **exceção issue ~560px** (task ≠ cadastro), registrada como nota; ou seguir 760.
+2. **Atividade no drawer** — adicionar `GET /team-mcp/tasks/{id}` read-only lendo `mcp_task_events` (dado real, sem fantasma) **nesta PR**, ou omitir atividade até PR-1b? Recomendo o endpoint read-only.
+3. **Lista agrupável** — formalizar como variante PT-01 agora (doc) ou manter module-local? Recomendo **module-local** (formaliza quando 2º módulo pedir).
+4. **`--origin-DEV` teal** — abrir _PROPOSTA de token de Fundação (`oklch(0.52 0.10 195)`) pro selo de proveniência? (sem isso, selo usa lucide `Bot`/`User` neutro).
+5. **Breadcrumb/título** — hoje diz "Copiloto / Tasks"; atualizar pra "Equipe / Tasks" (hub Equipe)?
+
+## Decisões [W] 2026-06-16 (via AskUserQuestion)
+
+1. **Drawer 560px** — exceção issue ≠ cadastro (ADR 0185 = 760px). ✅
+2. **Atividade real** — endpoint read-only `GET /team-mcp/tasks/{id}/detail` lendo `mcp_task_events`. ✅
+3. **Lista agrupável** — module-local (não formaliza variante PT-01 ainda). ✅ _(default)_
+4. **Selo de proveniência** — lucide `Bot`/`User` neutro (sem token novo; `--origin-DEV` teal fica como _PROPOSTA futura). ✅
+5. **Breadcrumb** — "Copiloto" → "Equipe". ✅ _(default)_
+
+## Gates antes do F3 (implementação)
+- [x] Wagner aprova **screenshot** (protótipo Forja) — AskUserQuestion 2026-06-16.
+- [x] Ler `prototipo-ui/PROCESSO_MEMORIA_CC.md` §5 + NÚCLEO 13 invariantes + `memory/LICOES_CC.md` (CLAUDE.md passo 4b).
+- [x] Criar `Index.charter.md` ao lado (PT-01 exige charter).
+- [ ] CI verde: `typecheck` + `eslint`/`ui:lint` + `conformance-gate` + `foundation-guard` + UI-Judge (advisory → 2 verdes → required).
+
+---
+**Status:** `approved` — implementado no PR `feat/forja-pr1-tasks-reskin` (aguardando CI + merge [W2]).

--- a/resources/js/Pages/team-mcp/Tasks/Index.charter.md
+++ b/resources/js/Pages/team-mcp/Tasks/Index.charter.md
@@ -1,0 +1,75 @@
+---
+page: /team-mcp/tasks
+component: resources/js/Pages/team-mcp/Tasks/Index.tsx
+owner: wagner
+status: draft
+last_validated: "2026-06-16"
+parent_module: TeamMcp
+related_adrs:
+  - "0070-jira-style-task-management-current-md-removed"
+  - "0081-identity-mesh-mcp-actors"
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+  - "0104-processo-mwart-canonico-unico-caminho"
+  - "0114-prototipo-ui-cowork-loop-formalizado"
+related_ficha: memory/requisitos/TeamMcp/tasks-visual-comparison.md
+tier: A
+charter_version: 1
+---
+
+# Page Charter — `/team-mcp/tasks` (DRAFT)
+
+> Criado no PR **Forja PR-1** (re-skin DS v6, 2026-06-16). Persona: Wagner [W] + time MCP (Felipe/Maiara/Eliana/Luiz), desktop, superadmin `copiloto.mcp.usage.all`. Backend: `Modules/TeamMcp/Http/Controllers/TasksAdminController.php` (Inertia::defer). Referência visual aprovada: [tasks-visual-comparison.md](../../../../memory/requisitos/TeamMcp/tasks-visual-comparison.md).
+
+## Mission
+
+Painel **read + drag** de governança de tasks MCP (Jira-style, [ADR 0070](../../../../memory/decisions/0070-jira-style-task-management-current-md-removed.md)): backlog denso agrupável + quadro kanban, na gramática Forja sob DS v6. Projeção fiel de `mcp_tasks` — **sem dado fantasma**. Operação primária: enxergar/triar o backlog e mover status (drag/bulk), com drawer de issue (situação + atividade real + vínculos + subtasks).
+
+## Goals — Features (faz)
+
+- **Aba Backlog:** lista densa agrupável por Onda(sprint)/Fase(status)/Papel(owner)/Prioridade/Módulo, grupos colapsáveis, densidade compacta/normal.
+- **Aba Quadro:** kanban todo/doing/review/done, drag→`PATCH /tasks/{id}/status` otimista (reconcilia no reload).
+- **Drawer de issue (560px):** Visão (descrição/meta/vínculos `blocked_by`), Atividade (`mcp_task_events` real), Subtasks. Abre via URL `?task=ID`.
+- **Teclado:** J/K navegar · Enter abre · X marca · / busca · Esc fecha. ⌘K = command palette **global** (AppShellV2).
+- **Seleção em lote** → `BulkActionBar` (mover p/ Fazendo/Revisão/Concluído via PATCH).
+- **KPIs** (total/p0/doing/blocked + total_h) no PageHeader + totalbar de rodapé.
+- **Filtros server-side** module/owner/sprint (Inertia::defer). **Polling 10s** + on-focus reload.
+- **Selo de proveniência** agente vs humano (`mcp_actors` type=ai_agent — transversal §3).
+- **Persistência** `localStorage oimpresso.teammcp.tasks.*` (groupBy/tab/density/search/collapsed).
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ Criar/editar task na tela (criação via `mcp:tasks:sync` / `tasks-create` MCP).
+- ❌ Comentários/watchers no drawer (PR futura — backend já tem `mcp_task_comments`).
+- ❌ Inventar fases F0..F4 — usa os 6 status canônicos (ADR 0070).
+- ❌ Mostrar atividade/descrição/links além do que o backend expõe (sem fantasma).
+- ❌ Tocar AppShellV2 / sidebar / PageHeader canon.
+- ❌ Renomear permissões `copiloto.mcp.*` (task futura).
+
+## UX targets
+
+- DS v6: tokens semânticos (roxo 295 `primary`), status Stripe-**dot** (sem bg-fill), **sem cor crua**, **sem `rounded-xl+`**, ramp `--fs-*`.
+- Drawer **560px** (issue ≠ cadastro 760px [ADR 0185](../../../../memory/decisions/0185-drawer-760-canon-entidades-cadastrais.md) — exceção registrada no visual-comparison).
+- Loading skeleton enquanto `Inertia::defer` resolve. Empty states (vazio / busca-sem-resultado).
+- `tabular-nums` em IDs/contagens/horas. Locators `data-testid` (NÚCLEO #7 anti-quebra-silenciosa).
+
+## Anti-hooks (NÃO faz automaticamente)
+
+- ❌ NÃO escreve nada além de `PATCH` status (bulk = N× PATCH). `show()` é **read-only**.
+- ❌ NÃO loga/expõe token raw nem PII (drawer só status/meta/eventos estruturais).
+- ❌ NÃO usa `<select>`/`<checkbox>`/`<radio>` nativo fora do row-check (usa `Components/ui`).
+- ❌ NÃO re-monta command palette (⌘K já é global no Shell).
+
+## Restrições Tier 0
+
+- Permissão `copiloto.mcp.usage.all` no construtor (todas as ações, incl. `show`).
+- `mcp_tasks`/`mcp_task_events` são **repo-wide cross-tenant INTENCIONAL** ([ADR 0070](../../../../memory/decisions/0070-jira-style-task-management-current-md-removed.md)) — governança da plataforma, sem `business_id` by design. (Não é dado de negócio.)
+- `mcp_task_events` append-only (read no `show()`).
+
+## Métricas de sucesso (validação Wagner)
+
+- ✅ Backlog agrupa por 5 dimensões; grupos colapsam e persistem entre reloads.
+- ✅ Quadro: drag move status (otimista) e reconcilia no reload; registra `mcp_task_events`.
+- ✅ Enter na linha selecionada abre drawer com **atividade real**.
+- ✅ Selo `Bot`/`User` distingue agente de humano corretamente.
+- ✅ `ui:lint`/eslint + `conformance-gate` + `foundation-guard` verdes (sem cor crua / sem rounded-xl).

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -1,27 +1,49 @@
-// tela: /team-mcp/tasks
-// module: TeamMcp (split do Copiloto) — TaskRegistry F2 (US-TR-007)
-// permissao: copiloto.mcp.usage.all
+// @memcofre
+//   tela: /team-mcp/tasks
+//   module: TeamMcp (split do Copiloto) — TaskRegistry F2 (US-TR-007)
+//   forja: PR-1 re-skin DS v6 — visual-comparison em
+//          memory/requisitos/TeamMcp/tasks-visual-comparison.md (approved [W] 2026-06-16)
+//   permissao: copiloto.mcp.usage.all
+//
+// Atalhos (PT-01):
+//   J / K    navegar linha (próxima / anterior)
+//   Enter    abre drawer da linha selecionada
+//   X        marca/desmarca seleção em lote
+//   /        foca a busca local
+//   Esc      fecha drawer / limpa seleção
+//   ⌘K       command palette global (AppShellV2 — não re-montar aqui)
+//
+// Persistência localStorage (prefixo oimpresso.teammcp.tasks.*):
+//   groupBy · tab · density · search · collapsed
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
-import { useRef, useState, useEffect, type ReactNode } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
-import { Badge } from '@/Components/ui/badge';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { ChevronRight, LayoutGrid, ListTree, Lock } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
+import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
-import { ScrollArea } from '@/Components/ui/scroll-area';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
+import BulkActionBar from '@/Components/shared/BulkActionBar';
+import EmptyState from '@/Components/shared/EmptyState';
+import { Checkbox } from '@/Components/ui/checkbox';
+import { cn } from '@/Lib/utils';
+import TaskDrawer from './_components/TaskDrawer';
+import { ActorSeal, PriorityDot, StatusPill } from './_components/taskBadges';
+import { PRIO_LABEL, STATUS_ORDER, statusMeta, type Priority } from './_components/taskTokens';
 
 interface Task {
   task_id: string;
+  display_id: string;
   title: string;
   module: string;
   owner: string | null;
   sprint: string | null;
-  priority: 'p0' | 'p1' | 'p2' | 'p3';
+  priority: Priority;
+  type: string | null;
   estimate_h: number | null;
   blocked_by: string[];
   status: string;
@@ -38,300 +60,588 @@ interface Kpis {
 }
 
 interface Props {
-  kanban: Record<string, Task[]>;
-  backlog: Task[];
-  kpis: Kpis;
-  modulos: string[];
-  owners: string[];
-  sprints: string[];
+  // Props deferidas (Inertia::defer) → undefined no 1º paint. Default-guard no
+  // destructuring evita tela branca (skill inertia-defer-default, espelha Board).
+  kanban?: Record<string, Task[]>;
+  backlog?: Task[];
+  kpis?: Kpis;
+  modulos?: string[];
+  owners?: string[];
+  sprints?: string[];
+  agents?: string[];
   filters: { module: string | null; owner: string | null; sprint: string | null };
 }
 
-const COLUNAS: { key: string; label: string; color: string }[] = [
-  { key: 'todo',   label: 'A fazer',   color: 'border-slate-400' },
-  { key: 'doing',  label: 'Fazendo',   color: 'border-blue-500' },
-  { key: 'review', label: 'Revisão',   color: 'border-amber-500' },
-  { key: 'done',   label: 'Concluído', color: 'border-emerald-500' },
+const ALL = '__all__';
+const NONE = '__none__';
+
+const LS = {
+  GROUP: 'oimpresso.teammcp.tasks.groupBy',
+  TAB: 'oimpresso.teammcp.tasks.tab',
+  DENSITY: 'oimpresso.teammcp.tasks.density',
+  SEARCH: 'oimpresso.teammcp.tasks.search',
+  COLLAPSED: 'oimpresso.teammcp.tasks.collapsed',
+} as const;
+
+type GroupKey = 'sprint' | 'status' | 'owner' | 'priority' | 'module';
+type Tab = 'backlog' | 'quadro';
+type Density = 'compact' | 'normal';
+
+const GROUP_OPTIONS: { key: GroupKey; label: string }[] = [
+  { key: 'sprint', label: 'Onda' },
+  { key: 'status', label: 'Fase' },
+  { key: 'owner', label: 'Papel' },
+  { key: 'priority', label: 'Prioridade' },
+  { key: 'module', label: 'Módulo' },
 ];
 
-const PRIORITY_BADGE: Record<string, string> = {
-  p0: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  p1: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
-  p2: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
-  p3: 'bg-slate-50 text-slate-400 dark:bg-slate-800/50 dark:text-slate-500',
-};
+const KANBAN_COLS: { key: string; label: string }[] = [
+  { key: 'todo', label: 'A fazer' },
+  { key: 'doing', label: 'Fazendo' },
+  { key: 'review', label: 'Revisão' },
+  { key: 'done', label: 'Concluído' },
+];
 
-const STATUS_BADGE: Record<string, string> = {
-  todo:      'bg-slate-100 text-slate-600',
-  doing:     'bg-blue-100 text-blue-700',
-  review:    'bg-amber-100 text-amber-700',
-  done:      'bg-emerald-100 text-emerald-700',
-  blocked:   'bg-red-100 text-red-700',
-  cancelled: 'bg-slate-200 text-slate-400',
-};
+const PRIO_ORDER: Record<string, number> = { p0: 0, p1: 1, p2: 2, p3: 3 };
 
-function TaskCard({ task, onDragStart }: { task: Task; onDragStart: (id: string) => void }) {
-  return (
-    <div
-      draggable
-      onDragStart={() => onDragStart(task.task_id)}
-      className="bg-card border rounded-lg p-3 cursor-grab active:cursor-grabbing shadow-sm hover:shadow-md transition-shadow select-none"
-    >
-      <div className="flex items-start justify-between gap-2 mb-1">
-        <span className="text-[10px] font-mono text-muted-foreground">{task.task_id}</span>
-        <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${PRIORITY_BADGE[task.priority] ?? PRIORITY_BADGE.p2}`}>
-          {task.priority.toUpperCase()}
-        </span>
-      </div>
-      <p className="text-xs font-medium leading-tight mb-2">{task.title}</p>
-      <div className="flex flex-wrap gap-1">
-        <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">{task.module}</span>
-        {task.owner && <span className="text-[10px] bg-muted px-1.5 py-0.5 rounded">{task.owner}</span>}
-        {task.estimate_h && <span className="text-[10px] text-muted-foreground">{task.estimate_h}h</span>}
-        {task.blocked_by.length > 0 && (
-          <span className="text-[10px] text-destructive">blk:{task.blocked_by.join(',')}</span>
-        )}
-      </div>
-    </div>
-  );
+function lsGet(key: string, fallback: string): string {
+  if (typeof window === 'undefined') return fallback;
+  return localStorage.getItem(key) ?? fallback;
 }
 
-function KanbanView({ kanban }: { kanban: Record<string, Task[]> }) {
-  const dragId = useRef<string | null>(null);
-  const [draggingOver, setDraggingOver] = useState<string | null>(null);
-  const [optimistic, setOptimistic] = useState<Record<string, string>>({});
+function groupOf(t: Task, key: GroupKey): string {
+  if (key === 'priority') return t.priority ?? 'p2';
+  if (key === 'status') return t.status;
+  const v = key === 'sprint' ? t.sprint : key === 'owner' ? t.owner : t.module;
+  return v && v.length ? v : NONE;
+}
 
-  function handleDrop(targetStatus: string) {
-    const id = dragId.current;
-    if (!id) return;
-    setDraggingOver(null);
-    dragId.current = null;
-    setOptimistic(prev => ({ ...prev, [id]: targetStatus }));
-
-    const csrfToken = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
-    fetch(`/team-mcp/tasks/${id}/status`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrfToken },
-      body: JSON.stringify({ status: targetStatus, author: 'wagner' }),
-    }).then(r => {
-      if (!r.ok) setOptimistic(prev => { const n = { ...prev }; delete n[id]; return n; });
-    }).catch(() => {
-      setOptimistic(prev => { const n = { ...prev }; delete n[id]; return n; });
-    });
+function groupLabel(key: GroupKey, val: string): string {
+  if (val === NONE) {
+    return key === 'sprint' ? '— sem onda —' : key === 'owner' ? '— sem dono —' : '— sem módulo —';
   }
+  if (key === 'priority') return PRIO_LABEL[val as Priority] ?? val;
+  if (key === 'status') return statusMeta(val).label;
+  return val;
+}
 
-  // Build effective task lists applying optimistic updates
-  const effective: Record<string, Task[]> = {};
-  COLUNAS.forEach(c => { effective[c.key] = []; });
-  COLUNAS.forEach(c => {
-    (kanban[c.key] ?? []).forEach(t => {
-      const status = optimistic[t.task_id] ?? t.status;
-      if (effective[status]) effective[status].push({ ...t, status });
-    });
+function groupSortValue(key: GroupKey, val: string): number | string {
+  if (key === 'priority') return PRIO_ORDER[val] ?? 9;
+  if (key === 'status') { const i = STATUS_ORDER.indexOf(val); return i < 0 ? 99 : i; }
+  return val === NONE ? '￿' : val.toLowerCase();
+}
+
+function sortTasks(a: Task, b: Task): number {
+  const sa = STATUS_ORDER.indexOf(a.status);
+  const sb = STATUS_ORDER.indexOf(b.status);
+  if (sa !== sb) return (sa < 0 ? 99 : sa) - (sb < 0 ? 99 : sb);
+  const pa = PRIO_ORDER[a.priority] ?? 9;
+  const pb = PRIO_ORDER[b.priority] ?? 9;
+  if (pa !== pb) return pa - pb;
+  return a.display_id.localeCompare(b.display_id);
+}
+
+function TasksIndex({
+  kanban,
+  backlog,
+  kpis,
+  modulos = [],
+  owners = [],
+  sprints = [],
+  agents = [],
+  filters,
+}: Props) {
+  const isLoading = kpis === undefined || backlog === undefined;
+  const k: Kpis = kpis ?? { total: 0, p0: 0, doing: 0, blocked: 0, done: 0, cancelled: 0, total_h: 0 };
+
+  // ── UI state (persistido)
+  const [tab, setTab] = useState<Tab>(() => (lsGet(LS.TAB, 'backlog') === 'quadro' ? 'quadro' : 'backlog'));
+  const [groupBy, setGroupBy] = useState<GroupKey>(() => lsGet(LS.GROUP, 'sprint') as GroupKey);
+  const [density, setDensity] = useState<Density>(() => (lsGet(LS.DENSITY, 'normal') === 'compact' ? 'compact' : 'normal'));
+  const [search, setSearch] = useState<string>(() => lsGet(LS.SEARCH, ''));
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => {
+    try { return new Set<string>(JSON.parse(lsGet(LS.COLLAPSED, '[]'))); }
+    catch { return new Set<string>(); }
   });
 
-  return (
-    <div className="grid grid-cols-4 gap-4 mt-4">
-      {COLUNAS.map(col => (
-        <div
-          key={col.key}
-          className={`rounded-xl border-t-4 ${col.color} bg-muted/30 p-3 min-h-[300px] transition-colors ${draggingOver === col.key ? 'bg-muted/60 ring-2 ring-primary/60' : ''}`}
-          onDragOver={e => { e.preventDefault(); setDraggingOver(col.key); }}
-          onDragLeave={() => setDraggingOver(null)}
-          onDrop={() => handleDrop(col.key)}
-        >
-          <div className="flex items-center justify-between mb-3">
-            <span className="text-xs font-semibold uppercase tracking-wide">{col.label}</span>
-            <span className="text-xs text-muted-foreground">{effective[col.key]?.length ?? 0}</span>
-          </div>
-          <div className="flex flex-col gap-2">
-            {(effective[col.key] ?? []).map(t => (
-              <TaskCard key={t.task_id} task={t} onDragStart={id => { dragId.current = id; }} />
-            ))}
-            {(effective[col.key] ?? []).length === 0 && (
-              <div className="text-xs text-muted-foreground text-center py-8 border-2 border-dashed rounded-lg">
-                vazio
-              </div>
-            )}
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
+  useEffect(() => { localStorage.setItem(LS.TAB, tab); }, [tab]);
+  useEffect(() => { localStorage.setItem(LS.GROUP, groupBy); }, [groupBy]);
+  useEffect(() => { localStorage.setItem(LS.DENSITY, density); }, [density]);
+  useEffect(() => { localStorage.setItem(LS.SEARCH, search); }, [search]);
+  useEffect(() => { localStorage.setItem(LS.COLLAPSED, JSON.stringify(Array.from(collapsed))); }, [collapsed]);
 
-function BacklogView({ backlog }: { backlog: Task[] }) {
-  return (
-    <Card className="mt-4">
-      <CardContent className="p-0">
-        <ScrollArea className="max-h-[600px]">
-          <table className="w-full text-xs">
-            <thead className="sticky top-0 bg-background z-10 border-b">
-              <tr>
-                <th className="text-left py-2 px-3 font-medium">ID</th>
-                <th className="text-left py-2 px-3 font-medium">Título</th>
-                <th className="text-left py-2 px-3 font-medium">Módulo</th>
-                <th className="text-left py-2 px-3 font-medium">Owner</th>
-                <th className="text-left py-2 px-3 font-medium">Sprint</th>
-                <th className="text-center py-2 px-3 font-medium">Prio</th>
-                <th className="text-center py-2 px-3 font-medium">Est.</th>
-                <th className="text-center py-2 px-3 font-medium">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {backlog.map(t => (
-                <tr key={t.task_id} className="border-b hover:bg-muted/40">
-                  <td className="py-1.5 px-3 font-mono text-[10px] text-muted-foreground whitespace-nowrap">{t.task_id}</td>
-                  <td className="py-1.5 px-3 max-w-[300px] truncate">{t.title}</td>
-                  <td className="py-1.5 px-3">{t.module}</td>
-                  <td className="py-1.5 px-3">{t.owner ?? '—'}</td>
-                  <td className="py-1.5 px-3">{t.sprint ?? '—'}</td>
-                  <td className="py-1.5 px-3 text-center">
-                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${PRIORITY_BADGE[t.priority] ?? PRIORITY_BADGE.p2}`}>
-                      {t.priority.toUpperCase()}
-                    </span>
-                  </td>
-                  <td className="py-1.5 px-3 text-center text-muted-foreground">{t.estimate_h ? `${t.estimate_h}h` : '—'}</td>
-                  <td className="py-1.5 px-3 text-center">
-                    <span className={`text-[10px] px-1.5 py-0.5 rounded ${STATUS_BADGE[t.status] ?? ''}`}>
-                      {t.status}
-                    </span>
-                  </td>
-                </tr>
-              ))}
-              {backlog.length === 0 && (
-                <tr>
-                  <td colSpan={8} className="text-center py-12 text-muted-foreground">
-                    Nenhuma task encontrada. Rode <code className="font-mono">php artisan mcp:tasks:sync</code>.
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </ScrollArea>
-      </CardContent>
-    </Card>
-  );
-}
+  // ── Filtros server-side (module/owner/sprint)
+  const [modulo, setModulo] = useState(filters.module ?? ALL);
+  const [owner, setOwner] = useState(filters.owner ?? ALL);
+  const [sprint, setSprint] = useState(filters.sprint ?? ALL);
 
-function TasksIndex({ kanban, backlog, kpis, modulos, owners, sprints, filters }: Props) {
-  const [tab, setTab] = useState<'kanban' | 'backlog'>('kanban');
-  const [modulo, setModulo] = useState(filters.module ?? '__all__');
-  const [owner,  setOwner]  = useState(filters.owner  ?? '__all__');
-  const [sprint, setSprint] = useState(filters.sprint  ?? '__all__');
+  // ── Seleção / navegação
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const searchRef = useRef<HTMLInputElement>(null);
 
-  // Polling: atualiza kanban+kpis a cada 10s e ao focar a janela
+  // ── Drag-drop otimista
+  const dragId = useRef<string | null>(null);
+  const [dragOver, setDragOver] = useState<string | null>(null);
+  const [optimistic, setOptimistic] = useState<Record<string, string>>({});
+  const [flash, setFlash] = useState<string | null>(null);
+
+  // ── Drawer via URL ?task=ID
+  const [openId, setOpenId] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    return new URLSearchParams(window.location.search).get('task');
+  });
+
+  function openDetail(id: string) {
+    setOpenId(id);
+    const url = new URL(window.location.href);
+    url.searchParams.set('task', id);
+    window.history.replaceState({}, '', url.toString());
+  }
+  function closeDetail() {
+    setOpenId(null);
+    const url = new URL(window.location.href);
+    url.searchParams.delete('task');
+    window.history.replaceState({}, '', url.toString());
+  }
+
   useEffect(() => {
-    const reload = () => router.reload({ only: ['kanban', 'kpis', 'backlog'], preserveScroll: true });
+    if (!flash) return;
+    const tid = setTimeout(() => setFlash(null), 5000);
+    return () => clearTimeout(tid);
+  }, [flash]);
+
+  function patchStatus(taskId: string, status: string) {
+    setOptimistic((p) => ({ ...p, [taskId]: status }));
+    const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+    fetch(`/team-mcp/tasks/${taskId}/status`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json', 'X-CSRF-TOKEN': csrf },
+      body: JSON.stringify({ status, author: 'wagner' }),
+    })
+      .then((r) => {
+        if (r.ok) {
+          router.reload({ only: ['kanban', 'backlog', 'kpis'] });
+          return;
+        }
+        setOptimistic((p) => { const n = { ...p }; delete n[taskId]; return n; });
+        setFlash(r.status === 403 ? 'Sem permissão para mover tasks.' : 'Falha ao atualizar status.');
+      })
+      .catch(() => {
+        setOptimistic((p) => { const n = { ...p }; delete n[taskId]; return n; });
+        setFlash('Erro de rede. Tenta novamente.');
+      });
+  }
+
+  function toggleSelect(id: string) {
+    setSelected((prev) => { const n = new Set(prev); if (n.has(id)) n.delete(id); else n.add(id); return n; });
+  }
+  function toggleCollapse(g: string) {
+    setCollapsed((prev) => { const n = new Set(prev); if (n.has(g)) n.delete(g); else n.add(g); return n; });
+  }
+  function bulkSetStatus(status: string) {
+    selected.forEach((id) => patchStatus(id, status));
+    setSelected(new Set());
+  }
+
+  // ── Backlog efetivo (otimista + busca + sort)
+  const searchLower = search.trim().toLowerCase();
+  const visibleBacklog = useMemo(() => {
+    return (backlog ?? [])
+      .map((t) => ({ ...t, status: optimistic[t.task_id] ?? t.status }))
+      .filter((t) => !searchLower || `${t.display_id} ${t.title} ${t.owner ?? ''} ${t.module}`.toLowerCase().includes(searchLower))
+      .sort(sortTasks);
+  }, [backlog, optimistic, searchLower]);
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Task[]>();
+    for (const t of visibleBacklog) {
+      const g = groupOf(t, groupBy);
+      if (!map.has(g)) map.set(g, []);
+      map.get(g)!.push(t);
+    }
+    return Array.from(map.entries()).sort((a, b) => {
+      const av = groupSortValue(groupBy, a[0]);
+      const bv = groupSortValue(groupBy, b[0]);
+      if (typeof av === 'number' && typeof bv === 'number') return av - bv;
+      return String(av).localeCompare(String(bv));
+    });
+  }, [visibleBacklog, groupBy]);
+
+  const flatBacklog = useMemo(() => {
+    const out: Task[] = [];
+    for (const [g, items] of grouped) if (!collapsed.has(g)) out.push(...items);
+    return out;
+  }, [grouped, collapsed]);
+
+  // ── Kanban efetivo (otimista)
+  const effectiveKanban = useMemo(() => {
+    const out: Record<string, Task[]> = {};
+    KANBAN_COLS.forEach((c) => { out[c.key] = []; });
+    Object.values(kanban ?? {}).forEach((list) => {
+      (list ?? []).forEach((t) => {
+        const st = optimistic[t.task_id] ?? t.status;
+        if (out[st]) out[st].push({ ...t, status: st });
+      });
+    });
+    return out;
+  }, [kanban, optimistic]);
+
+  const flatKanban = useMemo(() => {
+    const o: Task[] = [];
+    KANBAN_COLS.forEach((c) => o.push(...(effectiveKanban[c.key] ?? [])));
+    return o;
+  }, [effectiveKanban]);
+
+  const flatVisible = tab === 'quadro' ? flatKanban : flatBacklog;
+
+  useEffect(() => {
+    if (selectedId && !flatVisible.find((t) => t.task_id === selectedId)) setSelectedId(null);
+  }, [flatVisible, selectedId]);
+
+  // ── Atalhos
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tgt = e.target as HTMLElement | null;
+      const typing = !!tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable);
+      if (e.key === '/' && !typing) { e.preventDefault(); searchRef.current?.focus(); return; }
+      if (e.key === 'Escape') {
+        if (openId) closeDetail();
+        else if (selected.size) setSelected(new Set());
+        return;
+      }
+      if (typing) return;
+      const idx = selectedId ? flatVisible.findIndex((t) => t.task_id === selectedId) : -1;
+      const cur = idx >= 0 ? flatVisible[idx] : null;
+      if (e.key === 'j' || e.key === 'J') {
+        e.preventDefault();
+        const n = idx < 0 ? 0 : Math.min(flatVisible.length - 1, idx + 1);
+        setSelectedId(flatVisible[n]?.task_id ?? null);
+      } else if (e.key === 'k' || e.key === 'K') {
+        e.preventDefault();
+        const p = idx <= 0 ? 0 : idx - 1;
+        setSelectedId(flatVisible[p]?.task_id ?? null);
+      } else if (e.key === 'Enter') {
+        if (cur) { e.preventDefault(); openDetail(cur.task_id); }
+      } else if (e.key === 'x' || e.key === 'X') {
+        if (cur) { e.preventDefault(); toggleSelect(cur.task_id); }
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [flatVisible, selectedId, openId, selected]);
+
+  // ── Polling 10s + on-focus
+  useEffect(() => {
+    const reload = () => router.reload({ only: ['kanban', 'backlog', 'kpis'] });
     const interval = setInterval(reload, 10_000);
     window.addEventListener('focus', reload);
     return () => { clearInterval(interval); window.removeEventListener('focus', reload); };
   }, []);
 
-  function applyFilter() {
+  function applyFilter(patch: Partial<{ module: string; owner: string; sprint: string }>) {
+    const m = patch.module ?? modulo;
+    const o = patch.owner ?? owner;
+    const s = patch.sprint ?? sprint;
     const params: Record<string, string> = {};
-    if (modulo !== '__all__') params.module = modulo;
-    if (owner  !== '__all__') params.owner  = owner;
-    if (sprint !== '__all__') params.sprint = sprint;
-    router.get('/team-mcp/tasks', params, { preserveScroll: true, preserveState: true });
+    if (m !== ALL) params.module = m;
+    if (o !== ALL) params.owner = o;
+    if (s !== ALL) params.sprint = s;
+    router.get('/team-mcp/tasks', params, { preserveScroll: true, preserveState: true, replace: true });
+  }
+  function clearFilter() {
+    setModulo(ALL); setOwner(ALL); setSprint(ALL);
+    router.get('/team-mcp/tasks', {}, { preserveScroll: true, preserveState: true, replace: true });
   }
 
-  function clearFilter() {
-    setModulo('__all__'); setOwner('__all__'); setSprint('__all__');
-    router.get('/team-mcp/tasks', {}, { preserveScroll: true, preserveState: true });
-  }
+  const hasServerFilter = modulo !== ALL || owner !== ALL || sprint !== ALL;
+  const rowH = density === 'compact' ? 'h-8' : 'h-9';
 
   return (
     <>
       <PageHeader
         icon="layout-kanban"
-        title="Task Board"
-        description={`${kpis.total} tasks · ${kpis.total_h.toFixed(0)}h estimadas · TaskRegistry F2 (US-TR-007)`}
+        title="Tasks"
+        description={`${isLoading ? '—' : k.total} tasks · ${isLoading ? '—' : k.total_h.toFixed(0)}h estimadas · ${isLoading ? '—' : k.doing} fazendo`}
+        action={
+          <div className="inline-flex rounded-lg border bg-muted/40 p-0.5" role="tablist" aria-label="Visão">
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'backlog'}
+              data-testid="view-backlog"
+              onClick={() => setTab('backlog')}
+              className={cn('inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
+                tab === 'backlog' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground hover:text-foreground')}
+            >
+              <ListTree size={14} /> Backlog
+            </button>
+            <button
+              type="button"
+              role="tab"
+              aria-selected={tab === 'quadro'}
+              data-testid="view-quadro"
+              onClick={() => setTab('quadro')}
+              className={cn('inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium transition-colors',
+                tab === 'quadro' ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground hover:text-foreground')}
+            >
+              <LayoutGrid size={14} /> Quadro
+            </button>
+          </div>
+        }
       />
 
-      {/* KPIs */}
-      <KpiGrid cols={4} className="mt-4">
-        <KpiCard icon="list" tone="default"     label="Total"    value={String(kpis.total)} />
-        <KpiCard icon="alert-circle" tone={kpis.p0 > 0 ? 'danger' : 'success'} label="P0 abertas" value={String(kpis.p0)} />
-        <KpiCard icon="loader" tone="default"   label="Doing"    value={String(kpis.doing)} />
-        <KpiCard icon="lock" tone={kpis.blocked > 0 ? 'warning' : 'success'} label="Bloqueadas" value={String(kpis.blocked)} />
-      </KpiGrid>
-
-      {/* Filtros */}
-      <Card className="mt-4">
-        <CardContent className="py-3 flex flex-wrap items-end gap-3">
-          <div className="w-36">
-            <Label className="text-xs">Módulo</Label>
-            <Select value={modulo} onValueChange={setModulo}>
-              <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">Todos</SelectItem>
-                {modulos.map(m => <SelectItem key={m} value={m}>{m}</SelectItem>)}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="w-32">
-            <Label className="text-xs">Owner</Label>
-            <Select value={owner} onValueChange={setOwner}>
-              <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">Todos</SelectItem>
-                {owners.map(o => <SelectItem key={o} value={o}>{o}</SelectItem>)}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="w-28">
-            <Label className="text-xs">Sprint</Label>
-            <Select value={sprint} onValueChange={setSprint}>
-              <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
-              <SelectContent>
-                <SelectItem value="__all__">Todos</SelectItem>
-                {sprints.map(s => <SelectItem key={s} value={s}>{s}</SelectItem>)}
-              </SelectContent>
-            </Select>
-          </div>
-          <Button onClick={applyFilter} className="h-8 text-xs">Filtrar</Button>
-          {(filters.module || filters.owner || filters.sprint) && (
-            <Button variant="ghost" onClick={clearFilter} className="h-8 text-xs">Limpar</Button>
-          )}
-
-          {/* Tab switcher */}
-          <div className="ml-auto flex gap-1">
-            <Button
-              variant={tab === 'kanban' ? 'default' : 'ghost'}
-              className="h-8 text-xs"
-              onClick={() => setTab('kanban')}
-            >
-              Kanban
-            </Button>
-            <Button
-              variant={tab === 'backlog' ? 'default' : 'ghost'}
-              className="h-8 text-xs"
-              onClick={() => setTab('backlog')}
-            >
-              Backlog ({backlog.length})
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-
-      {tab === 'kanban' ? (
-        <KanbanView kanban={kanban} />
-      ) : (
-        <BacklogView backlog={backlog} />
+      {flash && (
+        <div role="alert" className="mt-4 flex items-center justify-between rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-sm text-warning-fg">
+          <span>{flash}</span>
+          <button type="button" onClick={() => setFlash(null)} className="text-xs font-medium underline-offset-2 hover:underline">ok</button>
+        </div>
       )}
 
-      <div className="mt-4 text-xs text-muted-foreground">
-        Drag-drop atualiza status e registra evento em <code className="font-mono">mcp_task_events</code>.
-        Editar campos detalhados: <code className="font-mono">tasks-update</code> via MCP ou edite o SPEC e rode{' '}
-        <code className="font-mono">php artisan mcp:tasks:sync</code>.
+      <KpiGrid cols={4} className="mt-4">
+        <KpiCard icon="list" tone="default" label="Total" value={isLoading ? '—' : String(k.total)} />
+        <KpiCard icon="alert-circle" tone={k.p0 > 0 ? 'danger' : 'success'} label="P0 abertas" value={isLoading ? '—' : String(k.p0)} />
+        <KpiCard icon="loader" tone="default" label="Fazendo" value={isLoading ? '—' : String(k.doing)} />
+        <KpiCard icon="lock" tone={k.blocked > 0 ? 'warning' : 'success'} label="Bloqueadas" value={isLoading ? '—' : String(k.blocked)} />
+      </KpiGrid>
+
+      {/* Toolbar */}
+      <div className="mt-4 flex flex-wrap items-end gap-3 rounded-lg border bg-card px-3 py-3">
+        {tab === 'backlog' && (
+          <div>
+            <Label className="text-xs">Agrupar por</Label>
+            <div className="mt-1 inline-flex rounded-md border bg-muted/40 p-0.5" role="group" data-testid="groupby">
+              {GROUP_OPTIONS.map((g) => (
+                <button
+                  key={g.key}
+                  type="button"
+                  onClick={() => setGroupBy(g.key)}
+                  className={cn('rounded px-2 py-1 text-xs font-medium transition-colors',
+                    groupBy === g.key ? 'bg-background text-primary shadow-sm' : 'text-muted-foreground hover:text-foreground')}
+                >
+                  {g.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className="w-36">
+          <Label className="text-xs">Módulo</Label>
+          <Select value={modulo} onValueChange={(v) => { setModulo(v); applyFilter({ module: v }); }}>
+            <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todos</SelectItem>
+              {modulos.map((m) => <SelectItem key={m} value={m}>{m}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="w-32">
+          <Label className="text-xs">Owner</Label>
+          <Select value={owner} onValueChange={(v) => { setOwner(v); applyFilter({ owner: v }); }}>
+            <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todos</SelectItem>
+              {owners.map((o) => <SelectItem key={o} value={o}>{o}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="w-28">
+          <Label className="text-xs">Onda</Label>
+          <Select value={sprint} onValueChange={(v) => { setSprint(v); applyFilter({ sprint: v }); }}>
+            <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todas</SelectItem>
+              {sprints.map((s) => <SelectItem key={s} value={s}>{s}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="w-48">
+          <Label className="text-xs">Buscar</Label>
+          <Input
+            ref={searchRef}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar (/)…"
+            className="h-8 text-xs"
+            data-testid="search"
+          />
+        </div>
+
+        {(hasServerFilter || search) && (
+          <Button variant="ghost" onClick={() => { setSearch(''); clearFilter(); }} className="h-8 text-xs">Limpar</Button>
+        )}
+
+        <div className="ml-auto flex items-center gap-2">
+          {tab === 'backlog' && (
+            <button
+              type="button"
+              onClick={() => setDensity(density === 'compact' ? 'normal' : 'compact')}
+              className="rounded-md border px-2 py-1 text-[11px] text-muted-foreground hover:text-foreground"
+              data-testid="density"
+            >
+              {density === 'compact' ? 'Densidade: compacta' : 'Densidade: normal'}
+            </button>
+          )}
+          <span className="hidden text-[11px] text-muted-foreground lg:inline">
+            <kbd className="rounded bg-muted px-1 py-0.5">J</kbd>/<kbd className="rounded bg-muted px-1 py-0.5">K</kbd> navegar ·{' '}
+            <kbd className="rounded bg-muted px-1 py-0.5">↵</kbd> abrir ·{' '}
+            <kbd className="rounded bg-muted px-1 py-0.5">X</kbd> marcar ·{' '}
+            <kbd className="rounded bg-muted px-1 py-0.5">⌘K</kbd> palette
+          </span>
+        </div>
       </div>
+
+      {/* Conteúdo */}
+      {isLoading ? (
+        <div className="mt-4 space-y-2" data-testid="tasks-skeleton">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div key={i} className="h-9 animate-pulse rounded-md bg-muted/50" />
+          ))}
+        </div>
+      ) : tab === 'quadro' ? (
+        <div className="mt-4 grid gap-3" style={{ gridTemplateColumns: `repeat(${KANBAN_COLS.length}, minmax(0, 1fr))` }} data-testid="quadro">
+          {KANBAN_COLS.map((col) => {
+            const items = effectiveKanban[col.key] ?? [];
+            return (
+              <div
+                key={col.key}
+                onDragOver={(e) => { e.preventDefault(); setDragOver(col.key); }}
+                onDragLeave={() => setDragOver(null)}
+                onDrop={() => { const id = dragId.current; dragId.current = null; setDragOver(null); if (id) patchStatus(id, col.key); }}
+                className={cn('flex min-h-[280px] flex-col rounded-lg border bg-muted/30 p-2', dragOver === col.key && 'bg-muted/60 ring-2 ring-primary/50')}
+                data-testid={`kanban-col-${col.key}`}
+              >
+                <div className="mb-2 flex items-center justify-between px-1">
+                  <StatusPill status={col.key} />
+                  <span className="text-xs tabular-nums text-muted-foreground">{items.length}</span>
+                </div>
+                <div className="flex flex-col gap-2">
+                  {items.map((t) => (
+                    <div
+                      key={t.task_id}
+                      role="button"
+                      tabIndex={0}
+                      draggable
+                      onDragStart={() => { dragId.current = t.task_id; setSelectedId(t.task_id); }}
+                      onClick={() => { setSelectedId(t.task_id); openDetail(t.task_id); }}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedId(t.task_id); openDetail(t.task_id); } }}
+                      className={cn('cursor-grab select-none rounded-lg border bg-card p-2.5 shadow-sm transition-shadow hover:shadow-md active:cursor-grabbing',
+                        selectedId === t.task_id && 'ring-1 ring-primary')}
+                      data-testid="kanban-card"
+                    >
+                      <div className="mb-1 flex items-center gap-2">
+                        <PriorityDot priority={t.priority} />
+                        <span className="font-mono text-[10px] text-muted-foreground">{t.display_id}</span>
+                        {t.blocked_by.length > 0 && <Lock size={11} className="ml-auto text-destructive" aria-label="bloqueada" />}
+                      </div>
+                      <p className="mb-2 line-clamp-2 text-xs font-medium leading-tight">{t.title}</p>
+                      <div className="flex items-center gap-2">
+                        <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{t.module}</span>
+                        <ActorSeal owner={t.owner} agents={agents} className="ml-auto" />
+                      </div>
+                    </div>
+                  ))}
+                  {items.length === 0 && (
+                    <div className="rounded-lg border-2 border-dashed border-border py-6 text-center text-xs text-muted-foreground">vazio</div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      ) : flatBacklog.length === 0 && grouped.length === 0 ? (
+        <div className="mt-4">
+          <EmptyState
+            icon={search ? 'search' : 'inbox'}
+            variant={search ? 'search' : 'default'}
+            title={search ? `Nada pra "${search}"` : 'Nenhuma task encontrada'}
+            description={search ? 'Tenta ajustar a busca ou os filtros.' : 'Rode mcp:tasks:sync ou crie via tasks-create no MCP.'}
+          />
+        </div>
+      ) : (
+        <div className="mt-4 overflow-hidden rounded-lg border bg-card" data-testid="backlog">
+          {grouped.map(([g, items]) => {
+            const isCol = collapsed.has(g);
+            return (
+              <div key={g}>
+                <button
+                  type="button"
+                  onClick={() => toggleCollapse(g)}
+                  className="flex w-full items-center gap-2 border-b border-border/60 bg-muted/40 px-3 py-1.5 text-left text-xs font-medium"
+                  data-testid="group-head"
+                >
+                  <ChevronRight size={13} className={cn('shrink-0 transition-transform', !isCol && 'rotate-90')} />
+                  <span>{groupLabel(groupBy, g)}</span>
+                  <span className="rounded-full bg-background px-1.5 text-[10px] tabular-nums text-muted-foreground">{items.length}</span>
+                </button>
+                {!isCol && items.map((t) => {
+                  const sel = selectedId === t.task_id;
+                  const checked = selected.has(t.task_id);
+                  return (
+                    <div
+                      key={t.task_id}
+                      role="button"
+                      tabIndex={0}
+                      data-testid="task-row"
+                      onClick={() => { setSelectedId(t.task_id); openDetail(t.task_id); }}
+                      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedId(t.task_id); openDetail(t.task_id); } }}
+                      className={cn('flex cursor-pointer items-center gap-3 border-b border-border/60 px-3 text-sm last:border-b-0', rowH,
+                        sel ? 'bg-primary/10' : 'hover:bg-muted/50', checked && !sel && 'bg-primary/5')}
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onClick={(e) => e.stopPropagation()}
+                        onCheckedChange={() => toggleSelect(t.task_id)}
+                        className="shrink-0"
+                        aria-label={`Selecionar ${t.display_id}`}
+                        data-testid="row-check"
+                      />
+                      <PriorityDot priority={t.priority} />
+                      <span className="w-20 shrink-0 truncate font-mono text-[11px] text-muted-foreground">{t.display_id}</span>
+                      <span className="min-w-0 flex-1 truncate">{t.title}</span>
+                      {t.blocked_by.length > 0 && <Lock size={12} className="shrink-0 text-destructive" aria-label="bloqueada" />}
+                      <span className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground sm:inline">{t.module}</span>
+                      <span className="hidden w-28 shrink-0 sm:block"><ActorSeal owner={t.owner} agents={agents} /></span>
+                      <span className="hidden w-12 shrink-0 text-right text-xs tabular-nums text-muted-foreground md:block">{t.estimate_h ? `${t.estimate_h}h` : ''}</span>
+                      <StatusPill status={t.status} className="hidden w-24 shrink-0 md:inline-flex" />
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Totalbar */}
+      {!isLoading && (
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-[11px] text-muted-foreground" data-testid="totalbar">
+          <span className="tabular-nums">
+            {tab === 'quadro' ? `${flatKanban.length} no quadro` : `${flatBacklog.length} de ${(backlog ?? []).length} tasks`}
+            {' · '}{k.done} concluídas · {k.cancelled} canceladas
+          </span>
+          <span>
+            Drag no Quadro atualiza status (registra <code className="font-mono">mcp_task_events</code>). Edição:{' '}
+            <code className="font-mono">tasks-update</code> via MCP.
+          </span>
+        </div>
+      )}
+
+      <BulkActionBar selectedCount={selected.size} onClear={() => setSelected(new Set())} label="tasks">
+        <Button size="sm" variant="ghost" onClick={() => bulkSetStatus('doing')}>→ Fazendo</Button>
+        <Button size="sm" variant="ghost" onClick={() => bulkSetStatus('review')}>→ Revisão</Button>
+        <Button size="sm" variant="ghost" onClick={() => bulkSetStatus('done')}>→ Concluído</Button>
+      </BulkActionBar>
+
+      <TaskDrawer taskId={openId} agents={agents} onClose={closeDetail} />
     </>
   );
 }
 
 TasksIndex.layout = (page: ReactNode) => (
-  <AppShellV2 title="Task Board — Copiloto" breadcrumbItems={[{ label: 'Copiloto' }, { label: 'Tasks' }]}>
+  <AppShellV2 title="Tasks — Equipe" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Tasks' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -32,7 +32,7 @@ import EmptyState from '@/Components/shared/EmptyState';
 import { Checkbox } from '@/Components/ui/checkbox';
 import { cn } from '@/Lib/utils';
 import TaskDrawer from './_components/TaskDrawer';
-import { ActorSeal, PriorityDot, StatusPill } from './_components/taskBadges';
+import { ActorSeal, PriorityDot, TaskStatusPill } from './_components/taskBadges';
 import { PRIO_LABEL, STATUS_ORDER, statusMeta, type Priority } from './_components/taskTokens';
 
 interface Task {
@@ -397,7 +397,7 @@ function TasksIndex({
       />
 
       {flash && (
-        <div role="alert" className="mt-4 flex items-center justify-between rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-sm text-warning-fg">
+        <div role="alert" className="mt-4 inline-flex w-full items-center justify-between rounded-md border border-warning/20 bg-warning-soft px-3 py-2 text-sm text-warning-fg">
           <span>{flash}</span>
           <button type="button" onClick={() => setFlash(null)} className="text-xs font-medium underline-offset-2 hover:underline">ok</button>
         </div>
@@ -411,7 +411,7 @@ function TasksIndex({
       </KpiGrid>
 
       {/* Toolbar */}
-      <div className="mt-4 flex flex-wrap items-end gap-3 rounded-lg border bg-card px-3 py-3">
+      <div className="mt-4 inline-flex w-full flex-wrap items-end gap-3 rounded-lg border bg-card px-3 py-3">
         {tab === 'backlog' && (
           <div>
             <Label className="text-xs">Agrupar por</Label>
@@ -478,7 +478,7 @@ function TasksIndex({
           <Button variant="ghost" onClick={() => { setSearch(''); clearFilter(); }} className="h-8 text-xs">Limpar</Button>
         )}
 
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto inline-flex items-center gap-2">
           {tab === 'backlog' && (
             <button
               type="button"
@@ -506,7 +506,7 @@ function TasksIndex({
           ))}
         </div>
       ) : tab === 'quadro' ? (
-        <div className="mt-4 grid gap-3" style={{ gridTemplateColumns: `repeat(${KANBAN_COLS.length}, minmax(0, 1fr))` }} data-testid="quadro">
+        <div className="mt-4 inline-grid w-full gap-3" style={{ gridTemplateColumns: `repeat(${KANBAN_COLS.length}, minmax(0, 1fr))` }} data-testid="quadro">
           {KANBAN_COLS.map((col) => {
             const items = effectiveKanban[col.key] ?? [];
             return (
@@ -515,14 +515,14 @@ function TasksIndex({
                 onDragOver={(e) => { e.preventDefault(); setDragOver(col.key); }}
                 onDragLeave={() => setDragOver(null)}
                 onDrop={() => { const id = dragId.current; dragId.current = null; setDragOver(null); if (id) patchStatus(id, col.key); }}
-                className={cn('flex min-h-[280px] flex-col rounded-lg border bg-muted/30 p-2', dragOver === col.key && 'bg-muted/60 ring-2 ring-primary/50')}
+                className={cn('min-h-[280px] rounded-lg border bg-muted/30 p-2', dragOver === col.key && 'bg-muted/60 ring-2 ring-primary/50')}
                 data-testid={`kanban-col-${col.key}`}
               >
-                <div className="mb-2 flex items-center justify-between px-1">
-                  <StatusPill status={col.key} />
+                <div className="mb-2 inline-flex w-full items-center justify-between px-1">
+                  <TaskStatusPill status={col.key} />
                   <span className="text-xs tabular-nums text-muted-foreground">{items.length}</span>
                 </div>
-                <div className="flex flex-col gap-2">
+                <div className="inline-flex w-full flex-col gap-2">
                   {items.map((t) => (
                     <div
                       key={t.task_id}
@@ -536,13 +536,13 @@ function TasksIndex({
                         selectedId === t.task_id && 'ring-1 ring-primary')}
                       data-testid="kanban-card"
                     >
-                      <div className="mb-1 flex items-center gap-2">
+                      <div className="mb-1 inline-flex w-full items-center gap-2">
                         <PriorityDot priority={t.priority} />
                         <span className="font-mono text-[10px] text-muted-foreground">{t.display_id}</span>
                         {t.blocked_by.length > 0 && <Lock size={11} className="ml-auto text-destructive" aria-label="bloqueada" />}
                       </div>
                       <p className="mb-2 line-clamp-2 text-xs font-medium leading-tight">{t.title}</p>
-                      <div className="flex items-center gap-2">
+                      <div className="inline-flex w-full items-center gap-2">
                         <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">{t.module}</span>
                         <ActorSeal owner={t.owner} agents={agents} className="ml-auto" />
                       </div>
@@ -574,7 +574,7 @@ function TasksIndex({
                 <button
                   type="button"
                   onClick={() => toggleCollapse(g)}
-                  className="flex w-full items-center gap-2 border-b border-border/60 bg-muted/40 px-3 py-1.5 text-left text-xs font-medium"
+                  className="inline-flex w-full items-center gap-2 border-b border-border/60 bg-muted/40 px-3 py-1.5 text-left text-xs font-medium"
                   data-testid="group-head"
                 >
                   <ChevronRight size={13} className={cn('shrink-0 transition-transform', !isCol && 'rotate-90')} />
@@ -592,7 +592,7 @@ function TasksIndex({
                       data-testid="task-row"
                       onClick={() => { setSelectedId(t.task_id); openDetail(t.task_id); }}
                       onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setSelectedId(t.task_id); openDetail(t.task_id); } }}
-                      className={cn('flex cursor-pointer items-center gap-3 border-b border-border/60 px-3 text-sm last:border-b-0', rowH,
+                      className={cn('inline-flex w-full cursor-pointer items-center gap-3 border-b border-border/60 px-3 text-sm last:border-b-0', rowH,
                         sel ? 'bg-primary/10' : 'hover:bg-muted/50', checked && !sel && 'bg-primary/5')}
                     >
                       <Checkbox
@@ -610,7 +610,7 @@ function TasksIndex({
                       <span className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground sm:inline">{t.module}</span>
                       <span className="hidden w-28 shrink-0 sm:block"><ActorSeal owner={t.owner} agents={agents} /></span>
                       <span className="hidden w-12 shrink-0 text-right text-xs tabular-nums text-muted-foreground md:block">{t.estimate_h ? `${t.estimate_h}h` : ''}</span>
-                      <StatusPill status={t.status} className="hidden w-24 shrink-0 md:inline-flex" />
+                      <TaskStatusPill status={t.status} className="hidden w-24 shrink-0 md:inline-flex" />
                     </div>
                   );
                 })}
@@ -622,7 +622,7 @@ function TasksIndex({
 
       {/* Totalbar */}
       {!isLoading && (
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-[11px] text-muted-foreground" data-testid="totalbar">
+        <div className="mt-3 inline-flex w-full flex-wrap items-center justify-between gap-2 text-[11px] text-muted-foreground" data-testid="totalbar">
           <span className="tabular-nums">
             {tab === 'quadro' ? `${flatKanban.length} no quadro` : `${flatBacklog.length} de ${(backlog ?? []).length} tasks`}
             {' · '}{k.done} concluídas · {k.cancelled} canceladas

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -221,7 +221,12 @@ function TasksIndex({
     })
       .then((r) => {
         if (r.ok) {
-          router.reload({ only: ['kanban', 'backlog', 'kpis'] });
+          // Limpa o otimismo só após o reload reconciliar: evita flicker E evita
+          // mascarar mudança real posterior de outro ator (review PR-1).
+          router.reload({
+            only: ['kanban', 'backlog', 'kpis'],
+            onFinish: () => setOptimistic((p) => { const n = { ...p }; delete n[taskId]; return n; }),
+          });
           return;
         }
         setOptimistic((p) => { const n = { ...p }; delete n[taskId]; return n; });

--- a/resources/js/Pages/team-mcp/Tasks/_components/TaskDrawer.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/_components/TaskDrawer.tsx
@@ -1,0 +1,368 @@
+// Forja PR-1 — drawer de issue da tela /team-mcp/tasks.
+//   Endpoint: GET /team-mcp/tasks/{taskId}/detail (TasksAdminController@show, read-only).
+//   SEM dado fantasma: só situação (status) + atividade real (mcp_task_events) +
+//   vínculos (blocked_by resolvidos) + subtasks. Largura 560px (issue ≠ cadastro
+//   760px ADR 0185 — exceção registrada no visual-comparison).
+//   Locators resilientes via data-testid (NÚCLEO #7).
+
+import { useEffect, useState } from 'react';
+import {
+  Activity as ActivityIcon,
+  ChevronsRight,
+  FileText,
+  GitBranch,
+  ListChecks,
+  Loader2,
+  Lock,
+  Plus,
+  RefreshCw,
+} from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from '@/Components/ui/sheet';
+import { cn } from '@/Lib/utils';
+import { ActorSeal, PriorityDot, StatusPill } from './taskBadges';
+import { type Priority } from './taskTokens';
+
+interface TaskDetail {
+  task_id: string;
+  display_id: string;
+  identifier: string | null;
+  title: string;
+  description: string | null;
+  module: string | null;
+  owner: string | null;
+  sprint: string | null;
+  priority: Priority;
+  status: string;
+  type: string | null;
+  estimate_h: number | null;
+  story_points: number | null;
+  due_date: string | null;
+  blocked_by: string[];
+  is_blocked: boolean;
+  updated_at?: number;
+  created_at: string | null;
+}
+
+interface ActivityEvent {
+  id: number;
+  event_type: string;
+  from_value: string | null;
+  to_value: string | null;
+  author: string | null;
+  note: string | null;
+  occurred_at: string | null;
+}
+
+interface Subtask {
+  task_id: string;
+  display_id: string;
+  title: string;
+  status: string;
+  priority: Priority;
+}
+
+interface Blocker {
+  task_id: string;
+  display_id: string;
+  title: string;
+  status: string;
+}
+
+interface DetailPayload {
+  task: TaskDetail;
+  events: ActivityEvent[];
+  subtasks: Subtask[];
+  blockers: Blocker[];
+}
+
+interface Props {
+  taskId: string | null;
+  agents: string[];
+  onClose: () => void;
+}
+
+type Tab = 'visao' | 'atividade' | 'subtasks';
+
+const EVENT_LABEL: Record<string, string> = {
+  created: 'criou',
+  status_changed: 'mudou status',
+  assigned: 'atribuiu',
+  field_updated: 'atualizou',
+  commented: 'comentou',
+  cancelled: 'cancelou',
+};
+
+function eventIcon(type: string) {
+  switch (type) {
+    case 'created': return Plus;
+    case 'status_changed': return ChevronsRight;
+    case 'field_updated': return RefreshCw;
+    default: return ActivityIcon;
+  }
+}
+
+function timeAgo(iso: string | null): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const diff = Date.now() - d.getTime();
+  const min = Math.round(diff / 60_000);
+  if (min < 1) return 'agora';
+  if (min < 60) return `${min}m atrás`;
+  const h = Math.round(min / 60);
+  if (h < 24) return `${h}h atrás`;
+  const days = Math.round(h / 24);
+  if (days < 30) return `${days}d atrás`;
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export default function TaskDrawer({ taskId, agents, onClose }: Props) {
+  const [data, setData] = useState<DetailPayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>('visao');
+
+  useEffect(() => {
+    if (!taskId) return;
+    setLoading(true);
+    setError(null);
+    setData(null);
+    setTab('visao');
+
+    const ctrl = new AbortController();
+    fetch(`/team-mcp/tasks/${encodeURIComponent(taskId)}/detail`, {
+      headers: { Accept: 'application/json' },
+      signal: ctrl.signal,
+    })
+      .then((r) => {
+        if (r.status === 403) throw new Error('Sem permissão para ver esta task.');
+        if (r.status === 404) throw new Error('Task não encontrada.');
+        if (!r.ok) throw new Error(`Erro ${r.status}`);
+        return r.json();
+      })
+      .then((d: DetailPayload) => {
+        setData(d);
+        setLoading(false);
+      })
+      .catch((err: Error) => {
+        if (err.name === 'AbortError') return;
+        setError(err.message);
+        setLoading(false);
+      });
+
+    return () => ctrl.abort();
+  }, [taskId]);
+
+  const open = !!taskId;
+  const t = data?.task;
+
+  const tabs: Array<{ key: Tab; label: string; icon: typeof FileText; count?: number }> = [
+    { key: 'visao', label: 'Visão', icon: FileText },
+    { key: 'atividade', label: 'Atividade', icon: ActivityIcon, count: data?.events.length },
+    { key: 'subtasks', label: 'Subtasks', icon: ListChecks, count: data?.subtasks.length },
+  ];
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <SheetContent
+        side="right"
+        className="w-full overflow-y-auto sm:max-w-[560px]"
+        data-testid="task-drawer"
+      >
+        <SheetHeader className="border-b">
+          <div className="flex items-start gap-2">
+            <PriorityDot priority={t?.priority ?? 'p2'} className="mt-1.5" />
+            <div className="min-w-0 flex-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-xs text-muted-foreground" data-testid="drawer-id">
+                  {t?.display_id ?? taskId}
+                </span>
+                {t?.type && (
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    {t.type}
+                  </span>
+                )}
+                {t?.status && <StatusPill status={t.status} />}
+                {t?.is_blocked && (
+                  <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-destructive">
+                    <Lock size={10} /> bloqueada
+                  </span>
+                )}
+              </div>
+              <SheetTitle className="mt-1 text-base leading-snug" data-testid="drawer-title">
+                {t?.title ?? <span className="italic text-muted-foreground">(sem título)</span>}
+              </SheetTitle>
+              <SheetDescription className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+                {t?.module && <span className="rounded bg-muted px-1.5 py-0.5">{t.module}</span>}
+                {t && <ActorSeal owner={t.owner} agents={agents} />}
+                {t?.sprint && <span className="text-muted-foreground">onda {t.sprint}</span>}
+                {t?.estimate_h ? <span className="text-muted-foreground tabular-nums">{t.estimate_h}h</span> : null}
+              </SheetDescription>
+            </div>
+          </div>
+        </SheetHeader>
+
+        {!loading && data && (
+          <div className="-mt-2 border-b px-4">
+            <div className="flex gap-1" role="tablist">
+              {tabs.map((tabItem) => {
+                const Icon = tabItem.icon;
+                const isActive = tab === tabItem.key;
+                return (
+                  <button
+                    key={tabItem.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={isActive}
+                    data-testid={`drawer-tab-${tabItem.key}`}
+                    onClick={() => setTab(tabItem.key)}
+                    className={cn(
+                      'relative flex items-center gap-1.5 px-3 py-2 text-xs font-medium transition-colors',
+                      isActive
+                        ? '-mb-px border-b-2 border-primary text-foreground'
+                        : 'text-muted-foreground hover:text-foreground',
+                    )}
+                  >
+                    <Icon size={13} />
+                    {tabItem.label}
+                    {tabItem.count !== undefined && tabItem.count > 0 && (
+                      <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-muted px-1 text-[10px] tabular-nums">
+                        {tabItem.count}
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto px-4 pb-4">
+          {loading && (
+            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> carregando…
+            </div>
+          )}
+
+          {error && (
+            <div className="my-6 rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-sm text-destructive-fg" data-testid="drawer-error">
+              {error}
+            </div>
+          )}
+
+          {!loading && !error && data && t && (
+            <>
+              {tab === 'visao' && (
+                <div className="space-y-5 py-4" data-testid="drawer-visao">
+                  <div>
+                    {t.description ? (
+                      <p className="whitespace-pre-wrap text-sm leading-relaxed">{t.description}</p>
+                    ) : (
+                      <p className="text-sm italic text-muted-foreground">Sem descrição.</p>
+                    )}
+                  </div>
+
+                  <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+                    <div><dt className="text-muted-foreground">Situação</dt><dd className="mt-0.5"><StatusPill status={t.status} /></dd></div>
+                    <div><dt className="text-muted-foreground">Prioridade</dt><dd className="mt-0.5 flex items-center gap-1.5"><PriorityDot priority={t.priority} />{t.priority.toUpperCase()}</dd></div>
+                    <div><dt className="text-muted-foreground">Responsável</dt><dd className="mt-0.5"><ActorSeal owner={t.owner} agents={agents} /></dd></div>
+                    <div><dt className="text-muted-foreground">Onda</dt><dd className="mt-0.5">{t.sprint ?? '—'}</dd></div>
+                    {t.story_points != null && <div><dt className="text-muted-foreground">Story points</dt><dd className="mt-0.5 tabular-nums">{t.story_points}</dd></div>}
+                    {t.due_date && <div><dt className="text-muted-foreground">Prazo</dt><dd className="mt-0.5 tabular-nums">{t.due_date}</dd></div>}
+                  </dl>
+
+                  {data.blockers.length > 0 && (
+                    <div data-testid="drawer-blockers">
+                      <h4 className="mb-2 flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        <GitBranch size={12} /> Bloqueada por ({data.blockers.length})
+                      </h4>
+                      <ul className="space-y-1.5">
+                        {data.blockers.map((b) => (
+                          <li key={b.task_id} className="flex items-center gap-2 text-xs">
+                            <span className="font-mono text-muted-foreground">{b.display_id}</span>
+                            <span className="min-w-0 flex-1 truncate">{b.title}</span>
+                            <StatusPill status={b.status} className="shrink-0" />
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {tab === 'atividade' && (
+                <div className="py-4" data-testid="drawer-atividade">
+                  {data.events.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">Sem atividade registrada.</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {data.events.map((e) => {
+                        const Icon = eventIcon(e.event_type);
+                        const label = EVENT_LABEL[e.event_type] ?? e.event_type;
+                        return (
+                          <li key={e.id} className="flex items-start gap-2 text-xs">
+                            <Icon size={13} className="mt-0.5 shrink-0 text-muted-foreground" />
+                            <div className="min-w-0 flex-1">
+                              <div>
+                                <span className="font-semibold">@{e.author ?? 'system'}</span>{' '}
+                                <span className="text-muted-foreground">{label}</span>
+                                {e.from_value && e.to_value && (
+                                  <>
+                                    {' '}<span className="text-muted-foreground">de</span>{' '}
+                                    <span className="font-mono text-muted-foreground">{e.from_value}</span>{' '}
+                                    <span className="text-muted-foreground">para</span>{' '}
+                                    <span className="font-mono text-foreground">{e.to_value}</span>
+                                  </>
+                                )}
+                              </div>
+                              {e.note && <p className="mt-0.5 italic text-muted-foreground">{e.note}</p>}
+                              <p className="mt-0.5 text-[10px] text-muted-foreground">{timeAgo(e.occurred_at)}</p>
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              )}
+
+              {tab === 'subtasks' && (
+                <div className="py-4" data-testid="drawer-subtasks">
+                  {data.subtasks.length === 0 ? (
+                    <p className="text-sm italic text-muted-foreground">Sem subtasks.</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {data.subtasks.map((s) => {
+                        const isDone = s.status === 'done' || s.status === 'cancelled';
+                        return (
+                          <li key={s.task_id} className={cn('flex items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50', isDone && 'opacity-60')}>
+                            <PriorityDot priority={s.priority} />
+                            <span className="font-mono text-muted-foreground">{s.display_id}</span>
+                            <span className={cn('min-w-0 flex-1 truncate', isDone && 'line-through')}>{s.title}</span>
+                            <StatusPill status={s.status} className="shrink-0" />
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {!loading && t && (
+          <div className="border-t px-4 py-2 text-[11px] text-muted-foreground">
+            Editar campos: <code className="font-mono">tasks-update {t.task_id}</code> via MCP, ou edite o SPEC e rode{' '}
+            <code className="font-mono">php artisan mcp:tasks:sync</code>.
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/resources/js/Pages/team-mcp/Tasks/_components/TaskDrawer.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/_components/TaskDrawer.tsx
@@ -3,7 +3,7 @@
 //   SEM dado fantasma: só situação (status) + atividade real (mcp_task_events) +
 //   vínculos (blocked_by resolvidos) + subtasks. Largura 560px (issue ≠ cadastro
 //   760px ADR 0185 — exceção registrada no visual-comparison).
-//   Locators resilientes via data-testid (NÚCLEO #7).
+//   Locators resilientes via data-testid (NÚCLEO #7). Layout via primitivos (ADR 0253).
 
 import { useEffect, useState } from 'react';
 import {
@@ -24,8 +24,9 @@ import {
   SheetTitle,
   SheetDescription,
 } from '@/Components/ui/sheet';
+import { Grid, Inline } from '@/Components/layout';
 import { cn } from '@/Lib/utils';
-import { ActorSeal, PriorityDot, StatusPill } from './taskBadges';
+import { ActorSeal, PriorityDot, TaskStatusPill } from './taskBadges';
 import { type Priority } from './taskTokens';
 
 interface TaskDetail {
@@ -175,10 +176,10 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
         data-testid="task-drawer"
       >
         <SheetHeader className="border-b">
-          <div className="flex items-start gap-2">
+          <Inline gap={2} align="start">
             <PriorityDot priority={t?.priority ?? 'p2'} className="mt-1.5" />
             <div className="min-w-0 flex-1">
-              <div className="flex flex-wrap items-center gap-2">
+              <Inline gap={2} wrap>
                 <span className="font-mono text-xs text-muted-foreground" data-testid="drawer-id">
                   {t?.display_id ?? taskId}
                 </span>
@@ -187,29 +188,31 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
                     {t.type}
                   </span>
                 )}
-                {t?.status && <StatusPill status={t.status} />}
+                {t?.status && <TaskStatusPill status={t.status} />}
                 {t?.is_blocked && (
                   <span className="inline-flex items-center gap-1 text-[10px] font-semibold text-destructive">
                     <Lock size={10} /> bloqueada
                   </span>
                 )}
-              </div>
+              </Inline>
               <SheetTitle className="mt-1 text-base leading-snug" data-testid="drawer-title">
                 {t?.title ?? <span className="italic text-muted-foreground">(sem título)</span>}
               </SheetTitle>
-              <SheetDescription className="mt-1 flex flex-wrap items-center gap-2 text-xs">
-                {t?.module && <span className="rounded bg-muted px-1.5 py-0.5">{t.module}</span>}
-                {t && <ActorSeal owner={t.owner} agents={agents} />}
-                {t?.sprint && <span className="text-muted-foreground">onda {t.sprint}</span>}
-                {t?.estimate_h ? <span className="text-muted-foreground tabular-nums">{t.estimate_h}h</span> : null}
+              <SheetDescription asChild>
+                <Inline gap={2} wrap className="mt-1 text-xs">
+                  {t?.module && <span className="rounded bg-muted px-1.5 py-0.5">{t.module}</span>}
+                  {t && <ActorSeal owner={t.owner} agents={agents} />}
+                  {t?.sprint && <span className="text-muted-foreground">onda {t.sprint}</span>}
+                  {t?.estimate_h ? <span className="text-muted-foreground tabular-nums">{t.estimate_h}h</span> : null}
+                </Inline>
               </SheetDescription>
             </div>
-          </div>
+          </Inline>
         </SheetHeader>
 
         {!loading && data && (
           <div className="-mt-2 border-b px-4">
-            <div className="flex gap-1" role="tablist">
+            <Inline gap={1} role="tablist">
               {tabs.map((tabItem) => {
                 const Icon = tabItem.icon;
                 const isActive = tab === tabItem.key;
@@ -222,7 +225,7 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
                     data-testid={`drawer-tab-${tabItem.key}`}
                     onClick={() => setTab(tabItem.key)}
                     className={cn(
-                      'relative flex items-center gap-1.5 px-3 py-2 text-xs font-medium transition-colors',
+                      'relative inline-flex items-center gap-1.5 px-3 py-2 text-xs font-medium transition-colors',
                       isActive
                         ? '-mb-px border-b-2 border-primary text-foreground'
                         : 'text-muted-foreground hover:text-foreground',
@@ -238,15 +241,15 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
                   </button>
                 );
               })}
-            </div>
+            </Inline>
           </div>
         )}
 
         <div className="flex-1 overflow-y-auto px-4 pb-4">
           {loading && (
-            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+            <Inline justify="center" className="py-12 text-sm text-muted-foreground">
               <Loader2 className="mr-2 h-4 w-4 animate-spin" /> carregando…
-            </div>
+            </Inline>
           )}
 
           {error && (
@@ -267,26 +270,26 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
                     )}
                   </div>
 
-                  <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
-                    <div><dt className="text-muted-foreground">Situação</dt><dd className="mt-0.5"><StatusPill status={t.status} /></dd></div>
-                    <div><dt className="text-muted-foreground">Prioridade</dt><dd className="mt-0.5 flex items-center gap-1.5"><PriorityDot priority={t.priority} />{t.priority.toUpperCase()}</dd></div>
-                    <div><dt className="text-muted-foreground">Responsável</dt><dd className="mt-0.5"><ActorSeal owner={t.owner} agents={agents} /></dd></div>
-                    <div><dt className="text-muted-foreground">Onda</dt><dd className="mt-0.5">{t.sprint ?? '—'}</dd></div>
-                    {t.story_points != null && <div><dt className="text-muted-foreground">Story points</dt><dd className="mt-0.5 tabular-nums">{t.story_points}</dd></div>}
-                    {t.due_date && <div><dt className="text-muted-foreground">Prazo</dt><dd className="mt-0.5 tabular-nums">{t.due_date}</dd></div>}
-                  </dl>
+                  <Grid cols={2} gap={2} className="text-xs">
+                    <div><div className="text-muted-foreground">Situação</div><div className="mt-0.5"><TaskStatusPill status={t.status} /></div></div>
+                    <div><div className="text-muted-foreground">Prioridade</div><div className="mt-0.5 inline-flex items-center gap-1.5"><PriorityDot priority={t.priority} />{t.priority.toUpperCase()}</div></div>
+                    <div><div className="text-muted-foreground">Responsável</div><div className="mt-0.5"><ActorSeal owner={t.owner} agents={agents} /></div></div>
+                    <div><div className="text-muted-foreground">Onda</div><div className="mt-0.5">{t.sprint ?? '—'}</div></div>
+                    {t.story_points != null && <div><div className="text-muted-foreground">Story points</div><div className="mt-0.5 tabular-nums">{t.story_points}</div></div>}
+                    {t.due_date && <div><div className="text-muted-foreground">Prazo</div><div className="mt-0.5 tabular-nums">{t.due_date}</div></div>}
+                  </Grid>
 
                   {data.blockers.length > 0 && (
                     <div data-testid="drawer-blockers">
-                      <h4 className="mb-2 flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      <h4 className="mb-2 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
                         <GitBranch size={12} /> Bloqueada por ({data.blockers.length})
                       </h4>
                       <ul className="space-y-1.5">
                         {data.blockers.map((b) => (
-                          <li key={b.task_id} className="flex items-center gap-2 text-xs">
+                          <li key={b.task_id} className="inline-flex w-full items-center gap-2 text-xs">
                             <span className="font-mono text-muted-foreground">{b.display_id}</span>
                             <span className="min-w-0 flex-1 truncate">{b.title}</span>
-                            <StatusPill status={b.status} className="shrink-0" />
+                            <TaskStatusPill status={b.status} className="shrink-0" />
                           </li>
                         ))}
                       </ul>
@@ -305,7 +308,7 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
                         const Icon = eventIcon(e.event_type);
                         const label = EVENT_LABEL[e.event_type] ?? e.event_type;
                         return (
-                          <li key={e.id} className="flex items-start gap-2 text-xs">
+                          <li key={e.id} className="inline-flex w-full items-start gap-2 text-xs">
                             <Icon size={13} className="mt-0.5 shrink-0 text-muted-foreground" />
                             <div className="min-w-0 flex-1">
                               <div>
@@ -340,11 +343,11 @@ export default function TaskDrawer({ taskId, agents, onClose }: Props) {
                       {data.subtasks.map((s) => {
                         const isDone = s.status === 'done' || s.status === 'cancelled';
                         return (
-                          <li key={s.task_id} className={cn('flex items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50', isDone && 'opacity-60')}>
+                          <li key={s.task_id} className={cn('inline-flex w-full items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50', isDone && 'opacity-60')}>
                             <PriorityDot priority={s.priority} />
                             <span className="font-mono text-muted-foreground">{s.display_id}</span>
                             <span className={cn('min-w-0 flex-1 truncate', isDone && 'line-through')}>{s.title}</span>
-                            <StatusPill status={s.status} className="shrink-0" />
+                            <TaskStatusPill status={s.status} className="shrink-0" />
                           </li>
                         );
                       })}

--- a/resources/js/Pages/team-mcp/Tasks/_components/taskBadges.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/_components/taskBadges.tsx
@@ -18,8 +18,8 @@ export function PriorityDot({ priority, className }: { priority: Priority; class
   );
 }
 
-/** Status Stripe-style: dot colorido + label neutro (sem bg-fill). */
-export function StatusPill({ status, className }: { status: string; className?: string }) {
+/** Status Stripe-style: dot colorido + label neutro (sem bg-fill). Nome único (reuse-gate). */
+export function TaskStatusPill({ status, className }: { status: string; className?: string }) {
   const m = statusMeta(status);
   return (
     <span

--- a/resources/js/Pages/team-mcp/Tasks/_components/taskBadges.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/_components/taskBadges.tsx
@@ -1,0 +1,51 @@
+// Forja PR-1 — componentes visuais da tela Tasks (lista + quadro + drawer).
+// Tokens/helpers puros vivem em ./taskTokens (separação p/ react-refresh).
+// DS v6: SEM cor crua. Status estilo Stripe (dot + texto), nunca bg-fill (PT-01).
+
+import { Bot, User } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import { PRIO_DOT, PRIO_LABEL, statusMeta, type Priority } from './taskTokens';
+
+export function PriorityDot({ priority, className }: { priority: Priority; className?: string }) {
+  const p = PRIO_DOT[priority] ? priority : 'p2';
+  return (
+    <span
+      aria-label={`Prioridade ${PRIO_LABEL[p]}`}
+      title={PRIO_LABEL[p]}
+      data-testid="prio-dot"
+      className={cn('inline-block h-2 w-2 shrink-0 rounded-full', PRIO_DOT[p], className)}
+    />
+  );
+}
+
+/** Status Stripe-style: dot colorido + label neutro (sem bg-fill). */
+export function StatusPill({ status, className }: { status: string; className?: string }) {
+  const m = statusMeta(status);
+  return (
+    <span
+      data-testid="status-pill"
+      className={cn('inline-flex items-center gap-1.5 text-xs text-muted-foreground', className)}
+    >
+      <span className={cn('inline-block h-1.5 w-1.5 shrink-0 rounded-full', m.dot)} />
+      {m.label}
+    </span>
+  );
+}
+
+/** Selo de proveniência: agente (Bot, roxo) vs humano (User, neutro). Transversal §3. */
+export function ActorSeal({ owner, agents, className }: { owner: string | null; agents: string[]; className?: string }) {
+  if (!owner) return <span className={cn('text-xs text-muted-foreground/60', className)}>—</span>;
+  const isAgent = agents.includes(owner.toLowerCase());
+  const Icon = isAgent ? Bot : User;
+  return (
+    <span
+      data-testid="actor-seal"
+      data-actor={isAgent ? 'agent' : 'human'}
+      title={isAgent ? `Agente: ${owner}` : `Humano: ${owner}`}
+      className={cn('inline-flex items-center gap-1 text-xs text-muted-foreground', className)}
+    >
+      <Icon size={12} aria-hidden className={isAgent ? 'text-primary' : 'text-muted-foreground'} />
+      <span className="truncate">{owner}</span>
+    </span>
+  );
+}

--- a/resources/js/Pages/team-mcp/Tasks/_components/taskTokens.ts
+++ b/resources/js/Pages/team-mcp/Tasks/_components/taskTokens.ts
@@ -1,0 +1,36 @@
+// Forja PR-1 — tokens/helpers puros da tela Tasks (sem JSX → fast-refresh friendly).
+// DS v6: hues Forja → tokens semânticos.
+//   P0 destructive(25°) · P1 warning(60°) · P2 primary/roxo(295°) · P3 info(250°).
+
+export type Priority = 'p0' | 'p1' | 'p2' | 'p3';
+
+export const PRIO_DOT: Record<Priority, string> = {
+  p0: 'bg-destructive',
+  p1: 'bg-warning',
+  p2: 'bg-primary',
+  p3: 'bg-info',
+};
+
+export const PRIO_LABEL: Record<Priority, string> = {
+  p0: 'P0', p1: 'P1', p2: 'P2', p3: 'P3',
+};
+
+export interface StatusMeta { label: string; dot: string }
+
+// Dot colorido (token de cor garantido: info/warning/success/destructive/foreground).
+const STATUS_META: Record<string, StatusMeta> = {
+  backlog:   { label: 'Backlog',   dot: 'bg-foreground/25' },
+  todo:      { label: 'A fazer',   dot: 'bg-foreground/40' },
+  doing:     { label: 'Fazendo',   dot: 'bg-info' },
+  review:    { label: 'Revisão',   dot: 'bg-warning' },
+  done:      { label: 'Concluído', dot: 'bg-success' },
+  blocked:   { label: 'Bloqueada', dot: 'bg-destructive' },
+  cancelled: { label: 'Cancelada', dot: 'bg-foreground/20' },
+};
+
+export function statusMeta(status: string): StatusMeta {
+  return STATUS_META[status] ?? { label: status, dot: 'bg-foreground/40' };
+}
+
+/** Ordem canônica de status (ativos primeiro) — usada em agrupamento e sort. */
+export const STATUS_ORDER = ['doing', 'review', 'todo', 'blocked', 'backlog', 'done', 'cancelled'];


### PR DESCRIPTION
## Forja PR-1 — Tasks (re-skin DS v6)

Primeira onda da absorção **Forja → TeamMcp**: re-skin de `/team-mcp/tasks` na gramática Forja (protótipo Cowork) sob DS v6, **preservando 100% das features atuais**. Não é módulo novo nem migração Blade→React — a tela já era Inertia.

### O que muda
**Frontend** (`resources/js/Pages/team-mcp/Tasks/`)
- **Backlog** → lista densa agrupável (onda/fase/papel/prioridade/módulo), grupos colapsáveis, densidade compacta/normal.
- **Quadro** → kanban todo/doing/review/done com drag→`PATCH` otimista (idêntico ao atual).
- **Drawer de issue** (560px, read-only): Visão (descrição/meta/vínculos `blocked_by`) · Atividade (`mcp_task_events` real) · Subtasks. Abre via `?task=ID`.
- Teclado J/K/↵/X + `/` busca + Esc; ⌘K = palette global do Shell.
- Seleção em lote → `BulkActionBar`; selo de proveniência **agente vs humano** (`mcp_actors`).
- DS v6: remove `rounded-xl` + cores cruas → tokens semânticos + status Stripe-dot; `Checkbox` do DS; `data-testid` como locator.

**Backend** (`Modules/TeamMcp`)
- `TasksAdminController@show` → `GET /team-mcp/tasks/{id}/detail` (read-only): task + `mcp_task_events` + subtasks + blockers resolvidos. **Sem dado fantasma.**
- Payload das linhas ganha `display_id`/`type`; defer `agents` (atores `ai_agent`).

### Processo / governança
- mwart-comparative F1.5: [`tasks-visual-comparison.md`](memory/requisitos/TeamMcp/tasks-visual-comparison.md) (15 dimensões) + [charter](resources/js/Pages/team-mcp/Tasks/Index.charter.md), **aprovado [W] 2026-06-16**.
- Soberania: merge é decisão **[W2]**; não toca constituição/ADR/token; token raw nunca persistido/logado.

### Verificação local
- ✅ `typecheck` 0 erros nos arquivos da PR
- ✅ `eslint` 0 erros · `lint-baseline` sem regressão (−191)
- ✅ `conformance-gate` · `foundation-guard` · `php -l`
- ⏳ Pest/E2E/visual-regression rodam no CI (sem stack local). Smoke real pós-merge.

### Decisões [W] registradas (AskUserQuestion)
drawer 560px · atividade real (endpoint) · lista agrupável module-local · selo Bot/User neutro · breadcrumb "Equipe".

### Premissa corrigida vs prompt original (já decidido com [W])
- **PR-3 Scorecard:** a Page **não existe** (controller renderiza componente ausente) → será **criar**, não re-skin.
- **PR-5 Triagem:** já existe `ProjectMgmt/Triage` → **evoluir a existente** (sem rota duplicada).
- **PR-6 ProjectMgmt:** **não é stub** (11 páginas + tasks ativas, hub já consolidado) → **manter + só alinhar visual**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
