### PR TITLE
docs(adr): proposta ingestão WhatsApp perda-zero (padrão profissional pós-#2726)

### DIFF
--- a/memory/decisions/proposals/whatsapp-ingestao-perda-zero.md
+++ b/memory/decisions/proposals/whatsapp-ingestao-perda-zero.md
@@ -1,0 +1,99 @@
+---
+status: proposal
+title: Ingestão WhatsApp à prova de perda (zero-loss) — padrão profissional pós-#2726
+proposed_by: Wagner + Claude
+proposed_at: 2026-06-16
+relates_to:
+  - 0204-whatsmeow-driver-substituto-baileys
+  - 0135-omnichannel-inbox-arquitetura
+  - 0093-multi-tenant-isolation-tier-0
+---
+
+# PROPOSAL — Ingestão WhatsApp à prova de perda (zero-loss)
+
+> **Status:** `proposal` — Wagner promove pra ADR aceita após revisão. Construção
+> **fase a fase, cada uma testada** (a lição do #2726: mudança na via crítica sem
+> verificar = 3 dias mudo). Decisão de ambição: Wagner pediu o **padrão completo
+> (perda zero)** em 2026-06-16.
+
+## Contexto
+
+Incidente 2026-06-16 (#2726): o recebimento de WhatsApp ficou morto 3 dias sem
+ninguém ver. O fix + a detecção (sentinela `whatsapp_inbound_flow`, PR #2813)
+já estão no ar, mas o padrão atual é **piso, não profissional**:
+
+- **Detecção lenta:** ~6h (threshold de silêncio) — não dá pra "perder mensagem
+  é coisa séria".
+- **Perde na falha:** webhook recusado vai pra fila `webhook_errors`
+  fire-and-forget do WuzAPI → **descartado** (sem replay).
+- Sem auto-cura, sem fallback ativo pro whatsmeow, sem auto-teste do alarme.
+
+Pra quando clientes reais dependerem disso (hoje é piloto/teste), o alvo é o que
+Intercom/Front/Zendesk fazem: **não perder, ponto.**
+
+## Decisão proposta — 5 camadas
+
+### SLOs alvo
+- **Perda de mensagem: 0** (toda inbound eventualmente visível na Caixa).
+- **Detecção de quebra: < 5 min** (definitiva, sem falso-alarme).
+- **Recuperação: auto** pras causas conhecidas; **humano avisado < 5 min** + runbook.
+
+### Camada 1 — Canário (detecção <5min, definitiva) · `whatsapp:webhook-canary`
+Cron a cada ~5 min posta um evento sintético benigno (`Presence`, que o controller
+ACKa em 200 SEM criar mensagem — provado em `WhatsmeowWebhookAuthTest`) na própria
+URL pública com o `?wh=` secret e confere **200**. Não-200 → ALERT imediato (`mcp_alertas`).
+Pega a classe do #2726 (app recusando) em 5 min. **Combinado com a janela de retry do
+daemon (~10-15 min), a maioria das falhas é detectada+corrigida ANTES de qualquer
+mensagem ser descartada → perda zero sem reescrever durabilidade.** O canário também
+É o auto-teste do alarme (camada 5).
+
+### Camada 2 — Backfill/reconciliação (a rede final + recupera os 3 dias) ⭐
+O WuzAPI expõe **`GET /session/history`** (sync de histórico por chat, parâmetros
+count/chat/oldest-id) → emite eventos `HistorySync`. Plano:
+1. Controller + Job passam a tratar evento **`HistorySync`** (extrai mensagens do
+   payload, faz upsert dedupando por `provider_message_id` — idempotente, já é a chave UNIQUE).
+2. Command `whatsapp:backfill-inbound {channel} --since=` que dispara `/session/history`
+   pra cada conversa ativa e reconcilia o que faltou.
+3. Roda **on-recovery** (quando o canário detecta que voltou) + agendado defensivo.
+**Bônus:** o mesmo mecanismo **recupera as mensagens dos 3 dias do #2726** — resolve o
+"backlog perdido" da US-WA-311 de graça.
+
+### Camada 3 — Auto-cura
+Sessão caiu (`Disconnected`/stream error) → `WhatsmeowReconciler` reconecta sozinho
+(já resolve pending-pair; estender pra reconexão proativa). Falha transitória de
+webhook → a retry nativa do daemon já cobre.
+
+### Camada 4 — Sem ponto único: fallback Meta Cloud
+Fiar o framework de fallback que já existe (`config('whatsapp.fallback')`,
+`auto_switch_after_status=degraded`) pro driver whatsmeow — quando o canal degrada,
+roteia envio/recebimento pela API **oficial Meta Cloud**. Tira o daemon não-oficial
+de ponto único de falha total.
+
+### Camada 5 — Auto-teste do alarme
+O canário (camada 1) PROVA continuamente que o caminho + o alerta funcionam. Sem isso,
+o monitor pode apodrecer mentindo "verde" (raiz do #2726). Opcional: um 2º canário
+no CT 100 testando o caminho daemon→app (rede), não só app→app.
+
+## Faseamento (cada fase = 1 PR testado, pode parar entre fases)
+1. **Canário** (camada 1+5) — maior salto isolado: detecção <5min + perda-zero pra
+   maioria das falhas. Baixo risco (só observa, não toca a via de recebimento).
+2. **Backfill/HistorySync** (camada 2) — perda-zero pra qualquer duração + recupera os 3 dias.
+   Risco médio (toca controller/Job — testar com fixture real, contract-test).
+3. **Auto-cura + fallback Meta** (camadas 3+4) — resiliência. Risco médio-alto (Reconciler
+   + roteamento) — staging primeiro.
+
+## Estratégia de teste (anti-#2726)
+- Cada fase com Pest cobrindo o caminho REAL (fixture do emissor, não credencial forjada —
+  padrão do PR #2814).
+- Camada 2/3/4 passam por **staging** antes de prod (`criar-staging`).
+- Smoke pós-deploy: o próprio canário confirma 200 em prod logo após o deploy.
+
+## Consequências
+- **+:** perda zero, detecção em minutos, recupera os 3 dias, daemon deixa de ser SPOF.
+- **−:** mais código na via crítica (mitigado por faseamento + teste + staging); `/session/history`
+  pode trazer duplicatas (mitigado pelo dedup `provider_message_id`); custo de CI dos canários (trivial).
+- **Tier 0 preservado:** backfill respeita `business_id` (dedup + escopo por channel/business).
+
+## Métrica de pronto
+`jana:health-check` ganha `whatsapp_inbound_canary` (verde = caminho provado <5min) e a
+contagem de mensagens reconciliadas pelo backfill. Painel: 0 perdidas em 30d.


### PR DESCRIPTION
## Blueprint: padrão profissional "perda zero" pro WhatsApp (pós-#2726)

Wagner pediu o **padrão completo (perda zero)** — "perder mensagem é coisa séria". Esta proposta de ADR é o blueprint executável pra construir fase a fase, **cada uma testada** (a lição do #2726: não mexer na via crítica sem verificar).

**5 camadas** (SLO: 0 perdidas · detecção <5min · recuperação auto):
1. **Canário** (<5min, definitivo) — combinado com a janela de retry do daemon (~10-15min) = perda-zero pra maioria das falhas, sem reescrever durabilidade.
2. **Backfill via `GET /session/history`** (confirmado que existe) — rede final pra qualquer outage **+ recupera as mensagens dos 3 dias do #2726** (2 em 1).
3. Auto-cura (reconexão). 4. Fallback Meta Cloud (tira o daemon de SPOF). 5. Auto-teste do alarme.

Faseamento + estratégia de teste (fixture real + staging) no doc. Não é pra mergear-e-rodar — é o plano pra Wagner revisar e a gente construir testado.

Refs: incidente 2026-06-16 (#2726) · review adversarial · US-WA-311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
