### PR TITLE
feat(team-mcp): Forja PR-2 — re-skin DS v6 da tela CcSessions

### DIFF
--- a/memory/requisitos/TeamMcp/cc-sessions-visual-comparison.md
+++ b/memory/requisitos/TeamMcp/cc-sessions-visual-comparison.md
@@ -1,0 +1,84 @@
+---
+slug: teammcp-cc-sessions-visual-comparison
+title: "TeamMcp — Comparativo visual da tela CcSessions (Atividade CC)"
+type: visual-comparison
+module: TeamMcp
+status: approved
+approved_by: wagner
+approved_at: 2026-06-16
+date: 2026-06-16
+canon_reference: forja-cowork (forja-page.jsx — view .fj-changelog/.fj-feed)
+blade_source: "N/A — tela já é Inertia (re-skin DS v6)"
+inertia_target: resources/js/Pages/team-mcp/CcSessions/Index.tsx
+pr_branch: feat/forja-pr2-ccsessions
+---
+
+# TeamMcp — Comparativo visual · tela **CcSessions** (Atividade CC)
+
+> **F1.5 do MWART V4** · PR-2 da onda **Forja**. Re-skin DS v6 de `/team-mcp/cc-sessions` (`CcSessionsController` → `team-mcp/CcSessions/Index`). Pré-aprovado pelo padrão Forja (Wagner "pode seguir" 2026-06-16). **Frontend-only** — backend (`index`/`show`/`search`) preservado.
+
+## Contexto
+
+Hoje a tela é split-panel (lista + preview lateral) com paginator 25/pg, filtros (busca FULLTEXT summary, dev, status, projeto), KPIs (sessões/devs/custo/top tools) e thread no preview. O PR-2 conforma à gramática **Changelog/Atividade** da Forja: **feed cronológico** + **drawer lateral** pra thread, preservando 100% das features. Selo **agente vs humano**: toda sessão é atividade de **agente (Claude Code)** em nome de um **humano (dev)** — marcado explicitamente (transversal §3).
+
+## Princípio de override (UI-0013) — canon vence
+
+| Aspecto | Atual | Forja | Decisão |
+|---|---|---|---|
+| Cores das bolhas/tools | paleta crua (`bg-blue-50`, `bg-green-100`…) | hue por tipo | **tokens semânticos /opacity** (primary/info/success/warning/muted) |
+| Status sessão | `Badge` bg-fill verde/cinza | dot | **dot Stripe** + label |
+| Detalhe | split-panel inline | drawer lateral | **drawer** (Sheet) 640px (thread precisa largura) |
+| Header | PageHeader custom | — | PageHeader shared, breadcrumb "Equipe" |
+
+## Matriz de preservação (não perder)
+
+| Feature | PR-2 |
+|---|---|
+| Paginator 25/pg + links | ✅ |
+| Filtros user_id/from/to/q(FULLTEXT summary)/status/project | ✅ (Components/ui/select) |
+| KPIs sessions_hoje/total/custo_hoje/30d/devs_ativos/tools_top | ✅ |
+| Detalhe `show` (thread ≤500 + truncated flag) | ✅ no drawer |
+| Busca debounce 350ms | ✅ |
+| RBAC read_all vs próprio · curate | ✅ (props.permissions intactas) |
+| Atalhos j/k/↵/Esc/`/` | ✅ |
+
+## Restrição de dados — sem dado fantasma
+
+Projeta só o que `index`/`show` retornam (dev, projeto, branch, cc_version, entrypoint, started/ended, msgs/tokens/custo, status, summary, thread). Nada inventado. Search profundo cross-dev (`/cc-sessions/search` em content_text) **não** entra no PR-2 (endpoint existe mas não estava na UI; fica pra PR futura).
+
+## 15 dimensões (Atual · Forja · Decisão DS v6)
+
+| # | Dimensão | Atual | Forja | Decisão |
+|---|---|---|---|---|
+| 1 | Layout | split list+preview | feed + drawer | PageHeader › KPIs › Toolbar › **feed cronológico** › Drawer thread |
+| 2 | Hierarquia | tabela densa | feed item (dot+ref+resumo+meta) | feed item por sessão; sem ação primária (read-only) |
+| 3 | Densidade | linhas tabela | feed item ~64px | item compacto com summary line-clamp-2 |
+| 4 | Iconografia | lucide misto | dot+SVG | lucide (`Bot`/`User` selo, `FolderOpen`, `GitBranch`) |
+| 5 | Estados | empty/loading/sel | idem | empty (sem ingest) / busca-vazia / loading skeleton / selected / erro |
+| 6 | Atalhos | j/k/Esc// | idem | **preservar** j/k/↵/Esc/`/` |
+| 7 | Persistência | filtros URL | — | filtros na URL (compartilhável) — mantém |
+| 8 | Shared | PageHeader/Kpi | custom | PageHeader, KpiGrid/Card, Sheet (drawer); feed module-local |
+| 9 | Tipografia num | mono custo/tokens | mono | `tabular-nums` custo/tokens/msgs; ramp `--fs` |
+| 10 | Espaçamento | py-1.5 | gap feed | gap-0 entre items com divisória; drawer px-4 |
+| 11 | Cores | **cru** (typeStyle/toolColor) | hue | **tokens semânticos** (bolha por tipo via /opacity; tool = chip neutro) |
+| 12 | Microinterações | hover row | dot feed | hover bg-muted; drawer slide-in (--ease); focus ring |
+| 13 | Ref aprovada | — | Forja Cowork | ✅ |
+| 14 | Benchmark | — | Linear/Vercel activity, GitHub commits feed | feed cronológico de atividade |
+| 15 | Persona | — | Wagner+time, desktop | (1) escanear quem fez o quê/quanto custou, (2) selo agente vs humano, (3) thread sob demanda |
+
+## Decisões [W] (pré-aprovado "pode seguir")
+
+1. **Drawer 640px** pra thread (mais largo que issue 560 — conteúdo de conversa).
+2. **Feed** substitui split-panel (gramática Changelog Forja).
+3. **Tool/bolha** = tokens semânticos (perde paleta por-tool; ganha DS — bolha por tipo via /opacity, tool chip neutro).
+4. **Selo**: sessão = agente (Claude Code, `Bot` + cc_version) em nome do humano (`User` + dev). Agente nunca se disfarça de humano.
+5. Breadcrumb "Copiloto" → "Equipe".
+
+## Gates antes do F3
+- [x] Padrão Forja aprovado ([W] "pode seguir" 2026-06-16).
+- [x] PROCESSO_MEMORIA_CC §5 + NÚCLEO lidos (PR-1).
+- [x] Charter `Index.charter.md` ao lado.
+- [ ] CI: typecheck + eslint/lint-baseline + conformance + foundation + UI-Judge.
+
+---
+**Status:** `approved` — implementado no PR `feat/forja-pr2-ccsessions`.

--- a/resources/js/Pages/team-mcp/CcSessions/Index.charter.md
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.charter.md
@@ -1,0 +1,68 @@
+---
+page: /team-mcp/cc-sessions
+component: resources/js/Pages/team-mcp/CcSessions/Index.tsx
+owner: wagner
+status: draft
+last_validated: "2026-06-16"
+parent_module: TeamMcp
+related_adrs:
+  - "0053-mcp-server-governanca-como-produto"
+  - "0081-identity-mesh-mcp-actors"
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+  - "0104-processo-mwart-canonico-unico-caminho"
+  - "0114-prototipo-ui-cowork-loop-formalizado"
+related_ficha: memory/requisitos/TeamMcp/cc-sessions-visual-comparison.md
+tier: A
+charter_version: 1
+---
+
+# Page Charter — `/team-mcp/cc-sessions` (DRAFT)
+
+> Criado no PR **Forja PR-2** (re-skin DS v6, 2026-06-16). Persona: Wagner [W] (admin, `jana.cc.read.all`) + cada dev (vê só as próprias). Backend: `CcSessionsController` (Inertia::defer). Ref visual: [cc-sessions-visual-comparison.md](../../../../memory/requisitos/TeamMcp/cc-sessions-visual-comparison.md).
+
+## Mission
+
+KB read-only de **atividade do Claude Code do time** (sessões `mcp_cc_*`): feed cronológico de sessões + drawer de thread, na gramática Changelog Forja sob DS v6. Projeção fiel — **sem dado fantasma**. Operação primária: escanear quem rodou o quê, quanto custou, e abrir a thread sob demanda. Toda sessão é **agente (Claude Code)** em nome de um **humano (dev)** — marcado explicitamente.
+
+## Goals — Features (faz)
+
+- **Feed cronológico** de sessões (dot de status + dev + projeto/branch + data relativa + summary + meta msgs/tokens/custo/duração).
+- **Drawer** (640px) com a thread (`show`): header meta + summary + mensagens (≤500, flag truncated), bolhas por tipo (DS-clean), tool chips.
+- **Filtros**: busca FULLTEXT summary (debounce 350ms), dev (se `read_all`), status, projeto. Limpar.
+- **KPIs**: sessões hoje/total, devs ativos hoje, custo hoje/30d, top tools.
+- **Paginator** 25/pg + links.
+- **Selo agente vs humano**: `Bot` (Claude Code + cc_version) + `User` (dev).
+- **Atalhos** J/K navegar · Enter/click abre drawer · `/` busca · Esc fecha.
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ Busca profunda cross-dev em `content_text` (`/cc-sessions/search` existe como API; UI fica pra PR futura).
+- ❌ Editar/curar sessão (curate flag preservada, sem UI de mutação no PR-2).
+- ❌ Mostrar PII/segredo de thread além do que `show` já retorna.
+- ❌ Tocar AppShellV2/PageHeader canon.
+
+## UX targets
+
+- DS v6: tokens semânticos (bolha por tipo via /opacity, status Stripe-dot), **sem cor crua**, ramp `--fs`, `tabular-nums` em custo/tokens/msgs.
+- Drawer 640px (thread precisa largura); slide-in `--ease`; loading/empty/erro.
+- Locators `data-testid`.
+
+## Anti-hooks (NÃO faz automaticamente)
+
+- ❌ NÃO escreve nada (tela 100% read-only).
+- ❌ NÃO loga/expõe PII além do `show`; respeita RBAC `acessivelPara` no backend.
+- ❌ NÃO usa `<select>` nativo (Components/ui).
+
+## Restrições Tier 0
+
+- Permissão `copiloto.cc.read.team` no construtor; `jana.cc.read.all` libera ver todos, senão só próprias (backend `acessivelPara`).
+- Multi-tenant: scope de acesso é do backend (não reimplementar no front).
+
+## Métricas de sucesso (validação Wagner)
+
+- ✅ Feed lista sessões em ordem cronológica com custo/msgs corretos.
+- ✅ Click/Enter abre drawer com a thread real (≤500, aviso truncado).
+- ✅ Selo distingue Claude Code (agente) do dev (humano).
+- ✅ Filtros + busca + paginação preservados; RBAC intacto.
+- ✅ Sem cor crua (conformance/foundation/eslint-baseline verdes).

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -1,31 +1,32 @@
 // @memcofre
 //   tela: /team-mcp/cc-sessions
-//   module: TeamMcp (split do Copiloto, ADR pendente)
-//   stories: MEM-CC-UI-1 (SPEC memory/requisitos/Copiloto/SPEC-cc-sessions.md)
+//   module: TeamMcp (split do Copiloto)
+//   forja: PR-2 re-skin DS v6 — visual-comparison em
+//          memory/requisitos/TeamMcp/cc-sessions-visual-comparison.md (approved [W] 2026-06-16)
+//   stories: MEM-CC-UI-1 (SPEC-cc-sessions)
 //   permissao: copiloto.cc.read.team
 //
-// V1: lista de sessões CC do time + preview lateral (split layout) com thread.
-// Reaproveita patterns de /copiloto/admin/memoria.
+// Feed cronológico de sessões Claude Code do time (gramática Changelog Forja) +
+// drawer lateral pra thread. Toda sessão = agente (Claude Code) em nome de humano (dev).
+// Atalhos: J/K navegar · Enter/click abre drawer · / busca · Esc fecha.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
-import { useEffect, useRef, useState, type ReactNode } from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { Bot, GitBranch, User } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
-import { Badge } from '@/Components/ui/badge';
-import {
-  Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
-} from '@/Components/ui/select';
 import { Label } from '@/Components/ui/label';
-import { ScrollArea } from '@/Components/ui/scroll-area';
-import { FolderOpen, Inbox } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
-import { toast } from 'sonner';
+import EmptyState from '@/Components/shared/EmptyState';
+import { cn } from '@/Lib/utils';
+import SessionDrawer from './_components/SessionDrawer';
+import { brl, fmtDuration, fmtRelative, num, sessionStatusMeta } from './_components/sessionTokens';
 
-interface Dev { id: number; nome: string; }
+interface Dev { id: number; nome: string }
 
 interface Session {
   id: number;
@@ -77,94 +78,30 @@ interface Kpis {
 }
 
 interface Props {
-  sessions: Paginator<Session>;
+  // sessions/kpis/devs/projects deferidos → undefined no 1º paint (default-guard).
+  sessions?: Paginator<Session>;
   filters: Filters;
-  kpis: Kpis;
-  devs: Dev[];
-  projects: string[];
+  kpis?: Kpis;
+  devs?: Dev[];
+  projects?: string[];
   permissions: { read_all: boolean; curate: boolean };
 }
 
-interface Message {
-  id: number;
-  msg_uuid: string;
-  parent_uuid: string | null;
-  msg_type: 'user' | 'assistant' | 'tool_use' | 'tool_result' | 'attachment' | 'hook' | 'system';
-  role: string | null;
-  tool_name: string | null;
-  content_text: string | null;
-  tokens_in: number | null;
-  tokens_out: number | null;
-  cache_read: number | null;
-  cost_usd: number;
-  ts: string | null;
-}
+const ALL = '__all__';
 
-interface SessionDetail {
-  session: Session;
-  messages: Message[];
-  truncated: boolean;
-}
+function CcSessionsIndex({ sessions, filters, kpis, devs, projects, permissions }: Props) {
+  const isLoading = !sessions || !kpis;
+  const sData = useMemo(() => sessions?.data ?? [], [sessions]);
+  const k: Kpis = kpis ?? { sessions_hoje: 0, sessions_total: 0, custo_hoje_brl: 0, custo_30d_brl: 0, devs_ativos_hoje: 0, tools_top: [] };
+  const devList = devs ?? [];
+  const projList = projects ?? [];
 
-const brl = (v: number) =>
-  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
-
-const num = (v: number) => new Intl.NumberFormat('pt-BR').format(v ?? 0);
-
-function fmtDateTime(iso: string | null): string {
-  if (!iso) return '—';
-  return new Date(iso).toLocaleString('pt-BR', {
-    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
-  });
-}
-
-function fmtRelative(iso: string | null): string {
-  if (!iso) return '—';
-  const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
-  if (diffSec < 60) return 'agora';
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}min atrás`;
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h atrás`;
-  if (diffSec < 86400 * 7) return `${Math.floor(diffSec / 86400)}d atrás`;
-  return fmtDateTime(iso);
-}
-
-function fmtDuration(start: string | null, end: string | null): string {
-  if (!start) return '—';
-  const startMs = new Date(start).getTime();
-  const endMs = end ? new Date(end).getTime() : Date.now();
-  const sec = Math.floor((endMs - startMs) / 1000);
-  if (sec < 60) return `${sec}s`;
-  if (sec < 3600) return `${Math.floor(sec / 60)}m${sec % 60}s`;
-  return `${Math.floor(sec / 3600)}h${Math.floor((sec % 3600) / 60)}m`;
-}
-
-function toolColor(tool: string | null): string {
-  const map: Record<string, string> = {
-    Bash:      'bg-green-100 text-green-800',
-    Edit:      'bg-orange-100 text-orange-800',
-    Read:      'bg-gray-100 text-gray-700',
-    Grep:      'bg-blue-100 text-blue-800',
-    Glob:      'bg-blue-100 text-blue-800',
-    Write:     'bg-purple-100 text-purple-800',
-    WebSearch: 'bg-cyan-100 text-cyan-800',
-    WebFetch:  'bg-cyan-100 text-cyan-800',
-    Agent:     'bg-pink-100 text-pink-800',
-    Task:      'bg-pink-100 text-pink-800',
-  };
-  return map[tool ?? ''] ?? 'bg-gray-100 text-gray-700';
-}
-
-function CcSessionsIndex(props: Props) {
-  const { sessions, filters, kpis, devs, projects, permissions } = props;
   const [search, setSearch] = useState(filters.q ?? '');
   const [selectedUuid, setSelectedUuid] = useState<string | null>(null);
-  const [detail, setDetail] = useState<SessionDetail | null>(null);
-  const [loadingDetail, setLoadingDetail] = useState(false);
-  const [previewOpen, setPreviewOpen] = useState(false);
-  const previewRef = useRef<HTMLDivElement | null>(null);
+  const [openUuid, setOpenUuid] = useState<string | null>(null);
   const searchRef = useRef<HTMLInputElement | null>(null);
 
-  // Debounce busca
+  // Debounce busca → server (FULLTEXT summary)
   useEffect(() => {
     if (search === (filters.q ?? '')) return;
     const t = setTimeout(() => applyFilter({ q: search }), 350);
@@ -172,377 +109,217 @@ function CcSessionsIndex(props: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search]);
 
-  // Scroll-to-top quando muda doc
+  // Atalhos J/K/Enter/Esc//
   useEffect(() => {
-    if (detail && previewRef.current) previewRef.current.scrollTop = 0;
-  }, [detail?.session?.session_uuid]);
-
-  // Atalhos j/k/Esc/`/`
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement)?.tagName;
-      const isTyping = tag === 'INPUT' || tag === 'TEXTAREA' || (e.target as HTMLElement)?.isContentEditable;
-      if (e.key === '/' && !isTyping) { e.preventDefault(); searchRef.current?.focus(); return; }
-      if (e.key === 'Escape' && previewOpen && !isTyping) { e.preventDefault(); closePreview(); return; }
-      if (isTyping) return;
-      if (e.key === 'j' || e.key === 'k') {
+    function onKey(e: KeyboardEvent) {
+      const tgt = e.target as HTMLElement | null;
+      const typing = !!tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable);
+      if (e.key === '/' && !typing) { e.preventDefault(); searchRef.current?.focus(); return; }
+      if (e.key === 'Escape') { if (openUuid) setOpenUuid(null); return; }
+      if (typing || sData.length === 0) return;
+      const idx = selectedUuid ? sData.findIndex((s) => s.session_uuid === selectedUuid) : -1;
+      if (e.key === 'j' || e.key === 'J') {
         e.preventDefault();
-        if (sessions.data.length === 0) return;
-        const idx = selectedUuid ? sessions.data.findIndex(s => s.session_uuid === selectedUuid) : -1;
-        let next = idx;
-        if (e.key === 'j') next = Math.min(sessions.data.length - 1, idx + 1);
-        if (e.key === 'k') next = Math.max(0, idx === -1 ? 0 : idx - 1);
-        if (next !== idx) openSession(sessions.data[next].session_uuid);
+        const n = sData[idx < 0 ? 0 : Math.min(sData.length - 1, idx + 1)];
+        if (n) setSelectedUuid(n.session_uuid);
+      } else if (e.key === 'k' || e.key === 'K') {
+        e.preventDefault();
+        const p = sData[idx <= 0 ? 0 : idx - 1];
+        if (p) setSelectedUuid(p.session_uuid);
+      } else if (e.key === 'Enter' && selectedUuid) {
+        e.preventDefault();
+        setOpenUuid(selectedUuid);
       }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-     
-  }, [sessions.data, selectedUuid, previewOpen]);
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sData, selectedUuid, openUuid]);
 
   function applyFilter(patch: Partial<Filters>) {
-    const params = { ...filters, ...patch, page: 1 };
-    Object.keys(params).forEach((k) => {
-      const v = (params as Record<string, unknown>)[k];
-      if (v === '' || v === null || v === undefined) delete (params as Record<string, unknown>)[k];
+    const params: Record<string, unknown> = { ...filters, ...patch, page: 1 };
+    Object.keys(params).forEach((key) => {
+      const v = params[key];
+      if (v === '' || v === null || v === undefined) delete params[key];
     });
-    router.get('/team-mcp/cc-sessions', params, {
+    router.get('/team-mcp/cc-sessions', params as Record<string, string>, {
       preserveScroll: true, preserveState: true, only: ['sessions', 'filters', 'kpis'],
     });
   }
 
-  function openSession(uuid: string) {
-    setSelectedUuid(uuid);
-    setDetail(null);
-    setPreviewOpen(true);
-    setLoadingDetail(true);
-    fetch(`/team-mcp/cc-sessions/${uuid}`, {
-      headers: { 'X-Requested-With': 'XMLHttpRequest', 'Accept': 'application/json' },
-    })
-      .then(r => r.json())
-      .then((d: SessionDetail) => setDetail(d))
-      .catch(() => toast.error('Erro ao carregar sessão'))
-      .finally(() => setLoadingDetail(false));
-  }
-
-  function closePreview() {
-    setPreviewOpen(false);
-    setSelectedUuid(null);
-    setDetail(null);
-  }
+  function openSession(uuid: string) { setSelectedUuid(uuid); setOpenUuid(uuid); }
 
   const hasFilters = !!(filters.q || filters.user_id || filters.from || filters.to || filters.status || filters.project_path);
-  const isEmpty = sessions.total === 0 && !hasFilters;
-
-  // ─── Lista ────────────────────────────────────────────────────────────
-  const ListPanel = (
-    <Card className="flex flex-col h-full">
-      <CardHeader className="py-3 border-b flex-row items-center justify-between space-y-0 gap-2">
-        <CardTitle className="text-sm flex items-center gap-2">
-          <span>{num(sessions.total)} sessões</span>
-          {hasFilters && <Badge variant="outline" className="text-[10px]">filtrado</Badge>}
-          {sessions.total > 0 && (
-            <span className="text-xs text-muted-foreground font-normal">
-              {sessions.from}-{sessions.to} · pág {sessions.current_page}/{sessions.last_page}
-            </span>
-          )}
-        </CardTitle>
-        <div className="text-[10px] text-muted-foreground hidden md:flex items-center gap-2">
-          <kbd className="px-1.5 py-0.5 rounded bg-muted border">j/k</kbd>
-          <kbd className="px-1.5 py-0.5 rounded bg-muted border">/</kbd>
-          <kbd className="px-1.5 py-0.5 rounded bg-muted border">Esc</kbd>
-        </div>
-      </CardHeader>
-      <CardContent className="p-0 flex-1 overflow-hidden">
-        {isEmpty ? (
-          <div className="p-8 text-center text-muted-foreground space-y-3">
-            <Inbox className="h-10 w-10 mx-auto text-muted-foreground/60" />
-            <div className="text-sm font-medium">Nenhuma sessão Claude Code ingestada ainda</div>
-            <div className="text-xs max-w-md mx-auto">
-              Schema <code className="font-mono text-[10px]">mcp_cc_*</code> está pronto, mas o
-              watcher Node ainda não foi instalado pelos devs. Setup em
-              {' '}
-              <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Copiloto/SPEC-cc-sessions.md#us-copi-cc-040--watcher-node-ingere-sessions-jsonl-local"
-                 target="_blank" rel="noopener noreferrer"
-                 className="text-primary hover:underline">SPEC US-COPI-CC-040</a>.
-            </div>
-            <div className="text-[10px] text-muted-foreground">
-              Endpoint pronto: <code className="font-mono">POST /api/cc/ingest</code>
-            </div>
-          </div>
-        ) : (
-          <ScrollArea className="h-full">
-            <table className="w-full text-xs">
-              <thead className="sticky top-0 bg-background z-10">
-                <tr className="border-b">
-                  <th className="text-left py-2 px-2 font-medium">Dev / Início</th>
-                  {!previewOpen && <th className="text-left py-2 px-2 font-medium">Summary</th>}
-                  <th className="text-right py-2 px-2 font-medium w-16">Msgs</th>
-                  <th className="text-right py-2 px-2 font-medium w-20">Custo</th>
-                  {!previewOpen && <th className="text-left py-2 px-2 font-medium w-20">Status</th>}
-                </tr>
-              </thead>
-              <tbody>
-                {sessions.data.map((s) => {
-                  const isSel = s.session_uuid === selectedUuid;
-                  return (
-                    <tr key={s.id}
-                      className={`border-b cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-primary/5 border-l-2 border-primary' : ''}`}
-                      onClick={() => openSession(s.session_uuid)}>
-                      <td className="py-1.5 px-2 align-top">
-                        <div className="font-medium text-xs leading-tight">{s.user_nome}</div>
-                        <div className="text-[10px] text-muted-foreground" title={s.started_at ?? ''}>
-                          {fmtRelative(s.started_at)} · {fmtDuration(s.started_at, s.ended_at)}
-                        </div>
-                        {!previewOpen && s.git_branch && (
-                          <div className="text-[10px] text-muted-foreground font-mono mt-0.5">{s.git_branch}</div>
-                        )}
-                      </td>
-                      {!previewOpen && (
-                        <td className="py-1.5 px-2 align-top">
-                          <div className="text-xs leading-tight line-clamp-2 max-w-md" title={s.summary_auto ?? ''}>
-                            {s.summary_auto ?? <span className="text-muted-foreground">(sem summary)</span>}
-                          </div>
-                        </td>
-                      )}
-                      <td className="text-right py-1.5 px-2 align-top font-mono text-[10px]">{num(s.total_messages)}</td>
-                      <td className="text-right py-1.5 px-2 align-top font-mono text-[10px]">{brl(s.total_cost_brl)}</td>
-                      {!previewOpen && (
-                        <td className="py-1.5 px-2 align-top">
-                          {s.status === 'active' && <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200 text-[10px]">ativa</Badge>}
-                          {s.status === 'closed' && <Badge variant="outline" className="text-[10px]">fechada</Badge>}
-                          {s.status === 'archived' && <Badge variant="outline" className="bg-muted text-muted-foreground text-[10px]">arquivada</Badge>}
-                        </td>
-                      )}
-                    </tr>
-                  );
-                })}
-                {sessions.data.length === 0 && hasFilters && (
-                  <tr><td colSpan={previewOpen ? 3 : 5} className="text-center py-8 text-muted-foreground">Nenhuma sessão bate com os filtros.</td></tr>
-                )}
-              </tbody>
-            </table>
-          </ScrollArea>
-        )}
-      </CardContent>
-      {sessions.last_page > 1 && (
-        <div className="border-t p-2 flex justify-center gap-1 flex-wrap">
-          {sessions.links.map((l, i) => (
-            <Button key={i} variant={l.active ? 'default' : 'outline'} size="sm" className="h-7 px-2 text-xs"
-              disabled={!l.url}
-              onClick={() => l.url && router.get(l.url, {}, { preserveScroll: true, preserveState: true, only: ['sessions'] })}
-              dangerouslySetInnerHTML={{ __html: l.label }} />
-          ))}
-        </div>
-      )}
-    </Card>
-  );
-
-  // ─── Preview ──────────────────────────────────────────────────────────
-  const PreviewPanel = (
-    <Card className="flex flex-col h-full">
-      <CardHeader className="py-3 border-b flex-row items-center justify-between space-y-0 gap-2">
-        <CardTitle className="text-sm truncate flex-1 min-w-0">
-          {detail ? `${detail.session.user_nome} · ${fmtRelative(detail.session.started_at)}`
-            : selectedUuid ? `Carregando...`
-            : 'Preview'}
-        </CardTitle>
-        <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={closePreview} title="Fechar (Esc)">✕</Button>
-      </CardHeader>
-
-      {!selectedUuid && (
-        <div className="flex-1 flex items-center justify-center text-muted-foreground p-12 text-sm text-center">
-          ← Selecione uma sessão.<br />
-          <span className="text-[10px] mt-2 block">(j/k navega · Esc fecha · / busca)</span>
-        </div>
-      )}
-
-      {selectedUuid && loadingDetail && (
-        <div className="flex-1 flex items-center justify-center text-muted-foreground p-12 text-sm">Carregando...</div>
-      )}
-
-      {detail && !loadingDetail && (
-        <>
-          <div className="px-4 pt-3 pb-2 border-b text-xs space-y-1">
-            <div className="flex flex-wrap gap-2 items-center">
-              <span className="font-mono text-[10px] text-muted-foreground">{detail.session.session_uuid.slice(0, 8)}</span>
-              {detail.session.cc_version && <Badge variant="outline" className="text-[10px]">cc v{detail.session.cc_version}</Badge>}
-              {detail.session.entrypoint && <Badge variant="outline" className="text-[10px]">{detail.session.entrypoint}</Badge>}
-              {detail.session.git_branch && <Badge variant="outline" className="text-[10px] font-mono">{detail.session.git_branch}</Badge>}
-            </div>
-            <div className="text-[11px] text-muted-foreground inline-flex items-center">
-              <FolderOpen className="h-3 w-3 mr-1 shrink-0" /> <span className="font-mono">{detail.session.project_path}</span>
-            </div>
-            <div className="text-[11px] text-muted-foreground">
-              {fmtDateTime(detail.session.started_at)} → {detail.session.ended_at ? fmtDateTime(detail.session.ended_at) : 'em curso'}
-              {' · '}
-              {fmtDuration(detail.session.started_at, detail.session.ended_at)}
-              {' · '}
-              {num(detail.session.total_messages)} msgs
-              {' · '}
-              {num(detail.session.total_tokens)} tokens
-              {' · '}
-              <span className="font-mono">{brl(detail.session.total_cost_brl)}</span>
-            </div>
-            {detail.session.summary_auto && (
-              <div className="mt-2 p-2 bg-muted/40 rounded text-[11px] leading-relaxed">
-                <span className="font-medium text-muted-foreground">Summary:</span> {detail.session.summary_auto}
-              </div>
-            )}
-          </div>
-          <div className="flex-1 overflow-auto" ref={previewRef}>
-            <div className="p-3 space-y-2">
-              {detail.messages.map((m) => (
-                <MessageBubble key={m.id} m={m} />
-              ))}
-              {detail.truncated && (
-                <div className="text-center text-xs text-muted-foreground py-4">
-                  ⚠️ Truncado em 500 mensagens. Total: {num(detail.session.total_messages)}.
-                </div>
-              )}
-            </div>
-          </div>
-        </>
-      )}
-    </Card>
-  );
 
   return (
     <>
       <PageHeader
         icon="code-2"
-        title="CC do time"
-        description={`Sessões Claude Code do time agregadas. ${permissions.read_all ? 'Visão admin' : 'Visão do dev'}.`}
+        title="Atividade CC"
+        description={`Sessões Claude Code do time (agente em nome do dev). ${permissions.read_all ? 'Visão admin.' : 'Visão do dev.'}`}
       />
 
-      <KpiGrid cols={4} className="mt-6">
-        <KpiCard icon="activity" tone="info" label="Sessões hoje" value={num(kpis.sessions_hoje)} description={`${num(kpis.sessions_total)} no total`} />
-        <KpiCard icon="users" tone="default" label="Devs ativos hoje" value={num(kpis.devs_ativos_hoje)} description={permissions.read_all ? 'time' : 'você'} />
-        <KpiCard icon="dollar-sign" tone="warning" label="Custo hoje" value={brl(kpis.custo_hoje_brl)} description={`30d: ${brl(kpis.custo_30d_brl)}`} />
-        <KpiCard icon="zap" tone="default" label="Top tools" value={kpis.tools_top.length.toString()}
-          description={kpis.tools_top.slice(0, 3).map(t => `${t.tool}(${t.count})`).join(' · ') || '—'} />
+      <KpiGrid cols={4} className="mt-4">
+        <KpiCard icon="activity" tone="info" label="Sessões hoje" value={isLoading ? '—' : num(k.sessions_hoje)} description={isLoading ? undefined : `${num(k.sessions_total)} no total`} />
+        <KpiCard icon="users" tone="default" label="Devs ativos hoje" value={isLoading ? '—' : num(k.devs_ativos_hoje)} description={permissions.read_all ? 'time' : 'você'} />
+        <KpiCard icon="dollar-sign" tone="warning" label="Custo hoje" value={isLoading ? '—' : brl(k.custo_hoje_brl)} description={isLoading ? undefined : `30d: ${brl(k.custo_30d_brl)}`} />
+        <KpiCard icon="zap" tone="default" label="Top tools" value={isLoading ? '—' : String(k.tools_top.length)} description={k.tools_top.slice(0, 3).map((t) => `${t.tool}(${t.count})`).join(' · ') || '—'} />
       </KpiGrid>
 
-      <Card className="mt-4">
-        <CardContent className="py-3 flex flex-wrap items-end gap-3">
-          <div className="flex-1 min-w-[200px]">
-            <Label className="text-xs">Busca <span className="text-[10px] text-muted-foreground">(/, debounce)</span></Label>
-            <Input ref={searchRef} placeholder="summary ou keyword..." value={search}
-              onChange={(e) => setSearch(e.target.value)} className="h-8" />
-          </div>
-          {permissions.read_all && devs.length > 1 && (
-            <div className="w-40">
-              <Label className="text-xs">Dev</Label>
-              <Select value={filters.user_id?.toString() ?? '__all__'}
-                onValueChange={(v) => applyFilter({ user_id: v === '__all__' ? null : Number(v) })}>
-                <SelectTrigger className="h-8"><SelectValue placeholder="Todos" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todos</SelectItem>
-                  {devs.map((d) => <SelectItem key={d.id} value={d.id.toString()}>{d.nome}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-          <div className="w-32">
-            <Label className="text-xs">Status</Label>
-            <Select value={filters.status ?? '__all__'}
-              onValueChange={(v) => applyFilter({ status: v === '__all__' ? '' : v })}>
+      {/* Toolbar */}
+      <div className="mt-4 flex flex-wrap items-end gap-3 rounded-lg border bg-card px-3 py-3">
+        <div className="min-w-[200px] flex-1">
+          <Label className="text-xs">Busca <span className="text-[10px] text-muted-foreground">(/, summary)</span></Label>
+          <Input ref={searchRef} placeholder="summary ou keyword…" value={search} onChange={(e) => setSearch(e.target.value)} className="h-8 text-xs" data-testid="search" />
+        </div>
+        {permissions.read_all && devList.length > 1 && (
+          <div className="w-40">
+            <Label className="text-xs">Dev</Label>
+            <Select value={filters.user_id?.toString() ?? ALL} onValueChange={(v) => applyFilter({ user_id: v === ALL ? null : Number(v) })}>
               <SelectTrigger className="h-8"><SelectValue placeholder="Todos" /></SelectTrigger>
               <SelectContent>
-                <SelectItem value="__all__">Todos</SelectItem>
-                <SelectItem value="active">Ativa</SelectItem>
-                <SelectItem value="closed">Fechada</SelectItem>
-                <SelectItem value="archived">Arquivada</SelectItem>
+                <SelectItem value={ALL}>Todos</SelectItem>
+                {devList.map((d) => <SelectItem key={d.id} value={d.id.toString()}>{d.nome}</SelectItem>)}
               </SelectContent>
             </Select>
           </div>
-          {projects.length > 1 && (
-            <div className="w-48">
-              <Label className="text-xs">Projeto</Label>
-              <Select value={filters.project_path ?? '__all__'}
-                onValueChange={(v) => applyFilter({ project_path: v === '__all__' ? '' : v })}>
-                <SelectTrigger className="h-8"><SelectValue placeholder="Todos" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="__all__">Todos</SelectItem>
-                  {projects.map((p) => <SelectItem key={p} value={p}>{p}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-          {hasFilters && (
-            <Button variant="outline" className="h-8 text-xs"
-              onClick={() => { setSearch(''); applyFilter({ q: '', user_id: null, status: '', project_path: '' }); }}>
-              Limpar
-            </Button>
-          )}
-        </CardContent>
-      </Card>
-
-      <div className="mt-4" style={{ height: '78vh' }}>
-        {!previewOpen ? (
-          <div className="h-full">{ListPanel}</div>
-        ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-12 gap-2 h-full">
-            <div className="lg:col-span-5 h-full">{ListPanel}</div>
-            <div className="lg:col-span-7 h-full">{PreviewPanel}</div>
+        )}
+        <div className="w-32">
+          <Label className="text-xs">Status</Label>
+          <Select value={filters.status ?? ALL} onValueChange={(v) => applyFilter({ status: v === ALL ? '' : v })}>
+            <SelectTrigger className="h-8"><SelectValue placeholder="Todos" /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>Todos</SelectItem>
+              <SelectItem value="active">Ativa</SelectItem>
+              <SelectItem value="closed">Fechada</SelectItem>
+              <SelectItem value="archived">Arquivada</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+        {projList.length > 1 && (
+          <div className="w-48">
+            <Label className="text-xs">Projeto</Label>
+            <Select value={filters.project_path ?? ALL} onValueChange={(v) => applyFilter({ project_path: v === ALL ? '' : v })}>
+              <SelectTrigger className="h-8"><SelectValue placeholder="Todos" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value={ALL}>Todos</SelectItem>
+                {projList.map((p) => <SelectItem key={p} value={p}>{p}</SelectItem>)}
+              </SelectContent>
+            </Select>
           </div>
         )}
+        {hasFilters && (
+          <Button variant="ghost" className="h-8 text-xs" onClick={() => { setSearch(''); applyFilter({ q: '', user_id: null, status: '', project_path: '' }); }}>
+            Limpar
+          </Button>
+        )}
+        <div className="ml-auto hidden text-[11px] text-muted-foreground lg:block">
+          <kbd className="rounded bg-muted px-1 py-0.5">J</kbd>/<kbd className="rounded bg-muted px-1 py-0.5">K</kbd> navegar · <kbd className="rounded bg-muted px-1 py-0.5">↵</kbd> abrir · <kbd className="rounded bg-muted px-1 py-0.5">/</kbd> buscar
+        </div>
       </div>
+
+      {/* Feed */}
+      {isLoading ? (
+        <div className="mt-4 space-y-2" data-testid="cc-skeleton">
+          {Array.from({ length: 8 }).map((_, i) => <div key={i} className="h-16 animate-pulse rounded-md bg-muted/50" />)}
+        </div>
+      ) : sData.length === 0 && !hasFilters ? (
+        <div className="mt-4">
+          <EmptyState
+            icon="inbox"
+            title="Nenhuma sessão Claude Code ingestada ainda"
+            description="O schema mcp_cc_* está pronto; falta o watcher Node nos devs (POST /api/cc/ingest)."
+            action={
+              <a
+                href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Copiloto/SPEC-cc-sessions.md"
+                target="_blank" rel="noopener noreferrer"
+                className="text-sm text-primary hover:underline"
+              >Ver SPEC do watcher →</a>
+            }
+          />
+        </div>
+      ) : sData.length === 0 ? (
+        <div className="mt-4">
+          <EmptyState icon="search" variant="search" title="Nada bate com os filtros" description="Tenta ajustar a busca ou limpar os filtros." />
+        </div>
+      ) : (
+        <>
+          <div className="mt-4 flex items-center justify-between text-[11px] text-muted-foreground">
+            <span className="tabular-nums">{num(sessions!.total)} sessões{hasFilters ? ' (filtrado)' : ''} · {sessions!.from}–{sessions!.to} · pág {sessions!.current_page}/{sessions!.last_page}</span>
+          </div>
+          <div className="mt-2 overflow-hidden rounded-lg border bg-card" data-testid="cc-feed">
+            {sData.map((s) => {
+              const sel = s.session_uuid === selectedUuid;
+              const meta = sessionStatusMeta(s.status);
+              return (
+                <div
+                  key={s.id}
+                  role="button"
+                  tabIndex={0}
+                  data-testid="cc-feed-item"
+                  onClick={() => openSession(s.session_uuid)}
+                  onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openSession(s.session_uuid); } }}
+                  className={cn('flex cursor-pointer gap-3 border-b border-border/60 px-3 py-2.5 last:border-b-0', sel ? 'bg-primary/10' : 'hover:bg-muted/50')}
+                >
+                  <span className={cn('mt-1.5 inline-block h-2 w-2 shrink-0 rounded-full', meta.dot)} title={meta.label} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2 text-xs">
+                      <span className="inline-flex items-center gap-1 font-medium">
+                        <User size={12} className="text-muted-foreground" aria-hidden /> {s.user_nome}
+                      </span>
+                      <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary" title="Sessão de agente (Claude Code)">
+                        <Bot size={10} /> CC{s.cc_version ? ` v${s.cc_version}` : ''}
+                      </span>
+                      <span className="truncate font-mono text-[10px] text-muted-foreground">{s.project_path}</span>
+                      {s.git_branch && (
+                        <span className="hidden items-center gap-1 font-mono text-[10px] text-muted-foreground sm:inline-flex">
+                          <GitBranch size={10} /> {s.git_branch}
+                        </span>
+                      )}
+                      <span className="ml-auto shrink-0 text-[10px] text-muted-foreground" title={s.started_at ?? ''}>{fmtRelative(s.started_at)}</span>
+                    </div>
+                    <p className="mt-0.5 line-clamp-2 text-xs text-foreground/90">
+                      {s.summary_auto ?? <span className="text-muted-foreground">(sem summary)</span>}
+                    </p>
+                    <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[10px] text-muted-foreground tabular-nums">
+                      <span>{num(s.total_messages)} msgs</span>
+                      <span>{num(s.total_tokens)} tokens</span>
+                      <span className="font-mono">{brl(s.total_cost_brl)}</span>
+                      <span>{fmtDuration(s.started_at, s.ended_at)}</span>
+                      <span className="inline-flex items-center gap-1">
+                        <span className={cn('inline-block h-1.5 w-1.5 rounded-full', meta.dot)} /> {meta.label}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {sessions!.last_page > 1 && (
+            <div className="mt-3 flex flex-wrap justify-center gap-1">
+              {sessions!.links.map((l, i) => (
+                <Button
+                  key={i}
+                  variant={l.active ? 'default' : 'outline'}
+                  size="sm"
+                  className="h-7 px-2 text-xs"
+                  disabled={!l.url}
+                  onClick={() => l.url && router.get(l.url, {}, { preserveScroll: true, preserveState: true, only: ['sessions'] })}
+                  dangerouslySetInnerHTML={{ __html: l.label }}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      <SessionDrawer sessionUuid={openUuid} onClose={() => setOpenUuid(null)} />
     </>
   );
 }
 
-function MessageBubble({ m }: { m: Message }) {
-  const [expanded, setExpanded] = useState(false);
-  const text = m.content_text ?? '';
-  const isLong = text.length > 300;
-  const display = expanded || !isLong ? text : text.slice(0, 300);
-
-  const typeStyle: Record<string, string> = {
-    user:        'bg-blue-50 border-blue-200 dark:bg-blue-950/30',
-    assistant:   'bg-gray-50 border-gray-200 dark:bg-gray-900/40',
-    tool_use:    'bg-amber-50 border-amber-200 dark:bg-amber-950/20',
-    tool_result: 'bg-green-50 border-green-200 dark:bg-green-950/20',
-    system:      'bg-purple-50 border-purple-200 dark:bg-purple-950/20',
-    hook:        'bg-pink-50 border-pink-200 dark:bg-pink-950/20',
-    attachment:  'bg-cyan-50 border-cyan-200 dark:bg-cyan-950/20',
-  };
-
-  return (
-    <div className={`border rounded-md p-2 ${typeStyle[m.msg_type] ?? 'bg-muted/30'}`}>
-      <div className="flex items-center gap-2 text-[10px] text-muted-foreground mb-1">
-        <span className="font-mono font-medium uppercase">{m.msg_type}</span>
-        {m.tool_name && (
-          <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${toolColor(m.tool_name)}`}>
-            {m.tool_name}
-          </span>
-        )}
-        {m.ts && <span>{new Date(m.ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}</span>}
-        {(m.tokens_in || m.tokens_out) && (
-          <span className="ml-auto font-mono">
-            ↓{m.tokens_in ?? 0} ↑{m.tokens_out ?? 0}
-            {m.cache_read ? ` (${m.cache_read} cache)` : ''}
-          </span>
-        )}
-      </div>
-      {text && (
-        <div className="text-xs whitespace-pre-wrap break-words font-mono leading-relaxed">
-          {display}
-          {isLong && !expanded && <span className="text-muted-foreground"> ...</span>}
-        </div>
-      )}
-      {isLong && (
-        <button onClick={() => setExpanded(!expanded)}
-          className="text-[10px] text-primary hover:underline mt-1">
-          {expanded ? '▲ recolher' : `▼ ver mais (${text.length} chars)`}
-        </button>
-      )}
-    </div>
-  );
-}
-
 CcSessionsIndex.layout = (page: ReactNode) => (
-  <AppShellV2 title="CC do time — Sessões Claude Code" breadcrumbItems={[{ label: 'Copiloto' }, { label: 'Sessões CC' }]}>
+  <AppShellV2 title="Atividade CC — Equipe" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Atividade CC' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/CcSessions/_components/SessionDrawer.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/_components/SessionDrawer.tsx
@@ -1,0 +1,204 @@
+// Forja PR-2 — drawer de thread da tela /team-mcp/cc-sessions.
+//   Endpoint: GET /team-mcp/cc-sessions/{uuid} (CcSessionsController@show, read-only).
+//   Thread ≤500 msgs + flag truncated. Largura 640px (conversa precisa largura).
+//   DS v6: bolha por tipo via tokens semânticos; tool chip neutro. data-testid locators.
+
+import { useEffect, useRef, useState } from 'react';
+import { Bot, FolderOpen, GitBranch, Loader2, User } from 'lucide-react';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/Components/ui/sheet';
+import { cn } from '@/Lib/utils';
+import { brl, fmtDateTime, fmtDuration, msgBubbleClass, num } from './sessionTokens';
+
+interface SessionMeta {
+  session_uuid: string;
+  user_id: number;
+  user_nome: string;
+  project_path: string;
+  git_branch: string | null;
+  cc_version: string | null;
+  entrypoint: string | null;
+  started_at: string | null;
+  ended_at: string | null;
+  total_messages: number;
+  total_tokens: number;
+  total_cost_brl: number;
+  status: string;
+  summary_auto: string | null;
+  metadata: Record<string, unknown> | null;
+}
+
+interface Message {
+  id: number;
+  msg_uuid: string;
+  parent_uuid: string | null;
+  msg_type: string;
+  role: string | null;
+  tool_name: string | null;
+  content_text: string | null;
+  tokens_in: number | null;
+  tokens_out: number | null;
+  cache_read: number | null;
+  cost_usd: number;
+  ts: string | null;
+}
+
+interface SessionDetail {
+  session: SessionMeta;
+  messages: Message[];
+  truncated: boolean;
+}
+
+interface Props {
+  sessionUuid: string | null;
+  onClose: () => void;
+}
+
+function MessageBubble({ m }: { m: Message }) {
+  const [expanded, setExpanded] = useState(false);
+  const text = m.content_text ?? '';
+  const isLong = text.length > 300;
+  const display = expanded || !isLong ? text : text.slice(0, 300);
+
+  return (
+    <div className={cn('rounded-md border p-2', msgBubbleClass(m.msg_type))} data-testid="cc-message">
+      <div className="mb-1 flex items-center gap-2 text-[10px] text-muted-foreground">
+        <span className="font-mono font-medium uppercase">{m.msg_type}</span>
+        {m.tool_name && (
+          <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">
+            {m.tool_name}
+          </span>
+        )}
+        {m.ts && <span>{new Date(m.ts).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit', second: '2-digit' })}</span>}
+        {(m.tokens_in || m.tokens_out) && (
+          <span className="ml-auto font-mono tabular-nums">
+            ↓{m.tokens_in ?? 0} ↑{m.tokens_out ?? 0}{m.cache_read ? ` (${m.cache_read} cache)` : ''}
+          </span>
+        )}
+      </div>
+      {text && (
+        <div className="whitespace-pre-wrap break-words font-mono text-xs leading-relaxed">
+          {display}{isLong && !expanded && <span className="text-muted-foreground"> …</span>}
+        </div>
+      )}
+      {isLong && (
+        <button type="button" onClick={() => setExpanded(!expanded)} className="mt-1 text-[10px] text-primary hover:underline">
+          {expanded ? '▲ recolher' : `▼ ver mais (${text.length} chars)`}
+        </button>
+      )}
+    </div>
+  );
+}
+
+export default function SessionDrawer({ sessionUuid, onClose }: Props) {
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!sessionUuid) return;
+    setLoading(true);
+    setError(null);
+    setDetail(null);
+
+    const ctrl = new AbortController();
+    fetch(`/team-mcp/cc-sessions/${encodeURIComponent(sessionUuid)}`, {
+      headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+      signal: ctrl.signal,
+    })
+      .then((r) => {
+        if (r.status === 403) throw new Error('Sem permissão para ver esta sessão.');
+        if (r.status === 404) throw new Error('Sessão não encontrada.');
+        if (!r.ok) throw new Error(`Erro ${r.status}`);
+        return r.json();
+      })
+      .then((d: SessionDetail) => { setDetail(d); setLoading(false); })
+      .catch((err: Error) => { if (err.name === 'AbortError') return; setError(err.message); setLoading(false); });
+
+    return () => ctrl.abort();
+  }, [sessionUuid]);
+
+  useEffect(() => { if (bodyRef.current) bodyRef.current.scrollTop = 0; }, [detail?.session?.session_uuid]);
+
+  const open = !!sessionUuid;
+  const s = detail?.session;
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
+      <SheetContent side="right" className="flex w-full flex-col overflow-hidden p-0 sm:max-w-[640px]" data-testid="session-drawer">
+        <SheetHeader className="border-b px-4">
+          <div className="flex items-center gap-2">
+            <User size={14} className="text-muted-foreground" aria-hidden />
+            <SheetTitle className="text-base" data-testid="drawer-dev">
+              {s?.user_nome ?? (loading ? 'Carregando…' : 'Sessão')}
+            </SheetTitle>
+            {s?.cc_version && (
+              <span className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary" title="Sessão de agente (Claude Code)">
+                <Bot size={11} /> Claude Code v{s.cc_version}
+              </span>
+            )}
+          </div>
+          {s && (
+            <SheetDescription className="space-y-1 text-xs">
+              <span className="flex flex-wrap items-center gap-2">
+                <span className="font-mono text-[10px] text-muted-foreground">{s.session_uuid.slice(0, 8)}</span>
+                {s.entrypoint && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px]">{s.entrypoint}</span>}
+                {s.git_branch && (
+                  <span className="inline-flex items-center gap-1 font-mono text-[10px] text-muted-foreground">
+                    <GitBranch size={10} /> {s.git_branch}
+                  </span>
+                )}
+              </span>
+              <span className="flex items-center gap-1 text-muted-foreground">
+                <FolderOpen size={11} className="shrink-0" /> <span className="truncate font-mono">{s.project_path}</span>
+              </span>
+              <span className="block text-[11px] text-muted-foreground tabular-nums">
+                {fmtDateTime(s.started_at)} → {s.ended_at ? fmtDateTime(s.ended_at) : 'em curso'}
+                {' · '}{fmtDuration(s.started_at, s.ended_at)}
+                {' · '}{num(s.total_messages)} msgs · {num(s.total_tokens)} tokens · <span className="font-mono">{brl(s.total_cost_brl)}</span>
+              </span>
+            </SheetDescription>
+          )}
+        </SheetHeader>
+
+        {s?.summary_auto && (
+          <div className="border-b bg-muted/40 px-4 py-2 text-[11px] leading-relaxed">
+            <span className="font-medium text-muted-foreground">Resumo:</span> {s.summary_auto}
+          </div>
+        )}
+
+        <div className="flex-1 overflow-auto px-3 py-3" ref={bodyRef}>
+          {loading && (
+            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" /> carregando thread…
+            </div>
+          )}
+          {error && (
+            <div className="my-6 rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-sm text-destructive-fg" data-testid="drawer-error">
+              {error}
+            </div>
+          )}
+          {!loading && !error && detail && (
+            <div className="space-y-2">
+              {detail.messages.map((m) => <MessageBubble key={m.id} m={m} />)}
+              {detail.messages.length === 0 && (
+                <p className="py-8 text-center text-sm italic text-muted-foreground">Sessão sem mensagens ingestadas.</p>
+              )}
+              {detail.truncated && (
+                <div className="py-4 text-center text-xs text-muted-foreground">
+                  ⚠️ Truncado em 500 mensagens. Total: {num(detail.session.total_messages)}.
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/resources/js/Pages/team-mcp/CcSessions/_components/sessionTokens.ts
+++ b/resources/js/Pages/team-mcp/CcSessions/_components/sessionTokens.ts
@@ -1,0 +1,61 @@
+// Forja PR-2 — tokens/helpers puros da tela CcSessions (sem JSX → react-refresh friendly).
+// DS v6: SEM cor crua. Bolhas/status via tokens semânticos.
+
+export type SessionStatus = 'active' | 'closed' | 'archived';
+
+export interface StatusMeta { label: string; dot: string }
+
+const STATUS_META: Record<string, StatusMeta> = {
+  active:   { label: 'Ativa',      dot: 'bg-success' },
+  closed:   { label: 'Fechada',    dot: 'bg-foreground/40' },
+  archived: { label: 'Arquivada',  dot: 'bg-foreground/20' },
+};
+
+export function sessionStatusMeta(s: string): StatusMeta {
+  return STATUS_META[s] ?? { label: s, dot: 'bg-foreground/40' };
+}
+
+export const brl = (v: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
+
+export const num = (v: number) => new Intl.NumberFormat('pt-BR').format(v ?? 0);
+
+export function fmtDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('pt-BR', {
+    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
+  });
+}
+
+export function fmtRelative(iso: string | null): string {
+  if (!iso) return '—';
+  const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
+  if (diffSec < 60) return 'agora';
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}min atrás`;
+  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h atrás`;
+  if (diffSec < 86400 * 7) return `${Math.floor(diffSec / 86400)}d atrás`;
+  return fmtDateTime(iso);
+}
+
+export function fmtDuration(start: string | null, end: string | null): string {
+  if (!start) return '—';
+  const startMs = new Date(start).getTime();
+  const endMs = end ? new Date(end).getTime() : Date.now();
+  const sec = Math.floor((endMs - startMs) / 1000);
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.floor(sec / 60)}m${sec % 60}s`;
+  return `${Math.floor(sec / 3600)}h${Math.floor((sec % 3600) / 60)}m`;
+}
+
+/** Estilo da bolha por tipo de mensagem — tokens semânticos /opacity (DS v6, sem cor crua). */
+export function msgBubbleClass(type: string): string {
+  switch (type) {
+    case 'user':        return 'border-primary/20 bg-primary/5';
+    case 'tool_use':    return 'border-info/20 bg-info/5';
+    case 'tool_result': return 'border-success/20 bg-success/5';
+    case 'hook':        return 'border-warning/20 bg-warning/5';
+    case 'system':      return 'border-border bg-muted/40';
+    case 'attachment':  return 'border-border bg-muted/30';
+    default:            return 'border-border bg-muted/30'; // assistant
+  }
+}


### PR DESCRIPTION
## Forja PR-2 — CcSessions (re-skin DS v6)

Segunda onda da absorção **Forja → TeamMcp**: re-skin de `/team-mcp/cc-sessions` na gramática **Changelog/Atividade** da Forja sob DS v6. **Frontend-only** — backend (`index`/`show`/`search`) intacto. Split-panel → **feed cronológico + drawer lateral** pra thread.

### O que muda
- **Feed** (`resources/js/Pages/team-mcp/CcSessions/Index.tsx`): 1 item por sessão — dot de status + dev + chip **Claude Code** (cc_version) + projeto/branch (mono) + data relativa + summary (line-clamp-2) + meta (msgs/tokens/custo/duração). Selo **agente vs humano** explícito (`Bot`=Claude Code, `User`=dev).
- **Drawer** (`_components/SessionDrawer.tsx`, 640px): thread via `show()` (≤500 msgs + flag truncated), bolhas por tipo **DS-clean** (tokens semânticos /opacity), tool chips neutros, header com meta + summary.
- **Preservado 100%**: busca FULLTEXT summary (debounce 350ms), filtros dev/status/projeto, KPIs (sessões/devs/custo/top tools), paginação 25/pg + links, RBAC (read_all/próprio/curate), atalhos J/K/↵/Esc/`/`.
- **DS v6**: removida toda paleta crua (`typeStyle`, `toolColor`, status badges `bg-green-50`…) → tokens semânticos + status Stripe-dot. Breadcrumb "Copiloto" → "Equipe".

### Sem dado fantasma
Projeta só o que `index`/`show` retornam. Busca profunda cross-dev em `content_text` (`/cc-sessions/search`, já existe como API) **não** entra aqui — fica pra PR futura.

### Processo
- mwart-comparative F1.5: [`cc-sessions-visual-comparison.md`](memory/requisitos/TeamMcp/cc-sessions-visual-comparison.md) + [charter](resources/js/Pages/team-mcp/CcSessions/Index.charter.md). Padrão Forja pré-aprovado ([W] "pode seguir").
- Merge é **[W2]**.

### Verificação local
- ✅ `typecheck` 0 erros nos arquivos · `eslint` 0 erros · `lint-baseline` sem regressão
- ✅ `conformance-gate` · `foundation-guard`
- ⏳ Pest/E2E/visual-regression no CI; smoke real pós-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
