### PR TITLE
feat(team-mcp): Forja PR-3 — cria a tela Scorecard (Saúde · Facts+Checks)

### DIFF
--- a/memory/requisitos/TeamMcp/scorecard-visual-comparison.md
+++ b/memory/requisitos/TeamMcp/scorecard-visual-comparison.md
@@ -1,0 +1,65 @@
+---
+slug: teammcp-scorecard-visual-comparison
+title: "TeamMcp — Comparativo visual da tela Scorecard (Saúde)"
+type: visual-comparison
+module: TeamMcp
+status: approved
+approved_by: wagner
+approved_at: 2026-06-16
+date: 2026-06-16
+canon_reference: forja-cowork (forja-page.jsx — view .fj-saude/.fj-metric/.fj-gate-health)
+blade_source: "N/A — Page nova (rota existia sem componente)"
+inertia_target: resources/js/Pages/team-mcp/Scorecard/Index.tsx
+pr_branch: feat/forja-pr3-scorecard
+---
+
+# TeamMcp — Comparativo visual · tela **Scorecard** (Saúde)
+
+> **F1.5 do MWART V4** · PR-3 da onda **Forja**. Pré-aprovado pelo padrão Forja ([W] "pode seguir" 2026-06-16).
+
+## Premissa corrigida vs prompt
+
+O prompt tratava PR-3 como **re-skin**. A realidade: `ScorecardController@index` renderiza `team-mcp/Scorecard/Index` mas **a Page nunca existiu** no repo → a rota `/team-mcp/scorecard` está **quebrada** hoje. Logo PR-3 = **criar** a Page (não re-skin). Backend (`ScorecardBuilderService` Facts+Checks) já existe e fica intacto.
+
+## Contexto
+
+Padrão **Facts + Checks** (ADR 0091): Facts = números sem juízo (tokens_ativos, calls_7d, cost_7d_brl, users_ativos_7d, top_tools_7d, flags de presença de tabela); Checks = `{name, ok, detail}` (schema mcp_tokens/audit_log, brief recente, tokens sem orphan, custo médio sanity). `meta` eager (generated_at/period_days/pattern/source). Tudo via `Inertia::defer`.
+
+## Sobre o **sparkline** (decisão §3)
+
+A Forja `.fj-saude` mostra sparklines por métrica. **O builder não expõe série temporal** — só pontos atuais. Renderizar sparkline exigiria fabricar série (fantasma) OU adicionar uma nova métrica (`buildTrends`), o que contraria o escopo do prompt "**sem inventar métrica — só Facts+Checks atuais**". → **Sparkline deferido.** Se quiser, abro PR-3b com um `buildTrends()` real (buckets diários de mcp_audit_log) — aí o sparkline vira dado honesto.
+
+## 15 dimensões (Forja · Decisão DS v6)
+
+| # | Dimensão | Forja `.fj-saude` | Decisão DS v6 |
+|---|---|---|---|
+| 1 | Layout | grid de métricas + gate-health | PageHeader › Semáforo geral › Facts (KpiGrid) › Top tools › Checks (lista) |
+| 2 | Hierarquia | métricas + gates | banner semáforo no topo (resposta "tá verde?") → Facts → Checks |
+| 3 | Densidade | cards metric | KpiCard padrão + lista de checks py-2.5 |
+| 4 | Iconografia | dot + spark | lucide `CheckCircle2`/`AlertCircle`/`RefreshCw`/`heart-pulse` |
+| 5 | Estados | metric ok/warn/bad | loading skeleton (defer) · empty top-tools · aviso tabela ausente |
+| 6 | Atalhos | — | `R` recarrega (+ botão Atualizar) |
+| 7 | Persistência | — | nenhuma (read-only, sem estado de UI persistente) |
+| 8 | Shared | custom | **PageHeader + KpiGrid + KpiCard** reusados; checks list module-local |
+| 9 | Tipografia num | spark + valor | KPI value (KpiCard) `tabular-nums`; contagens mono |
+| 10 | Espaçamento | grid gap | KpiGrid cols=4; seções com `mt-6` |
+| 11 | Cores | hue ok/warn/bad | **success/warning/destructive** tokens (dot+texto, soft bg); zero cru |
+| 12 | Microinterações | — | hover linhas; banner colorido por estado |
+| 13 | Ref aprovada | Forja Cowork | ✅ |
+| 14 | Benchmark | Vercel/Datadog health, Linear insights | painel de saúde Facts+Checks |
+| 15 | Persona | Wagner superadmin | (1) "tá tudo verde?" em 2s, (2) números reais sob demanda, (3) sem ruído |
+
+## Decisões [W] (pré-aprovado)
+
+1. **PR-3 = criar** a Page (não re-skin) — rota quebrada.
+2. **Sem sparkline** (sem série real; evita fantasma / nova métrica). PR-3b opcional com trends reais.
+3. Frontend-only — `ScorecardController`/`ScorecardBuilderService` intactos (preserva contrato Pest Wave 23).
+4. Breadcrumb "Equipe / Saúde".
+
+## Gates antes do F3
+- [x] Padrão Forja aprovado ([W] "pode seguir").
+- [x] Charter `Index.charter.md` ao lado.
+- [ ] CI: typecheck + eslint/lint-baseline + conformance + foundation + a rota renderiza (smoke).
+
+---
+**Status:** `approved` — implementado no PR `feat/forja-pr3-scorecard`.

--- a/resources/js/Pages/team-mcp/Scorecard/Index.casos.md
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.casos.md
@@ -1,0 +1,53 @@
+---
+casos: Saúde do MCP · Scorecard Facts+Checks · /team-mcp/scorecard
+irmaos: Index.charter.md (lei) · Index.tsx (tela)
+tecnica: Caso de uso = narrativa + critério de aceite verificável
+owner: wagner
+last_run: "2026-06-16"
+---
+
+# Casos de uso — /team-mcp/scorecard
+
+> **Status:** ✅ passa (provado por teste) · 🧪 em teste (Pest escrito, aguarda run verde) · ⬜ não verificado · ❌ quebrou.
+
+> Forja PR-3. A rota existia mas o componente nunca existiu (route quebrada) — este trio nasce com a Page. Padrão Facts+Checks (ADR 0091): Facts = números sem juízo, Checks = semáforo ok/fail. Persona: Wagner [W] (superadmin). Tela read-only.
+
+## UC-SC-01 — A rota deixa de quebrar (a Page existe)
+Status: ⬜ (smoke pós-merge — abrir `/team-mcp/scorecard` em prod)
+Antes deste PR, `ScorecardController@index` renderizava `team-mcp/Scorecard/Index` sem componente → Inertia 500.
+**Pronto quando:** abrir `/team-mcp/scorecard` renderiza a tela (sem tela branca / 500).
+
+## UC-SC-02 — Semáforo geral reflete os checks
+Status: ⬜ (manual/visual)
+Banner no topo: verde "Tudo verde — N/N checks OK" quando todos passam; amarelo "N de M falhando" caso contrário.
+**Pronto quando:** com todos os checks `ok=true`, o banner é verde com a contagem certa; com ≥1 `ok=false`, fica amarelo.
+
+## UC-SC-03 — Facts são números reais do builder
+Status: 🧪 (cobertura futura — assert sobre `ScorecardBuilderService::buildFacts()`)
+KpiCards: tokens ativos · calls 7d · custo 7d (BRL) · devs ativos 7d, + Top tools (7d). Sem juízo, só contagem.
+**Pronto quando:** os valores batem 1:1 com o retorno de `buildFacts()` (`tokens_ativos`, `calls_7d`, `cost_7d_brl`, `users_ativos_7d`, `top_tools_7d`).
+
+## UC-SC-04 — Checks listam ok/fail com detalhe
+Status: 🧪 (cobertura futura — assert sobre `buildChecks()`)
+Lista cada dimensão (schema mcp_tokens/audit_log, brief recente, tokens sem orphan, custo médio sanity) com ícone ok/fail + nome + detail + pill.
+**Pronto quando:** cada item de `buildChecks()` aparece com `CheckCircle2` (ok) ou `AlertCircle` (fail) e o `detail` do backend.
+
+## UC-SC-05 — Sem sparkline (sem dado fantasma · §3)
+Status: 🧪 (cobertura: o payload não tem série temporal)
+O builder só expõe pontos atuais (sem série). A tela NÃO renderiza sparkline fabricado — só Facts+Checks reais.
+**Pronto quando:** não há nenhum gráfico de série na tela; nenhum dado derivado é apresentado como medido.
+
+## UC-SC-06 — DS v6 (sem cor crua)
+Status: 🧪 (cobertura: eslint `ds/*` = 0 + conformance ratchet)
+Tokens semânticos (success/warning/destructive), `tabular-nums`, layout via `inline-flex`/`KpiGrid` — zero paleta crua, zero `rounded-xl+`.
+**Pronto quando:** `eslint resources/js/Pages/team-mcp/Scorecard/Index.tsx` = 0 `ds/*` e `conformance-gate` verde.
+
+## UC-SC-07 — Read-only (a tela não muta nada)
+Status: ⬜ (manual — só `router.reload` de facts/checks)
+Nenhuma ação edita estado; o único efeito é recarregar os dados deferidos (botão Atualizar / atalho R).
+**Pronto quando:** não há nenhuma ação na tela que escreva no banco.
+
+## UC-SC-08 — Acesso (auth + permissão)
+Status: ⬜ (manual — rota sob `auth` + `copiloto.mcp.usage.all`)
+`/team-mcp/scorecard` exige login + `copiloto.mcp.usage.all` (mesma do TeamController). Repo-wide cross-business intencional (ADR 0093) pro superadmin ver saúde global.
+**Pronto quando:** usuário sem `copiloto.mcp.usage.all` recebe 403.

--- a/resources/js/Pages/team-mcp/Scorecard/Index.charter.md
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.charter.md
@@ -1,0 +1,61 @@
+---
+page: /team-mcp/scorecard
+component: resources/js/Pages/team-mcp/Scorecard/Index.tsx
+owner: wagner
+status: draft
+last_validated: "2026-06-16"
+parent_module: TeamMcp
+related_adrs:
+  - "0091-daily-brief"
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+  - "0104-processo-mwart-canonico-unico-caminho"
+  - "0114-prototipo-ui-cowork-loop-formalizado"
+related_ficha: memory/requisitos/TeamMcp/scorecard-visual-comparison.md
+tier: A
+charter_version: 1
+---
+
+# Page Charter — `/team-mcp/scorecard` (DRAFT)
+
+> Criado no PR **Forja PR-3** (2026-06-16). **A Page não existia** — `ScorecardController@index` renderizava `team-mcp/Scorecard/Index` sem componente correspondente (rota quebrada). Este PR cria a Page em DS v6. Persona: Wagner [W] (superadmin, `copiloto.mcp.usage.all`). Backend: `ScorecardController` + `ScorecardBuilderService` (Inertia::defer facts/checks). Ref: [scorecard-visual-comparison.md](../../../../memory/requisitos/TeamMcp/scorecard-visual-comparison.md).
+
+## Mission
+
+Painel **read-only** de saúde do MCP no padrão **Facts + Checks** (ADR 0091): separa número (sem juízo) de juízo (semáforo ok/fail). Operação primária: Wagner bate o olho em "tá tudo verde?" e, se não, entra nos números. **Sem dado fantasma** — projeta só o que `ScorecardBuilderService` retorna.
+
+## Goals — Features (faz)
+
+- **Semáforo geral**: banner verde (tudo OK) / amarelo (N falhando).
+- **Facts** (KpiCards): tokens ativos · calls 7d · custo 7d (BRL) · devs ativos 7d + Top tools 7d + aviso de tabela ausente.
+- **Checks** (lista semáforo): cada dimensão com ícone ok/fail + nome + detail + pill.
+- Atalho `R` + botão Atualizar (reload defer facts/checks).
+- Loading skeleton (defer) + meta (gerado em / pattern / fonte).
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ **Sparkline** — não há série temporal real no builder; render de série exigiria nova métrica (fora de "só Facts+Checks atuais", §3). Deferido até existir um trends builder real.
+- ❌ Drill que abre outra tela (detail já vem inline no check).
+- ❌ Mutação (tela 100% read-only).
+- ❌ Filtro business_id — scorecard é repo-wide intencional (ADR 0093).
+
+## UX targets
+
+- DS v6: semáforo via tokens semânticos (success/warning/destructive), **sem cor crua**, `tabular-nums` nos números, ramp `--fs`.
+- KpiCard shared pros Facts; lista de checks com ícones lucide. Locators `data-testid`.
+
+## Anti-hooks (NÃO faz automaticamente)
+
+- ❌ NÃO escreve nada. ❌ NÃO inventa métrica/série. ❌ NÃO expõe valor de cap de custo (Tier 0 — o backend já redige o label).
+
+## Restrições Tier 0
+
+- Permissão `copiloto.mcp.usage.all` no construtor.
+- Repo-wide cross-business INTENCIONAL (ADR 0093) — governança da plataforma.
+
+## Métricas de sucesso (validação Wagner)
+
+- ✅ Rota `/team-mcp/scorecard` deixa de quebrar (Page existe).
+- ✅ Semáforo reflete N/M checks; verde quando todos OK.
+- ✅ Facts mostram números reais do builder; Top tools listado.
+- ✅ Sem cor crua (conformance/foundation/eslint-baseline verdes).

--- a/resources/js/Pages/team-mcp/Scorecard/Index.tsx
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.tsx
@@ -119,7 +119,7 @@ function ScorecardIndex({ facts, checks, meta }: Props) {
           {facts!.top_tools_7d.length === 0 ? (
             <p className="text-xs italic text-muted-foreground">Sem chamadas registradas na janela.</p>
           ) : (
-            <ul className="flex flex-wrap gap-2">
+            <ul className="inline-flex w-full flex-wrap gap-2">
               {facts!.top_tools_7d.map((t) => (
                 <li key={t.tool} className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs">
                   <span className="font-mono">{t.tool}</span>
@@ -145,7 +145,7 @@ function ScorecardIndex({ facts, checks, meta }: Props) {
       ) : (
         <ul className="mt-2 overflow-hidden rounded-lg border bg-card" data-testid="scorecard-checks">
           {checkList.map((c, i) => (
-            <li key={i} className="flex items-start gap-3 border-b border-border/60 px-3 py-2.5 last:border-b-0">
+            <li key={i} className="inline-flex w-full items-start gap-3 border-b border-border/60 px-3 py-2.5 last:border-b-0">
               {c.ok
                 ? <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-success" aria-label="ok" />
                 : <AlertCircle size={16} className="mt-0.5 shrink-0 text-destructive" aria-label="falha" />}

--- a/resources/js/Pages/team-mcp/Scorecard/Index.tsx
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.tsx
@@ -1,0 +1,179 @@
+// @memcofre
+//   tela: /team-mcp/scorecard
+//   module: TeamMcp — G1 FICHA W22 (Facts + Checks)
+//   forja: PR-3 — CRIA a Page (rota existia mas o componente não; route quebrada).
+//          visual-comparison em memory/requisitos/TeamMcp/scorecard-visual-comparison.md
+//   permissao: copiloto.mcp.usage.all
+//
+// Padrão Facts+Checks (ADR 0091): Facts = números sem juízo · Checks = semáforo ok/fail.
+// SEM dado fantasma: projeta só o que ScorecardBuilderService retorna (sem sparkline —
+// não há série temporal real; adicionar série = nova métrica, fora do escopo §3).
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { router } from '@inertiajs/react';
+import { useEffect, type ReactNode } from 'react';
+import { AlertCircle, CheckCircle2, RefreshCw } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import PageHeader from '@/Components/shared/PageHeader';
+import KpiGrid from '@/Components/shared/KpiGrid';
+import KpiCard from '@/Components/shared/KpiCard';
+import { cn } from '@/Lib/utils';
+
+interface Check { name: string; ok: boolean; detail: string }
+
+interface Facts {
+  tokens_ativos: number;
+  calls_7d: number;
+  cost_7d_brl: number;
+  users_ativos_7d: number;
+  top_tools_7d: Array<{ tool: string; count: number }>;
+  audit_log_present: boolean;
+  tokens_table_present: boolean;
+}
+
+interface Meta {
+  generated_at: string;
+  period_days: number;
+  pattern: string;
+  source: string;
+}
+
+interface Props {
+  // facts/checks deferidos → undefined no 1º paint (default-guard).
+  facts?: Facts;
+  checks?: Check[];
+  meta: Meta;
+}
+
+const brl = (v: number) => new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
+const num = (v: number) => new Intl.NumberFormat('pt-BR').format(v ?? 0);
+
+function fmtWhen(iso: string): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
+}
+
+function ScorecardIndex({ facts, checks, meta }: Props) {
+  const isLoading = facts === undefined || checks === undefined;
+  const checkList = checks ?? [];
+  const okCount = checkList.filter((c) => c.ok).length;
+  const allOk = checkList.length > 0 && okCount === checkList.length;
+
+  // Atalho: R recarrega facts/checks
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tgt = e.target as HTMLElement | null;
+      const typing = !!tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable);
+      if (!typing && (e.key === 'r' || e.key === 'R')) {
+        e.preventDefault();
+        router.reload({ only: ['facts', 'checks'] });
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  return (
+    <>
+      <PageHeader
+        icon="heart-pulse"
+        title="Saúde do MCP"
+        description={`Facts + Checks · janela ${meta.period_days}d · fonte ${meta.source}`}
+        action={
+          <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={() => router.reload({ only: ['facts', 'checks'] })}>
+            <RefreshCw size={13} className="mr-1" /> Atualizar
+          </Button>
+        }
+      />
+
+      {/* Semáforo geral */}
+      <div
+        role="status"
+        data-testid="scorecard-semaphore"
+        className={cn('mt-4 flex items-center gap-2 rounded-lg border px-4 py-3 text-sm',
+          isLoading ? 'border-border bg-muted/40 text-muted-foreground'
+            : allOk ? 'border-success/30 bg-success/10 text-success-fg'
+              : 'border-warning/30 bg-warning-soft text-warning-fg')}
+      >
+        {isLoading ? (
+          <span>Carregando checks…</span>
+        ) : allOk ? (
+          <><CheckCircle2 size={16} /> <span className="font-medium">Tudo verde — {okCount}/{checkList.length} checks OK</span></>
+        ) : (
+          <><AlertCircle size={16} /> <span className="font-medium">{checkList.length - okCount} de {checkList.length} checks falhando</span></>
+        )}
+      </div>
+
+      {/* Facts (números — sem juízo) */}
+      <h2 className="mt-6 text-sm font-semibold text-foreground">Facts <span className="font-normal text-muted-foreground">— números, sem juízo</span></h2>
+      <KpiGrid cols={4} className="mt-2">
+        <KpiCard icon="key-round" tone="default" label="Tokens ativos" value={isLoading ? '—' : num(facts!.tokens_ativos)} />
+        <KpiCard icon="activity" tone="default" label="Calls 7d" value={isLoading ? '—' : num(facts!.calls_7d)} />
+        <KpiCard icon="dollar-sign" tone="warning" label="Custo 7d" value={isLoading ? '—' : brl(facts!.cost_7d_brl)} />
+        <KpiCard icon="users" tone="default" label="Devs ativos 7d" value={isLoading ? '—' : num(facts!.users_ativos_7d)} />
+      </KpiGrid>
+
+      {!isLoading && (
+        <div className="mt-3 rounded-lg border bg-card p-3" data-testid="scorecard-tools">
+          <div className="mb-2 text-xs font-medium text-muted-foreground">Top tools (7d)</div>
+          {facts!.top_tools_7d.length === 0 ? (
+            <p className="text-xs italic text-muted-foreground">Sem chamadas registradas na janela.</p>
+          ) : (
+            <ul className="flex flex-wrap gap-2">
+              {facts!.top_tools_7d.map((t) => (
+                <li key={t.tool} className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2 py-1 text-xs">
+                  <span className="font-mono">{t.tool}</span>
+                  <span className="rounded-full bg-muted px-1.5 text-[10px] tabular-nums text-muted-foreground">{num(t.count)}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {(!facts!.audit_log_present || !facts!.tokens_table_present) && (
+            <p className="mt-2 text-[11px] text-warning-fg">
+              ⚠ {!facts!.audit_log_present && 'mcp_audit_log ausente. '}{!facts!.tokens_table_present && 'mcp_tokens ausente. '}Rodar migrations.
+            </p>
+          )}
+        </div>
+      )}
+
+      {/* Checks (semáforo ok/fail) */}
+      <h2 className="mt-6 text-sm font-semibold text-foreground">Checks <span className="font-normal text-muted-foreground">— saúde por dimensão</span></h2>
+      {isLoading ? (
+        <div className="mt-2 space-y-2" data-testid="scorecard-skeleton">
+          {Array.from({ length: 5 }).map((_, i) => <div key={i} className="h-12 animate-pulse rounded-md bg-muted/50" />)}
+        </div>
+      ) : (
+        <ul className="mt-2 overflow-hidden rounded-lg border bg-card" data-testid="scorecard-checks">
+          {checkList.map((c, i) => (
+            <li key={i} className="flex items-start gap-3 border-b border-border/60 px-3 py-2.5 last:border-b-0">
+              {c.ok
+                ? <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-success" aria-label="ok" />
+                : <AlertCircle size={16} className="mt-0.5 shrink-0 text-destructive" aria-label="falha" />}
+              <div className="min-w-0 flex-1">
+                <div className={cn('text-sm font-medium', c.ok ? 'text-foreground' : 'text-destructive')}>{c.name}</div>
+                <div className="text-xs text-muted-foreground">{c.detail}</div>
+              </div>
+              <span className={cn('shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium',
+                c.ok ? 'bg-success/15 text-success-fg' : 'bg-destructive-soft text-destructive-fg')}>
+                {c.ok ? 'ok' : 'falha'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <p className="mt-4 text-[11px] text-muted-foreground">
+        Gerado {fmtWhen(meta.generated_at)} · pattern <code className="font-mono">{meta.pattern}</code> · <kbd className="rounded bg-muted px-1 py-0.5">R</kbd> atualiza.
+        Scorecard é repo-wide (governança cross-business, superadmin) — sem filtro business_id (ADR 0093, intencional).
+      </p>
+    </>
+  );
+}
+
+ScorecardIndex.layout = (page: ReactNode) => (
+  <AppShellV2 title="Saúde do MCP — Equipe" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Saúde' }]}>
+    {page}
+  </AppShellV2>
+);
+
+export default ScorecardIndex;

--- a/resources/js/Pages/team-mcp/Scorecard/Index.tsx
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.tsx
@@ -14,7 +14,7 @@ import { router } from '@inertiajs/react';
 import { useEffect, type ReactNode } from 'react';
 import { AlertCircle, CheckCircle2, RefreshCw } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
-import PageHeader from '@/Components/shared/PageHeader';
+import { PageHeader } from '@/Components/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { cn } from '@/Lib/utils';
@@ -64,6 +64,7 @@ function ScorecardIndex({ facts, checks, meta }: Props) {
     function onKey(e: KeyboardEvent) {
       const tgt = e.target as HTMLElement | null;
       const typing = !!tgt && (tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable);
+      if (e.ctrlKey || e.metaKey || e.altKey) return; // não sequestrar Ctrl/Cmd+R do browser
       if (!typing && (e.key === 'r' || e.key === 'R')) {
         e.preventDefault();
         router.reload({ only: ['facts', 'checks'] });
@@ -76,10 +77,9 @@ function ScorecardIndex({ facts, checks, meta }: Props) {
   return (
     <>
       <PageHeader
-        icon="heart-pulse"
         title="Saúde do MCP"
-        description={`Facts + Checks · janela ${meta.period_days}d · fonte ${meta.source}`}
-        action={
+        subtitle={`Facts + Checks · janela ${meta.period_days}d · fonte ${meta.source}`}
+        actions={
           <Button variant="ghost" size="sm" className="h-8 text-xs" onClick={() => router.reload({ only: ['facts', 'checks'] })}>
             <RefreshCw size={13} className="mr-1" /> Atualizar
           </Button>


### PR DESCRIPTION
## Forja PR-3 — Scorecard / Saúde (DS v6)

Terceira onda **Forja → TeamMcp**. ⚠️ **Premissa corrigida:** não era re-skin — a rota `/team-mcp/scorecard` estava **quebrada** (`ScorecardController` renderiza `team-mcp/Scorecard/Index`, mas o componente **nunca existiu**). Este PR **cria a Page** no padrão **Facts + Checks** (ADR 0091), DS v6, **frontend-only** (controller + `ScorecardBuilderService` intactos — preserva contrato Pest W23).

### O que muda
- **Semáforo geral** no topo: verde (tudo OK) / amarelo (N de M falhando).
- **Facts** (KpiCards): tokens ativos · calls 7d · custo 7d (BRL) · devs ativos 7d + **Top tools 7d** + aviso de tabela ausente.
- **Checks**: lista semáforo (`CheckCircle2`/`AlertCircle` + nome + detail + pill ok/falha).
- Atalho `R` + botão **Atualizar** (reload `defer` facts/checks). Loading skeleton.
- DS v6: tokens semânticos (success/warning/destructive), **sem cor crua**, `tabular-nums`.

### Decisão sobre o sparkline (§3 — sem dado fantasma)
A Forja `.fj-saude` tem sparklines, mas o builder **não expõe série temporal** — só pontos atuais. Render de série exigiria **fabricar dado** (fantasma) ou **adicionar métrica nova**, o que contraria o escopo do prompt ("**só Facts+Checks atuais**"). → **Sparkline deferido.** Posso abrir **PR-3b** com `buildTrends()` real (buckets diários de `mcp_audit_log`) se quiser sparkline honesto.

### Processo
- mwart-comparative F1.5: [`scorecard-visual-comparison.md`](memory/requisitos/TeamMcp/scorecard-visual-comparison.md) + [charter](resources/js/Pages/team-mcp/Scorecard/Index.charter.md). Merge é **[W2]**.

### Verificação local
- ✅ `typecheck` 0 erros · `eslint` 0 problemas · `lint-baseline` sem regressão
- ✅ `conformance-gate` · `foundation-guard`
- ⏳ CI + smoke (a rota deixa de quebrar — bom alvo de smoke pós-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
