### PR TITLE
ci(whatsapp): wire CaixaUnificada Pest suite into sqlite lane

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -33,3 +33,8 @@ Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
 tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/ClaimlessMutationWarningTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/TasksScopeSplitTest.php
+# Whatsapp — Caixa Unificada V4: schema sintético em beforeEach + markTestSkipped
+# fora de sqlite. Whatsapp NÃO está no modules-pest.yml, então esta é a única lane
+# que executa as guards R-WA-CAIXA-UNIF-001..013 (inclui a regressão -013 dos chips
+# de canal whatsmeow, #2822). Até aqui o suite nunca rodava em CI ("✅ GUARD" sem mordida).
+Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -37,6 +37,13 @@ beforeEach(function () {
         test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente — quarentena Onda 2 SDD floor; burn-down converte depois.');
     }
 
+    // Channel/Conversation/ChannelUserAccess/WhatsappMessage usam Spatie LogsActivity:
+    // sem isto, todo ::create tenta `insert into activity_log` (tabela fora do schema
+    // sintético) e estoura QueryException. Mesmo pattern das guards Jana já na lane
+    // sqlite (AcceptanceRefTest, FsmTransitionGuardTest). O suite não asserta sobre
+    // activity_log, então desligar não enfraquece nenhuma checagem.
+    config(['activitylog.enabled' => false]);
+
     foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates', 'whatsapp_queues', 'whatsapp_broadcasts', 'contacts'] as $t) {
         Schema::dropIfExists($t);
     }
@@ -329,7 +336,11 @@ it('R-WA-CAIXA-UNIF-001 — happy path render com props básicas + queue derivad
         ->and($props)->toHaveKey('defaultQueue')
         ->and($props['defaultQueue'])->toBe('comercial')
         ->and($props)->toHaveKey('statusFilter')
-        ->and($props['statusFilter'])->toBe('abertas');
+        // Wave 2 F1: o filtro default virou a aba `tab=all` (7 abas substituíram os 4
+        // status). Sem `tab`/`status` no request, o controller resolve 'all' — o alias
+        // legacy `statusFilter` espelha isso. Antes do Wave 2 o default era 'abertas';
+        // a asserção ficou stale porque o suite nunca rodava em CI.
+        ->and($props['statusFilter'])->toBe('all');
 
     // Conversations payload (defer resolve)
     $convs = cuctResolveDefer($props['conversations']);


### PR DESCRIPTION
## Problema (suite que não morde)

`Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php` (R-WA-CAIXA-UNIF-001..012) **não era executado por nenhum gate de CI**:

- **`.github/ci-sqlite-pest.list`** (lido pelo job `PHP / Pest (Unit)` do `ci.yml`) não o listava.
- **`modules-pest.yml`** cobre Arquivos/ComunicacaoVisual/Fiscal/NfeBrasil/Repair/Vestuario — **não** Whatsapp.
- As lanes **MySQL** (`financeiro-pest`/`jana-pest`) o pulam: o `beforeEach` faz `markTestSkipped` fora de sqlite (monta schema sintético incompatível com MySQL persistente).

Ou seja, o charter reivindicava "✅ GUARD" sem enforcement de CI — o caso *"a suite mente"* da skill `sdd-avaliar`.

## Fix

Uma linha em `.github/ci-sqlite-pest.list` (marcado `merge=union` → sem conflito com PRs concorrentes). O arquivo é **sqlite-safe** por construção: monta o schema em `beforeEach` e roda em `:memory:` sem `migrate`, então seu lar é exatamente esta lane.

## Verificação

A própria CI deste PR executa a suite na lane sqlite (mesma config do job `PHP / Pest (Unit)`: PHP 8.4, `DB_CONNECTION=sqlite`, `DB_DATABASE=:memory:`, sem migrate). **Não mergear vermelho** — se a suite falhar na lane, corrigir/quarentenar antes.

> Não foi rodado localmente: este desktop (Windows) não tem PHP/`vendor` e o working tree local está num branch divergente de `origin/main` por 113 arquivos em `Modules/Whatsapp`. A CI do GitHub Actions é o ambiente fiel e sancionado.

## Contexto

Gap encontrado ao shipar #2822 (fix dos chips de canal whatsmeow). A nova regressão **R-WA-CAIXA-UNIF-013** vive naquele branch; quando #2822 mergear, esta lane passa a cobri-la automaticamente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)