### PR TITLE
fix(ui): dark mode real — ativa por [data-theme=dark], não só .dark (ADR 0281)

### DIFF
--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-13T19:57:12.215Z",
-    "total_lines": 20424,
+    "generated_at": "2026-06-16T13:45:44.932Z",
+    "total_lines": 20434,
     "file_count": 29,
     "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
     "refs": [
@@ -22,7 +22,7 @@
     "resources/css/fin-output.css": 1004,
     "resources/css/fiscal-cockpit.css": 1381,
     "resources/css/foundations.css": 45,
-    "resources/css/inertia.css": 408,
+    "resources/css/inertia.css": 418,
     "resources/css/kb.css": 184,
     "resources/css/screen-grade.css": 16,
     "resources/css/sells-cowork-curadoria.css": 312,

--- a/memory/decisions/0281-dark-mode-bridge-data-theme-tokens.md
+++ b/memory/decisions/0281-dark-mode-bridge-data-theme-tokens.md
@@ -1,0 +1,95 @@
+---
+slug: 0281-dark-mode-bridge-data-theme-tokens
+number: 281
+title: "Dark mode ativa por [data-theme=dark] (mecanismo real do AppShellV2), não só pela classe .dark — bridge no inertia.css"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-16"
+module: design-system
+tags: [ui, dark-mode, tokens, foundations, tailwind, cockpit, constituicao-ui, tier-0]
+supersedes: []
+superseded_by: []
+related:
+  - 0094-constituicao-v2-7-camadas-8-principios
+---
+
+# ADR 0281 — Dark mode ativa por `[data-theme="dark"]`, não só pela classe `.dark`
+
+## Contexto
+
+O dark mode do app tinha **dois mecanismos desconectados**, e por isso telas inteiras
+ficavam **brancas no escuro** (incidente reportado por [W] na Caixa Unificada,
+investigação durante a PR #2818):
+
+1. **Camada Cockpit/Cowork** — `foundations.css` e `cockpit.css` redefinem os tokens
+   Cowork (`--surface`, `--bg`, `--text`, sombras, atmosfera) sob **`[data-theme="dark"]`**.
+   O `AppShellV2.tsx` aplica `data-theme={userTheme}` no `.cockpit` (o `userTheme` vem de
+   `auth.user.ui_theme`, server-side). → a **casca** do cockpit escurece.
+
+2. **Camada Tailwind (`@theme`)** — o `inertia.css` redefine os tokens `--color-*`
+   (`card`, `background`, `foreground`, `warning-*`, `info`, `destructive-*`, etc.) e a
+   variant `dark:` **apenas sob a classe `.dark`**.
+
+O furo: **nada nunca aplica a classe `.dark`** (o `AppShellV2` só seta `data-theme`).
+Um comentário stale no `inertia.css` ainda afirmava o contrário ("ativa quando
+`<html class="dark">`" + "`data-theme=dark` não é ativado em nenhuma tela"). Resultado
+medido ao vivo em produção (`.cockpit[data-theme="dark"]`): `--color-card` resolvia para
+`oklch(100%)` (branco) — então toda tela construída com utilities Tailwind
+(`bg-card`, `text-foreground`, `bg-warning-soft`, …) ficava **clara dentro de uma casca
+escura** (o "miolo branco"). Telas que herdam o visual via vars Cowork escureciam; as
+"modernas" tokenizadas, não.
+
+Isto é Fundação (Constituição UI v2 · [ADR UI-0013] — tokens cor/tipo/espaço imutáveis
+via ADR), por isso a decisão é registrada aqui.
+
+## Decisão
+
+**Os tokens Tailwind e a variant `dark:` passam a ativar pelos DOIS seletores**, com os
+mesmos valores dark já afinados. Duas linhas no `inertia.css`:
+
+- `@custom-variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *))`
+- bloco de tokens dark: `.dark, [data-theme="dark"] { … }`
+
+Assim, quando o `AppShellV2` seta `data-theme="dark"` no `.cockpit`, os `--color-*`
+flipam e **toda tela Tailwind escurece de verdade** — sem cunhar token novo, sem tocar a
+paleta, sem override por-tela. A classe `.dark` (legado shadcn) continua válida para
+qualquer contexto fora do `.cockpit`.
+
+## Consequências
+
+**Positivas**
+- A Caixa Unificada (e qualquer Page com utilities Tailwind) escurece corretamente.
+  A tokenização da PR #2818 (`bg-white`→`bg-card`, âmbar→`warning-*`) passa a ser
+  **efetiva** — antes era correta mas inerte no mecanismo real.
+- Fix sistêmico de uma fonte única, não 1-por-tela.
+
+**Riscos / pegadinhas**
+- Blast radius = app inteiro. Telas que "pareciam ok no escuro" só porque os tokens
+  **não** flipavam podem revelar contraste a corrigir (cor clara hardcoded `bg-white`/
+  `#fff`/oklch claro cru). **Latente**, não introduzido — agora visível. Spot-check em
+  Sells, Financeiro (unificado) e Cliente: escurecem limpo, sem regressão.
+- **Portals fora do `.cockpit`** (Radix dialog/popover renderizados no `body`) não herdam
+  `[data-theme]` nem `.dark` → permanecem claros no escuro. Pré-existente, fora do escopo
+  desta ADR (item separado se virar sinal).
+- `foundation-guard`/`conformance-gate` seguem verdes (o `inertia.css` já é arquivo
+  token-def allowlisted; só ganhou um seletor irmão).
+
+## Alternativas consideradas
+
+- **Aplicar `.dark` no `<html>` via JS no AppShell** (espelhando `ui_theme`): dual de
+  estado (classe + atributo), mais JS, risco de flash. Rejeitada — o bridge de seletor é
+  declarativo e reusa o que já existe.
+- **Override dark escopado só nos componentes da Caixa Unificada**: zero blast radius, mas
+  não-canônico (contradiz tokens), não conserta as outras telas e multiplica dívida.
+  Rejeitada.
+
+## Verificação
+
+Probe de injeção em produção replicando o bridge sob `.cockpit[data-theme="dark"]`:
+`--color-card` → `oklch(0.208 …)` (escuro), bolha inbound e fundo da thread flipam,
+texto legível nos 2 temas; Sells/Financeiro/Cliente conferidos no escuro. Confirmação
+final do build real fica no smoke pós-deploy.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **285** arquivos · **270** números únicos · máx **0280**
-- **ADRs ATIVOS (lifecycle ativo): 245** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 223 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 245 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **286** arquivos · **271** números únicos · máx **0281**
+- **ADRs ATIVOS (lifecycle ativo): 246** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 224 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 246 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (285)
+## Todas as ADRs (286)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -317,3 +317,4 @@ _(íntegra)_
 | 0278 | aceito | ativo | meta | Arquitetura durável de automação multi-IA (anti-vazamento, thread-aware, em rede |
 | 0279 | aceito | ativo | meta | Fechar o elo MEDIR→GOVERNAR do floor (transporte CT100 → scorecard, Opção A) |
 | 0280 | aceito | ativo | meta | Postura multi-tenant das tabelas mcp_* — governança de plataforma é repo-wide (s |
+| 0281 | aceito | ativo | decision | Dark mode ativa por [data-theme=dark] (mecanismo real do AppShellV2), não só pel |

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
-@custom-variant dark (&:where(.dark, .dark *));
+/* Dark ativa por DOIS mecanismos (ADR 0281): a classe `.dark` (legado shadcn,
+   nunca aplicada na prática) E `[data-theme="dark"]` — que é o que o AppShellV2
+   realmente seta no `.cockpit` (linha data-theme={userTheme}). Sem o segundo seletor
+   as utilities `dark:` nunca disparavam em produção (painel branco no escuro). */
+@custom-variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
 
 /* Sells/Index Cowork visual — escopado em .sells-cowork (ver scripts/scope-sells-cowork-css.py) */
 @import "./sells-cowork.css";
@@ -191,11 +195,17 @@
 }
 
 /* ==========================================================================
-   Dark mode — ativa quando <html class="dark">
-   Anti-flash: script inline em layouts/inertia.blade.php aplica a classe
+   Dark mode — ativa por `.dark` (classe legado shadcn) OU `[data-theme="dark"]`.
+   ADR 0281: o AppShellV2 seta `data-theme={userTheme}` no `.cockpit`, NUNCA a
+   classe `.dark` — então sem `[data-theme="dark"]` aqui os tokens Tailwind
+   `--color-*` jamais flipavam e toda tela feita com utilities (bg-card,
+   text-foreground, warning-*, etc.) ficava branca no escuro. Os dois seletores
+   compartilham os MESMOS valores dark já afinados.
+   Anti-flash: script inline em layouts/inertia.blade.php aplica o tema
    ANTES do React hidratar, evitando "piscar" branco-para-escuro.
    ========================================================================== */
-.dark {
+.dark,
+[data-theme="dark"] {
   /* DS harmonizado 2026-06-13: dark fica COOL neutro (cream warm não inverte
      coerente — a tela já decidiu isso); só refina a neutralidade da borda. */
   --color-border: oklch(0.27 0.006 250);


### PR DESCRIPTION
## TL;DR

Investigando o bug do dark da Caixa Unificada (reportado por [W]), descobri que **o dark nunca funcionou de verdade em telas Tailwind** — e a PR [#2818](https://github.com/wagnerra23/oimpresso.com/pull/2818) (tokenização) era **correta porém inerte**. Esta PR religa o mecanismo.

## Causa-raiz (medida ao vivo em prod)

Dois mecanismos de dark desconectados:
1. **Cockpit/Cowork** — `foundations.css`/`cockpit.css` flipam `--surface`/`--bg`/`--text` sob **`[data-theme="dark"]`**. O `AppShellV2` aplica `data-theme={userTheme}` no `.cockpit`. → casca escurece.
2. **Tailwind `@theme`** — `inertia.css` flipa `--color-*` e a variant `dark:` **só sob `.dark`**.

**Nada nunca aplica `.dark`** (o AppShell só seta `data-theme`). Logo `--color-card` resolvia para `oklch(100%)` (branco) no escuro → telas tokenizadas (`bg-card`, `text-foreground`, `warning-*`) ficavam **claras numa casca escura** = "miolo branco".

## Fix (2 linhas, `inertia.css`)

```css
@custom-variant dark (&:where(.dark, .dark *, [data-theme="dark"], [data-theme="dark"] *));
.dark, [data-theme="dark"] { /* …mesmos valores dark já afinados… */ }
```

Quando o AppShell seta `data-theme="dark"`, os `--color-*` flipam e **toda tela Tailwind escurece** — zero token novo, zero override por-tela, zero mudança de paleta.

## Verificação

Probe de injeção em produção (replicando o bridge sob `.cockpit[data-theme="dark"]`):

| Tela | Resultado no escuro |
|---|---|
| **Caixa Unificada** (thread 503) | bolhas inbound viram card escuro, nota/banner/chips legíveis, verde-WA mantido, sidebar Contexto legível ✓ |
| **Sells / Vendas** | KPIs + tabela + badges (Pendente/Paga) escurecem limpo ✓ |
| **Financeiro / Unificado** | KPIs + lançamentos + status (Atrasado/Recebido) legíveis ✓ |
| **Cliente** (índice) | KPIs + tabela + tipos PF/PJ legíveis ✓ |

`--color-card` medido sob o mecanismo real: `oklch(0.208…)` (escuro). `foundation-guard` / `conformance-gate` / `ds-canon` verdes localmente.

## Escopo / riscos

- **Foundation (Constituição UI v2 · ADR UI-0013)** — blast radius = app inteiro. Telas que "pareciam ok" só porque os tokens não flipavam podem revelar contraste latente (cor clara hardcoded). Os 4 spot-checks acima não mostraram regressão.
- **Portals fora do `.cockpit`** (dialog/popover Radix no `body`) seguem claros no escuro — **pré-existente**, item separado.
- Depende de #2818 (já mergeado) pra Caixa Unificada ficar 100%.

ADR canônica: `memory/decisions/0281-dark-mode-bridge-data-theme-tokens.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
