### PR TITLE
fix(team-mcp): corrige link SPEC morto no empty-state CcSessions

### DIFF
--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -230,7 +230,7 @@ function CcSessionsIndex({ sessions, filters, kpis, devs, projects, permissions 
             description="O schema mcp_cc_* está pronto; falta o watcher Node nos devs (POST /api/cc/ingest)."
             action={
               <a
-                href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Copiloto/SPEC-cc-sessions.md"
+                href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Jana/SPEC-cc-sessions.md"
                 target="_blank" rel="noopener noreferrer"
                 className="text-sm text-primary hover:underline"
               >Ver SPEC do watcher →</a>


### PR DESCRIPTION
Follow-up de review do [#2821](https://github.com/wagnerra23/oimpresso.com/pull/2821) (mergeado antes do nit landar). O empty-state de `/team-mcp/cc-sessions` aponta pra `memory/requisitos/Copiloto/SPEC-cc-sessions.md` (inexistente) — o caminho real é `memory/requisitos/Jana/SPEC-cc-sessions.md`. 1 linha. Só aparece quando zero sessões CC foram ingestadas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)