### PR TITLE
feat(whatsapp): canário do webhook (Fase 1 perda-zero, detecção <5min do #2726)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -38,3 +38,6 @@ Modules/Jana/Tests/Feature/TaskRegistry/TasksScopeSplitTest.php
 # que executa as guards R-WA-CAIXA-UNIF-001..013 (inclui a regressão -013 dos chips
 # de canal whatsmeow, #2822). Até aqui o suite nunca rodava em CI ("✅ GUARD" sem mordida).
 Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+# Fase 1 perda-zero — canário do webhook WhatsApp (US-WA-311, incidente #2726)
+Modules/Whatsapp/Tests/Feature/WebhookCanaryCommandTest.php
+Modules/Jana/Tests/Feature/Smoke/WhatsappInboundCanaryCheckTest.php

--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -28,6 +28,10 @@ use Modules\Jana\Services\CharterHealthChecker;
  *   8b. Whatsapp inbound flow (sentinela de fluxo real · incidente 2026-06-16
  *       #2726) — por canal ativo com histórico, último inbound > Nh em horário
  *       comercial = ALERTA. Pega QUALQUER causa de silêncio no recebimento.
+ *   8c. Whatsapp inbound canary (auto-teste do alarme · Fase 1 perda-zero) — lê
+ *       o último tick do cron `whatsapp:webhook-canary`; stale/falha em horário
+ *       comercial = ALERTA. Prova que a VIA responde 200 E que o monitor não
+ *       apodreceu mentindo verde (raiz do #2726).
  *   9. MCP webhook 5xx 2h (US-FIN-043 incident 2026-05-21) — webhook GitHub
  *      retornando 5xx nas últimas 2h indica drift no DB sync (tasks/memory)
  *  10. Memoria recall backend (resiliência Meilisearch) — MCP/Meilisearch
@@ -72,6 +76,7 @@ class HealthCheckCommand extends Command
             $this->checkSpecIdDrift(),
             $this->checkWhatsappMediaPending1h(),
             $this->checkWhatsappInboundFlow(),
+            $this->checkWhatsappInboundCanary(),
             $this->checkMcpWebhookHealth2h(),
             $this->checkMemoriaRecallBackend(),
             $this->checkLessonLedgerGraduation(),
@@ -614,6 +619,104 @@ class HealthCheckCommand extends Command
         }
 
         return ['ok' => $mudos === [], 'vigiados' => $vigiados, 'mudos' => $mudos, 'fora_horario' => false];
+    }
+
+    /**
+     * Check 8c — Whatsapp INBOUND CANARY (auto-teste do alarme · camada 5 da
+     * proposta perda-zero · Fase 1).
+     *
+     * Onde o inbound_flow (8b) mede o RESULTADO (chegou mensagem?), este mede a
+     * VIA (o webhook responde 200?) — e, principalmente, prova que o próprio
+     * canário (`whatsapp:webhook-canary`, cron 5min) está VIVO. Sem isso o monitor
+     * pode apodrecer mentindo "verde" (a raiz do #2726: tudo verde com o
+     * recebimento morto). Lê o último tick do canário em cache:
+     *   - fresco + ok      → verde (caminho provado <maxAge)
+     *   - fresco + não-200 → ALERTA (webhook quebrado AGORA)
+     *   - velho (stale)    → ALERTA (cron do canário morreu = perdeu o sinal)
+     *   - cold (nunca rodou) → verde com grace (pós-deploy; o tick popula em ≤5min)
+     *
+     * Hard check em horário comercial BRT (mesma janela do canário); fora dela e
+     * em ambiente sem segredo (dev/CI) não acende.
+     */
+    protected function checkWhatsappInboundCanary(): array
+    {
+        $name = 'whatsapp_inbound_canary';
+        $maxAge = (int) config('whatsapp.canary.freshness_max_age_minutes', 15);
+        $configured = (bool) config('whatsapp.canary.enabled', true)
+            && (string) config('whatsapp.whatsmeow.webhook_url_secret', '') !== '';
+
+        try {
+            $last = \Illuminate\Support\Facades\Cache::get('whatsapp:webhook-canary:last');
+            $r = self::evaluateCanaryFreshness(
+                $configured,
+                is_array($last) ? $last : null,
+                now()->setTimezone('America/Sao_Paulo'),
+                $maxAge,
+            );
+
+            $messages = [
+                'nao-configurado' => 'Skipped (canário do webhook não configurado — dev/CI)',
+                'fora-horario' => 'Fora do horário comercial BRT — canário em pausa, não alarma agora',
+                'cold' => 'Canário ainda não reportou (cold-start pós-deploy — popula em ≤5min)',
+                'fresco' => "Webhook provado há {$r['age_min']}min (≤ {$maxAge}min) — caminho de recebimento vivo",
+                'stale' => "ALERTA: canário sem reportar há {$r['age_min']}min (> {$maxAge}min) — cron whatsapp:webhook-canary pode estar morto (sinal perdido, classe #2726)",
+                'falha' => 'ALERTA: último canário do webhook FALHOU — recebimento WhatsApp pode estar parado (classe #2726)',
+            ];
+
+            return [
+                'name' => $name,
+                'ok' => $r['ok'],
+                'value' => $r['age_min'] !== null ? "{$r['age_min']}min" : $r['state'],
+                'threshold' => "<= {$maxAge}min",
+                'message' => $messages[$r['state']] ?? $r['state'],
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'name' => $name,
+                'ok' => false,
+                'value' => null,
+                'threshold' => "<= {$maxAge}min",
+                'message' => 'ERRO: ' . $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Lógica pura do frescor do canário — pública e estática pra ser testável sem
+     * cache nem relógio real (mesmo padrão de evaluateInboundFlow).
+     *
+     * @param  array{ok?: bool, status?: ?int, reason?: string, at?: string}|null  $last
+     * @return array{ok: bool, state: string, age_min: ?int}
+     */
+    public static function evaluateCanaryFreshness(bool $configured, ?array $last, \Illuminate\Support\Carbon $nowBrt, int $maxAgeMinutes): array
+    {
+        if (! $configured) {
+            return ['ok' => true, 'state' => 'nao-configurado', 'age_min' => null];
+        }
+
+        // Mesma janela do cron do canário (08–20, seg–sáb). Fora dela ele não roda.
+        $horaComercial = $nowBrt->hour >= 8 && $nowBrt->hour < 20 && $nowBrt->dayOfWeek !== \Carbon\Carbon::SUNDAY;
+        if (! $horaComercial) {
+            return ['ok' => true, 'state' => 'fora-horario', 'age_min' => null];
+        }
+
+        // Cold-start: chave ausente = canário nunca reportou (pós-deploy). Grace
+        // pra não falso-alarmar antes do primeiro tick (≤5min). O cenário de
+        // apodrecimento (cron morre DEPOIS de rodar) cai em 'stale', não aqui.
+        if ($last === null || empty($last['at'])) {
+            return ['ok' => true, 'state' => 'cold', 'age_min' => null];
+        }
+
+        $at = \Illuminate\Support\Carbon::parse((string) $last['at']);
+        $ageMin = (int) abs($at->diffInMinutes($nowBrt));
+        if ($ageMin > $maxAgeMinutes) {
+            return ['ok' => false, 'state' => 'stale', 'age_min' => $ageMin];
+        }
+        if (($last['ok'] ?? false) !== true) {
+            return ['ok' => false, 'state' => 'falha', 'age_min' => $ageMin];
+        }
+
+        return ['ok' => true, 'state' => 'fresco', 'age_min' => $ageMin];
     }
 
     /**

--- a/Modules/Jana/Tests/Feature/Smoke/WhatsappInboundCanaryCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/WhatsappInboundCanaryCheckTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Auto-teste do alarme do canário do webhook (camada 5 · Fase 1 perda-zero,
+ * incidente 2026-06-16 #2726).
+ *
+ * A lógica vive em evaluateCanaryFreshness (estática, sem cache nem relógio real
+ * — mesmo padrão de evaluateInboundFlow). O último teste prova que o check está
+ * registrado no jana:health-check e é HARD (derruba o exit code).
+ *
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php::checkWhatsappInboundCanary
+ * @see Modules/Whatsapp/Console/Commands/WebhookCanaryCommand.php
+ */
+$comercial = fn (): Carbon => Carbon::parse('2026-06-16 10:00:00', 'America/Sao_Paulo'); // terça 10h BRT
+$tick = fn (Carbon $now, int $agoMin, bool $ok): array => [
+    'ok' => $ok,
+    'status' => $ok ? 200 : 401,
+    'at' => $now->copy()->subMinutes($agoMin)->toIso8601String(),
+];
+
+test('não-configurado (dev/CI sem segredo) não acende', function () use ($comercial) {
+    $r = HealthCheckCommand::evaluateCanaryFreshness(false, null, $comercial(), 15);
+    expect($r['ok'])->toBeTrue();
+    expect($r['state'])->toBe('nao-configurado');
+});
+
+test('tick fresco e verde = ok (caminho provado)', function () use ($comercial, $tick) {
+    $r = HealthCheckCommand::evaluateCanaryFreshness(true, $tick($comercial(), 5, true), $comercial(), 15);
+    expect($r['ok'])->toBeTrue();
+    expect($r['state'])->toBe('fresco');
+    expect($r['age_min'])->toBe(5);
+});
+
+test('tick fresco mas FALHOU = alerta (webhook quebrado agora)', function () use ($comercial, $tick) {
+    $r = HealthCheckCommand::evaluateCanaryFreshness(true, $tick($comercial(), 3, false), $comercial(), 15);
+    expect($r['ok'])->toBeFalse();
+    expect($r['state'])->toBe('falha');
+});
+
+test('tick velho (stale) = alerta (cron do canário morreu — o monitor apodreceu)', function () use ($comercial, $tick) {
+    $r = HealthCheckCommand::evaluateCanaryFreshness(true, $tick($comercial(), 40, true), $comercial(), 15);
+    expect($r['ok'])->toBeFalse();
+    expect($r['state'])->toBe('stale');
+    expect($r['age_min'])->toBe(40);
+});
+
+test('cold-start (nunca reportou) = ok com grace pós-deploy', function () use ($comercial) {
+    $r = HealthCheckCommand::evaluateCanaryFreshness(true, null, $comercial(), 15);
+    expect($r['ok'])->toBeTrue();
+    expect($r['state'])->toBe('cold');
+});
+
+test('fora do horário comercial BRT não acende (canário em pausa à noite)', function () use ($tick) {
+    $noite = Carbon::parse('2026-06-16 23:00:00', 'America/Sao_Paulo');
+    $r = HealthCheckCommand::evaluateCanaryFreshness(true, $tick($noite, 120, true), $noite, 15);
+    expect($r['ok'])->toBeTrue();
+    expect($r['state'])->toBe('fora-horario');
+});
+
+test('whatsapp_inbound_canary está registrado no jana:health-check e é hard (não-advisory)', function () {
+    Cache::flush(); // garante cold-start determinístico (ok=true) — não falha o exit por este check
+    Artisan::call('jana:health-check', ['--json' => true]);
+    $out = Artisan::output();
+    $start = strpos($out, '{');
+    $json = $start === false ? [] : json_decode(substr($out, (int) $start), true);
+
+    $check = collect($json['checks'] ?? [])->firstWhere('name', 'whatsapp_inbound_canary');
+    expect($check)->not->toBeNull('check whatsapp_inbound_canary ausente do jana:health-check');
+    expect($check['advisory'] ?? false)->toBeFalse(); // hard check — derruba exit + ALERT
+    expect($check)->toHaveKeys(['name', 'ok', 'value', 'threshold', 'message']);
+});

--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -77,6 +77,27 @@ return [
         'request_timeout' => (int) env('WHATSMEOW_TIMEOUT', 15),
     ],
 
+    /*
+     * Canário do webhook (Fase 1 perda-zero — proposta whatsapp-ingestao-perda-zero.md).
+     *
+     * Cron `whatsapp:webhook-canary` (a cada 5min em horário comercial BRT) posta
+     * um Presence sintético na URL pública com `?wh=` e confere 200; não-200 →
+     * ALERT + exit≠0. Pega a classe do #2726 (webhook recusando) em <5min — dentro
+     * da janela de retry do daemon, ou seja, antes de qualquer mensagem ser perdida.
+     *
+     * `business_uuid` = endereço público da rota (NÃO segredo). Vazio = o comando
+     * deriva do primeiro channel whatsmeow ativo. WR2 (biz=1) =
+     * 29aa9931-108e-4f7d-a3ce-d15e4f35cbd4.
+     */
+    'canary' => [
+        'enabled' => (bool) env('WHATSAPP_CANARY_ENABLED', true),
+        'business_uuid' => env('WHATSAPP_CANARY_BUSINESS_UUID', ''),
+        'timeout_seconds' => (int) env('WHATSAPP_CANARY_TIMEOUT', 10),
+        // Idade máxima do último tick (min) pro jana:health-check considerar o
+        // canário "fresco". 15min = 3 ticks de 5min perdidos = cron claramente morto.
+        'freshness_max_age_minutes' => (int) env('WHATSAPP_CANARY_FRESHNESS_MAX_AGE_MIN', 15),
+    ],
+
     'health_check' => [
         'interval_seconds' => env('WHATSAPP_HEALTH_INTERVAL', 21600), // 6h
         'consecutive_failures_to_degrade' => 5,

--- a/Modules/Whatsapp/Console/Commands/WebhookCanaryCommand.php
+++ b/Modules/Whatsapp/Console/Commands/WebhookCanaryCommand.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Canário do webhook Whatsmeow — Fase 1 (camadas 1 + 5) do padrão de ingestão
+ * perda-zero (proposta memory/decisions/proposals/whatsapp-ingestao-perda-zero.md).
+ *
+ * POSTa um evento sintético BENIGNO (`Presence`, envelope real do WuzAPI
+ * `{instanceName, jsonData}`) na PRÓPRIA URL pública do webhook com o segredo
+ * `?wh=<secret>` e confere HTTP **200**. Não-200 (401/500/timeout) → ALERT
+ * imediato (Log::error + mcp_alertas_eventos se existir) + exit não-zero.
+ *
+ * **Por que pega o #2726:** o incidente (hardening de auth deixou o recebimento
+ * morto 3 dias sem ninguém ver) seria detectado em <5min — o canário prova
+ * continuamente o caminho público inteiro (TLS → edge → rota → middleware de
+ * auth → controller). Combinado com a janela de retry do daemon (~10-15 min),
+ * detectar+corrigir dentro dela = mensagens re-entregues = perda zero, SEM
+ * reescrever durabilidade.
+ *
+ * **Por que é benigno:** um evento `Presence` cujo `instanceName` não casa
+ * nenhum channel cai no ramo `no_channel` do WhatsmeowWebhookController e é
+ * ACKado em 200 SEM criar mensagem, sem dispatch de job, sem escrita no DB
+ * (provado por WhatsmeowWebhookAuthTest "contrato REAL do daemon"). O canário
+ * só OBSERVA a via — não altera o recebimento.
+ *
+ * **Camada 5 (auto-teste do alarme):** grava o resultado de cada tick em cache
+ * (`self::CACHE_KEY`); o `jana:health-check` lê (check `whatsapp_inbound_canary`)
+ * pra detectar se o próprio canário apodreceu (cron morto = sem provas frescas).
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** o canário não toca dados de tenant — só
+ * posta um evento sintético e lê config. O business_uuid do alvo é só o
+ * endereço público da rota (já é parte da URL que o daemon usa).
+ *
+ * Uso:
+ *   php artisan whatsapp:webhook-canary
+ *   php artisan whatsapp:webhook-canary --json
+ *   php artisan whatsapp:webhook-canary --url=https://staging.../api/whatsapp/webhook/whatsmeow/<uuid>
+ *
+ * @see Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php (auth ?wh=)
+ * @see Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php (ACK 200)
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php (check whatsapp_inbound_canary)
+ */
+class WebhookCanaryCommand extends Command
+{
+    protected $signature = 'whatsapp:webhook-canary
+                            {--json : Output JSON em vez de texto}
+                            {--url= : Override do alvo (default = rota pública whatsmeow do business configurado)}';
+
+    protected $description = 'Canário do webhook WhatsApp — prova que o recebimento responde 200 (<5min); alerta + exit≠0 se quebrou (incidente #2726)';
+
+    /**
+     * Chave de cache do último resultado (lida pelo jana:health-check). Literal
+     * compartilhado de propósito (acoplamento mínimo entre módulos): o check de
+     * frescor funciona mesmo sem o módulo Whatsapp carregado.
+     */
+    public const CACHE_KEY = 'whatsapp:webhook-canary:last';
+
+    /** Nome identificável nos logs/access-log do receiver — não casa channel real. */
+    private const SYNTHETIC_INSTANCE = 'oimpresso-webhook-canary';
+
+    public function handle(): int
+    {
+        if (! (bool) config('whatsapp.canary.enabled', true)) {
+            return $this->report(['skipped' => true, 'reason' => 'canário desabilitado (whatsapp.canary.enabled=false)'], self::SUCCESS);
+        }
+
+        $secret = (string) config('whatsapp.whatsmeow.webhook_url_secret', '');
+        if ($secret === '') {
+            // Sem segredo o caminho ?wh= é inerte (dev/CI) — nada a provar. Não
+            // grava cache: o check de frescor trata "ausente" como cold-start.
+            return $this->report(['skipped' => true, 'reason' => 'WHATSMEOW_WEBHOOK_URL_SECRET não configurado (dev/CI)'], self::SUCCESS);
+        }
+
+        $baseUrl = $this->resolveBaseUrl();
+        if ($baseUrl === null) {
+            return $this->report(['skipped' => true, 'reason' => 'sem business alvo (config whatsapp.canary.business_uuid e nenhum channel whatsmeow ativo)'], self::SUCCESS);
+        }
+
+        $host = (string) (parse_url($baseUrl, PHP_URL_HOST) ?: $baseUrl);
+        $timeout = (int) config('whatsapp.canary.timeout_seconds', 10);
+        $status = null;
+        $error = null;
+
+        try {
+            $response = Http::timeout($timeout)
+                ->withHeaders(['Content-Type' => 'application/json'])
+                ->withBody(self::syntheticPresenceBody(), 'application/json')
+                ->post($baseUrl . '?wh=' . rawurlencode($secret));
+            $status = $response->status();
+        } catch (\Throwable $e) {
+            // Timeout / conexão recusada / DNS — tudo conta como quebra do caminho.
+            $error = mb_substr($e->getMessage(), 0, 120);
+        }
+
+        $r = self::evaluateCanary($status, $error);
+
+        // Camada 5: registra o tick (TTL longo — o frescor é computado pelo
+        // timestamp, não pela expiração da chave, pra distinguir stale de cold).
+        Cache::put(self::CACHE_KEY, [
+            'ok' => $r['ok'],
+            'status' => $r['status'],
+            'reason' => $r['reason'],
+            'at' => now()->toIso8601String(),
+        ], now()->addDay());
+
+        if ($r['ok']) {
+            return $this->report([
+                'ok' => true,
+                'status' => $r['status'],
+                'reason' => $r['reason'],
+                'target_host' => $host,
+            ], self::SUCCESS);
+        }
+
+        // ── Quebra: ALERT imediato (sem segredo no log) + exit≠0 ───────────────
+        $msg = "ALERTA recebimento WhatsApp: canário do webhook falhou — {$r['reason']} "
+            . '(classe do incidente #2726: webhook recusando/indisponível; mensagens '
+            . 'em risco até a janela de retry do daemon ~10-15min expirar). '
+            . "Checar auth/rota/worker/edge/daemon. Host: {$host}";
+        Log::channel('single')->error($msg);
+        $this->persistAlert($r);
+
+        return $this->report([
+            'ok' => false,
+            'status' => $r['status'],
+            'reason' => $r['reason'],
+            'target_host' => $host,
+        ], self::FAILURE);
+    }
+
+    /**
+     * Lógica pura do veredito — pública e estática pra ser testável sem rede
+     * (mesmo padrão de HealthCheckCommand::evaluateInboundFlow/parseLessonLedger).
+     *
+     * @return array{ok: bool, status: ?int, reason: string}
+     */
+    public static function evaluateCanary(?int $status, ?string $error, int $expectedStatus = 200): array
+    {
+        if ($error !== null) {
+            return ['ok' => false, 'status' => null, 'reason' => "erro de conexão: {$error}"];
+        }
+        if ($status === $expectedStatus) {
+            return ['ok' => true, 'status' => $status, 'reason' => "HTTP {$status}"];
+        }
+
+        return ['ok' => false, 'status' => $status, 'reason' => "HTTP {$status} (esperado {$expectedStatus})"];
+    }
+
+    /**
+     * Envelope idêntico ao que o daemon WuzAPI emite: `{instanceName, jsonData}`
+     * com jsonData = JSON-string aninhada {event, type}. Evento `Presence` com
+     * instanceName sintético → controller ACKa 200 `no_channel` sem efeito.
+     */
+    public static function syntheticPresenceBody(): string
+    {
+        return (string) json_encode([
+            'instanceName' => self::SYNTHETIC_INSTANCE,
+            'jsonData' => json_encode([
+                'event' => ['Info' => ['Chat' => '']],
+                'type' => 'Presence',
+            ]),
+        ]);
+    }
+
+    /**
+     * URL base (sem o `?wh=`) da rota pública do webhook. Override via --url;
+     * senão resolve o business_uuid alvo (config OU primeiro channel whatsmeow
+     * ativo) e gera a rota canônica.
+     */
+    private function resolveBaseUrl(): ?string
+    {
+        $override = (string) ($this->option('url') ?? '');
+        if ($override !== '') {
+            // Remove qualquer ?wh= que o operador tenha colado — o segredo é
+            // sempre re-anexado a partir da config (evita vazar no histórico).
+            return (string) strtok($override, '?');
+        }
+
+        $uuid = $this->resolveBusinessUuid();
+        if ($uuid === null) {
+            return null;
+        }
+
+        return route('whatsapp.webhook.whatsmeow.handle', ['business_uuid' => $uuid]);
+    }
+
+    private function resolveBusinessUuid(): ?string
+    {
+        $configured = (string) config('whatsapp.canary.business_uuid', '');
+        if ($configured !== '') {
+            return $configured;
+        }
+
+        // Sem config: deriva do business do primeiro channel whatsmeow ativo
+        // (cross-tenant read intencional — comando ops, sem session). Tier 0:
+        // só lê o uuid público da rota, não dados de negócio.
+        try {
+            if (! Schema::hasTable('channels') || ! Schema::hasTable('business')) {
+                return null;
+            }
+            $businessId = DB::table('channels')
+                ->where('type', \Modules\Whatsapp\Entities\Channel::TYPE_WHATSAPP_WHATSMEOW)
+                ->where('status', 'active')
+                ->min('business_id');
+            if ($businessId === null) {
+                return null;
+            }
+            $uuid = DB::table('business')->where('id', (int) $businessId)->value('uuid');
+
+            return is_string($uuid) && $uuid !== '' ? $uuid : null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Persiste alerta idempotente (1×/dia) em mcp_alertas_eventos se a tabela
+     * existir. Espelha o padrão PersistsDriftAlert (Governance). Falha de
+     * persistência NUNCA derruba o canário (o Log::error já é o sinal realtime).
+     *
+     * @param  array{ok: bool, status: ?int, reason: string}  $r
+     */
+    private function persistAlert(array $r): void
+    {
+        try {
+            if (! Schema::hasTable('mcp_alertas_eventos')) {
+                return;
+            }
+            $chave = mb_substr('whatsapp_webhook_canary:' . now()->format('Y-m-d'), 0, 200);
+            if (DB::table('mcp_alertas_eventos')->where('chave_idempotencia', $chave)->exists()) {
+                return;
+            }
+            DB::table('mcp_alertas_eventos')->insert([
+                'user_id' => null,
+                'business_id' => null, // repo-wide: alerta de infra do caminho de webhook (ADR 0093 §Exceção mcp_*)
+                'tipo' => 'whatsapp_webhook_canary',
+                'severidade' => 'high',
+                'titulo' => 'Canário do webhook WhatsApp falhou',
+                'descricao' => "Recebimento WhatsApp pode estar parado — {$r['reason']} (classe #2726).",
+                'chave_idempotencia' => $chave,
+                'metadata' => json_encode([
+                    'reason' => $r['reason'],
+                    'status' => $r['status'],
+                    'detected_at' => now()->toIso8601String(),
+                ], JSON_UNESCAPED_UNICODE),
+                'status' => 'aberto',
+                'criado_em' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } catch (\Throwable $e) {
+            Log::channel('single')->warning('whatsapp:webhook-canary — falha ao persistir mcp_alertas_eventos: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * Output (tabela/JSON) + exit code. Centraliza pra os ramos skip/ok/fail.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    private function report(array $payload, int $exit): int
+    {
+        if ($this->option('json')) {
+            $this->line((string) json_encode($payload + ['checked_at' => now()->toIso8601String()], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+            return $exit;
+        }
+
+        if ($payload['skipped'] ?? false) {
+            $this->warn('⏭  canário pulado: ' . $payload['reason']);
+        } elseif ($payload['ok'] ?? false) {
+            $this->info("✓ webhook WhatsApp respondeu {$payload['reason']} — caminho de recebimento provado.");
+        } else {
+            $this->error("✗ webhook WhatsApp NÃO respondeu 200 — {$payload['reason']}. ALERT disparado.");
+        }
+
+        return $exit;
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -34,6 +34,7 @@ use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
 use Modules\Whatsapp\Console\Commands\RetryRecentMediaDownloadsCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
 use Modules\Whatsapp\Console\Commands\SlaScanCommand;
+use Modules\Whatsapp\Console\Commands\WebhookCanaryCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
@@ -92,6 +93,7 @@ class WhatsappServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 DriverHealthCheckAllCommand::class,
+                WebhookCanaryCommand::class,            // Fase 1 perda-zero — canário webhook <5min (incidente #2726)
                 BackfillChannelAccessCommand::class,
                 AuditChannelAccessCommand::class,       // Wagner 2026-06-13 — auditor flip-flop revoke/reativação ACL canal
                 RegisterWhatsappPermissionsCommand::class,

--- a/Modules/Whatsapp/Tests/Feature/WebhookCanaryCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WebhookCanaryCommandTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Modules\Whatsapp\Console\Commands\WebhookCanaryCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Canário do webhook WhatsApp — Fase 1 perda-zero (incidente 2026-06-16 #2726).
+ *
+ * A lógica de veredito vive em evaluateCanary (estática, sem rede — mesmo padrão
+ * de HealthCheckCommand::evaluateInboundFlow). Os testes de fiação usam Http::fake
+ * (determinístico, sem rede real — o host de dev não tem PHP/pest; o vermelho roda
+ * no CI). O shape sintético espelha o "contrato REAL do daemon" provado em
+ * WhatsmeowWebhookAuthTest (Presence → 200 sem criar mensagem).
+ *
+ * @see Modules/Whatsapp/Console/Commands/WebhookCanaryCommand.php
+ */
+
+// ─── Lógica pura do veredito ────────────────────────────────────────────────
+
+test('evaluateCanary: HTTP 200 = ok', function () {
+    $r = WebhookCanaryCommand::evaluateCanary(200, null);
+    expect($r['ok'])->toBeTrue();
+    expect($r['status'])->toBe(200);
+    expect($r['reason'])->toBe('HTTP 200');
+});
+
+test('evaluateCanary: não-200 (401/500) = falha', function () {
+    expect(WebhookCanaryCommand::evaluateCanary(401, null)['ok'])->toBeFalse();
+    $r = WebhookCanaryCommand::evaluateCanary(500, null);
+    expect($r['ok'])->toBeFalse();
+    expect($r['reason'])->toContain('500');
+    expect($r['reason'])->toContain('esperado 200');
+});
+
+test('evaluateCanary: erro de conexão (timeout) = falha sem status', function () {
+    $r = WebhookCanaryCommand::evaluateCanary(null, 'cURL error 28: timeout');
+    expect($r['ok'])->toBeFalse();
+    expect($r['status'])->toBeNull();
+    expect($r['reason'])->toContain('erro de conexão');
+});
+
+test('syntheticPresenceBody espelha o envelope real do daemon (Presence, sem PII)', function () {
+    $outer = json_decode(WebhookCanaryCommand::syntheticPresenceBody(), true);
+    expect($outer)->toHaveKeys(['instanceName', 'jsonData']);
+
+    $inner = json_decode($outer['jsonData'], true);
+    expect($inner['type'])->toBe('Presence');           // benigno — ACKa 200 sem criar mensagem
+    expect($inner['event']['Info']['Chat'])->toBe('');   // sem JID real → no_channel → 200
+});
+
+// ─── Fiação do comando (Http::fake, sem rede) ───────────────────────────────
+
+test('200 → exit 0, grava tick verde no cache, manda o segredo na query e Presence no body', function () {
+    Cache::flush();
+    Http::fake(['*' => Http::response('{"ok":true,"note":"no_channel"}', 200)]);
+    config([
+        'whatsapp.canary.enabled' => true,
+        'whatsapp.whatsmeow.webhook_url_secret' => 'wh-test',
+    ]);
+
+    $this->artisan('whatsapp:webhook-canary', [
+        '--url' => 'http://localhost/api/whatsapp/webhook/whatsmeow/uuid-alvo',
+    ])->assertExitCode(0);
+
+    $last = Cache::get(WebhookCanaryCommand::CACHE_KEY);
+    expect($last['ok'])->toBeTrue();
+    expect($last['status'])->toBe(200);
+    expect($last['at'])->not->toBeNull();
+
+    Http::assertSent(fn ($req) => str_contains($req->url(), 'wh=wh-test')
+        && str_contains($req->body(), 'Presence')
+        && str_contains($req->body(), 'oimpresso-webhook-canary'));
+});
+
+test('não-200 → exit 1 e grava tick vermelho no cache', function () {
+    Cache::flush();
+    Http::fake(['*' => Http::response('unauthorized', 401)]);
+    config([
+        'whatsapp.canary.enabled' => true,
+        'whatsapp.whatsmeow.webhook_url_secret' => 'wh-test',
+    ]);
+
+    $this->artisan('whatsapp:webhook-canary', [
+        '--url' => 'http://localhost/api/whatsapp/webhook/whatsmeow/uuid-alvo',
+    ])->assertExitCode(1);
+
+    $last = Cache::get(WebhookCanaryCommand::CACHE_KEY);
+    expect($last['ok'])->toBeFalse();
+    expect($last['status'])->toBe(401);
+});
+
+test('sem segredo configurado → pula (exit 0) e NÃO grava cache (cold-start no health-check)', function () {
+    Cache::flush();
+    Http::fake();
+    config([
+        'whatsapp.canary.enabled' => true,
+        'whatsapp.whatsmeow.webhook_url_secret' => '',
+    ]);
+
+    $this->artisan('whatsapp:webhook-canary')->assertExitCode(0);
+
+    expect(Cache::get(WebhookCanaryCommand::CACHE_KEY))->toBeNull();
+    Http::assertNothingSent();
+});
+
+test('desabilitado via config → pula (exit 0) sem tocar a rede', function () {
+    Cache::flush();
+    Http::fake();
+    config([
+        'whatsapp.canary.enabled' => false,
+        'whatsapp.whatsmeow.webhook_url_secret' => 'wh-test',
+    ]);
+
+    $this->artisan('whatsapp:webhook-canary')->assertExitCode(0);
+    Http::assertNothingSent();
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -178,6 +178,25 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Canário do webhook WhatsApp — Fase 1 perda-zero (proposta
+        // whatsapp-ingestao-perda-zero.md, camadas 1+5). Posta um Presence
+        // sintético na URL pública com ?wh= e confere 200; não-200 → ALERT + exit≠0.
+        // Cadência 5min em horário comercial BRT: detecta a classe do incidente
+        // #2726 (webhook recusando, 3 dias mudo) em <5min — dentro da janela de
+        // retry do daemon (~10-15min), logo ANTES de qualquer mensagem ser perdida.
+        // Só OBSERVA a via (Presence ACKa 200 sem criar mensagem) — baixo risco.
+        $schedule->command('whatsapp:webhook-canary')
+            ->everyFiveMinutes()
+            ->timezone('America/Sao_Paulo')
+            ->between('8:00', '20:00')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:webhook-canary FALHOU — recebimento WhatsApp pode estar parado (classe #2726)'
+                );
+            });
+
         // US-SELL-COWORK-R6-SMOKE — smoke automatizado Sells/Index Cowork.
         // 5 sinais críticos: schema essencial + multi-tenant biz=1/biz=4 com vendas 30d
         // + Vite manifest contém chunks Cowork (Sale*.tsx) + CSS scoped imports

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13016,7 +13016,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 50
+			count: 54
 			path: Modules/Whatsapp/Config/config.php
 
 		-


### PR DESCRIPTION
## O quê

**Fase 1** do projeto "Ingestão WhatsApp à prova de perda (zero-loss)" — o **canário de webhook** (camadas 1 + 5 da [proposta](memory/decisions/proposals/whatsapp-ingestao-perda-zero.md)). Detecta em **< 5 min** se o recebimento de WhatsApp parou — o que faltou no incidente #2726 (PR #2726 deixou o webhook recusando 401 por **3 dias sem ninguém ver**).

- **Command `whatsapp:webhook-canary`** — POSTa um evento `Presence` sintético (envelope REAL do daemon WuzAPI `{instanceName, jsonData}`, sem HMAC/Token) na própria URL pública do webhook com `?wh=<secret>` e confere **200**. Não-200/timeout → `Log::error` + `mcp_alertas_eventos` (idempotente/dia, se a tabela existir) + **exit ≠ 0**.
- **Cron a cada 5 min** em horário comercial BRT (`everyFiveMinutes()->timezone('America/Sao_Paulo')->between('8:00','20:00')->environments(['live'])->withoutOverlapping()->onFailure(...)`) — espelha a sentinela `whatsapp_inbound_flow`.
- **Camada 5 (auto-teste do alarme)** — cada tick grava o resultado em cache; `jana:health-check` ganha o check **`whatsapp_inbound_canary`** (fresco / stale / falha), que prova que o próprio canário está vivo e que o monitor não apodreceu mentindo "verde" (a raiz do #2726).
- **Tests Pest determinísticos** — `evaluateCanary` + `evaluateCanaryFreshness` (lógica pura, sem rede/relógio/DB) + fiação `Http::fake`. Ambos na lane sqlite per-PR (`ci-sqlite-pest.list`).

### Por que isto = perda-zero
A janela de retry do daemon é ~10-15 min. Se o canário detecta + a causa é corrigida dentro dela, as mensagens são **re-entregues → 0 perdidas** — sem reescrever durabilidade (isso é a Fase 2, fora deste PR).

## Infra Contract

**Mudança de infra:** novo cron (`app/Console/Kernel.php`, só `live`) + novo command que faz **uma chamada HTTP de saída** pra própria URL pública do webhook. **Não toca a via de recebimento** — só observa (um `Presence` cai no ramo `no_channel` do controller e é ACKado em 200 **sem criar mensagem, sem job, sem escrita no DB** — provado por `WhatsmeowWebhookAuthTest` "contrato REAL do daemon").

**Auth-boundary (`.claude/rules/auth-boundary.md`):** este PR **NÃO remove, troca nem endurece** nenhuma auth de webhook. `VerifyWhatsmeowSignature` e `TrustProxies` ficam intactos; o canário apenas **exercita** o caminho `?wh=` já existente (segredo lido de `config('whatsapp.whatsmeow.webhook_url_secret')`, nunca logado). Sem reabrir o buraco Tier 0 do #2726 (zero dependência de IP/`X-Forwarded-For`).

**Validação em prod (pós-deploy):** rodar o próprio canário confirma o caminho 200 (é o "smoke" da proposta):

```bash
# no servidor live, após deploy + config:cache rebuild
php artisan whatsapp:webhook-canary --json
# espera: {"ok":true,"status":200,"reason":"HTTP 200","target_host":"...","checked_at":"..."}

# equivalente curl do que o canário executa (secret via ?wh=, envelope Presence):
curl -sv -X POST "https://<app>/api/whatsapp/webhook/whatsmeow/<business_uuid>?wh=$WHATSMEOW_WEBHOOK_URL_SECRET" \
  -H 'Content-Type: application/json' \
  -d '{"instanceName":"oimpresso-webhook-canary","jsonData":"{\"event\":{\"Info\":{\"Chat\":\"\"}},\"type\":\"Presence\"}"}'
# espera: < HTTP/2 200  + body {"ok":true,"note":"no_channel"}
```

Config (env, default inerte em dev/CI): `WHATSAPP_CANARY_ENABLED` (def true), `WHATSAPP_CANARY_BUSINESS_UUID` (vazio = deriva do 1º channel whatsmeow ativo; WR2 biz=1 = `29aa9931-108e-4f7d-a3ce-d15e4f35cbd4`), `WHATSAPP_CANARY_TIMEOUT` (10s), `WHATSAPP_CANARY_FRESHNESS_MAX_AGE_MIN` (15). Sem `WHATSMEOW_WEBHOOK_URL_SECRET` o canário **pula** (exit 0) — não falso-alarma em dev/CI.

## Teste

- `Modules/Whatsapp/Tests/Feature/WebhookCanaryCommandTest.php` — `evaluateCanary` (200/401/500/timeout), shape do envelope sintético, fiação `Http::fake` (200→exit 0+cache verde; 401→exit 1+cache vermelho; sem segredo/disabled→pula sem tocar a rede).
- `Modules/Jana/Tests/Feature/Smoke/WhatsappInboundCanaryCheckTest.php` — `evaluateCanaryFreshness` (não-configurado/fresco/falha/stale/cold/fora-horário) + registro do check `whatsapp_inbound_canary` no `jana:health-check` (hard, não-advisory).
- Host de dev sem PHP → o vermelho roda no CI (lane sqlite). phpstan: command/health-check estão em `Modules/*/Console/*` (excluído level 5); `env()` só em config dir; `Kernel.php` sem `env()` novo.

## Tier 0 (ADR 0093)
O canário não consulta dado de tenant — só posta um evento sintético e lê config/cache. O alerta `mcp_alertas_eventos` é repo-wide (`business_id = null`, exceção `mcp_*` observabilidade), igual ao padrão `PersistsDriftAlert`.

## Fora de escopo (vêm depois)
Fase 2 = backfill `GET /session/history` (recupera os 3 dias + rede final perda-zero) · Fase 3 = auto-cura + fallback Meta Cloud.

Refs: US-WA-311 · ADR proposta #2820 · incidente #2726

🤖 Generated with [Claude Code](https://claude.com/claude-code)
