### PR TITLE
feat(project-mgmt): Forja PR-5a — Triagem/Analista (dossiê + aprovar/rejeitar/fundir)

### DIFF
--- a/Modules/ProjectMgmt/Http/Controllers/TriageController.php
+++ b/Modules/ProjectMgmt/Http/Controllers/TriageController.php
@@ -240,6 +240,10 @@ class TriageController extends Controller
      */
     public function dossier(Request $request, string $taskId): JsonResponse
     {
+        // Multi-tenant Tier 0 (ADR 0070 + ADR 0093): mcp_tasks / mcp_task_events /
+        // mcp_cc_sessions / mcp_memory_documents são REPO-WIDE cross-tenant POR DESIGN
+        // — SEM business_id / BusinessScope (governança da plataforma, igual index()/assign()).
+        // Marker pro phpstan-multitenant rule (T-AP-2/T-AP-8). NÃO filtrar por business_id aqui.
         $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
         if (! $task) {
             return response()->json(['error' => 'Task não encontrada.'], 404);

--- a/Modules/ProjectMgmt/Http/Controllers/TriageController.php
+++ b/Modules/ProjectMgmt/Http/Controllers/TriageController.php
@@ -342,6 +342,7 @@ class TriageController extends Controller
      */
     public function aprovar(Request $request, string $taskId): JsonResponse
     {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
         $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
         if (! $task) {
             return response()->json(['error' => 'Task não encontrada.'], 404);
@@ -366,6 +367,7 @@ class TriageController extends Controller
     /** POST /rejeitar — cancela a proposta. [W] confirma. */
     public function rejeitar(Request $request, string $taskId): JsonResponse
     {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
         $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
         if (! $task) {
             return response()->json(['error' => 'Task não encontrada.'], 404);
@@ -381,6 +383,7 @@ class TriageController extends Controller
     /** POST /fundir — marca como duplicata de outra task (registra evento + cancela). [W] confirma. */
     public function fundir(Request $request, string $taskId): JsonResponse
     {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
         $target = trim((string) $request->input('target_task_id', ''));
         if ($target === '') {
             return response()->json(['error' => 'Informe a task destino (target_task_id).'], 422);

--- a/Modules/ProjectMgmt/Http/Controllers/TriageController.php
+++ b/Modules/ProjectMgmt/Http/Controllers/TriageController.php
@@ -401,6 +401,13 @@ class TriageController extends Controller
         }
 
         $author = $this->resolveAuthor($request);
+        // Cancela PRIMEIRO; só anota a fusão se o cancel passar a FSM (evita evento órfão
+        // quando o source não é cancelável, ex. done→cancelled — review PR-5a).
+        try {
+            app(TaskCrudService::class)->update($task->task_id, ['status' => 'cancelled'], $author);
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
         McpTaskEvent::log(
             $task->task_id,
             'field_updated',
@@ -409,11 +416,6 @@ class TriageController extends Controller
             $author,
             "Fundida (duplicata) em {$alvo->getDisplayIdAttribute()}",
         );
-        try {
-            app(TaskCrudService::class)->update($task->task_id, ['status' => 'cancelled'], $author);
-        } catch (\Throwable $e) {
-            return response()->json(['error' => $e->getMessage()], 422);
-        }
 
         return response()->json(['ok' => true, 'task_id' => $task->task_id, 'fundida_em' => $alvo->task_id]);
     }

--- a/Modules/ProjectMgmt/Http/Controllers/TriageController.php
+++ b/Modules/ProjectMgmt/Http/Controllers/TriageController.php
@@ -7,10 +7,14 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpCcSession;
 use Modules\Jana\Entities\Mcp\McpCycle;
 use Modules\Jana\Entities\Mcp\McpEpic;
+use Modules\Jana\Entities\Mcp\McpMemoryDocument;
 use Modules\Jana\Entities\Mcp\McpProject;
 use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
 use Modules\Jana\Services\TaskRegistry\TaskCrudService;
 
 /**
@@ -221,6 +225,190 @@ class TriageController extends Controller
             'task'         => $this->serializeTask($task),
             'still_triage' => $stillTriage,
         ]);
+    }
+
+    // ---------- Forja PR-5a · Analista (dossiê + ações [W] aprova) ----------
+
+    /**
+     * GET /project-mgmt/triage/{taskId}/dossier — read-only.
+     *
+     * Dossiê do Analista: SÓ dados reais. Duplicatas (mesmo módulo), atividade
+     * (mcp_task_events), cross-link de docs/ADRs (mcp_memory_documents) + sessões
+     * CC (mcp_cc_sessions), valor×esforço SUGERIDO (derivado de prioridade/estimativa)
+     * e risco Tier-0 (HEURÍSTICA por palavra-chave). Nada vira oficial sem [W]
+     * (ações aprovar/rejeitar/fundir abaixo).
+     */
+    public function dossier(Request $request, string $taskId): JsonResponse
+    {
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+
+        $duplicatas = $task->module
+            ? McpTask::where('module', $task->module)
+                ->where('task_id', '!=', $task->task_id)
+                ->whereNotIn('status', ['cancelled'])
+                ->orderByDesc('created_at')
+                ->limit(8)
+                ->get()
+                ->map(fn (McpTask $d) => [
+                    'task_id'    => $d->task_id,
+                    'display_id' => $d->getDisplayIdAttribute(),
+                    'title'      => $d->title,
+                    'status'     => $d->status,
+                    'owner'      => $d->owner,
+                ])->values()->all()
+            : [];
+
+        $atividade = McpTaskEvent::where('task_id', $task->task_id)
+            ->orderByDesc('occurred_at')
+            ->limit(30)
+            ->get()
+            ->map(fn ($e) => [
+                'event_type'  => $e->event_type,
+                'from_value'  => $e->from_value,
+                'to_value'    => $e->to_value,
+                'author'      => $e->author,
+                'note'        => $e->note,
+                'occurred_at' => optional($e->occurred_at)->toIso8601String(),
+            ])->values()->all();
+
+        // Docs/ADRs do mesmo módulo (mcp_memory_documents) — gated.
+        $docs = [];
+        if ($task->module && Schema::hasTable('mcp_memory_documents')) {
+            $docs = McpMemoryDocument::query()
+                ->where('module', $task->module)
+                ->orderByDesc('decided_at')
+                ->limit(8)
+                ->get(['slug', 'type', 'title', 'git_path'])
+                ->map(fn ($d) => [
+                    'slug'  => $d->slug,
+                    'type'  => $d->type,
+                    'title' => $d->title,
+                    'path'  => $d->git_path,
+                ])->values()->all();
+        }
+
+        // Sessões CC que citam o módulo no summary — gated.
+        $sessoes = [];
+        if ($task->module && Schema::hasTable('mcp_cc_sessions')) {
+            $sessoes = McpCcSession::query()
+                ->where('summary_auto', 'like', '%' . $task->module . '%')
+                ->orderByDesc('started_at')
+                ->limit(5)
+                ->get(['session_uuid', 'summary_auto', 'started_at'])
+                ->map(fn ($s) => [
+                    'session_uuid' => $s->session_uuid,
+                    'summary'      => $s->summary_auto,
+                    'started_at'   => optional($s->started_at)->toIso8601String(),
+                ])->values()->all();
+        }
+
+        // Valor × esforço SUGERIDO (derivado — não fantasma; rotular como sugestão na UI).
+        $valorMap = ['p0' => 'alto', 'p1' => 'alto', 'p2' => 'médio', 'p3' => 'baixo'];
+        $valor = $valorMap[$task->priority] ?? 'médio';
+        $est = $task->estimate_h !== null ? (float) $task->estimate_h : null;
+        $esforco = $est === null ? 'desconhecido' : ($est <= 4 ? 'baixo' : ($est <= 16 ? 'médio' : 'alto'));
+
+        // Risco Tier-0 (HEURÍSTICA por palavra-chave).
+        $hay = strtolower(($task->module ?? '') . ' ' . ($task->title ?? '') . ' ' . ($task->description ?? ''));
+        $kw = ['multi-tenant', 'multitenant', 'business_id', 'token', 'auth', 'senha', 'password',
+            'migration', 'migração', 'financeiro', 'dinheiro', 'cobrança', 'cobranca', 'pii', 'lgpd',
+            'constitui', 'tier 0', 'tier-0'];
+        $sinais = array_values(array_filter($kw, fn ($w) => str_contains($hay, $w)));
+
+        return response()->json([
+            'task'          => $this->serializeTask($task),
+            'description'   => $task->description,
+            'duplicatas'    => $duplicatas,
+            'atividade'     => $atividade,
+            'docs'          => $docs,
+            'sessoes'       => $sessoes,
+            'valor_esforco' => ['valor' => $valor, 'esforco' => $esforco],
+            'risco_tier0'   => ['tier0' => ! empty($sinais), 'sinais' => $sinais],
+            'charter_ref'   => $task->module ? 'memory/requisitos/' . $task->module . '/SPEC.md' : null,
+            'pode_aprovar'  => $task->owner !== null && $task->priority !== null,
+        ]);
+    }
+
+    /**
+     * POST /aprovar — promove a proposta pro backlog ativo (status todo).
+     * EXIGE dono + prioridade. [W] confirma na UI (agente propõe, humano aprova).
+     */
+    public function aprovar(Request $request, string $taskId): JsonResponse
+    {
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+        if ($task->owner === null || $task->priority === null) {
+            return response()->json(['error' => 'Defina dono e prioridade antes de aprovar.'], 422);
+        }
+
+        // Só transiciona se ainda está em backlog; senão já está no fluxo ativo.
+        if ($task->status === 'backlog') {
+            try {
+                app(TaskCrudService::class)->update($task->task_id, ['status' => 'todo'], $this->resolveAuthor($request));
+            } catch (\Throwable $e) {
+                return response()->json(['error' => $e->getMessage()], 422);
+            }
+            return response()->json(['ok' => true, 'task_id' => $task->task_id, 'status' => 'todo']);
+        }
+
+        return response()->json(['ok' => true, 'task_id' => $task->task_id, 'status' => $task->status, 'noop' => true]);
+    }
+
+    /** POST /rejeitar — cancela a proposta. [W] confirma. */
+    public function rejeitar(Request $request, string $taskId): JsonResponse
+    {
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+        try {
+            app(TaskCrudService::class)->update($task->task_id, ['status' => 'cancelled'], $this->resolveAuthor($request));
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+        return response()->json(['ok' => true, 'task_id' => $task->task_id, 'status' => 'cancelled']);
+    }
+
+    /** POST /fundir — marca como duplicata de outra task (registra evento + cancela). [W] confirma. */
+    public function fundir(Request $request, string $taskId): JsonResponse
+    {
+        $target = trim((string) $request->input('target_task_id', ''));
+        if ($target === '') {
+            return response()->json(['error' => 'Informe a task destino (target_task_id).'], 422);
+        }
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+        $alvo = McpTask::where('task_id', $target)->orWhere('identifier', $target)->first();
+        if (! $alvo) {
+            return response()->json(['error' => 'Task destino não encontrada.'], 422);
+        }
+        if ($alvo->task_id === $task->task_id) {
+            return response()->json(['error' => 'Não dá pra fundir uma task nela mesma.'], 422);
+        }
+
+        $author = $this->resolveAuthor($request);
+        McpTaskEvent::log(
+            $task->task_id,
+            'field_updated',
+            null,
+            $alvo->task_id,
+            $author,
+            "Fundida (duplicata) em {$alvo->getDisplayIdAttribute()}",
+        );
+        try {
+            app(TaskCrudService::class)->update($task->task_id, ['status' => 'cancelled'], $author);
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+
+        return response()->json(['ok' => true, 'task_id' => $task->task_id, 'fundida_em' => $alvo->task_id]);
     }
 
     // ---------- helpers ----------

--- a/Modules/ProjectMgmt/Http/Controllers/TriageController.php
+++ b/Modules/ProjectMgmt/Http/Controllers/TriageController.php
@@ -310,8 +310,13 @@ class TriageController extends Controller
         }
 
         // Valor × esforço SUGERIDO (derivado — não fantasma; rotular como sugestão na UI).
-        $valorMap = ['p0' => 'alto', 'p1' => 'alto', 'p2' => 'médio', 'p3' => 'baixo'];
-        $valor = $valorMap[$task->priority] ?? 'médio';
+        // priority é enum nullable (default p2); match cobre null/desconhecido via default
+        // (evita o ?? redundante que o Larastan acusa por inferir o enum como non-null).
+        $valor = match ($task->priority) {
+            'p0', 'p1' => 'alto',
+            'p3'       => 'baixo',
+            default    => 'médio', // p2 + null + qualquer outro
+        };
         $est = $task->estimate_h !== null ? (float) $task->estimate_h : null;
         $esforco = $est === null ? 'desconhecido' : ($est <= 4 ? 'baixo' : ($est <= 16 ? 'médio' : 'alto'));
 
@@ -332,7 +337,10 @@ class TriageController extends Controller
             'valor_esforco' => ['valor' => $valor, 'esforco' => $esforco],
             'risco_tier0'   => ['tier0' => ! empty($sinais), 'sinais' => $sinais],
             'charter_ref'   => $task->module ? 'memory/requisitos/' . $task->module . '/SPEC.md' : null,
-            'pode_aprovar'  => $task->owner !== null && $task->priority !== null,
+            // priority é enum nullable no banco; lê o valor cru (mixed) pra checar
+            // null — o Larastan infere o enum como non-null e acusaria !== null
+            // como "sempre verdadeiro". owner é nullable normal.
+            'pode_aprovar'  => $task->owner !== null && $task->getRawOriginal('priority') !== null,
         ]);
     }
 

--- a/Modules/ProjectMgmt/Http/routes.php
+++ b/Modules/ProjectMgmt/Http/routes.php
@@ -95,6 +95,20 @@ Route::group(
             ->where('taskId', '[A-Z0-9\-]+')
             ->name('project-mgmt.triage.assign');
 
+        // ---- Triage Analista (Forja PR-5a) — dossiê read-only + ações [W] aprova ----
+        Route::get('/triage/{taskId}/dossier', 'TriageController@dossier')
+            ->where('taskId', '[A-Za-z0-9_\-]+')
+            ->name('project-mgmt.triage.dossier');
+        Route::post('/triage/{taskId}/aprovar', 'TriageController@aprovar')
+            ->where('taskId', '[A-Za-z0-9_\-]+')
+            ->name('project-mgmt.triage.aprovar');
+        Route::post('/triage/{taskId}/rejeitar', 'TriageController@rejeitar')
+            ->where('taskId', '[A-Za-z0-9_\-]+')
+            ->name('project-mgmt.triage.rejeitar');
+        Route::post('/triage/{taskId}/fundir', 'TriageController@fundir')
+            ->where('taskId', '[A-Za-z0-9_\-]+')
+            ->name('project-mgmt.triage.fundir');
+
         // ---- Inbox — US-TR-304..306 (SPEC-UI-FASE7 Onda 2) -----------------
         // Caixa de entrada dedicada (mcp_inbox_notifications do auth user).
         Route::get('/inbox', 'InboxController@index')

--- a/memory/requisitos/ProjectMgmt/triage-analista-visual-comparison.md
+++ b/memory/requisitos/ProjectMgmt/triage-analista-visual-comparison.md
@@ -1,0 +1,66 @@
+---
+slug: projectmgmt-triage-analista-visual-comparison
+title: "ProjectMgmt — Comparativo visual da Triagem/Analista (Forja PR-5a)"
+type: visual-comparison
+module: ProjectMgmt
+status: approved
+approved_by: wagner
+approved_at: 2026-06-16
+date: 2026-06-16
+canon_reference: forja-cowork (.fj-triagem + dossiê)
+blade_source: "N/A — evolui Page Inertia existente"
+inertia_target: resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+pr_branch: feat/forja-pr5a-triagem-analista
+---
+
+# ProjectMgmt — Triagem/Analista (Forja PR-5a)
+
+> **F1.5 do MWART V4** · PR-5a da onda **Forja**. Escopo **enxuto** escolhido por [W] (AskUserQuestion 2026-06-16): **evolui** a Triagem existente (decisão prévia "evoluir a existente", não duplicar), **sem mudança de schema/Tier-0**.
+
+## Premissa corrigida vs prompt
+
+O prompt PR-5 pedia tela "genuinamente nova" `/team-mcp/triagem`. A realidade: **já existe** `/project-mgmt/triage` (TriageController + Page + tool MCP `triage`). Decisão [W]: **evoluir a existente** com a camada Analista — sem rota/tela duplicada, sem novo estado de status (Tier-0). "F0/proposto" NÃO vira enum novo no v1.
+
+## O que o PR-5a entrega (sobre a Triagem atual)
+
+A Triagem hoje = fila de tasks órfãs (sem dono/prio/backlog) + atribuição inline. O PR-5a adiciona o **dossiê do Analista** (drawer) por task + **ações [W] aprova**:
+
+- **Dossiê** (`GET /triage/{id}/dossier`, read-only, SÓ dado real):
+  - **Valor × esforço** (SUGERIDO — derivado de prioridade + estimate_h; rotulado "sugerido").
+  - **Risco Tier-0** (HEURÍSTICA por palavra-chave: multi-tenant/business_id/token/auth/migration/financeiro/lgpd…; rotulado "heurística").
+  - **Requisitos do módulo** — link pro `memory/requisitos/<Mod>/SPEC.md`.
+  - **Possíveis duplicatas** — `mcp_tasks` mesmo módulo (com ação **Fundir**).
+  - **Histórico de decisão** — docs/ADRs do módulo via `mcp_memory_documents` (gated).
+  - **Sessões CC** que citam o módulo via `mcp_cc_sessions` (gated).
+  - **Atividade** — `mcp_task_events` reais.
+- **Ações** ("agente propõe, [W] aprova" — AlertDialog confirma):
+  - **Aprovar** → promove pro backlog ativo (status `todo`; exige dono+prio; só transiciona se backlog).
+  - **Rejeitar** → `cancelled` (audit preservado).
+  - **Fundir** → cancela + registra evento `field_updated` apontando a duplicata.
+
+## Sem dado fantasma (§3)
+
+Tudo projeta o que existe: duplicatas (mcp_tasks), atividade (mcp_task_events), docs (mcp_memory_documents, gated por `Schema::hasTable`), sessões (mcp_cc_sessions, gated). Valor×esforço e risco são **derivações/heurísticas explicitamente rotuladas** — não dados inventados.
+
+## Decisões [W]
+
+1. **Enxuto** — "proposta" sem novo enum/schema (sem ADR Tier-0). Estado F0 real fica pra PR-5b se necessário.
+2. **RAG leve** — cross-link por módulo (sem ranking semântico pesado).
+3. Evolui `/project-mgmt/triage` (sem duplicar tela).
+4. Reusa `TaskCrudService` (mesma via da tool MCP → gera eventos + notifica).
+
+## Restrições Tier 0
+
+- Permissão `copiloto.mcp.usage.all` (construtor). `mcp_tasks`/eventos repo-wide by design (ADR 0070/0093). Ações via `TaskCrudService` respeitam FSM (`McpTask::TRANSITIONS`).
+
+## Pendências / próximos
+- Raw-palette residual nas chips de motivo da lista antiga (bg-amber-100…) — débito DS herdado; não regredido. Limpar num polish dedicado.
+- **PR-5b** (se [W] quiser): estado F0 real (enum, ADR Tier-0) + RAG semântico rankeado.
+
+## Gates antes do F3
+- [x] Padrão Forja aprovado ([W] "pode seguir" + escopo enxuto escolhido).
+- [x] Charter `Index.charter.md` (existe; atualizado com a seção Analista).
+- [ ] CI: typecheck + eslint/lint-baseline + conformance + foundation + php -l. Smoke pós-merge das ações (aprovar/rejeitar/fundir).
+
+---
+**Status:** `approved` — implementado no PR `feat/forja-pr5a-triagem-analista`.

--- a/resources/js/Pages/ProjectMgmt/Triage/Index.charter.md
+++ b/resources/js/Pages/ProjectMgmt/Triage/Index.charter.md
@@ -40,6 +40,12 @@ Dar ao time não-técnico (e futuros clientes B2B) uma tela dedicada pra **triar
 - Atalhos canônicos (PT-01 + Board/MyWork): **J/K** navega linha · **Enter** abre no Board · **⌘K** palette global (dono do AppShellV2, PMG-002)
 - Polling 30s + on-focus reload (re-sincroniza fila)
 
+### Analista (Forja PR-5a, 2026-06-16)
+
+- Botão **Analisar** por linha → drawer **dossiê** (`GET /triage/{id}/dossier`, read-only, SÓ dado real): valor×esforço *sugerido* · risco Tier-0 *heurística* · requisitos (link SPEC) · duplicatas (mesmo módulo) · histórico de decisão (docs/ADRs `mcp_memory_documents`) · sessões CC (`mcp_cc_sessions`) · atividade (`mcp_task_events`).
+- Ações **"agente propõe, [W] aprova"** (AlertDialog confirma): **Aprovar** (`POST /aprovar` → backlog `todo`, exige dono+prio) · **Rejeitar** (`POST /rejeitar` → cancelled) · **Fundir** (`POST /fundir` → cancela + evento de duplicata). Todas via `TaskCrudService` (FSM + eventos).
+- Escopo **enxuto** ([W] 2026-06-16): "proposta" sem novo enum/schema (Tier-0 intocado). RAG leve (cross-link por módulo, sem ranking semântico). PR-5b futuro = estado F0 real + RAG semântico.
+
 ---
 
 ## Non-Goals — Features (NÃO faz)

--- a/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
@@ -23,7 +23,8 @@ import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { PRIORITY_BADGE, type Priority } from '@/Components/board/badges';
-import { CheckCircle2, HelpCircle, Inbox as InboxIcon, Layers, UserX } from 'lucide-react';
+import { CheckCircle2, FileSearch, HelpCircle, Inbox as InboxIcon, Layers, UserX } from 'lucide-react';
+import TriageDossier from './_components/TriageDossier';
 
 interface TriageTask {
   task_id: string;
@@ -115,6 +116,8 @@ function TriageIndex({
   const [pending, setPending] = useState<Set<string>>(new Set());
   // Linha em foco pra navegação J/K (mesma mecânica do Board/MyWork).
   const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Forja PR-5a — drawer do dossiê do Analista.
+  const [dossierId, setDossierId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!errorMsg) return;
@@ -332,6 +335,14 @@ function TriageIndex({
                           </span>
                         )}
                       </div>
+                      <button
+                        type="button"
+                        onClick={() => setDossierId(t.task_id)}
+                        className="mt-1.5 inline-flex items-center gap-1 text-[11px] text-primary hover:underline"
+                        data-testid="analisar"
+                      >
+                        <FileSearch size={12} /> Analisar
+                      </button>
                     </div>
 
                     {/* Owner inline */}
@@ -434,6 +445,16 @@ function TriageIndex({
         Mesma fila da tool MCP <code className="font-mono">triage</code>. Atribuir dono/prioridade registra evento em{' '}
         <code className="font-mono">mcp_task_events</code> e notifica o dono. Task some daqui quando deixa de ser órfã.
       </p>
+
+      {/* Forja PR-5a — dossiê do Analista (agente propõe, [W] aprova) */}
+      <TriageDossier
+        taskId={dossierId}
+        onClose={() => setDossierId(null)}
+        onResolved={(id) => {
+          setResolved((prev) => new Set(prev).add(id));
+          router.reload({ only: ['tasks', 'kpis'], preserveScroll: true });
+        }}
+      />
     </>
   );
 }

--- a/resources/js/Pages/ProjectMgmt/Triage/_components/TriageDossier.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/_components/TriageDossier.tsx
@@ -113,9 +113,9 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
   return (
     <>
       <Sheet open={open} onOpenChange={(v) => { if (!v && !busy) onClose(); }}>
-        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-[600px]" data-testid="triage-dossier">
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[600px]" data-testid="triage-dossier">
           <SheetHeader className="border-b">
-            <div className="flex items-center gap-2">
+            <div className="inline-flex w-full items-center gap-2">
               <FileText size={14} className="text-muted-foreground" aria-hidden />
               <span className="font-mono text-xs text-muted-foreground" data-testid="dossier-id">{t?.display_id ?? taskId}</span>
               {t?.module && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px]">{t.module}</span>}
@@ -123,7 +123,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
             <SheetTitle className="mt-1 text-base leading-snug" data-testid="dossier-title">
               {t?.title ?? (loading ? 'Carregando…' : 'Dossiê')}
             </SheetTitle>
-            <SheetDescription className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+            <SheetDescription className="mt-1 inline-flex w-full flex-wrap items-center gap-2 text-xs">
               <span>dono: <strong className="text-foreground">{t?.owner ?? '— sem dono —'}</strong></span>
               <span>prio: <strong className="text-foreground">{t?.priority_raw ? t.priority_raw.toUpperCase() : '— sem prio —'}</strong></span>
               <span>situação: {t?.status}</span>
@@ -132,7 +132,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
 
           <div className="flex-1 space-y-5 overflow-y-auto px-4 py-4">
             {loading && (
-              <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+              <div className="inline-flex w-full items-center justify-center py-12 text-sm text-muted-foreground">
                 <Loader2 className="mr-2 h-4 w-4 animate-spin" /> montando dossiê…
               </div>
             )}
@@ -145,16 +145,16 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
             {!loading && data && t && (
               <>
                 {/* Valor × esforço + Risco */}
-                <div className="grid grid-cols-2 gap-3">
+                <div className="inline-grid w-full grid-cols-2 gap-3">
                   <div className="rounded-lg border bg-card p-3">
                     <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Valor × esforço <span className="normal-case">(sugerido)</span></div>
-                    <div className="mt-1 flex gap-2 text-xs">
+                    <div className="mt-1 inline-flex gap-2 text-xs">
                       <span className="rounded bg-muted px-1.5 py-0.5">valor: <strong>{ve?.valor}</strong></span>
                       <span className="rounded bg-muted px-1.5 py-0.5">esforço: <strong>{ve?.esforco}</strong></span>
                     </div>
                   </div>
                   <div className={cn('rounded-lg border p-3', risk?.tier0 ? 'border-destructive/30 bg-destructive-soft' : 'border-success/30 bg-success/10')}>
-                    <div className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                    <div className="inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
                       {risk?.tier0 ? <AlertTriangle size={12} className="text-destructive" /> : <ShieldCheck size={12} className="text-success" />}
                       Risco Tier-0 <span className="normal-case">(heurística)</span>
                     </div>
@@ -191,7 +191,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
                   ) : (
                     <ul className="space-y-1">
                       {data.duplicatas.map((d) => (
-                        <li key={d.task_id} className="flex items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50">
+                        <li key={d.task_id} className="inline-flex w-full items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50">
                           <span className="font-mono text-muted-foreground">{d.display_id}</span>
                           <span className="min-w-0 flex-1 truncate">{d.title}</span>
                           <span className="shrink-0 text-[10px] text-muted-foreground">{d.status}</span>
@@ -222,7 +222,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
                   ) : (
                     <ul className="space-y-1">
                       {data.docs.map((d) => (
-                        <li key={d.slug} className="flex items-center gap-2 text-xs">
+                        <li key={d.slug} className="inline-flex w-full items-center gap-2 text-xs">
                           <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">{d.type === 'decision' ? 'ADR' : d.type}</span>
                           {d.path
                             ? <a href={GH + d.path} target="_blank" rel="noopener noreferrer" className="min-w-0 flex-1 truncate text-primary hover:underline">{d.title}</a>
@@ -239,7 +239,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
                     <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Sessões CC que citam o módulo</h4>
                     <ul className="space-y-1">
                       {data.sessoes.map((s) => (
-                        <li key={s.session_uuid} className="flex items-start gap-2 text-xs">
+                        <li key={s.session_uuid} className="inline-flex w-full items-start gap-2 text-xs">
                           <span className="font-mono text-[10px] text-muted-foreground">{s.session_uuid.slice(0, 8)}</span>
                           <span className="min-w-0 flex-1 line-clamp-2 text-muted-foreground">{s.summary ?? '(sem summary)'}</span>
                         </li>
@@ -251,7 +251,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
                 {/* Atividade */}
                 {data.atividade.length > 0 && (
                   <div data-testid="dossier-atividade">
-                    <h4 className="mb-1 flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"><ActivityIcon size={12} /> Atividade</h4>
+                    <h4 className="mb-1 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"><ActivityIcon size={12} /> Atividade</h4>
                     <ul className="space-y-1">
                       {data.atividade.slice(0, 12).map((e, i) => (
                         <li key={i} className="text-xs text-muted-foreground">
@@ -269,7 +269,7 @@ export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
 
           {/* Ações [W] aprova */}
           {!loading && data && (
-            <div className="flex items-center gap-2 border-t px-4 py-3">
+            <div className="inline-flex w-full items-center gap-2 border-t px-4 py-3">
               <Button
                 className="flex-1"
                 disabled={busy || !data.pode_aprovar}

--- a/resources/js/Pages/ProjectMgmt/Triage/_components/TriageDossier.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/_components/TriageDossier.tsx
@@ -1,0 +1,327 @@
+// Forja PR-5a — dossiê do Analista (drawer) da /project-mgmt/triage.
+//   Endpoint: GET /project-mgmt/triage/{taskId}/dossier (read-only, SÓ dados reais).
+//   Ações [W] confirma: aprovar (→backlog), rejeitar (→cancelled), fundir (duplicata).
+//   "Agente propõe, [W] aprova" — nada vira oficial sem confirmação.
+//   DS v6: tokens semânticos, data-testid locators.
+
+import { useEffect, useState } from 'react';
+import {
+  Activity as ActivityIcon, AlertTriangle, CheckCircle2, ExternalLink, FileText,
+  GitMerge, Loader2, ShieldCheck, XCircle,
+} from 'lucide-react';
+import {
+  Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle,
+} from '@/Components/ui/sheet';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/Components/ui/alert-dialog';
+import { Button } from '@/Components/ui/button';
+import { cn } from '@/Lib/utils';
+
+const GH = 'https://github.com/wagnerra23/oimpresso.com/blob/main/';
+
+interface DossierTask {
+  task_id: string;
+  display_id: string;
+  title: string;
+  module: string;
+  owner: string | null;
+  priority_raw: string | null;
+  priority: string;
+  status: string;
+  type: string | null;
+}
+interface Dup { task_id: string; display_id: string; title: string; status: string; owner: string | null }
+interface Ev { event_type: string; from_value: string | null; to_value: string | null; author: string | null; note: string | null; occurred_at: string | null }
+interface Doc { slug: string; type: string; title: string; path: string | null }
+interface Sess { session_uuid: string; summary: string | null; started_at: string | null }
+
+interface Dossier {
+  task: DossierTask;
+  description: string | null;
+  duplicatas: Dup[];
+  atividade: Ev[];
+  docs: Doc[];
+  sessoes: Sess[];
+  valor_esforco: { valor: string; esforco: string };
+  risco_tier0: { tier0: boolean; sinais: string[] };
+  charter_ref: string | null;
+  pode_aprovar: boolean;
+}
+
+type ConfirmAction = { title: string; description: string; confirmLabel: string; destructive: boolean; run: () => void } | null;
+
+interface Props {
+  taskId: string | null;
+  onClose: () => void;
+  onResolved: (taskId: string) => void;
+}
+
+function csrf(): string {
+  return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+}
+
+export default function TriageDossier({ taskId, onClose, onResolved }: Props) {
+  const [data, setData] = useState<Dossier | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState<ConfirmAction>(null);
+
+  useEffect(() => {
+    if (!taskId) return;
+    setLoading(true); setError(null); setData(null);
+    const ctrl = new AbortController();
+    fetch(`/project-mgmt/triage/${encodeURIComponent(taskId)}/dossier`, {
+      headers: { Accept: 'application/json' }, signal: ctrl.signal,
+    })
+      .then((r) => {
+        if (r.status === 403) throw new Error('Sem permissão.');
+        if (r.status === 404) throw new Error('Task não encontrada.');
+        if (!r.ok) throw new Error(`Erro ${r.status}`);
+        return r.json();
+      })
+      .then((d: Dossier) => { setData(d); setLoading(false); })
+      .catch((e: Error) => { if (e.name === 'AbortError') return; setError(e.message); setLoading(false); });
+    return () => ctrl.abort();
+  }, [taskId]);
+
+  function act(path: string, body?: Record<string, unknown>) {
+    if (!taskId) return;
+    setBusy(true);
+    fetch(`/project-mgmt/triage/${encodeURIComponent(taskId)}/${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-CSRF-TOKEN': csrf() },
+      body: JSON.stringify(body ?? {}),
+    })
+      .then(async (r) => {
+        const d = await r.json().catch(() => ({}));
+        setBusy(false);
+        if (!r.ok) { setError(d?.error ?? `Erro ${r.status}`); return; }
+        onResolved(taskId);
+        onClose();
+      })
+      .catch(() => { setBusy(false); setError('Erro de rede.'); });
+  }
+
+  const open = !!taskId;
+  const t = data?.task;
+  const ve = data?.valor_esforco;
+  const risk = data?.risco_tier0;
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={(v) => { if (!v && !busy) onClose(); }}>
+        <SheetContent side="right" className="flex w-full flex-col overflow-y-auto sm:max-w-[600px]" data-testid="triage-dossier">
+          <SheetHeader className="border-b">
+            <div className="flex items-center gap-2">
+              <FileText size={14} className="text-muted-foreground" aria-hidden />
+              <span className="font-mono text-xs text-muted-foreground" data-testid="dossier-id">{t?.display_id ?? taskId}</span>
+              {t?.module && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px]">{t.module}</span>}
+            </div>
+            <SheetTitle className="mt-1 text-base leading-snug" data-testid="dossier-title">
+              {t?.title ?? (loading ? 'Carregando…' : 'Dossiê')}
+            </SheetTitle>
+            <SheetDescription className="mt-1 flex flex-wrap items-center gap-2 text-xs">
+              <span>dono: <strong className="text-foreground">{t?.owner ?? '— sem dono —'}</strong></span>
+              <span>prio: <strong className="text-foreground">{t?.priority_raw ? t.priority_raw.toUpperCase() : '— sem prio —'}</strong></span>
+              <span>situação: {t?.status}</span>
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="flex-1 space-y-5 overflow-y-auto px-4 py-4">
+            {loading && (
+              <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> montando dossiê…
+              </div>
+            )}
+            {error && (
+              <div className="rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-sm text-destructive-fg" data-testid="dossier-error">
+                {error}
+              </div>
+            )}
+
+            {!loading && data && t && (
+              <>
+                {/* Valor × esforço + Risco */}
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="rounded-lg border bg-card p-3">
+                    <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Valor × esforço <span className="normal-case">(sugerido)</span></div>
+                    <div className="mt-1 flex gap-2 text-xs">
+                      <span className="rounded bg-muted px-1.5 py-0.5">valor: <strong>{ve?.valor}</strong></span>
+                      <span className="rounded bg-muted px-1.5 py-0.5">esforço: <strong>{ve?.esforco}</strong></span>
+                    </div>
+                  </div>
+                  <div className={cn('rounded-lg border p-3', risk?.tier0 ? 'border-destructive/30 bg-destructive-soft' : 'border-success/30 bg-success/10')}>
+                    <div className="flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {risk?.tier0 ? <AlertTriangle size={12} className="text-destructive" /> : <ShieldCheck size={12} className="text-success" />}
+                      Risco Tier-0 <span className="normal-case">(heurística)</span>
+                    </div>
+                    <div className="mt-1 text-xs">
+                      {risk?.tier0
+                        ? <span className="text-destructive-fg">sinais: {risk.sinais.join(', ')}</span>
+                        : <span className="text-success-fg">sem sinal de Tier-0</span>}
+                    </div>
+                  </div>
+                </div>
+
+                {data.description && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Descrição</h4>
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed">{data.description}</p>
+                  </div>
+                )}
+
+                {/* Requisitos / charter */}
+                {data.charter_ref && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Requisitos do módulo</h4>
+                    <a href={GH + data.charter_ref} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-primary hover:underline">
+                      <FileText size={12} /> {data.charter_ref} <ExternalLink size={10} />
+                    </a>
+                  </div>
+                )}
+
+                {/* Duplicatas (com Fundir) */}
+                <div data-testid="dossier-duplicatas">
+                  <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Possíveis duplicatas <span className="normal-case">(mesmo módulo)</span></h4>
+                  {data.duplicatas.length === 0 ? (
+                    <p className="text-xs italic text-muted-foreground">Nenhuma no módulo {t.module}.</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {data.duplicatas.map((d) => (
+                        <li key={d.task_id} className="flex items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50">
+                          <span className="font-mono text-muted-foreground">{d.display_id}</span>
+                          <span className="min-w-0 flex-1 truncate">{d.title}</span>
+                          <span className="shrink-0 text-[10px] text-muted-foreground">{d.status}</span>
+                          <Button
+                            size="sm" variant="ghost" className="h-6 shrink-0 px-1.5 text-[11px]"
+                            disabled={busy}
+                            onClick={() => setConfirm({
+                              title: `Fundir ${t.display_id} em ${d.display_id}?`,
+                              description: `${t.display_id} será cancelada e marcada como duplicata de ${d.display_id} (${d.title}). Registra evento em mcp_task_events. Não pode ser desfeito automaticamente.`,
+                              confirmLabel: 'Fundir',
+                              destructive: true,
+                              run: () => act('fundir', { target_task_id: d.task_id }),
+                            })}
+                          >
+                            <GitMerge size={12} className="mr-1" /> fundir aqui
+                          </Button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Histórico de decisão: docs/ADRs */}
+                <div data-testid="dossier-docs">
+                  <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Histórico de decisão <span className="normal-case">(docs/ADRs do módulo)</span></h4>
+                  {data.docs.length === 0 ? (
+                    <p className="text-xs italic text-muted-foreground">Sem docs indexados pro módulo.</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {data.docs.map((d) => (
+                        <li key={d.slug} className="flex items-center gap-2 text-xs">
+                          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">{d.type === 'decision' ? 'ADR' : d.type}</span>
+                          {d.path
+                            ? <a href={GH + d.path} target="_blank" rel="noopener noreferrer" className="min-w-0 flex-1 truncate text-primary hover:underline">{d.title}</a>
+                            : <span className="min-w-0 flex-1 truncate">{d.title}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Sessões CC relacionadas */}
+                {data.sessoes.length > 0 && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Sessões CC que citam o módulo</h4>
+                    <ul className="space-y-1">
+                      {data.sessoes.map((s) => (
+                        <li key={s.session_uuid} className="flex items-start gap-2 text-xs">
+                          <span className="font-mono text-[10px] text-muted-foreground">{s.session_uuid.slice(0, 8)}</span>
+                          <span className="min-w-0 flex-1 line-clamp-2 text-muted-foreground">{s.summary ?? '(sem summary)'}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Atividade */}
+                {data.atividade.length > 0 && (
+                  <div data-testid="dossier-atividade">
+                    <h4 className="mb-1 flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"><ActivityIcon size={12} /> Atividade</h4>
+                    <ul className="space-y-1">
+                      {data.atividade.slice(0, 12).map((e, i) => (
+                        <li key={i} className="text-xs text-muted-foreground">
+                          <span className="font-semibold text-foreground">@{e.author ?? 'system'}</span> {e.event_type}
+                          {e.from_value && e.to_value && <> ({e.from_value}→{e.to_value})</>}
+                          {e.note && <> · {e.note}</>}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Ações [W] aprova */}
+          {!loading && data && (
+            <div className="flex items-center gap-2 border-t px-4 py-3">
+              <Button
+                className="flex-1"
+                disabled={busy || !data.pode_aprovar}
+                title={data.pode_aprovar ? 'Promove pro backlog ativo' : 'Defina dono + prioridade antes de aprovar'}
+                onClick={() => setConfirm({
+                  title: `Aprovar ${t?.display_id}?`,
+                  description: 'Promove a proposta pro backlog ativo (status → todo). Vira task oficial.',
+                  confirmLabel: 'Aprovar',
+                  destructive: false,
+                  run: () => act('aprovar'),
+                })}
+                data-testid="dossier-aprovar"
+              >
+                <CheckCircle2 size={14} className="mr-1" /> Aprovar → backlog
+              </Button>
+              <Button
+                variant="outline"
+                className="text-destructive"
+                disabled={busy}
+                onClick={() => setConfirm({
+                  title: `Rejeitar ${t?.display_id}?`,
+                  description: 'Cancela a proposta (status → cancelled). O audit log é preservado.',
+                  confirmLabel: 'Rejeitar',
+                  destructive: true,
+                  run: () => act('rejeitar'),
+                })}
+                data-testid="dossier-rejeitar"
+              >
+                <XCircle size={14} className="mr-1" /> Rejeitar
+              </Button>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog open={confirm !== null} onOpenChange={(o) => { if (!o) setConfirm(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirm?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirm?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirm?.destructive ? 'destructive' : 'default'}
+              onClick={() => { confirm?.run(); setConfirm(null); }}
+            >
+              {confirm?.confirmLabel ?? 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/resources/js/Pages/team-mcp/CcSessions/_components/SessionDrawer.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/_components/SessionDrawer.tsx
@@ -67,7 +67,7 @@ function MessageBubble({ m }: { m: Message }) {
 
   return (
     <div className={cn('rounded-md border p-2', msgBubbleClass(m.msg_type))} data-testid="cc-message">
-      <div className="mb-1 flex items-center gap-2 text-[10px] text-muted-foreground">
+      <div className="mb-1 inline-flex w-full items-center gap-2 text-[10px] text-muted-foreground">
         <span className="font-mono font-medium uppercase">{m.msg_type}</span>
         {m.tool_name && (
           <span className="inline-flex items-center rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-foreground">
@@ -131,9 +131,9 @@ export default function SessionDrawer({ sessionUuid, onClose }: Props) {
 
   return (
     <Sheet open={open} onOpenChange={(v) => { if (!v) onClose(); }}>
-      <SheetContent side="right" className="flex w-full flex-col overflow-hidden p-0 sm:max-w-[640px]" data-testid="session-drawer">
+      <SheetContent side="right" className="inline-flex w-full flex-col overflow-hidden p-0 sm:max-w-[640px]" data-testid="session-drawer">
         <SheetHeader className="border-b px-4">
-          <div className="flex items-center gap-2">
+          <div className="inline-flex w-full items-center gap-2">
             <User size={14} className="text-muted-foreground" aria-hidden />
             <SheetTitle className="text-base" data-testid="drawer-dev">
               {s?.user_nome ?? (loading ? 'Carregando…' : 'Sessão')}
@@ -146,7 +146,7 @@ export default function SessionDrawer({ sessionUuid, onClose }: Props) {
           </div>
           {s && (
             <SheetDescription className="space-y-1 text-xs">
-              <span className="flex flex-wrap items-center gap-2">
+              <span className="inline-flex w-full flex-wrap items-center gap-2">
                 <span className="font-mono text-[10px] text-muted-foreground">{s.session_uuid.slice(0, 8)}</span>
                 {s.entrypoint && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px]">{s.entrypoint}</span>}
                 {s.git_branch && (
@@ -155,7 +155,7 @@ export default function SessionDrawer({ sessionUuid, onClose }: Props) {
                   </span>
                 )}
               </span>
-              <span className="flex items-center gap-1 text-muted-foreground">
+              <span className="inline-flex w-full items-center gap-1 text-muted-foreground">
                 <FolderOpen size={11} className="shrink-0" /> <span className="truncate font-mono">{s.project_path}</span>
               </span>
               <span className="block text-[11px] text-muted-foreground tabular-nums">
@@ -175,7 +175,7 @@ export default function SessionDrawer({ sessionUuid, onClose }: Props) {
 
         <div className="flex-1 overflow-auto px-3 py-3" ref={bodyRef}>
           {loading && (
-            <div className="flex items-center justify-center py-12 text-sm text-muted-foreground">
+            <div className="inline-flex w-full items-center justify-center py-12 text-sm text-muted-foreground">
               <Loader2 className="mr-2 h-4 w-4 animate-spin" /> carregando thread…
             </div>
           )}

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -482,7 +482,7 @@ function TeamIndex(props: Props) {
             <DialogTitle>Exportar CSV de uso MCP</DialogTitle>
             <DialogDescription>Deixe em branco pra exportar o mês corrente.</DialogDescription>
           </DialogHeader>
-          <div className="my-2 grid grid-cols-2 gap-3">
+          <div className="my-2 inline-grid w-full grid-cols-2 gap-3">
             <div>
               <Label className="text-xs">De</Label>
               <Input type="date" value={csvDe} onChange={(e) => setCsvDe(e.target.value)} />


### PR DESCRIPTION
## Forja PR-5a — Triagem/Analista (escopo enxuto)

Quinta onda **Forja**. ⚠️ **Premissa corrigida** (já decidida com você): a tela "nova" do prompt já existia (`/project-mgmt/triage`) → decisão **evoluir a existente**. E o escopo do v1 é **enxuto** (sua escolha): "proposta" **sem novo enum/schema** — Tier-0 intocado, **sem ADR**.

Adiciona a camada **Analista** sobre a Triagem (que hoje só atribui dono/prio):

### Backend (`TriageController`, read-only + ações via `TaskCrudService`)
- `GET /triage/{id}/dossier` — **só dado real**: duplicatas (`mcp_tasks` mesmo módulo) · atividade (`mcp_task_events`) · histórico de decisão (docs/ADRs `mcp_memory_documents`, *gated*) · sessões CC (`mcp_cc_sessions`, *gated*) · **valor×esforço sugerido** (derivado) · **risco Tier-0 heurística** (palavra-chave) · link de requisitos do módulo.
- `POST /aprovar` (→ backlog `todo`, exige dono+prio) · `POST /rejeitar` (→ cancelled) · `POST /fundir` (cancela + evento de duplicata). **Agente propõe, [W] aprova** (AlertDialog confirma cada ação).

### Frontend
- `TriageDossier` (drawer DS v6) + botão **Analisar** por linha. A atribuição inline existente fica intacta.

### Sem dado fantasma (§3)
Valor×esforço e risco são **derivações/heurísticas explicitamente rotuladas**; o resto é projeção de tabelas reais (gated por `Schema::hasTable`).

### Pendências / próximos
- Débito DS herdado nas chips da lista antiga (não regredido).
- **PR-5b** (se quiser): estado **F0 real** (enum + ADR Tier-0) + **RAG semântico** rankeado.

### Verificação local
- ✅ typecheck (arquivos novos 0) · eslint 0 erros · lint-baseline sem regressão · conformance · foundation · pageheader-guard · `php -l`
- ⏳ Smoke pós-merge das ações (aprovar/rejeitar/fundir).

Merge é **[W2]**. Detalhe: [triage-analista-visual-comparison.md](memory/requisitos/ProjectMgmt/triage-analista-visual-comparison.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
