### PR TITLE
refactor(reuse): dedup fmtRelative em @/Lib/datetime-br (gate reuse verde)

### DIFF
--- a/resources/js/Lib/datetime-br.ts
+++ b/resources/js/Lib/datetime-br.ts
@@ -1,0 +1,29 @@
+// Helpers de formatação de data/hora BR — exibição relativa.
+//
+// Canônico ÚNICO de `fmtRelative` (chave do ratchet reuse-index: util:fmtRelative).
+// Antes vivia duplicado em `kb/_lib/helpers.ts` e `team-mcp/CcSessions/_components/sessionTokens.ts`;
+// extraído pra cá pra reusar em vez de recriar (reuse > recria · MANUAL-CSS-JS #5 · ADR 0240).
+
+/**
+ * Distância relativa humana em pt-BR a partir de um ISO timestamp.
+ *   "agora" · "5min atrás" · "3h atrás" · "2d atrás" · "16/06 14:30" (>7d)
+ *
+ * - `null`        → "—"
+ * - data inválida → devolve a string original (compat seeds com valor já relativo)
+ */
+export function fmtRelative(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso).getTime();
+  if (Number.isNaN(d)) return iso; // já é relativo (compat seed)
+  const diffSec = (Date.now() - d) / 1000;
+  if (diffSec < 60) return 'agora';
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}min atrás`;
+  if (diffSec < 86_400) return `${Math.floor(diffSec / 3600)}h atrás`;
+  if (diffSec < 86_400 * 7) return `${Math.floor(diffSec / 86_400)}d atrás`;
+  return new Date(iso).toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}

--- a/resources/js/Pages/kb/_lib/helpers.ts
+++ b/resources/js/Pages/kb/_lib/helpers.ts
@@ -57,24 +57,11 @@ export function freshnessLevel(updatedAt: string | null): FreshnessInfo {
 
 // ──────────────────────────────────────────────────────────────────
 // fmtRelative — "agora", "5min atrás", "3h atrás", "2d atrás", data
+// Canônico mora em @/Lib/datetime-br (reuse > recria). Re-exportado aqui
+// pra preservar a ergonomia do barrel `_lib/helpers` dos componentes KB.
 // ──────────────────────────────────────────────────────────────────
 
-export function fmtRelative(iso: string | null): string {
-  if (!iso) return '—';
-  const d = new Date(iso).getTime();
-  if (Number.isNaN(d)) return iso; // já é relativo (compat seed)
-  const diffSec = (Date.now() - d) / 1000;
-  if (diffSec < 60) return 'agora';
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}min atrás`;
-  if (diffSec < 86_400) return `${Math.floor(diffSec / 3600)}h atrás`;
-  if (diffSec < 86_400 * 7) return `${Math.floor(diffSec / 86_400)}d atrás`;
-  return new Date(iso).toLocaleString('pt-BR', {
-    day: '2-digit',
-    month: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
+export { fmtRelative } from '@/Lib/datetime-br';
 
 export const numBR = (v: number): string =>
   new Intl.NumberFormat('pt-BR').format(v ?? 0);

--- a/resources/js/Pages/team-mcp/CcSessions/_components/sessionTokens.ts
+++ b/resources/js/Pages/team-mcp/CcSessions/_components/sessionTokens.ts
@@ -1,6 +1,10 @@
 // Forja PR-2 — tokens/helpers puros da tela CcSessions (sem JSX → react-refresh friendly).
 // DS v6: SEM cor crua. Bolhas/status via tokens semânticos.
 
+// fmtRelative é canônico em @/Lib/datetime-br (reuse > recria) — re-exportado
+// pra manter o import único `./sessionTokens` da tela CcSessions.
+export { fmtRelative } from '@/Lib/datetime-br';
+
 export type SessionStatus = 'active' | 'closed' | 'archived';
 
 export interface StatusMeta { label: string; dot: string }
@@ -25,16 +29,6 @@ export function fmtDateTime(iso: string | null): string {
   return new Date(iso).toLocaleString('pt-BR', {
     day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
   });
-}
-
-export function fmtRelative(iso: string | null): string {
-  if (!iso) return '—';
-  const diffSec = (Date.now() - new Date(iso).getTime()) / 1000;
-  if (diffSec < 60) return 'agora';
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}min atrás`;
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h atrás`;
-  if (diffSec < 86400 * 7) return `${Math.floor(diffSec / 86400)}d atrás`;
-  return fmtDateTime(iso);
 }
 
 export function fmtDuration(start: string | null, end: string | null): string {


### PR DESCRIPTION
## Por quê

O gate **Reuse · ratchet de duplicatas** (`scripts/reuse-index.mjs --gate`) estava **vermelho em todo PR** por uma duplicata NOVA fora do baseline:

```
util:fmtRelative  (2×)
   - resources/js/Pages/kb/_lib/helpers.ts:62
   - resources/js/Pages/team-mcp/CcSessions/_components/sessionTokens.ts:30
```

As duas eram `export function fmtRelative(iso: string | null): string` funcionalmente equivalentes. A segunda entrou no main via #2821 (Forja PR-2, re-skin DS v6 CcSessions, commit `14d094929`) sem reaproveitar a existente nem atualizar o baseline. O gate é advisory/override-admin hoje, mas é dívida real — esta PR fecha (Opção 1: **DRY de verdade**).

## O que mudou

- **Novo canônico:** `resources/js/Lib/datetime-br.ts` exporta `fmtRelative` (versão robusta da `kb/_lib/helpers` — inclui guard de `NaN` pra seeds com valor já relativo; superset comportamental das duas originais).
- `kb/_lib/helpers.ts` e `CcSessions/_components/sessionTokens.ts` passam a **re-exportar** de `@/Lib/datetime-br` em vez de definir local.
- Consumidores ficam **intactos** (`kb` HealthPanel/NodeReader importam de `../_lib/helpers`; `CcSessions/Index` importa de `./sessionTokens`). Re-export `export { x } from ...` **não é indexado** pelo reuse-index → gate verde **sem mexer no baseline**.

3 arquivos · +36/−26 · 1 PR = 1 intent.

## Validação

```
$ node scripts/reuse-index.mjs --gate
✓ gate reuse:duplicates OK — nenhuma duplicata NOVA (baseline: 21).
```

`@/Lib/` é alias estabelecido (`@/Lib/utils`, `@/Lib/consent`, …). `tsc --noEmit` não roda local (sem `node_modules` no worktree) → coberto pelo CI typecheck.

## Fora de escopo (follow-up)

Existem 3 cópias **inline não-exportadas** de `fmtRelative` (não disparam o gate, ficam em arquivos de render): `kb/Index.tsx`, `team-mcp/Team/Index.tsx`, `Admin/_components/HealthPanelV4.tsx`. Consolidá-las é outro intent (mexe em `.tsx` de UI) — deixadas pra PR separada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)