### PR TITLE
refactor(reuse): kb/Index reusa fmtRelative canônico de @/Lib/datetime-br

### DIFF
--- a/resources/js/Pages/kb/Index.tsx
+++ b/resources/js/Pages/kb/Index.tsx
@@ -34,6 +34,7 @@ import { ScrollArea } from '@/Components/ui/scroll-area';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
+import { fmtRelative } from '@/Lib/datetime-br';
 import { toast } from 'sonner';
 import { Copy, Lock, Github, History, Trash2, BookOpen } from 'lucide-react';
 
@@ -99,24 +100,6 @@ interface DocDetail {
 }
 
 const num = (v: number) => new Intl.NumberFormat('pt-BR').format(v ?? 0);
-
-function fmtDate(iso: string | null): string {
-  if (!iso) return '—';
-  return new Date(iso).toLocaleString('pt-BR', {
-    day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit',
-  });
-}
-
-function fmtRelative(iso: string | null): string {
-  if (!iso) return '—';
-  const d = new Date(iso).getTime();
-  const diffSec = (Date.now() - d) / 1000;
-  if (diffSec < 60) return 'agora';
-  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}min atrás`;
-  if (diffSec < 86400) return `${Math.floor(diffSec / 3600)}h atrás`;
-  if (diffSec < 86400 * 7) return `${Math.floor(diffSec / 86400)}d atrás`;
-  return fmtDate(iso);
-}
 
 function fmtSize(chars: number): string {
   if (chars < 1024) return `${chars}c`;


### PR DESCRIPTION
## O quê
`resources/js/Pages/kb/Index.tsx` tinha uma cópia inline **não-exportada** de `fmtRelative` funcionalmente idêntica ao canônico que vive em [`resources/js/Lib/datetime-br.ts`](resources/js/Lib/datetime-br.ts) (criado no #2831, já mergeado). Troco pela `import { fmtRelative } from '@/Lib/datetime-br'` e removo a definição local.

Removo também o `fmtDate` local órfão — seu **único** consumidor era a cópia inline de `fmtRelative`, então deixá-lo quebraria `noUnusedLocals`.

## Por quê
Duplicação real. Não dispara o gate `reuse:duplicates` (só símbolos `export`ados são indexados), mas é cópia que dá manutenção dobrada e drift de comportamento. O canônico ainda traz **de brinde** o guard de `NaN` (devolve a string original em vez de "Invalid Date").

## Sem mudança visual
Saída byte-a-byte igual para os dados reais da tela: `indexed_at` / `ultimo_sync` são timestamps ISO, nunca seeds já-relativos — o branch de `NaN` é inalcançável aqui. Mesmos buckets (`agora` / `Xmin atrás` / `Xh atrás` / `Xd atrás` / data absoluta >7d). Troca é lógica pura.

## Escopo: só 1 das 3 cópias
A task original listava 3 cópias inline. Investigando, **só esta (kb) é duplicata real**. As outras duas **não** são byte-copies — têm copy/buckets próprios e intencionais, então ficaram **intactas** (trocá-las pelo canônico seria regressão de UX):

| arquivo | divergência do canônico |
|---|---|
| `team-mcp/Team/Index.tsx` | `Nunca usado`, `agora há pouco`, `há X min/h/dias/meses/anos` (buckets meses+anos) — G-DESIGN-04 |
| `Admin/_components/HealthPanelV4.tsx` | `nunca` p/ null/NaN, arredonda em minutos (`Math.round`), **sem** fallback de data absoluta >7d |

Disambiguação dessas duas fica como follow-up separado (decisão de UX, não dedup).

## Validação
- `node scripts/reuse-index.mjs --gate` → ✓ verde (baseline 21, nenhuma duplicata nova)
- `tsc --noEmit` → no CI (sem `node_modules` local); type-soundness conferida por inspeção: assinatura idêntica, 3 call sites recebem `string | null`, nenhum símbolo órfão, `noUnusedLocals` satisfeito.

Refs: reuse-gate ratchet · MANUAL-CSS-JS #5 · ADR 0240

🤖 Generated with [Claude Code](https://claude.com/claude-code)