### PR TITLE
refactor(reuse): renomeia 2 locais fmtRelative divergentes (fmtLastUsed / fmtAgoNoDate)

### DIFF
--- a/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
+++ b/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
@@ -32,7 +32,9 @@ interface Props {
   snapshot: HealthSnapshot | null;
 }
 
-function fmtRelative(iso: string | null): string {
+// Nome próprio (não `fmtRelative`): minutos arredondados + sem fallback de data
+// absoluta p/ >7d (mostra 'Xd atrás'), divergem do canônico @/Lib/datetime-br.
+function fmtAgoNoDate(iso: string | null): string {
   if (!iso) return 'nunca';
   const d = new Date(iso).getTime();
   if (Number.isNaN(d)) return 'nunca';
@@ -77,7 +79,7 @@ export default function HealthPanelV4({ open, onOpenChange, snapshot }: Props) {
               primary={
                 snapshot.scorecard_cron_ok ? 'Operacional' : 'Falha last_run'
               }
-              detail={`last run ${fmtRelative(snapshot.scorecard_last_run_at)}`}
+              detail={`last run ${fmtAgoNoDate(snapshot.scorecard_last_run_at)}`}
             />
             <HealthCard
               title="AI baseline 30d"
@@ -95,7 +97,7 @@ export default function HealthPanelV4({ open, onOpenChange, snapshot }: Props) {
               tone={snapshot.otel_collector_up ? 'ok' : 'bad'}
               icon={<Activity size={14} />}
               primary={snapshot.otel_collector_up ? 'Up' : 'Down'}
-              detail={`last ping ${fmtRelative(snapshot.otel_collector_last_ping_at)}`}
+              detail={`last ping ${fmtAgoNoDate(snapshot.otel_collector_last_ping_at)}`}
             />
             <HealthCard
               title="Cobertura buckets"

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -84,8 +84,10 @@ function fmtDate(iso: string | null): string {
   return d.toLocaleString('pt-BR', { day: '2-digit', month: '2-digit', hour: '2-digit', minute: '2-digit' });
 }
 
-// G-DESIGN-04 — relativo PT-BR pra last_used_at no TokensListDialog
-function fmtRelative(iso: string | null): string {
+// G-DESIGN-04 — relativo PT-BR pra last_used_at no TokensListDialog.
+// Nome próprio (não `fmtRelative`): buckets meses/anos + null→'Nunca usado'
+// são contrato do charter (G-DESIGN-04), divergem do canônico @/Lib/datetime-br.
+function fmtLastUsed(iso: string | null): string {
   if (!iso) return 'Nunca usado';
   const d = new Date(iso).getTime();
   const diff = (Date.now() - d) / 1000;
@@ -685,7 +687,7 @@ function TokensListDialog({
                         title={t.last_used_at ? new Date(t.last_used_at).toLocaleString('pt-BR') : ''}
                       >
                         {t.last_used_at
-                          ? fmtRelative(t.last_used_at)
+                          ? fmtLastUsed(t.last_used_at)
                           : <span className="text-muted-foreground">Nunca usado</span>}
                       </td>
                       <td className="py-2 px-2 font-mono text-xs">


### PR DESCRIPTION
## Contexto

A #2832 deduplicou a **única** cópia inline real de `fmtRelative` (em `kb/Index.tsx`) trocando-a pelo canônico `@/Lib/datetime-br`. Durante a investigação descobriu-se que **outras duas** funções locais chamadas `fmtRelative` **NÃO são duplicatas** — têm copy/buckets próprios e intencionais. Trocá-las pelo canônico seria **regressão de UX**.

O problema remanescente é o **nome colidente**: `fmtRelative` significando 3 coisas diferentes. Foi exatamente esse footgun que quase causou regressão na #2832 (a premissa "as 3 são idênticas" estava errada).

## Decisão (após adversário)

Wagner pediu adversário ("não sei resposta certa, crie um adversário"). Resultado:

| Opção | Veredicto |
|---|---|
| **A** deixar como está | ❌ mantém o footgun que causou a near-miss |
| **B** alinhar ao canônico | ❌ **canon-blocked no Team** — viola o charter `Team/Index.charter.md` (G-DESIGN-04: `'Nunca usado'` + relativo PT-BR). Só meio-aplicável (HealthPanelV4), e essa metade exigiria gate visual |
| **D** parametrizar o canônico | ⚠️ "mais puro" porém **YAGNI**: precisaria de 4 eixos de config p/ ficar byte-idêntico, p/ 2 callers; mexe em util de Fundações; jscpd nem vê os corpos como clones (dedup só conceitual) |
| **C** renomear ✅ | mata o footgun, **zero risco de UX**, sem conflito de charter, sem gate, ~6 linhas, mecanicamente seguro |

## O que muda

Apenas o **nome** das duas funções — corpos **byte-idênticos**, comportamento visível **inalterado**. Os nomes novos *anunciam* a divergência (anti-footgun):

- `team-mcp/Team/Index.tsx`: `fmtRelative` → **`fmtLastUsed`** (null→`'Nunca usado'` + buckets meses/anos — contrato G-DESIGN-04)
- `Admin/_components/HealthPanelV4.tsx`: `fmtRelative` → **`fmtAgoNoDate`** (null/NaN→`'nunca'`, minutos arredondados, sem data absoluta p/ >7d)

Ambas **não-exportadas**, 1–2 call sites cada, sem ripple externo.

## Verificação

- ✅ `node scripts/reuse-index.mjs --gate` → OK (sem duplicata nova; baseline 21 — funções não-exportadas não entram no índice)
- ✅ `git grep fmtRelative` nos 2 arquivos → só comentários explicativos remanescem; todas defs + call sites renomeados
- ⏳ `tsc --noEmit` → roda no CI (sem `node_modules` no ambiente local). Rename é type-safe por construção: funções não-exportadas, sem refs cross-module, todos os call sites in-file atualizados.

## Follow-up opcional (NÃO neste PR)

Pergunta de UX em aberto que o adversário levantou: o `'400d atrás'` do HealthPanelV4 (sem data absoluta p/ >7d) é **intencional ou drift**? Se for drift, vale um PR separado alinhando *só* esse arquivo ao canônico (com gate visual). HealthPanelV4 não tem charter, então não há contrato a violar.

Refs: #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)