### PR TITLE
feat(financeiro): Tribunal Onda 2 — drawer/lista lideram com a conclusão

### DIFF
--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -4826,10 +4826,17 @@
 .fin-cowork .fin-copyval.ok .fin-copyval-ic { opacity: 1; }
 
 /* F2 — ficha de campos: cartão com lavanda sutil (label nunca flutua em branco · [W] 06-11) */
+/* #6 Tribunal Onda 2 (cadeira Reichenstein · [W] "tirar cor, manter fios" 2026-06-16) —
+   a queixa era "caixa colorida fazendo o trabalho da tipografia". Tira a cor (fundo
+   lavanda + borda accent + radius) e mantém ESTRUTURA neutra discreta (fios topo/baixo)
+   pra a ficha não flutuar em branco (pedido [W] 06-11). Tipografia agrupa. Tokens only
+   (transparent + var(--border-2)) → não adiciona cor-crua ao conformance-gate. */
 .fin-cowork .fin-kv-card {
-  background: color-mix(in oklab, var(--accent) 2.5%, var(--surface));
-  border: 1px solid color-mix(in oklab, var(--accent) 10%, var(--border-2));
-  border-radius: 10px; padding: 10px 14px 12px;
+  background: transparent;
+  border: 0;
+  border-top: 1px solid var(--border-2);
+  border-bottom: 1px solid var(--border-2);
+  border-radius: 0; padding: 11px 0 12px;
 }
 
 /* R2 — Categoria editável inline (Canal segue read-only · decisão [W] 2026-06-11):

--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -4826,17 +4826,10 @@
 .fin-cowork .fin-copyval.ok .fin-copyval-ic { opacity: 1; }
 
 /* F2 — ficha de campos: cartão com lavanda sutil (label nunca flutua em branco · [W] 06-11) */
-/* #6 Tribunal Onda 2 (cadeira Reichenstein · [W] "tirar cor, manter fios" 2026-06-16) —
-   a queixa era "caixa colorida fazendo o trabalho da tipografia". Tira a cor (fundo
-   lavanda + borda accent + radius) e mantém ESTRUTURA neutra discreta (fios topo/baixo)
-   pra a ficha não flutuar em branco (pedido [W] 06-11). Tipografia agrupa. Tokens only
-   (transparent + var(--border-2)) → não adiciona cor-crua ao conformance-gate. */
+/* #6 Tribunal Onda 2 ([W] "tirar cor, manter fios" 2026-06-16) — ficha sem caixa colorida: fios neutros agrupam, não flutuam (rationale: charter v16). */
 .fin-cowork .fin-kv-card {
-  background: transparent;
-  border: 0;
-  border-top: 1px solid var(--border-2);
-  border-bottom: 1px solid var(--border-2);
-  border-radius: 0; padding: 11px 0 12px;
+  background: transparent; border: 0;
+  border-top: 1px solid var(--border-2); border-bottom: 1px solid var(--border-2); border-radius: 0; padding: 11px 0 12px;
 }
 
 /* R2 — Categoria editável inline (Canal segue read-only · decisão [W] 2026-06-11):

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -3,7 +3,7 @@ page: /financeiro/unificado
 component: resources/js/Pages/Financeiro/Unificado/Index.tsx
 owner: wagner
 status: live
-last_validated: "2026-06-10"
+last_validated: "2026-06-16"
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
 related_adrs: [93, 94]
@@ -12,13 +12,14 @@ related_prototype: canon REAL public/cowork-preview/Oimpresso ERP - Chat.html (a
 canon_method: Bundle copy CSS 9054 LOC inteiro (regra Tier 0 feedback-cowork-bundle-aplicar-inteiro) — Ondas 12-21
 runbook: memory/requisitos/Financeiro/RUNBOOK-unificado.md
 tier: A
-charter_version: 15
+charter_version: 16
 ---
 
 # Page Charter — /financeiro/unificado
 
 > **Status:** F3 entregue (PR #349). Charter retroativo (sessão 2026-05-09 audit) — sem `Index.charter.md` original, divergências do ADR ui/0002 documentadas abaixo.
 > Persona: **Eliana [E]** — financeiro escritório, densidade alta, atalhos teclado.
+> **v16 (2026-06-16):** Tribunal Onda 2 ([W] aprovou Onda 2 pra produção) — drawer/lista **lideram com a conclusão** (ver Goals: veredito no topo · "vs média" cross-sectional · selo→dado · FSM-resumo · acento de ação na linha · ficha sem caixa). Non-Goal de comparação **emendado** (cross-sectional ≠ delta_pct temporal). Vetos Larissa preservados (ícones coloridos das lentes + tipografia do valor).
 > **v15 (2026-06-10):** drawer 3 camadas F2 (ver Goals — hero fixo + lentes + Lente Fiscal).
 > **v14 (2026-06-10):** US-FIN-029 ENTREGUE — header "3 lentes" (ver Goals). Pacote F2 aprovado [W] 2026-06-10 ("aprovado", sessão Cowork).
 > **v10 (2026-05-31):** integrado o feedback de [W] da sessão Cowork (handoff de design) — anti-patterns de densidade do header + direção "3 lentes" registrada como intenção **pendente** (ainda **não** aplicada ao live; ver Backlog US-FIN-029). Origem: charter Cowork `Financeiro.charter.md` v1 (superada por este v10 canônico).
@@ -32,6 +33,14 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 ---
 
 ## Goals — Features (faz)
+
+- **Tribunal Onda 2 — drawer/lista lideram com a conclusão** (2026-06-16, charter v16, método "O Tribunal" · [W] aprovou Onda 2 pra produção): 6 mudanças de **mérito** (não-bug), cor só por token semântico, vetos Larissa intactos.
+  - **#1 Veredito no topo do drawer** (cadeira Victor): 1ª coisa do corpo (acima de Vínculos), 1 linha + sub, derivada 100% do estado do título (`status`/`nfe_numero`/`vencimento`) — sem mock. Tons `pos/warn/neg/muted` (success/warning/destructive/muted) com ícone redondo preenchido. `vencimento` é ISO → contagem de dias confiável.
+  - **#2 "vs média" no valor** (cadeira Tufte): linha neutra sob o hero comparando o título com a **média dos pares** (mesma categoria + mesmo kind, valor>0) do conjunto carregado client-side. **Cross-sectional** (≠ delta_pct temporal). Anti-slop: só renderiza com **≥2 pares reais**; tom neutro (seta + %), sem valência. Reusa `lancamentos` (mesma fonte do `FinAnomalyDetector`).
+  - **#3 Selo→dado** (Tufte/Rams): tira o `status` de sucesso redundante das 3 lentes (Conciliação `100% match`→`null` · Fiscal `NF vinculada`→`null` · Cobrança `encerrada`→`null`); mantém os que carregam info nova (`aguardando`/`sem NF`/`em atraso`).
+  - **#4 Item liquidado: FSM 1-linha** (Victor/Rams): título liquidado não gasta ~80px com 4 etapas todas marcadas — vira `✓ Lançado → Liquidado · 4 etapas`. Aberto mantém o stepper completo. (Suffix "no prazo/atraso" omitido: `liquidacao` chega como "DD MMM", sem data parseável; vira proposta se o shape expor a data ISO da baixa.)
+  - **#5 Acento de ação na linha** (Victor/Saarinen): `box-shadow: inset 3px` na 1ª `<td>` — vencido = destructive, vencendo (não pago) = warning, resto = nada. Eliana acha o que pede ação sem abrir.
+  - **#6 Ficha de campos sem caixa** (Reichenstein · [W] "tirar cor, manter fios" 2026-06-16): `.fin-kv-card` perde fundo lavanda + borda accent + radius; ganha **fios neutros** topo/baixo (`var(--border-2)`), pra não flutuar em branco. Tokens only → conformance-gate intacto (215=215).
 
 - **Header "3 lentes" (US-FIN-029)** (2026-06-10, charter v14, direção [W] 2026-05-31 aprovada / F2 [W] 2026-06-10): segmented **Caixa · A receber · A pagar** no header (pattern pill do Fluxo) é a **camada 1** do filtro grosso — `?lente=caixa|receber|pagar`, clamp default `caixa`, deep-link funciona. Chips lifecycle **refinam DENTRO da lente**; chip incompatível com a lente não renderiza. **KPI-click seta a lente** correspondente (drill-down ADR ui/0002 preservado: "Recebido"→lente receber+chip re, "A pagar"→lente pagar+chip ap, hero→caixa+ar/ap). Backend: `parseFilters()['lente']` + interseção lifecycle∩lente (interseção vazia = lente inteira, defense-in-depth). O menu `···` e o topnav compartilhado **já estavam entregues** via `FinanceiroSubNav` (`_shared/`, ADR 0180 Fase 5, PR #1365) — gatilho US-FIN-TOPNAV-COMPONENT já satisfeito antes desta US. MWART: `memory/requisitos/Financeiro/unificado-3-lentes-visual-comparison.md`. Cobertura `UnificadoLentesGuardTest` (clamp · lente→estados · inválida→caixa · Tier 0 · GET sem mutação).
 
@@ -135,7 +144,7 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 - ❌ Edição de `tipo`, `origem`, `origem_id`, `status`, `emissao` — imutáveis (anti-corrupção contábil; alterar requer cancelar+criar novo). Onda Edit edita só campos seguros + valor pré-baixa.
 - ❌ Pagination explícita (default `limit(200)` no controller) — paginar quando 1000+ títulos virar dor
 - ❌ Aging buckets <30 / 30-60 / 60-90 / 90+ — ADR ui/0002 previa, F1 simplifica pra status `atrasado` único
-- ❌ Comparação `+12% vs mês anterior` — ADR ui/0002 previa `delta_pct`, F1 não calcula
+- ❌ Comparação **temporal** `+12% vs mês anterior` (delta_pct por KPI) — ADR ui/0002 previa; F1 não calcula; segue em **US-FIN-023**. ⚠️ **≠ da comparação cross-sectional "vs média da categoria"** (Tribunal Onda 2 #2, charter v16) que **É feita** no hero do drawer — esta compara o título com a média dos pares (mesma categoria+kind) do conjunto carregado, anti-slop ≥2 pares, tom neutro. Distinção registrada por decisão [W] 2026-06-16.
 - ❌ Combobox cliente/contraparte com autocomplete — F1 só filtra por chip, sem typeahead
 - ❌ Mobile responsive (cards stack 2×2) — F1 só desktop ≥1024px (Eliana é desktop)
 - ❌ Export PDF/Excel — Onda 4

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -2262,10 +2262,10 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                       check pequeno), não banda verde — padrão F2-aprovado [W]. */}
                   {(() => {
                     const settled = selected.status === 'recebido' || selected.status === 'pago';
+                    // #3 Tribunal Onda 2 (Tufte/Rams) — selo de sucesso que só re-anuncia o corpo
+                    // = tinta não-dado. Liquidado: tira "100% match" do header (o box abaixo já
+                    // prova). Aberto mantém "aguardando" (info real).
                     return (
-                      {/* #3 Tribunal Onda 2 (Tufte/Rams) — selo de sucesso que só re-anuncia o
-                          corpo = tinta não-dado. Liquidado: tira "100% match" do header (o box
-                          abaixo já prova). Aberto mantém "aguardando" (info real). */}
                       <DrawerLens icon={Landmark} title="Conciliação extrato" status={settled ? null : 'aguardando'} tone={settled ? 'pos' : 'muted'} hue={settled ? 'pos' : 'muted'}>
                         {settled ? (
                           <Inline align="start" gap={2} className="gap-2.5 rounded-md border border-border bg-muted px-3 py-2">
@@ -2299,9 +2299,9 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     const hasNf = !!selected.nfe_numero;
                     const iss = isIn ? (selected.valor ?? 0) * 0.05 : 0;
                     const das = isIn ? (selected.valor ?? 0) * 0.06 : 0;
+                    // #3 — com NF: tira "NF vinculada" do header (o nº da NF aparece no corpo).
+                    // Sem NF: mantém "sem NF" (warn — buraco real).
                     return (
-                      {/* #3 — com NF: tira "NF vinculada" do header (o nº da NF aparece no corpo).
-                          Sem NF: mantém "sem NF" (warn — buraco real). */}
                       <DrawerLens icon={Percent} title="Fiscal" status={hasNf ? null : 'sem NF'} tone={hasNf ? 'pos' : 'warn'} hue="warn">
                         <Grid cols={2} gap={0} className="gap-x-5">
                           <div>

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1011,13 +1011,21 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
     paid_at: settled ? row.liquidacao : null,
     vencimento: row.vencimento,
   };
+  // #5 Tribunal Onda 2 (cadeira Victor/Saarinen) — acento de AÇÃO na borda esquerda da
+  // linha pra achar o que pede ação sem abrir: vencido = destructive, vencendo (não pago)
+  // = warning, resto = nada. box-shadow inset na 1ª <td> (border-collapse ignora
+  // border-left no <tr>); var(--color-*) do @theme Tailwind v4 (token, não cor crua).
+  const actAccent =
+    row.status === 'atrasado' ? 'inset 3px 0 0 var(--color-destructive)'
+    : (row.status === 'vencendo' && !settled) ? 'inset 3px 0 0 var(--color-warning)'
+    : undefined;
   return (
     <tr
       className={`${dens.row} ${dens.text} border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer ${selected ? 'bg-amber-50/40' : ''} ${bulkSelected ? 'bg-primary/5' : ''}`}
       onClick={onSelect}
     >
       {/* Onda 12 (2026-05-20): checkbox bulk-select. stopPropagation pra nao abrir drawer. */}
-      <td className="pl-4 pr-1" onClick={(e) => e.stopPropagation()}>
+      <td className="pl-4 pr-1" style={actAccent ? { boxShadow: actAccent } : undefined} onClick={(e) => e.stopPropagation()}>
         <Checkbox
           checked={bulkSelected}
           onCheckedChange={onToggleBulk}
@@ -1962,6 +1970,22 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 // ainda não vive no shape → estágio 2 fica no caminho, não asserido).
                 const etapas = ['Lançado', 'Conferido', 'Conciliado', 'Liquidado'];
                 const stage = settled ? 3 : selected.conferido_at ? 1 : 0;
+                // #2 Tribunal Onda 2 (cadeira Tufte) — tira o número do isolamento: compara
+                // com a média dos PARES reais (mesma categoria + mesmo kind, valor>0) no
+                // conjunto carregado client-side. Anti-slop: só renderiza com ≥2 pares; tom
+                // NEUTRO (seta + %), sem valência verde/vermelho. É cross-sectional, ≠ do
+                // delta_pct temporal "+X% vs mês anterior" adiado em US-FIN-023 (charter).
+                const vsAvg = (() => {
+                  if (!selected.categoria) return null;
+                  const pares = lancamentos.filter(
+                    (r) => r.id !== selected.id && r.categoria === selected.categoria && r.kind === selected.kind && (r.valor ?? 0) > 0,
+                  );
+                  if (pares.length < 2) return null;
+                  const media = pares.reduce((s, r) => s + (r.valor ?? 0), 0) / pares.length;
+                  if (media <= 0) return null;
+                  const pct = Math.round((((selected.valor ?? 0) - media) / media) * 100);
+                  return { pct, n: pares.length + 1 };
+                })();
                 return (
                   <div className="shrink-0 px-5 pt-3 pb-3.5 border-b border-border fin-dw-hero">
                     <Inline align="end" justify="between" gap={3}>
@@ -1974,6 +1998,15 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                           <span className={`text-[length:var(--fs-9,38px)] leading-none font-semibold tracking-tight font-mono tabular-nums ${isIn ? 'text-success-foreground' : 'text-foreground'}`}>{intPart}</span>
                           <span className="text-[13.5px] text-muted-foreground font-mono">,{decPart}</span>
                         </Inline>
+                        {vsAvg && (
+                          <div
+                            className="mt-1 text-[11px] text-muted-foreground tabular-nums"
+                            title={`Comparação com a média de ${vsAvg.n} títulos de "${selected.categoria}" (${isIn ? 'a receber' : 'a pagar'})`}
+                          >
+                            <span aria-hidden>{vsAvg.pct > 0 ? '↑' : vsAvg.pct < 0 ? '↓' : '→'}</span>{' '}
+                            {vsAvg.pct > 0 ? '+' : ''}{vsAvg.pct}% vs média · {selected.categoria}
+                          </div>
+                        )}
                       </div>
                       <Stack gap={1} align="end" className="gap-1.5 shrink-0 pb-0.5">
                         {/* FA-5 R3 — estado dito 1×: o label uppercase colorido (acima) já diz o
@@ -1989,26 +2022,39 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                         </div>
                       </Stack>
                     </Inline>
-                    <Inline gap={0} className="mt-3" role="img" aria-label={`Etapa do ciclo: ${etapas[stage]}`}>
-                      {etapas.map((lbl, i) => (
-                        <React.Fragment key={lbl}>
-                          {i > 0 && <span className={`h-px flex-1 mx-1.5 ${i <= stage ? 'bg-primary' : 'bg-border'}`} aria-hidden />}
-                          <span className="inline-flex items-center gap-1" aria-hidden>
-                            <span className={
-                              'w-[15px] h-[15px] rounded-full grid place-items-center text-[9px] font-semibold border ' +
-                              (i < stage
-                                ? 'bg-primary border-primary text-primary-foreground'
-                                : i === stage
-                                  ? 'bg-background border-primary text-primary shadow-[0_0_0_3px] shadow-primary/15'
-                                  : 'bg-background border-border text-muted-foreground')
-                            }>
-                              {i < stage ? '✓' : i + 1}
+                    {/* #4 Tribunal Onda 2 (Victor/Rams) — título liquidado não gasta ~80px com
+                        4 etapas todas marcadas: vira resumo de 1 linha. Aberto mantém o stepper
+                        completo. ("no prazo/atraso" omitido de propósito: `liquidacao` chega
+                        como "DD MMM" — sem data parseável pra asserir sem fabricar; a data da
+                        baixa já aparece no hero acima. Suffix vira proposta se o shape expor a
+                        data ISO da liquidação.) */}
+                    {settled ? (
+                      <Inline gap={2} className="mt-3 text-[11.5px] text-muted-foreground" role="img" aria-label={`Ciclo concluído: ${etapas.join(' → ')}`}>
+                        <span className="inline-grid place-items-center w-[15px] h-[15px] rounded-full bg-primary text-primary-foreground text-[9px] font-semibold shrink-0" aria-hidden>✓</span>
+                        <span><b className="font-medium text-foreground">{etapas[0]} → {etapas[etapas.length - 1]}</b> · {etapas.length} etapas</span>
+                      </Inline>
+                    ) : (
+                      <Inline gap={0} className="mt-3" role="img" aria-label={`Etapa do ciclo: ${etapas[stage]}`}>
+                        {etapas.map((lbl, i) => (
+                          <React.Fragment key={lbl}>
+                            {i > 0 && <span className={`h-px flex-1 mx-1.5 ${i <= stage ? 'bg-primary' : 'bg-border'}`} aria-hidden />}
+                            <span className="inline-flex items-center gap-1" aria-hidden>
+                              <span className={
+                                'w-[15px] h-[15px] rounded-full grid place-items-center text-[9px] font-semibold border ' +
+                                (i < stage
+                                  ? 'bg-primary border-primary text-primary-foreground'
+                                  : i === stage
+                                    ? 'bg-background border-primary text-primary shadow-[0_0_0_3px] shadow-primary/15'
+                                    : 'bg-background border-border text-muted-foreground')
+                              }>
+                                {i < stage ? '✓' : i + 1}
+                              </span>
+                              <span className={`text-[10.5px] ${i === stage ? 'text-primary font-semibold' : i < stage ? 'text-foreground' : 'text-muted-foreground'}`}>{lbl}</span>
                             </span>
-                            <span className={`text-[10.5px] ${i === stage ? 'text-primary font-semibold' : i < stage ? 'text-foreground' : 'text-muted-foreground'}`}>{lbl}</span>
-                          </span>
-                        </React.Fragment>
-                      ))}
-                    </Inline>
+                          </React.Fragment>
+                        ))}
+                      </Inline>
+                    )}
                   </div>
                 );
               })()}
@@ -2073,6 +2119,44 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                   permite o footer (irmão, fora do scroll) ficar sticky-bottom. */}
               {drawerTab === 'detalhes' && (
                 <div className="mt-3 px-5 pb-4 space-y-5 text-[13px] flex-1 overflow-y-auto min-h-0">
+                  {/* #1 Veredito (Tribunal Onda 2 · cadeira Victor) — a tela conclui pelo usuário
+                      antes de qualquer varredura: 1ª coisa do corpo, acima dos Vínculos, 1 linha
+                      + sub. 100% derivado do estado do título (status/NF/vencimento) — sem mock.
+                      Tom por token semântico (success/warning/destructive/muted). vencimento é
+                      ISO YYYY-MM-DD → contagem de dias confiável. */}
+                  {(() => {
+                    const liq = selected.status === 'recebido' || selected.status === 'pago';
+                    const temNf = !!selected.nfe_numero;
+                    const hojeMs = (() => { const n = new Date(); return Date.UTC(n.getFullYear(), n.getMonth(), n.getDate()); })();
+                    const vp = (selected.vencimento || '').split('-');
+                    const vencMs = vp.length === 3 ? Date.UTC(+vp[0], +vp[1] - 1, +vp[2]) : null;
+                    const dias = vencMs != null ? Math.round((vencMs - hojeMs) / 86400000) : null;
+                    const v = liq
+                      ? (temNf
+                          ? { tone: 'pos' as const, glyph: '✓', head: 'Nada pendente.', sub: 'Pago, conciliado e com NF vinculada.' }
+                          : { tone: 'warn' as const, glyph: '!', head: 'Pago, mas sem NF.', sub: 'Falta vincular o documento fiscal.' })
+                      : selected.status === 'atrasado'
+                        ? { tone: 'neg' as const, glyph: '!', head: dias != null && dias <= -1 ? `Vencida há ${Math.abs(dias)} ${Math.abs(dias) === 1 ? 'dia' : 'dias'} — cobrar.` : 'Vencida — cobrar.', sub: selected.contraparte || 'Cobrança pendente.' }
+                        : selected.status === 'vencendo'
+                          ? { tone: 'warn' as const, glyph: '!', head: dias != null && dias > 0 ? `Vence em ${dias} ${dias === 1 ? 'dia' : 'dias'}.` : 'Vence hoje — preparar cobrança.', sub: selected.contraparte || 'Prepare a cobrança.' }
+                          : { tone: 'muted' as const, glyph: '•', head: dias != null && dias > 0 ? `Em aberto — vence em ${dias} dias.` : 'Em aberto.', sub: 'Nada urgente por agora.' };
+                    const t = {
+                      pos: { box: 'bg-success/10 ring-success/25', ic: 'bg-success text-white' },
+                      warn: { box: 'bg-warning/10 ring-warning/30', ic: 'bg-warning text-white' },
+                      neg: { box: 'bg-destructive/10 ring-destructive/25', ic: 'bg-destructive text-white' },
+                      muted: { box: 'bg-muted ring-border', ic: 'bg-muted-foreground/25 text-muted-foreground' },
+                    }[v.tone];
+                    return (
+                      <div className={`flex items-start gap-2.5 rounded-md px-3 py-2.5 ring-1 ring-inset ${t.box}`}>
+                        <span className={`w-[22px] h-[22px] rounded-full grid place-items-center shrink-0 mt-px text-[12px] font-bold leading-none ${t.ic}`} aria-hidden>{v.glyph}</span>
+                        <div className="min-w-0">
+                          <div className="text-[13px] font-semibold text-foreground leading-snug">{v.head}</div>
+                          <div className="text-[11.5px] text-muted-foreground leading-snug mt-0.5 truncate">{v.sub}</div>
+                        </div>
+                      </div>
+                    );
+                  })()}
+
                   {/* FA-5 — Vínculos: chips estruturados derivados dos tokens #V-/#OS- da descrição
                       + nfe_numero (mesma fonte do FinCrossLinkify; não inventa dado). */}
                   <FinVinculosChips descricao={selected.descricao} nfeNumero={selected.nfe_numero} />
@@ -2179,7 +2263,10 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                   {(() => {
                     const settled = selected.status === 'recebido' || selected.status === 'pago';
                     return (
-                      <DrawerLens icon={Landmark} title="Conciliação extrato" status={settled ? '100% match' : 'aguardando'} tone={settled ? 'pos' : 'muted'} hue={settled ? 'pos' : 'muted'}>
+                      {/* #3 Tribunal Onda 2 (Tufte/Rams) — selo de sucesso que só re-anuncia o
+                          corpo = tinta não-dado. Liquidado: tira "100% match" do header (o box
+                          abaixo já prova). Aberto mantém "aguardando" (info real). */}
+                      <DrawerLens icon={Landmark} title="Conciliação extrato" status={settled ? null : 'aguardando'} tone={settled ? 'pos' : 'muted'} hue={settled ? 'pos' : 'muted'}>
                         {settled ? (
                           <Inline align="start" gap={2} className="gap-2.5 rounded-md border border-border bg-muted px-3 py-2">
                             <span className="w-[18px] h-[18px] rounded-full grid place-items-center bg-success/15 text-success-foreground shrink-0 mt-px" aria-hidden>
@@ -2213,7 +2300,9 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     const iss = isIn ? (selected.valor ?? 0) * 0.05 : 0;
                     const das = isIn ? (selected.valor ?? 0) * 0.06 : 0;
                     return (
-                      <DrawerLens icon={Percent} title="Fiscal" status={hasNf ? 'NF vinculada' : 'sem NF'} tone={hasNf ? 'pos' : 'warn'} hue="warn">
+                      {/* #3 — com NF: tira "NF vinculada" do header (o nº da NF aparece no corpo).
+                          Sem NF: mantém "sem NF" (warn — buraco real). */}
+                      <DrawerLens icon={Percent} title="Fiscal" status={hasNf ? null : 'sem NF'} tone={hasNf ? 'pos' : 'warn'} hue="warn">
                         <Grid cols={2} gap={0} className="gap-x-5">
                           <div>
                             <div className="text-[10.5px] uppercase tracking-[0.08em] text-muted-foreground">{isIn ? 'NF-e de saída' : 'Documento fiscal'}</div>
@@ -2255,7 +2344,9 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     const settledCob = selected.status === 'recebido' || selected.status === 'pago';
                     const isInCob = selected.kind === 'receivable';
                     const hasBoleto = !!selected.boleto?.linha_digitavel;
-                    const cobStatus = settledCob ? 'encerrada' : selected.status === 'atrasado' ? 'em atraso' : hasBoleto ? 'boleto emitido' : 'a gerar';
+                    // #3 — liquidado: tira "encerrada" do header (o corpo diz "Título liquidado
+                    // — cobrança encerrada"). Aberto mantém "em atraso"/"boleto emitido"/"a gerar".
+                    const cobStatus = settledCob ? null : selected.status === 'atrasado' ? 'em atraso' : hasBoleto ? 'boleto emitido' : 'a gerar';
                     const cobTone: 'pos' | 'warn' | 'muted' = settledCob ? 'pos' : selected.status === 'atrasado' ? 'warn' : 'muted';
                     return (
                       <DrawerLens icon={Send} title="Cobrança" status={cobStatus} tone={cobTone} hue={settledCob ? 'pos' : selected.status === 'atrasado' ? 'warn' : 'accent'}>


### PR DESCRIPTION
> **Draft de propósito.** Onda 2 do método **"O Tribunal"** no Financeiro/Unificado (mérito, não-bug). [W] aprovou levar pra produção. **NÃO MERGEAR** até: (1) [W] aprovar o **screenshot** (loop Cowork, ADR 0114 — não tabela) e (2) CI verde (tsc/eslint/vite build/Pest — não rodam neste host sem `node_modules`).

## As 6 mudanças
| # | Cadeira | O quê | Onde |
|---|---|---|---|
| **#1** | Victor | Veredito inferido no topo do drawer (1 linha + sub), derivado de `status`/`nfe_numero`/`vencimento` — sem mock | acima de `FinVinculosChips` |
| **#2** | Tufte | "vs média" cross-sectional sob o valor (média dos pares mesma categoria+kind), anti-slop ≥2 pares, tom neutro | hero do drawer |
| **#3** | Tufte/Rams | Selo→dado: tira status de sucesso redundante das 3 lentes (`100% match`/`NF vinculada`/`encerrada`→`null`) | `DrawerLens` |
| **#4** | Victor/Rams | Título liquidado: stepper FSM 4-etapas → resumo de 1 linha | hero do drawer |
| **#5** | Victor/Saarinen | Acento de ação na linha (vencido=destructive, vencendo=warning) via `box-shadow inset` na 1ª `<td>` | `<tr>` da tabela |
| **#6** | Reichenstein | Ficha de campos sem caixa colorida → fios neutros | `.fin-kv-card` (CSS) |

## Decisões [W] (AskUser 2026-06-16)
- **#6 → "tirar cor, manter fios"**: `.fin-kv-card` vira `transparent` + `border-top/bottom var(--border-2)`, sem radius.
- **#2 → implementar junto**: feito client-side (sem backend; `lancamentos` já no escopo). Charter v16 **emenda o Non-Goal** distinguindo cross-sectional (feito) de `delta_pct` temporal (segue em US-FIN-023).

## Desvios honestos do prompt (confirmados contra o `main`)
- **#4 sem o sufixo "no prazo / Nd de atraso"**: `liquidacao` chega do controller como `isoFormat('DD MMM')` (ex "12 mai") — **sem data parseável** pra asserir sem fabricar (lição F3: não inventar dado). Resumo entrega o essencial (`✓ Lançado → Liquidado · 4 etapas`); a data da baixa já aparece no hero. Sufixo vira proposta se o shape expor a data ISO da liquidação.
- **#4 labels reais**: `Lançado → Conferido → Conciliado → Liquidado` (não "Emitido" do protótipo).
- **Tokens traduzidos**: o protótipo usa `var(--neg/--warn/--pos)` (vanilla, inexistentes no repo) → traduzido pros tokens `@theme` do repo (`destructive/warning/success/muted`) e `var(--color-*)` no `box-shadow` do #5.

## Vetos Larissa preservados (lei)
- ✅ Ícones-quadradinho coloridos das lentes **mantidos**.
- ✅ Tipografia do valor (inteiro grande + centavos/prefixo pequenos) **intacta**.

## Gates
- ✅ `conformance-gate --all`: cor-crua 215=215 (#6 é tokens-only), `--accent` roxo, papel de token, type-ramp.
- ✅ `ds-canon-color-guard`: canon sem paleta crua.
- ⏳ `tsc`/`eslint`/`vite build`/Pest: **CI** (host desktop sem `node_modules`; revisão manual feita região-a-região).

## Base
Branch limpo de `origin/main` (não da `fix/financeiro-adversario-wave1`; `Index.tsx` idêntico entre os dois). Charter v15→v16. Handoff: `PROMPT_PARA_CODE_FINANCEIRO-ONDA2-TRIBUNAL.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
