### PR TITLE
refactor(admin): HealthPanelV4 usa fmtRelative canônico (data absoluta >7d)

### DIFF
--- a/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
+++ b/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
@@ -14,6 +14,7 @@ import {
   Layers,
   Sparkles,
 } from 'lucide-react';
+import { fmtRelative } from '@/Lib/datetime-br';
 import { cn } from '@/Lib/utils';
 import type { HealthSnapshot } from './governanceV4Types';
 
@@ -30,19 +31,6 @@ interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   snapshot: HealthSnapshot | null;
-}
-
-// Nome próprio (não `fmtRelative`): minutos arredondados + sem fallback de data
-// absoluta p/ >7d (mostra 'Xd atrás'), divergem do canônico @/Lib/datetime-br.
-function fmtAgoNoDate(iso: string | null): string {
-  if (!iso) return 'nunca';
-  const d = new Date(iso).getTime();
-  if (Number.isNaN(d)) return 'nunca';
-  const diff = Math.round((Date.now() - d) / 60_000);
-  if (diff < 1) return 'agora';
-  if (diff < 60) return `${diff}min atrás`;
-  if (diff < 1440) return `${Math.round(diff / 60)}h atrás`;
-  return `${Math.round(diff / 1440)}d atrás`;
 }
 
 export default function HealthPanelV4({ open, onOpenChange, snapshot }: Props) {
@@ -79,7 +67,7 @@ export default function HealthPanelV4({ open, onOpenChange, snapshot }: Props) {
               primary={
                 snapshot.scorecard_cron_ok ? 'Operacional' : 'Falha last_run'
               }
-              detail={`last run ${fmtAgoNoDate(snapshot.scorecard_last_run_at)}`}
+              detail={`last run ${fmtRelative(snapshot.scorecard_last_run_at)}`}
             />
             <HealthCard
               title="AI baseline 30d"
@@ -97,7 +85,7 @@ export default function HealthPanelV4({ open, onOpenChange, snapshot }: Props) {
               tone={snapshot.otel_collector_up ? 'ok' : 'bad'}
               icon={<Activity size={14} />}
               primary={snapshot.otel_collector_up ? 'Up' : 'Down'}
-              detail={`last ping ${fmtAgoNoDate(snapshot.otel_collector_last_ping_at)}`}
+              detail={`last ping ${fmtRelative(snapshot.otel_collector_last_ping_at)}`}
             />
             <HealthCard
               title="Cobertura buckets"


### PR DESCRIPTION
## Contexto

Follow-up aprovado da #2835. Lá renomeei o `fmtAgoNoDate` local do HealthPanelV4 pra deixar a divergência explícita; aqui **elimino** a divergência reusando o canônico `@/Lib/datetime-br`.

## O que muda (visível)

Só a linha `detail` dos HealthCards. Aprovado pelo Wagner via mockup before/after (gate visual · Constituição UI v2 · ADR UI-0013):

| Estado | Antes (`fmtAgoNoDate`) | Depois (canônico `fmtRelative`) |
|---|---|---|
| > 7 dias | `400d atrás` (ilimitado) | `16/06 14:30` (data absoluta) ✅ o fix |
| null (nunca rodou) | `nunca` | `—` (convenção canônica) |
| 1h30 atrás | `2h atrás` (round) | `1h atrás` (floor — convenção "X atrás") |

`null→'—'` confirmado pelo Wagner (opção "travessão / canônico puro").

## Por que é seguro

HealthPanelV4 **não tem charter** — não há contrato de copy a violar (diferente do `Team/Index.tsx`, que é travado por G-DESIGN-04 e por isso ficou só com rename na #2835). Net **-12 linhas**: remove a 3ª/última cópia divergente de relativo no front.

## Verificação

- ✅ `node scripts/reuse-index.mjs --gate` → OK
- ✅ Mockup before/after aprovado (Wagner)
- ⏳ `tsc --noEmit` + Vite build + `visual-regression` → CI

Refs: #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)