### PR TITLE
feat(team-mcp): Forja PR-A — shell do cockpit do cowork loop

### DIFF
--- a/Modules/TeamMcp/Http/Controllers/DataController.php
+++ b/Modules/TeamMcp/Http/Controllers/DataController.php
@@ -163,6 +163,36 @@ class DataController extends Controller
                         ],
                     ]
                 )->order(91); // Logo após Copiloto (90)
+
+                // ---- Forja — cockpit do cowork loop (Onda Forja PR-A) ----
+                // Entry PRÓPRIA (não é ghost da Equipe): tem topnav próprio de 6
+                // abas (config/core_topnavs.php['Forja']) e raiz /forja. Mora no
+                // TeamMcp (absorção, não módulo novo). Read-only nesta onda.
+                $menu->dropdown(
+                    'Forja',
+                    function ($sub) {
+                        $sub->url('/forja',           'Triagem',   ['icon' => 'fa fas fa-inbox',     'active' => request()->path() === 'forja']);
+                        $sub->url('/forja/backlog',   'Backlog',   ['icon' => 'fa fas fa-list-ul',   'active' => request()->segment(2) === 'backlog']);
+                        $sub->url('/forja/quadro',    'Quadro',    ['icon' => 'fa fas fa-columns',   'active' => request()->segment(2) === 'quadro']);
+                        $sub->url('/forja/changelog', 'Changelog', ['icon' => 'fa fas fa-history',   'active' => request()->segment(2) === 'changelog']);
+                        $sub->url('/forja/mcp',       'MCP',       ['icon' => 'fa fas fa-plug',      'active' => request()->segment(2) === 'mcp']);
+                        $sub->url('/forja/saude',     'Saúde',     ['icon' => 'fa fas fa-heartbeat', 'active' => request()->segment(2) === 'saude']);
+                    },
+                    [
+                        'icon'     => 'fa fas fa-hammer',
+                        'active'   => request()->segment(1) === 'forja',
+                        'group'    => 'equipe',
+                        'shortcut' => 'G F',
+                        'ghosts'   => [
+                            ['key' => 'triagem',   'label' => 'Triagem',   'href' => '/forja'],
+                            ['key' => 'backlog',   'label' => 'Backlog',   'href' => '/forja/backlog'],
+                            ['key' => 'quadro',    'label' => 'Quadro',    'href' => '/forja/quadro'],
+                            ['key' => 'changelog', 'label' => 'Changelog', 'href' => '/forja/changelog'],
+                            ['key' => 'mcp',       'label' => 'MCP',       'href' => '/forja/mcp'],
+                            ['key' => 'saude',     'label' => 'Saúde',     'href' => '/forja/saude'],
+                        ],
+                    ]
+                )->order(92); // Logo após Equipe (91)
             }
         );
     }

--- a/Modules/TeamMcp/Http/Controllers/ForjaController.php
+++ b/Modules/TeamMcp/Http/Controllers/ForjaController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * ForjaController — cockpit do cowork loop (/forja).
+ *
+ * Absorção em TeamMcp (NÃO é módulo novo — kickoff Forja). As 6 abas projetam
+ * estado que JÁ EXISTE (mcp_tasks + git/PR/ADR/sessão + gates/memory-health) —
+ * sem dado fantasma. Todas renderizam o mesmo shell `team-mcp/Forja/Cockpit`
+ * com a aba ativa via prop `tab`; o topnav de 6 abas vem de
+ * config/core_topnavs.php['Forja'] (useAutoModuleNav casa por 1º segmento /forja
+ * — por isso a raiz é /forja e não /team-mcp/forja, que colidiria com o hub Equipe).
+ *
+ * Onda Forja PR-A: SHELL navegável — abas ainda em construção (cada uma vira uma
+ * PR própria com seu gate visual). Referência aprovada (F1.5 ADR 0114):
+ * memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md.
+ *
+ * Multi-tenant Tier 0: cockpit é repo-wide (governança cross-business do loop)
+ * — sem filtro business_id, INTENCIONAL (ADR 0093), igual Scorecard.
+ *
+ * Permissão: copiloto.mcp.usage.all (Wagner/superadmin), igual Scorecard/Team.
+ */
+class ForjaController extends Controller
+{
+    /**
+     * Abas do cockpit (label + intro). Ordem = ordem do topnav.
+     *
+     * @var array<string,array{label:string,subtitle:string}>
+     */
+    private const TABS = [
+        'triagem'   => ['label' => 'Triagem',   'subtitle' => 'Tickets propostos aguardando o analista [AN] e sua aprovação — é o F0 do protocolo, formalizado.'],
+        'backlog'   => ['label' => 'Backlog',   'subtitle' => 'Issues agrupáveis por Onda / Fase / Papel / Prioridade / Módulo.'],
+        'quadro'    => ['label' => 'Quadro',    'subtitle' => 'Fluxo do cowork loop por fase: F0 Brief → F1 Design → F1.5 Critique → F2 Screenshot → F3 Code → F3.5 A11y.'],
+        'changelog' => ['label' => 'Changelog', 'subtitle' => 'O que shippou — PRs, ADRs, sessões e ondas.'],
+        'mcp'       => ['label' => 'MCP',       'subtitle' => 'Contrato de ferramentas, tokens e auditoria — design; o enforce real é do servidor TeamMcp.'],
+        'saude'     => ['label' => 'Saúde',     'subtitle' => 'Semáforo do loop — memory-health, baselines de gate e frescor. Cada métrica linka a uma ação.'],
+    ];
+
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('can:copiloto.mcp.usage.all');
+    }
+
+    public function triagem(): Response
+    {
+        return $this->renderTab('triagem');
+    }
+
+    public function backlog(): Response
+    {
+        return $this->renderTab('backlog');
+    }
+
+    public function quadro(): Response
+    {
+        return $this->renderTab('quadro');
+    }
+
+    public function changelog(): Response
+    {
+        return $this->renderTab('changelog');
+    }
+
+    public function mcp(): Response
+    {
+        return $this->renderTab('mcp');
+    }
+
+    public function saude(): Response
+    {
+        return $this->renderTab('saude');
+    }
+
+    /**
+     * Renderiza o shell do cockpit com a aba ativa. Onda Forja PR-A: dados reais
+     * entram aba a aba (cada PR). O shell + topnav + rotas já ficam de pé aqui.
+     */
+    private function renderTab(string $tab): Response
+    {
+        $meta = self::TABS[$tab] ?? self::TABS['triagem'];
+
+        return Inertia::render('team-mcp/Forja/Cockpit', [
+            'tab'      => $tab,
+            'tabLabel' => $meta['label'],
+            'subtitle' => $meta['subtitle'],
+            'meta'     => [
+                'generated_at' => now()->toIso8601String(),
+                'onda'         => 'Forja',
+            ],
+        ]);
+    }
+}

--- a/Modules/TeamMcp/Http/routes.php
+++ b/Modules/TeamMcp/Http/routes.php
@@ -72,6 +72,28 @@ Route::group(
 );
 
 // ===========================================================================
+// 1b) Forja — cockpit do cowork loop (Onda Forja). Prefixo /forja (segmento
+//     PRÓPRIO: useAutoModuleNav casa o topnav por 1º segmento, e /team-mcp já é
+//     do hub Equipe — colidiria). Controller mora aqui no TeamMcp (absorção, não
+//     módulo novo). Permissão copiloto.mcp.usage.all (superadmin), igual Scorecard.
+// ===========================================================================
+Route::group(
+    [
+        'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
+        'prefix'     => 'forja',
+        'namespace'  => 'Modules\TeamMcp\Http\Controllers',
+    ],
+    function () {
+        Route::get('/',          'ForjaController@triagem')->name('forja.triagem');
+        Route::get('/backlog',   'ForjaController@backlog')->name('forja.backlog');
+        Route::get('/quadro',    'ForjaController@quadro')->name('forja.quadro');
+        Route::get('/changelog', 'ForjaController@changelog')->name('forja.changelog');
+        Route::get('/mcp',       'ForjaController@mcp')->name('forja.mcp');
+        Route::get('/saude',     'ForjaController@saude')->name('forja.saude');
+    }
+);
+
+// ===========================================================================
 // 2) Rotas de instalação 1-clique — prefixo /team-mcp/install
 // ===========================================================================
 Route::group(

--- a/config/core_topnavs.php
+++ b/config/core_topnavs.php
@@ -92,4 +92,22 @@ return [
             ],
         ],
     ],
+
+    // Forja — cockpit do cowork loop (Onda Forja PR-A). Raiz /forja é segmento
+    // PRÓPRIO de propósito: useAutoModuleNav() casa o topnav pelo 1º segmento da
+    // URL, então /team-mcp/* (hub Equipe) e /forja/* não se sobrepõem. Controller
+    // mora em Modules/TeamMcp (absorção, não módulo novo).
+    // Ref: memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md
+    'Forja' => [
+        'label' => 'Forja',
+        'icon'  => 'Hammer',
+        'items' => [
+            ['label' => 'Triagem',   'href' => '/forja',           'icon' => 'Inbox',        'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Backlog',   'href' => '/forja/backlog',   'icon' => 'List',         'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Quadro',    'href' => '/forja/quadro',    'icon' => 'LayoutKanban', 'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Changelog', 'href' => '/forja/changelog', 'icon' => 'History',      'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'MCP',       'href' => '/forja/mcp',       'icon' => 'Plug',         'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Saúde',     'href' => '/forja/saude',     'icon' => 'Activity',     'can' => 'copiloto.mcp.usage.all'],
+        ],
+    ],
 ];

--- a/memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md
+++ b/memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md
@@ -1,0 +1,127 @@
+---
+slug: teammcp-forja-cockpit-visual-comparison
+title: "TeamMcp — Comparativo visual do cockpit Forja (6 abas + projeção do git)"
+type: visual-comparison
+module: TeamMcp
+status: approved
+date: "2026-06-16"
+approved_by: wagner
+approved_at: "2026-06-16"
+canon_reference: os-page.jsx
+blade_source: "N/A — tela nova (cockpit do cowork loop, sem legacy Blade)"
+inertia_target: resources/js/Pages/team-mcp/Forja/*.tsx
+---
+
+# Forja — cockpit do cowork loop (F1.5 · referência aprovada)
+
+> **Referência visual aprovada:** protótipos Cowork `forja-*.jsx` colados por Wagner em 2026-06-16
+> (estado atual + 6 telas "esperado": Triagem, Backlog, Quadro, Changelog, MCP, Saúde).
+> Status `approved` = Wagner forneceu **e aprovou os screenshots** (gate F1.5 ADR 0114 satisfeito
+> pela entrega do design — não há 2ª iteração pendente).
+> **Mora em `Modules/TeamMcp`** (kickoff: "absorção em TeamMcp, NÃO é módulo novo"). Sidebar "Forja" +
+> topnav próprio de 6 abas, ao lado da entry Equipe/Team existente.
+
+## O conceito (o que a Forja É)
+
+Cockpit de **observabilidade + governança do próprio loop de desenvolvimento** (humano ↔ agente).
+Não inventa dados: **projeta** o que já existe — `mcp_tasks` (issues), git/PRs/ADRs/sessões (changelog),
+baselines de gate + `memory-health` (saúde). Header fixo: breadcrumb `DESENVOLVIMENTO · MCP · PROJEÇÃO DO GIT`,
+título **Forja**, subtítulo _"Cockpit do cowork loop — backlog, quadro F0→F4, changelog e atores (humano vs agente)."_
+
+### Taxonomia do loop (núcleo, transversal às abas)
+
+- **Fases (F0→F4):** F0 Brief → F1 Design → F1.5 Critique → F2 Screenshot → F3 Code → F3.5 A11y → F4 (merged).
+- **Papéis/atores (selo):** `[W]` Wagner (humano · aprova) · `[W2]` 2º gate humano (merge) · `[CC]` Claude Code ·
+  `[CD]` Claude Design · `[CL]` Claude (loop) · `[CA]` · `[AN]` Analista. **Humano vs agente** é cidadão de 1ª classe.
+- **Onda:** agrupador de épico/lote (SEM ONDA, V1.1, FA-1, FA-2, Q1…).
+- **Contrato de permissão (soberania — kickoff):** agente default = `read + propose`; **`git.merge` só [W2]**,
+  **`constituicao.edit` (ADR/PROTOCOL/BRIEFING) só [W]** — negados no **contrato**, não por convenção.
+
+## Fundações DS v6 (herdadas · imutáveis)
+
+| Token | Uso na Forja |
+|---|---|
+| Roxo canon `oklch(0.55 0.15 295)` | primário: aba ativa, **+ Novo issue**, **Analisar**, **Aprovar → backlog** |
+| Status Stripe-dot (sem bg-fill) | dot colorido por fase/tipo/changelog (sem pílula preenchida de cor crua) |
+| `--fs-1..9` / `--sh-1/2` | tipografia numérica (KPIs, contadores) + sombras sutis |
+| `tabular-nums` | contadores de aba, KPIs Saúde, contagem por grupo |
+| Componentes `Components/ui/*` + `Components/layout/*` | zero select/checkbox nativo, layout via `Inline/Stack/Grid` |
+| Drawer lateral | dossiê do Analista (reusa padrão `TriageDossier` já shipado em ProjectMgmt) |
+
+## As 6 abas (layout + dados + decisões)
+
+### 1. Triagem — `F0 formalizado`
+- **Texto-âncora:** _"Tickets propostos aguardando o analista [AN] enriquecer e sua aprovação. Entram no backlog só depois."_
+- **Linha:** ID `FORJA-152` · badge de **tipo** (Tela=roxo · Bug=âmbar · Refino=azul) · título · selo módulo (KB/Financeiro/Atendimento) · selo ator `[CC]` · botão **Analisar** (roxo).
+- **Ação Analisar:** abre **dossiê lateral** (reusa o padrão Analista de ProjectMgmt: valor×esforço, risco Tier-0, duplicatas, Aprovar→backlog / Rejeitar). Badge na aba = nº de propostas (3).
+- **Dado:** `mcp_tasks` project=FORJA em estado proposto (sem onda/sem aprovação).
+
+### 2. Backlog — agrupável
+- **Controles:** `AGRUPAR [Onda|Fase|Papel|Prioridade|Módulo]` · ☆favoritos · filtro **Papéis** `[todos·W·CC·CD·CL·CA·AN·W2]` · **VISÕES + salvar visão** · busca `is:p0 @CL ~FA-1 tipo:bug` · **+ Perguntar**.
+- **Grupos (ex. por Onda):** SEM ONDA (7) · V1.1 · PROTOCOLO V1.1 (1) · FA-1 (1) · FA-2 (1) · Q1 · G-3 E2E REQUIRED (1).
+- **Colunas/linha:** ID · tipo · título · refs (`ADR 0235`, `SES …`, `PR #…`) · módulo · `sync Nd` · **fase** (`F0 Brief`/`F1 Design`/`F3 Code`) · selo ator · ☆. Pills: `⚠ inferido` (âmbar), `✓ @main` (verde).
+- **Rodapé:** `11 issues · 2 P0 · 1 bloqueados · 4 não-verificados`. Atalhos `j/k navegar · Enter abrir · ⌘K buscar`.
+- **Dado:** `mcp_tasks` project=FORJA; agrupador = campo derivado (onda/fase/papel mapeados de metadados existentes).
+
+### 3. Quadro — board F0→F4
+- **Colunas:** `F0 Brief (1)` · `F1 Design (5)` · `F1.5 Critique (0)` · `F2 Screenshot (0)` · `F3 Code (5)` · `F3.5 A11y (0)` (`F4` fora do board = merged).
+- **Card:** ID · tipo · ☆ · título · selo ator · onda pill · `sync/⚠inferido/✓@main`. Drop zone vazia "arraste aqui".
+- **Dado:** mesma projeção, agrupada por **fase**. Drag = `issue.transition` (PROPÕE → [W] aprova; ver contrato MCP).
+
+### 4. Changelog — o que shippou
+- **Filtros:** `Tudo · PRs · ADRs · Sessões · Ondas`.
+- **Linha:** dot · ID (`#2417` / `ADR 0264 TIER-0` / `2026-06-12-produtos`) · título · selo ator `[CL]/[CC]` · módulo · data à direita.
+- **Dado 100% real:** PRs (gh) + ADRs (`memory/decisions`) + sessões (`mcp_cc_sessions` / `memory/sessions`) + ondas.
+
+### 5. MCP — contrato + tokens + auditoria  ·  **MOCKADO por design**
+- **Banner:** _"Contrato e auditoria como **design** — o enforcement real é do servidor TeamMcp ([CL]). Default = read + propose; merge e constituicao.edit negados no contrato, não por convenção."_
+- **Contrato de ferramentas:** `backlog.read` PERMITIDO · `changelog.read` PERMITIDO · `issue.transition` PROPÕE→[W] · `changelog.append` PROPÕE · `adr.propose` PROPÕE (nunca decisions/NNNN) · **`git.merge` NEGADO só [W2]** · **`constituicao.edit` NEGADO só [W]**.
+- **Tokens ativos:** `frj_cc_live` (read+propose · exp 30d) · `frj_cl_ci` (read+propose · 90d) · `frj_cd_rev` (read · 30d) + **revogar**.
+- **Auditoria (regra 6 mecanizada):** toda ação de agente — ts · ator · ação · detalhe · resultado (`ok` / `NEGADO — só [W2]`/`[W]`).
+- **Dado:** read-only/mock — o enforce real é o servidor TeamMcp. **Token raw nunca persistido/logado** (Tier 0 ADR 0081).
+
+### 6. Saúde — semáforo do loop
+- **Texto-âncora:** _"Semáforo do loop, alimentado pelo que já existe (memory-health · baselines de gate · frescor). Cada métrica linka a uma ação — nada decorativo."_
+- **KPIs:** Não-verificados `7` (meta 0) · Bloqueados `1` · P0 abertos `2` · Gates verdes `5/7` (ratchet só-desce). Cada card tem sparkline + link `ver →`.
+- **Fluxo · WIP por fase:** barras F0=1 · F1=5 · F1.5=0 · F2=0 · F3=5 · F3.5=0 · F4=0. `8 entregas · 3 fresco · 3 atenção · 5 parado`.
+- **Automação (toggles):** "Gate vermelho trava avanço de fase" (on) · "F1 exige ✓ lido @main antes de avançar" (on) · "PR merged → move issue p/ F4 (auto)" (off · requer #9).
+- **Dado 100% real:** reusa `ScorecardBuilderService` + baselines de gate (`.foundation-guard-baseline.json` etc.) + `memory-health`.
+
+## 15 dimensões (nível cockpit)
+
+| # | Dimensão | Decisão Forja |
+|---|---|---|
+| 1 | Layout | Sidebar light + header canon (breadcrumb+título+subtítulo) + **topnav 6 abas** + corpo por aba |
+| 2 | Hierarquia | 1 primária por aba (Novo issue / Analisar / Aprovar) · contadores tabular-nums |
+| 3 | Densidade | linhas compactas (backlog/changelog) · cards arejados (quadro) |
+| 4 | Iconografia | lucide (sem emoji) · selos de ator como pílulas `[XX]` monoespaçadas |
+| 5 | Estados | empty ("Nada pra triar" / "arraste aqui") · inferido · bloqueado · @main |
+| 6 | Atalhos | `⌘K` buscar · `j/k` navegar · `Enter` abrir · `Esc` fecha dossiê |
+| 7 | Persistência | VISÕES salvas + agrupador via `localStorage oimpresso.forja.*` |
+| 8 | Componentes shared | PageHeader canon · KpiCard · DataTable · drawer (TriageDossier) · ui/* |
+| 9 | Tipografia num. | KPIs Saúde + contadores de aba/grupo em `--fs-*` + tabular-nums |
+| 10 | Espaçamento | tokens de espaço canon (sem px crus) |
+| 11 | Cor semântica | dot por fase/tipo/resultado · sem cor crua (gate conformance) |
+| 12 | Microinterações | hover de linha · transição de aba · drag no quadro |
+| 13 | Referência aprovada | screenshots Cowork 2026-06-16 (Wagner) |
+| 14 | Benchmark | Linear (backlog/board) · Vercel (saúde) · GitHub (changelog) |
+| 15 | Persona | Wagner [W] superadmin — decide/aprova/merge; agentes propõem |
+
+## Sequência de entrega (onda · 1 PR por aba · cada uma fecha no gate visual)
+
+| PR | Aba | Fonte | Dep. modelo de issue |
+|---|---|---|---|
+| A | Shell (sidebar + topnav + rota + landing) | — | não |
+| B | Saúde | ScorecardBuilderService + gates + memory-health | não |
+| C | Changelog | git/PRs + ADRs + sessões + ondas | não |
+| D | Backlog agrupável | `mcp_tasks` project=FORJA | **sim** |
+| E | Quadro F0→F4 | idem, por fase | **sim** |
+| F | Triagem + dossiê | idem + padrão Analista | **sim** |
+| G | MCP (contrato/tokens/auditoria) | read-only MOCKADO | não |
+
+## Anti-regressões (Tier 0 · herdadas)
+
+- ⛔ Token raw **nunca** persistido/logado ([ADR 0081](../../decisions/0081-identity-mesh-mcp-actors.md)).
+- ⛔ `git.merge` / `constituicao.edit` **negados no contrato** (só [W2]/[W]) — espelha a soberania do kickoff.
+- ⛔ `mcp_*` repo-wide cross-tenant **por design** — sem `business_id` ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)).
+- ⛔ Sem dado fantasma: valor×esforço/risco são **sugestão derivada** rotulada; nada inventado como medido.

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.casos.md
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.casos.md
@@ -1,0 +1,48 @@
+---
+casos: Forja · cockpit do cowork loop · /forja
+irmaos: Cockpit.charter.md (lei) · Cockpit.tsx (tela)
+tecnica: Caso de uso = narrativa + critério de aceite verificável
+owner: wagner
+last_run: "2026-06-16"
+---
+
+# Casos de uso — /forja (cockpit Forja · shell)
+
+> **Status:** ✅ passa (provado por teste) · 🧪 em teste (Pest escrito, aguarda run verde) · ⬜ não verificado · ❌ quebrou.
+
+> Onda Forja **PR-A**: SHELL navegável (sidebar + 6 abas + rotas). As abas reais entram 1 PR cada (B–G). Persona: Wagner [W] (superadmin). Read-only nesta onda. Referência: [forja-cockpit-visual-comparison.md](../../../../memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md).
+
+## UC-FORJA-01 — As 6 rotas /forja respondem (shell no ar)
+Status: ⬜ (smoke pós-merge — abrir cada rota em prod)
+Antes desta PR não havia rota `/forja`. `ForjaController` serve `/forja` (Triagem), `/forja/backlog`, `/forja/quadro`, `/forja/changelog`, `/forja/mcp`, `/forja/saude`.
+**Pronto quando:** cada uma das 6 rotas renderiza o shell (sem 500 / tela branca).
+
+## UC-FORJA-02 — Topnav de 6 abas aparece e navega
+Status: ⬜ (manual/visual)
+O topnav vem de `config/core_topnavs.php['Forja']` via `useAutoModuleNav` (casa raiz `/forja`). 6 abas: Triagem · Backlog · Quadro · Changelog · MCP · Saúde.
+**Pronto quando:** as 6 abas aparecem no header, navegam entre as rotas e destacam a ativa por URL.
+
+## UC-FORJA-03 — Entry "Forja" na sidebar
+Status: ⬜ (manual/visual)
+`DataController@modifyAdminMenu` injeta o dropdown "Forja" (ícone martelo, atalho `G F`, ghosts = as 6 abas), separado do hub Equipe.
+**Pronto quando:** "Forja" aparece na sidebar e leva ao cockpit; ghosts listam as 6 abas.
+
+## UC-FORJA-04 — Sem colisão de topnav com /team-mcp
+Status: 🧪 (cobertura: raiz `/forja` ≠ `/team-mcp` no `useAutoModuleNav`)
+`useAutoModuleNav` casa pelo 1º segmento da URL. Forja usa raiz própria `/forja` pra não herdar o topnav do hub Equipe (`/team-mcp`).
+**Pronto quando:** em `/forja/*` o topnav mostrado é o da Forja (6 abas), não o da Equipe.
+
+## UC-FORJA-05 — Read-only (o shell não muta nada)
+Status: ⬜ (manual)
+Nenhuma rota desta onda escreve estado; todas são GET de render.
+**Pronto quando:** não há ação na tela que escreva no banco.
+
+## UC-FORJA-06 — DS v6 (sem cor crua · PageHeader canon)
+Status: 🧪 (cobertura: eslint `ds/*` = 0 + conformance + layout + pageheader ratchets)
+PageHeader canon (`@/Components/PageHeader`), layout via `inline-flex`, tokens semânticos, zero paleta crua / `rounded-xl+`.
+**Pronto quando:** `conformance-gate`, `layout-primitives`, `pageheader-gate` e `eslint` verdes pro Cockpit.tsx.
+
+## UC-FORJA-07 — Acesso (auth + permissão)
+Status: ⬜ (manual — rota sob `auth` + `copiloto.mcp.usage.all`)
+`ForjaController` exige login + `copiloto.mcp.usage.all` (mesma do Scorecard/Team). Repo-wide cross-business intencional (ADR 0093) pro superadmin.
+**Pronto quando:** usuário sem `copiloto.mcp.usage.all` recebe 403.

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.charter.md
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.charter.md
@@ -1,0 +1,60 @@
+---
+page: /forja
+component: resources/js/Pages/team-mcp/Forja/Cockpit.tsx
+owner: wagner
+status: draft
+last_validated: "2026-06-16"
+parent_module: TeamMcp
+related_adrs:
+  - "0114-prototipo-ui-cowork-loop-formalizado"
+  - "0081-identity-mesh-mcp-actors"
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+related_ficha: memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md
+tier: A
+charter_version: 1
+---
+
+# Page Charter — `/forja` cockpit (DRAFT · Onda Forja PR-A · shell)
+
+> Criado no PR **Forja PR-A** (2026-06-16). Cockpit do cowork loop (humano ↔ agente). **Absorção em TeamMcp** (não é módulo novo). Esta PR entrega o **shell navegável** — sidebar "Forja" + topnav de 6 abas + rotas `/forja/*` + landing. As 6 abas reais entram 1 PR cada (B–G). Persona: Wagner [W] (superadmin, `copiloto.mcp.usage.all`). Backend: `ForjaController` (TeamMcp). Ref: [forja-cockpit-visual-comparison.md](../../../../memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md).
+
+## Mission
+
+Cockpit **read-only** de observabilidade/governança do próprio loop de desenvolvimento. **Projeta** estado que já existe (`mcp_tasks` + git/PR/ADR/sessão + gates/memory-health) — **sem dado fantasma**. Header fixo (Forja + subtítulo do loop) + 6 abas: Triagem · Backlog · Quadro (F0→F4) · Changelog · MCP · Saúde.
+
+## Goals — Features (faz)
+
+- **Shell navegável** (PR-A): entry "Forja" na sidebar + topnav de 6 abas + rotas `/forja`, `/forja/{backlog,quadro,changelog,mcp,saude}` + landing (Triagem).
+- Cada rota renderiza o mesmo shell `Cockpit.tsx` com a aba ativa via prop `tab` (topnav highlight por URL).
+- Abas reais entregues incrementalmente (B Saúde · C Changelog · D Backlog · E Quadro · F Triagem+dossiê · G MCP).
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ Tabela/entidade nova — issues = projeção sobre `mcp_tasks` (Tier 0: sem schema sem ADR mãe).
+- ❌ Enforce de permissão de tool — a aba MCP é **design/MOCKADO**; o enforce real é do servidor TeamMcp.
+- ❌ Merge ou `constituicao.edit` pela UI — soberania: merge só `[W2]`, ADR/PROTOCOL/BRIEFING só `[W]`.
+- ❌ Filtro business_id — cockpit é repo-wide intencional (ADR 0093).
+
+## UX targets
+
+- DS v6: roxo canon na aba ativa / primárias, status Stripe-dot, `tabular-nums`, ramp `--fs`, **sem cor crua**.
+- Topnav auto via `config/core_topnavs.php['Forja']` + `useAutoModuleNav` (raiz `/forja`, segmento próprio pra não colidir com `/team-mcp`).
+- Layout via `inline-flex`/primitivos; PageHeader **canon** (`@/Components/PageHeader`). Locators `data-testid`.
+
+## Anti-hooks (NÃO faz automaticamente)
+
+- ❌ NÃO escreve nada nesta onda (read-only). ❌ NÃO inventa métrica/issue. ❌ NÃO persiste/loga token raw (Tier 0 ADR 0081).
+
+## Restrições Tier 0
+
+- Permissão `copiloto.mcp.usage.all` no construtor do `ForjaController`.
+- Repo-wide cross-business INTENCIONAL (ADR 0093) — governança da plataforma.
+- `mcp_*` sem `business_id` por design.
+
+## Métricas de sucesso (validação Wagner)
+
+- ✅ As 6 rotas `/forja/*` respondem (sem 500 / tela branca).
+- ✅ Entry "Forja" aparece na sidebar e o topnav de 6 abas navega + destaca a ativa.
+- ✅ Sem cor crua / PageHeader canon (conformance/foundation/layout/pageheader verdes).
+- ✅ Acesso negado (403) sem `copiloto.mcp.usage.all`.

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.tsx
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.tsx
@@ -1,0 +1,68 @@
+// @memcofre
+//   tela: /forja (+ /forja/{backlog,quadro,changelog,mcp,saude})
+//   module: TeamMcp — cockpit Forja (cowork loop). Onda Forja PR-A (shell).
+//   forja: PR-A — shell navegável (sidebar + 6 abas + rotas). Abas reais entram
+//          1 PR cada. visual-comparison aprovada:
+//          memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md (F1.5 ADR 0114)
+//   permissao: copiloto.mcp.usage.all
+//
+// Projeta estado que JÁ existe (mcp_tasks + git/PR/ADR/sessão + gates) — sem dado
+// fantasma. As 6 rotas renderizam este shell com a aba ativa em `tab`; o topnav
+// de 6 abas vem de config/core_topnavs.php['Forja'] (useAutoModuleNav).
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { type ReactNode } from 'react';
+import { Hammer, Construction } from 'lucide-react';
+import { PageHeader } from '@/Components/PageHeader';
+
+interface Meta {
+  generated_at: string;
+  onda: string;
+}
+
+interface Props {
+  tab: string;
+  tabLabel: string;
+  subtitle: string;
+  meta: Meta;
+}
+
+const COCKPIT_SUBTITLE =
+  'Cockpit do cowork loop — backlog, quadro F0→F4, changelog e atores (humano vs agente).';
+
+function ForjaCockpit({ tab, tabLabel, subtitle }: Props) {
+  return (
+    <>
+      <PageHeader title="Forja" subtitle={COCKPIT_SUBTITLE} />
+
+      <section className="mt-6" data-testid={`forja-tab-${tab}`}>
+        <h2 className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
+          <Hammer size={15} className="text-primary" /> {tabLabel}
+        </h2>
+        <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+
+        {/* Onda Forja PR-A: shell de pé; cada aba real entra numa PR própria. */}
+        <div className="mt-4 inline-flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center">
+          <Construction size={22} className="text-muted-foreground" />
+          <p className="text-sm font-medium text-foreground">Aba “{tabLabel}” em construção</p>
+          <p className="max-w-md text-xs text-muted-foreground">
+            O shell do cockpit (sidebar + 6 abas + rotas) está no ar. Cada aba entra como
+            uma PR própria desta onda, com seu gate visual — referência aprovada na
+            visual-comparison do cockpit Forja.
+          </p>
+        </div>
+      </section>
+    </>
+  );
+}
+
+ForjaCockpit.layout = (page: ReactNode) => (
+  <AppShellV2
+    title="Forja — cockpit do cowork loop"
+    breadcrumbItems={[{ label: 'Desenvolvimento' }, { label: 'Forja' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default ForjaCockpit;


### PR DESCRIPTION
## Onda Forja · PR-A (shell)

Primeira PR da onda do **cockpit Forja** (cowork loop humano↔agente), **absorvido em TeamMcp** (não é módulo novo — kickoff).

Entrega o **shell navegável** — as 6 abas reais entram 1 PR cada.

### O que entra
- `ForjaController` (TeamMcp) — 6 abas `triagem/backlog/quadro/changelog/mcp/saude`; cada rota renderiza `team-mcp/Forja/Cockpit` com a aba ativa.
- Rotas `/forja/*` — **segmento próprio** de propósito: `useAutoModuleNav` casa o topnav pelo 1º segmento da URL, e `/team-mcp` já é do hub Equipe (colidiria).
- Topnav de 6 abas via `config/core_topnavs.php['Forja']`.
- Entry **Forja** na sidebar (`DataController` dropdown · atalho `G F` · ghosts das 6 abas).
- `Cockpit.tsx` (DS v6 · PageHeader **canon**) + trio **charter** + **casos**.
- F1.5 **visual-comparison** aprovada (commit anterior) = referência do design.

### Fora de escopo (próximas PRs)
B Saúde · C Changelog · D Backlog · E Quadro · F Triagem+dossiê · G MCP. Read-only nesta onda.

### Gates rodados localmente (verde)
casos-coverage · layout-primitives · eslint · foundation-guard · pageheader-migration · components-tree. PHPStan: `ForjaController` sem Eloquent query → fora do `NoMissingTenantScopeRule`.

### Tier 0
Repo-wide cross-business intencional (ADR 0093) · `mcp_*` sem business_id · token raw nunca logado (ADR 0081) · merge só `[W2]` / `constituicao.edit` só `[W]` (soberania).

Refs: FORJA PR-A · ADR 0114 · ADR 0081 · ADR 0093

🤖 Generated with [Claude Code](https://claude.com/claude-code)