### PR TITLE
fix(caixa-unificada): SLA pill 4 estados + dot animado (Onda 2.2)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -33,6 +33,9 @@ import {
   avatarHue,
   relativeTimeBR,
   slaState,
+  slaWaitedMin,
+  slaWaitedShort,
+  SLA_META,
 } from './helpers';
 import { useInboxFavs } from './useInboxFavs';
 
@@ -494,26 +497,22 @@ export default function ConversationListV4({
                       {relativeTimeBR(conv.last_message_at)}
                     </span>
                   </span>
-                  {/* Polish V2 §1 — pill SLA (âmbar ≥75%, vermelho estourado) */}
-                  {sla === 'breached' && (
-                    <span
-                      className="font-mono text-[9px] font-bold px-1.5 py-px rounded-full bg-destructive/10 text-destructive border border-destructive/30"
-                      title={`SLA ${conv.queue.sla} estourado — cliente aguardando resposta`}
-                      data-testid={`caixa-unif-sla-${conv.id}`}
-                    >
-                      SLA
-                    </span>
-                  )}
-                  {sla === 'warning' && (
-                    <span
-                      className="font-mono text-[9px] font-bold px-1.5 py-px rounded-full"
-                      style={{ background: 'oklch(0.95 0.06 80)', color: 'oklch(0.40 0.12 80)', border: '1px solid oklch(0.82 0.10 80)' }}
-                      title={`SLA ${conv.queue.sla} perto de estourar`}
-                      data-testid={`caixa-unif-sla-${conv.id}`}
-                    >
-                      SLA
-                    </span>
-                  )}
+                  {/* Onda 2 — pill SLA 4 estados (fresh/aging/late/expired) + dot
+                      animado; compacto na lista (dot + tempo, a cor diz o estado). */}
+                  {sla && (() => {
+                    const m = SLA_META[sla];
+                    const waited = slaWaitedMin(conv);
+                    return (
+                      <span
+                        className={cn('inline-block font-mono text-[9px] font-bold px-1.5 py-px rounded-full border', m.pill)}
+                        title={`SLA ${conv.queue.sla} — ${m.label}`}
+                        data-testid={`caixa-unif-sla-${conv.id}`}
+                      >
+                        <span className={cn('inline-block w-1 h-1 rounded-full align-middle mr-1', m.dot, m.pulse && 'animate-pulse')} aria-hidden />
+                        {waited != null ? slaWaitedShort(waited) : m.label}
+                      </span>
+                    );
+                  })()}
                   {conv.unread_count > 0 && (
                     <span
                       className="bg-primary text-primary-foreground font-mono text-[10px] font-bold px-1.5 py-px rounded-full"

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -21,6 +21,9 @@ import {
   avatarHue,
   dayGroupLabel,
   slaState,
+  slaWaitedMin,
+  slaWaitedShort,
+  SLA_META,
 } from './helpers';
 import ComposerV4 from './ComposerV4';
 import InboxAiDialog, { type InboxAiMode } from './InboxAiDialog';
@@ -166,25 +169,25 @@ export default function ConversationThreadV4({
             )}
           </div>
         </div>
-        {/* Polish V2 §1 — pill SLA no header (cliente esperando além do alvo da fila) */}
-        {headerSla === 'breached' && (
-          <span
-            className="ml-auto font-mono text-[9.5px] font-bold px-2 py-px rounded-full bg-destructive/10 text-destructive border border-destructive/30 flex-shrink-0"
-            title={`SLA ${thread.queue.sla} da fila ${thread.queue.label} estourado`}
-            data-testid="caixa-unif-thread-sla"
-          >
-            SLA estourado
-          </span>
-        )}
-        {headerSla === 'warning' && (
-          <span
-            className="ml-auto font-mono text-[9.5px] font-bold px-2 py-px rounded-full flex-shrink-0 bg-warning/15 text-warning-fg border border-warning/30"
-            title={`SLA ${thread.queue.sla} da fila ${thread.queue.label} perto de estourar`}
-            data-testid="caixa-unif-thread-sla"
-          >
-            SLA
-          </span>
-        )}
+        {/* Onda 2 — pill SLA no header: 4 estados (fresh/aging/late/expired) +
+            dot animado (pulsa em aging/late/expired) + tempo esperando. */}
+        {headerSla && (() => {
+          const m = SLA_META[headerSla];
+          const waited = slaWaitedMin({
+            last_message_direction: lastRealMsg?.direction ?? null,
+            last_inbound_at: thread.last_inbound_at,
+          });
+          return (
+            <span
+              className={cn('ml-auto inline-block font-mono text-[9.5px] font-bold px-2 py-px rounded-full border flex-shrink-0', m.pill)}
+              title={`SLA ${thread.queue.sla} da fila ${thread.queue.label} — ${m.label}`}
+              data-testid="caixa-unif-thread-sla"
+            >
+              <span className={cn('inline-block w-1.5 h-1.5 rounded-full align-middle mr-1', m.dot, m.pulse && 'animate-pulse')} aria-hidden />
+              {m.label}{waited != null ? ` ${slaWaitedShort(waited)}` : ''}
+            </span>
+          );
+        })()}
         {/* PR-9 — IA: Resumir / Perguntar (laravel/ai server-side, PII redigida) */}
         <button
           type="button"

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -316,28 +316,82 @@ export function parseSlaMinutes(sla: string | null | undefined): number | null {
   return minutes > 0 ? minutes : null;
 }
 
-export type SlaState = 'ok' | 'warning' | 'breached' | null;
+// Onda 2 — 4 níveis espelhando `.om-sla-pill` do protótipo (fresh/aging/late/expired).
+export type SlaState = 'fresh' | 'aging' | 'late' | 'expired' | null;
 
 /**
- * Polish V2 §1 — estado do SLA de 1ª resposta da conversa.
- *
- * Só conta quando o cliente falou por último (`last_message_direction ===
- * 'inbound'`) — depois que o atendente respondeu o relógio para. `warning`
- * a partir de 75% do SLA, `breached` ao estourar.
+ * Minutos que o cliente está esperando 1ª resposta. `null` quando não está
+ * esperando (atendente respondeu por último) ou sem timestamp inbound.
+ */
+export function slaWaitedMin(conv: {
+  last_message_direction: 'inbound' | 'outbound' | null;
+  last_inbound_at: string | null;
+}): number | null {
+  if (conv.last_message_direction !== 'inbound' || !conv.last_inbound_at) return null;
+  return (Date.now() - new Date(conv.last_inbound_at).getTime()) / 60000;
+}
+
+/** Duração compacta pra pill SLA: "12min" / "3h" / "2d". */
+export function slaWaitedShort(min: number): string {
+  if (min < 60) return `${Math.max(1, Math.round(min))}min`;
+  if (min < 1440) return `${Math.round(min / 60)}h`;
+  return `${Math.round(min / 1440)}d`;
+}
+
+/**
+ * Estado do SLA de 1ª resposta (4 níveis). Só conta enquanto o cliente espera
+ * (`last_message_direction === 'inbound'`) — quando o atendente responde, o
+ * relógio para. Limiares sobre o SLA da fila: fresh <60% · aging 60–90% ·
+ * late 90–100% · expired ≥100%.
  */
 export function slaState(conv: {
   last_message_direction: 'inbound' | 'outbound' | null;
   last_inbound_at: string | null;
   queue: { sla: string | null };
 }): SlaState {
-  if (conv.last_message_direction !== 'inbound' || !conv.last_inbound_at) return null;
+  const waitedMin = slaWaitedMin(conv);
+  if (waitedMin === null) return null;
   const slaMin = parseSlaMinutes(conv.queue.sla);
   if (slaMin === null) return null;
-  const waitedMin = (Date.now() - new Date(conv.last_inbound_at).getTime()) / 60000;
-  if (waitedMin >= slaMin) return 'breached';
-  if (waitedMin >= slaMin * 0.75) return 'warning';
-  return 'ok';
+  const pct = waitedMin / slaMin;
+  if (pct >= 1) return 'expired';
+  if (pct >= 0.9) return 'late';
+  if (pct >= 0.6) return 'aging';
+  return 'fresh';
 }
+
+/**
+ * Meta visual da pill SLA por estado — classes Tailwind dark-safe via tokens.
+ * `late` (laranja, hue 30) não tem token → oklch arbitrário dark-aware (flipa
+ * via ADR 0281); os demais usam success/warning/destructive. `pill` traz só
+ * bg+texto+cor-da-borda (o `border` em si vem no render).
+ */
+export const SLA_META: Record<Exclude<SlaState, null>, { label: string; pill: string; dot: string; pulse: boolean }> = {
+  fresh: {
+    label: 'no prazo',
+    pill: 'bg-success-soft text-success-fg border-success/25',
+    dot: 'bg-success',
+    pulse: false,
+  },
+  aging: {
+    label: 'atenção',
+    pill: 'bg-warning-soft text-warning-fg border-warning/30',
+    dot: 'bg-warning',
+    pulse: true,
+  },
+  late: {
+    label: 'atrasando',
+    pill: 'bg-[oklch(0.94_0.07_30)] text-[oklch(0.45_0.16_30)] border-[oklch(0.84_0.09_30)] dark:bg-[oklch(0.30_0.06_30)] dark:text-[oklch(0.82_0.13_30)] dark:border-[oklch(0.42_0.08_30)]',
+    dot: 'bg-[oklch(0.62_0.18_30)]',
+    pulse: true,
+  },
+  expired: {
+    label: 'estourado',
+    pill: 'bg-destructive/15 text-destructive border-destructive/30',
+    dot: 'bg-destructive',
+    pulse: true,
+  },
+};
 
 export function cuLsGet(key: string, fallback = ''): string {
   if (typeof window === 'undefined') return fallback;


### PR DESCRIPTION
## Onda 2 — item 2: SLA pill 4 estados + dot animado

Espelha `.om-sla-pill` do protótipo. `slaState` passa de 3 → **4 estados** sobre o SLA da fila:

| Estado | Limiar | Cor | Dot |
|---|---|---|---|
| `fresh` | <60% | success (verde) | estático |
| `aging` | 60–90% | warning (âmbar) | pulsa |
| `late` | 90–100% | laranja (hue 30) | pulsa |
| `expired` | ≥100% | destructive (vermelho) | pulsa |

Pill agora tem **dot colorido** (`animate-pulse` em aging/late/expired) + **tempo esperando** (`slaWaitedShort`: "12min"/"3h"/"2d"). Header = label+tempo; lista = compacto (dot+tempo). **Tudo dark-safe**: tokens success/warning/destructive; `late` (sem token laranja) usa oklch arbitrário dark-aware (flipa via ADR 0281, padrão já usado em `FinStatStrip`). De quebra, troquei o oklch cru não-dark-aware que sobrava no pill `warning` da lista por token.

`helpers.ts` (lógica + `SLA_META`) + `ConversationThreadV4` (header) + `ConversationListV4` (lista). Dot é `inline-block` (sem flex → **layout-primitives ratchet verde**). Verificado por probe nos 2 temas (screenshot no chat). Gates DS locais verdes.

## Onda 2 — restante
"SLA · alternada" (label de distribuição) · tom-por-canal (baixo valor — só WhatsApp ativo). **Onda 3** (backend): OS/Saldo/Histórico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
