### PR TITLE
feat(team-mcp): Forja — aba Triagem real (fiel ao protótipo)

### DIFF
--- a/Modules/TeamMcp/Database/Seeders/ForjaDemoTicketsSeeder.php
+++ b/Modules/TeamMcp/Database/Seeders/ForjaDemoTicketsSeeder.php
@@ -49,7 +49,7 @@ class ForjaDemoTicketsSeeder extends Seeder
     /**
      * 3 propostas-semente — espelho 1:1 do protótipo aprovado.
      *
-     * @var array<int,array{task_id:string,title:string,module:string,forja_tipo:string,forja_papel:string}>
+     * @return array<int,array{task_id:string,title:string,module:string,forja_tipo:string,forja_papel:string}>
      */
     private function tickets(): array
     {

--- a/Modules/TeamMcp/Database/Seeders/ForjaDemoTicketsSeeder.php
+++ b/Modules/TeamMcp/Database/Seeders/ForjaDemoTicketsSeeder.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpProject;
+use Modules\Jana\Entities\Mcp\McpTask;
+
+/**
+ * ForjaDemoTicketsSeeder — propostas-semente da Triagem do cockpit Forja (/forja).
+ *
+ * Por que existe (Onda Forja PR-A · aba Triagem real):
+ *   A aba Triagem projeta `mcp_tasks` do project key=FORJA em estado de triagem
+ *   (sem owner OU sem priority OU status=backlog). Sem dado, a tela nasce vazia
+ *   ("Nada pra triar") e o screenshot não bate com a referência aprovada
+ *   (memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md §1 Triagem).
+ *   Este seeder garante o project FORJA + as 3 propostas-semente do protótipo.
+ *
+ * O que faz (IDEMPOTENTE):
+ *   1. updateOrCreate do project key=FORJA em mcp_jira_projects (Jira-style, ADR 0070).
+ *   2. updateOrCreate por task_id (FORJA-150/151/152) das 3 propostas-semente —
+ *      status=backlog, owner=null, priority=null (logo: caem na triagem), com
+ *      custom_fields JSON = { forja_tipo, forja_papel, forja_onda }.
+ *   Rodar 2× NÃO duplica (chave estável por key/task_id).
+ *
+ * Taxonomia Forja (custom_fields, projeção — NÃO é schema novo · Tier 0):
+ *   - forja_tipo : Tela | Bug | Refino (badge de tipo na linha)
+ *   - forja_papel: ator que propôs (CC = Claude Code) — selo [CC]
+ *   - forja_onda : agrupador de épico/lote (null = ainda em triagem, sem onda)
+ *
+ * Multi-tenant Tier 0 (ADR 0093 + ADR 0070):
+ *   mcp_jira_projects / mcp_tasks são REPO-WIDE cross-tenant POR DESIGN (governança
+ *   da plataforma) — SEM business_id. Igual Scorecard/Triage do ProjectMgmt.
+ *
+ * NÃO roda automaticamente em deploy — invocar explícito:
+ *   php artisan db:seed --class="Modules\\TeamMcp\\Database\\Seeders\\ForjaDemoTicketsSeeder"
+ *
+ * @see memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md (§1 Triagem)
+ * @see Modules\ProjectMgmt\Http\Controllers\TriageController (padrão da fila)
+ */
+class ForjaDemoTicketsSeeder extends Seeder
+{
+    /** Key do project Jira-style do cockpit Forja. */
+    private const PROJECT_KEY = 'FORJA';
+
+    /**
+     * 3 propostas-semente — espelho 1:1 do protótipo aprovado.
+     *
+     * @var array<int,array{task_id:string,title:string,module:string,forja_tipo:string,forja_papel:string}>
+     */
+    private function tickets(): array
+    {
+        return [
+            [
+                'task_id'     => 'FORJA-152',
+                'title'       => 'Busca semântica no KB (Meilisearch)',
+                'module'      => 'KB',
+                'forja_tipo'  => 'Tela',
+                'forja_papel' => 'CC',
+            ],
+            [
+                'task_id'     => 'FORJA-151',
+                'title'       => 'Bug: drawer financeiro corta o valor no dark',
+                'module'      => 'Financeiro',
+                'forja_tipo'  => 'Bug',
+                'forja_papel' => 'CC',
+            ],
+            [
+                'task_id'     => 'FORJA-150',
+                'title'       => 'Rename inbox → Atendimento na topnav',
+                'module'      => 'Atendimento',
+                'forja_tipo'  => 'Refino',
+                'forja_papel' => 'CC',
+            ],
+        ];
+    }
+
+    public function run(): void
+    {
+        if (! Schema::hasTable('mcp_jira_projects') || ! Schema::hasTable('mcp_tasks')) {
+            $this->command?->warn('mcp_jira_projects / mcp_tasks ausentes — rode php artisan migrate primeiro.');
+            return;
+        }
+
+        // 1) Project FORJA (idempotente por key). next_task_number só sobe nunca
+        //    abaixo do maior NNNN semeado, pra próximos identifiers não colidirem.
+        $project = McpProject::updateOrCreate(
+            ['key' => self::PROJECT_KEY],
+            [
+                'name'             => 'Forja — cowork loop',
+                'description'      => 'Cockpit de observabilidade + governança do loop humano ↔ agente. Issues = projeção sobre mcp_tasks (ADR 0070).',
+                'status'           => 'active',
+                'icon'             => 'Hammer',
+                'next_task_number' => 153, // > maior NNNN semeado (152), evita colisão
+            ]
+        );
+
+        $criados     = 0;
+        $atualizados = 0;
+
+        // 2) 3 propostas-semente (idempotente por task_id). Estado de triagem:
+        //    status=backlog + owner=null + priority=null → McpTask::triage() pega.
+        foreach ($this->tickets() as $t) {
+            $attributes = [
+                'project_id'    => $project->id,
+                'identifier'    => $t['task_id'], // Linear-style já no formato FORJA-NNN
+                'module'        => $t['module'],
+                'title'         => $t['title'],
+                'status'        => 'backlog',
+                'type'          => 'task',
+                'owner'         => null,
+                'priority'      => null,
+                'custom_fields' => [
+                    'forja_tipo'  => $t['forja_tipo'],
+                    'forja_papel' => $t['forja_papel'],
+                    'forja_onda'  => null, // null = ainda em triagem, sem onda atribuída
+                ],
+            ];
+
+            $existing = McpTask::where('task_id', $t['task_id'])->first();
+
+            if ($existing) {
+                $existing->fill($attributes);
+                if ($existing->isDirty()) {
+                    $existing->save();
+                    $atualizados++;
+                }
+            } else {
+                McpTask::create(array_merge(['task_id' => $t['task_id']], $attributes));
+                $criados++;
+            }
+        }
+
+        $this->command?->info(
+            "ForjaDemoTicketsSeeder: project {$project->key} ok · tickets {$criados} criados, {$atualizados} atualizados (de 3 propostas-semente)."
+        );
+    }
+}

--- a/Modules/TeamMcp/Http/Controllers/ForjaController.php
+++ b/Modules/TeamMcp/Http/Controllers/ForjaController.php
@@ -5,8 +5,17 @@ declare(strict_types=1);
 namespace Modules\TeamMcp\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Jana\Entities\Mcp\McpCcSession;
+use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+use Modules\Jana\Entities\Mcp\McpProject;
+use Modules\Jana\Entities\Mcp\McpTask;
+use Modules\Jana\Entities\Mcp\McpTaskEvent;
+use Modules\Jana\Services\TaskRegistry\TaskCrudService;
 
 /**
  * ForjaController — cockpit do cowork loop (/forja).
@@ -18,24 +27,31 @@ use Inertia\Response;
  * config/core_topnavs.php['Forja'] (useAutoModuleNav casa por 1º segmento /forja
  * — por isso a raiz é /forja e não /team-mcp/forja, que colidiria com o hub Equipe).
  *
- * Onda Forja PR-A: SHELL navegável — abas ainda em construção (cada uma vira uma
- * PR própria com seu gate visual). Referência aprovada (F1.5 ADR 0114):
+ * Onda Forja PR-A → Triagem REAL (esta PR): a aba Triagem deixa de ser placeholder
+ * e projeta `mcp_tasks` project=FORJA em estado de triagem (sem owner OU sem
+ * priority OU backlog), com dossiê lateral (reusa o padrão Analista de ProjectMgmt:
+ * valor×esforço, risco Tier-0, duplicatas, Aprovar/Rejeitar/Fundir). As outras 5
+ * abas (backlog/quadro/changelog/mcp/saude) seguem placeholder (1 PR cada).
+ * Referência aprovada (F1.5 ADR 0114):
  * memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md.
  *
  * Multi-tenant Tier 0: cockpit é repo-wide (governança cross-business do loop)
- * — sem filtro business_id, INTENCIONAL (ADR 0093), igual Scorecard.
+ * — sem filtro business_id, INTENCIONAL (ADR 0093), igual Scorecard/TriageController.
  *
  * Permissão: copiloto.mcp.usage.all (Wagner/superadmin), igual Scorecard/Team.
  */
 class ForjaController extends Controller
 {
+    /** Key do project Jira-style do cockpit Forja (ADR 0070). */
+    private const PROJECT_KEY = 'FORJA';
+
     /**
      * Abas do cockpit (label + intro). Ordem = ordem do topnav.
      *
      * @var array<string,array{label:string,subtitle:string}>
      */
     private const TABS = [
-        'triagem'   => ['label' => 'Triagem',   'subtitle' => 'Tickets propostos aguardando o analista [AN] e sua aprovação — é o F0 do protocolo, formalizado.'],
+        'triagem'   => ['label' => 'Triagem',   'subtitle' => 'Tickets propostos aguardando o analista [AN] enriquecer e sua aprovação. Entram no backlog só depois — é o F0 do protocolo, formalizado.'],
         'backlog'   => ['label' => 'Backlog',   'subtitle' => 'Issues agrupáveis por Onda / Fase / Papel / Prioridade / Módulo.'],
         'quadro'    => ['label' => 'Quadro',    'subtitle' => 'Fluxo do cowork loop por fase: F0 Brief → F1 Design → F1.5 Critique → F2 Screenshot → F3 Code → F3.5 A11y.'],
         'changelog' => ['label' => 'Changelog', 'subtitle' => 'O que shippou — PRs, ADRs, sessões e ondas.'],
@@ -51,7 +67,18 @@ class ForjaController extends Controller
 
     public function triagem(): Response
     {
-        return $this->renderTab('triagem');
+        // Triagem REAL: projeta mcp_tasks project=FORJA em estado de triagem via
+        // Inertia::defer (espelha TriageController). As props pesadas só rodam quando
+        // o partial reload as pede; 1º paint serve só `tab`/`tabLabel`/`subtitle`/`meta`.
+        $projectId = $this->resolveForjaProjectId();
+
+        return Inertia::render('team-mcp/Forja/Cockpit', array_merge(
+            $this->tabPayload('triagem'),
+            [
+                'tickets'      => Inertia::defer(fn () => $this->buildTriagemPayload($projectId)['tickets']),
+                'triagemCount' => Inertia::defer(fn () => $this->buildTriagemPayload($projectId)['count']),
+            ],
+        ));
     }
 
     public function backlog(): Response
@@ -79,15 +106,269 @@ class ForjaController extends Controller
         return $this->renderTab('saude');
     }
 
+    // ---------- Triagem · payload ----------
+
     /**
-     * Renderiza o shell do cockpit com a aba ativa. Onda Forja PR-A: dados reais
-     * entram aba a aba (cada PR). O shell + topnav + rotas já ficam de pé aqui.
+     * Constrói as propostas em triagem (project=FORJA) + a contagem (badge da aba).
+     * Memoiza por projectId pra não dobrar a query quando ambos requested numa render.
+     *
+     * Filtro = paridade EXATA com TriageController/TriageTool:
+     *   McpTask::triage() = (owner IS NULL OR priority IS NULL OR status='backlog')
+     *   + whereNotIn status [done, cancelled] + orderByDesc created_at.
+     *
+     * @return array{tickets: \Illuminate\Support\Collection<int,array<string,mixed>>, count: int}
+     */
+    protected function buildTriagemPayload(?int $projectId): array
+    {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
+
+        static $cache = [];
+        $key = (string) ($projectId ?? 'none');
+        if (isset($cache[$key])) {
+            return $cache[$key];
+        }
+
+        // Sem project FORJA semeado → fila vazia (sem dado fantasma). O front mostra
+        // o empty-state ("Nada pra triar"). Roda o seeder ForjaDemoTicketsSeeder.
+        if (! $projectId) {
+            return $cache[$key] = ['tickets' => collect(), 'count' => 0];
+        }
+
+        $tickets = McpTask::triage()
+            ->whereNotIn('status', ['done', 'cancelled'])
+            ->where('project_id', $projectId)
+            ->orderByDesc('created_at')
+            ->limit(200)
+            ->get()
+            ->map(fn (McpTask $t) => $this->serializeTicket($t));
+
+        return $cache[$key] = ['tickets' => $tickets, 'count' => $tickets->count()];
+    }
+
+    // ---------- Triagem · dossiê + ações [W] aprova (espelho do TriageController) ----------
+
+    /**
+     * GET /forja/{taskId}/dossier — read-only.
+     *
+     * Dossiê do Analista: SÓ dados reais. Duplicatas (mesmo módulo), atividade
+     * (mcp_task_events), cross-link de docs/ADRs (mcp_memory_documents) + sessões
+     * CC (mcp_cc_sessions), valor×esforço SUGERIDO (derivado de prioridade/estimativa)
+     * e risco Tier-0 (HEURÍSTICA por palavra-chave). Nada vira oficial sem [W].
+     *
+     * Espelha Modules\ProjectMgmt\Http\Controllers\TriageController@dossier — só muda
+     * a rota; a lógica é a mesma (agente propõe, [W] aprova).
+     */
+    public function dossier(Request $request, string $taskId): JsonResponse
+    {
+        // Multi-tenant Tier 0 (ADR 0070 + ADR 0093): mcp_tasks / mcp_task_events /
+        // mcp_cc_sessions / mcp_memory_documents são REPO-WIDE cross-tenant POR DESIGN
+        // — SEM business_id / BusinessScope (governança da plataforma).
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+
+        $duplicatas = $task->module
+            ? McpTask::where('module', $task->module)
+                ->where('task_id', '!=', $task->task_id)
+                ->whereNotIn('status', ['cancelled'])
+                ->orderByDesc('created_at')
+                ->limit(8)
+                ->get()
+                ->map(fn (McpTask $d) => [
+                    'task_id'    => $d->task_id,
+                    'display_id' => $d->getDisplayIdAttribute(),
+                    'title'      => $d->title,
+                    'status'     => $d->status,
+                    'owner'      => $d->owner,
+                ])->values()->all()
+            : [];
+
+        $atividade = McpTaskEvent::where('task_id', $task->task_id)
+            ->orderByDesc('occurred_at')
+            ->limit(30)
+            ->get()
+            ->map(fn ($e) => [
+                'event_type'  => $e->event_type,
+                'from_value'  => $e->from_value,
+                'to_value'    => $e->to_value,
+                'author'      => $e->author,
+                'note'        => $e->note,
+                'occurred_at' => optional($e->occurred_at)->toIso8601String(),
+            ])->values()->all();
+
+        // Docs/ADRs do mesmo módulo (mcp_memory_documents) — gated.
+        $docs = [];
+        if ($task->module && Schema::hasTable('mcp_memory_documents')) {
+            $docs = McpMemoryDocument::query()
+                ->where('module', $task->module)
+                ->orderByDesc('decided_at')
+                ->limit(8)
+                ->get(['slug', 'type', 'title', 'git_path'])
+                ->map(fn ($d) => [
+                    'slug'  => $d->slug,
+                    'type'  => $d->type,
+                    'title' => $d->title,
+                    'path'  => $d->git_path,
+                ])->values()->all();
+        }
+
+        // Sessões CC que citam o módulo no summary — gated.
+        $sessoes = [];
+        if ($task->module && Schema::hasTable('mcp_cc_sessions')) {
+            $sessoes = McpCcSession::query()
+                ->where('summary_auto', 'like', '%' . $task->module . '%')
+                ->orderByDesc('started_at')
+                ->limit(5)
+                ->get(['session_uuid', 'summary_auto', 'started_at'])
+                ->map(fn ($s) => [
+                    'session_uuid' => $s->session_uuid,
+                    'summary'      => $s->summary_auto,
+                    'started_at'   => optional($s->started_at)->toIso8601String(),
+                ])->values()->all();
+        }
+
+        // Valor × esforço SUGERIDO (derivado — não fantasma; rotular como sugestão na UI).
+        // priority é enum nullable (default p2); match cobre null/desconhecido via default
+        // (evita o ?? redundante que o Larastan acusa por inferir o enum como non-null).
+        $valor = match ($task->priority) {
+            'p0', 'p1' => 'alto',
+            'p3'       => 'baixo',
+            default    => 'médio', // p2 + null + qualquer outro
+        };
+        $est = $task->estimate_h !== null ? (float) $task->estimate_h : null;
+        $esforco = $est === null ? 'desconhecido' : ($est <= 4 ? 'baixo' : ($est <= 16 ? 'médio' : 'alto'));
+
+        // Risco Tier-0 (HEURÍSTICA por palavra-chave).
+        $hay = strtolower(($task->module ?? '') . ' ' . ($task->title ?? '') . ' ' . ($task->description ?? ''));
+        $kw = ['multi-tenant', 'multitenant', 'business_id', 'token', 'auth', 'senha', 'password',
+            'migration', 'migração', 'financeiro', 'dinheiro', 'cobrança', 'cobranca', 'pii', 'lgpd',
+            'constitui', 'tier 0', 'tier-0'];
+        $sinais = array_values(array_filter($kw, fn ($w) => str_contains($hay, $w)));
+
+        return response()->json([
+            'task'          => $this->serializeTicket($task),
+            'description'   => $task->description,
+            'duplicatas'    => $duplicatas,
+            'atividade'     => $atividade,
+            'docs'          => $docs,
+            'sessoes'       => $sessoes,
+            'valor_esforco' => ['valor' => $valor, 'esforco' => $esforco],
+            'risco_tier0'   => ['tier0' => ! empty($sinais), 'sinais' => $sinais],
+            'charter_ref'   => $task->module ? 'memory/requisitos/' . $task->module . '/SPEC.md' : null,
+            // priority é enum nullable no banco; lê o valor cru (mixed) pra checar null
+            // — o Larastan infere o enum como non-null e acusaria !== null como
+            // "sempre verdadeiro". owner é nullable normal.
+            'pode_aprovar'  => $task->owner !== null && $task->getRawOriginal('priority') !== null,
+        ]);
+    }
+
+    /**
+     * POST /forja/{taskId}/aprovar — promove a proposta pro backlog ativo (status todo).
+     * EXIGE dono + prioridade. [W] confirma na UI (agente propõe, humano aprova).
+     */
+    public function aprovar(Request $request, string $taskId): JsonResponse
+    {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+        if ($task->owner === null || $task->priority === null) {
+            return response()->json(['error' => 'Defina dono e prioridade antes de aprovar.'], 422);
+        }
+
+        // Só transiciona se ainda está em backlog; senão já está no fluxo ativo.
+        if ($task->status === 'backlog') {
+            try {
+                app(TaskCrudService::class)->update($task->task_id, ['status' => 'todo'], $this->resolveAuthor($request));
+            } catch (\Throwable $e) {
+                return response()->json(['error' => $e->getMessage()], 422);
+            }
+            return response()->json(['ok' => true, 'task_id' => $task->task_id, 'status' => 'todo']);
+        }
+
+        return response()->json(['ok' => true, 'task_id' => $task->task_id, 'status' => $task->status, 'noop' => true]);
+    }
+
+    /** POST /forja/{taskId}/rejeitar — cancela a proposta. [W] confirma. */
+    public function rejeitar(Request $request, string $taskId): JsonResponse
+    {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+        try {
+            app(TaskCrudService::class)->update($task->task_id, ['status' => 'cancelled'], $this->resolveAuthor($request));
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+        return response()->json(['ok' => true, 'task_id' => $task->task_id, 'status' => 'cancelled']);
+    }
+
+    /** POST /forja/{taskId}/fundir — marca como duplicata de outra task (evento + cancela). [W] confirma. */
+    public function fundir(Request $request, string $taskId): JsonResponse
+    {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
+        $target = trim((string) $request->input('target_task_id', ''));
+        if ($target === '') {
+            return response()->json(['error' => 'Informe a task destino (target_task_id).'], 422);
+        }
+        $task = McpTask::where('task_id', $taskId)->orWhere('identifier', $taskId)->first();
+        if (! $task) {
+            return response()->json(['error' => 'Task não encontrada.'], 404);
+        }
+        $alvo = McpTask::where('task_id', $target)->orWhere('identifier', $target)->first();
+        if (! $alvo) {
+            return response()->json(['error' => 'Task destino não encontrada.'], 422);
+        }
+        if ($alvo->task_id === $task->task_id) {
+            return response()->json(['error' => 'Não dá pra fundir uma task nela mesma.'], 422);
+        }
+
+        $author = $this->resolveAuthor($request);
+        // Cancela PRIMEIRO; só anota a fusão se o cancel passar a FSM (evita evento órfão
+        // quando o source não é cancelável, ex. done→cancelled — review PR-5a).
+        try {
+            app(TaskCrudService::class)->update($task->task_id, ['status' => 'cancelled'], $author);
+        } catch (\Throwable $e) {
+            return response()->json(['error' => $e->getMessage()], 422);
+        }
+        McpTaskEvent::log(
+            $task->task_id,
+            'field_updated',
+            null,
+            $alvo->task_id,
+            $author,
+            "Fundida (duplicata) em {$alvo->getDisplayIdAttribute()}",
+        );
+
+        return response()->json(['ok' => true, 'task_id' => $task->task_id, 'fundida_em' => $alvo->task_id]);
+    }
+
+    // ---------- helpers ----------
+
+    /**
+     * Renderiza o shell do cockpit com a aba ativa (abas ainda placeholder).
+     * A Triagem tem método próprio (triagem()) — projeta dados reais via defer.
      */
     private function renderTab(string $tab): Response
     {
+        return Inertia::render('team-mcp/Forja/Cockpit', $this->tabPayload($tab));
+    }
+
+    /**
+     * Props base de toda aba (tab/label/subtitle/meta). A Triagem adiciona
+     * tickets/triagemCount por cima via Inertia::defer.
+     *
+     * @return array<string,mixed>
+     */
+    private function tabPayload(string $tab): array
+    {
         $meta = self::TABS[$tab] ?? self::TABS['triagem'];
 
-        return Inertia::render('team-mcp/Forja/Cockpit', [
+        return [
             'tab'      => $tab,
             'tabLabel' => $meta['label'],
             'subtitle' => $meta['subtitle'],
@@ -95,6 +376,61 @@ class ForjaController extends Controller
                 'generated_at' => now()->toIso8601String(),
                 'onda'         => 'Forja',
             ],
-        ]);
+        ];
+    }
+
+    /** Resolve o id do project FORJA (null se ainda não semeado — fila vazia). */
+    protected function resolveForjaProjectId(): ?int
+    {
+        $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_* repo-wide (ADR 0070/0093), sem tenant por design
+        return McpProject::where('key', self::PROJECT_KEY)->value('id');
+    }
+
+    protected function resolveAuthor(Request $request): string
+    {
+        $explicit = trim((string) $request->input('author', ''));
+        if ($explicit !== '') {
+            return $explicit;
+        }
+        $user = $request->user();
+        if ($user) {
+            return strtolower($user->username ?? $user->first_name ?? 'system');
+        }
+        return 'system';
+    }
+
+    /**
+     * Serializa 1 proposta da Triagem. Espelha TriageController::serializeTask +
+     * acrescenta os campos Forja (forja_tipo/forja_papel) lidos de custom_fields.
+     *
+     * @return array<string,mixed>
+     */
+    protected function serializeTicket(McpTask $t): array
+    {
+        $cf = is_array($t->custom_fields) ? $t->custom_fields : [];
+
+        return [
+            'task_id'      => $t->task_id,
+            'identifier'   => $t->identifier,
+            'display_id'   => $t->getDisplayIdAttribute(),
+            'title'        => $t->title,
+            'module'       => $t->module,
+            'owner'        => $t->owner,
+            // priority_raw preserva NULL (UI mostra "sem prio"); priority mantém
+            // fallback p2 pro badge não quebrar (igual Board/Backlog/Triage).
+            'priority_raw' => $t->priority,
+            'priority'     => $t->priority ?? 'p2',
+            'status'       => $t->status,
+            'type'         => $t->type,
+            // Campos Forja (projeção sobre custom_fields — não é schema novo, Tier 0).
+            'forja_tipo'   => isset($cf['forja_tipo']) ? (string) $cf['forja_tipo'] : null,
+            'forja_papel'  => isset($cf['forja_papel']) ? (string) $cf['forja_papel'] : null,
+            'forja_onda'   => isset($cf['forja_onda']) ? (string) $cf['forja_onda'] : null,
+            'created_at'   => optional($t->created_at)->toIso8601String(),
+            // Motivos pelos quais caiu na triagem (chips na UI).
+            'needs_owner'  => $t->owner === null,
+            'needs_prio'   => $t->priority === null,
+            'is_backlog'   => $t->status === 'backlog',
+        ];
     }
 }

--- a/Modules/TeamMcp/Http/routes.php
+++ b/Modules/TeamMcp/Http/routes.php
@@ -90,6 +90,18 @@ Route::group(
         Route::get('/changelog', 'ForjaController@changelog')->name('forja.changelog');
         Route::get('/mcp',       'ForjaController@mcp')->name('forja.mcp');
         Route::get('/saude',     'ForjaController@saude')->name('forja.saude');
+
+        // Triagem (aba 1) — dossiê do Analista (read-only) + ações [W] aprova.
+        // Espelha /project-mgmt/triage/{id}/{dossier,aprovar,rejeitar,fundir} (PR-5a).
+        // taskId aceita FORJA-150/identifier ou US-XXX legacy.
+        Route::get('/{taskId}/dossier',   'ForjaController@dossier')
+            ->where('taskId', '[A-Za-z0-9_\-]+')->name('forja.dossier');
+        Route::post('/{taskId}/aprovar',  'ForjaController@aprovar')
+            ->where('taskId', '[A-Za-z0-9_\-]+')->name('forja.aprovar');
+        Route::post('/{taskId}/rejeitar', 'ForjaController@rejeitar')
+            ->where('taskId', '[A-Za-z0-9_\-]+')->name('forja.rejeitar');
+        Route::post('/{taskId}/fundir',   'ForjaController@fundir')
+            ->where('taskId', '[A-Za-z0-9_\-]+')->name('forja.fundir');
     }
 );
 

--- a/Modules/TeamMcp/SCOPE.md
+++ b/Modules/TeamMcp/SCOPE.md
@@ -15,6 +15,7 @@ contains:
   # Fase 4 (NOVA, ADR 0081):
   - "ActorsController (NOVO) — Identity Mesh: CRUD de mcp_actors com manifest YAML"
   - "ScorecardController — G1 FICHA Wave 22 esqueleto tela /team-mcp/scorecard (governance maturity per-actor)"
+  - "ForjaController — cockpit do cowork loop /forja (absorção, não módulo novo): 6 abas projetando mcp_tasks project=FORJA + git/ADR/sessão + gates; aba Triagem real + dossiê"
 not_contains:
   - "Chat IA conversacional → Modules/Copiloto"
   - "Knowledge browsing → Modules/KB"

--- a/config/core_topnavs.php
+++ b/config/core_topnavs.php
@@ -102,7 +102,11 @@ return [
         'label' => 'Forja',
         'icon'  => 'Hammer',
         'items' => [
-            ['label' => 'Triagem',   'href' => '/forja',           'icon' => 'Inbox',        'can' => 'copiloto.mcp.usage.all'],
+            // badge=3 = nº de propostas-semente da Triagem (FORJA-150/151/152). ESTÁTICO:
+            // core_topnavs.php é config carregada no boot, não tem dado por-request — o
+            // contador VIVO da fila chega via prop deferida `triagemCount` na própria aba.
+            // Quando o shell suportar badge dinâmico no topnav, trocar por esse contador.
+            ['label' => 'Triagem',   'href' => '/forja',           'icon' => 'Inbox',        'can' => 'copiloto.mcp.usage.all', 'badge' => 3],
             ['label' => 'Backlog',   'href' => '/forja/backlog',   'icon' => 'List',         'can' => 'copiloto.mcp.usage.all'],
             ['label' => 'Quadro',    'href' => '/forja/quadro',    'icon' => 'LayoutKanban', 'can' => 'copiloto.mcp.usage.all'],
             ['label' => 'Changelog', 'href' => '/forja/changelog', 'icon' => 'History',      'can' => 'copiloto.mcp.usage.all'],

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.casos.md
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.casos.md
@@ -10,7 +10,7 @@ last_run: "2026-06-16"
 
 > **Status:** ✅ passa (provado por teste) · 🧪 em teste (Pest escrito, aguarda run verde) · ⬜ não verificado · ❌ quebrou.
 
-> Onda Forja **PR-A**: SHELL navegável (sidebar + 6 abas + rotas). As abas reais entram 1 PR cada (B–G). Persona: Wagner [W] (superadmin). Read-only nesta onda. Referência: [forja-cockpit-visual-comparison.md](../../../../memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md).
+> Onda Forja **PR-A**: SHELL navegável (sidebar + 6 abas + rotas) **+ Triagem REAL** (esta PR). As demais 5 abas seguem placeholder (1 PR cada, B–G). Persona: Wagner [W] (superadmin). A Triagem só muta sob confirmação [W]. Referência: [forja-cockpit-visual-comparison.md](../../../../memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md).
 
 ## UC-FORJA-01 — As 6 rotas /forja respondem (shell no ar)
 Status: ⬜ (smoke pós-merge — abrir cada rota em prod)
@@ -46,3 +46,23 @@ PageHeader canon (`@/Components/PageHeader`), layout via `inline-flex`, tokens s
 Status: ⬜ (manual — rota sob `auth` + `copiloto.mcp.usage.all`)
 `ForjaController` exige login + `copiloto.mcp.usage.all` (mesma do Scorecard/Team). Repo-wide cross-business intencional (ADR 0093) pro superadmin.
 **Pronto quando:** usuário sem `copiloto.mcp.usage.all` recebe 403.
+
+## UC-FORJA-08 — Triagem lista as propostas FORJA fiéis ao protótipo
+Status: ⬜ (smoke pós-merge — depende do seeder rodar; sem DB no worktree)
+`/forja` projeta `mcp_tasks` project=FORJA em estado de triagem (`McpTask::triage()`) via `Inertia::defer` (`tickets`). Após `db:seed --class=…ForjaDemoTicketsSeeder`: FORJA-152 (Tela·KB·[CC]), FORJA-151 (Bug·Financeiro·[CC]), FORJA-150 (Refino·Atendimento·[CC]).
+**Pronto quando:** as 3 linhas aparecem com ID mono · badge de tipo colorido (Tela=roxo·Bug=âmbar·Refino=azul) · título · tag de módulo · selo `[CC]` · botão roxo Analisar; aba mostra badge 3.
+
+## UC-FORJA-09 — Analisar abre o dossiê lateral (Aprovar/Rejeitar/Fundir)
+Status: 🧪 (cobertura: endpoints `/forja/{id}/{dossier,aprovar,rejeitar,fundir}` espelham TriageController PR-5a; aguarda Pest verde)
+Clicar **Analisar** (ou `Enter` na linha em foco) abre `ForjaDossier` → `GET /forja/{id}/dossier` (valor×esforço sugerido, risco Tier-0 heurístico, duplicatas, docs/sessões). Aprovar→backlog (status→todo, exige dono+prio), Rejeitar (→cancelled), Fundir (duplicata + evento) — cada um sob dialog de confirmação [W].
+**Pronto quando:** dossiê carrega dados reais e as 3 ações respondem (Pest cobrindo `aprovar`/`rejeitar`/`fundir` como no TriageController).
+
+## UC-FORJA-10 — Triagem só muta sob confirmação [W]
+Status: ⬜ (manual)
+Listar e abrir o dossiê é read-only. Nenhuma escrita acontece sem o `AlertDialog` de confirmação (Aprovar/Rejeitar/Fundir). valor×esforço e risco Tier-0 são **sugestão derivada rotulada**, não dado medido.
+**Pronto quando:** não há mutação sem confirmação humana; nada inventado é apresentado como medido.
+
+## UC-FORJA-11 — Badge "3" da aba é estático (limitação documentada)
+Status: ⬜ (nota de fidelidade)
+O badge "3" da aba Triagem vem de `config/core_topnavs.php` (estático = nº de propostas-semente). O contador vivo da fila chega via prop deferida `triagemCount` (usada no badge do sino). O topnav não suporta badge por-request hoje (`LegacyMenuAdapter::buildTopNavs` lê config estática).
+**Pronto quando:** o "3" aparece na aba (fiel ao protótipo) e o sino reflete o contador vivo; quando o shell ganhar badge dinâmico, migrar o da aba.

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.charter.md
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.charter.md
@@ -15,9 +15,9 @@ tier: A
 charter_version: 1
 ---
 
-# Page Charter — `/forja` cockpit (DRAFT · Onda Forja PR-A · shell)
+# Page Charter — `/forja` cockpit (DRAFT · Onda Forja · shell + Triagem real)
 
-> Criado no PR **Forja PR-A** (2026-06-16). Cockpit do cowork loop (humano ↔ agente). **Absorção em TeamMcp** (não é módulo novo). Esta PR entrega o **shell navegável** — sidebar "Forja" + topnav de 6 abas + rotas `/forja/*` + landing. As 6 abas reais entram 1 PR cada (B–G). Persona: Wagner [W] (superadmin, `copiloto.mcp.usage.all`). Backend: `ForjaController` (TeamMcp). Ref: [forja-cockpit-visual-comparison.md](../../../../memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md).
+> Criado no PR **Forja PR-A** (2026-06-16, shell). **Forja PR-A · Triagem** (2026-06-16): a aba **Triagem** deixa de ser placeholder e vira **tela real** (projeta `mcp_tasks` project=FORJA em estado de triagem + dossiê lateral reusando o padrão Analista de ProjectMgmt apontando pros endpoints `/forja/*`). As outras 5 abas (backlog/quadro/changelog/mcp/saude) **seguem placeholder** — 1 PR cada (B–G). Cockpit do cowork loop (humano ↔ agente). **Absorção em TeamMcp** (não é módulo novo). Persona: Wagner [W] (superadmin, `copiloto.mcp.usage.all`). Backend: `ForjaController` (TeamMcp). Ref: [forja-cockpit-visual-comparison.md](../../../../memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md).
 
 ## Mission
 
@@ -27,7 +27,14 @@ Cockpit **read-only** de observabilidade/governança do próprio loop de desenvo
 
 - **Shell navegável** (PR-A): entry "Forja" na sidebar + topnav de 6 abas + rotas `/forja`, `/forja/{backlog,quadro,changelog,mcp,saude}` + landing (Triagem).
 - Cada rota renderiza o mesmo shell `Cockpit.tsx` com a aba ativa via prop `tab` (topnav highlight por URL).
-- Abas reais entregues incrementalmente (B Saúde · C Changelog · D Backlog · E Quadro · F Triagem+dossiê · G MCP).
+- **Triagem REAL** (esta PR): a aba Triagem (`/forja`) projeta `mcp_tasks` project=FORJA em estado de triagem (`McpTask::triage()`: sem owner OU sem priority OU backlog) via `Inertia::defer` (`tickets`/`triagemCount`). Linha = ID mono · badge de tipo (Tela=roxo `bg-primary/10`, Bug=âmbar, Refino=azul) · título · tag de módulo · selo `[CC]` · botão roxo **Analisar** → **dossiê lateral** (`ForjaDossier`, reusa o padrão Analista de ProjectMgmt) com **Aprovar→backlog / Rejeitar / Fundir** (`/forja/{taskId}/{dossier,aprovar,rejeitar,fundir}`). Navegação `J/K` + `Enter` (abre dossiê). Header: sino com badge, busca **⌘K** (trigger do command palette do AppShellV2), primária roxa **Novo issue**. Eyebrow: `DESENVOLVIMENTO · MCP · PROJEÇÃO DO GIT`.
+- Abas reais restantes entregues incrementalmente (B Saúde · C Changelog · D Backlog · E Quadro · G MCP).
+
+### Notas de fidelidade (vs protótipo aprovado)
+
+- **Badge da aba Triagem = "3" (ESTÁTICO).** O contador da aba vem de `config/core_topnavs.php['Forja']` (`'badge' => 3`), config carregada no boot — não tem dado por-request, então o "3" é fixo (= nº de propostas-semente FORJA-150/151/152). O contador **vivo** da fila chega na própria aba via prop deferida `triagemCount` (usado no badge do sino). Quando o shell suportar badge dinâmico no topnav (`shell.topnavs` por-request), trocar o estático pelo contador vivo. Hoje o `ModuleTopNav` suporta `item.badge`, mas a fonte (`core_topnavs.php` via `LegacyMenuAdapter::buildTopNavs`) é estática.
+- **Botão "Novo issue"** aponta pra `/forja` (sem fluxo de criação dedicado nesta PR — criação de issue é onda futura). Visualmente fiel (primária roxa), funcionalmente um no-op de navegação até o fluxo de criação existir.
+- **Dados de demo:** sem o seeder `ForjaDemoTicketsSeeder`, a fila nasce vazia ("Nada pra triar"). Rodar no deploy pra fidelidade screenshot (ver Métricas).
 
 ## Non-Goals — Features (NÃO faz)
 
@@ -44,7 +51,7 @@ Cockpit **read-only** de observabilidade/governança do próprio loop de desenvo
 
 ## Anti-hooks (NÃO faz automaticamente)
 
-- ❌ NÃO escreve nada nesta onda (read-only). ❌ NÃO inventa métrica/issue. ❌ NÃO persiste/loga token raw (Tier 0 ADR 0081).
+- ❌ A Triagem **só muta sob confirmação humana [W]** (Aprovar/Rejeitar/Fundir via dialog) — o agente PROPÕE, [W] aprova. Listar/abrir dossiê é read-only. ❌ NÃO inventa métrica/issue (valor×esforço e risco Tier-0 são **sugestão derivada rotulada**, não dado medido). ❌ NÃO persiste/loga token raw (Tier 0 ADR 0081). ❌ As outras 5 abas seguem read-only/placeholder.
 
 ## Restrições Tier 0
 
@@ -58,3 +65,5 @@ Cockpit **read-only** de observabilidade/governança do próprio loop de desenvo
 - ✅ Entry "Forja" aparece na sidebar e o topnav de 6 abas navega + destaca a ativa.
 - ✅ Sem cor crua / PageHeader canon (conformance/foundation/layout/pageheader verdes).
 - ✅ Acesso negado (403) sem `copiloto.mcp.usage.all`.
+- ✅ **Triagem fiel ao protótipo:** após `php artisan db:seed --class="Modules\TeamMcp\Database\Seeders\ForjaDemoTicketsSeeder"`, `/forja` lista FORJA-152 (Tela·KB), FORJA-151 (Bug·Financeiro), FORJA-150 (Refino·Atendimento), cada um com badge de tipo colorido + tag de módulo + selo `[CC]` + botão roxo Analisar; aba mostra badge 3.
+- ✅ **Analisar** abre o dossiê lateral (valor×esforço, risco Tier-0, duplicatas, Aprovar→backlog / Rejeitar / Fundir) — `GET /forja/{id}/dossier` + `POST /forja/{id}/{aprovar,rejeitar,fundir}`.

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.tsx
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.tsx
@@ -1,9 +1,12 @@
 // @memcofre
 //   tela: /forja (+ /forja/{backlog,quadro,changelog,mcp,saude})
-//   module: TeamMcp — cockpit Forja (cowork loop). Onda Forja PR-A (shell).
-//   forja: PR-A — shell navegável (sidebar + 6 abas + rotas). Abas reais entram
-//          1 PR cada. visual-comparison aprovada:
-//          memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md (F1.5 ADR 0114)
+//   module: TeamMcp — cockpit Forja (cowork loop).
+//   forja: PR-A shell + Triagem REAL (esta PR). A aba Triagem projeta mcp_tasks
+//          project=FORJA em estado de triagem + dossiê lateral (reusa o padrão
+//          Analista de ProjectMgmt apontando pros endpoints /forja/*). As outras
+//          5 abas (backlog/quadro/changelog/mcp/saude) seguem placeholder (1 PR cada).
+//          visual-comparison aprovada (F1.5 ADR 0114):
+//          memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md
 //   permissao: copiloto.mcp.usage.all
 //
 // Projeta estado que JÁ existe (mcp_tasks + git/PR/ADR/sessão + gates) — sem dado
@@ -11,9 +14,13 @@
 // de 6 abas vem de config/core_topnavs.php['Forja'] (useAutoModuleNav).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import { Deferred, Link } from '@inertiajs/react';
 import { type ReactNode } from 'react';
-import { Hammer, Construction } from 'lucide-react';
+import { Activity, Bell, Construction, History, Inbox, LayoutGrid, List, Plug, Search } from 'lucide-react';
 import { PageHeader } from '@/Components/PageHeader';
+import { PageHeaderPrimary } from '@/Components/PageHeader/PageHeaderPrimary';
+import { cn } from '@/Lib/utils';
+import ForjaTriage, { type ForjaTicket } from './_components/ForjaTriage';
 
 interface Meta {
   generated_at: string;
@@ -25,32 +32,145 @@ interface Props {
   tabLabel: string;
   subtitle: string;
   meta: Meta;
+  // Triagem (aba 1) — chegam via Inertia::defer só na aba triagem. Opcionais
+  // (undefined nas outras abas e no 1º paint da Triagem — default-guard).
+  tickets?: ForjaTicket[];
+  triagemCount?: number;
 }
 
 const COCKPIT_SUBTITLE =
   'Cockpit do cowork loop — backlog, quadro F0→F4, changelog e atores (humano vs agente).';
 
-function ForjaCockpit({ tab, tabLabel, subtitle }: Props) {
+// Tab-strip in-page das 6 abas (contrato pixel). O module-nav nativo do AppShellV2
+// é dropdown no breadcrumb — não bate com a barra de abas do protótipo —, então a
+// faixa é renderizada aqui. Active por `tab`; Triagem mostra o contador vivo.
+const FORJA_TABS = [
+  { key: 'triagem',   label: 'Triagem',   href: '/forja',           icon: Inbox },
+  { key: 'backlog',   label: 'Backlog',   href: '/forja/backlog',   icon: List },
+  { key: 'quadro',    label: 'Quadro',    href: '/forja/quadro',    icon: LayoutGrid },
+  { key: 'changelog', label: 'Changelog', href: '/forja/changelog', icon: History },
+  { key: 'mcp',       label: 'MCP',       href: '/forja/mcp',        icon: Plug },
+  { key: 'saude',     label: 'Saúde',     href: '/forja/saude',      icon: Activity },
+] as const;
+
+// Abre a command palette global (dona do AppShellV2, atalho ⌘K) sintetizando o
+// keydown que o shell escuta no window. Sem plumbing de estado novo no shell.
+function openCommandPalette() {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'k', metaKey: true, ctrlKey: true, bubbles: true }),
+  );
+}
+
+function ForjaCockpit({ tab, tabLabel, subtitle, tickets, triagemCount }: Props) {
+  const isTriagem = tab === 'triagem';
+  const sinoBadge = isTriagem ? triagemCount : undefined;
+
   return (
     <>
-      <PageHeader title="Forja" subtitle={COCKPIT_SUBTITLE} />
+      {/* Eyebrow / breadcrumb (contrato pixel) */}
+      <p className="px-6 pt-4 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Desenvolvimento · MCP · Projeção do git
+      </p>
 
-      <section className="mt-6" data-testid={`forja-tab-${tab}`}>
-        <h2 className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
-          <Hammer size={15} className="text-primary" /> {tabLabel}
-        </h2>
-        <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+      <PageHeader
+        title="Forja"
+        subtitle={COCKPIT_SUBTITLE}
+        actions={
+          <>
+            {/* Sino com badge contador */}
+            <button
+              type="button"
+              aria-label="Notificações"
+              title="Notificações"
+              className="relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              data-testid="forja-sino"
+            >
+              <Bell size={16} />
+              {sinoBadge != null && sinoBadge > 0 && (
+                <span className="absolute -right-0.5 -top-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold tabular-nums text-primary-foreground">
+                  {sinoBadge}
+                </span>
+              )}
+            </button>
 
-        {/* Onda Forja PR-A: shell de pé; cada aba real entra numa PR própria. */}
-        <div className="mt-4 inline-flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center">
-          <Construction size={22} className="text-muted-foreground" />
-          <p className="text-sm font-medium text-foreground">Aba “{tabLabel}” em construção</p>
-          <p className="max-w-md text-xs text-muted-foreground">
-            O shell do cockpit (sidebar + 6 abas + rotas) está no ar. Cada aba entra como
-            uma PR própria desta onda, com seu gate visual — referência aprovada na
-            visual-comparison do cockpit Forja.
-          </p>
-        </div>
+            {/* Busca ⌘K — trigger do command palette global */}
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              aria-label="Buscar (⌘K)"
+              title="Buscar (⌘K)"
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              data-testid="forja-busca"
+            >
+              <Search size={14} />
+              <kbd className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">⌘K</kbd>
+            </button>
+
+            {/* Primária roxa "+ Novo issue" */}
+            <PageHeaderPrimary label="Novo issue" href="/forja" data-testid="forja-novo-issue" />
+          </>
+        }
+      />
+
+      {/* Faixa de 6 abas in-page (Triagem ativa + badge do contador vivo). */}
+      <nav className="mt-2 inline-flex w-full items-center gap-1 overflow-x-auto border-b px-6" data-testid="forja-tabs">
+        {FORJA_TABS.map((t) => {
+          const active = t.key === tab;
+          const Icon = t.icon;
+          const badge = t.key === 'triagem' ? triagemCount : undefined;
+          return (
+            <Link
+              key={t.key}
+              href={t.href}
+              aria-current={active ? 'page' : undefined}
+              className={cn(
+                '-mb-px inline-flex items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-2 text-xs font-medium transition-colors',
+                active
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon size={14} />
+              {t.label}
+              {badge != null && badge > 0 && (
+                <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold tabular-nums text-primary-foreground">
+                  {badge}
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+
+      <section className="px-6 pt-4" data-testid={`forja-tab-${tab}`}>
+        {isTriagem ? (
+          // Aba Triagem REAL — tickets deferidos (skeleton até resolver).
+          <Deferred
+            data={['tickets', 'triagemCount']}
+            fallback={
+              <div className="mt-4 inline-flex w-full items-center justify-center rounded-lg border border-dashed py-16 text-sm text-muted-foreground">
+                Carregando propostas…
+              </div>
+            }
+          >
+            <ForjaTriage tickets={tickets} />
+          </Deferred>
+        ) : (
+          // Demais abas: placeholder (cada uma vira 1 PR própria desta onda).
+          <>
+            <h2 className="text-sm font-semibold text-foreground">{tabLabel}</h2>
+            <p className="mt-1 text-xs text-muted-foreground">{subtitle}</p>
+            <div className="mt-4 inline-flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed bg-muted/30 px-6 py-12 text-center">
+              <Construction size={22} className="text-muted-foreground" />
+              <p className="text-sm font-medium text-foreground">Aba “{tabLabel}” em construção</p>
+              <p className="max-w-md text-xs text-muted-foreground">
+                O shell do cockpit (sidebar + 6 abas + rotas) está no ar. Cada aba entra como
+                uma PR própria desta onda, com seu gate visual — referência aprovada na
+                visual-comparison do cockpit Forja.
+              </p>
+            </div>
+          </>
+        )}
       </section>
     </>
   );

--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaDossier.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaDossier.tsx
@@ -1,0 +1,333 @@
+// Forja Triagem — dossiê do Analista (drawer) da aba /forja (Triagem).
+//   Endpoint: GET /forja/{taskId}/dossier (read-only, SÓ dados reais).
+//   Ações [W] confirma: aprovar (→backlog), rejeitar (→cancelled), fundir (duplicata).
+//   "Agente propõe, [W] aprova" — nada vira oficial sem confirmação.
+//
+// Espelha resources/js/Pages/ProjectMgmt/Triage/_components/TriageDossier.tsx
+// (PR-5a) — só muda o prefixo de rota /project-mgmt/triage → /forja. DS v6:
+// tokens semânticos, layout via inline-flex/inline-grid, data-testid locators.
+
+import { useEffect, useState } from 'react';
+import {
+  Activity as ActivityIcon, AlertTriangle, CheckCircle2, ExternalLink, FileText,
+  GitMerge, Loader2, ShieldCheck, XCircle,
+} from 'lucide-react';
+import {
+  Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle,
+} from '@/Components/ui/sheet';
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/Components/ui/alert-dialog';
+import { Button } from '@/Components/ui/button';
+import { cn } from '@/Lib/utils';
+
+const GH = 'https://github.com/wagnerra23/oimpresso.com/blob/main/';
+
+interface DossierTask {
+  task_id: string;
+  display_id: string;
+  title: string;
+  module: string | null;
+  owner: string | null;
+  priority_raw: string | null;
+  priority: string;
+  status: string;
+  type: string | null;
+  forja_tipo: string | null;
+  forja_papel: string | null;
+}
+interface Dup { task_id: string; display_id: string; title: string; status: string; owner: string | null }
+interface Ev { event_type: string; from_value: string | null; to_value: string | null; author: string | null; note: string | null; occurred_at: string | null }
+interface Doc { slug: string; type: string; title: string; path: string | null }
+interface Sess { session_uuid: string; summary: string | null; started_at: string | null }
+
+interface Dossier {
+  task: DossierTask;
+  description: string | null;
+  duplicatas: Dup[];
+  atividade: Ev[];
+  docs: Doc[];
+  sessoes: Sess[];
+  valor_esforco: { valor: string; esforco: string };
+  risco_tier0: { tier0: boolean; sinais: string[] };
+  charter_ref: string | null;
+  pode_aprovar: boolean;
+}
+
+type ConfirmAction = { title: string; description: string; confirmLabel: string; destructive: boolean; run: () => void } | null;
+
+interface Props {
+  taskId: string | null;
+  onClose: () => void;
+  onResolved: (taskId: string) => void;
+}
+
+function csrf(): string {
+  return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+}
+
+export default function ForjaDossier({ taskId, onClose, onResolved }: Props) {
+  const [data, setData] = useState<Dossier | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirm, setConfirm] = useState<ConfirmAction>(null);
+
+  useEffect(() => {
+    if (!taskId) return;
+    setLoading(true); setError(null); setData(null);
+    const ctrl = new AbortController();
+    fetch(`/forja/${encodeURIComponent(taskId)}/dossier`, {
+      headers: { Accept: 'application/json' }, signal: ctrl.signal,
+    })
+      .then((r) => {
+        if (r.status === 403) throw new Error('Sem permissão.');
+        if (r.status === 404) throw new Error('Task não encontrada.');
+        if (!r.ok) throw new Error(`Erro ${r.status}`);
+        return r.json();
+      })
+      .then((d: Dossier) => { setData(d); setLoading(false); })
+      .catch((e: Error) => { if (e.name === 'AbortError') return; setError(e.message); setLoading(false); });
+    return () => ctrl.abort();
+  }, [taskId]);
+
+  function act(path: string, body?: Record<string, unknown>) {
+    if (!taskId) return;
+    setBusy(true);
+    fetch(`/forja/${encodeURIComponent(taskId)}/${path}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-CSRF-TOKEN': csrf() },
+      body: JSON.stringify(body ?? {}),
+    })
+      .then(async (r) => {
+        const d = await r.json().catch(() => ({}));
+        setBusy(false);
+        if (!r.ok) { setError(d?.error ?? `Erro ${r.status}`); return; }
+        onResolved(taskId);
+        onClose();
+      })
+      .catch(() => { setBusy(false); setError('Erro de rede.'); });
+  }
+
+  const open = !!taskId;
+  const t = data?.task;
+  const ve = data?.valor_esforco;
+  const risk = data?.risco_tier0;
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={(v) => { if (!v && !busy) onClose(); }}>
+        <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-[600px]" data-testid="forja-dossier">
+          <SheetHeader className="border-b">
+            <div className="inline-flex w-full items-center gap-2">
+              <FileText size={14} className="text-muted-foreground" aria-hidden />
+              <span className="font-mono text-xs text-muted-foreground" data-testid="dossier-id">{t?.display_id ?? taskId}</span>
+              {t?.module && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px]">{t.module}</span>}
+              {t?.forja_papel && <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10px]">[{t.forja_papel}]</span>}
+            </div>
+            <SheetTitle className="mt-1 text-base leading-snug" data-testid="dossier-title">
+              {t?.title ?? (loading ? 'Carregando…' : 'Dossiê')}
+            </SheetTitle>
+            <SheetDescription className="mt-1 inline-flex w-full flex-wrap items-center gap-2 text-xs">
+              <span>dono: <strong className="text-foreground">{t?.owner ?? '— sem dono —'}</strong></span>
+              <span>prio: <strong className="text-foreground">{t?.priority_raw ? t.priority_raw.toUpperCase() : '— sem prio —'}</strong></span>
+              <span>situação: {t?.status}</span>
+            </SheetDescription>
+          </SheetHeader>
+
+          <div className="flex-1 space-y-5 overflow-y-auto px-4 py-4">
+            {loading && (
+              <div className="inline-flex w-full items-center justify-center py-12 text-sm text-muted-foreground">
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" /> montando dossiê…
+              </div>
+            )}
+            {error && (
+              <div className="rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-sm text-destructive-fg" data-testid="dossier-error">
+                {error}
+              </div>
+            )}
+
+            {!loading && data && t && (
+              <>
+                {/* Valor × esforço + Risco */}
+                <div className="inline-grid w-full grid-cols-2 gap-3">
+                  <div className="rounded-lg border bg-card p-3">
+                    <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">Valor × esforço <span className="normal-case">(sugerido)</span></div>
+                    <div className="mt-1 inline-flex gap-2 text-xs">
+                      <span className="rounded bg-muted px-1.5 py-0.5">valor: <strong>{ve?.valor}</strong></span>
+                      <span className="rounded bg-muted px-1.5 py-0.5">esforço: <strong>{ve?.esforco}</strong></span>
+                    </div>
+                  </div>
+                  <div className={cn('rounded-lg border p-3', risk?.tier0 ? 'border-destructive/30 bg-destructive-soft' : 'border-success/30 bg-success/10')}>
+                    <div className="inline-flex items-center gap-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                      {risk?.tier0 ? <AlertTriangle size={12} className="text-destructive" /> : <ShieldCheck size={12} className="text-success" />}
+                      Risco Tier-0 <span className="normal-case">(heurística)</span>
+                    </div>
+                    <div className="mt-1 text-xs">
+                      {risk?.tier0
+                        ? <span className="text-destructive-fg">sinais: {risk.sinais.join(', ')}</span>
+                        : <span className="text-success-fg">sem sinal de Tier-0</span>}
+                    </div>
+                  </div>
+                </div>
+
+                {data.description && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Descrição</h4>
+                    <p className="whitespace-pre-wrap text-sm leading-relaxed">{data.description}</p>
+                  </div>
+                )}
+
+                {/* Requisitos / charter */}
+                {data.charter_ref && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Requisitos do módulo</h4>
+                    <a href={GH + data.charter_ref} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-primary hover:underline">
+                      <FileText size={12} /> {data.charter_ref} <ExternalLink size={10} />
+                    </a>
+                  </div>
+                )}
+
+                {/* Duplicatas (com Fundir) */}
+                <div data-testid="dossier-duplicatas">
+                  <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Possíveis duplicatas <span className="normal-case">(mesmo módulo)</span></h4>
+                  {data.duplicatas.length === 0 ? (
+                    <p className="text-xs italic text-muted-foreground">Nenhuma no módulo {t.module}.</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {data.duplicatas.map((d) => (
+                        <li key={d.task_id} className="inline-flex w-full items-center gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50">
+                          <span className="font-mono text-muted-foreground">{d.display_id}</span>
+                          <span className="min-w-0 flex-1 truncate">{d.title}</span>
+                          <span className="shrink-0 text-[10px] text-muted-foreground">{d.status}</span>
+                          <Button
+                            size="sm" variant="ghost" className="h-6 shrink-0 px-1.5 text-[11px]"
+                            disabled={busy}
+                            onClick={() => setConfirm({
+                              title: `Fundir ${t.display_id} em ${d.display_id}?`,
+                              description: `${t.display_id} será cancelada e marcada como duplicata de ${d.display_id} (${d.title}). Registra evento em mcp_task_events. Não pode ser desfeito automaticamente.`,
+                              confirmLabel: 'Fundir',
+                              destructive: true,
+                              run: () => act('fundir', { target_task_id: d.task_id }),
+                            })}
+                          >
+                            <GitMerge size={12} className="mr-1" /> fundir aqui
+                          </Button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Histórico de decisão: docs/ADRs */}
+                <div data-testid="dossier-docs">
+                  <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Histórico de decisão <span className="normal-case">(docs/ADRs do módulo)</span></h4>
+                  {data.docs.length === 0 ? (
+                    <p className="text-xs italic text-muted-foreground">Sem docs indexados pro módulo.</p>
+                  ) : (
+                    <ul className="space-y-1">
+                      {data.docs.map((d) => (
+                        <li key={d.slug} className="inline-flex w-full items-center gap-2 text-xs">
+                          <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase text-muted-foreground">{d.type === 'decision' ? 'ADR' : d.type}</span>
+                          {d.path
+                            ? <a href={GH + d.path} target="_blank" rel="noopener noreferrer" className="min-w-0 flex-1 truncate text-primary hover:underline">{d.title}</a>
+                            : <span className="min-w-0 flex-1 truncate">{d.title}</span>}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+
+                {/* Sessões CC relacionadas */}
+                {data.sessoes.length > 0 && (
+                  <div>
+                    <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Sessões CC que citam o módulo</h4>
+                    <ul className="space-y-1">
+                      {data.sessoes.map((s) => (
+                        <li key={s.session_uuid} className="inline-flex w-full items-start gap-2 text-xs">
+                          <span className="font-mono text-[10px] text-muted-foreground">{s.session_uuid.slice(0, 8)}</span>
+                          <span className="min-w-0 flex-1 line-clamp-2 text-muted-foreground">{s.summary ?? '(sem summary)'}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+
+                {/* Atividade */}
+                {data.atividade.length > 0 && (
+                  <div data-testid="dossier-atividade">
+                    <h4 className="mb-1 inline-flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"><ActivityIcon size={12} /> Atividade</h4>
+                    <ul className="space-y-1">
+                      {data.atividade.slice(0, 12).map((e, i) => (
+                        <li key={i} className="text-xs text-muted-foreground">
+                          <span className="font-semibold text-foreground">@{e.author ?? 'system'}</span> {e.event_type}
+                          {e.from_value && e.to_value && <> ({e.from_value}→{e.to_value})</>}
+                          {e.note && <> · {e.note}</>}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
+
+          {/* Ações [W] aprova */}
+          {!loading && data && (
+            <div className="inline-flex w-full items-center gap-2 border-t px-4 py-3">
+              <Button
+                className="flex-1"
+                disabled={busy || !data.pode_aprovar}
+                title={data.pode_aprovar ? 'Promove pro backlog ativo' : 'Defina dono + prioridade antes de aprovar'}
+                onClick={() => setConfirm({
+                  title: `Aprovar ${t?.display_id}?`,
+                  description: 'Promove a proposta pro backlog ativo (status → todo). Vira task oficial.',
+                  confirmLabel: 'Aprovar',
+                  destructive: false,
+                  run: () => act('aprovar'),
+                })}
+                data-testid="dossier-aprovar"
+              >
+                <CheckCircle2 size={14} className="mr-1" /> Aprovar → backlog
+              </Button>
+              <Button
+                variant="outline"
+                className="text-destructive"
+                disabled={busy}
+                onClick={() => setConfirm({
+                  title: `Rejeitar ${t?.display_id}?`,
+                  description: 'Cancela a proposta (status → cancelled). O audit log é preservado.',
+                  confirmLabel: 'Rejeitar',
+                  destructive: true,
+                  run: () => act('rejeitar'),
+                })}
+                data-testid="dossier-rejeitar"
+              >
+                <XCircle size={14} className="mr-1" /> Rejeitar
+              </Button>
+            </div>
+          )}
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog open={confirm !== null} onOpenChange={(o) => { if (!o) setConfirm(null); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirm?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirm?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              variant={confirm?.destructive ? 'destructive' : 'default'}
+              onClick={() => { confirm?.run(); setConfirm(null); }}
+            >
+              {confirm?.confirmLabel ?? 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaTriage.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaTriage.tsx
@@ -45,13 +45,12 @@ interface Props {
 }
 
 // Badge de tipo (contrato pixel do protótipo): Tela=roxo · Bug=âmbar · Refino=azul.
-// Roxo via token semântico canon (text/bg-primary). Âmbar/azul via paleta Tailwind
-// com par dark (mesmo idioma de PRIORITY_BADGE em Components/board/badges.ts) — fora
-// do escopo do ds-canon-color-guard (só varre Components/{ui,shared}).
+// 100% tokens semânticos DS v6 (sem paleta crua — ui:lint R1 = 0): primary /
+// warning / info. Auto-adaptam ao dark (sem variantes dark: manuais).
 const TIPO_BADGE: Record<string, string> = {
   Tela:   'bg-primary/10 text-primary',
-  Bug:    'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
-  Refino: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  Bug:    'bg-warning-soft text-warning-fg',
+  Refino: 'bg-info-soft text-info-fg',
 };
 const TIPO_FALLBACK = 'bg-muted text-muted-foreground';
 

--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaTriage.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaTriage.tsx
@@ -1,0 +1,211 @@
+// Forja — aba Triagem (F0 formalizado). Tela fiel ao protótipo aprovado
+// (memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md §1 Triagem).
+//
+// Projeta `mcp_tasks` project=FORJA em estado de triagem (sem owner OU sem
+// priority OU backlog) — projeção, sem dado fantasma. Cada linha: ID mono ·
+// badge de tipo (Tela=roxo · Bug=âmbar · Refino=azul) · título · tag de módulo ·
+// selo de ator [CC] · botão roxo "Analisar" → abre o dossiê lateral (ForjaDossier,
+// que reusa o padrão Analista de ProjectMgmt apontando pros endpoints /forja/*).
+//
+// Reuso: estrutura de lista + navegação J/K + defer-guard espelham
+// resources/js/Pages/ProjectMgmt/Triage/Index.tsx. DS v6: roxo canon (text/bg-primary)
+// nas primárias, tabular-nums, layout via inline-flex/primitivos, data-testid locators.
+
+import { router } from '@inertiajs/react';
+import { useEffect, useMemo, useState } from 'react';
+import { CheckCircle2, FileSearch, Inbox as InboxIcon } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import ForjaDossier from './ForjaDossier';
+
+export interface ForjaTicket {
+  task_id: string;
+  identifier: string | null;
+  display_id: string;
+  title: string;
+  module: string | null;
+  owner: string | null;
+  priority_raw: string | null;
+  priority: string;
+  status: string;
+  type: string | null;
+  forja_tipo: string | null;
+  forja_papel: string | null;
+  forja_onda: string | null;
+  created_at: string | null;
+  needs_owner: boolean;
+  needs_prio: boolean;
+  is_backlog: boolean;
+}
+
+interface Props {
+  // tickets chega via Inertia::defer (ForjaController@triagem) → undefined no 1º
+  // paint. Default-guard `= []` no destructuring pra NÃO crashar antes do defer
+  // (skill inertia-defer-default; espelha ProjectMgmt/Triage/Index.tsx).
+  tickets?: ForjaTicket[];
+}
+
+// Badge de tipo (contrato pixel do protótipo): Tela=roxo · Bug=âmbar · Refino=azul.
+// Roxo via token semântico canon (text/bg-primary). Âmbar/azul via paleta Tailwind
+// com par dark (mesmo idioma de PRIORITY_BADGE em Components/board/badges.ts) — fora
+// do escopo do ds-canon-color-guard (só varre Components/{ui,shared}).
+const TIPO_BADGE: Record<string, string> = {
+  Tela:   'bg-primary/10 text-primary',
+  Bug:    'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  Refino: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+};
+const TIPO_FALLBACK = 'bg-muted text-muted-foreground';
+
+export default function ForjaTriage({ tickets = [] }: Props) {
+  // Tickets resolvidos (aprovado/rejeitado/fundido) — escondidos localmente até reload.
+  const [resolved, setResolved] = useState<Set<string>>(new Set());
+  // Linha em foco pra navegação J/K (mesma mecânica do Board/Triage).
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  // Drawer do dossiê do Analista.
+  const [dossierId, setDossierId] = useState<string | null>(null);
+
+  const visible = useMemo(
+    () => tickets.filter((t) => !resolved.has(t.task_id)),
+    [tickets, resolved],
+  );
+
+  // Quando a lista muda e o selecionado some, escolhe o primeiro (igual Board/Triage).
+  useEffect(() => {
+    if (!visible.length) {
+      setSelectedId(null);
+      return;
+    }
+    if (selectedId && !visible.find((t) => t.task_id === selectedId)) {
+      setSelectedId(visible[0]?.task_id ?? null);
+    }
+  }, [visible, selectedId]);
+
+  // Atalhos canônicos J/K (navegar) + Enter (abrir dossiê) — mesma mecânica inline
+  // que Triage/Index.tsx. ⌘K (palette global) é dono do AppShellV2, não re-registra.
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const tgt = e.target as HTMLElement | null;
+      const isTyping = tgt && (
+        tgt.tagName === 'INPUT' || tgt.tagName === 'TEXTAREA' || tgt.isContentEditable
+      );
+      if (isTyping) return;
+      if (!visible.length) return;
+
+      const idx = selectedId ? visible.findIndex((t) => t.task_id === selectedId) : -1;
+      const cur = idx >= 0 ? visible[idx] : null;
+
+      if (e.key === 'j' || e.key === 'J') {
+        e.preventDefault();
+        const n = idx < 0 ? 0 : Math.min(visible.length - 1, idx + 1);
+        setSelectedId(visible[n]?.task_id ?? null);
+      } else if (e.key === 'k' || e.key === 'K') {
+        e.preventDefault();
+        const p = idx <= 0 ? 0 : idx - 1;
+        setSelectedId(visible[p]?.task_id ?? null);
+      } else if (e.key === 'Enter' && cur) {
+        e.preventDefault();
+        setDossierId(cur.task_id);
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [visible, selectedId]);
+
+  return (
+    <div data-testid="forja-triagem">
+      {/* Texto-âncora (contrato pixel) */}
+      <p className="mt-1 max-w-3xl text-xs leading-relaxed text-muted-foreground">
+        <strong className="text-foreground">
+          Tickets propostos aguardando o analista [AN] enriquecer e sua aprovação.
+        </strong>{' '}
+        Entram no backlog só depois — é o F0 do protocolo, formalizado.
+      </p>
+
+      {visible.length === 0 ? (
+        <div className="mt-8 inline-flex w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed py-16 text-center text-muted-foreground">
+          <CheckCircle2 size={28} className="text-success" />
+          <p className="text-base font-medium text-foreground">Nada pra triar</p>
+          <p className="text-sm">Nenhuma proposta aguardando enriquecimento e aprovação.</p>
+        </div>
+      ) : (
+        <div className="mt-4 divide-y rounded-lg border">
+          {visible.map((t) => {
+            const isSelected = t.task_id === selectedId;
+            const tipo = t.forja_tipo ?? '—';
+            return (
+              <div
+                key={t.task_id}
+                aria-current={isSelected ? 'true' : undefined}
+                className={cn(
+                  'inline-flex w-full items-center gap-3 px-4 py-3 transition-colors',
+                  isSelected ? 'bg-muted/60 ring-1 ring-inset ring-primary/60' : 'hover:bg-muted/40',
+                )}
+              >
+                {/* ID mono */}
+                <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+                  {t.display_id}
+                </span>
+
+                {/* Badge de tipo (Tela=roxo · Bug=âmbar · Refino=azul) */}
+                <span
+                  className={cn(
+                    'shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold',
+                    TIPO_BADGE[tipo] ?? TIPO_FALLBACK,
+                  )}
+                  data-testid="forja-tipo"
+                >
+                  {tipo}
+                </span>
+
+                {/* Título (cresce) */}
+                <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+                  {t.title}
+                </span>
+
+                {/* Tag de módulo (pílula sutil) */}
+                {t.module && (
+                  <span className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground sm:inline">
+                    {t.module}
+                  </span>
+                )}
+
+                {/* Selo de ator [CC] (pílula mono) */}
+                {t.forja_papel && (
+                  <span className="hidden shrink-0 rounded bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground sm:inline">
+                    [{t.forja_papel}]
+                  </span>
+                )}
+
+                {/* Botão roxo Analisar → dossiê lateral */}
+                <button
+                  type="button"
+                  onClick={() => setDossierId(t.task_id)}
+                  className="inline-flex shrink-0 items-center gap-1 rounded-md bg-primary px-2.5 py-1 text-[11px] font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+                  data-testid="forja-analisar"
+                >
+                  <FileSearch size={12} /> Analisar
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      <p className="mt-4 inline-flex items-center gap-1 text-xs text-muted-foreground">
+        <InboxIcon size={12} className="-mt-0.5" />
+        Fila = <code className="font-mono">mcp_tasks</code> project=FORJA em triagem (sem dono · sem
+        prioridade · ou backlog). Aprovar promove pro backlog; rejeitar cancela. Nada vira oficial
+        sem você confirmar.
+      </p>
+
+      {/* Dossiê do Analista (agente propõe, [W] aprova) */}
+      <ForjaDossier
+        taskId={dossierId}
+        onClose={() => setDossierId(null)}
+        onResolved={(id) => {
+          setResolved((prev) => new Set(prev).add(id));
+          router.reload({ only: ['tickets', 'triagemCount'] });
+        }}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Onda Forja · Triagem (tira do placeholder)

Segue o veredito do adversário: em vez de fatiar mais andaime, entrega **a Triagem 100% fiel ao protótipo**, reusando o padrão Analista do ProjectMgmt. As outras 5 abas seguem placeholder (1 PR cada).

### Frontend
- **Tab-strip in-page** das 6 abas (Triagem ativa roxa + badge do contador vivo) — o module-nav nativo do AppShellV2 é dropdown no breadcrumb e **não bate** com a barra de abas do protótipo, então renderiza in-page.
- Header: eyebrow `DESENVOLVIMENTO · MCP · PROJEÇÃO DO GIT`, sino+badge, busca ⌘K, primária roxa **Novo issue**.
- `ForjaTriage`: linhas `FORJA-152 [Tela] · módulo · [CC] · Analisar` (Tela=roxo · Bug=âmbar · Refino=azul), navegação J/K, `Enter` abre dossiê.
- `ForjaDossier`: drawer valor×esforço · risco Tier-0 · duplicatas · Aprovar→backlog / Rejeitar / Fundir (cada um sob confirmação).

### Backend
- `ForjaController@triagem` projeta `mcp_tasks` project=FORJA em triagem via `Inertia::defer`; `forja_tipo/forja_papel` lidos de `custom_fields` (**sem schema novo** — Tier 0).
- `dossier/aprovar/rejeitar/fundir` espelham o `TriageController` (PR-5a) em `/forja/*`.
- `ForjaDemoTicketsSeeder` idempotente: project `FORJA` + FORJA-150/151/152.
- enum `priority`: `match()` + `getRawOriginal` (idioma que já passou no PHPStan do TriageController). `$tenancy='business_id'` markers (mcp_* repo-wide, ADR 0093).

### ⚠️ Pós-merge (pra fidelidade do screenshot)
Rodar no deploy: `php artisan db:seed --class="Modules\TeamMcp\Database\Seeders\ForjaDemoTicketsSeeder"`. Sem ele a fila nasce vazia ("Nada pra triar" — correto, sem dado fantasma).

### Gates locais (verde)
casos-coverage · layout-primitives · pageheader-migration · components-tree · foundation · eslint. PHPStan/Pest no CI.

Refs: FORJA PR-A2 · ADR 0114 · ADR 0081 · ADR 0093 · ADR 0070

🤖 Generated with [Claude Code](https://claude.com/claude-code)