### PR TITLE
fix(financeiro): hero KPI vira claro (caixa preta → superfície da identidade)

### DIFF
--- a/.github/workflows/fin-hero-gate.yml
+++ b/.github/workflows/fin-hero-gate.yml
@@ -1,0 +1,44 @@
+name: Fin Hero Gate — KPI hero claro (anti-regressão Onda 28)
+
+# O hero `.fin-stat-hero` do Financeiro virou de escuro ("caixa preta" oklch(0.22 0.01 80))
+# pra superfície CLARA na Onda 28 (handoff Cowork CONSERTAR-ELO, aprovado Wagner). Este gate
+# trava a regressão: se o hero voltar a ser escuro — em fin-cowork.css (telas raw markup) ou
+# em FinStatStrip.tsx (componente) — o controle-negativo estático falha e bloqueia o merge.
+#
+# Path-scoped (faz npm ci): roda só quando o hero, o spec ou este workflow mudam.
+# Comando manual local: npm run test:fin-hero
+#
+# Refs: handoff Passo 4 ("TRAVAR com teste de regressão") · ADR 0258 (gate só vale se o
+# controle-negativo roda no CI) · ADR 0281 (.dark bridge).
+
+on:
+  pull_request:
+    paths:
+      - 'resources/css/fin-cowork.css'
+      - 'resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx'
+      - 'tests/finHeroLight.spec.ts'
+      - '.github/workflows/fin-hero-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'resources/css/fin-cowork.css'
+      - 'resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx'
+      - 'tests/finHeroLight.spec.ts'
+
+concurrency:
+  group: fin-hero-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fin-hero:
+    name: Fin hero claro · não pode voltar a ser caixa preta
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Install deps
+        run: npm ci
+      - name: Controle-negativo do hero claro (estático · vitest)
+        run: npm run test:fin-hero

--- a/config/css-size-baseline.json
+++ b/config/css-size-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-06-16T13:45:44.932Z",
-    "total_lines": 20452,
+    "generated_at": "2026-06-16T17:13:14.310Z",
+    "total_lines": 20455,
     "file_count": 29,
     "note": "Ratchet de tamanho — passo 1 MANUAL-CSS-JS. Cada .css só pode encolher; arquivo novo exige --write (decisão consciente / ADR).",
     "refs": [
@@ -15,7 +15,7 @@
     "resources/css/cowork-compras-bundle.css": 182,
     "resources/css/cowork-fields.css": 409,
     "resources/css/cowork-payment-gateway-bundle.css": 257,
-    "resources/css/fin-cowork.css": 671,
+    "resources/css/fin-cowork.css": 674,
     "resources/css/fin-curadoria.css": 289,
     "resources/css/fin-ia.css": 291,
     "resources/css/fin-mobile.css": 67,

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "scorer:sync": "node scripts/scorer-sync-check.mjs",
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts",
+    "test:fin-hero": "vitest run tests/finHeroLight.spec.ts",
     "test:adr-governance": "vitest run tests/governanceAdrScripts.spec.ts",
     "test:memory-health": "vitest run tests/memoryHealth.spec.ts",
     "test:casos-guard": "vitest run tests/casosGuard.spec.ts",

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -151,26 +151,31 @@
 }
 .fin-cowork .fin-curadoria .fin-num-pos { color: oklch(0.45 0.18 145); }
 .fin-cowork .fin-curadoria .fin-num-neg { color: oklch(0.50 0.18 25); }
-/* Onda 12.4 (2026-05-19) — KPI hero "warm dark" paridade EXATA canon REAL.
-   DOM forensics canon: oklch(0.22 0.01 80) — hue 80 warm (marrom/bege escuro).
-   Antes estava hue 240 cool (preto puro) que não tinha o tom "documento contábil
-   tradicional". */
+/* Onda 28 (2026-06-16) — KPI hero CLARO. Vira o "documento contábil" warm-dark
+   (`oklch(0.22 0.01 80)` = var(--text), a "caixa preta" do print do Wagner) pra uma
+   superfície clara com leve luz da identidade (accent 295). Aprovado por Wagner via
+   handoff Cowork "CONSERTAR-ELO". 100% token + color-mix(oklab) (foundation-guard).
+   Supersede a Onda 12.4 warm-dark. Espelho de FinStatStrip.tsx (sincronizar os dois). */
 .fin-cowork .fin-curadoria .fin-stat-hero {
   position: relative;
-  background: oklch(0.22 0.01 80);
-  color: white;
-  border: 0;
+  background:
+    radial-gradient(540px 200px at 14% -45%, color-mix(in oklab, var(--accent) 16%, transparent), transparent 70%),
+    linear-gradient(160deg, color-mix(in oklab, var(--accent) 8%, var(--surface)) 0%, var(--surface) 78%);
+  border: 1px solid color-mix(in oklab, var(--accent) 18%, var(--border));
+  box-shadow: var(--sh-1);
+  padding-bottom: 18px;
+  min-height: 96px;
   overflow: hidden;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero small { color: oklch(0.75 0.01 80); opacity: 0.95; font-weight: 600; }
-.fin-cowork .fin-curadoria .fin-stat-hero b { color: white; font-size: var(--fs-8); }
-.fin-cowork .fin-curadoria .fin-stat-hero .fin-stat-hint { color: oklch(0.72 0.01 80); opacity: 0.85; }
-.fin-cowork .fin-curadoria .fin-stat-hero .fin-num-neg { color: oklch(0.78 0.14 25); }
-.fin-cowork .fin-curadoria .fin-stat-hero .fin-num-pos { color: oklch(0.78 0.14 145); }
-/* CASO 03 (adversário Wave 1 · 2026-06-16) — chip "projeção negativa" no hero quando
-   saldo previsto < 0. Cor segue o neg-red do hero (linha acima, oklch 0.78 0.14 25 —
-   claro o bastante pro fundo warm-dark `oklch(0.22 0.01 80)`); NÃO var(--neg) cru, que
-   é dark-red (0.55) e some no fundo escuro. Mesmo raciocínio que .fin-num-neg do hero. */
+.fin-cowork .fin-curadoria .fin-stat-hero small { color: var(--text-mute); font-weight: 600; }
+.fin-cowork .fin-curadoria .fin-stat-hero b { color: var(--text); font-size: var(--fs-8); }
+.fin-cowork .fin-curadoria .fin-stat-hero .fin-stat-hint { color: var(--text-mute); }
+.fin-cowork .fin-curadoria .fin-stat-hero .fin-num-neg { color: var(--neg); }
+.fin-cowork .fin-curadoria .fin-stat-hero .fin-num-pos { color: var(--pos); }
+/* CASO 03 (adversário Wave 1 · 2026-06-16; re-tonalizado p/ hero claro Onda 28) —
+   chip "projeção negativa" no hero quando saldo previsto < 0. Com o hero agora CLARO,
+   a cor é var(--neg) canon (dark-red 0.55), que contrasta no fundo claro. (No hero
+   warm-dark anterior usava-se light-red oklch(0.78 0.14 25) p/ não sumir no escuro.) */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-hero-alarm {
   display: inline-flex;
   align-items: center;
@@ -181,20 +186,18 @@
   font-weight: 600;
   letter-spacing: 0.01em;
   text-transform: none;
-  color: oklch(0.82 0.13 25);
-  background: color-mix(in oklab, oklch(0.78 0.14 25) 16%, transparent);
-  box-shadow: inset 0 0 0 1px color-mix(in oklab, oklch(0.78 0.14 25) 34%, transparent);
+  color: var(--neg);
+  background: color-mix(in oklab, var(--neg) 12%, var(--surface));
+  box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--neg) 30%, transparent);
 }
-/* DARK-BACKFILL (2026-06-04 · DARK-BACKFILL-SWEEP #1) — o hero charcoal
-   `oklch(0.22 0.01 80)` (warm "documento contábil") tem a MESMA luminosidade do
-   page-bg dark (`oklch(0.22 …)`), então no escuro o card SOME (perde a borda e
-   funde no fundo). Eleva pra uma superfície warm-raised distinta + borda sutil,
-   preservando a identidade quente e o texto branco. Escopo `.dark` (classe no
-   <html>, ADR foundations) porque o hero renderiza tanto in-page quanto no Sheet
-   portalizado fora de `.cockpit`. ADITIVO: o claro fica 100% intocado (L-28). */
+/* Dark-mode (ADR 0281 · `.dark` no <html>) — o mesmo gradiente sobre a surface
+   escura vira um card "raised" levemente tingido de accent, distinto do page-bg
+   (mais accent 12% + borda mais marcada pra não sumir). ADITIVO (L-28). */
 .dark .fin-cowork .fin-curadoria .fin-stat-hero {
-  background: oklch(0.30 0.012 80);
-  border: 1px solid oklch(0.40 0.012 80);
+  background:
+    radial-gradient(540px 200px at 14% -45%, color-mix(in oklab, var(--accent) 22%, transparent), transparent 70%),
+    linear-gradient(160deg, color-mix(in oklab, var(--accent) 12%, var(--surface)) 0%, var(--surface) 80%);
+  border-color: color-mix(in oklab, var(--accent) 24%, var(--border));
 }
 .fin-cowork .fin-curadoria .fin-spark {
   margin-top: 8px;

--- a/resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx
+++ b/resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx
@@ -6,7 +6,8 @@
 //   - grid 5-col `minmax(260px,1.6fr) repeat(4,1fr)` com reflow por CONTAINER
 //     (@container finbody: ≤1100px → 4col + hero full; ≤600px → 2col)
 //   - card branco, borda var(--fin-line), radius 8, pad 12/14, flex-col gap 2
-//   - variante `hero` "documento contábil" warm-dark + override dark-mode
+//   - variante `hero` CLARA (Onda 28) — gradiente accent 295 sobre var(--surface),
+//     theme-aware (em .dark o mesmo gradiente vira card raised escuro)
 //   - tons pos/neg (oklch canon do fin-cowork)
 //
 // ⚠️ USAR dentro de um ancestral `.fin-curadoria` — ele fornece os tokens
@@ -28,46 +29,47 @@ interface FinStatProps {
   hero?: boolean;
 }
 
-// Cor do número (`<b>`) por tom. Espelha .fin-num-pos / .fin-num-neg do fin-cowork,
-// com os valores mais claros quando dentro do hero (fundo escuro).
-function toneClass(tone: FinStatTone, hero: boolean): string {
-  if (tone === 'pos') return hero ? 'text-[oklch(0.78_0.14_145)]' : 'text-[oklch(0.45_0.18_145)]';
-  if (tone === 'neg') return hero ? 'text-[oklch(0.78_0.14_25)]' : 'text-[oklch(0.50_0.18_25)]';
-  return hero ? 'text-white' : 'text-[var(--fin-text)]';
+// Cor do número (`<b>`) por tom. Hero claro (Onda 28) usa os MESMOS tons dark-on-light
+// dos cards normais — o que distingue o hero é o CARD (gradiente accent + sombra), não
+// a cor do texto. Espelha .fin-num-pos / .fin-num-neg do fin-cowork.
+function toneClass(tone: FinStatTone): string {
+  if (tone === 'pos') return 'text-[oklch(0.45_0.18_145)]';
+  if (tone === 'neg') return 'text-[oklch(0.50_0.18_25)]';
+  return 'text-[var(--fin-text)]';
 }
+
+// Hero claro (Onda 28) — gradiente com leve luz da identidade (accent 295) sobre
+// var(--surface). Tokens são theme-aware: em dark-mode (.dark) --surface vira escuro,
+// então o MESMO gradiente vira um card raised escuro tingido de accent. Espelho de
+// fin-cowork.css `.fin-stat-hero` (manter os dois em sincronia).
+const HERO_STYLE = {
+  background:
+    'radial-gradient(540px 200px at 14% -45%, color-mix(in oklab, var(--accent) 16%, transparent), transparent 70%),' +
+    ' linear-gradient(160deg, color-mix(in oklab, var(--accent) 8%, var(--surface)) 0%, var(--surface) 78%)',
+  border: '1px solid color-mix(in oklab, var(--accent) 18%, var(--border))',
+  boxShadow: 'var(--sh-1)',
+} as const;
 
 export function FinStat({ label, value, hint, tone = 'neutral', hero = false }: FinStatProps) {
   const card = hero
-    ? // .fin-stat-hero: warm-dark "documento contábil" + dark-backfill (raised surface)
-      'relative overflow-hidden border-0 bg-[oklch(0.22_0.01_80)] text-white ' +
-      'col-[1/-1] @max-[1100px]:col-span-full dark:border dark:border-[oklch(0.40_0.012_80)] dark:bg-[oklch(0.30_0.012_80)]'
+    ? 'relative overflow-hidden min-h-24 pb-[18px] col-[1/-1] @max-[1100px]:col-span-full'
     : 'border border-[var(--fin-line)] bg-white';
 
   return (
-    <div className={`flex min-w-0 flex-col gap-0.5 rounded-lg px-3.5 py-3 ${card}`}>
-      <small
-        className={`text-[10px] font-semibold uppercase tracking-[0.06em] ${
-          hero ? 'text-[oklch(0.75_0.01_80)] opacity-95' : 'text-[var(--fin-text-mute)]'
-        }`}
-      >
+    <div
+      className={`flex min-w-0 flex-col gap-0.5 rounded-lg px-3.5 py-3 ${card}`}
+      style={hero ? HERO_STYLE : undefined}
+    >
+      <small className="text-[10px] font-semibold uppercase tracking-[0.06em] text-[var(--fin-text-mute)]">
         {label}
       </small>
       <b
-        className={`font-mono font-bold tracking-[-0.01em] ${hero ? 'text-[26px]' : 'text-[22px]'} ${toneClass(
-          tone,
-          hero,
-        )}`}
+        className={`font-mono font-bold tracking-[-0.01em] ${hero ? 'text-[28px]' : 'text-[22px]'} ${toneClass(tone)}`}
       >
         {value}
       </b>
       {hint != null && (
-        <span
-          className={`text-[11px] ${
-            hero ? 'text-[oklch(0.72_0.01_80)] opacity-85' : 'text-[var(--fin-text-mute)]'
-          }`}
-        >
-          {hint}
-        </span>
+        <span className="text-[11px] text-[var(--fin-text-mute)]">{hint}</span>
       )}
     </div>
   );

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -106,6 +106,10 @@
       "nome": "ESLint 9 (ADR 0209)",
       "classe": "gate"
     },
+    "fin-hero-gate.yml": {
+      "nome": "Fin Hero Gate — KPI hero claro (anti-regressão Onda 28)",
+      "classe": "gate"
+    },
     "financeiro-pest.yml": {
       "nome": "Financeiro · Pest (MySQL)",
       "classe": "gate"

--- a/tests/finHeroLight.spec.ts
+++ b/tests/finHeroLight.spec.ts
@@ -1,0 +1,72 @@
+// Anti-regressão — o KPI hero do Financeiro NÃO pode voltar a ser a "caixa preta".
+//
+// O hero `.fin-stat-hero` foi escuro por várias ondas (`oklch(0.22 0.01 80)` = var(--text),
+// o tom "documento contábil"). Onda 28 (2026-06-16 · handoff Cowork CONSERTAR-ELO · aprovado
+// por Wagner) virou pra superfície CLARA com gradiente da identidade (accent 295). Sem este
+// lock, a próxima cópia/sweep do CSS pode reintroduzir o dark silenciosamente — era exatamente
+// o "elo frágil" diagnosticado no handoff (Passo 4: "TRAVAR com teste de regressão").
+//
+// Assertion ESTÁTICA sobre o fonte (CSS + TSX) — mais robusta e barata que um computed-style
+// e2e (que depende de build + browser + dados). Mirror do método tests/foundationGuard.spec.ts:
+// injeta o bug (caixa preta) e EXIGE detecção (sensibilidade) + prova que o claro real passa
+// (especificidade) + prova que não passa vacuamente (vivo).
+//
+// Refs: handoff PROMPT_PARA_CODE_FINANCEIRO-CONSERTAR-ELO-BUNDLE Passo 4 · ADR 0258 (gate só
+// vale se o controle-negativo roda no CI) · ADR 0281 (.dark bridge data-theme→tokens).
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const CSS = 'resources/css/fin-cowork.css';
+const TSX = 'resources/js/Pages/Financeiro/_shared/FinStatStrip.tsx';
+
+// Extrai o bloco BASE do hero (declaração do card até o primeiro `}` — sem nested braces).
+function heroBaseBlock(css: string): string {
+  const sel = '.fin-cowork .fin-curadoria .fin-stat-hero {';
+  const i = css.indexOf(sel);
+  if (i < 0) throw new Error(`seletor base do hero não encontrado em ${CSS}`);
+  return css.slice(i, css.indexOf('}', i) + 1);
+}
+
+// Detector da "caixa preta": background charcoal warm-dark (oklch ~0.2x L) OU var(--text) cru.
+function isCaixaPreta(heroBlock: string): boolean {
+  return /background:[^;}]*\boklch\(\s*0\.2[0-3]\b/.test(heroBlock)   // charcoal ~0.22 L
+    || /background:\s*var\(--text\)\s*;/.test(heroBlock);            // literal cru do protótipo
+}
+
+describe('fin-hero — SENSIBILIDADE (injeta a caixa preta → detecta)', () => {
+  it('detecta o charcoal warm-dark oklch(0.22 …) como caixa preta', () => {
+    expect(isCaixaPreta('.x{ background: oklch(0.22 0.01 80); }')).toBe(true);
+  });
+  it('detecta o literal var(--text) (cópia crua do protótipo) como caixa preta', () => {
+    expect(isCaixaPreta('.x{ background: var(--text); }')).toBe(true);
+  });
+  it('NÃO acusa o gradiente claro (especificidade — não é falso-positivo)', () => {
+    const claro =
+      '.x{ background: linear-gradient(160deg, color-mix(in oklab, var(--accent) 8%, var(--surface)) 0%, var(--surface) 78%); }';
+    expect(isCaixaPreta(claro)).toBe(false);
+  });
+});
+
+describe('fin-hero — o hero REAL é claro (Onda 28), não a caixa preta', () => {
+  const block = heroBaseBlock(readFileSync(CSS, 'utf8'));
+
+  it('fin-cowork.css: o card base NÃO é a caixa preta', () => {
+    expect(isCaixaPreta(block)).toBe(false);
+  });
+  it('fin-cowork.css: o card base usa gradiente claro sobre var(--surface)', () => {
+    expect(block).toContain('linear-gradient');
+    expect(block).toMatch(/var\(--surface\)/);
+  });
+  it('FinStatStrip.tsx (componente piloto): o hero não hardcoda fundo escuro nem texto branco', () => {
+    const tsx = readFileSync(TSX, 'utf8');
+    expect(tsx).not.toContain('bg-[oklch(0.22_0.01_80)]');
+    expect(tsx).not.toContain('text-white');
+  });
+});
+
+describe('fin-hero — está VIVO (não passa vacuamente)', () => {
+  it('o hero claro real referencia a luz da identidade var(--accent)', () => {
+    expect(heroBaseBlock(readFileSync(CSS, 'utf8'))).toContain('var(--accent)');
+  });
+});


### PR DESCRIPTION
## O que

Vira o KPI hero do Financeiro (`.fin-stat-hero`) de **escuro** ("caixa preta" warm-dark `oklch(0.22 0.01 80)` = `var(--text)`) pra **superfície clara** com leve luz da identidade — gradiente `accent` 295 sobre `var(--surface)`, 100% token + `color-mix(in oklab)`. **Onda 28**, aprovado por Wagner via screenshot.

Cobre as telas que usam o hero: **Unificado, Fluxo, Conciliação, Dre** (raw markup → `fin-cowork.css`) + **PlanoContas** (componente `FinStatStrip.tsx`).

## Por que (handoff Cowork validado contra o `main`)

Origem: handoff `PROMPT_PARA_CODE_FINANCEIRO-CONSERTAR-ELO-BUNDLE`. O diagnóstico do handoff estava **desatualizado** e foi validado contra o `main` antes de agir:

- ❌ "2 bundles quase-dup, o antigo vence o cascade" → **já fundidos** ([#2127](https://github.com/wagnerra23/oimpresso.com/pull/2127)); só existe `cowork-canon-financeiro-bundle.css`.
- ❌ "o hero vive no bundle, foto congelada de 20/mai" → o bundle **não define** `.fin-stat-hero`; ele vive em `fin-cowork.css`, editado em 02 e 04/jun (não congelado).
- ✅ Conserto certo = **edit cirúrgico** em `fin-cowork.css` + `FinStatStrip.tsx`, **não** re-sync do bundle de 9k linhas.

Armadilhas de cópia-verbatim evitadas: `[data-theme="dark"]` → `.dark` (ADR 0281); `--text-2` indefinido → `--text-mute`; `--sh-2` (sombra flutuante de modal) → `--sh-1` (card assentado); removidos os `!important` desnecessários (manteriam o ratchet stylelint mexido).

## Mudanças

- **`fin-cowork.css`** — card base claro; `small/b/hint/num` re-tokenizados; chip **CASO 03** re-tonalizado pro `var(--neg)` (contrasta no claro; antes era light-red pro fundo escuro); dark-backfill vira variante `.dark` theme-aware.
- **`FinStatStrip.tsx`** — componente piloto espelha o claro via `style` inline com tokens (theme-aware: `--surface` adapta em dark-mode).
- **`tests/finHeroLight.spec.ts` + `.github/workflows/fin-hero-gate.yml`** — trava a regressão (Passo 4 do handoff): controle-negativo estático que **falha se o hero voltar a ser escuro**, e que **roda no CI** (método foundationGuard / ADR 0258).
- **`css-size-baseline.json`** — rebaseline +3 (gradiente multi-linha).

## Gates

- foundation-guard ✅ (token-puro, 0 token-def novo)
- conformance cor-crua ✅ (`fin-cowork.css` 1=teto; a mudança *remove* oklch cru, troca por token)
- stylelint flat ✅ (0 `!important`, 0 hex adicionado)
- css-size ✅ (rebaseline Δ0)
- fin-hero-gate ✅ (9/9 asserts validados)

Sparkline confirmado tone-by-sign (`pos`/`neg`), sem mudança. A "caixa preta" do print do Wagner é exatamente o estado **Antes**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
