### PR TITLE
feat(caixa-unificada): Saldo + Histórico do cliente no Contexto (US-WA-308 · Onda 3)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -98,6 +98,7 @@ class CaixaUnificadaController extends Controller
         // Thread aberta?
         $thread = null;
         $messages = null;
+        $customerContext = null;
         if ($threadId) {
             $threadQuery = Conversation::query()
                 ->where('business_id', $businessId)
@@ -106,6 +107,11 @@ class CaixaUnificadaController extends Controller
             $threadModel = $threadQuery->find($threadId);
             if ($threadModel) {
                 $thread = $this->convToThreadArray($threadModel);
+                // Onda 3 — Saldo + Histórico do cliente (Tier 0; contact da conversa)
+                $customerContext = $this->buildCustomerContextPayload(
+                    $businessId,
+                    $threadModel->contact_id !== null ? (int) $threadModel->contact_id : null,
+                );
                 $messages = Message::query()
                     ->where('business_id', $businessId)
                     ->where('conversation_id', $threadId)
@@ -166,6 +172,9 @@ class CaixaUnificadaController extends Controller
             'activeTagIds' => array_values($activeTagIds),
             'thread' => $thread,
             'messages' => $messages,
+            // Onda 3 — contexto comercial do cliente (Saldo + Histórico); eager,
+            // refresca no thread switch via only:['customerContext'].
+            'customerContext' => $customerContext,
             'centrifugoConfig' => $centrifugoConfig,
 
             // US-WA-301 (ADR 0267) — filas agora vêm do DB (seed lazy do config
@@ -174,6 +183,46 @@ class CaixaUnificadaController extends Controller
             'defaultQueue' => (string) config('whatsapp.default_queue', 'comercial'),
             'canManageQueues' => (bool) (auth()->user()?->can('whatsapp.settings.manage') ?? false),
         ]);
+    }
+
+    /**
+     * Onda 3 — contexto comercial do cliente da conversa (Saldo + Histórico) pra
+     * sidebar. Reusa o agregador canônico do painel Cliente (ContactController):
+     * uma query group-by em `transactions`. Tier 0 ADR 0093 — escopado em
+     * `business_id`; o `contact_id` vem da conversa (já do business atual).
+     * `total_paid` não existe no schema → subquery em `transaction_payments`
+     * (mesma expressão do painel Cliente). Contagem/LTV só de venda real
+     * (`status != 'draft'`); saldo só de `due`/`partial`.
+     *
+     * @return array{linked: bool, sells_count: int, ltv: float, saldo_aberto: float}
+     */
+    protected function buildCustomerContextPayload(int $businessId, ?int $contactId): array
+    {
+        if ($contactId === null) {
+            return ['linked' => false, 'sells_count' => 0, 'ltv' => 0.0, 'saldo_aberto' => 0.0];
+        }
+
+        // DB::table (não Eloquent) — agregado puro, sem hidratar Model nem global
+        // scope; o filtro Tier 0 é explícito aqui.
+        $row = \DB::table('transactions')
+            ->where('business_id', $businessId)
+            ->where('contact_id', $contactId)
+            ->where('type', 'sell')
+            ->selectRaw("
+                SUM(CASE WHEN status != 'draft' THEN 1 ELSE 0 END) AS sells_count,
+                SUM(CASE WHEN status != 'draft' THEN final_total ELSE 0 END) AS ltv,
+                SUM(CASE WHEN status != 'draft' AND payment_status IN ('due','partial')
+                    THEN (final_total - (SELECT COALESCE(SUM(tp.amount), 0) FROM transaction_payments tp WHERE tp.transaction_id = transactions.id))
+                    ELSE 0 END) AS saldo_aberto
+            ")
+            ->first();
+
+        return [
+            'linked' => true,
+            'sells_count' => (int) ($row?->sells_count ?? 0),
+            'ltv' => (float) ($row?->ltv ?? 0),
+            'saldo_aberto' => (float) ($row?->saldo_aberto ?? 0),
+        ];
     }
 
     /** Cache per-request do mapa slug => QueueConfig (evita reler DB nos payloads). */

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -44,7 +44,7 @@ beforeEach(function () {
     // activity_log, então desligar não enfraquece nenhuma checagem.
     config(['activitylog.enabled' => false]);
 
-    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates', 'whatsapp_queues', 'whatsapp_broadcasts', 'contacts'] as $t) {
+    foreach (['messages', 'channel_user_access', 'whatsapp_conversation_tags', 'whatsapp_tags', 'conversations', 'channels', 'users', 'whatsapp_templates', 'whatsapp_queues', 'whatsapp_broadcasts', 'contacts', 'transactions', 'transaction_payments'] as $t) {
         Schema::dropIfExists($t);
     }
 
@@ -70,6 +70,24 @@ beforeEach(function () {
         $table->string('mobile', 30)->nullable();
         $table->timestamp('whatsapp_opt_in_at')->nullable();
         $table->softDeletes();
+        $table->timestamps();
+    });
+
+    // Onda 3 — Saldo + Histórico (transactions UPOS + transaction_payments p/ saldo)
+    Schema::create('transactions', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('type', 20)->default('sell');
+        $table->string('status', 20)->default('final');
+        $table->string('payment_status', 20)->default('paid');
+        $table->decimal('final_total', 22, 4)->default(0);
+        $table->timestamps();
+    });
+    Schema::create('transaction_payments', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedBigInteger('transaction_id');
+        $table->decimal('amount', 22, 4)->default(0);
         $table->timestamps();
     });
 
@@ -910,4 +928,63 @@ it('R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL cana
     $convAlien = cuctMakeConv(99, $chAlien->id);
     expect(fn () => $ai->summarize(cuctPostRequest("/atendimento/inbox/{$convAlien->id}/ai/summarize"), $convAlien->id))
         ->toThrow(\Illuminate\Database\Eloquent\ModelNotFoundException::class);
+});
+
+// ============================================================================
+// 13. Onda 3 — customerContext (Saldo + Histórico) agregado do contact, Tier 0
+// ============================================================================
+
+it('R-WA-CAIXA-UNIF-013 — customerContext agrega Saldo+Histórico do contact (Tier 0) + fallback sem contact', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-013-uuid');
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    // Contact CRM do business 1
+    $contactId = (int) DB::table('contacts')->insertGetId([
+        'business_id' => 1, 'name' => 'Cliente A', 'created_at' => now(), 'updated_at' => now(),
+    ]);
+
+    // Conversa vinculada ao contact (contact_id)
+    $conv = cuctMakeConv(1, $ch->id);
+    $conv->forceFill(['contact_id' => $contactId])->save();
+
+    // Vendas do contact (business 1):
+    //  - final paga: final 1000 (conta no LTV, sem saldo)
+    //  - final due:  final 420, pago 100 → saldo 320
+    //  - draft due:  final 9999 → IGNORADA (status='draft' fora de count/ltv/saldo)
+    DB::table('transactions')->insert([
+        'business_id' => 1, 'contact_id' => $contactId, 'type' => 'sell', 'status' => 'final',
+        'payment_status' => 'paid', 'final_total' => 1000, 'created_at' => now(), 'updated_at' => now(),
+    ]);
+    $tDue = (int) DB::table('transactions')->insertGetId([
+        'business_id' => 1, 'contact_id' => $contactId, 'type' => 'sell', 'status' => 'final',
+        'payment_status' => 'due', 'final_total' => 420, 'created_at' => now(), 'updated_at' => now(),
+    ]);
+    DB::table('transactions')->insert([
+        'business_id' => 1, 'contact_id' => $contactId, 'type' => 'sell', 'status' => 'draft',
+        'payment_status' => 'due', 'final_total' => 9999, 'created_at' => now(), 'updated_at' => now(),
+    ]);
+    DB::table('transaction_payments')->insert([
+        'transaction_id' => $tDue, 'amount' => 100, 'created_at' => now(), 'updated_at' => now(),
+    ]);
+    // Tier 0 — venda do business 99 pro MESMO contact_id NÃO pode contar
+    DB::table('transactions')->insert([
+        'business_id' => 99, 'contact_id' => $contactId, 'type' => 'sell', 'status' => 'final',
+        'payment_status' => 'due', 'final_total' => 5000, 'created_at' => now(), 'updated_at' => now(),
+    ]);
+
+    $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest(['thread' => $conv->id]));
+
+    expect($props)->toHaveKey('customerContext');
+    $cc = $props['customerContext'];
+    expect($cc['linked'])->toBeTrue();
+    expect((int) $cc['sells_count'])->toBe(2);          // final paga + final due (draft fora)
+    expect((float) $cc['ltv'])->toBe(1420.0);           // 1000 + 420 (status != draft)
+    expect((float) $cc['saldo_aberto'])->toBe(320.0);   // due 420 − 100 pago; biz 99 fora (Tier 0)
+
+    // Fallback — conversa sem contact_id vinculado → linked false, zeros
+    $conv2 = cuctMakeConv(1, $ch->id);
+    $props2 = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest(['thread' => $conv2->id]));
+    expect($props2['customerContext']['linked'])->toBeFalse();
+    expect((int) $props2['customerContext']['sells_count'])->toBe(0);
+    expect((float) $props2['customerContext']['saldo_aberto'])->toBe(0.0);
 });

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 12
+charter_version: 13
 permissao: whatsapp.access
 ---
 
@@ -146,8 +146,12 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 3. **Canal · Conta** — short label + handle mono.
 4. **Tags** — chips coloridos quando há tags aplicadas.
 5. **OS vinculada** — placeholder (TODO US-WA-XXX: linkar Repair).
-6. **Saldo cliente** — placeholder (TODO US-WA-XXX: Financeiro).
-7. **Histórico** — placeholder (TODO US-WA-XXX: agregar Transactions).
+6. **Saldo cliente** — a receber em aberto do cliente (Onda 3, US-WA-308):
+   soma de `transactions` UPOS `due`/`partial` (status != draft, − pagamentos via
+   subquery `transaction_payments`). Tier 0 escopado por `business_id`.
+7. **Histórico** — pedidos + LTV (Onda 3, US-WA-308): count + `SUM(final_total)`
+   de sells reais (status != draft) por `contact_id`. Tier 0. Eager,
+   refresca no thread switch via `only:['customerContext']`.
 8. **Último contato** — relativeTimeBR do `last_message_at`.
 9. **Ações** — 3 botões (Emitir cobrança · Enviar arte · Ligar) — placeholders.
 

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -64,6 +64,7 @@ import type {
   ChannelCatalogItem,
   Paginated,
   QueueConfig,
+  CustomerContext,
 } from './_components/helpers';
 
 interface Props {
@@ -100,6 +101,7 @@ interface Props {
   q: string;
   thread: CaixaUnifThread | null;
   messages: CaixaUnifMessage[] | null;
+  customerContext: CustomerContext | null;
   centrifugoConfig: CentrifugoConfig | null;
   queues: Record<string, QueueConfig>;
   defaultQueue: string;
@@ -110,7 +112,7 @@ export default function CaixaUnificadaIndex({
   queuesAdmin, canManageQueues,
   businessId: _businessId,
   statusFilter, channelTypeFilter, accountFilter, queueFilter: _queueFilter, q,
-  thread, messages, centrifugoConfig,
+  thread, messages, customerContext, centrifugoConfig,
   queues, defaultQueue: _defaultQueue,
   within24h, unlinked, mediaInbound24h, inboundAging, orderBy, activeTagIds,
 }: Props) {
@@ -194,7 +196,7 @@ export default function CaixaUnificadaIndex({
       {
         preserveScroll: true,
         preserveState: true,
-        only: ['thread', 'messages'],
+        only: ['thread', 'messages', 'customerContext'],
       },
     );
   }
@@ -546,6 +548,7 @@ export default function CaixaUnificadaIndex({
           <Deferred data="availableChannels" fallback={null}>
             <ContextSidebarV4
               thread={thread}
+              customerContext={customerContext}
               channels={availableChannels ?? []}
               queues={queues}
               availableTags={availableTags ?? []}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -33,13 +33,16 @@ import type {
   ChannelCatalogItem,
   ConvTag,
   QueueConfig,
+  CustomerContext,
 } from './helpers';
-import { avatarHue, initials, relativeTimeBR } from './helpers';
+import { avatarHue, formatBRL, initials, relativeTimeBR } from './helpers';
 
 interface Props {
   thread: CaixaUnifThread;
   channels: ChannelCatalogItem[];
   queues: Record<string, QueueConfig>;
+  /** Onda 3 — contexto comercial do cliente (Saldo + Histórico). null = sem thread/contato. */
+  customerContext?: CustomerContext | null;
   /**
    * Wave 3 F1 (US-WA-095 paridade Inbox legacy): catálogo de tags do business
    * pro editor inline. Default [] quando deferred ainda não resolveu.
@@ -52,7 +55,7 @@ interface Props {
   availableAssignees?: AssigneeItem[];
 }
 
-export default function ContextSidebarV4({ thread, channels, queues, availableTags = [], availableAssignees = [] }: Props) {
+export default function ContextSidebarV4({ thread, customerContext, channels, queues, availableTags = [], availableAssignees = [] }: Props) {
   const channel = channels.find(c => c.id === thread.channel_type);
   const queueCfg = queues[thread.queue.slug] ?? null;
   const isPreview = thread.preview_only;
@@ -446,26 +449,38 @@ export default function ContextSidebarV4({ thread, channels, queues, availableTa
           {/* TODO US-WA-XXX: linkar Modules/Repair JobSheet via repair_jobsheet_id na conversa */}
         </div>
 
-        {/* 6. Saldo cliente — placeholder */}
+        {/* 6. Saldo cliente — Onda 3: a receber em aberto (transactions UPOS, due/partial) */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
           <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Saldo cliente
           </small>
-          <b className="text-[12.5px] font-medium text-muted-foreground italic">
-            —
-          </b>
-          {/* TODO US-WA-XXX: integrar Modules/Financeiro Titulo (sum tipo=receber) */}
+          {!customerContext?.linked ? (
+            <b className="text-[12.5px] font-medium text-muted-foreground italic" data-testid="caixa-unif-ctx-saldo">—</b>
+          ) : customerContext.saldo_aberto > 0 ? (
+            <b className="text-[12.5px] font-semibold text-destructive" data-testid="caixa-unif-ctx-saldo">
+              {formatBRL(customerContext.saldo_aberto)} a receber
+            </b>
+          ) : (
+            <b className="text-[12.5px] font-medium text-muted-foreground" data-testid="caixa-unif-ctx-saldo">
+              {formatBRL(0)} · em dia
+            </b>
+          )}
         </div>
 
-        {/* 7. Histórico — placeholder */}
+        {/* 7. Histórico — Onda 3: pedidos + LTV (transactions, status != draft) */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
           <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">
             Histórico
           </small>
-          <b className="text-[12.5px] font-medium text-muted-foreground italic">
-            —
-          </b>
-          {/* TODO US-WA-XXX: agregar Transaction.count + sum(final_total) por contact_id */}
+          {customerContext?.linked && customerContext.sells_count > 0 ? (
+            <b className="text-[12.5px] font-medium" data-testid="caixa-unif-ctx-historico">
+              {customerContext.sells_count} {customerContext.sells_count === 1 ? 'pedido' : 'pedidos'} · {formatBRL(customerContext.ltv)} LTV
+            </b>
+          ) : (
+            <b className="text-[12.5px] font-medium text-muted-foreground italic" data-testid="caixa-unif-ctx-historico">
+              {customerContext?.linked ? 'sem pedidos ainda' : '—'}
+            </b>
+          )}
         </div>
 
         {/* 8. Último contato */}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -393,6 +393,21 @@ export const SLA_META: Record<Exclude<SlaState, null>, { label: string; pill: st
   },
 };
 
+// Onda 3 — contexto comercial do cliente da conversa (Saldo + Histórico),
+// agregado server-side de `transactions` (CaixaUnificadaController). `linked`
+// false = conversa sem Contact CRM vinculado.
+export interface CustomerContext {
+  linked: boolean;
+  sells_count: number;
+  ltv: number;
+  saldo_aberto: number;
+}
+
+/** Formata BRL pt-BR sem centavos (valores agregados): 1420 → "R$ 1.420". */
+export function formatBRL(value: number): string {
+  return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL', maximumFractionDigits: 0 });
+}
+
 export function cuLsGet(key: string, fallback = ''): string {
   if (typeof window === 'undefined') return fallback;
   return localStorage.getItem(key) ?? fallback;


### PR DESCRIPTION
## Onda 3 — Saldo + Histórico (backend Tier 0)

Popula 2 sections que eram placeholder TODO na sidebar do Contexto, espelhando o protótipo Cowork (`R$ 380 a receber` · `4 pedidos · R$ 1.420 LTV`). **Pré-flight via agente `como-integrar`** → reusa o agregador canônico do painel Cliente (`ContactController`), sem duplicar nem inventar Service (LICOES_F3 §1).

### Backend (`CaixaUnificadaController`)
`buildCustomerContextPayload($businessId, ?$contactId)` → `{linked, sells_count, ltv, saldo_aberto}` — **uma query agregada** em `transactions` (`DB::table`, sem hidratar Model):
- `sells_count` + `ltv` = sells reais (`status != 'draft'`)
- `saldo_aberto` = `due`/`partial` (status != draft) − pagamentos (subquery `transaction_payments`, pois `total_paid` não é coluna)
- **Tier 0 ADR 0093**: `where business_id` + `contact_id` da conversa (já do business)

Prop **eager** `customerContext` (só quando thread aberta), refresca no thread-switch via `only:['customerContext']`, persiste no polling.

### Frontend
`ContextSidebarV4` sections 6/7 com `formatBRL` (pt-BR sem centavos); saldo>0 vermelho "a receber", 0 "em dia"; sem contato CRM → "—".

### Decisões [W]
- Fonte do saldo = **transactions UPOS** (= painel Cliente; não diverge durante a bridge)
- **OS vinculada PULADA** — não há vínculo conversa↔OS no schema; fica TODO honesto (decisão consciente, não M-AP-1)

### Teste
`R-WA-CAIXA-UNIF-013` (sqlite sintético): agrega 2 sells (draft fora) → LTV 1420, saldo 320 (−pagamento), **Tier 0** (biz 99 no mesmo contact NÃO conta) + fallback sem `contact_id`. Charter → v13.

Gates DS frontend verdes (layout/ds-canon/DS-GUARD). PHPStan/Pest no CI.

## Onda 2 — fechada (stripe já existia; botões + SLA mergeados). Onda 3 restante: OS vinculada (decisão de vínculo pendente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
