### PR TITLE
fix(financeiro): sub-nav segue a entry do active (corrige regressão split ADR 0180)

### DIFF
--- a/.github/workflows/fin-subnav-gate.yml
+++ b/.github/workflows/fin-subnav-gate.yml
@@ -1,0 +1,45 @@
+name: Fin SubNav Gate — abas por entry (anti-regressão ADR 0180 split)
+
+# Pós-ADR 0180 (2026-05-26) o grupo FINANÇAS virou 4 entries flat (Caixa / Cobrança /
+# Financeiro / Cobrança Recorrente). O FinanceiroSubNav fazia `.find(group === 'financas')`
+# → pegava SEMPRE a 1ª entry (Caixa), então /financeiro/unificado e Fluxo/DRE/Impostos/
+# Plano de Contas/Contas a Pagar/Cobrança mostravam as abas do CAIXA e não destacavam nada
+# (regressão silenciosa desde o split, detectada em prod 2026-06-16). `pickFinanceiroEntry`
+# agora escolhe a entry DONA do `active`. Este gate trava a volta da regressão.
+#
+# Path-scoped (faz npm ci): roda só quando o subnav, o helper, o spec ou este workflow mudam.
+# Comando manual local: npm run test:fin-subnav
+#
+# Refs: ADR 0180 (split FINANÇAS) · ADR 0258 (gate só vale se o controle-negativo roda no CI).
+
+on:
+  pull_request:
+    paths:
+      - 'resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx'
+      - 'resources/js/Pages/Financeiro/_shared/financeiroMenu.ts'
+      - 'tests/financeiroSubNav.spec.ts'
+      - '.github/workflows/fin-subnav-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx'
+      - 'resources/js/Pages/Financeiro/_shared/financeiroMenu.ts'
+      - 'tests/financeiroSubNav.spec.ts'
+
+concurrency:
+  group: fin-subnav-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fin-subnav:
+    name: Fin subnav · abas seguem a entry do active (não cair no Caixa)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - name: Install deps
+        run: npm ci
+      - name: pickFinanceiroEntry — regressão (vitest)
+        run: npm run test:fin-subnav

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "test:conformance": "vitest run tests/conformanceGate.spec.ts",
     "test:foundation-guard": "vitest run tests/foundationGuard.spec.ts",
     "test:fin-hero": "vitest run tests/finHeroLight.spec.ts",
+    "test:fin-subnav": "vitest run tests/financeiroSubNav.spec.ts",
     "test:adr-governance": "vitest run tests/governanceAdrScripts.spec.ts",
     "test:memory-health": "vitest run tests/memoryHealth.spec.ts",
     "test:casos-guard": "vitest run tests/casosGuard.spec.ts",

--- a/resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx
+++ b/resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx
@@ -1,9 +1,10 @@
 // FinanceiroSubNav (ADR 0180 Fase 5 — extraído como shared 2026-05-21)
 //
-// Lê primary/ghosts da entry "Financeiro" do shell.menu (Inertia shared prop
-// populado via LegacyMenuAdapter — Fase 4 piloto declarou attrs no
-// Modules/Financeiro/Http/Controllers/DataController). Renderiza ghost tabs
-// ARIA tablist abaixo do header `os-page-h` custom da tela.
+// Lê primary/ghosts da entry do grupo FINANÇAS DONA do `active` do shell.menu (Inertia
+// shared prop populado via LegacyMenuAdapter — Fase 4 piloto declarou attrs no
+// Modules/Financeiro/Http/Controllers/DataController). A seleção da entry vive em
+// ./financeiroMenu (pickFinanceiroEntry — pós-split ADR 0180 são 4 entries). Renderiza
+// ghost tabs ARIA tablist abaixo do header `os-page-h` custom da tela.
 //
 // Active prop = key do ghost atual (ex 'unificado' em Unificado/Index.tsx,
 // 'contas-receber' em ContasReceber/Index.tsx, etc). Fallback: nada renderiza
@@ -15,11 +16,8 @@
 // Caller pode passar `hidePrimary` pra renderizar o primary separadamente.
 
 import { usePage } from '@inertiajs/react';
-import PageHeaderTabs, {
-  type PageHeaderGhost,
-  type PageHeaderPrimary,
-  type PageHeaderOverflowItem,
-} from '@/Components/shared/PageHeaderTabs';
+import PageHeaderTabs, { type PageHeaderOverflowItem } from '@/Components/shared/PageHeaderTabs';
+import { pickFinanceiroEntry, type FinMenuEntry } from './financeiroMenu';
 
 export interface FinanceiroSubNavProps {
   active: string;
@@ -30,13 +28,9 @@ export interface FinanceiroSubNavProps {
 }
 
 export default function FinanceiroSubNav({ active, extraOverflowItems, hidePrimary }: FinanceiroSubNavProps) {
-  const sharedShell = (usePage().props as any)?.shell as {
-    menu?: Array<{ label: string; group?: string; primary?: PageHeaderPrimary; ghosts?: PageHeaderGhost[] }>;
-  } | undefined;
+  const sharedShell = (usePage().props as any)?.shell as { menu?: FinMenuEntry[] } | undefined;
 
-  const finItem = sharedShell?.menu?.find(
-    (m) => m.group === 'fin-op' || m.group === 'financas' || m.label?.toLowerCase() === 'financeiro',
-  );
+  const finItem = pickFinanceiroEntry(sharedShell?.menu, active);
 
   if (!finItem?.ghosts?.length) return null;
 

--- a/resources/js/Pages/Financeiro/_shared/financeiroMenu.ts
+++ b/resources/js/Pages/Financeiro/_shared/financeiroMenu.ts
@@ -1,0 +1,40 @@
+// Seleção da entry do grupo FINANÇAS pra montar o sub-nav do Financeiro.
+//
+// ADR 0180 (2026-05-26) dividiu o grupo FINANÇAS em 4 entries FLAT (Caixa / Cobrança /
+// Financeiro / Cobrança Recorrente), cada uma com seus próprios ghosts e keys ÚNICAS.
+// O `.find(group === 'financas')` antigo (em FinanceiroSubNav) pegava SEMPRE a 1ª entry
+// do grupo (Caixa) → toda página de Cobrança/Financeiro (Unificado, Fluxo, DRE, Impostos,
+// Plano de Contas, Contas a Pagar…) renderizava as abas do CAIXA e não destacava nada.
+// Regressão silenciosa desde o split (só as 4 telas do próprio Caixa funcionavam, por
+// sorte de ser a 1ª). Detectada em prod 2026-06-16 (WR2 Sistemas vs cache antigo do ROTA LIVRE).
+//
+// Módulo PURO (só `import type` → zero runtime React) pra ser testável direto:
+// tests/financeiroSubNav.spec.ts.
+
+import type { PageHeaderGhost, PageHeaderPrimary } from '@/Components/shared/PageHeaderTabs';
+
+export type FinMenuEntry = {
+  label: string;
+  group?: string;
+  primary?: PageHeaderPrimary;
+  ghosts?: PageHeaderGhost[];
+};
+
+/**
+ * Seleciona a entry DONA do `active` (a que tem um ghost com esse key — keys são únicas
+ * por entry pós-ADR 0180); fallback: a entry "Financeiro" (hub) e, por último, a 1ª do
+ * grupo FINANÇAS. Devolve `undefined` se não há entry de FINANÇAS (ex sem permissão).
+ */
+export function pickFinanceiroEntry(
+  menu: FinMenuEntry[] | undefined,
+  active: string,
+): FinMenuEntry | undefined {
+  const fin = (menu ?? []).filter(
+    (m) => m.group === 'fin-op' || m.group === 'financas' || m.label?.toLowerCase() === 'financeiro',
+  );
+  return (
+    fin.find((m) => m.ghosts?.some((g) => g.key === active)) ??
+    fin.find((m) => m.label?.toLowerCase() === 'financeiro') ??
+    fin[0]
+  );
+}

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -110,6 +110,10 @@
       "nome": "Fin Hero Gate — KPI hero claro (anti-regressão Onda 28)",
       "classe": "gate"
     },
+    "fin-subnav-gate.yml": {
+      "nome": "Fin SubNav Gate — abas seguem a entry do active (anti-regressão ADR 0180 split)",
+      "classe": "gate"
+    },
     "financeiro-pest.yml": {
       "nome": "Financeiro · Pest (MySQL)",
       "classe": "gate"

--- a/tests/financeiroSubNav.spec.ts
+++ b/tests/financeiroSubNav.spec.ts
@@ -1,0 +1,93 @@
+// Regressão — pickFinanceiroEntry escolhe a entry CERTA do grupo FINANÇAS por `active`.
+//
+// Bug (detectado em prod 2026-06-16, WR2 Sistemas): pós-ADR 0180 (26/mai) o grupo FINANÇAS
+// virou 4 entries flat. O FinanceiroSubNav fazia `.find(group === 'financas')` → pegava
+// SEMPRE a 1ª (Caixa). Resultado: /financeiro/unificado (e Fluxo/DRE/Impostos/Plano de
+// Contas/Contas a Pagar/Cobrança) mostrava as abas do CAIXA e não destacava nada. Só as
+// 4 telas do próprio Caixa funcionavam, por sorte de ser a 1ª. O fix seleciona a entry
+// DONA do `active` (keys são únicas por entry). Este teste FALHA se a regressão voltar.
+//
+// Fixture = shell.menu real lido ao vivo de prod (window.history.state.page.props.shell.menu).
+
+import { describe, it, expect } from 'vitest';
+import { pickFinanceiroEntry, type FinMenuEntry } from '@/Pages/Financeiro/_shared/financeiroMenu';
+
+const MENU: FinMenuEntry[] = [
+  {
+    label: 'Caixa',
+    group: 'financas',
+    ghosts: [
+      { key: 'caixa', label: 'Caixa', href: '/financeiro/caixa' },
+      { key: 'conciliacao', label: 'Conciliação', href: '/financeiro/conciliacao' },
+      { key: 'contas-bancarias', label: 'Contas Bancárias', href: '/financeiro/contas-bancarias' },
+      { key: 'extrato', label: 'Extrato', href: '/financeiro/extrato' },
+    ],
+  },
+  {
+    label: 'Cobrança',
+    group: 'financas',
+    ghosts: [
+      { key: 'cobranca', label: 'Cobrança', href: '/financeiro/cobranca' },
+      { key: 'contas-receber', label: 'Contas a Receber', href: '/financeiro/contas-receber' },
+      { key: 'gateway', label: 'Gateway', href: '/settings/payment-gateways' },
+    ],
+  },
+  {
+    label: 'Financeiro',
+    group: 'financas',
+    ghosts: [
+      { key: 'unificado', label: 'Lançamentos', href: '/financeiro/unificado' },
+      { key: 'contas-pagar', label: 'Contas a Pagar', href: '/financeiro/contas-pagar' },
+      { key: 'fluxo', label: 'Fluxo de Caixa', href: '/financeiro/fluxo' },
+      { key: 'dre', label: 'DRE', href: '/financeiro/dre' },
+      { key: 'impostos', label: 'Impostos', href: '/financeiro/impostos' },
+      { key: 'plano-contas', label: 'Plano de Contas', href: '/financeiro/plano-contas' },
+    ],
+  },
+  {
+    label: 'Cobrança Recorrente',
+    group: 'financas',
+    ghosts: [{ key: 'recurring-billing', label: 'Assinaturas', href: '/recurring-billing' }],
+  },
+];
+
+describe('pickFinanceiroEntry — regressão ADR 0180 split (não cair sempre no Caixa)', () => {
+  it('REGRESSÃO: active=unificado → entry "Financeiro" (hub), NÃO "Caixa"', () => {
+    const e = pickFinanceiroEntry(MENU, 'unificado');
+    expect(e?.label).toBe('Financeiro');
+    expect(e?.label).not.toBe('Caixa'); // o bug pegava o Caixa (1ª do grupo)
+    expect(e?.ghosts?.map((g) => g.key)).toEqual(
+      expect.arrayContaining(['unificado', 'fluxo', 'dre', 'impostos', 'plano-contas']),
+    );
+  });
+
+  it('cada página vai pra entry DONA do seu active key', () => {
+    expect(pickFinanceiroEntry(MENU, 'caixa')?.label).toBe('Caixa');
+    expect(pickFinanceiroEntry(MENU, 'conciliacao')?.label).toBe('Caixa');
+    expect(pickFinanceiroEntry(MENU, 'extrato')?.label).toBe('Caixa');
+    expect(pickFinanceiroEntry(MENU, 'cobranca')?.label).toBe('Cobrança');
+    expect(pickFinanceiroEntry(MENU, 'contas-receber')?.label).toBe('Cobrança');
+    expect(pickFinanceiroEntry(MENU, 'fluxo')?.label).toBe('Financeiro');
+    expect(pickFinanceiroEntry(MENU, 'dre')?.label).toBe('Financeiro');
+    expect(pickFinanceiroEntry(MENU, 'impostos')?.label).toBe('Financeiro');
+    expect(pickFinanceiroEntry(MENU, 'plano-contas')?.label).toBe('Financeiro');
+    expect(pickFinanceiroEntry(MENU, 'contas-pagar')?.label).toBe('Financeiro');
+  });
+
+  it('active desconhecido → fallback no hub "Financeiro"', () => {
+    expect(pickFinanceiroEntry(MENU, 'xpto-inexistente')?.label).toBe('Financeiro');
+  });
+
+  it('ignora entries de OUTROS grupos (não vaza pra Vendas/etc)', () => {
+    const noisy: FinMenuEntry[] = [
+      { label: 'Vendas', group: 'comercial', ghosts: [{ key: 'unificado', label: 'x', href: '/x' }] },
+      ...MENU,
+    ];
+    expect(pickFinanceiroEntry(noisy, 'unificado')?.label).toBe('Financeiro');
+  });
+
+  it('menu vazio/undefined → undefined (componente renderiza null)', () => {
+    expect(pickFinanceiroEntry([], 'unificado')).toBeUndefined();
+    expect(pickFinanceiroEntry(undefined, 'unificado')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## O bug (regressão silenciosa de ~3 semanas)

Diagnosticado **ao vivo em prod** (browser-MCP, business WR2 Sistemas em `oimpresso.com/financeiro/unificado`).

O ADR 0180 (26/mai) dividiu o grupo FINANÇAS do sidebar em **4 entries flat** — Caixa / Cobrança / Financeiro / Cobrança Recorrente — cada uma com seus próprios `ghosts` (abas) e keys únicas. Mas `FinanceiroSubNav` continuava fazendo:

```ts
sharedShell?.menu?.find((m) => m.group === 'financas' || ...)
```

`.find` devolve a **primeira** match → sempre a entry **Caixa**. Então toda página de Cobrança/Financeiro (`/financeiro/unificado`, Fluxo, DRE, Impostos, Plano de Contas, Contas a Pagar, Cobrança…) renderizava **as abas do Caixa** (Caixa/Conciliação/Contas Bancárias/Extrato) e **não destacava nada** (o `active` não existia entre os ghosts do Caixa). Só as 4 telas do próprio Caixa funcionavam — por sorte de ser a 1ª.

O print do ROTA LIVRE com as abas "ricas" (Cobrança/DRE/Impostos) era o **build cacheado pré-26/mai** — o "pegando de coisa antiga".

## O fix

`pickFinanceiroEntry(menu, active)` (módulo puro `financeiroMenu.ts`) seleciona a entry **dona do `active`** (a que tem um ghost com esse key — keys são únicas por entry), com fallback no hub "Financeiro" e depois na 1ª. Validado contra o `shell.menu` real lido ao vivo de prod:

| active | entry resolvida |
|---|---|
| `unificado`, `fluxo`, `dre`, `impostos`, `plano-contas`, `contas-pagar` | **Financeiro** (hub) ✅ |
| `caixa`, `conciliacao`, `extrato` | **Caixa** ✅ |
| `cobranca`, `contas-receber` | **Cobrança** ✅ |
| desconhecido | fallback **Financeiro** ✅ |

Corrige ~11 telas que estavam com as abas erradas.

## Gate

`tests/financeiroSubNav.spec.ts` (fixture = menu real de prod) + `fin-subnav-gate.yml` path-scoped, registrado no censo de gates (memory-health Check G). Trava a volta da regressão.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
