### PR TITLE
fix(caixa-unificada): wrapper flex-col alinha bolhas enviadas à direita

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -291,7 +291,11 @@ export default function ConversationThreadV4({
           messages.map((m, i) => {
             const showDay = i === 0 || dayGroupLabel(messages[i - 1]!.created_at) !== dayGroupLabel(m.created_at);
             return (
-              <div key={m.id}>
+              // Wrapper flex-col (canon Cowork `.om-msg-wrap`): sem pai flex o
+              // `self-start/self-end` + `ml-auto/mr-auto` da linha da bolha vira
+              // no-op e as enviadas (outbound) encostavam à esquerda junto das
+              // recebidas. Flex-col faz inbound→esquerda, outbound→direita.
+              <div key={m.id} className="flex flex-col">
                 {showDay && (
                   <div className="text-center my-3">
                     <span className="bg-card border rounded-full px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">


### PR DESCRIPTION
## Problema
Na Caixa Unificada, as bolhas de mensagem **enviadas** (verdes, \"Você\") encostavam à **esquerda** junto com as recebidas, em vez de irem pra **direita**. Confirmado ao vivo em prod (thread *BPO Financeiro · WP Assessoria*, biz WR2 Sistemas).

## Causa raiz
Cada mensagem da thread era envolvida por um `<div key={m.id}>` **block puro**. A linha da bolha usa `self-start`/`self-end` (+ `ml-auto`/`mr-auto`) pra alinhar — mas `align-self` e `margin:auto` **só funcionam com pai flex**. Sem isso, o alinhamento era no-op e tudo encostava à esquerda.

## Fix
Torna o wrapper de cada mensagem `flex flex-col` — exatamente o canon Cowork `.om-msg-wrap`:
```css
.om-msg-wrap { display: flex; flex-direction: column; align-items: flex-start; }
.om-msg-wrap:has(.om-bub.me) { align-items: flex-end; }
```
Resultado: inbound → esquerda · outbound → direita · bolha encolhe pro conteúdo. Diff de **1 linha** (+ comentário).

## Verificação
- ❌ Antes: confirmado bug em prod (screenshot da thread).
- ⏳ Pós-merge: smoke browser MCP na rota `/atendimento/caixa-unificada` (skill `tela-smoke-pos-merge`) — outbound deve renderizar à direita.

🤖 Generated with [Claude Code](https://claude.com/claude-code)