### PR TITLE
fix(caixa-unificada): wrapper da bolha usa primitivo Stack (catraca layout)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Check, CheckCheck, ClipboardCheck, FileDown, Presentation, Sparkles } from 'lucide-react';
 import { cn } from '@/Lib/utils';
+import { Stack } from '@/Components/layout';
 import {
   type CaixaUnifMessage,
   type CaixaUnifThread,
@@ -291,11 +292,12 @@ export default function ConversationThreadV4({
           messages.map((m, i) => {
             const showDay = i === 0 || dayGroupLabel(messages[i - 1]!.created_at) !== dayGroupLabel(m.created_at);
             return (
-              // Wrapper flex-col (canon Cowork `.om-msg-wrap`): sem pai flex o
-              // `self-start/self-end` + `ml-auto/mr-auto` da linha da bolha vira
-              // no-op e as enviadas (outbound) encostavam à esquerda junto das
-              // recebidas. Flex-col faz inbound→esquerda, outbound→direita.
-              <div key={m.id} className="flex flex-col">
+              // Stack (flex-col · primitivo DS ADR 0253 · canon Cowork `.om-msg-wrap`):
+              // sem pai flex o `self-start/self-end` + `ml-auto/mr-auto` da linha da
+              // bolha vira no-op e as enviadas (outbound) encostavam à esquerda junto
+              // das recebidas. Stack faz inbound→esquerda, outbound→direita.
+              // gap={0}: espaçamento vem do `gap-1` do container + `my-3` do dia.
+              <Stack key={m.id} gap={0}>
                 {showDay && (
                   <div className="text-center my-3">
                     <span className="bg-card border rounded-full px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
@@ -434,7 +436,7 @@ export default function ConversationThreadV4({
                   </div>
                   </div>
                 )}
-              </div>
+              </Stack>
             );
           })
         )}


### PR DESCRIPTION
Segue **[#2849](https://github.com/wagnerra23/oimpresso.com/pull/2849)** (alinhamento das bolhas, já em main).

Aquele PR usou `<div className=\"flex flex-col\">` cru, o que disparou (advisory) as catracas **Layout primitives · ratchet** (ADR 0253, flex/grid solto 6→7) e **module-grades-gate**. Como são advisory, mergeou — mas deixou a regressão no main.

Este PR troca pelo primitivo canônico `<Stack gap={0}>` (`@/Components/layout`): mesma semântica `flex flex-col`, conta como composição DS (não flex solto), zera a regressão. `gap={0}` preserva o espaçamento exato.

Guard local: `✅ Sem regressões vs baseline`. Sem mudança visual (Stack = flex-col).

🤖 Generated with [Claude Code](https://claude.com/claude-code)