### PR TITLE
fix(caixa-unificada): composer com botões discretos (fiel ao protótipo)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -606,7 +606,7 @@ export default function ComposerV4({
           disabled={!canType || suggesting}
           title="IA sugere a próxima resposta — você revisa antes de enviar"
           data-testid="caixa-unif-composer-suggest"
-          className="h-8 px-2.5 rounded-full border bg-card inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+          className="h-6 px-2 rounded-md border bg-card inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
         >
           {suggesting ? <Loader2 size={11} className="animate-spin" aria-hidden /> : <Sparkles size={11} aria-hidden />}
           Sugerir
@@ -620,8 +620,10 @@ export default function ComposerV4({
         title="Resposta cliente / Nota interna (⌘⇧N)"
         data-testid="caixa-unif-composer-toggle-mode"
         className={cn(
-          'h-8 px-3 rounded-full border text-[11px] font-semibold transition-colors flex-shrink-0',
-          !internalMode && 'bg-card border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground',
+          'h-6 px-2.5 rounded-md border text-[11px] font-semibold transition-colors flex-shrink-0',
+          !internalMode
+            ? 'bg-card border-border text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:border-muted-foreground'
+            : 'opacity-100',
         )}
         style={
           internalMode
@@ -645,7 +647,7 @@ export default function ComposerV4({
           ? `Templates do canal (${channelTemplates.length} ${channelTemplates.length === 1 ? 'disponível' : 'disponíveis'})`
           : 'Canal não suporta templates'}
         data-testid="caixa-unif-composer-templates"
-        className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+        className="w-6 h-6 rounded-md border bg-card grid place-items-center text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
       >
         <FileText size={12} aria-hidden />
       </button>
@@ -664,7 +666,7 @@ export default function ComposerV4({
             disabled={internalMode || !canType}
             title="Macros — atalhos / com ações (digite / no input pra autocomplete)"
             data-testid="caixa-unif-composer-macros"
-            className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+            className="w-6 h-6 rounded-md border bg-card grid place-items-center text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
           >
             <Slash size={12} aria-hidden />
           </button>
@@ -718,7 +720,7 @@ export default function ComposerV4({
               disabled={!canType}
               title="Inserir variável no texto ({{nome}}, {{telefone}}, {{operador}})"
               data-testid="caixa-unif-composer-vars"
-              className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+              className="w-6 h-6 rounded-md border bg-card grid place-items-center text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
             >
               <Braces size={12} aria-hidden />
             </button>
@@ -761,13 +763,14 @@ export default function ComposerV4({
         disabled={internalMode || !canType}
         title="Anexar imagem, PDF ou áudio"
         data-testid="caixa-unif-composer-attach"
-        className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+        className="w-6 h-6 rounded-md border bg-card grid place-items-center text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
       >
         <Paperclip size={12} aria-hidden />
       </button>
 
       {/* Wave 4-B F1 — MicRecorder (gravar áudio voz PTT) */}
       <MicRecorder
+        compact
         disabled={internalMode || !canType || uploading}
         onSend={handleSendVoice}
       />
@@ -780,7 +783,7 @@ export default function ComposerV4({
           disabled={internalMode || !canType}
           title="Enviar mensagem interativa (List/Button)"
           data-testid="caixa-unif-composer-interactive"
-          className="w-8 h-8 rounded-full border bg-card grid place-items-center text-muted-foreground hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
+          className="w-6 h-6 rounded-md border bg-card grid place-items-center text-muted-foreground opacity-70 hover:opacity-100 hover:text-foreground hover:bg-muted disabled:opacity-45 disabled:cursor-not-allowed flex-shrink-0"
         >
           <LayoutList size={12} aria-hidden />
         </button>

--- a/resources/js/Pages/Whatsapp/_components/MicRecorder.tsx
+++ b/resources/js/Pages/Whatsapp/_components/MicRecorder.tsx
@@ -34,11 +34,14 @@ interface Props {
    * Retornar Promise — quando resolve/reject, componente sai do uploading.
    */
   onSend: (blob: Blob, durationS: number) => Promise<void>;
+  /** Caixa Unificada V4 — botão idle discreto 24px alinhado aos demais do
+   *  composer (default false preserva o tamanho do Inbox legacy). */
+  compact?: boolean;
 }
 
 const MAX_DURATION_MS = 5 * 60 * 1000; // 5min — limite WhatsApp PTT
 
-export default function MicRecorder({ disabled, onSend }: Props) {
+export default function MicRecorder({ disabled, onSend, compact = false }: Props) {
   const [state, setState] = useState<'idle' | 'recording' | 'uploading'>('idle');
   const [elapsedMs, setElapsedMs] = useState(0);
   const [error, setError] = useState<string | null>(null);
@@ -255,14 +258,14 @@ export default function MicRecorder({ disabled, onSend }: Props) {
         size="sm"
         onClick={startRecording}
         disabled={disabled || state === 'uploading'}
-        className="h-8 px-2"
+        className={compact ? 'h-6 w-6 p-0 opacity-70 hover:opacity-100' : 'h-8 px-2'}
         title={disabled ? 'Indisponível neste modo' : 'Gravar áudio (max 5min)'}
         aria-label="Gravar áudio"
         data-testid="composer-mic-start"
       >
         {state === 'uploading'
-          ? <Loader2 size={14} className="animate-spin" aria-hidden />
-          : <Mic size={14} aria-hidden />}
+          ? <Loader2 size={compact ? 12 : 14} className="animate-spin" aria-hidden />
+          : <Mic size={compact ? 12 : 14} aria-hidden />}
       </Button>
       {error && (
         <span className="text-[10px] text-destructive max-w-[160px] truncate" title={error}>


### PR DESCRIPTION
Wagner pediu: os botões do composer deviam ser **bem pequenos**, fiéis ao protótipo (1 linha).

Hoje são círculos de **32px com borda e opacity total** — pesados, disputando espaço com o input. O protótipo Cowork (`.om-input` + regra "Composer — botões discretos") usa **24px, opacity 0.7 (hover 1), cantos suaves**.

**Mudança (só className/size, sem novo flex):**
- 7 botões próprios do `ComposerV4` (Sugerir/Resp/Templates/Macros/Variáveis/Anexar/Interactive): `w-6 h-6` · `rounded-md` · `opacity-70 hover:opacity-100`.
- `MicRecorder` (compartilhado c/ Inbox legacy): novo prop opcional `compact` (default `false` **não altera o legacy**) → botão idle 24px só na Caixa Unificada.
- Input e Enviar mantêm o tamanho — input domina, botões recuam.

> ⚠️ As catracas advisory **Layout primitives** e **module-grades** vão acusar `ConversationThreadV4.tsx 6→7` — isso é o `flex flex-col` do #2849 **ainda no main**, será zerado pelo #2850 (Stack). NÃO é desta mudança (que não toca aquele arquivo nem adiciona flex).

Verificação pós-deploy: smoke na rota `/atendimento/caixa-unificada`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)