### PR TITLE
fix(forja): fusão real — Jana não rouba /team-mcp/* (follow-up adversário)

### DIFF
--- a/Modules/Jana/Resources/menus/topnav.php
+++ b/Modules/Jana/Resources/menus/topnav.php
@@ -29,9 +29,11 @@ return [
         // Link cross-module aqui pra continuidade visual.
         ['label' => 'KB →',                               'href' => '/kb',                      'icon' => 'BookOpen',        'can' => 'jana.mcp.memory.manage'],
         ['label' => 'Qualidade IA',                       'href' => '/ia/admin/qualidade',  'icon' => 'TrendingUp',      'can' => 'jana.mcp.usage.all'],
-        // Team MCP saiu do Copiloto e virou módulo próprio (split TeamMcp).
-        // Mantém entry como atalho cross-module pra Wagner.
-        ['label' => 'Team MCP →',                         'href' => '/team-mcp/team',           'icon' => 'Users',           'can' => 'jana.mcp.usage.all'],
+        // Fusão Forja↔TeamMcp (2026-06-16): o cross-link "Team MCP →" foi REMOVIDO
+        // daqui porque o item /team-mcp/team roubava o match de /team-mcp/* no
+        // useAutoModuleNav (este topnav vem antes da Forja no Object.values),
+        // fazendo as telas absorvidas mostrarem o nav do Copiloto em vez do hub
+        // Forja. Agora o hub Forja (core_topnavs['Forja']) é dono de /team-mcp/*.
         ['label' => 'copiloto::copiloto.menu.plataforma', 'href' => '/ia/superadmin/metas', 'icon' => 'Building2',       'can' => 'jana.superadmin'],
     ],
 ];

--- a/Modules/TeamMcp/Http/Controllers/DataController.php
+++ b/Modules/TeamMcp/Http/Controllers/DataController.php
@@ -178,9 +178,9 @@ class DataController extends Controller
                             // /project-mgmt/{triage,inbox} (NÃO dobrar prefixo). Ao lado de My Work.
                             ['key' => 'board',       'label' => 'Board',       'href' => '/project-mgmt/board'],
                             ['key' => 'my-work',     'label' => 'My Work',     'href' => '/project-mgmt/my-work'],
-                            ['key' => 'triage',      'label' => 'Triagem',           'href' => '/project-mgmt/triage'],
+                            ['key' => 'triage',      'label' => 'Triagem (PM)',      'href' => '/project-mgmt/triage'],
                             ['key' => 'inbox',       'label' => 'Caixa de entrada',  'href' => '/project-mgmt/inbox'],
-                            ['key' => 'backlog',     'label' => 'Backlog',     'href' => '/project-mgmt/backlog'],
+                            ['key' => 'backlog',     'label' => 'Backlog (PM)',      'href' => '/project-mgmt/backlog'],
                             ['key' => 'activity',    'label' => 'Activity',    'href' => '/project-mgmt/activity'],
                             ['key' => 'burndown',    'label' => 'Burndown',    'href' => '/project-mgmt/burndown'],
                             ['key' => 'roadmap',     'label' => 'Roadmap',     'href' => '/project-mgmt/roadmap'],

--- a/config/core_topnavs.php
+++ b/config/core_topnavs.php
@@ -107,15 +107,15 @@ return [
             // (Resources/menus/topnav.php) foi removido, este é o ÚNICO que casa
             // /team-mcp/* no useAutoModuleNav — então a nav é a mesma em todo o hub.
             // badge=3 ESTÁTICO (sementes FORJA); contador vivo via `triagemCount` na aba.
-            ['label' => 'Triagem',     'href' => '/forja',                'icon' => 'Inbox',        'can' => 'copiloto.mcp.usage.all', 'badge' => 3],
-            ['label' => 'Backlog',     'href' => '/forja/backlog',        'icon' => 'List',         'can' => 'copiloto.mcp.usage.all'],
-            ['label' => 'Quadro',      'href' => '/forja/quadro',         'icon' => 'LayoutKanban', 'can' => 'copiloto.mcp.usage.all'],
-            ['label' => 'Changelog',   'href' => '/forja/changelog',      'icon' => 'History',      'can' => 'copiloto.mcp.usage.all'],
-            ['label' => 'MCP',         'href' => '/forja/mcp',            'icon' => 'Plug',         'can' => 'copiloto.mcp.usage.all'],
-            ['label' => 'Tarefas',     'href' => '/team-mcp/tasks',       'icon' => 'Columns',      'can' => 'copiloto.mcp.usage.all'],
-            ['label' => 'Equipe',      'href' => '/team-mcp/team',        'icon' => 'Users',        'can' => 'copiloto.mcp.usage.all'],
-            ['label' => 'CC Sessions', 'href' => '/team-mcp/cc-sessions', 'icon' => 'Code2',        'can' => 'copiloto.cc.read.team'],
-            ['label' => 'Saúde',       'href' => '/team-mcp/scorecard',   'icon' => 'Activity',     'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Triagem',     'href' => '/forja',                'icon' => 'Inbox',         'can' => 'copiloto.mcp.usage.all', 'badge' => 3],
+            ['label' => 'Backlog',     'href' => '/forja/backlog',        'icon' => 'List',          'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Quadro',      'href' => '/forja/quadro',         'icon' => 'KanbanSquare',  'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Changelog',   'href' => '/forja/changelog',      'icon' => 'GitBranch',     'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'MCP',         'href' => '/forja/mcp',            'icon' => 'ShieldCheck',   'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Tarefas',     'href' => '/team-mcp/tasks',       'icon' => 'ClipboardList', 'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'Equipe',      'href' => '/team-mcp/team',        'icon' => 'Users',         'can' => 'copiloto.mcp.usage.all'],
+            ['label' => 'CC Sessions', 'href' => '/team-mcp/cc-sessions', 'icon' => 'MessageSquare', 'can' => 'copiloto.cc.read.team'],
+            ['label' => 'Saúde',       'href' => '/team-mcp/scorecard',   'icon' => 'Activity',      'can' => 'copiloto.mcp.usage.all'],
         ],
     ],
 ];


### PR DESCRIPTION
Follow-up da fusão (#2853 mergeou antes destes fixes). Revisão **adversarial** pegou que a fusão estava **mascarada**:

- **B1 (bloqueante):** `Modules/Jana/Resources/menus/topnav.php` tinha item `/team-mcp/team` e vem ANTES da Forja no `useAutoModuleNav` → `/team-mcp/*` mostrava o nav do **Copiloto**, não o hub Forja. A concorrência que o Wagner reclamou **continuava**. Removido o cross-link → agora o hub Forja é dono de `/team-mcp/*`.
- **N1:** ícones do topnav fora do whitelist (`LayoutKanban/History/Plug/Columns/Code2` → invisíveis) → `KanbanSquare/GitBranch/ShieldCheck/ClipboardList/MessageSquare`.
- **N4:** ghosts da sidebar tinham 2×Triagem e 2×Backlog → relabel PM como "(PM)".

Validação obrigatória pós-merge: abrir `/team-mcp/tasks` e confirmar que o nav é o **hub Forja** (não "Equipe"/Copiloto).

Refs: FORJA fusão · revisão adversarial

🤖 Generated with [Claude Code](https://claude.com/claude-code)