### PR TITLE
refactor(forja): marca única 'Forja' — atalho sidebar + breadcrumbs

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -545,9 +545,11 @@ function SidebarShortcuts({
         </a>
       )}
       {showEquipe && (
-        <a href="/team-mcp/team" className="sb-shortcut">
+        // Fusão 2026-06-16: atalho topo é o hub ÚNICO "Forja" → /forja (cockpit
+        // do cowork loop que absorveu as telas do TeamMcp). Era "Equipe" → /team-mcp/team.
+        <a href="/forja" className="sb-shortcut">
           <Users size={13} />
-          <span className="label">Equipe</span>
+          <span className="label">Forja</span>
         </a>
       )}
       {showAtendimento && (

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -19,6 +19,7 @@ import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import PageHeader from '@/Components/shared/PageHeader';
+import ForjaHub from '@/Pages/team-mcp/Forja/_components/ForjaHub';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import EmptyState from '@/Components/shared/EmptyState';
@@ -152,6 +153,8 @@ function CcSessionsIndex({ sessions, filters, kpis, devs, projects, permissions 
 
   return (
     <>
+      <ForjaHub active="cc" />
+
       <PageHeader
         icon="code-2"
         title="Atividade CC"

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -319,7 +319,7 @@ function CcSessionsIndex({ sessions, filters, kpis, devs, projects, permissions 
 }
 
 CcSessionsIndex.layout = (page: ReactNode) => (
-  <AppShellV2 title="Atividade CC — Equipe" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Atividade CC' }]}>
+  <AppShellV2 title="CC Sessions — Forja" breadcrumbItems={[{ label: 'Forja' }, { label: 'CC Sessions' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/Forja/Cockpit.tsx
+++ b/resources/js/Pages/team-mcp/Forja/Cockpit.tsx
@@ -1,25 +1,18 @@
 // @memcofre
-//   tela: /forja (+ /forja/{backlog,quadro,changelog,mcp,saude})
-//   module: TeamMcp — cockpit Forja (cowork loop).
-//   forja: PR-A shell + Triagem REAL (esta PR). A aba Triagem projeta mcp_tasks
-//          project=FORJA em estado de triagem + dossiê lateral (reusa o padrão
-//          Analista de ProjectMgmt apontando pros endpoints /forja/*). As outras
-//          5 abas (backlog/quadro/changelog/mcp/saude) seguem placeholder (1 PR cada).
-//          visual-comparison aprovada (F1.5 ADR 0114):
-//          memory/requisitos/TeamMcp/forja-cockpit-visual-comparison.md
+//   tela: /forja (+ /forja/{backlog,quadro,changelog,mcp})
+//   module: TeamMcp — cockpit Forja (cowork loop · hub ÚNICO pós-fusão).
+//   forja: header vem do <ForjaHub> compartilhado (mesmo header em TODAS as abas,
+//          inclusive nas telas TeamMcp absorvidas). Eyebrow removido (Wagner 2026-06-16).
+//          Abas: Triagem/Backlog/Quadro/Changelog/MCP (próprias) + Tarefas/Equipe/
+//          CC Sessions/Saúde (telas ricas /team-mcp/* reusadas).
 //   permissao: copiloto.mcp.usage.all
 //
-// Projeta estado que JÁ existe (mcp_tasks + git/PR/ADR/sessão + gates) — sem dado
-// fantasma. As 6 rotas renderizam este shell com a aba ativa em `tab`; o topnav
-// de 6 abas vem de config/core_topnavs.php['Forja'] (useAutoModuleNav).
+// Projeta estado que JÁ existe (mcp_tasks + git/PR/ADR/sessão + gates) — sem dado fantasma.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { Deferred, Link } from '@inertiajs/react';
+import { Deferred } from '@inertiajs/react';
 import { type ReactNode } from 'react';
-import { Activity, Bell, Code2, Columns3, History, Inbox, LayoutGrid, List, Plug, Search, Users } from 'lucide-react';
-import { PageHeader } from '@/Components/PageHeader';
-import { PageHeaderPrimary } from '@/Components/PageHeader/PageHeaderPrimary';
-import { cn } from '@/Lib/utils';
+import ForjaHub from './_components/ForjaHub';
 import ForjaTriage, { type ForjaTicket } from './_components/ForjaTriage';
 import ForjaBacklog, { type BacklogTask } from './_components/ForjaBacklog';
 import ForjaQuadro, { type QuadroData } from './_components/ForjaQuadro';
@@ -36,8 +29,6 @@ interface Props {
   tabLabel: string;
   subtitle: string;
   meta: Meta;
-  // Props por aba — chegam via Inertia::defer só na aba ativa. Opcionais
-  // (undefined nas outras abas e no 1º paint — default-guard nos componentes).
   tickets?: ForjaTicket[];
   triagemCount?: number;
   backlog?: BacklogTask[];
@@ -45,36 +36,7 @@ interface Props {
   changelog?: ChangelogEntry[];
 }
 
-const COCKPIT_SUBTITLE =
-  'Cockpit do cowork loop — backlog, quadro F0→F4, changelog e atores (humano vs agente).';
-
-// Tab-strip in-page das 6 abas (contrato pixel). O module-nav nativo do AppShellV2
-// é dropdown no breadcrumb — não bate com a barra de abas do protótipo —, então a
-// faixa é renderizada aqui. Active por `tab`; Triagem mostra o contador vivo.
-const FORJA_TABS = [
-  { key: 'triagem',   label: 'Triagem',     href: '/forja',                icon: Inbox },
-  { key: 'backlog',   label: 'Backlog',     href: '/forja/backlog',        icon: List },
-  { key: 'quadro',    label: 'Quadro',      href: '/forja/quadro',         icon: LayoutGrid },
-  { key: 'changelog', label: 'Changelog',   href: '/forja/changelog',      icon: History },
-  { key: 'mcp',       label: 'MCP',         href: '/forja/mcp',            icon: Plug },
-  // Telas TeamMcp absorvidas (fusão 2026-06-16) — reusam as canônicas ricas.
-  { key: 'tarefas',   label: 'Tarefas',     href: '/team-mcp/tasks',       icon: Columns3 },
-  { key: 'equipe',    label: 'Equipe',      href: '/team-mcp/team',        icon: Users },
-  { key: 'cc',        label: 'CC Sessions', href: '/team-mcp/cc-sessions', icon: Code2 },
-  { key: 'saude',     label: 'Saúde',       href: '/team-mcp/scorecard',   icon: Activity },
-] as const;
-
-// Abre a command palette global (dona do AppShellV2, atalho ⌘K) sintetizando o
-// keydown que o shell escuta no window. Sem plumbing de estado novo no shell.
-function openCommandPalette() {
-  window.dispatchEvent(
-    new KeyboardEvent('keydown', { key: 'k', metaKey: true, ctrlKey: true, bubbles: true }),
-  );
-}
-
 function ForjaCockpit({ tab, subtitle, tickets, triagemCount, backlog, quadro, changelog }: Props) {
-  const sinoBadge = tab === 'triagem' ? triagemCount : undefined;
-
   const loading = (txt: string) => (
     <div className="mt-4 inline-flex w-full items-center justify-center rounded-lg border border-dashed py-16 text-sm text-muted-foreground">
       Carregando {txt}…
@@ -83,80 +45,7 @@ function ForjaCockpit({ tab, subtitle, tickets, triagemCount, backlog, quadro, c
 
   return (
     <>
-      {/* Eyebrow / breadcrumb (contrato pixel) */}
-      <p className="px-6 pt-4 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
-        Desenvolvimento · MCP · Projeção do git
-      </p>
-
-      <PageHeader
-        title="Forja"
-        subtitle={COCKPIT_SUBTITLE}
-        actions={
-          <>
-            {/* Sino com badge contador */}
-            <button
-              type="button"
-              aria-label="Notificações"
-              title="Notificações"
-              className="relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              data-testid="forja-sino"
-            >
-              <Bell size={16} />
-              {sinoBadge != null && sinoBadge > 0 && (
-                <span className="absolute -right-0.5 -top-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold tabular-nums text-primary-foreground">
-                  {sinoBadge}
-                </span>
-              )}
-            </button>
-
-            {/* Busca ⌘K — trigger do command palette global */}
-            <button
-              type="button"
-              onClick={openCommandPalette}
-              aria-label="Buscar (⌘K)"
-              title="Buscar (⌘K)"
-              className="inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
-              data-testid="forja-busca"
-            >
-              <Search size={14} />
-              <kbd className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">⌘K</kbd>
-            </button>
-
-            {/* Primária roxa "+ Novo issue" */}
-            <PageHeaderPrimary label="Novo issue" href="/forja" data-testid="forja-novo-issue" />
-          </>
-        }
-      />
-
-      {/* Faixa de 6 abas in-page (Triagem ativa + badge do contador vivo). */}
-      <nav className="mt-2 inline-flex w-full items-center gap-1 overflow-x-auto border-b px-6" data-testid="forja-tabs">
-        {FORJA_TABS.map((t) => {
-          const active = t.key === tab;
-          const Icon = t.icon;
-          const badge = t.key === 'triagem' ? triagemCount : undefined;
-          return (
-            <Link
-              key={t.key}
-              href={t.href}
-              aria-current={active ? 'page' : undefined}
-              className={cn(
-                '-mb-px inline-flex items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-2 text-xs font-medium transition-colors',
-                active
-                  ? 'border-primary text-primary'
-                  : 'border-transparent text-muted-foreground hover:text-foreground',
-              )}
-            >
-              <Icon size={14} />
-              {t.label}
-              {badge != null && badge > 0 && (
-                <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold tabular-nums text-primary-foreground">
-                  {badge}
-                </span>
-              )}
-            </Link>
-          );
-        })}
-      </nav>
+      <ForjaHub active={tab} triagemCount={triagemCount} />
 
       <section className="px-6 pt-4" data-testid={`forja-tab-${tab}`}>
         {/* Intro da aba (texto-âncora). Triagem renderiza o seu próprio; MCP tem banner. */}
@@ -191,10 +80,7 @@ function ForjaCockpit({ tab, subtitle, tickets, triagemCount, backlog, quadro, c
 }
 
 ForjaCockpit.layout = (page: ReactNode) => (
-  <AppShellV2
-    title="Forja — cockpit do cowork loop"
-    breadcrumbItems={[{ label: 'Desenvolvimento' }, { label: 'Forja' }]}
-  >
+  <AppShellV2 title="Forja — cockpit do cowork loop" breadcrumbItems={[{ label: 'Forja' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaHub.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaHub.tsx
@@ -1,0 +1,112 @@
+// ForjaHub — header ÚNICO do hub Forja, usado por TODAS as abas (cockpit /forja/*
+// + telas absorvidas /team-mcp/*) pra que o header seja IDÊNTICO em tudo:
+// título "Forja" + ações (sino/⌘K/Novo issue) + tab-strip de 9 abas.
+// SEM eyebrow (removido a pedido do Wagner 2026-06-16).
+//
+// Fonte única da tab-strip — antes vivia inline no Cockpit; extraída pra
+// reuso nas telas TeamMcp absorvidas (Equipe/Tarefas/CC Sessions/Saúde).
+
+import { Link } from '@inertiajs/react';
+import { Activity, Bell, Code2, Columns3, History, Inbox, LayoutGrid, List, Plug, Search, Users } from 'lucide-react';
+import { PageHeader } from '@/Components/PageHeader';
+import { PageHeaderPrimary } from '@/Components/PageHeader/PageHeaderPrimary';
+import { cn } from '@/Lib/utils';
+
+const COCKPIT_SUBTITLE =
+  'Cockpit do cowork loop — backlog, quadro F0→F4, changelog e atores (humano vs agente).';
+
+export const FORJA_TABS = [
+  { key: 'triagem',   label: 'Triagem',     href: '/forja',                icon: Inbox },
+  { key: 'backlog',   label: 'Backlog',     href: '/forja/backlog',        icon: List },
+  { key: 'quadro',    label: 'Quadro',      href: '/forja/quadro',         icon: LayoutGrid },
+  { key: 'changelog', label: 'Changelog',   href: '/forja/changelog',      icon: History },
+  { key: 'mcp',       label: 'MCP',         href: '/forja/mcp',            icon: Plug },
+  // Telas TeamMcp absorvidas (fusão) — reusam as canônicas ricas.
+  { key: 'tarefas',   label: 'Tarefas',     href: '/team-mcp/tasks',       icon: Columns3 },
+  { key: 'equipe',    label: 'Equipe',      href: '/team-mcp/team',        icon: Users },
+  { key: 'cc',        label: 'CC Sessions', href: '/team-mcp/cc-sessions', icon: Code2 },
+  { key: 'saude',     label: 'Saúde',       href: '/team-mcp/scorecard',   icon: Activity },
+] as const;
+
+// Abre a command palette global (dona do AppShellV2, atalho ⌘K) sintetizando o
+// keydown que o shell escuta no window.
+function openCommandPalette() {
+  window.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'k', metaKey: true, ctrlKey: true, bubbles: true }),
+  );
+}
+
+export default function ForjaHub({ active, triagemCount }: { active: string; triagemCount?: number }) {
+  const sinoBadge = active === 'triagem' ? triagemCount : undefined;
+
+  return (
+    <>
+      <PageHeader
+        title="Forja"
+        subtitle={COCKPIT_SUBTITLE}
+        actions={
+          <>
+            <button
+              type="button"
+              aria-label="Notificações"
+              title="Notificações"
+              className="relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              data-testid="forja-sino"
+            >
+              <Bell size={16} />
+              {sinoBadge != null && sinoBadge > 0 && (
+                <span className="absolute -right-0.5 -top-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold tabular-nums text-primary-foreground">
+                  {sinoBadge}
+                </span>
+              )}
+            </button>
+
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              aria-label="Buscar (⌘K)"
+              title="Buscar (⌘K)"
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              data-testid="forja-busca"
+            >
+              <Search size={14} />
+              <kbd className="rounded bg-muted px-1 py-0.5 font-mono text-[10px]">⌘K</kbd>
+            </button>
+
+            <PageHeaderPrimary label="Novo issue" href="/forja" data-testid="forja-novo-issue" />
+          </>
+        }
+      />
+
+      {/* Tab-strip de 9 abas — idêntica em todas as telas do hub. */}
+      <nav className="mt-2 inline-flex w-full items-center gap-1 overflow-x-auto border-b px-6" data-testid="forja-tabs">
+        {FORJA_TABS.map((t) => {
+          const isActive = t.key === active;
+          const Icon = t.icon;
+          const badge = t.key === 'triagem' ? triagemCount : undefined;
+          return (
+            <Link
+              key={t.key}
+              href={t.href}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                '-mb-px inline-flex items-center gap-1.5 whitespace-nowrap border-b-2 px-3 py-2 text-xs font-medium transition-colors',
+                isActive
+                  ? 'border-primary text-primary'
+                  : 'border-transparent text-muted-foreground hover:text-foreground',
+              )}
+            >
+              <Icon size={14} />
+              {t.label}
+              {badge != null && badge > 0 && (
+                <span className="ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold tabular-nums text-primary-foreground">
+                  {badge}
+                </span>
+              )}
+            </Link>
+          );
+        })}
+      </nav>
+    </>
+  );
+}

--- a/resources/js/Pages/team-mcp/Scorecard/Index.tsx
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.tsx
@@ -171,7 +171,7 @@ function ScorecardIndex({ facts, checks, meta }: Props) {
 }
 
 ScorecardIndex.layout = (page: ReactNode) => (
-  <AppShellV2 title="Saúde do MCP — Equipe" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Saúde' }]}>
+  <AppShellV2 title="Saúde — Forja" breadcrumbItems={[{ label: 'Forja' }, { label: 'Saúde' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/Scorecard/Index.tsx
+++ b/resources/js/Pages/team-mcp/Scorecard/Index.tsx
@@ -15,6 +15,7 @@ import { useEffect, type ReactNode } from 'react';
 import { AlertCircle, CheckCircle2, RefreshCw } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { PageHeader } from '@/Components/PageHeader';
+import ForjaHub from '@/Pages/team-mcp/Forja/_components/ForjaHub';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { cn } from '@/Lib/utils';
@@ -76,6 +77,7 @@ function ScorecardIndex({ facts, checks, meta }: Props) {
 
   return (
     <>
+      <ForjaHub active="saude" />
       <PageHeader
         title="Saúde do MCP"
         subtitle={`Facts + Checks · janela ${meta.period_days}d · fonte ${meta.source}`}

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -31,6 +31,7 @@ import BulkActionBar from '@/Components/shared/BulkActionBar';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Checkbox } from '@/Components/ui/checkbox';
 import { cn } from '@/Lib/utils';
+import ForjaHub from '@/Pages/team-mcp/Forja/_components/ForjaHub';
 import TaskDrawer from './_components/TaskDrawer';
 import { ActorSeal, PriorityDot, TaskStatusPill } from './_components/taskBadges';
 import { PRIO_LABEL, STATUS_ORDER, statusMeta, type Priority } from './_components/taskTokens';
@@ -364,6 +365,7 @@ function TasksIndex({
 
   return (
     <>
+      <ForjaHub active="tarefas" />
       <PageHeader
         icon="layout-kanban"
         title="Tasks"

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -646,7 +646,7 @@ function TasksIndex({
 }
 
 TasksIndex.layout = (page: ReactNode) => (
-  <AppShellV2 title="Tasks — Equipe" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Tasks' }]}>
+  <AppShellV2 title="Tarefas — Forja" breadcrumbItems={[{ label: 'Forja' }, { label: 'Tarefas' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -828,7 +828,7 @@ function QuotaForm({ user, onClose }: { user: TeamMember; onClose: () => void })
 }
 
 TeamIndex.layout = (page: ReactNode) => (
-  <AppShellV2 title="Time — Equipe (MCP)" breadcrumbItems={[{ label: 'Equipe' }, { label: 'Time' }]}>
+  <AppShellV2 title="Equipe — Forja" breadcrumbItems={[{ label: 'Forja' }, { label: 'Equipe' }]}>
     {page}
   </AppShellV2>
 );

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -31,6 +31,7 @@ import { Badge } from '@/Components/ui/badge';
 import { Checkbox } from '@/Components/ui/checkbox';
 import { BarChart3, ClipboardList, Package, Trash2 } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
+import ForjaHub from '@/Pages/team-mcp/Forja/_components/ForjaHub';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { toast } from 'sonner';
@@ -248,6 +249,7 @@ function TeamIndex(props: Props) {
 
   return (
     <>
+      <ForjaHub active="equipe" />
 
       <PageHeader
         icon="users"


### PR DESCRIPTION
Fecha a fusão visual: elimina o 'Equipe' que persistia hardcoded no front.

- Atalho sidebar 'Equipe'→'Forja' (→ /forja).
- Breadcrumbs das 4 telas absorvidas (Tasks/Team/CcSessions/Scorecard) → 'Forja'.

Com o B1 (topnav, já no main) + isto, é **'Forja' em todo lugar**: sidebar, topnav, breadcrumbs. Telas ricas intactas. eslint error em Sidebar.tsx:689 é pré-existente (baseline).

Refs: FORJA fusão

🤖 Generated with [Claude Code](https://claude.com/claude-code)