### PR TITLE
feat(caixa-unificada): Contexto recolhível (trilho 44px, canon Cowork)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -128,6 +128,16 @@ export default function CaixaUnificadaIndex({
   const [cheatOpen, setCheatOpen] = useState(false);
   // Polish V2 §5 — mobile tabs (<lg mostra 1 coluna por vez; desktop intacto)
   const [mobileView, setMobileView] = useState<MobileView>('list');
+  // Contexto recolhível (canon Cowork `.om-ctx`) — auto-recolhe < 1440px, lembra a escolha
+  const [ctxOpen, setCtxOpen] = useState(() => {
+    if (typeof window === 'undefined') return true;
+    const saved = localStorage.getItem('oimpresso.caixa-unif.ctx-open');
+    if (saved !== null) return saved === '1';
+    return window.innerWidth >= 1440;
+  });
+  useEffect(() => {
+    try { localStorage.setItem('oimpresso.caixa-unif.ctx-open', ctxOpen ? '1' : '0'); } catch { /* ignore */ }
+  }, [ctxOpen]);
 
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -436,7 +446,9 @@ export default function CaixaUnificadaIndex({
       />
 
       {/* Shell 3-col */}
-      <div className="flex-1 grid grid-cols-1 lg:grid-cols-[320px_1fr_300px] gap-0 min-h-0 overflow-hidden border rounded-md">
+      <div className={`flex-1 grid grid-cols-1 gap-0 min-h-0 overflow-hidden border rounded-md ${
+        thread ? (ctxOpen ? 'lg:grid-cols-[320px_1fr_300px]' : 'lg:grid-cols-[320px_1fr_44px]') : 'lg:grid-cols-[320px_1fr]'
+      }`}>
         {/* Lista esquerda — no mobile só aparece na tab Conversas */}
         <div className={mobileView === 'list' ? 'min-h-0 h-full' : 'min-h-0 h-full hidden lg:block'}>
         <Deferred
@@ -553,6 +565,8 @@ export default function CaixaUnificadaIndex({
               queues={queues}
               availableTags={availableTags ?? []}
               availableAssignees={availableAssignees ?? []}
+              open={ctxOpen}
+              onToggle={() => setCtxOpen((v) => !v)}
             />
           </Deferred>
           </div>

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -53,9 +53,12 @@ interface Props {
    * Default [] enquanto deferred não resolveu.
    */
   availableAssignees?: AssigneeItem[];
+  /** Caixa Unificada — Contexto recolhível (canon Cowork `.om-ctx`). */
+  open?: boolean;
+  onToggle?: () => void;
 }
 
-export default function ContextSidebarV4({ thread, customerContext, channels, queues, availableTags = [], availableAssignees = [] }: Props) {
+export default function ContextSidebarV4({ thread, customerContext, channels, queues, availableTags = [], availableAssignees = [], open = true, onToggle }: Props) {
   const channel = channels.find(c => c.id === thread.channel_type);
   const queueCfg = queues[thread.queue.slug] ?? null;
   const isPreview = thread.preview_only;
@@ -151,8 +154,42 @@ export default function ContextSidebarV4({ thread, customerContext, channels, qu
       className="flex flex-col bg-card border-l min-h-0 min-w-0"
       aria-label="Contexto da conversa"
     >
-      <div className="flex items-baseline gap-2 border-b px-3.5 pt-3 pb-2">
+      {/* Recolhido (canon Cowork `.om-ctx-expand`) — trilho 44px só no desktop;
+          no mobile a tab Contexto sempre mostra o painel cheio. */}
+      {!open && (
+        <button
+          type="button"
+          onClick={onToggle}
+          className="hidden lg:block w-full h-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+          title="Expandir contexto"
+          aria-label="Expandir contexto"
+          data-testid="caixa-unif-ctx-expand"
+        >
+          <Stack gap={2} align="center" justify="center" className="h-full py-3.5">
+            <span className="text-[15px] font-semibold leading-none" aria-hidden>‹</span>
+            <span
+              className="text-[10px] font-semibold uppercase tracking-[0.08em]"
+              style={{ writingMode: 'vertical-rl' }}
+            >
+              Contexto
+            </span>
+          </Stack>
+        </button>
+      )}
+
+      <Stack gap={0} className={`${open ? '' : 'lg:hidden'} flex-1 min-h-0 min-w-0`}>
+      <div className="flex items-center gap-2 border-b px-3.5 pt-3 pb-2">
         <b className="text-[13px] font-semibold text-foreground">Contexto</b>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="ml-auto hidden lg:block w-6 h-6 rounded-md border text-center text-[14px] leading-[20px] text-muted-foreground hover:text-foreground hover:border-muted-foreground transition-colors"
+          title="Recolher contexto"
+          aria-label="Recolher contexto"
+          data-testid="caixa-unif-ctx-toggle"
+        >
+          <span aria-hidden>›</span>
+        </button>
       </div>
 
       <div className="flex-1 overflow-auto px-4 py-3 flex flex-col gap-2.5">
@@ -574,6 +611,7 @@ export default function ContextSidebarV4({ thread, customerContext, channels, qu
           </button>
         </div>
       </div>
+      </Stack>
 
       {/* Wave 3-B F1 — Contact CRM picker modal (reusa legacy Pages/Whatsapp) */}
       <ContactPickerModal


### PR DESCRIPTION
Primeira área da varredura sistemática contra o **protótipo canônico** (Cowork export `oimpresso.com.html` → `inbox-page.jsx`/`inbox-page.css`, que o Wagner mandou implementar). Área **G — Contexto**.

O painel Contexto não tinha o **collapse do painel inteiro** que existe no protótipo (`.om-ctx` recolhível, `[W]: "colapsar? em tela pequena fica feio"`).

**Implementado (fiel ao canon):**
- Painel colapsa num **trilho de 44px** com "Contexto" na vertical (`writing-mode: vertical-rl`) + `‹` pra expandir / `›` pra recolher.
- **Auto-recolhe < 1440px** (igual `window.innerWidth >= 1440` do protótipo) e **lembra a escolha** em `localStorage` (`oimpresso.caixa-unif.ctx-open`).
- Grid do shell vira `320px 1fr 44px` quando recolhido (vs `320px 1fr 300px`).
- **Desktop-only** — no mobile a tab Contexto continua mostrando o painel cheio.
- Rail/wrapper via primitivo `Stack` (ADR 0253) → catraca layout `✅ sem regressão`.

Verificação pós-deploy: smoke na rota `/atendimento/caixa-unificada` (recolher/expandir + persistência).

🤖 Generated with [Claude Code](https://claude.com/claude-code)