### PR TITLE
fix(forja): tab-strip não colapsa nas telas absorvidas (shrink-0)

### DIFF
--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaHub.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaHub.tsx
@@ -78,8 +78,11 @@ export default function ForjaHub({ active, triagemCount }: { active: string; tri
         }
       />
 
-      {/* Tab-strip de 9 abas — idêntica em todas as telas do hub. */}
-      <nav className="mt-2 inline-flex w-full items-center gap-1 overflow-x-auto border-b px-6" data-testid="forja-tabs">
+      {/* Tab-strip de 9 abas — idêntica em todas as telas do hub.
+          shrink-0: o slot do AppShellV2 é flex-column de altura limitada; sem isto
+          o flex-shrink esmaga o nav (que tem overflow-x-auto) a ~3px nas telas
+          longas absorvidas (/team-mcp/*). Mantém o tab-strip sempre em altura cheia. */}
+      <nav className="mt-2 inline-flex w-full shrink-0 items-center gap-1 overflow-x-auto border-b px-6" data-testid="forja-tabs">
         {FORJA_TABS.map((t) => {
           const isActive = t.key === active;
           const Icon = t.icon;


### PR DESCRIPTION
## Problema
Nas telas absorvidas pelo hub Forja (`/team-mcp/{tasks,team,cc-sessions,scorecard}`) o tab-strip do `ForjaHub` colapsava a ~3px e sumia atrás do conteúdo. Causa: o slot do `AppShellV2` é uma flex-column de altura limitada e o `flex-shrink` esmagava o `<nav>` (que tem `overflow-x-auto`). No `/forja` (conteúdo curto) não ocorria.

## Fix
`shrink-0` no `<nav>` → tab-strip sempre em altura cheia (34px) em todas as abas.

## Verificação
Em produção via DOM: `flex-shrink:0` restaura nav a 34px e `navBottom == tasksTop` (sem sobreposição). Screenshot pós-deploy.

Refs: FORJA header único (pós #2857)