### PR TITLE
docs(handoff): §16 Integridade do handoff — lei do handoff (5 regras)

### DIFF
--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -949,3 +949,23 @@ Continuação da entrada Q1 acima (mesma sessão). Validação §10.4 contra mai
 - **golden (FA-5)**: F3 de protótipo Cowork = SEMPRE mapear token Cowork→live ANTES de colar CSS. O gabarito FA-5 referenciava `--text-2/--sunken/--pos-soft/--hairline` (vocabulário do protótipo) que não existe no live; e cor semântica no drawer vai por Tailwind `@theme`, não `var(--pos)` (o drawer é portal FORA de `.cockpit`, onde `--pos` de cockpit.css mora). Sintoma se ignorado: CSS "verde" que renderiza INCOLOR (var indefinida = sem cor). Resolve: tokens neutros do escopo `.fin-cowork` + Fundação (`--sh-2/--ease/--fs-*`); semântico via classe utilitária.
 - **gotcha (FA-5)**: colisão de atalho `R` — `R` era global "novo recebimento"; o 9.75 quer `R`=liquida no drawer. Resolvido por PRECEDÊNCIA (drawer aberto + título liquidável → `openBaixa`; senão cai no novo-lançamento). Mesmo guard de foco (INPUT/TEXTAREA/SELECT/contentEditable + meta/ctrl/alt).
 - **gotcha (FA-5)**: inline-edit (R2 KVEdit) precisa de rota de save POR CAMPO — `Canal` não tem (`UpdateTituloRequest` só aceita categoria_id/plano/venc/valor/forma/conta). Deferido em vez de inventar PATCH (T-AP-10). Regra: KVEdit inline só onde o campo já tem rota de update provada.
+
+---
+
+## 2026-06-16 [CL] → [W] — Integridade do handoff (TAREFA 2) · TAREFA 1 pulada (premissa stale)
+
+**Origem:** prompt colado [W]/Cowork (2 tarefas). Gate §10.4 contra `origin/main` fresco ANTES de codar mudou tudo. Worktree dedicado off `origin/main` (`D:/oimpresso-handoff`), 1 PR por onda.
+
+### TAREFA 1 — migrar headers `os-page-h` inline → `<PageHeader>`: **NÃO FEITO** ([W] confirmou "pular")
+Onda 0 (inventário) revelou que o pedido confundia 2 coisas distintas:
+- `os-page-h`/`fin-page-h` = **CSS canon** do bundle Cowork (Tier 0 `feedback-cowork-bundle-aplicar-inteiro`), **não** alvo de migração.
+- `@/Components/shared/PageHeader` = o **componente** que o `pageheader:guard` ratcheteia (104 baseline) — **verde**, não toca essas telas.
+
+Estado real no `main`: **Dre** e **ContasPagar** já migrados pra `<PageHeader>` (Wave 4, 25/mai) — "pendente" no prompt era **ref morta** (a doença que a TAREFA 2 cura). **Unificado** charter v15 (10/jun) re-afirma `os-page-h` como "Markup canon EXATO" + hero "3 lentes" aprovado [W]; **Dashboard** foi DELIBERADAMENTE movido PRA `os-page-h` (19/mai, "paridade Unificado"). Migrar = regressão Tier 0 charter-protegida. [W] decidiu **pular**. Caixa Unificada dark + H1 600×700 não tocados (já no main / espera [W]).
+
+### TAREFA 2 — gate de integridade do handoff: **FEITO** (2 ondas, 1 PR cada)
+A fila `COWORK_NOTES.md` apodrecia invisível (refs mortas pra `PROMPT_PARA_CODE_*` inexistentes + prompts órfãos) e nada travava.
+- **Onda 1 — regra (doc):** PR **#2864** — `PROCESSO_MEMORIA_CC.md` §16 (5 regras: sem órfão · auto-contido · linha d'água · "pousou" só pós-`main` · ondas) + IT8.
+- **Onda 2 — gate (CI):** PR **#2865** — `scripts/handoff-integrity-guard.mjs` (catraca acima da linha d'água `<!-- LINHA-DAGUA-HANDOFF -->`) + auto-teste controle-negativo (8 casos: órfão/ref-morta injetados → vermelho) + baseline 0/0 + workflow advisory (ADR 0271/0275, `paths:` na fila + dir handoffs) + npm scripts. **Home confirmado antes (Regra 7):** `cowork-inbox.py` é mover-de-conteúdo (não validador) → estendi a família `*-guard.mjs`, não dupliquei.
+
+**Status:** PRs **#2864** + **#2865** abertos, **aguardando merge [W]** (publication-policy). "Pousou" só vira `PROCESSADO → main` quando estiver no `main` (regra §16.4 deste próprio PR). Se a §16 virar ADR formal = Tier 0 = número é [W] (não cunhei).

--- a/prototipo-ui/PROCESSO_MEMORIA_CC.md
+++ b/prototipo-ui/PROCESSO_MEMORIA_CC.md
@@ -279,11 +279,27 @@ O processo sobrevive só enquanto for **lido, medido e auto-corrigido**. Invaria
 | IT5 | Benchmark (§11) tem linha da última sessão | sem medição (Sobrevivência #1) |
 | IT6 | DS-GUARD limpo nos arquivos canônicos do DS | DS contaminado |
 | IT7 | Nenhum doc referenciado na espinha que não exista (link morto) | rastro quebrado |
+| IT8 | Fila ativa ↔ prompts de handoff consistentes (§16 · gate `handoff:check`) | tarefa invisível / PR errado |
 
 **Veredito:** qualquer IT falho → estrutura **comprometida**: parar e consertar antes de evoluir (vira Reestruturação §12 se reincidir).
 
-## 16. Trilha do tempo
+## 16. Integridade do handoff (fila ↔ prompts)
+
+> Por que existe: a fila ([`COWORK_NOTES.md`](COWORK_NOTES.md) → acima da linha d'água) apodrece de dois jeitos que ninguém vê na hora — **prompt citado que não existe mais** (link morto → [CL] erra o PR, faz a coisa errada) e **prompt criado que nunca entrou na fila** (tarefa invisível → nunca pousa). Memória manda no git; git é SSOT (ADR 0239) — então a fila e os `PROMPT_PARA_CODE_*.md` têm que casar. Defesa que dispara > regra que se lê (§5/NÚCLEO-5): a regra abaixo é a lei; o gate `handoff:check` é o dente.
+
+**As 5 regras (lei do handoff):**
+
+1. **Sem prompt órfão.** Criar um `PROMPT_PARA_CODE_<slug>.md` e **não** citá-lo na fila ativa = proibido. Prompt que existe no dir mas ninguém aponta = tarefa invisível (🔴 ÓRFÃO). Criou → cita na fila no mesmo passo.
+2. **Prompt durável é auto-contido.** O corpo não depende de URL efêmera (`claudeusercontent.com`/Cowork share expiram ~1h — L-09/§10.1). Todo contexto necessário pra executar mora no próprio arquivo, versionado no git. URL no corpo = só conveniência, nunca a fonte.
+3. **Linha d'água separa ativo de processado.** O marcador `<!-- LINHA-DAGUA-HANDOFF -->` em `COWORK_NOTES.md` corta a fila: **acima = ativo** (o gate vigia; toda referência tem que casar) · **abaixo = processado/histórico** (ignorado — append-only, não se mexe). Item que pousou **desce** pra baixo da linha; não some, vira histórico.
+4. **"Pousou" só depois do `main` confirmar.** Não declaro entregue/processado por ter aberto PR ou commitado (L-06: não afirmo commit). Um handoff só vira "processado" quando o retorno em [`CODE_NOTES.md`](CODE_NOTES.md) **no `main`** registra `PROCESSADO → main` (PR mergeado). Antes disso continua **ativo, acima da linha**.
+5. **Ondas por padrão.** 1 tela/arquivo = 1 PR (commit-discipline · 1 PR = 1 intent). Validar contra `origin/main` fresco **antes** de codar (Passo 0 · PROTOCOL §10.4) — se já está no main, não refaz.
+
+**Mecanização (catraca · §5/§13):** [`scripts/handoff-integrity-guard.mjs`](../scripts/handoff-integrity-guard.mjs) lê a fila acima da linha d'água + os `PROMPT_PARA_CODE_*.md` do dir e falha em **NOVO** órfão ou **NOVA** ref morta. Baseline (`config/handoff-integrity-baseline.json`) congela a dívida atual — só o que entra novo trava. Auto-teste de controle-negativo prova que o dente morde (órfão injetado → vermelho; tudo citado → verde). Workflow advisory de nascença (ADR 0271/0275). Rodar: `npm run handoff:check`.
+
+## 17. Trilha do tempo
 - 2026-06-02 · [CC] criou a raiz do processo. Rodou TESTE-01..04, achou 3 fraquezas, corrigiu 2 estruturalmente (§3, §5) e mitigou 1 (§4/§7). Modelo validado com a condição da §7.
 - 2026-06-02 · **1ª passada real (TESTE-05):** D-01 rodado Avaliar→Testar em produção; ciclo segurou ponta-a-ponta (nota 8.5). Regra de corte §6×Register adicionada. D-01 está 🧪 aguardando veredito [W].
 - 2026-06-02 · **DS-GUARD (TESTE-06):** check mecânico criado (§8) — pega L-02/L-21/L-23 nos arquivos tocados, sem depender de memória. Achou 2 fraquezas no próprio guard (ruído árvore-inteira + skip silencioso), corrigiu as duas. Defesa migrou de FRACA→FORTE. Gate visual entrou na Regra de Ouro do STATUS.
 - 2026-06-02 · **Bateria de Testes de Evolução (§9) + Manual de Evolução (§10):** regressão contra L-01…L-23 (cobertura conhecimento ~9.5, execução ~6 → confiança composta 7.5). 14 testes (5 duros), cobrindo todos os erros cometidos. Pendente pra subir a confiança: hooks auto (Cowork CI), construir guards propostos (L-07/11/14/21/22), changed-files automático, verificador rodando DS-GUARD sempre.
+- 2026-06-16 · **§16 Integridade do handoff (Onda 1):** lei do handoff escrita (5 regras: sem órfão · prompt auto-contido · linha d'água · "pousou" só pós-`main` · ondas) + IT8. Origem: fila `COWORK_NOTES.md` apodreceu (refs mortas pra `PROMPT_PARA_CODE_*` inexistentes + prompts nunca citados). Onda 2 mecaniza via `handoff:check` (catraca + baseline + auto-teste controle-negativo).


### PR DESCRIPTION
## TAREFA 2 · Onda 1 (regra/doc — mergeável autônomo)

Encode a **lei do handoff** em `prototipo-ui/PROCESSO_MEMORIA_CC.md` §16 — a fila `COWORK_NOTES.md` apodrece de 2 jeitos invisíveis e nada trava isso hoje:
- **ref morta** — prompt citado que não existe mais → [CL] erra o PR;
- **órfão** — `PROMPT_PARA_CODE_*.md` criado que nunca entrou na fila → tarefa invisível.

### As 5 regras
1. **Sem órfão** — criar prompt sem citá-lo na fila ativa = proibido.
2. **Auto-contido** — prompt durável não depende de URL efêmera (Cowork/`claudeusercontent` expiram ~1h; git é SSOT, ADR 0239).
3. **Linha d'água** — marcador `<!-- LINHA-DAGUA-HANDOFF -->` separa **ativo (acima)** de **processado (abaixo, ignorado)**.
4. **"Pousou" só pós-`main`** — só vira processado quando `CODE_NOTES.md@main` registra `PROCESSADO → main` (não basta abrir PR — L-06).
5. **Ondas por padrão** — 1 tela/arquivo = 1 PR, validando contra `origin/main` fresco antes de codar (Passo 0 · §10.4).

`+ IT8` na §15 (Testes de Integridade) apontando pro gate.

### Escopo
Doc apenas (1 arquivo, +17/−1). **Onda 2** (PR separado) mecaniza via `scripts/handoff-integrity-guard.mjs` + baseline + auto-teste controle-negativo + workflow advisory.

> Nota: a numeração da "Trilha do tempo" virou §17 (era §16) — sem refs externas por número (verificado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
