### PR TITLE
feat(handoff): + C3 (cabeçalho fundido) na catraca de integridade do handoff

### DIFF
--- a/config/handoff-integrity-baseline.json
+++ b/config/handoff-integrity-baseline.json
@@ -1,10 +1,12 @@
 {
   "_meta": {
-    "generated_at": "2026-06-16T20:57:23.126Z",
+    "generated_at": "2026-06-16T21:25:36.000Z",
     "orphans": 0,
     "dead_refs": 0,
-    "note": "Integridade do handoff (PROCESSO_MEMORIA_CC.md §16 · IT8). Congela a dívida atual de órfãos/refs-mortas acima da linha d'água em COWORK_NOTES.md. Só NOVO trava. Marcador: LINHA-DAGUA-HANDOFF."
+    "fused_headers": 0,
+    "note": "Integridade do handoff (PROCESSO_MEMORIA_CC.md §16 · IT8). Congela a dívida atual de órfãos/refs-mortas/cabeçalhos-fundidos acima da linha d'água em COWORK_NOTES.md + prompts. Só NOVO trava. Marcador: LINHA-DAGUA-HANDOFF."
   },
   "orphans": [],
-  "dead_refs": []
+  "dead_refs": [],
+  "fused_headers": []
 }

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -969,3 +969,20 @@ A fila `COWORK_NOTES.md` apodrecia invisível (refs mortas pra `PROMPT_PARA_CODE
 - **Onda 2 — gate (CI):** PR **#2865** — `scripts/handoff-integrity-guard.mjs` (catraca acima da linha d'água `<!-- LINHA-DAGUA-HANDOFF -->`) + auto-teste controle-negativo (8 casos: órfão/ref-morta injetados → vermelho) + baseline 0/0 + workflow advisory (ADR 0271/0275, `paths:` na fila + dir handoffs) + npm scripts. **Home confirmado antes (Regra 7):** `cowork-inbox.py` é mover-de-conteúdo (não validador) → estendi a família `*-guard.mjs`, não dupliquei.
 
 **Status:** PRs **#2864** + **#2865** abertos, **aguardando merge [W]** (publication-policy). "Pousou" só vira `PROCESSADO → main` quando estiver no `main` (regra §16.4 deste próprio PR). Se a §16 virar ADR formal = Tier 0 = número é [W] (não cunhei).
+
+---
+
+## TAREFA 2 — C3 salvage (extensão do guard do main) — PR #2869
+_handoff 2026-06-16 · [CL] · verificado vs main @f17072b86 · reconcilia colisão de sessões paralelas_
+
+Uma sessão paralela mergeou #2864 (§16) + #2865 (handoff-integrity-guard = C4 órfão/ref-morta) DURANTE a minha. Fechei minhas duplicatas (#2866 §16, #2868 guard) e salvei só o **C3** (único valor único), **estendendo** o guard do main — não paralelo (Regra 7).
+
+| item | veredito | prova |
+|---|---|---|
+| C3 no `handoff-integrity-guard.mjs` | `:** > **` na fila ativa + `PROMPT_PARA_CODE_*`; baseline `fused_headers` (0); abaixo-da-linha ignorado | self-test 18/18 |
+| §16 6ª regra "Sem cabeçalho fundido" | doc + nota de mecanização atualizadas | `integrity-check` §15 verde |
+| C4/C5 | C4 já do #2865 (não dupliquei); C5 vs-main não-mecanizável (fila Cowork-only) | — |
+
+### new_design_memories
+- **golden**: re-validar `origin/main` ANTES de cada novo intent, não só no início — a sessão paralela mergeou o mesmo trabalho no meio da minha. Fechei a duplicata e salvei só o delta (C3), estendendo o canon.
+- **gotcha**: a paralela alegou "Dashboard charter-protegido" pra pular TAREFA 1 — FALSO (não há charter). Conclusão de skip ≠ fato; conferir o disco antes de pular.

--- a/prototipo-ui/PROCESSO_MEMORIA_CC.md
+++ b/prototipo-ui/PROCESSO_MEMORIA_CC.md
@@ -287,15 +287,16 @@ O processo sobrevive só enquanto for **lido, medido e auto-corrigido**. Invaria
 
 > Por que existe: a fila ([`COWORK_NOTES.md`](COWORK_NOTES.md) → acima da linha d'água) apodrece de dois jeitos que ninguém vê na hora — **prompt citado que não existe mais** (link morto → [CL] erra o PR, faz a coisa errada) e **prompt criado que nunca entrou na fila** (tarefa invisível → nunca pousa). Memória manda no git; git é SSOT (ADR 0239) — então a fila e os `PROMPT_PARA_CODE_*.md` têm que casar. Defesa que dispara > regra que se lê (§5/NÚCLEO-5): a regra abaixo é a lei; o gate `handoff:check` é o dente.
 
-**As 5 regras (lei do handoff):**
+**As 6 regras (lei do handoff):**
 
 1. **Sem prompt órfão.** Criar um `PROMPT_PARA_CODE_<slug>.md` e **não** citá-lo na fila ativa = proibido. Prompt que existe no dir mas ninguém aponta = tarefa invisível (🔴 ÓRFÃO). Criou → cita na fila no mesmo passo.
 2. **Prompt durável é auto-contido.** O corpo não depende de URL efêmera (`claudeusercontent.com`/Cowork share expiram ~1h — L-09/§10.1). Todo contexto necessário pra executar mora no próprio arquivo, versionado no git. URL no corpo = só conveniência, nunca a fonte.
 3. **Linha d'água separa ativo de processado.** O marcador `<!-- LINHA-DAGUA-HANDOFF -->` em `COWORK_NOTES.md` corta a fila: **acima = ativo** (o gate vigia; toda referência tem que casar) · **abaixo = processado/histórico** (ignorado — append-only, não se mexe). Item que pousou **desce** pra baixo da linha; não some, vira histórico.
 4. **"Pousou" só depois do `main` confirmar.** Não declaro entregue/processado por ter aberto PR ou commitado (L-06: não afirmo commit). Um handoff só vira "processado" quando o retorno em [`CODE_NOTES.md`](CODE_NOTES.md) **no `main`** registra `PROCESSADO → main` (PR mergeado). Antes disso continua **ativo, acima da linha**.
 5. **Ondas por padrão.** 1 tela/arquivo = 1 PR (commit-discipline · 1 PR = 1 intent). Validar contra `origin/main` fresco **antes** de codar (Passo 0 · PROTOCOL §10.4) — se já está no main, não refaz.
+6. **Sem cabeçalho fundido.** Uma edição não pode fundir dois blocos numa linha só — `**…:** > **Outro:**` (heurística `:** > **`) deixa a fila/prompt ilegível (classe **C3**). Cada bloco na sua linha; quem funde, o gate recusa.
 
-**Mecanização (catraca · §5/§13):** [`scripts/handoff-integrity-guard.mjs`](../scripts/handoff-integrity-guard.mjs) lê a fila acima da linha d'água + os `PROMPT_PARA_CODE_*.md` do dir e falha em **NOVO** órfão ou **NOVA** ref morta. Baseline (`config/handoff-integrity-baseline.json`) congela a dívida atual — só o que entra novo trava. Auto-teste de controle-negativo prova que o dente morde (órfão injetado → vermelho; tudo citado → verde). Workflow advisory de nascença (ADR 0271/0275). Rodar: `npm run handoff:check`.
+**Mecanização (catraca · §5/§13):** [`scripts/handoff-integrity-guard.mjs`](../scripts/handoff-integrity-guard.mjs) lê a fila acima da linha d'água + os `PROMPT_PARA_CODE_*.md` do dir e falha em **NOVO** órfão, **NOVA** ref morta ou **NOVO** cabeçalho fundido (`:** > **` · C3). Baseline (`config/handoff-integrity-baseline.json`) congela a dívida atual — só o que entra novo trava. Auto-teste de controle-negativo prova que o dente morde (órfão/ref-morta/fundido injetado → vermelho; tudo limpo → verde). Workflow advisory de nascença (ADR 0271/0275). Rodar: `npm run handoff:check`.
 
 ## 17. Trilha do tempo
 - 2026-06-02 · [CC] criou a raiz do processo. Rodou TESTE-01..04, achou 3 fraquezas, corrigiu 2 estruturalmente (§3, §5) e mitigou 1 (§4/§7). Modelo validado com a condição da §7.

--- a/scripts/handoff-integrity-guard.mjs
+++ b/scripts/handoff-integrity-guard.mjs
@@ -6,6 +6,7 @@
 // vê na hora — e que hoje nada trava:
 //   • ÓRFÃO     — PROMPT_PARA_CODE_*.md existe no dir mas NÃO é citado acima da linha → tarefa invisível.
 //   • REF MORTA — citação de PROMPT_PARA_CODE_*.md acima da linha que NÃO existe no dir → [CL] erra o PR.
+//   • FUNDIDO   — linha (fila ativa OU prompt) que funde dois cabeçalhos numa só (`:** > **`) → bloco ilegível (C3).
 //
 // Ratchet (gêmeo de scripts/pageheader-migration-guard.mjs e scripts/tests/foundation-ratchet.mjs):
 // o baseline CONGELA a dívida atual; só ÓRFÃO/REF-MORTA NOVO (fora do baseline) falha. Abaixo da
@@ -65,6 +66,17 @@ const fileSet = new Set(files);
 const orphans = files.filter((f) => !cited.has(f)).sort();              // existe, não citado
 const deadRefs = [...cited].filter((c) => !fileSet.has(c)).sort();      // citado, não existe
 
+// C3 — cabeçalho de bloco fundido: `:** > **` numa linha (dois headers colados por edição).
+// Varre a fila ATIVA (acima da linha) + cada PROMPT_PARA_CODE_*.md. Abaixo da linha = ignorado.
+const C3_RE = /:\*\*\s*>\s*\*\*/;
+const fusedIn = (label, text) => text.split(/\r?\n/)
+  .filter((l) => C3_RE.test(l))
+  .map((l) => `${label}::${l.trim().slice(0, 100)}`);
+const fused = [
+  ...fusedIn('COWORK_NOTES.md', activeRegion),
+  ...files.flatMap((f) => fusedIn(f, readFileSync(resolve(HANDOFF_DIR, f), 'utf8'))),
+].sort();
+
 // --- write baseline ---------------------------------------------------------
 if (MODE_WRITE) {
   const out = {
@@ -72,13 +84,15 @@ if (MODE_WRITE) {
       generated_at: new Date().toISOString(),
       orphans: orphans.length,
       dead_refs: deadRefs.length,
-      note: 'Integridade do handoff (PROCESSO_MEMORIA_CC.md §16 · IT8). Congela a dívida atual de órfãos/refs-mortas acima da linha d\'água em COWORK_NOTES.md. Só NOVO trava. Marcador: LINHA-DAGUA-HANDOFF.',
+      fused_headers: fused.length,
+      note: 'Integridade do handoff (PROCESSO_MEMORIA_CC.md §16 · IT8). Congela a dívida atual de órfãos/refs-mortas/cabeçalhos-fundidos acima da linha d\'água em COWORK_NOTES.md + prompts. Só NOVO trava. Marcador: LINHA-DAGUA-HANDOFF.',
     },
     orphans,
     dead_refs: deadRefs,
+    fused_headers: fused,
   };
   writeFileSync(BASELINE, JSON.stringify(out, null, 2) + '\n');
-  console.log(`✅ Baseline gravado: ${orphans.length} órfão(s) + ${deadRefs.length} ref(s) morta(s) → ${relative(ROOT, BASELINE)}`);
+  console.log(`✅ Baseline gravado: ${orphans.length} órfão(s) + ${deadRefs.length} ref(s) morta(s) + ${fused.length} fundido(s) → ${relative(ROOT, BASELINE)}`);
   process.exit(0);
 }
 
@@ -86,18 +100,21 @@ if (MODE_WRITE) {
 const baseline = existsSync(BASELINE) ? JSON.parse(readFileSync(BASELINE, 'utf8')) : { orphans: [], dead_refs: [] };
 const baseOrphans = new Set(baseline.orphans || []);
 const baseDead = new Set(baseline.dead_refs || []);
+const baseFused = new Set(baseline.fused_headers || []);
 
 const newOrphans = orphans.filter((o) => !baseOrphans.has(o));
 const newDeadRefs = deadRefs.filter((d) => !baseDead.has(d));
+const newFused = fused.filter((f) => !baseFused.has(f));
 const fixedOrphans = [...baseOrphans].filter((o) => !orphans.includes(o));
 const fixedDead = [...baseDead].filter((d) => !deadRefs.includes(d));
+const fixedFused = [...baseFused].filter((f) => !fused.includes(f));
 
 if (MODE_JSON) {
   console.log(JSON.stringify({
     has_marker: hasMarker, files: files.length, cited: cited.size,
-    orphans, dead_refs: deadRefs,
-    new_orphans: newOrphans, new_dead_refs: newDeadRefs,
-    fixed_orphans: fixedOrphans, fixed_dead_refs: fixedDead,
+    orphans, dead_refs: deadRefs, fused_headers: fused,
+    new_orphans: newOrphans, new_dead_refs: newDeadRefs, new_fused: newFused,
+    fixed_orphans: fixedOrphans, fixed_dead_refs: fixedDead, fixed_fused: fixedFused,
   }, null, 2));
   process.exit(0);
 }
@@ -112,24 +129,28 @@ if (sumFile) {
     `| Citados acima da linha | ${cited.size} |`,
     `| Órfãos | ${orphans.length} (${baseOrphans.size}) |`,
     `| Refs mortas | ${deadRefs.length} (${baseDead.size}) |`,
+    `| Cabeçalhos fundidos | ${fused.length} (${baseFused.size}) |`,
     `| 🔴 NOVO órfão | ${newOrphans.length} |`,
     `| 🔴 NOVA ref morta | ${newDeadRefs.length} |`,
+    `| 🔴 NOVO fundido | ${newFused.length} |`,
   ];
   if (newOrphans.length) rows.push('', '**Órfãos novos:** ' + newOrphans.join(', '));
   if (newDeadRefs.length) rows.push('', '**Refs mortas novas:** ' + newDeadRefs.join(', '));
+  if (newFused.length) rows.push('', '**Fundidos novos:** ' + newFused.join(' · '));
   try { writeFileSync(sumFile, rows.join('\n') + '\n', { flag: 'a' }); } catch { /* noop */ }
 }
 
 if (!hasMarker) {
   console.log(`⚠️  Marcador <!-- ${WATERLINE} --> ausente em ${relative(ROOT, QUEUE)} — fila inteira tratada como ATIVA. Adicione o marcador (PROCESSO_MEMORIA_CC.md §16).`);
 }
-console.log(`Handoff integrity · ${files.length} prompt(s) no dir · ${cited.size} citado(s) acima da linha · órfãos ${orphans.length}/${baseOrphans.size} · refs mortas ${deadRefs.length}/${baseDead.size}`);
+console.log(`Handoff integrity · ${files.length} prompt(s) no dir · ${cited.size} citado(s) acima da linha · órfãos ${orphans.length}/${baseOrphans.size} · refs mortas ${deadRefs.length}/${baseDead.size} · fundidos ${fused.length}/${baseFused.size}`);
 
 // --report: diagnóstico completo, sem falhar por baseline ---------------------
 if (MODE_REPORT) {
   if (orphans.length) { console.log('\n🔴 ÓRFÃOS (existem no dir, não citados acima da linha):'); for (const o of orphans) console.log('  • ' + o + (baseOrphans.has(o) ? ' (baseline)' : ' 🆕')); }
   if (deadRefs.length) { console.log('\n🔴 REFS MORTAS (citadas acima da linha, não existem):'); for (const d of deadRefs) console.log('  • ' + d + (baseDead.has(d) ? ' (baseline)' : ' 🆕')); }
-  if (!orphans.length && !deadRefs.length) console.log('✅ nada a reportar — fila e prompts casam.');
+  if (fused.length) { console.log('\n🔴 CABEÇALHOS FUNDIDOS (`:** > **` numa linha):'); for (const f of fused) console.log('  • ' + f + (baseFused.has(f) ? ' (baseline)' : ' 🆕')); }
+  if (!orphans.length && !deadRefs.length && !fused.length) console.log('✅ nada a reportar — fila e prompts casam.');
   process.exit(0);
 }
 
@@ -145,15 +166,20 @@ if (newDeadRefs.length) {
   for (const d of newDeadRefs) console.error('  🆕 ' + d);
   failed = true;
 }
+if (newFused.length) {
+  console.error(`\n❌ ${newFused.length} CABEÇALHO(S) FUNDIDO(S) NOVO(S) — dois blocos numa linha (\`:** > **\`); fila/prompt vira sopa ilegível (C3):`);
+  for (const f of newFused) console.error('  🆕 ' + f);
+  failed = true;
+}
 
 if (failed) {
   console.error(`\nConserte (PROCESSO_MEMORIA_CC.md §16): cite o prompt na fila ATIVA (acima de <!-- ${WATERLINE} -->) OU crie/arquive o arquivo. Se a mudança é legítima e muda a dívida, rode \`npm run handoff:baseline:write\` no mesmo PR.`);
   process.exit(1);
 }
 
-if (fixedOrphans.length || fixedDead.length) {
-  console.log(`✅ dívida CAIU (−${fixedOrphans.length} órfão · −${fixedDead.length} ref morta). Trave o ganho: \`npm run handoff:baseline:write\`.`);
+if (fixedOrphans.length || fixedDead.length || fixedFused.length) {
+  console.log(`✅ dívida CAIU (−${fixedOrphans.length} órfão · −${fixedDead.length} ref morta · −${fixedFused.length} fundido). Trave o ganho: \`npm run handoff:baseline:write\`.`);
 } else {
-  console.log('✅ sem NOVO órfão / ref morta — fila e prompts seguem casando.');
+  console.log('✅ sem NOVO órfão / ref morta / fundido — fila e prompts seguem casando.');
 }
 process.exit(0);

--- a/scripts/handoff-integrity-guard.test.mjs
+++ b/scripts/handoff-integrity-guard.test.mjs
@@ -21,14 +21,14 @@ const run = (root, extra = [], env = {}) =>
 const out = (r) => (r.stdout || '') + (r.stderr || '');
 
 // Monta um root falso: prototipo-ui/{PROMPT_PARA_CODE_*.md, COWORK_NOTES.md} + config/baseline.json
-function makeRoot({ files = [], aboveCites = [], belowCites = [], baseline = { orphans: [], dead_refs: [] }, marker = true }) {
+function makeRoot({ files = [], aboveCites = [], belowCites = [], aboveRaw = '', belowRaw = '', baseline = { orphans: [], dead_refs: [] }, marker = true }) {
   const root = mkdtempSync(join(tmpdir(), 'hig-'));
   mkdirSync(join(root, 'prototipo-ui'), { recursive: true });
   mkdirSync(join(root, 'config'), { recursive: true });
   for (const f of files) writeFileSync(join(root, 'prototipo-ui', f), `# ${f}\n`);
   const above = aboveCites.map((c) => `- ativo: [${c}](${c})`).join('\n');
   const below = belowCites.map((c) => `- PROCESSED ${c} → main`).join('\n');
-  const queue = `# COWORK_NOTES (fixture)\n\n## ATIVOS\n${above}\n\n${marker ? MARKER : ''}\n\n## HISTÓRICO\n${below}\n`;
+  const queue = `# COWORK_NOTES (fixture)\n\n## ATIVOS\n${above}\n${aboveRaw}\n\n${marker ? MARKER : ''}\n\n## HISTÓRICO\n${below}\n${belowRaw}\n`;
   writeFileSync(join(root, 'prototipo-ui', 'COWORK_NOTES.md'), queue);
   writeFileSync(join(root, 'config', 'handoff-integrity-baseline.json'), JSON.stringify(baseline));
   return root;
@@ -110,7 +110,33 @@ const drop = (root) => rmSync(root, { recursive: true, force: true });
   drop(root); drop(tmp);
 }
 
+// 9. C3 — cabeçalho fundido na fila ativa (`:** > **`) → vermelho acusando C3/FUNDIDO.
+{
+  const root = makeRoot({ files: ['PROMPT_PARA_CODE_A.md'], aboveCites: ['PROMPT_PARA_CODE_A.md'], aboveRaw: '**Status:** > **Artefato:** x' });
+  const r = run(root);
+  check('fundido na fila ativa → exit 1', r.status === 1);
+  check('fundido → rotula FUNDIDO/C3', /FUNDIDO|C3/.test(out(r)));
+  drop(root);
+}
+
+// 10. C3 ABAIXO da linha d'água → ignorado (exit 0).
+{
+  const root = makeRoot({ files: ['PROMPT_PARA_CODE_A.md'], aboveCites: ['PROMPT_PARA_CODE_A.md'], belowRaw: '**Status:** > **Artefato:** x' });
+  check('fundido ABAIXO da linha → exit 0 (ignorado)', run(root).status === 0);
+  drop(root);
+}
+
+// 11. C3 no baseline → não trava (dívida congelada).
+{
+  const root = makeRoot({
+    files: ['PROMPT_PARA_CODE_A.md'], aboveCites: ['PROMPT_PARA_CODE_A.md'], aboveRaw: '**Status:** > **Artefato:** x',
+    baseline: { orphans: [], dead_refs: [], fused_headers: ['COWORK_NOTES.md::**Status:** > **Artefato:** x'] },
+  });
+  check('fundido no baseline → exit 0 (congelado)', run(root).status === 0);
+  drop(root);
+}
+
 console.log('');
-if (fails === 0) { console.log('[PASS] catraca de handoff MORDE — órfão novo = vermelho, ref morta nova = vermelho, baseline congela, abaixo-da-linha ignora.'); process.exit(0); }
+if (fails === 0) { console.log('[PASS] catraca de handoff MORDE — órfão/ref-morta/fundido novo = vermelho, baseline congela, abaixo-da-linha ignora.'); process.exit(0); }
 console.log(`[FAIL] ${fails} caso(s) — a catraca NÃO está garantida. NÃO mergear.`);
 process.exit(1);


### PR DESCRIPTION
## O quê

**Salvage do C3** (cabeçalho de bloco fundido) — o único valor único da minha PR #2868 (fechada) — **estendendo** o `handoff-integrity-guard.mjs` que já está no main (#2865), em vez de um guard paralelo (Regra 7).

Contexto: rodei o mesmo handoff em paralelo a outra sessão; ela mergeou #2864 (§16) + #2865 (guard órfão/ref-morta = **C4**). Fechei minhas duplicatas (#2866/#2868). Restou **C3**, que nem o §16 nem o guard cobriam — e que a tua "Por quê" lista como erro recorrente ("edição que funde dois blocos").

## Mudança
- **C3 no guard**: detecta `:** > **` numa linha (dois cabeçalhos colados por edição) na **fila ativa** (`COWORK_NOTES.md` acima da linha d'água) **+** em cada `PROMPT_PARA_CODE_*.md`. Mesma região/idioma do guard existente.
- **Baseline** ganha `fused_headers` (ratchet só-NOVO-trava; abaixo da linha = ignorado). Estado atual: **0** (a classe nunca ocorreu nos artefatos git — o gate é preventivo).
- **Self-test** +4 casos controle-negativo: morde fundido na fila ativa, **ignora** abaixo da linha, **respeita** baseline. Total 18/18 OK.
- **§16** ganha a **6ª regra** "Sem cabeçalho fundido" + C3 na nota de mecanização.
- **Sem novo workflow/baseline/registry** — reusa o `handoff-integrity.yml` existente (que já roda self-test → guard).

## Verificação local
```
node scripts/handoff-integrity-guard.test.mjs   → 18/18 OK (4 novos C3)
node scripts/handoff-integrity-guard.mjs --write-baseline → +fused_headers: []
node scripts/handoff-integrity-guard.mjs        → exit 0 (estável)
node prototipo-ui/integrity-check.mjs           → IT1–IT7 verde
```

## Notas
- **C4** (órfão/ref-morta) já é do #2865 — não dupliquei. **C5** (carimbo vs-main) segue não-mecanizável em git (fila viva é Cowork-only).
- Baseline `generated_at` é dado gerado.

Refs: Guard da Reincidência (handoff TAREFA-2 · classe C3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
