### PR TITLE
docs(handoff): §16 Regra 7 (C5 verificado-vs-main) + tabela Caçador de reincidência

### DIFF
--- a/prototipo-ui/PROCESSO_MEMORIA_CC.md
+++ b/prototipo-ui/PROCESSO_MEMORIA_CC.md
@@ -287,7 +287,7 @@ O processo sobrevive só enquanto for **lido, medido e auto-corrigido**. Invaria
 
 > Por que existe: a fila ([`COWORK_NOTES.md`](COWORK_NOTES.md) → acima da linha d'água) apodrece de dois jeitos que ninguém vê na hora — **prompt citado que não existe mais** (link morto → [CL] erra o PR, faz a coisa errada) e **prompt criado que nunca entrou na fila** (tarefa invisível → nunca pousa). Memória manda no git; git é SSOT (ADR 0239) — então a fila e os `PROMPT_PARA_CODE_*.md` têm que casar. Defesa que dispara > regra que se lê (§5/NÚCLEO-5): a regra abaixo é a lei; o gate `handoff:check` é o dente.
 
-**As 6 regras (lei do handoff):**
+**As 7 regras (lei do handoff):**
 
 1. **Sem prompt órfão.** Criar um `PROMPT_PARA_CODE_<slug>.md` e **não** citá-lo na fila ativa = proibido. Prompt que existe no dir mas ninguém aponta = tarefa invisível (🔴 ÓRFÃO). Criou → cita na fila no mesmo passo.
 2. **Prompt durável é auto-contido.** O corpo não depende de URL efêmera (`claudeusercontent.com`/Cowork share expiram ~1h — L-09/§10.1). Todo contexto necessário pra executar mora no próprio arquivo, versionado no git. URL no corpo = só conveniência, nunca a fonte.
@@ -295,6 +295,21 @@ O processo sobrevive só enquanto for **lido, medido e auto-corrigido**. Invaria
 4. **"Pousou" só depois do `main` confirmar.** Não declaro entregue/processado por ter aberto PR ou commitado (L-06: não afirmo commit). Um handoff só vira "processado" quando o retorno em [`CODE_NOTES.md`](CODE_NOTES.md) **no `main`** registra `PROCESSADO → main` (PR mergeado). Antes disso continua **ativo, acima da linha**.
 5. **Ondas por padrão.** 1 tela/arquivo = 1 PR (commit-discipline · 1 PR = 1 intent). Validar contra `origin/main` fresco **antes** de codar (Passo 0 · PROTOCOL §10.4) — se já está no main, não refaz.
 6. **Sem cabeçalho fundido.** Uma edição não pode fundir dois blocos numa linha só — `**…:** > **Outro:**` (heurística `:** > **`) deixa a fila/prompt ilegível (classe **C3**). Cada bloco na sua linha; quem funde, o gate recusa.
+7. **Carimbo verificado-vs-`main`.** Todo item ativo (acima da linha) leva no corpo `verificado vs main @<SHA>` — a prova de que foi conferido contra `origin/main` fresco **antes** de virar fila (Regra 5 · PROTOCOL §10.4). Item ativo sem o carimbo = enfileirado às cegas → retrabalho (classe **C5**); o gate recusa.
+
+### Caçador de reincidência — classes de erro & condição de morte
+
+Os erros que reincidem no loop de handoff têm a mesma cura: **uma máquina que recusa no instante da ação** (§5 / NÚCLEO-5 — defesa que dispara > regra que se lê). Seis classes; o corte é por **onde a trava vive**.
+
+**C1 · C2 · C6 — rituais Cowork.** Classes curadas por ritual do lado Cowork (não git-mecanizáveis por gate de PR). A definição canônica vive no handoff Cowork (`PROMPT_PARA_CODE_HANDOFF-INTEGRITY-GATE.md`) — ⚠️ ainda **não versionado no git**; backfill pendente (não invento canon · Tier 0 — ver [`CODE_NOTES.md`](CODE_NOTES.md)).
+
+**C3 · C4 · C5 — git-gates.** Mecanizáveis no CI:
+
+| Classe | Erro recorrente | Condição de morte (a trava) | Estado |
+|---|---|---|---|
+| **C3** | edição funde dois cabeçalhos numa linha (`:** > **`) → bloco ilegível, [CL] erra o PR | gate recusa **NOVO** fundido | ✅ [`handoff-integrity-guard.mjs`](../scripts/handoff-integrity-guard.mjs) |
+| **C4** | órfão (prompt criado sem citação) · ref morta (citação sem arquivo) acima da linha → tarefa invisível / PR errado | gate recusa **NOVO** órfão/ref-morta | ✅ `handoff-integrity-guard.mjs` + `memory-health` CHECK 8 (Cowork) |
+| **C5** | item enfileirado sem conferir `main` fresco → retrabalho | item ativo carrega `verificado vs main @<SHA>`; senão 🔴 | 🔜 regra escrita (Regra 7, esta onda) · catraca **pendente** (próxima onda) |
 
 **Mecanização (catraca · §5/§13):** [`scripts/handoff-integrity-guard.mjs`](../scripts/handoff-integrity-guard.mjs) lê a fila acima da linha d'água + os `PROMPT_PARA_CODE_*.md` do dir e falha em **NOVO** órfão, **NOVA** ref morta ou **NOVO** cabeçalho fundido (`:** > **` · C3). Baseline (`config/handoff-integrity-baseline.json`) congela a dívida atual — só o que entra novo trava. Auto-teste de controle-negativo prova que o dente morde (órfão/ref-morta/fundido injetado → vermelho; tudo limpo → verde). Workflow advisory de nascença (ADR 0271/0275). Rodar: `npm run handoff:check`.
 
@@ -304,3 +319,4 @@ O processo sobrevive só enquanto for **lido, medido e auto-corrigido**. Invaria
 - 2026-06-02 · **DS-GUARD (TESTE-06):** check mecânico criado (§8) — pega L-02/L-21/L-23 nos arquivos tocados, sem depender de memória. Achou 2 fraquezas no próprio guard (ruído árvore-inteira + skip silencioso), corrigiu as duas. Defesa migrou de FRACA→FORTE. Gate visual entrou na Regra de Ouro do STATUS.
 - 2026-06-02 · **Bateria de Testes de Evolução (§9) + Manual de Evolução (§10):** regressão contra L-01…L-23 (cobertura conhecimento ~9.5, execução ~6 → confiança composta 7.5). 14 testes (5 duros), cobrindo todos os erros cometidos. Pendente pra subir a confiança: hooks auto (Cowork CI), construir guards propostos (L-07/11/14/21/22), changed-files automático, verificador rodando DS-GUARD sempre.
 - 2026-06-16 · **§16 Integridade do handoff (Onda 1):** lei do handoff escrita (5 regras: sem órfão · prompt auto-contido · linha d'água · "pousou" só pós-`main` · ondas) + IT8. Origem: fila `COWORK_NOTES.md` apodreceu (refs mortas pra `PROMPT_PARA_CODE_*` inexistentes + prompts nunca citados). Onda 2 mecaniza via `handoff:check` (catraca + baseline + auto-teste controle-negativo).
+- 2026-06-16 · **§16 Regra 7 (C5) + Caçador de reincidência (doc):** escrita a regra do carimbo `verificado vs main @<SHA>` no item ativo (classe C5 · cura do "enfileirou sem conferir o `main` → retrabalho") + tabela das classes git-gate C3/C4/C5 com condição de morte. C1/C2/C6 (rituais Cowork) ficam referenciadas sem invenção — def. canônica no handoff Cowork não-versionado (Tier 0: não cunho canon). Mecanização do C5 (catraca) é a próxima onda — depende de [W] confirmar a heurística de "item ativo" (a fila real usa bullets `- **…**`, não `> … → [CL]`).


### PR DESCRIPTION
## Tarefa 2 — Guard da Reincidência · Onda 1 (regra/doc · pode mergear autônomo)

**verificado vs main @0ab12e59b** (origin/main no início desta sessão).

### Contexto (validado contra `main`)
- O **C3** (PR #2869, mergeado hoje 21:31Z) já escreveu as **6 regras** do §16 e mecanizou **C3/C4** (órfão·ref-morta·fundido) em `scripts/handoff-integrity-guard.mjs`.
- Faltava o **C5** (carimbo `verificado vs main`). Esta onda fecha o **doc**; a **catraca** (Onda 2) fica pendente.

### O que muda (doc-only, 1 arquivo)
`prototipo-ui/PROCESSO_MEMORIA_CC.md`:
- **§16 Regra 7** — todo item ativo carrega `verificado vs main @<SHA>` (classe **C5** · cura do "enfileirou sem conferir o `main` → retrabalho").
- **§16 tabela "Caçador de reincidência"** — classes git-gate **C3/C4/C5** com condição de morte. **C1/C2/C6** (rituais Cowork) referenciadas **sem inventar canon** (Tier 0): a def. canônica vive no handoff Cowork (`PROMPT_PARA_CODE_HANDOFF-INTEGRITY-GATE.md`) **não versionado no git**.
- **§17** trilha.

### Verificação
- `node scripts/handoff-integrity-guard.mjs` → verde (queue intocada)
- `node scripts/handoff-integrity-guard.test.mjs` → PASS
- `node prototipo-ui/integrity-check.mjs` → estrutura sã (IT1–IT7)
- `node prototipo-ui/ds-guard.mjs PROCESSO_MEMORIA_CC.md` → limpo

### ⚠️ Bloqueio da Onda 2 (catraca C5) — precisa de [W]
A heurística do prompt (`item ativo = > … → [CL]`) **não casa** com a fila real (`COWORK_NOTES.md` usa bullets `- **…**` acima da linha; os `→ [CL]` estão todos abaixo da linha d'água). Antes de mecanizar o C5 preciso confirmar **o que conta como "item ativo"**.
Também: o arquivo de referência `prototipo-ui-patch/PROMPT_PARA_CODE_HANDOFF-INTEGRITY-GATE.md` (com o código Node + a tabela C1–C6 canônica) **não existe** neste checkout — daí C1/C2/C6 ficarem referenciadas, não preenchidas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)