### PR TITLE
PR Onda B: intake via GitHub Issue + congela fila COWORK_NOTES (decisão [W])

### DIFF
--- a/.github/ISSUE_TEMPLATE/cowork-intake.yml
+++ b/.github/ISSUE_TEMPLATE/cowork-intake.yml
@@ -1,0 +1,47 @@
+name: "Pedido de design/tela (intake Cowork)"
+description: "Intake canônico de pedido pro loop Cowork↔Code (substitui a fila markdown COWORK_NOTES — Onda B, proposta #2874)."
+title: "[intake] "
+labels: ["cowork-intake"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Este é o **intake nativo** (Onda B do Protocolo v2): pedido vira Issue
+        (label · assignee · notificação · link-pro-PR), em vez de linha na fila
+        `COWORK_NOTES.md`. O loop segue o `PROTOCOL.md` (F0→F1→...). Git = SSOT.
+  - type: input
+    id: tela
+    attributes:
+      label: "Tela / módulo"
+      description: "Ex.: Sells/Create, Financeiro/Conciliacao, módulo inteiro."
+      placeholder: "Mod/Tela"
+    validations:
+      required: true
+  - type: dropdown
+    id: prioridade
+    attributes:
+      label: "Prioridade"
+      options: ["P0 — agora", "P1 — esta semana", "P2 — backlog próximo", "P3 — quando der"]
+    validations:
+      required: true
+  - type: textarea
+    id: contexto
+    attributes:
+      label: "Contexto"
+      description: "O que precisa, pra quem (persona/cliente), por quê. Sinal qualificado (ADR 0105) se houver."
+    validations:
+      required: true
+  - type: textarea
+    id: restricoes
+    attributes:
+      label: "Restrições / não-fazer"
+      description: "Proibições, invariantes, o que NÃO pode mudar. Multi-tenant Tier 0 se aplicável."
+    validations:
+      required: false
+  - type: input
+    id: charter
+    attributes:
+      label: "Charter / protótipo existente (se houver)"
+      description: "Link/caminho pro .charter.md, prototipos/<tela>/ ou proposta relacionada."
+    validations:
+      required: false

--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -1,5 +1,7 @@
 # COWORK_NOTES.md — INBOX: Wagner → Claude Design
 
+> 🧊 **CONGELADA pra NOVOS itens** (Onda B · proposta #2874 · [W] aprovou 2026-06-16 · ADR a numerar por [W]). Intake novo de pedido/tarefa → **GitHub Issue** (form `cowork-intake` · label/assignee/notificação/link-pro-PR) ou drop em `cowork-inbox/`. **Não adicionar item novo aqui.** Os itens ativos abaixo continuam drenando pelo gate `handoff:check` até pousarem (`CODE_NOTES.md@main`); quando o último pousar, este arquivo vira histórico. Motivo: a fila markdown apodreceu (órfãos + refs mortas) e o nativo faz intake/notificação/link melhor. Reversível.
+
 > Wagner escreve aqui. Claude Design ([CD]/[CC]) lê aqui pra produzir protótipo + crítica.
 > **Append-only.** Não edita pedidos antigos — adiciona resposta abaixo.
 > Formato em [PROTOCOL.md §4](PROTOCOL.md).


### PR DESCRIPTION
Onda B (proposta #2874). **Intake nativo** substitui a fila markdown que apodreceu (órfãos + refs mortas).

- **Novo:** `.github/ISSUE_TEMPLATE/cowork-intake.yml` — form (tela · prioridade · contexto · restrições). Pedido vira **Issue** (label/assignee/notificação/link-pro-PR).
- **COWORK_NOTES.md:** banner 🧊 **CONGELADA pra NOVOS itens** no topo. Itens ativos abaixo **continuam drenando** pelo gate `handoff:check` até pousarem; quando o último pousar, vira histórico.

Self-check `handoff-integrity-guard`: **0 órfão / 0 ref morta / 0 fundido**. Aditivo, reversível.

🤖 Generated with [Claude Code](https://claude.com/claude-code)