### PR TITLE
fix(caixa-unificada): header usa <Inline> — fecha o layout-primitives ratchet do #2879

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -26,6 +26,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/Components/ui/dropdown-menu';
+import { Inline } from '@/Components/layout';
 import { cn } from '@/Lib/utils';
 import {
   type AccountItem,
@@ -204,11 +205,11 @@ export default function ConversationListV4({
       aria-label="Lista de conversas"
     >
       {/* Header da coluna: título + count + Status (dropdown) + Filtros (popover) — Onda 2 */}
-      <div className="flex items-center justify-between gap-2 border-b px-3 pt-2.5 pb-2">
-        <div className="flex items-baseline gap-2 min-w-0">
+      <Inline align="center" justify="between" className="border-b px-3 pt-2.5 pb-2">
+        <Inline align="baseline" className="min-w-0">
           <b className="text-[13px] font-semibold text-foreground">Conversas</b>
           <span className="font-mono text-[11px] text-muted-foreground">{conversations.total}</span>
-        </div>
+        </Inline>
 
         <div className="flex items-center gap-1.5 shrink-0">
           {/* Status — 7 tabs canônicas num DropdownMenu (substitui a fileira de tabs) */}
@@ -277,7 +278,7 @@ export default function ConversationListV4({
               </button>
             </PopoverTrigger>
             <PopoverContent align="end" className="w-72 p-0">
-              <div className="flex items-center justify-between px-3 py-2 border-b">
+              <Inline align="center" justify="between" className="px-3 py-2 border-b">
                 <span className="text-[12px] font-semibold">Filtros</span>
                 {activeFilterCount > 0 && (
                   <button
@@ -289,7 +290,7 @@ export default function ConversationListV4({
                     <X size={11} aria-hidden /> Limpar ({activeFilterCount})
                   </button>
                 )}
-              </div>
+              </Inline>
 
               <div className="max-h-[60vh] overflow-auto p-2.5 flex flex-col gap-3">
                 {channels.length > 0 && (
@@ -427,7 +428,7 @@ export default function ConversationListV4({
             </PopoverContent>
           </Popover>
         </div>
-      </div>
+      </Inline>
 
       {/* Busca inline */}
       <div className="relative border-b px-3.5 py-2">

--- a/tests/a11y-primitives.test.tsx
+++ b/tests/a11y-primitives.test.tsx
@@ -23,6 +23,13 @@ import { Checkbox } from "@/Components/ui/checkbox"
 import { Textarea } from "@/Components/ui/textarea"
 import { Badge } from "@/Components/ui/badge"
 import { Card, CardHeader, CardTitle, CardContent } from "@/Components/ui/card"
+import { Popover, PopoverTrigger, PopoverContent } from "@/Components/ui/popover"
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/Components/ui/dropdown-menu"
 
 afterEach(cleanup)
 
@@ -63,6 +70,28 @@ describe("a11y axe (jsdom) — componentes canon, uso válido, 0 violações ser
           Conteúdo do cartão <Badge>novo</Badge>
         </CardContent>
       </Card>,
+    )
+    expect(await impactfulViolations(container)).toEqual([])
+  })
+
+  it("overlays canon (gatilho fechado): Popover + DropdownMenu com nome acessível", async () => {
+    const { container } = render(
+      <div>
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button>Filtros</Button>
+          </PopoverTrigger>
+          <PopoverContent>conteúdo do popover</PopoverContent>
+        </Popover>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button>Status</Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem>Todas</DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>,
     )
     expect(await impactfulViolations(container)).toEqual([])
   })


### PR DESCRIPTION
## Follow-up do #2879 (Onda 2) — fecha o ratchet vermelho

**verificado vs main @32616faa9.** O #2879 mergeou com o check **"Layout primitives · ratchet" FAILURE** (BLOCKED, mas mergeado) → `main` ficou com **+3 flex/grid solto** no `ConversationListV4` (9→12, ADR 0253). Isso deixa o ratchet vermelho pra quem tocar layout depois.

### Fix
Recomponho os 3 containers estruturais do header novo (control-bar · grupo-título · header-do-popover) com o primitivo **`<Inline>`** (`@/Components/layout`) — gêmeo do uso nos irmãos `BroadcastSheet`/`ChannelsDrawer`/`ComposerV4`. Volta ao baseline (9), **sem subir baseline** (sem dívida).

### Verificação (local, `npm ci` no worktree)
- `node scripts/layout-primitives-guard.mjs` → ✅ **sem regressões vs baseline**.
- `npx tsc --noEmit` → limpo no arquivo.
- `npm run build:inertia` → verde (ConversationListV4 bundlou).

Mudança puramente estrutural (div→Inline), zero mudança de comportamento/visual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)