### PR TITLE
ci(a11y): a11y-axe em todo PR com short-circuit (Onda C — torna ADR 0282 verdadeira)

### DIFF
--- a/.github/workflows/a11y-axe-gate.yml
+++ b/.github/workflows/a11y-axe-gate.yml
@@ -17,13 +17,12 @@ on:
       - 'tests/js/setup.ts'
       - 'package-lock.json'
       - '.github/workflows/a11y-axe-gate.yml'
+  # Onda C / ADR 0282: roda em TODO PR pra main, pra ser um required check ESTÁVEL.
+  # (Required path-filtrado trava PRs que não tocam o path — footgun do GitHub.)
+  # O short-circuit por `git diff` no job evita o imposto de CI: sem mudança em
+  # componente/dep a11y, o job passa em segundos, sem npm ci/vitest.
   pull_request:
-    paths:
-      - 'resources/js/Components/ui/**'
-      - 'tests/a11y-primitives.test.tsx'
-      - 'tests/js/setup.ts'
-      - 'package-lock.json'
-      - '.github/workflows/a11y-axe-gate.yml'
+    branches: [main]
 
 concurrency:
   group: a11y-axe-gate-${{ github.ref }}
@@ -36,16 +35,37 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # short-circuit precisa do diff vs base
+
+      - name: Detectar mudança a11y-relevante (short-circuit)
+        id: scope
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"   # push já é filtrado por paths
+            exit 0
+          fi
+          base="${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "$base"...HEAD | grep -qE '^(resources/js/Components/ui/|tests/a11y-primitives\.test\.tsx|tests/js/setup\.ts|package-lock\.json|\.github/workflows/a11y-axe-gate\.yml)'; then
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "Mudança a11y-relevante detectada → roda axe de verdade."
+          else
+            echo "relevant=false" >> "$GITHUB_OUTPUT"
+            echo "Nenhum componente/dep a11y mudou → short-circuit: check passa sem npm ci/vitest."
+          fi
 
       - name: Setup Node.js
+        if: steps.scope.outputs.relevant == 'true'
         uses: actions/setup-node@v4
         with:
           node-version: '24'
 
       - name: Install deps (npm ci — instala axe-core do lock)
+        if: steps.scope.outputs.relevant == 'true'
         run: npm ci
 
       - name: axe runtime nos componentes canon (jsdom)
+        if: steps.scope.outputs.relevant == 'true'
         run: npm run a11y:axe
 
       - name: Diagnóstico em caso de falha


### PR DESCRIPTION
Fecha o nó #10 da conferência: a ADR 0282 (append-only) diz 'a11y-axe required', mas eu tinha revertido (footgun: required path-filtrado trava PR de doc). Em vez de anotar a lei como 'superestimada', **torno a lei verdadeira**.

**Patch:** `a11y-axe-gate.yml` roda em **todo** PR pra main, com **short-circuit por `git diff`** — sem mudança em `resources/js/Components/ui/**` (nem tests/deps/este yml), passa em segundos **sem `npm ci`/vitest**; com mudança, roda o axe de verdade. `push` mantém o filtro de paths (sem imposto por merge).

Resultado: a11y gateia quando importa · PRs de doc/memória (cowork-inbox, agora frequentes) não travam nem pagam CI. **Após merge eu re-adiciono o check aos required** → ADR 0282/PROTOCOL voltam a ser literais.

🤖 Generated with [Claude Code](https://claude.com/claude-code)