### PR TITLE
fix(essentials): stored-XSS no chat de mensagens (+ href scheme no Jana)

### DIFF
--- a/Modules/Essentials/Http/Controllers/EssentialsMessageController.php
+++ b/Modules/Essentials/Http/Controllers/EssentialsMessageController.php
@@ -73,7 +73,9 @@ class EssentialsMessageController extends Controller
         // authorize() do StoreMessageRequest já checa permission essentials.create_message
 
         $userId = $request->user()->id;
-        $text   = nl2br($request->string('message'));
+        // Segurança: armazena texto CRU (sem nl2br/HTML). O render escapa como texto
+        // (whitespace-pre-wrap) — evita stored-XSS. Ver Messages/Index.tsx.
+        $text   = (string) $request->string('message');
         $locId  = $request->input('location_id') ?: null;
 
         $lastMessage = EssentialsMessage::where('business_id', $businessId)

--- a/resources/js/Pages/Essentials/Messages/Index.tsx
+++ b/resources/js/Pages/Essentials/Messages/Index.tsx
@@ -206,11 +206,14 @@ export default function MessagesIndex({
                           )}
                         </div>
                         <div
-                          className={`inline-block px-3 py-2 rounded-lg text-sm max-w-full break-words ${
+                          className={`inline-block px-3 py-2 rounded-lg text-sm max-w-full break-words whitespace-pre-wrap ${
                             mine ? 'bg-primary text-primary-foreground' : 'bg-muted'
                           }`}
-                          dangerouslySetInnerHTML={{ __html: m.message }}
-                        />
+                        >
+                          {/* Segurança: render como TEXTO (React escapa) — NUNCA dangerouslySetInnerHTML
+                              com conteúdo de usuário (era stored-XSS). <br> legado vira quebra de linha. */}
+                          {m.message.replace(/<br\s*\/?>/gi, '\n')}
+                        </div>
                       </div>
                     </li>
                   );

--- a/resources/js/Pages/Jana/Cockpit.tsx
+++ b/resources/js/Pages/Jana/Cockpit.tsx
@@ -566,8 +566,12 @@ function MarkdownBubble({ m }: { m: MarkdownMsg }) {
       const linkMatch = text.slice(i).match(/^\[([^\]]+)\]\(([^)]+)\)/);
       if (linkMatch) {
         flush();
+        // Segurança: só schemes seguros (bloqueia javascript:/data: — XSS via href).
+        const safeHref = /^(https?:\/\/|mailto:|\/)/i.test(linkMatch[2].trim())
+          ? linkMatch[2].trim()
+          : '#';
         tokens.push(
-          <a key={key++} className="text-primary underline" href={linkMatch[2]}>
+          <a key={key++} className="text-primary underline" href={safeHref} rel="noopener noreferrer">
             {linkMatch[1]}
           </a>,
         );


### PR DESCRIPTION
## 🔴 Segurança — stored-XSS (same-tenant)

**Achado pelo red-team adversarial** (sessão 2026-06-17) — passava pelos **17 required checks** porque nenhum gate atual morde conteúdo em `.tsx`.

### Vulnerabilidade
- `EssentialsMessageController@store` salvava `nl2br($request->string('message'))` — **sem escapar HTML**.
- `Essentials/Messages/Index.tsx:212` renderizava via `dangerouslySetInnerHTML={{ __html: m.message }}`.
- → Um usuário digita `<img src=x onerror=...>` no chat interno → executa no navegador de **todos os colegas do mesmo `business`** que abrem Mensagens (inclui dono/admin). Roubo de sessão / ação-como-vítima / escalada lateral. Escopado por `business_id` (não cross-tenant), mas real.

### Correção (sem dependência nova)
- **`Messages/Index.tsx`** — render como **texto** (React escapa) + `whitespace-pre-wrap`; `<br>` legado vira quebra de linha. **Fecha linhas já salvas e novas.**
- **`EssentialsMessageController`** — armazena texto **cru** (sem `nl2br`/HTML).
- **`Jana/Cockpit.tsx`** — valida scheme do `href` do markdown (bloqueia `javascript:`/`data:`) + `rel="noopener noreferrer"`.

### Follow-up recomendado
Adicionar **regressão Pest** (assert mensagem com `<script>` renderiza escapada) e — estrategicamente — um **lint anti-`dangerouslySetInnerHTML`/href-cru** + **smoke autenticado cross-tenant**: seriam o primeiro gate a morder `.tsx` (ver proposta `handoff-loop-zero-paste`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
