### PR TITLE
fix(xss): dangerouslySetInnerHTML em campos de dado (Todo description + contact_address)

### DIFF
--- a/resources/js/Pages/Essentials/Todo/Show.tsx
+++ b/resources/js/Pages/Essentials/Todo/Show.tsx
@@ -322,10 +322,11 @@ export default function TodoShow({
             {todo.description && (
               <div className="md:col-span-3">
                 <div className="text-xs text-muted-foreground mb-0.5">Descrição</div>
-                <div
-                  className="text-sm whitespace-pre-wrap rounded bg-muted/30 p-3"
-                  dangerouslySetInnerHTML={{ __html: todo.description }}
-                />
+                <div className="text-sm whitespace-pre-wrap rounded bg-muted/30 p-3">
+                  {/* Segurança: render como TEXTO (React escapa) — NÃO dangerouslySetInnerHTML
+                      com input de usuário (era stored-XSS). <br> legado vira quebra de linha. */}
+                  {todo.description.replace(/<br\s*\/?>/gi, '\n')}
+                </div>
               </div>
             )}
           </CardContent>

--- a/resources/js/Pages/TransactionPayment/Show.tsx
+++ b/resources/js/Pages/TransactionPayment/Show.tsx
@@ -114,10 +114,10 @@ function Show({ single_payment_line, transaction, payment_types }: Props) {
                 <div className="text-sm text-muted-foreground">{transaction.contact.supplier_business_name}</div>
               )}
               {transaction.contact.contact_address && (
-                <div
-                  className="text-sm mt-2"
-                  dangerouslySetInnerHTML={{ __html: transaction.contact.contact_address }}
-                />
+                <div className="text-sm mt-2 whitespace-pre-wrap">
+                  {/* Segurança: render como TEXTO — endereço é dado do cliente; HTML cru executaria (XSS). */}
+                  {transaction.contact.contact_address.replace(/<br\s*\/?>/gi, '\n')}
+                </div>
               )}
               <div className="text-sm mt-2 space-y-1">
                 {transaction.contact.tax_number && (


### PR DESCRIPTION
## 🔴 Segurança — 2 sinks da mesma classe do #2891

Inventário pós-#2891 (red-team) achou mais usos de `dangerouslySetInnerHTML` em **campos de dado** (não-paginação):

- **`Essentials/Todo/Show.tsx`** — `todo.description` (texto digitado pelo usuário) renderizado como HTML cru → stored-XSS same-tenant.
- **`TransactionPayment/Show.tsx`** — `contact.contact_address` (dado do cliente/fornecedor) como HTML cru → XSS se o endereço contém markup.

### Correção
Render como **texto** (React escapa) + `whitespace-pre-wrap`; `<br>` legado vira quebra de linha. Mesmo fix do #2891. Cobre linhas já salvas e novas.

### Fora deste PR (allowlist do futuro lint anti-`dSIH`)
- `link.label`/`l.label` (Todo/Index, Financeiro/Dashboard, Auditoria, Cliente/SalesTab, TransactionPayment/Index) — HTML do **paginator Laravel**, baixo risco.
- `Knowledge/Show+Index` — `content` de autor **admin**, decisão documentada no charter.
- `Components/shared/DataTable.tsx` — sink genérico, auditar callers.

Próxima parcela do oráculo: **lint que falha em `dSIH` novo fora do allowlist** + fixture known-bad no `gate-selftest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
