### PR TITLE
fix(essentials): sanitiza HTML da KB com HTMLPurifier antes do dSIH

### DIFF
--- a/Modules/Cms/Services/SiteContentService.php
+++ b/Modules/Cms/Services/SiteContentService.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Cms\Services;
 
+use App\Util\HtmlSanitizer;
 use App\Util\OtelHelper;
 use Modules\Cms\Entities\CmsPage;
 use Modules\Cms\Entities\CmsSiteDetail;
@@ -50,19 +51,8 @@ class SiteContentService
             return '';
         }
 
-        return OtelHelper::spanBiz('cms.service.sanitize_html', function () use ($html) {
-            $cacheDir = storage_path('app/htmlpurifier');
-            if (! is_dir($cacheDir)) {
-                @mkdir($cacheDir, 0775, true);
-            }
-
-            $config = \HTMLPurifier_Config::createDefault();
-            $config->set('Cache.SerializerPath', $cacheDir);
-            $config->set('HTML.TargetBlank', true);
-            $config->set('Attr.AllowedFrameTargets', ['_blank']);
-
-            return (new \HTMLPurifier($config))->purify($html);
-        });
+        // Fonte unica do purifier vive em App\Util\HtmlSanitizer (reusado pela KB).
+        return OtelHelper::spanBiz('cms.service.sanitize_html', fn () => HtmlSanitizer::clean($html));
     }
 
     /**

--- a/Modules/Essentials/Http/Controllers/KnowledgeBaseController.php
+++ b/Modules/Essentials/Http/Controllers/KnowledgeBaseController.php
@@ -3,6 +3,7 @@
 namespace Modules\Essentials\Http\Controllers;
 
 use App\User;
+use App\Util\HtmlSanitizer;
 use App\Utils\ModuleUtil;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
@@ -150,7 +151,7 @@ class KnowledgeBaseController extends Controller
             'item' => [
                 'id'         => $obj->id,
                 'title'      => $obj->title,
-                'content'    => $obj->content,
+                'content'    => HtmlSanitizer::clean($obj->content),
                 'kb_type'    => $obj->kb_type,
                 'share_with' => $obj->share_with,
                 'shared_users' => $obj->users->map(fn ($u) => $u->user_full_name)->values(),
@@ -241,14 +242,14 @@ class KnowledgeBaseController extends Controller
         return [
             'id'          => $k->id,
             'title'       => $k->title,
-            'content'     => $k->content,
+            'content'     => HtmlSanitizer::clean($k->content),
             'kb_type'     => $k->kb_type,
             'share_with'  => $k->share_with,
             'children'    => $k->relationLoaded('children')
                 ? $k->children->map(fn ($section) => [
                     'id'       => $section->id,
                     'title'    => $section->title,
-                    'content'  => $section->content,
+                    'content'  => HtmlSanitizer::clean($section->content),
                     'kb_type'  => $section->kb_type,
                     'children' => $section->relationLoaded('children')
                         ? $section->children->map(fn ($article) => [

--- a/app/Util/HtmlSanitizer.php
+++ b/app/Util/HtmlSanitizer.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Util;
+
+/**
+ * HtmlSanitizer — sanitização canônica de HTML rico antes de render cru (dangerouslySetInnerHTML).
+ *
+ * Defesa contra stored-XSS para conteúdo HTML editável (CMS page/blog, KB knowledge-base):
+ * HTMLPurifier (ezyang/htmlpurifier, já no composer) remove <script>, handlers on*,
+ * javascript:/data: e tags perigosas, preservando markup de texto rico (h/p/a/img/ul/strong/etc).
+ * Null-safe, idempotente.
+ *
+ * Fonte única: usado por Modules\Cms\Services\SiteContentService (Site/Page, Site/BlogPost) e
+ * Modules\Essentials\Http\Controllers\KnowledgeBaseController (Knowledge/Index, Knowledge/Show).
+ * Origem: red-team 2026-06-17 — KB renderizava HTML de admin sem sanitização server-side
+ * (o CMS já purificava; a KB não). Ver gate scripts/dsih-gate.mjs + proposals/handoff-loop-zero-paste.md.
+ */
+class HtmlSanitizer
+{
+    public static function clean(?string $html): string
+    {
+        if ($html === null || $html === '') {
+            return '';
+        }
+
+        $cacheDir = storage_path('app/htmlpurifier');
+        if (! is_dir($cacheDir)) {
+            @mkdir($cacheDir, 0775, true);
+        }
+
+        $config = \HTMLPurifier_Config::createDefault();
+        $config->set('Cache.SerializerPath', $cacheDir);
+        $config->set('HTML.TargetBlank', true);
+        $config->set('Attr.AllowedFrameTargets', ['_blank']);
+
+        return (new \HTMLPurifier($config))->purify($html);
+    }
+}


### PR DESCRIPTION
## Defense-in-depth — última peça da classe `dangerouslySetInnerHTML`

O red-team (2026-06-17) achou que a **base de conhecimento** renderizava `item.content`/`book.content`/`section.content` via `dangerouslySetInnerHTML` **sem sanitização server-side** — ao contrário do CMS (`SiteContentService` já usava HTMLPurifier). Risco **admin-XSS** (charter `Knowledge/Index.charter.md:28` "confiamos source autor admin" — defesa fraca).

### Correção (DRY, sem acoplar nem duplicar)
- **`app/Util/HtmlSanitizer`** (novo) — purifier compartilhado, fonte única (HTMLPurifier, null-safe).
- **`Cms/SiteContentService::sanitizeHtml`** — passa a **delegar** pro util (comportamento idêntico; sem bloco duplicado → sem jscpd).
- **`Essentials/KnowledgeBaseController`** — `HtmlSanitizer::clean()` nos **3 payloads renderizados** (`Show` item + `toBookShape` book + seções). `Edit`/`Create` (editor WYSIWYG) **não** tocados (sanitizar corromperia a edição).

### Notas
- O `dSIH` **continua** na KB (precisa de HTML rico) — agora com conteúdo purificado → fica **allowlistado** no `.dsih-baseline.json` (teto inalterado, gate #2894 segue verde).
- **Resta** (menor): auditar `Components/shared/DataTable.tsx:214` (dSIH genérico de string) — quais callers passam dado de usuário. Fora deste PR.

Fecha o chip do red-team. Refs: PRs #2891/#2893 (stored-XSS), #2894 (gate dSIH).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
