### PR TITLE
test(essentials): cobertura de regressão XSS da KB + corrige charter (follow-up #2895)

### DIFF
--- a/.dsih-baseline.json
+++ b/.dsih-baseline.json
@@ -5,7 +5,6 @@
   "resources/js/Pages/Essentials/Knowledge/Index.tsx": 1,
   "resources/js/Pages/Essentials/Knowledge/Show.tsx": 1,
   "resources/js/Pages/Essentials/Todo/Index.tsx": 1,
-  "resources/js/Pages/Essentials/Todo/Show.tsx": 1,
   "resources/js/Pages/Financeiro/Dashboard/Index.tsx": 2,
   "resources/js/Pages/MemCofre/Inbox.tsx": 1,
   "resources/js/Pages/Ponto/Aprovacoes/Index.tsx": 1,
@@ -18,7 +17,6 @@
   "resources/js/Pages/Site/BlogPost.tsx": 1,
   "resources/js/Pages/Site/Page.tsx": 1,
   "resources/js/Pages/TransactionPayment/Index.tsx": 1,
-  "resources/js/Pages/TransactionPayment/Show.tsx": 1,
   "resources/js/Pages/kb/Index.tsx": 1,
   "resources/js/Pages/team-mcp/CcSessions/Index.tsx": 1
 }

--- a/Modules/Essentials/Tests/Feature/KnowledgeXssSanitizationTest.php
+++ b/Modules/Essentials/Tests/Feature/KnowledgeXssSanitizationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Util\HtmlSanitizer;
+use Modules\Essentials\Entities\KnowledgeBase;
+use Modules\Essentials\Http\Controllers\KnowledgeBaseController;
+
+uses(\Modules\Essentials\Tests\Feature\EssentialsTestCase::class);
+
+/**
+ * Defesa-em-profundidade XSS — Base de Conhecimento (Essentials/Knowledge).
+ *
+ * O fix de sanitização server-side chegou em #2895 (HtmlSanitizer::clean nos 3
+ * payloads renderizados via dangerouslySetInnerHTML) SEM testes. Este arquivo é a
+ * cobertura de regressão que faltou — a última peça da classe dSIH (#2891/#2893/#2894).
+ *
+ * Contexto do risco: autoria de KB NÃO é admin-only — qualquer user do tenant com
+ * assinatura `essentials_module` autora; com share_with=public o HTML roda pra todos
+ * os viewers do business (incl. admins). Por isso o `content` é sanitizado (não
+ * escapado — KB precisa de HTML rico) antes do Inertia.
+ *
+ * 3 camadas de prova:
+ *   1. (pura, qualquer driver) política HtmlSanitizer::clean correta
+ *   2. (source-level, qualquer driver) Controller realmente aplica a política (anti-regressão)
+ *   3. (DB real, skip SQLite) payload Inertia do show() vem sanitizado ponta-a-ponta
+ *
+ * @see app/Util/HtmlSanitizer.php
+ * @see scripts/dsih-gate.mjs
+ */
+
+function knowledgeXssIsSqlite(): bool
+{
+    $default = config('database.default');
+
+    return $default === 'sqlite'
+        || config("database.connections.{$default}.driver") === 'sqlite';
+}
+
+// ------------------------------------------------------------------
+// 1) Política de sanitização (pura — não toca DB nem rota)
+// ------------------------------------------------------------------
+
+it('HtmlSanitizer::clean remove sinks de XSS e preserva HTML rico', function () {
+    // <script> some por completo (tag + conteúdo)
+    expect(HtmlSanitizer::clean('<script>alert(1)</script>'))->toBe('');
+
+    // handler inline on* é removido
+    expect(HtmlSanitizer::clean('<img src=x onerror="alert(1)">'))
+        ->not->toContain('onerror');
+
+    // esquema javascript: em href é neutralizado
+    expect(HtmlSanitizer::clean('<a href="javascript:alert(1)">clique</a>'))
+        ->not->toContain('javascript:');
+
+    // markup de texto rico legítimo é PRESERVADO (KB precisa de HTML, não vira texto)
+    $rico = HtmlSanitizer::clean(
+        '<h2>Procedimento</h2><p><strong>Passo 1</strong></p>'
+        .'<ul><li>item</li></ul><a href="https://exemplo.com">link</a>'
+    );
+    expect($rico)
+        ->toContain('<h2>')
+        ->and($rico)->toContain('<strong>')
+        ->and($rico)->toContain('<ul>')
+        ->and($rico)->toContain('<li>')
+        ->and($rico)->toContain('href="https://exemplo.com"');
+});
+
+it('HtmlSanitizer::clean é null-safe e idempotente', function () {
+    expect(HtmlSanitizer::clean(null))->toBe('');
+    expect(HtmlSanitizer::clean(''))->toBe('');
+
+    $sujo = '<p>ok</p><script>alert(1)</script><b onclick="x()">b</b>';
+    $umaVez = HtmlSanitizer::clean($sujo);
+    expect(HtmlSanitizer::clean($umaVez))->toBe($umaVez); // idempotente
+});
+
+// ------------------------------------------------------------------
+// 2) Controller aplica a política (source-level — anti-regressão dSIH)
+// ------------------------------------------------------------------
+
+it('KnowledgeBaseController roteia todo content por HtmlSanitizer::clean', function () {
+    $src = file_get_contents((new \ReflectionClass(KnowledgeBaseController::class))->getFileName());
+
+    // importa a política canônica
+    expect($src)->toContain('use App\\Util\\HtmlSanitizer;');
+
+    // item.content (show) + book.content + section.content (toBookShape) = 3 sinks sanitizados
+    expect(substr_count($src, 'HtmlSanitizer::clean('))->toBeGreaterThanOrEqual(3);
+
+    // não pode voltar a serializar content cru (regressão silenciosa)
+    expect($src)->not->toMatch('/=>\s*\$obj->content\b/');
+    expect($src)->not->toMatch('/=>\s*\$k->content\b/');
+    expect($src)->not->toMatch('/=>\s*\$section->content\b/');
+});
+
+// ------------------------------------------------------------------
+// 3) End-to-end: payload Inertia do show() vem sanitizado (skip SQLite)
+// ------------------------------------------------------------------
+
+it('show() entrega item.content sanitizado no payload Inertia', function () {
+    if (knowledgeXssIsSqlite()) {
+        $this->markTestSkipped('SQLite incompatível com schema UltimatePOS legacy (triggers MySQL).');
+    }
+
+    $admin = $this->actAsAdmin();
+
+    $kb = KnowledgeBase::create([
+        'business_id' => $admin->business_id,
+        'created_by'  => $admin->id,
+        'title'       => 'dSIH XSS regression book',
+        'content'     => '<p><strong>conteúdo seguro</strong></p>'
+            .'<script>alert(document.cookie)</script>'
+            .'<img src=x onerror="fetch(\'//evil\')">',
+        'kb_type'     => 'knowledge_base',
+        'share_with'  => 'public',
+    ]);
+
+    try {
+        $response = $this->inertiaGet("/essentials/knowledge-base/{$kb->id}");
+        $response->assertStatus(200);
+
+        $content = $response->json('props.item.content');
+
+        expect($content)->not->toContain('<script')
+            ->and($content)->not->toContain('onerror')
+            ->and($content)->toContain('<strong>'); // HTML rico preservado
+    } finally {
+        $kb->delete();
+    }
+});

--- a/resources/js/Pages/Essentials/Knowledge/Index.charter.md
+++ b/resources/js/Pages/Essentials/Knowledge/Index.charter.md
@@ -3,11 +3,11 @@ page: /essentials/knowledge-base
 component: resources/js/Pages/Essentials/Knowledge/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-06-17"
 parent_module: Essentials
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [93, 94, 101, 104]
 tier: B
-charter_version: 1
+charter_version: 2
 ---
 
 # Page Charter — /essentials/knowledge-base (Base de conhecimento interna)
@@ -25,7 +25,7 @@ Organizar **manuais, procedimentos e artigos internos** em estrutura hierárquic
 ## Goals (faz)
 
 - Grid responsivo (1/2/3 cols) de cards "Livro" com:
-  - Título + content preview (HTML render via `dangerouslySetInnerHTML` — confiamos source autor admin)
+  - Título + content preview (HTML render via `dangerouslySetInnerHTML` — **NÃO** confiar no autor: autoria não é admin-only, qualquer user do tenant com assinatura `essentials_module` autora; `content` é sanitizado server-side no Controller via `App\Util\HtmlSanitizer::clean` (HTMLPurifier, mesma política do CMS) antes do Inertia — #2895)
   - Quick actions: Ver / Editar / Excluir / Adicionar seção (4 botões topo)
   - Lista colapsável de seções (collapse local `useState`)
   - Sub-lista artigos quando seção aberta (Ver / Editar / Excluir / Adicionar artigo)


### PR DESCRIPTION
> **Reconciliação:** o fix de sanitização da KB foi shipado em paralelo por #2895 (mesma classe dSIH). Este PR foi **re-escopado** pra entregar o que #2895 deixou de fora — **teste de regressão** (ele mergeou sem nenhum) + **correção da charter**. Nenhuma duplicação de código.

## O que entra

### 1. Cobertura de regressão (faltava em #2895)
`Modules/Essentials/Tests/Feature/KnowledgeXssSanitizationTest.php` — comportamento validado contra **HTMLPurifier v4.19.0**:
- política `HtmlSanitizer::clean` (script→`''`, `on*`/`javascript:` neutralizados, HTML rico preservado, null-safe, idempotente)
- guard **source-level** anti-regressão no Controller (os 3 sinks `show` item + `toBookShape` livro + seção via `::clean`)
- **e2e** payload Inertia do `show()` sanitizado (skip SQLite, padrão do módulo)

### 2. Charter `Index.charter.md`
- corrige a premissa **"confiamos source autor admin"** → autoria **não é admin-only**: a rota exige só `auth` + assinatura `essentials_module`; `StoreKnowledgeBaseRequest::authorize()` libera qualquer user logado e `KnowledgeBasePolicy::create()` qualquer user do mesmo business. Com `share_with=public`, um operador comum injeta JS que roda pra admins (low-priv → admin stored-XSS). Agora documenta a sanitização server-side.
- conserta o **frontmatter** (que falhava `charter.schema.json` ao ser tocado — bug latente grandfathered):
  - `last_validated` com aspas (era `Date` YAML; schema exige `string`) + bump
  - `related_adrs: [0093, 0094, 0101, 0104]` → `[93, 94, 101, 104]` — **`0101`/`0104` eram lidos como octal (65/68)**, mis-referenciando ADRs; agora inteiros corretos
  - `charter_version` 1 → 2

### 3. dsih-baseline (`--update`)
Baixa o teto removendo 2 entradas stale (drift pré-existente: `Todo/Show.tsx` — só comentário JSX; `TransactionPayment/Show.tsx` — sink já removido). Knowledge permanece (sink mantido, alimentado por conteúdo sanitizado). Commit separado.

## Auditoria DataTable
`DataTable.tsx:214` só renderiza `link.label` do paginator Laravel (números + `&laquo;`/`&raquo;`) — framework-generated, nunca dado de usuário. Seguro, sem mudança.

Refs: #2895 (fix core) · #2891 · #2893 · #2894 · red-team 2026-06-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)