### PR TITLE
fix(purchase): quota last_validated no RUNBOOK (follow-up #2898) [F]

### DIFF
--- a/memory/requisitos/Purchase/RUNBOOK-index.md
+++ b/memory/requisitos/Purchase/RUNBOOK-index.md
@@ -4,7 +4,7 @@ module: Purchase
 tela: Purchase/Index
 owner: F
 status: ativo
-last_validated: 2026-06-17
+last_validated: "2026-06-17"
 related_adrs:
   - 0104-processo-mwart-canonico-unico-caminho
   - 0093-multi-tenant-isolation-tier-0


### PR DESCRIPTION
## Follow-up do #2898

O #2898 (restaura botão Etiquetas) foi mergeado com o **RUNBOOK-gate vermelho** — o commit que corrigia o schema do RUNBOOK ficou fora do merge.

## Fix
`last_validated: 2026-06-17` → `last_validated: "2026-06-17"`. O YAML parseava a data como `Date`; o schema (`scripts/memory-schemas/runbook.schema.json`) exige `string`. Quotar resolve.

## Escopo
- 1 linha, **doc only** (`memory/requisitos/Purchase/RUNBOOK-index.md`)
- Sem código, sem cálculo, sem UI
- Fecha a dívida de schema no canon

🤖 Generated with [Claude Code](https://claude.com/claude-code)