### PR TITLE
chore(charters): normalize frontmatter to charter.schema.json

### DIFF
--- a/resources/js/Pages/Admin/FeatureFlags/Index.charter.md
+++ b/resources/js/Pages/Admin/FeatureFlags/Index.charter.md
@@ -3,9 +3,9 @@ page: /admin/feature-flags
 component: resources/js/Pages/Admin/FeatureFlags/Index.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-31
+last_validated: "2026-05-31"
 parent_module: Admin
-related_adrs: [0122, 0094, 0093, 0091, 0070]
+related_adrs: [122, 94, 93, 91, 70]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Admin/GovernanceV4Dashboard.charter.md
+++ b/resources/js/Pages/Admin/GovernanceV4Dashboard.charter.md
@@ -3,9 +3,9 @@ page: /admin/governance-v4
 component: resources/js/Pages/Admin/GovernanceV4Dashboard.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: Admin
-related_adrs: [0160, 0156, 0122, 0094, 0093, 0101]
+related_adrs: [160, 156, 122, 94, 93, 101]
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/Admin/Index.charter.md
+++ b/resources/js/Pages/Admin/Index.charter.md
@@ -3,9 +3,9 @@ page: /admin
 component: resources/js/Pages/Admin/Index.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-10
+last_validated: "2026-05-10"
 parent_module: Admin
-related_adrs: [0122, 0093, 0094, 0091, 0070, 0042, 0062]
+related_adrs: [122, 93, 94, 91, 70, 42, 62]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Admin/RagQualityDashboard.charter.md
+++ b/resources/js/Pages/Admin/RagQualityDashboard.charter.md
@@ -3,9 +3,9 @@ page: /admin/rag-quality
 component: resources/js/Pages/Admin/RagQualityDashboard.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-31
+last_validated: "2026-05-31"
 parent_module: Admin
-related_adrs: [0160, 0122, 0094, 0093, 0058, 0035]
+related_adrs: [160, 122, 94, 93, 58, 35]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Atendimento/Channels/Index.charter.md
+++ b/resources/js/Pages/Atendimento/Channels/Index.charter.md
@@ -3,10 +3,10 @@ page: /atendimento/channels
 component: resources/js/Pages/Atendimento/Channels/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Whatsapp
 parent_adr: memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
-related_adrs: [0093, 0094, 0117, 0135]
+related_adrs: [93, 94, 117, 135]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Atendimento/JanaTemplates.charter.md
+++ b/resources/js/Pages/Atendimento/JanaTemplates.charter.md
@@ -3,11 +3,11 @@ page: /atendimento/canais/jana-templates
 component: resources/js/Pages/Atendimento/JanaTemplates.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-12
+last_validated: "2026-05-12"
 parent_module: Whatsapp
 parent_capterra: memory/requisitos/Whatsapp/CAPTERRA-FICHA.md
 supersedes: resources/js/Pages/Whatsapp/Settings.charter.md
-related_adrs: [0035, 0048, 0093, 0135]
+related_adrs: [35, 48, 93, 135]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/Atendimento/Macros/Index.charter.md
+++ b/resources/js/Pages/Atendimento/Macros/Index.charter.md
@@ -3,10 +3,10 @@ page: /atendimento/macros
 component: resources/js/Pages/Atendimento/Macros/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Whatsapp
 parent_adr: memory/decisions/0135-omnichannel-inbox-arquitetura.md
-related_adrs: [0093, 0094, 0110]
+related_adrs: [93, 94, 110]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/Atendimento/Metricas/Index.charter.md
+++ b/resources/js/Pages/Atendimento/Metricas/Index.charter.md
@@ -3,10 +3,10 @@ page: /atendimento/metricas
 component: resources/js/Pages/Atendimento/Metricas/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Whatsapp
 parent_adr: memory/decisions/0135-omnichannel-inbox-arquitetura.md
-related_adrs: [0052, 0093, 0094]
+related_adrs: [52, 93, 94]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/Cliente/Import.charter.md
+++ b/resources/js/Pages/Cliente/Import.charter.md
@@ -3,9 +3,9 @@ page: /contacts/import
 component: resources/js/Pages/Cliente/Import.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149]
+related_adrs: [110, 107, 93, 94, 104, 149]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Cliente/Ledger.charter.md
+++ b/resources/js/Pages/Cliente/Ledger.charter.md
@@ -3,9 +3,9 @@ page: /contacts/ledger
 component: resources/js/Pages/Cliente/Ledger.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149]
+related_adrs: [110, 107, 93, 94, 104, 149]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Cliente/Map.charter.md
+++ b/resources/js/Pages/Cliente/Map.charter.md
@@ -3,9 +3,9 @@ page: /contacts/contact_map
 component: resources/js/Pages/Cliente/Map.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149]
+related_adrs: [110, 107, 93, 94, 104, 149]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Essentials/Holidays/Index.charter.md
+++ b/resources/js/Pages/Essentials/Holidays/Index.charter.md
@@ -3,9 +3,9 @@ page: /hrm/holiday
 component: resources/js/Pages/Essentials/Holidays/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: Essentials
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [93, 94, 101, 104]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/Essentials/Reminders/Index.charter.md
+++ b/resources/js/Pages/Essentials/Reminders/Index.charter.md
@@ -3,9 +3,9 @@ page: /essentials/reminder
 component: resources/js/Pages/Essentials/Reminders/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: Essentials
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [93, 94, 101, 104]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/Financeiro/Caixa/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Caixa/Index.charter.md
@@ -3,10 +3,10 @@ page: /financeiro/caixa
 component: resources/js/Pages/Financeiro/Caixa/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-21
+last_validated: "2026-05-21"
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
-related_adrs: [0093, 0094, 0104]
+related_adrs: [93, 94, 104]
 related_us: [US-FIN-CAIXA-F6-SOFT]
 related_prototype: n/a (F6 Soft wrapper — sem protótipo Cowork; reusa tabela cash_registers core UltimatePOS)
 related_decisions: memory/requisitos/Financeiro/caixa-visual-comparison.md (F6 Soft 2026-05-21)

--- a/resources/js/Pages/Financeiro/Cobranca/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.charter.md
@@ -3,10 +3,10 @@ page: /financeiro/cobranca
 component: resources/js/Pages/Financeiro/Cobranca/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-19
+last_validated: "2026-05-19"
 parent_module: Financeiro
 sister_module: PaymentGateway
-related_adrs: [0093, 0094, 0104, 0114, 0144, 0170]
+related_adrs: [93, 94, 104, 114, 144, 170]
 related_us: [US-PG-F3-COBRANCA]
 related_prototype: prototipo Cowork "payment-gateway-ui" F1+F1.5 aprovado [W] 2026-05-19 (Chat Cowork live)
 related_decisions: COWORK_HANDOFF.paymentgateway-ui.md (F1 score 96/93/93)

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md
@@ -3,10 +3,10 @@ page: /financeiro/contas-bancarias
 component: resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-19
+last_validated: "2026-05-19"
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
-related_adrs: [0101, 0144, 0170]
+related_adrs: [101, 144, 170]
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/Financeiro/Extrato/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Extrato/Index.charter.md
@@ -3,10 +3,10 @@ page: /financeiro/extrato/{contaId}
 component: resources/js/Pages/Financeiro/Extrato/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-07
+last_validated: "2026-05-07"
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
-related_adrs: [0101]
+related_adrs: [101]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Home/Index.charter.md
+++ b/resources/js/Pages/Home/Index.charter.md
@@ -3,10 +3,10 @@ page: /home
 component: resources/js/Pages/Home/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-22
+last_validated: "2026-05-22"
 parent_module: Dashboard
 parent_spec: memory/requisitos/Dashboard/SPEC.md
-related_adrs: [0093, 0094, 0101, 0104]
+related_adrs: [93, 94, 101, 104]
 related_us: [US-DASH-001, US-DASH-006]
 related_prototype: n/a (F6 Soft wrapper — sem protótipo Cowork; reusa session+queries core UltimatePOS)
 tier: A

--- a/resources/js/Pages/Jana/Admin/Governanca/Index.charter.md
+++ b/resources/js/Pages/Jana/Admin/Governanca/Index.charter.md
@@ -3,10 +3,10 @@ page: /copiloto/admin/governanca
 component: resources/js/Pages/Jana/Admin/Governanca/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Jana
 parent_adr: memory/decisions/0053-mcp-server-governanca-como-produto.md
-related_adrs: [0039, 0053, 0061, 0070, 0093, 0094, 0095, 0131]
+related_adrs: [39, 53, 61, 70, 93, 94, 95, 131]
 related_charters:
   - resources/js/Pages/Jana/Admin/Roadmap.charter.md
 related_specs:

--- a/resources/js/Pages/Jana/Admin/Roadmap.charter.md
+++ b/resources/js/Pages/Jana/Admin/Roadmap.charter.md
@@ -3,10 +3,10 @@ page: /jana/admin/roadmap
 component: resources/js/Pages/Jana/Admin/Roadmap.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-13
+last_validated: "2026-05-13"
 approved_by: wagner
 parent_module: Jana
-related_adrs: [0070, 0093, 0094, 0110]
+related_adrs: [70, 93, 94, 110]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/Jana/Chat.charter.md
+++ b/resources/js/Pages/Jana/Chat.charter.md
@@ -3,9 +3,9 @@ page: /jana/chat
 component: resources/js/Pages/Jana/Chat.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-18
+last_validated: "2026-05-18"
 parent_module: Jana
-related_adrs: [0110, 0094, 0107, 0114]
+related_adrs: [110, 94, 107, 114]
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/Jana/Dashboard.charter.md
+++ b/resources/js/Pages/Jana/Dashboard.charter.md
@@ -3,10 +3,10 @@ page: /copiloto/dashboard
 component: resources/js/Pages/Jana/Dashboard.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-18
+last_validated: "2026-05-18"
 parent_module: Jana
 parent_adr: memory/decisions/0052-memoria-jana-3-angulos-faturamento.md
-related_adrs: [0026, 0031, 0035, 0036, 0052, 0093, 0094, 0107, 0114]
+related_adrs: [26, 31, 35, 36, 52, 93, 94, 107, 114]
 related_charters:
   - resources/js/Pages/Jana/Chat.charter.md
   - resources/js/Pages/Jana/Cockpit.charter.md

--- a/resources/js/Pages/Jana/Memoria.charter.md
+++ b/resources/js/Pages/Jana/Memoria.charter.md
@@ -3,10 +3,10 @@ page: /copiloto/memoria
 component: resources/js/Pages/Jana/Memoria.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Jana
 parent_adr: memory/decisions/0052-memoria-jana-3-angulos-faturamento.md
-related_adrs: [0031, 0033, 0035, 0036, 0037, 0052, 0061, 0093, 0094, 0131]
+related_adrs: [31, 33, 35, 36, 37, 52, 61, 93, 94, 131]
 related_charters:
   - resources/js/Pages/Jana/Chat.charter.md
 related_specs:

--- a/resources/js/Pages/Jana/Pro.charter.md
+++ b/resources/js/Pages/Jana/Pro.charter.md
@@ -3,9 +3,9 @@ page: /ia/pro
 component: resources/js/Pages/Jana/Pro.tsx
 owner: wagner
 status: live
-last_validated: 2026-06-01
+last_validated: "2026-06-01"
 parent_module: Jana
-related_adrs: [0140, 0110, 0190, 0093]
+related_adrs: [140, 110, 190, 93]
 tier: B
 charter_version: 1
 ---

--- a/resources/js/Pages/NfeBrasil/Manifestacao/Index.charter.md
+++ b/resources/js/Pages/NfeBrasil/Manifestacao/Index.charter.md
@@ -3,9 +3,9 @@ page: /nfe-brasil/manifestacao
 component: resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-10
+last_validated: "2026-05-10"
 parent_module: NfeBrasil
-related_adrs: [0029, 0039, 0093, 0094, 0116]
+related_adrs: [29, 39, 93, 94, 116]
 related_us: [US-NFE-052, US-NFE-061]
 tier: A
 charter_version: 1

--- a/resources/js/Pages/NfeBrasil/Transactions/NfceStatus.charter.md
+++ b/resources/js/Pages/NfeBrasil/Transactions/NfceStatus.charter.md
@@ -3,9 +3,9 @@ page: /nfe-brasil/transactions/{tx}/status
 component: resources/js/Pages/NfeBrasil/Transactions/NfceStatus.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: NfeBrasil
-related_adrs: [0029, 0058, 0062, 0093, 0094, 0143]
+related_adrs: [29, 58, 62, 93, 94, 143]
 related_us: [US-NFE-002]
 tier: A
 charter_version: 1

--- a/resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.charter.md
+++ b/resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.charter.md
@@ -3,9 +3,9 @@ page: /nfe-brasil/tributacao/config-default
 component: resources/js/Pages/NfeBrasil/Tributacao/ConfigDefault.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: NfeBrasil
-related_adrs: [0029, 0093, 0094]
+related_adrs: [29, 93, 94]
 related_us: [US-NFE-010]
 tier: A
 charter_version: 1

--- a/resources/js/Pages/NfeBrasil/Tributacao/Index.charter.md
+++ b/resources/js/Pages/NfeBrasil/Tributacao/Index.charter.md
@@ -3,9 +3,9 @@ page: /nfe-brasil/tributacao
 component: resources/js/Pages/NfeBrasil/Tributacao/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-10
+last_validated: "2026-05-10"
 parent_module: NfeBrasil
-related_adrs: [0029, 0093, 0094]
+related_adrs: [29, 93, 94]
 related_us: [US-NFE-010, US-NFE-061]
 tier: A
 charter_version: 1

--- a/resources/js/Pages/Orcamento/Index.charter.md
+++ b/resources/js/Pages/Orcamento/Index.charter.md
@@ -3,9 +3,9 @@ page: /orcamento
 component: resources/js/Pages/Orcamento/Index.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-09
+last_validated: "2026-05-09"
 parent_module: Orcamento
-related_adrs: [0110, 0107, 0093]
+related_adrs: [110, 107, 93]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Produto/BulkEdit.charter.md
+++ b/resources/js/Pages/Produto/BulkEdit.charter.md
@@ -3,9 +3,9 @@ page: /products/mass-edit
 component: resources/js/Pages/Produto/BulkEdit.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0104, 0149, 0093, 0107]
+related_adrs: [104, 149, 93, 107]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/Create.charter.md
+++ b/resources/js/Pages/Produto/Create.charter.md
@@ -3,9 +3,9 @@ page: /products/create
 component: resources/js/Pages/Produto/Create.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0104, 0149, 0093, 0107]
+related_adrs: [104, 149, 93, 107]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/Edit.charter.md
+++ b/resources/js/Pages/Produto/Edit.charter.md
@@ -3,9 +3,9 @@ page: /products/{id}/edit
 component: resources/js/Pages/Produto/Edit.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0104, 0149, 0093, 0107]
+related_adrs: [104, 149, 93, 107]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/Index.charter.md
+++ b/resources/js/Pages/Produto/Index.charter.md
@@ -3,9 +3,9 @@ page: /products
 component: resources/js/Pages/Produto/Index.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0110, 0107, 0093, 0104, 0149]
+related_adrs: [110, 107, 93, 104, 149]
 tier: A
 charter_version: 2
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/SellingPrices.charter.md
+++ b/resources/js/Pages/Produto/SellingPrices.charter.md
@@ -3,9 +3,9 @@ page: /products/add-selling-prices/{id}
 component: resources/js/Pages/Produto/SellingPrices.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0104, 0149, 0093, 0107]
+related_adrs: [104, 149, 93, 107]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/Show.charter.md
+++ b/resources/js/Pages/Produto/Show.charter.md
@@ -3,9 +3,9 @@ page: /products/{id}
 component: resources/js/Pages/Produto/Show.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0104, 0149, 0093, 0107]
+related_adrs: [104, 149, 93, 107]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/StockHistory.charter.md
+++ b/resources/js/Pages/Produto/StockHistory.charter.md
@@ -3,9 +3,9 @@ page: /products/stock-history/{id}
 component: resources/js/Pages/Produto/StockHistory.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Produto
-related_adrs: [0104, 0149, 0093, 0107]
+related_adrs: [104, 149, 93, 107]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Produto/Unificado/Index.charter.md
+++ b/resources/js/Pages/Produto/Unificado/Index.charter.md
@@ -3,9 +3,9 @@ page: /produto/unificado
 component: resources/js/Pages/Produto/Unificado/Index.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-09
+last_validated: "2026-05-09"
 parent_module: Produto
-related_adrs: [0110, 0107, 0093, 0094]
+related_adrs: [110, 107, 93, 94]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/ProjectMgmt/Board/Index.charter.md
+++ b/resources/js/Pages/ProjectMgmt/Board/Index.charter.md
@@ -3,9 +3,9 @@ page: /project-mgmt/board
 component: resources/js/Pages/ProjectMgmt/Board/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-08
+last_validated: "2026-05-08"
 parent_module: ProjectMgmt
-related_adrs: [0110, 0070, 0100, 0039]
+related_adrs: [110, 70, 100, 39]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/RecurringBilling/Configuracoes/Index.charter.md
+++ b/resources/js/Pages/RecurringBilling/Configuracoes/Index.charter.md
@@ -3,9 +3,9 @@ page: /recurring-billing/configuracoes
 component: resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: RecurringBilling
-related_adrs: [0093, 0094, 0101, 0104, 0107, 0110, 0114, 0143]
+related_adrs: [93, 94, 101, 104, 107, 110, 114, 143]
 tier: A
 charter_version: 1
 visual_source: prototipo-ui/prototipos/recurring/recurring-page.jsx (tab Configurações — Onda 8)

--- a/resources/js/Pages/RecurringBilling/Faturas/Index.charter.md
+++ b/resources/js/Pages/RecurringBilling/Faturas/Index.charter.md
@@ -3,9 +3,9 @@ page: /recurring-billing/faturas
 component: resources/js/Pages/RecurringBilling/Faturas/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: RecurringBilling
-related_adrs: [0093, 0094, 0101, 0104, 0107, 0114, 0143]
+related_adrs: [93, 94, 101, 104, 107, 114, 143]
 tier: A
 charter_version: 1
 visual_source: prototipo-ui/prototipos/recurring/recurring-page.jsx (tab "Faturas" stub no Index)

--- a/resources/js/Pages/RecurringBilling/Planos/Create.charter.md
+++ b/resources/js/Pages/RecurringBilling/Planos/Create.charter.md
@@ -3,9 +3,9 @@ page: /recurring-billing/planos/novo
 component: resources/js/Pages/RecurringBilling/Planos/Create.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: RecurringBilling
-related_adrs: [0093, 0094, 0101, 0104, 0107, 0110]
+related_adrs: [93, 94, 101, 104, 107, 110]
 tier: A
 charter_version: 1
 sidebar_group: fin (FINANCEIRO)

--- a/resources/js/Pages/RecurringBilling/Planos/Edit.charter.md
+++ b/resources/js/Pages/RecurringBilling/Planos/Edit.charter.md
@@ -3,9 +3,9 @@ page: /recurring-billing/planos/{id}/editar
 component: resources/js/Pages/RecurringBilling/Planos/Edit.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: RecurringBilling
-related_adrs: [0093, 0094, 0101, 0104, 0107, 0110]
+related_adrs: [93, 94, 101, 104, 107, 110]
 tier: A
 charter_version: 1
 sidebar_group: fin (FINANCEIRO)

--- a/resources/js/Pages/RecurringBilling/Planos/Index.charter.md
+++ b/resources/js/Pages/RecurringBilling/Planos/Index.charter.md
@@ -3,9 +3,9 @@ page: /recurring-billing/planos
 component: resources/js/Pages/RecurringBilling/Planos/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: RecurringBilling
-related_adrs: [0093, 0094, 0101, 0104, 0107, 0110, 0114, 0143]
+related_adrs: [93, 94, 101, 104, 107, 110, 114, 143]
 tier: A
 charter_version: 1
 visual_source: prototipo-ui/prototipos/recurring/recurring-page.jsx

--- a/resources/js/Pages/Repair/Dashboard/Index.charter.md
+++ b/resources/js/Pages/Repair/Dashboard/Index.charter.md
@@ -3,10 +3,10 @@ page: /repair/dashboard
 component: resources/js/Pages/Repair/Dashboard/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-07
+last_validated: "2026-05-07"
 parent_module: Repair
 parent_capterra: memory/requisitos/Repair/CAPTERRA-FICHA.md
-related_adrs: [0101]
+related_adrs: [101]
 tier: A
 ---
 

--- a/resources/js/Pages/Repair/DeviceModels/Create.charter.md
+++ b/resources/js/Pages/Repair/DeviceModels/Create.charter.md
@@ -3,9 +3,9 @@ page: /repair/device-models/create
 component: resources/js/Pages/Repair/DeviceModels/Create.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: Repair
-related_adrs: [0093, 0104]
+related_adrs: [93, 104]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Repair/DeviceModels/Edit.charter.md
+++ b/resources/js/Pages/Repair/DeviceModels/Edit.charter.md
@@ -3,9 +3,9 @@ page: /repair/device-models/{id}/edit
 component: resources/js/Pages/Repair/DeviceModels/Edit.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: Repair
-related_adrs: [0093, 0104]
+related_adrs: [93, 104]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Repair/DeviceModels/Index.charter.md
+++ b/resources/js/Pages/Repair/DeviceModels/Index.charter.md
@@ -3,10 +3,10 @@ page: /repair/device-models
 component: resources/js/Pages/Repair/DeviceModels/Index.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-17
+last_validated: "2026-05-17"
 parent_module: Repair
 parent_capterra: memory/requisitos/Repair/CAPTERRA-FICHA.md
-related_adrs: [0093, 0101, 0104, 0121]
+related_adrs: [93, 101, 104, 121]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Repair/JobSheet/AddParts.charter.md
+++ b/resources/js/Pages/Repair/JobSheet/AddParts.charter.md
@@ -3,9 +3,9 @@ page: /repair/job-sheet/add-parts/{id}
 component: resources/js/Pages/Repair/JobSheet/AddParts.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Repair
-related_adrs: [0104, 0093]
+related_adrs: [104, 93]
 tier: A
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/os/"

--- a/resources/js/Pages/Repair/JobSheet/Create.charter.md
+++ b/resources/js/Pages/Repair/JobSheet/Create.charter.md
@@ -3,9 +3,9 @@ page: /repair/job-sheet/create
 component: resources/js/Pages/Repair/JobSheet/Create.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Repair
-related_adrs: [0104, 0093]
+related_adrs: [104, 93]
 tier: A
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/os/"

--- a/resources/js/Pages/Repair/JobSheet/Edit.charter.md
+++ b/resources/js/Pages/Repair/JobSheet/Edit.charter.md
@@ -3,9 +3,9 @@ page: /repair/job-sheet/{id}/edit
 component: resources/js/Pages/Repair/JobSheet/Edit.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Repair
-related_adrs: [0104, 0143, 0093]
+related_adrs: [104, 143, 93]
 tier: A
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/os/"

--- a/resources/js/Pages/Repair/JobSheet/Index.charter.md
+++ b/resources/js/Pages/Repair/JobSheet/Index.charter.md
@@ -3,10 +3,10 @@ page: /repair/job-sheet
 component: resources/js/Pages/Repair/JobSheet/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-07
+last_validated: "2026-05-07"
 parent_module: Repair
 parent_capterra: memory/requisitos/Repair/CAPTERRA-FICHA.md
-related_adrs: [0101, 0104, 0149, 0143, 0093]
+related_adrs: [101, 104, 149, 143, 93]
 tier: A
 charter_version: 2
 mwart_pattern_reuse:

--- a/resources/js/Pages/Repair/JobSheet/Show.charter.md
+++ b/resources/js/Pages/Repair/JobSheet/Show.charter.md
@@ -3,9 +3,9 @@ page: /repair/job-sheet/{id}
 component: resources/js/Pages/Repair/JobSheet/Show.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Repair
-related_adrs: [0104, 0143, 0093, 0149]
+related_adrs: [104, 143, 93, 149]
 tier: A
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/os/"

--- a/resources/js/Pages/Repair/Show.charter.md
+++ b/resources/js/Pages/Repair/Show.charter.md
@@ -3,9 +3,9 @@ page: /repair/repair/{id}
 component: resources/js/Pages/Repair/Show.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: "2026-05-15"
 parent_module: Repair
-related_adrs: [0104, 0143, 0093]
+related_adrs: [104, 143, 93]
 tier: A
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/os/"

--- a/resources/js/Pages/Repair/Status/Index.charter.md
+++ b/resources/js/Pages/Repair/Status/Index.charter.md
@@ -3,10 +3,10 @@ page: /repair/status
 component: resources/js/Pages/Repair/Status/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-07
+last_validated: "2026-05-07"
 parent_module: Repair
 parent_capterra: memory/requisitos/Repair/CAPTERRA-FICHA.md
-related_adrs: [0101]
+related_adrs: [101]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Whatsapp/Settings.charter.md
+++ b/resources/js/Pages/Whatsapp/Settings.charter.md
@@ -3,10 +3,10 @@ page: /whatsapp/settings
 component: resources/js/Pages/Whatsapp/Settings.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-27
+last_validated: "2026-05-27"
 parent_module: Whatsapp
 parent_adr: memory/decisions/0202-whatsapp-profissionalizacao-baileys-out.md
-related_adrs: [0093, 0094, 0096, 0117, 0135, 0202]
+related_adrs: [93, 94, 96, 117, 135, 202]
 related_adrs_ui: [UI-0013]
 tier: A
 charter_version: 2

--- a/resources/js/Pages/governance/Audit.charter.md
+++ b/resources/js/Pages/governance/Audit.charter.md
@@ -3,9 +3,9 @@ page: /governance/audit
 component: resources/js/Pages/governance/Audit.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Governance
-related_adrs: [0079, 0084, 0086, 0094, 0147]
+related_adrs: [79, 84, 86, 94, 147]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/governance/Dashboard.charter.md
+++ b/resources/js/Pages/governance/Dashboard.charter.md
@@ -3,9 +3,9 @@ page: /governance
 component: resources/js/Pages/governance/Dashboard.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-09
+last_validated: "2026-05-09"
 parent_module: Governance
-related_adrs: [0110, 0079, 0094, 0114]
+related_adrs: [110, 79, 94, 114]
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/governance/DriftAlerts.charter.md
+++ b/resources/js/Pages/governance/DriftAlerts.charter.md
@@ -3,9 +3,9 @@ page: /governance/drift
 component: resources/js/Pages/governance/DriftAlerts.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Governance
-related_adrs: [0079, 0086, 0094, 0147]
+related_adrs: [79, 86, 94, 147]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/governance/Policies.charter.md
+++ b/resources/js/Pages/governance/Policies.charter.md
@@ -3,9 +3,9 @@ page: /governance/policies
 component: resources/js/Pages/governance/Policies.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-16
+last_validated: "2026-05-16"
 parent_module: Governance
-related_adrs: [0079, 0086, 0094, 0147]
+related_adrs: [79, 86, 94, 147]
 tier: A
 charter_version: 1
 ---


### PR DESCRIPTION
## O quê

Normaliza o YAML frontmatter de **59 Page Charters** (`resources/js/Pages/**/*.charter.md`) pra satisfazer `scripts/memory-schemas/charter.schema.json`. São violações **pré-existentes / grandfathered**: o gate `memory-schema-gate.yml` (check "Charter") só valida charters **modificados** no PR, então passam hoje — mas corrompem dado via js-yaml e **bloqueariam qualquer PR futuro que tocasse esses arquivos**. Descoberto enquanto corrigia #2897.

## Os dois bugs

**1. `related_adrs` com leading-zero → corrupção octal/string (js-yaml).**
`[0093, 0104, 0070]` é lido como `["0093", 68, 56]` — valores só com dígitos 0–7 viram **octal** (`0104`→68, `0070`→56), e os com 8/9 viram string (`0093`→`"0093"`). Ambos falham o `oneOf` do schema (integer 1–9999 OU slug `^[0-9]{4}-[a-z0-9-]+$`).
**Fix:** strip pra o número **decimal** do ADR (preserva intenção humana, não o erro octal): `0104`→`104`, `0070`→`70`. Slugs já válidos (`0093-multi-tenant-...`) e ints já decimais ficam **byte-idênticos**.

**2. `last_validated` sem aspas → parseado como Date, não string.**
`last_validated: 2026-05-17` vira `Date` no js-yaml → falha `type: string`. **Fix:** aspas no lugar (`"2026-05-17"`), data inalterada.

## Escopo

- **59 arquivos, exatamente 2 linhas de frontmatter cada** (118/118). Corpos e line endings intocados.
- Validado localmente com a **stack exata do gate** (ajv 2020 + ajv-formats + gray-matter vs o schema): **0 falhas**.

## Excluído (1 arquivo)

`resources/js/Pages/Financeiro/Fluxo/Index.charter.md` — o `related_adrs` dele carrega refs **namespaced** (`arq/0005`, `ui/0114`) que o schema **não consegue representar** e que os dois bugs acima não cobrem. Converter pra inteiro apontaria pro ADR canon errado (namespace diferente). Deixado grandfathered; precisa de decisão à parte (possível extensão do schema). Flag de follow-up criada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)