### PR TITLE
fix(charter): Financeiro/Fluxo related_adrs + last_validated válidos no schema

### DIFF
--- a/resources/js/Pages/Financeiro/Fluxo/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.charter.md
@@ -3,10 +3,10 @@ page: /financeiro/fluxo
 component: resources/js/Pages/Financeiro/Fluxo/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-21
+last_validated: "2026-05-21"
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
-related_adrs: [arq/0005, ui/0114, 0093, 0094, 0104]
+related_adrs: [0005-financeiro-vs-accounting-paralelo, 0114-prototipo-ui-cowork-loop-formalizado, 0093-multi-tenant-isolation-tier-0, 0094-constituicao-v2-7-camadas-8-principios, 0104-processo-mwart-canonico-unico-caminho]
 related_us: [US-FIN-014, US-FIN-014c]
 related_prototype: prototipo Cowork "Fluxo de Caixa" (Financeiro.html), aprovado [W] 2026-05-09
 related_decisions: memory/requisitos/Financeiro/fluxo-visual-comparison.md (Q1-Q4 aprovadas [W] 2026-05-14)


### PR DESCRIPTION
## O quê

Corrige o frontmatter de `resources/js/Pages/Financeiro/Fluxo/Index.charter.md` pra satisfazer `scripts/memory-schemas/charter.schema.json`. É o **único arquivo deixado de fora** do #2900 (charter-frontmatter-schema-normalize), por carregar refs ADR **namespaced** que o schema não representa e cuja conversão exigia decisão à parte.

## Os 3 problemas (todos no frontmatter)

1. **`related_adrs` com refs namespaced** (`arq/0005`, `ui/0114`) — não batem o `oneOf` do schema (int 1–9999 OU slug `^[0-9]{4}-[a-z0-9-]+$`).
2. **leading-zero ints** (`0093`, `0094`, `0104`) — js-yaml lê como string/octal (`0104`→68). Mesmo bug do #2900.
3. **`last_validated` sem aspas** — parseado como `Date`, falha `type: string`.

## Decisão — opção (b): refs namespaced viram slug canônico

Descoberta que muda a premissa do follow-up: **`ui/0114` NÃO existe.** A série UI vai só até `0018` (`memory/requisitos/_DesignSystem/adr/ui/`). Era uma referência **mal-namespaced** ao **ADR canon `0114-prototipo-ui-cowork-loop-formalizado`** — exatamente o domínio desta página (o frontmatter cita o protótipo Cowork + visual-comparison; o charter irmão `Financeiro/Dre` referencia o mesmo ADR). Logo, mapear pra canon 0114 é o **correto**, não erro semântico.

| Antes | Depois | Por quê |
|---|---|---|
| `arq/0005` | `0005-financeiro-vs-accounting-paralelo` | ADR arq do módulo Financeiro; o slug descritivo desambigua do canon `0005-uuid-vs-bigint` |
| `ui/0114` | `0114-prototipo-ui-cowork-loop-formalizado` | canon (não existe ui/0114) |
| `0093/0094/0104` | slug canônico | preserva intenção, não o erro octal |
| `last_validated: 2026-05-21` | `"2026-05-21"` | string, não Date |

Precedente: `Financeiro/ProvaViva.charter.md` já referencia um ADR não-canon por slug (`0013-constituicao-ui-v2-camadas`) e passa o gate. Optei por (b) em vez de (a) estender o schema — extensão legitimaria refs quebradas (como o inexistente ui/0114) e mexeria num artefato de governança por 1 arquivo.

## Validação

Replicado o stack exato do `memory-schema-gate.yml` (Charter): `ajv/dist/2020` `{allErrors:true, strict:false}` + `ajv-formats` + `gray-matter` vs `charter.schema.json` → **PASS**. `last_validated` parseia como string; os 5 `related_adrs` como slug válido.

Refs: #2900

🤖 Generated with [Claude Code](https://claude.com/claude-code)
