### PR TITLE
fix(memory-schema-gate): try/catch matter() + conserta charters que crashavam o gate

### DIFF
--- a/.github/workflows/memory-schema-gate.yml
+++ b/.github/workflows/memory-schema-gate.yml
@@ -159,7 +159,20 @@ jobs:
           const violations = [];
           for (const file of files) {
             const raw = fs.readFileSync(file, 'utf8');
-            const { data } = matter(raw);
+            // 2026-06-17: frontmatter YAML malformado (backslash não-escapado,
+            // flow-seq `[W]` com texto colado, multiline key, etc) faz gray-matter
+            // THROW. Sem este try/catch a exceção derruba o job inteiro (exit 1 +
+            // stack trace) em vez de reportar a violação por-arquivo e seguir
+            // validando o resto. Conta como erro (strict bloqueia merge).
+            let data;
+            try {
+              ({ data } = matter(raw));
+            } catch (e) {
+              failed++;
+              const reason = e && e.message ? e.message.split('\n')[0] : String(e);
+              violations.push({ file, level: 'error', errors: [`YAML parse error: ${reason}`] });
+              continue;
+            }
             // grace period: arquivos sem frontmatter (legacy) — só warning
             if (!data || Object.keys(data).length === 0) {
               violations.push({ file, level: 'warn', errors: ['frontmatter ausente (legacy)'] });

--- a/resources/js/Pages/kb/Node.charter.md
+++ b/resources/js/Pages/kb/Node.charter.md
@@ -1,15 +1,16 @@
 ---
-page: kb/Node (drawer concept — não tem .tsx dedicado)
-controller: Modules\KB\Http\Controllers\KbNodeController
+page: /kb/nodes  # drawer concept — governa NodeReader/NodeList, sem .tsx de página dedicada
+component: resources/js/Pages/kb/_components/NodeReader.tsx
+controller: 'Modules\KB\Http\Controllers\KbNodeController'
 route: kb.nodes.{index,show,store,update,destroy,restore,reverify}
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Wagner / governança (1440px desktop)
 persona_secundaria: Larissa / operacional gráfica (1280px balcão, ONDA 6+)
-charter_version: 1.0
+charter_version: 1
 charter_at: 2026-05-16
 related_adrs:
-  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
   - 0093-multi-tenant-isolation-tier-0
   - 0061-conhecimento-canonico-git-mcp-zero-automem
   - 0104-processo-mwart-canonico-unico-caminho

--- a/resources/js/Pages/kb/Paths.charter.md
+++ b/resources/js/Pages/kb/Paths.charter.md
@@ -1,15 +1,16 @@
 ---
-page: kb/Paths (dialog concept — não tem .tsx dedicado)
-controller: Modules\KB\Http\Controllers\KbPathController
+page: /kb/paths  # dialog concept — governa PathsDialog, sem .tsx de página dedicada
+component: resources/js/Pages/kb/_components/PathsDialog.tsx
+controller: 'Modules\KB\Http\Controllers\KbPathController'
 route: kb.paths.{index,show,store,update}
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Larissa / operacional gráfica (1280px balcão)
 persona_secundaria: Wagner / governança (1440px desktop)
-charter_version: 1.0
+charter_version: 1
 charter_at: 2026-05-16
 related_adrs:
-  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
   - 0093-multi-tenant-isolation-tier-0
   - 0104-processo-mwart-canonico-unico-caminho
 related_briefing: ../../../memory/requisitos/KB/BRIEFING.md

--- a/resources/js/Pages/kb/Troubleshooter.charter.md
+++ b/resources/js/Pages/kb/Troubleshooter.charter.md
@@ -1,15 +1,16 @@
 ---
-page: kb/Troubleshooter (dialog concept — não tem .tsx dedicado)
-controller: Modules\KB\Http\Controllers\KbDecisionTreeController
+page: /kb/decision-trees  # dialog concept — governa TroubleshooterDialog, sem .tsx de página dedicada
+component: resources/js/Pages/kb/_components/TroubleshooterDialog.tsx
+controller: 'Modules\KB\Http\Controllers\KbDecisionTreeController'
 route: kb.decision-trees.{index,show,store,update}
 status: draft
-owner: [W] Wagner
+owner: wagner
 persona_principal: Larissa / operacional gráfica (1280px balcão)
 persona_secundaria: Wagner / governança (1440px desktop)
-charter_version: 1.0
+charter_version: 1
 charter_at: 2026-05-16
 related_adrs:
-  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
   - 0093-multi-tenant-isolation-tier-0
   - 0104-processo-mwart-canonico-unico-caminho
 related_briefing: ../../../memory/requisitos/KB/BRIEFING.md


### PR DESCRIPTION
## Problema

O job **Charter** (e os jobs irmãos da matriz) em `.github/workflows/memory-schema-gate.yml` parseiam cada arquivo alterado com `const { data } = matter(raw);` **sem try/catch**. Se um arquivo no changed-set tem frontmatter YAML malformada, o gray-matter **lança exceção não-capturada** e o job inteiro morre (exit 1 + stack trace) em vez de reportar uma violação limpa por-arquivo e seguir validando o resto.

Gatilho concreto: `resources/js/Pages/kb/Troubleshooter.charter.md` (e os irmãos `Paths`/`Node`) tinham `owner: [W] Wagner` — `[W]` é parseado como flow-sequence YAML e o texto colado depois derruba o parser. O js-yaml reporta o erro na **key seguinte** (`persona_principal`, linha 7), mascarando a causa real. Reprodução: `npm i --no-save gray-matter@^4`, rodar `matter()` no arquivo → `YAMLException: can not read a block mapping entry; a multiline key may not be an implicit key`.

## Fixes

**1. Gate resiliente** (`memory-schema-gate.yml`) — `matter(raw)` agora em try/catch. Arquivo que lança vira violação `level:'error'` (`YAML parse error: <reason>`), conta como falha (strict bloqueia merge) e o gate **segue validando o resto**.

**2. Charters que crashavam** — `kb/Troubleshooter`, `kb/Paths`, `kb/Node` (os 3 únicos parse-crashers do repo):
- `owner: [W] Wagner` → `owner: wagner` (causa do crash + enum do schema)
- FQCN com backslash → single-quotado (`'Modules\KB\...'`) — antes os backslashes eram silenciosamente comidos
- `page:` ganhou leading `/` (pattern `^/.*$`) + `component:` obrigatório (mapeado pro Dialog/Reader governado)
- `charter_version: 1.0` → `1`; removido ` (proposta)` do slug de ADR

Os 3 agora **parseiam E validam** contra `scripts/memory-schemas/charter.schema.json`. **Parse-failures de charter no repo vão a zero.**

## Verificação

- Extraí o script Node real do workflow e rodei contra um set com [malformado + válido + schema-inválido-porém-parseável]: o malformado reporta `YAML parse error`, o schema-inválido reporta os erros normais, o válido passa, job sai 1 — **sem crash**. O script **pré-fix** no mesmo input quebra com stack trace e nunca escreve `violations.json`.
- Scan repo-wide dos 137 charters: `PARSE_FAIL` 2 → **0** após o fix.

## Fora de escopo (de propósito)

Os ~60 charters com débito de schema (`last_validated` data sem aspas + `related_adrs` inválidos) **não** entram aqui — 59 já estão na branch `chore/charter-frontmatter-schema-normalize`. Essa branch **deixou 1 de fora**: `resources/js/Pages/Essentials/Knowledge/Index.charter.md` — vale adicionar lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)