### PR TITLE
fix(compras): restaura menu "Lista de compras" no sidebar (gated por compras_module)

### DIFF
--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -249,7 +249,7 @@ class AdminSidebarMenu
             if (in_array('purchases', $enabled_modules) && (auth()->user()->can('purchase.view') || auth()->user()->can('purchase.create') || auth()->user()->can('purchase.update'))) {
                 $menu->dropdown(
                     __('purchase.purchases'),
-                    function ($sub) use ($common_settings) {
+                    function ($sub) use ($common_settings, $enabled_modules) {
                         if (!empty($common_settings['enable_purchase_requisition']) && (auth()->user()->can('purchase_requisition.view_all') || auth()->user()->can('purchase_requisition.view_own'))) {
                             $sub->url(
                                 action([\App\Http\Controllers\PurchaseRequisitionController::class, 'index']),
@@ -265,18 +265,24 @@ class AdminSidebarMenu
                                 ['icon' => '', 'active' => request()->segment(1) == 'purchase-order']
                             );
                         }
-                        // Wagner 2026-05-22 P3: entry "List Purchase" → /purchases REMOVIDA.
-                        // Duplicava com Modules/Compras canon (entry "Compras" → /compras).
-                        // Rota /purchases continua funcionando (tela Blade legacy + sub-rotas
-                        // create/edit/return/etc preservadas abaixo). Apenas o item no menu
-                        // some pra evitar 2 "Compras" no sidebar.
-                        // if (auth()->user()->can('purchase.view') || auth()->user()->can('view_own_purchase')) {
-                        //     $sub->url(
-                        //         action([\App\Http\Controllers\PurchaseController::class, 'index']),
-                        //         __('purchase.list_purchase'),
-                        //         ['icon' => '', 'active' => request()->segment(1) == 'purchases' && request()->segment(2) == null]
-                        //     );
-                        // }
+                        // "Lista de compras" → /purchases (tela Blade legacy).
+                        // Wagner 2026-05-22 removeu este item achando que a entry canônica
+                        // "Compras" → /compras (Modules/Compras DataController) já substituía —
+                        // mas essa entry só aparece com `compras_module` ON. Pros businesses com
+                        // a flag OFF (ex: ROTA LIVRE biz=4) isso apagou o ÚNICO caminho de menu
+                        // pra consulta de compras (bug reportado 2026-06-17).
+                        // Fix: re-exibe GATED — some só quando o módulo canônico está ON (mesmo
+                        // gate `in_array(..., $enabled_modules)` usado nos outros dropdowns deste
+                        // arquivo, espelha isModuleEnabled('compras_module') do DataController),
+                        // então nunca dá 2 "Compras" no sidebar.
+                        // R-COM-301 (SPEC Compras): flag controla VISIBILIDADE, não bloqueia /purchases.
+                        if (! in_array('compras_module', $enabled_modules) && (auth()->user()->can('purchase.view') || auth()->user()->can('view_own_purchase'))) {
+                            $sub->url(
+                                action([\App\Http\Controllers\PurchaseController::class, 'index']),
+                                __('purchase.list_purchase'),
+                                ['icon' => '', 'active' => request()->segment(1) == 'purchases' && request()->segment(2) == null]
+                            );
+                        }
                         if (auth()->user()->can('purchase.create')) {
                             $sub->url(
                                 action([\App\Http\Controllers\PurchaseController::class, 'create']),

--- a/tests/Feature/Sidebar/ComprasLegacyListMenuTest.php
+++ b/tests/Feature/Sidebar/ComprasLegacyListMenuTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php. NÃO redeclarar.
+
+/**
+ * Anti-regressão — entry legacy "Lista de compras" no sidebar.
+ *
+ * Bug 2026-06-17 (cliente ROTA LIVRE / Guilherme): o dropdown "Compras" do
+ * sidebar legacy mostrava só "Adicionar compra" + "Lista de retornos de compra",
+ * sem caminho pra consulta de compras (/purchases). Causa: a remoção incondicional
+ * do item em 2026-05-22 (achando que a entry canônica "Compras" → /compras já
+ * substituía), mas essa entry só aparece com `compras_module` ON. Pros businesses
+ * com a flag OFF, isso apagou o ÚNICO caminho de menu pra lista.
+ *
+ * Contrato travado: o item "Lista de compras" → /purchases existe no
+ * AdminSidebarMenu, GATED por `! in_array('compras_module', $enabled_modules)`
+ * (some só quando o módulo canônico está ON — espelha isModuleEnabled do
+ * Modules/Compras DataController, evitando 2 "Compras" no sidebar).
+ *
+ * Assertion source-level (file_get_contents) seguindo o pattern de
+ * Biz4RotaLivreSidebarTest — não precisa boot/DB (testes rodam no CT 100).
+ *
+ * Refs:
+ *   - R-COM-301 (memory/requisitos/Compras/SPEC.md): flag controla VISIBILIDADE
+ *     do entry, NÃO bloqueia /purchases.
+ *   - app/Http/Middleware/AdminSidebarMenu.php (Purchase dropdown)
+ */
+describe('Anti-regressão sidebar — entry "Lista de compras" legacy', function () {
+    $middleware = dirname(__DIR__, 3) . '/app/Http/Middleware/AdminSidebarMenu.php';
+
+    it('AdminSidebarMenu re-publica "Lista de compras" → /purchases gated por compras_module', function () use ($middleware) {
+        $src = file_get_contents($middleware);
+
+        // O item existe e aponta pro PurchaseController@index (tela legacy /purchases)
+        expect($src)->toContain("__('purchase.list_purchase')");
+        expect($src)->toContain('\App\Http\Controllers\PurchaseController::class, \'index\'');
+
+        // Gate canon: some SÓ quando o módulo canônico Compras está ON
+        expect($src)->toContain("! in_array('compras_module', \$enabled_modules)");
+
+        // O closure do dropdown precisa receber $enabled_modules pra avaliar o gate
+        expect($src)->toContain('function ($sub) use ($common_settings, $enabled_modules)');
+    });
+
+    it('marcador da remoção antiga sumiu (não pode voltar a comentar o bloco)', function () use ($middleware) {
+        $src = file_get_contents($middleware);
+
+        // A remoção de 2026-05-22 deixava este marcador no comentário do bloco morto.
+        expect($src)->not->toContain('entry "List Purchase" → /purchases REMOVIDA');
+    });
+});


### PR DESCRIPTION
## Bug (cliente ROTA LIVRE, reportado 2026-06-17)

No sidebar, o dropdown **Compras** mostrava só *Adicionar compra* + *Lista de retornos de compra* — **sem caminho pra consulta de compras** (`/purchases`). O usuário só chegava na lista por acidente, depois de criar uma compra (o `store` redireciona pro index).

## Causa raiz

Em **2026-05-22** o item `"Lista de compras" → /purchases` foi removido **incondicionalmente** de `AdminSidebarMenu.php`, assumindo que a entry canônica `"Compras" → /compras` (`Modules/Compras/DataController::modifyAdminMenu`) já substituía.

Mas essa entry canônica **só aparece quando `compras_module` está ON** no business (`default => false`). Pros businesses com a flag **OFF** (ex: ROTA LIVRE biz=4), a remoção apagou o **único** caminho de menu pra lista.

Isso contradizia o próprio SPEC:

> **R-COM-301**: *"Feature flag `compras_module_enabled` controla **visibilidade do entry 'Compras'** no sidebar (não bloqueia `/purchases`)"*

A regra é esconder o menu legacy **só quando** `compras_module` está ON (Wave 8) — não antes.

## Fix

Re-exibe `"Lista de compras" → /purchases` no dropdown legacy, **gated** por `! in_array('compras_module', $enabled_modules)`:

- Flag **OFF** → item aparece (caminho legacy restaurado). ✅ resolve o cliente.
- Flag **ON** → item some, e a entry canônica `"Compras" → /compras` cobre. ✅ sem 2 "Compras".

O gate usa o mesmo padrão `in_array(..., $enabled_modules)` dos outros dropdowns deste arquivo e espelha o `isModuleEnabled('compras_module')` do DataController — garantindo complementaridade perfeita.

## Catraca

`tests/Feature/Sidebar/ComprasLegacyListMenuTest.php` trava o contrato (source-level, sem DB) pra essa remoção não acontecer de novo silenciosamente.

## Verificação

- `php -l` limpo nos 2 arquivos.
- `purchase.list_purchase` (pt-BR) → **"Lista de compras"**.
- Suite Pest roda no CI (CT 100) — worktree local não tem `vendor/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Infra Contract

> **Natureza da mudança:** este PR toca `app/Http/Middleware/AdminSidebarMenu.php` (builder do sidebar), mas **não altera roteamento nem comportamento HTTP**. Muda apenas *qual item do dropdown "Compras" é renderizado*, condicionado à flag `compras_module` do business. Nenhuma rota foi adicionada/removida — `/purchases` nunca saiu (só o item de menu foi removido em 2026-05-22).

### 1. Happy path — o que validar

A asserção real é **presença do item de menu** (não status HTTP). Verificável pós-deploy via browser logado num business com `compras_module` **OFF**: o dropdown "Compras" passa a exibir **"Lista de compras"** → `/purchases`.

A rota destino do link está viva (controle, capturado agora, não-autenticado):

```bash
$ curl -s -o /dev/null -w 'HTTP %{http_code} -> %{redirect_url}\n' https://oimpresso.com/purchases
HTTP 302 -> https://oimpresso.com/login   # rota existe + auth-protected (inalterada)
```

### 2. Regression adjacent — rotas que NÃO devem mudar (capturado agora, não-autenticado)

```bash
$ curl -s -o /dev/null -w 'HTTP %{http_code} -> %{redirect_url}\n' https://oimpresso.com/purchases/create
HTTP 302 -> https://oimpresso.com/login
$ curl -s -o /dev/null -w 'HTTP %{http_code} -> %{redirect_url}\n' https://oimpresso.com/purchase-return
HTTP 302 -> https://oimpresso.com/login
$ curl -s -o /dev/null -w 'HTTP %{http_code} -> %{redirect_url}\n' https://oimpresso.com/compras
HTTP 302 -> https://oimpresso.com/login
```

Os outros dois itens do dropdown (Adicionar compra, Lista de retornos) e a entry canônica `/compras` seguem intactos.

### 3. Environment delta — onde o Pest NÃO prova prod

- O `ComprasLegacyListMenuTest` é **source-level** (`file_get_contents`): prova que o item foi re-adicionado gated, **não** que o prod o renderiza.
- Middleware → **OPcache** pode servir bytecode antigo. Exigir `php artisan optimize:clear` + `opcache_reset` pós-deploy.
- O sidebar também é exposto via Inertia `shell.menu` (`HandleInertiaRequests`) → **LSCache** (LiteSpeed) pode servir HTML/props stale em prod. Confirmar com hard-reload.
- **Pest local + lint NÃO provam prod.** Validação real é o smoke de menu pós-deploy (seção 4).

### 4. Smoke prod pós-deploy (preencher após merge + git pull Hostinger)

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| Business com `compras_module` **OFF** | dropdown "Compras" mostra **"Lista de compras"** → `/purchases` | _(pós-deploy)_ | ⬜ |
| Business com `compras_module` **ON** | item legacy **ausente**; aparece entry canônica "Compras" → `/compras` (sem duplicar) | _(pós-deploy)_ | ⬜ |
| `/purchases` autenticado | `200` (lista carrega) | _(pós-deploy)_ | ⬜ |
