### PR TITLE
feat(teammcp): PR-1 loop handoff zero-paste — persistência + ingest assinado (Fase 0 ADR 0283)

### DIFF
--- a/Modules/TeamMcp/Config/config.php
+++ b/Modules/TeamMcp/Config/config.php
@@ -13,4 +13,14 @@ return [
     'module_icon'        => 'fa fa-users',
     'module_version'     => '0.1',
     'pid'                => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Loop de Handoff Zero-Paste (Fase 0 · ADR 0283)
+    |--------------------------------------------------------------------------
+    | Segredo HMAC pra validar a proveniência dos handoffs de design (A1). Vive
+    | SÓ no env do servidor + secret do pipeline de export do Cowork — NUNCA
+    | versionado, nunca no Cowork, nunca no Code. `handoff:ingest` aborta se vazio.
+    */
+    'handoff_secret' => env('HANDOFF_SECRET'),
 ];

--- a/Modules/TeamMcp/Console/Commands/HandoffIngestCommand.php
+++ b/Modules/TeamMcp/Console/Commands/HandoffIngestCommand.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
+
+/**
+ * HandoffIngestCommand — PR-1 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283).
+ *
+ * Parseia handoffs de design assinados, VALIDA a assinatura
+ * `HMAC-SHA256(body, HANDOFF_SECRET)` e cria registros 'pending' em
+ * `cowork_handoffs`.
+ *
+ * **Definição do `body` assinado (contrato com o pipeline de export):** o arquivo
+ * é `---\n<yaml>\n---\n<body>`. O `sig` cobre **apenas o `<body>`** (tudo após o
+ * frontmatter), com CRLF normalizado pra LF — determinístico cross-OS
+ * ({@see lição CRLF em writes}). Assinar só o corpo (não o frontmatter) é o que
+ * permite embutir o próprio `sig` no frontmatter.
+ *
+ * **Proveniência (A1 do adversário [AH]):** handoff sem `sig` válida é REJEITADO
+ * (logado, não inserido). Comparação timing-safe (`hash_equals`). O SECRET vive
+ * só no env do servidor / pipeline de export — NUNCA versionado, nunca no Cowork,
+ * nunca no Code.
+ *
+ * **Append-only (A6 · {@see ADR 0130}/0003):** revisão de um slug já aplicado vira
+ * NOVA version 'pending' + a anterior 'superseded'. Re-ingest idêntico (mesmo
+ * `source_hash`) é no-op.
+ *
+ * **Onde roda:** server-side, onde o DB existe (cron ou webhook git→DB espelhando
+ * `SyncMemoryWebhookController`). NÃO roda num runner de CI — o runner não alcança
+ * o DB de produção (decisão consciente, não "gate de mentira"). O trigger é wiring
+ * de deploy, fora do escopo do PR-1.
+ *
+ * Uso:
+ *   php artisan handoff:ingest                    # ingere prototipo-ui/handoffs/*.md
+ *   php artisan handoff:ingest --path=outro/dir   # caminho alternativo (abs ou relativo)
+ *   php artisan handoff:ingest --dry-run          # valida + mostra plano, não persiste
+ *   php artisan handoff:ingest --detail           # motivo de cada rejeição/skip
+ *
+ * Convenções ({@see .claude/rules/commands.md}): `--detail`/`--dry-run` (não
+ * `--verbose`), output PT-BR, exit 0 sucesso / 1 erro.
+ *
+ * @see Modules\TeamMcp\Entities\CoworkHandoff
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+final class HandoffIngestCommand extends Command
+{
+    protected $signature = 'handoff:ingest
+        {--path=prototipo-ui/handoffs : Diretório dos handoffs assinados (abs ou relativo à base do app)}
+        {--dry-run : Valida assinatura e mostra o plano, não persiste}
+        {--detail : Imprime o motivo de cada rejeição/skip}';
+
+    protected $description = 'Ingere handoffs de design assinados (HMAC) → cowork_handoffs pending. Rejeita sem sig válida. Append-only por slug/version.';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('cowork_handoffs')) {
+            $this->error('Tabela cowork_handoffs não existe. Rode php artisan migrate primeiro.');
+
+            return self::FAILURE;
+        }
+
+        $secret = (string) config('teammcp.handoff_secret', '');
+        if ($secret === '') {
+            $this->error('HANDOFF_SECRET não configurado (config teammcp.handoff_secret). Ingest assinado exige o segredo — abortando.');
+
+            return self::FAILURE;
+        }
+
+        $dir = $this->resolveDir((string) $this->option('path'));
+        if (! is_dir($dir)) {
+            $this->warn("Diretório não existe: {$dir} — nada a ingerir.");
+
+            return self::SUCCESS;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $detail = (bool) $this->option('detail');
+
+        $files = glob(rtrim($dir, '/\\') . '/*.md') ?: [];
+        $stats = ['rejeitado' => 0, 'sem_mudanca' => 0, 'novo' => 0, 'revisao' => 0];
+
+        foreach ($files as $file) {
+            try {
+                $this->processFile($file, $secret, $dryRun, $detail, $stats);
+            } catch (Throwable $e) {
+                $stats['rejeitado']++;
+                $this->warn('REJEITADO (erro de parse): ' . basename($file) . ($detail ? " — {$e->getMessage()}" : ''));
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '%s %d arquivo(s): %d novo · %d revisão · %d sem-mudança · %d rejeitado',
+            $dryRun ? '[DRY RUN]' : 'Ingest:',
+            count($files),
+            $stats['novo'],
+            $stats['revisao'],
+            $stats['sem_mudanca'],
+            $stats['rejeitado'],
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Resolve o diretório: aceita caminho absoluto (unix `/...` ou Windows `C:`)
+     * ou relativo à base do app.
+     */
+    private function resolveDir(string $path): string
+    {
+        $isAbsolute = str_starts_with($path, '/') || preg_match('#^[A-Za-z]:#', $path) === 1;
+
+        return $isAbsolute ? $path : base_path($path);
+    }
+
+    /**
+     * Processa um arquivo: parse frontmatter, valida HMAC, aplica append-only.
+     *
+     * @param  array<string,int>  $stats  acumulador (by-ref)
+     */
+    private function processFile(string $file, string $secret, bool $dryRun, bool $detail, array &$stats): void
+    {
+        [$fm, $body] = $this->parseFrontmatter((string) file_get_contents($file));
+
+        // A1: assinatura obrigatória — rejeita unsigned/forjado (timing-safe).
+        $expected = hash_hmac('sha256', $body, $secret);
+        $provided = (string) ($fm['sig'] ?? '');
+        if ($provided === '' || ! hash_equals($expected, $provided)) {
+            $stats['rejeitado']++;
+            $this->warn('REJEITADO (sig inválida): ' . basename($file));
+
+            return;
+        }
+
+        $slug = (string) ($fm['handoff_id'] ?? $fm['slug'] ?? '');
+        if ($slug === '') {
+            $stats['rejeitado']++;
+            $this->warn('REJEITADO (sem handoff_id): ' . basename($file));
+
+            return;
+        }
+
+        $hash = hash('sha256', $body);
+        $existing = CoworkHandoff::where('slug', $slug)->orderByDesc('version')->first();
+
+        // Re-ingest idêntico = no-op (dedup por source_hash).
+        if ($existing && $existing->source_hash === $hash) {
+            $stats['sem_mudanca']++;
+            if ($detail) {
+                $this->line("sem mudança: {$slug} v{$existing->version}");
+            }
+
+            return;
+        }
+
+        $version = $existing ? ((int) $existing->version + 1) : 1;
+        $isRevisao = (bool) $existing;
+        $supersede = $existing && $existing->status === 'applied';
+
+        if ($dryRun) {
+            $stats[$isRevisao ? 'revisao' : 'novo']++;
+            $this->line(sprintf(
+                '[plano] %s v%d (%s)%s',
+                $slug,
+                $version,
+                $isRevisao ? 'revisão' : 'novo',
+                $supersede ? ' + supersede anterior' : '',
+            ));
+
+            return;
+        }
+
+        // A6: revisão de algo já aplicado = lápide na anterior (append-only).
+        if ($existing !== null && $existing->status === 'applied') {
+            CoworkHandoff::where('id', $existing->id)->update(['status' => 'superseded']);
+        }
+
+        CoworkHandoff::create([
+            'slug'            => $slug,
+            'version'         => $version,
+            'tela'            => (string) ($fm['tela'] ?? ''),
+            'status'          => 'pending',
+            'audited_against' => $fm['audited_against'] ?? null,
+            'body_md'         => $body,
+            'files_json'      => (array) ($fm['files'] ?? []),
+            'source_hash'     => $hash,
+            'sig'             => $provided,
+            'created_by'      => (string) ($fm['created_by'] ?? 'CC'),
+            'created_at'      => now(),
+        ]);
+
+        $stats[$isRevisao ? 'revisao' : 'novo']++;
+        $this->info(($isRevisao ? "revisão {$slug} v{$version}" : "novo {$slug} v{$version}") . ' → pending');
+    }
+
+    /**
+     * Separa o frontmatter YAML do corpo markdown.
+     *
+     * Normaliza CRLF→LF ANTES de qualquer coisa pra o `body` (e portanto o HMAC)
+     * ser determinístico cross-OS. Sem frontmatter válido → ([], rawNormalizado).
+     *
+     * @return array{0: array<string,mixed>, 1: string}
+     */
+    private function parseFrontmatter(string $raw): array
+    {
+        $raw = str_replace("\r\n", "\n", $raw);
+
+        if (! preg_match('/^---\n(.*?)\n---\n(.*)$/s', $raw, $m)) {
+            return [[], $raw];
+        }
+
+        $fm = Yaml::parse($m[1]);
+
+        return [is_array($fm) ? $fm : [], $m[2]];
+    }
+}

--- a/Modules/TeamMcp/Database/Migrations/2026_06_17_120000_create_cowork_handoffs_table.php
+++ b/Modules/TeamMcp/Database/Migrations/2026_06_17_120000_create_cowork_handoffs_table.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * PR-1 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — fonte da verdade dos
+ * handoffs de design Cowork→Code.
+ *
+ * 1 linha por (slug, version). `handoff:ingest` valida HMAC e cria 'pending';
+ * revisão de um slug já aplicado vira NOVA version 'pending' + a anterior
+ * 'superseded' (append-only {@see ADR 0130}/0003 — NUNCA delete).
+ *
+ * Tier 0 ({@see ADR 0093}): SEM business_id — handoff de design é artefato do
+ * REPO (cross-tenant), não dado de tenant. Espelha mcp_ingest_heartbeat /
+ * mcp_cc_sessions. NUNCA adicionar global scope de business aqui.
+ *
+ * MySQL (DB_CONNECTION=mysql): a spec Cowork trazia DDL PostgreSQL
+ * (BIGSERIAL/JSONB/TIMESTAMPTZ/índice parcial `WHERE status='pending'`). Aqui o
+ * main vence: bigIncrements + json + timestamp; MySQL 8 não tem índice parcial
+ * → índice simples em `status`.
+ *
+ * Idempotente (hasTable) + reversível (down dropIfExists).
+ *
+ * @see Modules\TeamMcp\Console\Commands\HandoffIngestCommand (writer)
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('cowork_handoffs')) {
+            return;
+        }
+
+        Schema::create('cowork_handoffs', function (Blueprint $t) {
+            $t->bigIncrements('id');
+
+            $t->string('slug', 120)
+                ->comment('Identificador do handoff (ex: caixa-mobile-flutuante)');
+            $t->unsignedInteger('version')->default(1)
+                ->comment('Revisão = nova versão (append-only ADR 0130/0003)');
+            $t->string('tela', 160)
+                ->comment('Tela alvo (ex: Atendimento/CaixaUnificada)');
+            $t->string('status', 16)->default('pending')
+                ->comment('pending|applied|rejected|stale|superseded');
+            $t->string('audited_against', 40)->nullable()
+                ->comment('SHA do main lido por [CC] na auditoria (R1 ADR 0283)');
+            $t->longText('body_md')
+                ->comment('Corpo do handoff — DESIGN (dado), não comando');
+            $t->json('files_json')
+                ->comment('Arquivos que o handoff autoriza tocar (escopo do PR)');
+            $t->char('source_hash', 64)
+                ->comment('sha256(body) — dedup de re-ingest sem mudança');
+            $t->char('sig', 64)
+                ->comment('HMAC-SHA256(body, HANDOFF_SECRET) — proveniência (A1)');
+            $t->string('created_by', 40)->default('CC');
+            $t->timestamp('created_at')->useCurrent();
+            $t->timestamp('applied_at')->nullable()
+                ->comment('Quando o ack fechou o handoff (PR-2)');
+            $t->string('applied_by', 60)->nullable();
+            $t->text('pr_url')->nullable();
+            $t->json('gate_status')->nullable()
+                ->comment('{conformance,critique_score,a11y} gravado no ack (A3)');
+
+            $t->unique(['slug', 'version'], 'cowork_handoffs_slug_version_uq');
+            $t->index('status', 'cowork_handoffs_status_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cowork_handoffs');
+    }
+};

--- a/Modules/TeamMcp/Entities/CoworkHandoff.php
+++ b/Modules/TeamMcp/Entities/CoworkHandoff.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * CoworkHandoff — PR-1 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283).
+ *
+ * Fonte da verdade dos handoffs de design Cowork→Code (F1→F3). `handoff:ingest`
+ * cria 'pending'; o tool `handoff-ack` (PR-2) fecha pra 'applied'/'rejected'.
+ *
+ * Tier 0 ({@see ADR 0093}): SEM business_id e SEM HasBusinessScope — handoff de
+ * design é artefato do REPO (cross-tenant), não dado de tenant. Espelha
+ * {@see McpIngestHeartbeat}. NUNCA adicionar global scope de business aqui.
+ *
+ * Append-only no plano de slug ({@see ADR 0130}): revisão = nova version
+ * 'pending' + anterior 'superseded'. NUNCA delete.
+ *
+ * @property int $id
+ * @property string $slug
+ * @property int $version
+ * @property string $tela
+ * @property string $status
+ * @property string|null $audited_against
+ * @property string $body_md
+ * @property array $files_json
+ * @property string $source_hash
+ * @property string $sig
+ * @property string $created_by
+ * @property \Illuminate\Support\Carbon|null $applied_at
+ * @property string|null $applied_by
+ * @property string|null $pr_url
+ * @property array|null $gate_status
+ */
+class CoworkHandoff extends Model
+{
+    protected $table = 'cowork_handoffs';
+
+    // created_at via useCurrent na migration; applied_at gravado manualmente no
+    // ack. Sem updated_at (espelha McpAuditLog — escrita controlada).
+    public $timestamps = false;
+
+    protected $fillable = [
+        'slug', 'version', 'tela', 'status', 'audited_against',
+        'body_md', 'files_json', 'source_hash', 'sig', 'created_by',
+        'created_at', 'applied_at', 'applied_by', 'pr_url', 'gate_status',
+    ];
+
+    protected $casts = [
+        'version'     => 'integer',
+        'files_json'  => 'array',
+        'gate_status' => 'array',
+        'created_at'  => 'datetime',
+        'applied_at'  => 'datetime',
+    ];
+
+    /** Status válidos (espelha o comentário da coluna `status`). */
+    public const STATUSES = ['pending', 'applied', 'rejected', 'stale', 'superseded'];
+}

--- a/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
+++ b/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Modules\TeamMcp\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Modules\TeamMcp\Console\Commands\HandoffIngestCommand;
 use Modules\TeamMcp\Console\Commands\RotateTokenCommand;
 use Modules\TeamMcp\Console\Commands\SeedActorsCommand;
 
@@ -33,6 +34,9 @@ class TeamMcpServiceProvider extends ServiceProvider
             $this->commands([
                 SeedActorsCommand::class,
                 RotateTokenCommand::class,
+                // handoff:ingest — PR-1 loop handoff zero-paste (Fase 0 ADR 0283):
+                // ingere handoffs de design assinados (HMAC) → cowork_handoffs pending.
+                HandoffIngestCommand::class,
             ]);
         }
     }

--- a/Modules/TeamMcp/SCOPE.md
+++ b/Modules/TeamMcp/SCOPE.md
@@ -44,6 +44,7 @@ db_tables_owned:
   - mcp_user_module_access
   - mcp_actors (NOVA — Fase 4 ADR 0081)
   - mcp_audit_log (mantém append-only com trigger; UI Fase 5 fica em Modules/Governance)
+  - cowork_handoffs (NOVA — PR-1 loop handoff zero-paste Fase 0 ADR 0283; append-only por slug/version, cross-tenant)
   - mcp_cc_sessions / mcp_cc_messages / mcp_cc_blobs
   - mcp_tasks / mcp_epics / mcp_cycles / mcp_jira_projects (Jira-style)
   - mcp_inbox_notifications

--- a/Modules/TeamMcp/Tests/Feature/HandoffIngestTest.php
+++ b/Modules/TeamMcp/Tests/Feature/HandoffIngestTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+use Symfony\Component\Yaml\Yaml;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-1 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — GUARD do `handoff:ingest`.
+ *
+ * Provas (critério de aceite "Pronto quando" do PR-1 + A1/A6 do adversário [AH]):
+ *   1. handoff assinado → cria 'pending' com campos certos
+ *   2. handoff FORJADO (sig inválida) → REJEITADO, não insere (A1 — fecha RCE)
+ *   3. handoff SEM sig → REJEITADO (A1)
+ *   4. revisão de 'applied' → nova version 'pending' + anterior 'superseded' (A6, append-only)
+ *   5. re-ingest idêntico → no-op (dedup por source_hash)
+ *   6. HANDOFF_SECRET ausente → FAILURE, não ingere (sig assinada exige segredo)
+ *
+ * Estratégia (espelha IngestHeartbeatTest): tabela sintética sqlite-friendly +
+ * arquivos temporários reais. A assinatura do teste usa a MESMA definição de
+ * `body` do command (corpo após o frontmatter, CRLF→LF) — contrato self-consistente.
+ *
+ * Tier 0 ({@see ADR 0093}): tabela SEM business_id (cross-tenant by design).
+ *
+ * @see Modules\TeamMcp\Console\Commands\HandoffIngestCommand
+ * @see Modules\TeamMcp\Database\Migrations\2026_06_17_120000_create_cowork_handoffs_table.php
+ */
+
+const HANDOFF_TEST_SECRET = 'segredo-de-teste-hmac-pr1';
+
+/** Cria a tabela sintética (espelha a migration; sqlite-friendly). */
+function ensureCoworkHandoffsTable(): void
+{
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+
+    Schema::create('cowork_handoffs', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('slug', 120);
+        $t->unsignedInteger('version')->default(1);
+        $t->string('tela', 160)->default('');
+        $t->string('status', 16)->default('pending');
+        $t->string('audited_against', 40)->nullable();
+        $t->longText('body_md');
+        $t->json('files_json');
+        $t->char('source_hash', 64);
+        $t->char('sig', 64);
+        $t->string('created_by', 40)->default('CC');
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('applied_at')->nullable();
+        $t->string('applied_by', 60)->nullable();
+        $t->text('pr_url')->nullable();
+        $t->json('gate_status')->nullable();
+        $t->unique(['slug', 'version']);
+        $t->index('status');
+    });
+}
+
+/**
+ * Escreve um handoff .md no diretório temp. Por padrão assina corretamente; passe
+ * `sig` em $extraFm pra forjar, ou $secret=null pra omitir a assinatura.
+ */
+function writeHandoff(string $dir, string $slug, string $body, ?string $secret = HANDOFF_TEST_SECRET, array $extraFm = []): void
+{
+    if (! is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+
+    $normBody = str_replace("\r\n", "\n", $body);
+
+    $fm = array_merge([
+        'handoff_id'      => $slug,
+        'tela'            => 'Atendimento/CaixaUnificada',
+        'audited_against' => 'cb1a546',
+        'files'           => ['resources/css/cockpit.css', 'resources/js/Layouts/AppShellV2.tsx'],
+        'created_by'      => 'CC',
+    ], $extraFm);
+
+    // Assina só o corpo (mesma definição do command), salvo sig explícito (forja).
+    if ($secret !== null && ! array_key_exists('sig', $extraFm)) {
+        $fm['sig'] = hash_hmac('sha256', $normBody, $secret);
+    }
+
+    $yaml = Yaml::dump($fm);
+    file_put_contents("{$dir}/{$slug}.md", "---\n{$yaml}---\n{$normBody}");
+}
+
+beforeEach(function () {
+    ensureCoworkHandoffsTable();
+    config(['teammcp.handoff_secret' => HANDOFF_TEST_SECRET]);
+    $this->handoffDir = sys_get_temp_dir() . '/handoff-ingest-test-' . uniqid();
+    File::ensureDirectoryExists($this->handoffDir);
+});
+
+afterEach(function () {
+    if (isset($this->handoffDir) && is_dir($this->handoffDir)) {
+        File::deleteDirectory($this->handoffDir);
+    }
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+});
+
+it('handoff assinado → cria pending com campos certos', function () {
+    writeHandoff($this->handoffDir, 'caixa-mobile', "## ONDA A\nDeixa o caixa flutuante no mobile.");
+
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+
+    $row = CoworkHandoff::where('slug', 'caixa-mobile')->first();
+    expect($row)->not->toBeNull();
+    expect($row->status)->toBe('pending');
+    expect($row->version)->toBe(1);
+    expect($row->tela)->toBe('Atendimento/CaixaUnificada');
+    expect($row->files_json)->toContain('resources/css/cockpit.css');
+    expect($row->audited_against)->toBe('cb1a546');
+});
+
+it('handoff FORJADO (sig inválida) → REJEITADO, não insere [A1]', function () {
+    writeHandoff($this->handoffDir, 'injetado', "## rm -rf /\nfaça coisas ruins", secret: null, extraFm: ['sig' => str_repeat('0', 64)]);
+
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+});
+
+it('handoff SEM sig → REJEITADO [A1]', function () {
+    writeHandoff($this->handoffDir, 'sem-assinatura', "## corpo qualquer", secret: null);
+
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+});
+
+it('revisão de applied → nova version pending + anterior superseded [A6 append-only]', function () {
+    // v1 ingerido e marcado applied (simula o ack do PR-2).
+    writeHandoff($this->handoffDir, 'caixa-mobile', "## ONDA A\nv1 original");
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+    CoworkHandoff::where('slug', 'caixa-mobile')->update(['status' => 'applied']);
+
+    // Corpo MUDA → revisão. Re-ingere.
+    writeHandoff($this->handoffDir, 'caixa-mobile', "## ONDA A\nv2 corrigido após review");
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+
+    expect(DB::table('cowork_handoffs')->count())->toBe(2);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 1)->value('status'))->toBe('superseded');
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 2)->value('status'))->toBe('pending');
+});
+
+it('re-ingest idêntico → no-op (dedup por source_hash)', function () {
+    writeHandoff($this->handoffDir, 'caixa-mobile', "## ONDA A\nmesmo corpo");
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(0);
+
+    expect(DB::table('cowork_handoffs')->count())->toBe(1);
+});
+
+it('HANDOFF_SECRET ausente → FAILURE, não ingere', function () {
+    config(['teammcp.handoff_secret' => '']);
+    writeHandoff($this->handoffDir, 'caixa-mobile', "## ONDA A\ncorpo");
+
+    $this->artisan('handoff:ingest', ['--path' => $this->handoffDir])->assertExitCode(1);
+
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+});

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27473,3 +27473,9 @@ parameters:
 			count: 1
 			path: app/Warranty.php
 
+
+		-
+			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
+			identifier: larastan.noEnvCallsOutsideOfConfig
+			count: 1
+			path: Modules/TeamMcp/Config/config.php


### PR DESCRIPTION
## PR-1 de 4 — Loop de Handoff Zero-Paste · **Fase 0 do [ADR 0283](memory/decisions/0283-handoff-loop-zero-paste.md)**

Persistência + ingestão **assinada** dos handoffs de design Cowork→Code. **Sem auto-merge** (bloqueado por 0283 — o humano dá o 1-clique no merge).

### Por que esta forma (spec Cowork × main × ADR 0283)
O bloco Cowork pedia **PR-3 auto-merge** ("3 gates automáticos → entra no main sem [W]"). O **ADR 0283 (teu, 2026-06-17)** ruliu o oposto depois de 2 rodadas adversariais acharem **XSS vivo em prod que passou nos 17 required checks**: para `.tsx` multi-tenant, **humano-no-merge é estrutural**; **Fase 0 = ingest+pending+ack + 1-clique**. Implementei a Fase 0.

### O que entra (7 arquivos)
- **Migration `cowork_handoffs`** (MySQL): `json` + índice simples em `status`. A DDL da spec era PostgreSQL (`BIGSERIAL`/`JSONB`/`TIMESTAMPTZ`/índice parcial) — `DB_CONNECTION=mysql`, **main vence**. Cross-tenant, **sem `business_id`** (Tier 0 ADR 0093 — handoff é artefato do repo, espelha `mcp_ingest_heartbeat`).
- **`CoworkHandoff`** entity — append-only por `slug` (revisão = nova `version`, anterior `superseded`; ADR 0130).
- **`handoff:ingest`** command — valida `sig = HMAC-SHA256(body, HANDOFF_SECRET)` **timing-safe (`hash_equals`)**; rejeita sem sig (loga, não insere); append-only. `--dry-run`/`--detail`, PT-BR.
- **`config teammcp.handoff_secret`** = `env('HANDOFF_SECRET')` — env-only, nunca versionado.
- **Pest GUARD (6 testes)** — rejeita forjado/sem-sig (A1), aceita assinado→pending, revisão→`superseded` (A6), re-ingest no-op, secret-ausente→FAILURE.
- Registro no `TeamMcpServiceProvider` + `SCOPE.md` (`cowork_handoffs` em `db_tables_owned`).

### ✅ Fecha do adversário `[AH]`
- **A1 (proveniência / anti-RCE):** ingest exige HMAC válida; SECRET fora do Cowork/Code.
- **A6 (append-only):** revisão vira nova version + lápide na anterior (nada deletado).

### ⚠️ Decisões/abertos pra ti (review)
1. **Canal/fonte.** O ingest lê `prototipo-ui/handoffs/*.md` assinados (modelo HMAC por-arquivo). O **ADR 0283 R2** escolheu `COWORK_NOTES.md` "agora". Mantive o per-arquivo assinado por ser o que o HMAC pede em Fase 0 — **confirma ou redireciono**.
2. **Trigger do ingest.** **Não** adicionei GitHub Action rodando `handoff:ingest` num runner — o runner **não alcança o DB de produção** (seria mecanismo de mentira). Roda **server-side** (cron ou webhook git→DB espelhando `SyncMemoryWebhookController`). Wiring de deploy = follow-up.
3. **Contrato do `body` assinado.** `sig` cobre **só o corpo** (tudo após o frontmatter), com **CRLF→LF**. O pipeline de export do Cowork precisa assinar exatamente assim (documentado no docblock do command).

### Gate reality (pra PR-3 futuro, honesto)
Dos 3 gates do invariante: `conformance` ✓ e `a11y` ✓ existem; **`critique≥80` NÃO tem workflow CI** (é passo Cowork, não check automatizável) e o **scope-guard `files_json` não existe** (`scope-guard.yml` é controller-vs-`SCOPE.md`, ADR 0079 — função diferente). Por isso auto-merge fica pro "norte", coerente com 0283.

### Testes
Pest roda **no CI** (não localmente: o clone não tem `vendor/` e o checkout principal estava corrompido). Os 6 testes são sqlite-friendly (tabela sintética + arquivos temp), espelhando `IngestHeartbeatTest`.

## Infra Contract

> Mudança **console-only**: o único arquivo de runtime tocado é `TeamMcpServiceProvider.php`, e só pra registrar o command `handoff:ingest` em `runningInConsole()`. **Não há rota HTTP, middleware nem alteração do request-path de produção** — não há `curl -sv` aplicável. Contrato é de artisan (template `INFRA-CONTRACT.md` §"mudança sem rota HTTP testável").

### Artisan contract — output esperado (server-side, pós-`migrate`)
```bash
# 1) tabela ainda não migrada → falha controlada (exit 1)
$ php artisan handoff:ingest --dry-run
Tabela cowork_handoffs não existe. Rode php artisan migrate primeiro.

# 2) pós-migrate, sem segredo → aborta (exit 1), não ingere
$ HANDOFF_SECRET= php artisan handoff:ingest --dry-run
HANDOFF_SECRET não configurado (config teammcp.handoff_secret). Ingest assinado exige o segredo — abortando.

# 3) pós-migrate, com segredo, sem handoffs → no-op (exit 0)
$ php artisan handoff:ingest --dry-run
[DRY RUN] 0 arquivo(s): 0 novo · 0 revisão · 0 sem-mudança · 0 rejeitado
```

### Environment delta
- Os 6 Pest GUARD rodam **no CI** (sqlite-friendly) — não provam o MySQL de prod. Migration idempotente (`hasTable`) + reversível (`down`).
- Validação real é **server-side** (CT 100 / Hostinger, onde o DB existe), pós-`migrate` + provisão do `HANDOFF_SECRET`. Runner de CI **não** alcança o DB de prod — por isso nenhum trigger de ingest roda em CI (decisão consciente, não claim precoce).

### Próximos
PR-2 (tools `handoff-pending`/`handoff-ack` como `Laravel\Mcp\Server\Tool` em `OimpressoMcpServer`, **não** controller) · PR-4 (alerta pending-velho + audit) · scope-guard `files_json` novo como required.

> **Para review + 1-clique de [W]** (Fase 0). Não fiz self-merge.

Refs: ADR 0283 · relatório de divergência completo em `_handoff_spec/DIVERGENCE-REPORT.md` (local, gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
