### PR TITLE
feat(teammcp): PR-4 handoff:stale-alert — pending-velho → inbox ops (Fase 0 ADR 0283)

### DIFF
--- a/Modules/TeamMcp/Console/Commands/HandoffStaleAlertCommand.php
+++ b/Modules/TeamMcp/Console/Commands/HandoffStaleAlertCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpInboxNotification;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+
+/**
+ * HandoffStaleAlertCommand — PR-4 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283).
+ *
+ * Anti feedback-void: handoffs de design 'pending' há mais de N dias (default 3)
+ * alertam o ops — pra reauditar/aplicar ou rejeitar antes que apodreçam.
+ * Schedule daily 08:30 BRT (app/Console/Kernel.php).
+ *
+ * **"channel ops" da spec → modelo do main:** `McpInboxNotification` é per-user
+ * com `type` enum (SEM canal). Então o alerta vira 1 notificação `type='due_soon'`
+ * pro user de ops (`config('admin.wagner_user_id')`). Onde a spec diverge do main,
+ * o main vence.
+ *
+ * **Idempotente:** 1 digest por dia (marker {@see self::MARKER} + `whereDate` hoje)
+ * — evita spam diário; re-alerta no dia seguinte se ainda pendente (nag).
+ *
+ * Convenções ({@see .claude/rules/commands.md}): `--days`/`--dry-run` (não
+ * `--verbose`), output PT-BR, exit 0/1.
+ *
+ * @see Modules\TeamMcp\Entities\CoworkHandoff
+ * @see Modules\Jana\Entities\Mcp\McpInboxNotification
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+final class HandoffStaleAlertCommand extends Command
+{
+    /** Prefixo machine-detectável do body — usado no dedup diário. */
+    private const MARKER = '[handoff-stale]';
+
+    protected $signature = 'handoff:stale-alert
+        {--days=3 : Idade mínima (dias) pra considerar um pending velho}
+        {--dry-run : Mostra o que alertaria, não grava notificação}';
+
+    protected $description = 'Alerta no inbox ops handoffs de design pendentes há > N dias (anti feedback-void, ADR 0283). Idempotente: 1 digest/dia.';
+
+    public function handle(): int
+    {
+        if (! Schema::hasTable('cowork_handoffs')) {
+            $this->error('Tabela cowork_handoffs não existe. Rode php artisan migrate primeiro.');
+
+            return self::FAILURE;
+        }
+
+        $days = max(1, (int) $this->option('days'));
+        $cutoff = now()->subDays($days);
+
+        $stale = CoworkHandoff::query()
+            ->where('status', 'pending')
+            ->where('created_at', '<=', $cutoff)
+            ->orderBy('created_at')
+            ->get();
+
+        if ($stale->isEmpty()) {
+            $this->info("Nenhum handoff pendente há mais de {$days}d.");
+
+            return self::SUCCESS;
+        }
+
+        $lines = $stale->map(function (CoworkHandoff $h) {
+            $age = $h->created_at !== null ? (int) $h->created_at->diffInDays(now()) : 0;
+
+            return "• {$h->slug} v{$h->version} ({$h->tela}) — pendente há {$age}d";
+        });
+
+        $body = self::MARKER . " ⏰ {$stale->count()} handoff(s) de design pendente(s) há > {$days}d (Cowork→Code). "
+            . "Reaudite contra o main e aplique, ou rejeite com note:\n" . $lines->implode("\n");
+
+        $payload = [
+            'kind'  => 'handoff_stale',
+            'days'  => $days,
+            'count' => $stale->count(),
+            'slugs' => $stale->pluck('slug')->all(),
+        ];
+
+        if ((bool) $this->option('dry-run')) {
+            $this->info("[DRY RUN] alertaria {$stale->count()} handoff(s):");
+            $this->line($body);
+
+            return self::SUCCESS;
+        }
+
+        $opsUser = (int) config('admin.wagner_user_id', 1);
+
+        // Idempotência: 1 digest por dia (evita spam). Re-alerta amanhã se persistir.
+        $alreadyToday = McpInboxNotification::query()
+            ->where('user_id', $opsUser)
+            ->where('type', 'due_soon')
+            ->where('body', 'like', self::MARKER . '%')
+            ->whereDate('created_at', today())
+            ->exists();
+
+        if ($alreadyToday) {
+            $this->info("Já alertado hoje ({$stale->count()} pendente(s) > {$days}d) — sem duplicar.");
+
+            return self::SUCCESS;
+        }
+
+        McpInboxNotification::notify(
+            userId: $opsUser,
+            type: 'due_soon',
+            body: $body,
+            payload: $payload,
+        );
+
+        $this->info("Alertado: {$stale->count()} handoff(s) pendente(s) > {$days}d → inbox ops (user {$opsUser}).");
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
+++ b/Modules/TeamMcp/Providers/TeamMcpServiceProvider.php
@@ -4,6 +4,7 @@ namespace Modules\TeamMcp\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Modules\TeamMcp\Console\Commands\HandoffIngestCommand;
+use Modules\TeamMcp\Console\Commands\HandoffStaleAlertCommand;
 use Modules\TeamMcp\Console\Commands\RotateTokenCommand;
 use Modules\TeamMcp\Console\Commands\SeedActorsCommand;
 
@@ -37,6 +38,9 @@ class TeamMcpServiceProvider extends ServiceProvider
                 // handoff:ingest — PR-1 loop handoff zero-paste (Fase 0 ADR 0283):
                 // ingere handoffs de design assinados (HMAC) → cowork_handoffs pending.
                 HandoffIngestCommand::class,
+                // handoff:stale-alert — PR-4: handoffs pending > 3d alertam o inbox ops
+                // (anti feedback-void). Schedule daily em app/Console/Kernel.php.
+                HandoffStaleAlertCommand::class,
             ]);
         }
     }

--- a/Modules/TeamMcp/Tests/Feature/HandoffStaleAlertTest.php
+++ b/Modules/TeamMcp/Tests/Feature/HandoffStaleAlertTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpInboxNotification;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-4 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — GUARD do handoff:stale-alert.
+ *
+ * Provas ("Pronto quando" do PR-4 — anti feedback-void):
+ *   1. pending > N dias → 1 notificação due_soon pro ops, listando o slug velho;
+ *      pending fresco e applied NÃO entram.
+ *   2. idempotência: rodar 2× no mesmo dia → 1 notificação (sem spam).
+ *   3. zero stale → zero notificação.
+ *   4. --days respeitado (10d não pega um de 5d).
+ *
+ * Helpers com nomes ÚNICOS (prefixo stale*) pra não colidir com HandoffIngestTest /
+ * HandoffToolsTest no mesmo processo Pest. Tabelas sintéticas sqlite-friendly.
+ *
+ * @see Modules\TeamMcp\Console\Commands\HandoffStaleAlertCommand
+ */
+
+function staleMkCoworkTable(): void
+{
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+    Schema::create('cowork_handoffs', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('slug', 120);
+        $t->unsignedInteger('version')->default(1);
+        $t->string('tela', 160)->default('');
+        $t->string('status', 16)->default('pending');
+        $t->string('audited_against', 40)->nullable();
+        $t->longText('body_md');
+        $t->json('files_json');
+        $t->char('source_hash', 64);
+        $t->char('sig', 64);
+        $t->string('created_by', 40)->default('CC');
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('applied_at')->nullable();
+        $t->string('applied_by', 60)->nullable();
+        $t->text('pr_url')->nullable();
+        $t->json('gate_status')->nullable();
+        $t->unique(['slug', 'version']);
+        $t->index('status');
+    });
+}
+
+function staleMkInboxTable(): void
+{
+    if (Schema::hasTable('mcp_inbox_notifications')) {
+        Schema::drop('mcp_inbox_notifications');
+    }
+    Schema::create('mcp_inbox_notifications', function ($t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('user_id');
+        $t->string('type', 32);
+        $t->string('task_id', 40)->nullable();
+        $t->unsignedBigInteger('actor_id')->nullable();
+        $t->text('body')->nullable();
+        $t->json('payload')->nullable();
+        $t->timestamp('read_at')->nullable();
+        $t->timestamps();
+    });
+}
+
+function staleMkPending(string $slug, int $ageDays, string $status = 'pending'): void
+{
+    CoworkHandoff::create([
+        'slug'        => $slug,
+        'version'     => 1,
+        'tela'        => 'Atendimento/CaixaUnificada',
+        'status'      => $status,
+        'body_md'     => '## ONDA A',
+        'files_json'  => ['x.css'],
+        'source_hash' => str_repeat('a', 64),
+        'sig'         => str_repeat('b', 64),
+        'created_by'  => 'CC',
+        'created_at'  => now()->subDays($ageDays),
+    ]);
+}
+
+const STALE_OPS_USER = 99;
+
+beforeEach(function () {
+    staleMkCoworkTable();
+    staleMkInboxTable();
+    config(['admin.wagner_user_id' => STALE_OPS_USER]);
+});
+
+afterEach(function () {
+    foreach (['cowork_handoffs', 'mcp_inbox_notifications'] as $tbl) {
+        if (Schema::hasTable($tbl)) {
+            Schema::drop($tbl);
+        }
+    }
+});
+
+it('pending > 3d → 1 notificação due_soon pro ops; fresco e applied NÃO entram', function () {
+    staleMkPending('velho', ageDays: 5);
+    staleMkPending('fresco', ageDays: 1);
+    staleMkPending('ja-aplicado', ageDays: 9, status: 'applied');
+
+    $this->artisan('handoff:stale-alert')->assertExitCode(0);
+
+    $notes = McpInboxNotification::where('user_id', STALE_OPS_USER)->get();
+    expect($notes)->toHaveCount(1);
+    expect($notes[0]->type)->toBe('due_soon');
+    expect($notes[0]->body)->toContain('velho');
+    expect($notes[0]->body)->not->toContain('fresco');
+    expect($notes[0]->body)->not->toContain('ja-aplicado');
+});
+
+it('idempotência: 2 runs no mesmo dia → 1 notificação (sem spam)', function () {
+    staleMkPending('velho', ageDays: 5);
+
+    $this->artisan('handoff:stale-alert')->assertExitCode(0);
+    $this->artisan('handoff:stale-alert')->assertExitCode(0);
+
+    expect(McpInboxNotification::where('user_id', STALE_OPS_USER)->count())->toBe(1);
+});
+
+it('zero stale → zero notificação', function () {
+    staleMkPending('fresco', ageDays: 1);
+
+    $this->artisan('handoff:stale-alert')->assertExitCode(0);
+
+    expect(McpInboxNotification::count())->toBe(0);
+});
+
+it('--days=10 não pega pending de 5d', function () {
+    staleMkPending('cinco-dias', ageDays: 5);
+
+    $this->artisan('handoff:stale-alert', ['--days' => 10])->assertExitCode(0);
+
+    expect(McpInboxNotification::count())->toBe(0);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -100,6 +100,20 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // PR-4 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — anti feedback-void:
+        // handoffs de design pendentes > 3d alertam o inbox ops (Wagner) pra
+        // reauditar/aplicar ou rejeitar. Daily 08:30 BRT, idempotente (1 digest/dia).
+        $schedule->command('handoff:stale-alert')
+            ->dailyAt('08:30')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule handoff:stale-alert FALHOU — handoffs pendentes velhos não alertados'
+                );
+            });
+
         // MEM-MET-3 (ADRs 0050+0051) — apura 8 métricas obrigatórias + 3 RAGAS
         // por business + plataforma, gravando 1 linha/dia em
         // copiloto_memoria_metricas via upsert idempotente.


### PR DESCRIPTION
## PR-4 de 4 — Loop de Handoff Zero-Paste · **Fase 0 do [ADR 0283](memory/decisions/0283-handoff-loop-zero-paste.md)**

Anti **feedback-void**: handoffs de design `pending` há mais de N dias (default 3) **alertam o ops** pra reauditar/aplicar ou rejeitar antes que apodreçam. Fecha o último "Pronto quando" da Fase 0. Empilha sobre PR-1 (`cowork_handoffs`) + PR-2 (tools), ambos mergeados.

### O que entra
- **`handoff:stale-alert`** (`--days=3`, `--dry-run`): varre `cowork_handoffs` `pending` + `created_at <= now-Nd` → cria 1 digest no inbox. **Idempotente**: 1 por dia (marker `[handoff-stale]` + `whereDate`), re-alerta no dia seguinte se persistir (nag, sem spam).
- **Schedule** daily 08:30 BRT em `app/Console/Kernel.php` (`live`, `withoutOverlapping`, `onFailure→Log`) espelhando `jana:cycles:auto-close-expired`.
- Registro no `TeamMcpServiceProvider`.
- **4 Pest GUARD**: stale alerta (fresco/applied **não** entram), idempotência (2 runs = 1 nota), zero-stale = zero nota, `--days=10` não pega um de 5d.

### Divergência spec × main (main vence)
A spec diz "inbox **channel** `ops`". O `McpInboxNotification` do main é **per-user com `type` enum — não tem canal**. Então o alerta vira 1 notificação `type='due_soon'` pro user de ops (`config('admin.wagner_user_id')`). Documentado no docblock.

### Audit (parte do PR-4 na spec)
As calls `handoff-pending`/`-ack` **já são auditadas**: `McpAuthMiddleware` loga toda chamada MCP em `mcp_audit_log`, e o `handoff-ack` (PR-2) grava audit rico (slug/outcome/drift/pr_url). Este PR fecha só o alerta de pendência velha.

## Infra Contract

> Mudança **console-only**: toca `TeamMcpServiceProvider.php` (registrar o command) + `app/Console/Kernel.php` (schedule). **Sem rota HTTP / middleware / request-path** — não há `curl -sv` aplicável. Contrato é de artisan.

### Artisan contract — output esperado (server-side)
```bash
# sem pendentes velhos → no-op (exit 0)
$ php artisan handoff:stale-alert --dry-run
Nenhum handoff pendente há mais de 3d.

# com pendentes velhos → digest (dry-run não grava)
$ php artisan handoff:stale-alert --dry-run
[DRY RUN] alertaria N handoff(s):
[handoff-stale] ⏰ N handoff(s) de design pendente(s) há > 3d ...

# agendado: php artisan schedule:list mostra "handoff:stale-alert ... 08:30"
```

### Environment delta
- 4 Pest GUARD rodam **no CI** (sqlite-friendly, tabelas sintéticas). Não rodo Pest local (clone sem `vendor/`).
- O schedule só roda em `environments(['live'])` — valida em prod via `schedule:list` pós-deploy.

### 🎉 Fecha a Fase 0
Com PR-1 + PR-2 + PR-4: ingest assinado → `pending` → tools `handoff-pending`/`-ack` → alerta de pendência velha. **Sem auto-merge** (bloqueado por 0283).

### Ainda fora (próximo)
- **scope-guard `files_json`** novo como required (distinto do `scope-guard.yml` que é controller-vs-SCOPE.md).
- **Tua wiring UMA-VEZ**: seed `jana.mcp.handoff.ack` + token do ator-Code + `HANDOFF_SECRET`/`GITHUB_API_TOKEN` no env.

> **Para review + 1-clique de [W]** (Fase 0). Sem self-merge.

Refs: ADR 0283 · PR-1 #2904 · PR-2 #2905 (mergeados)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
