### PR TITLE
docs(adr): proposta — pipeline de incidente graduado por confiança (2 frentes)

### DIFF
--- a/memory/decisions/proposals/2026-06-17-pipeline-incidente-graduado-confianca.md
+++ b/memory/decisions/proposals/2026-06-17-pipeline-incidente-graduado-confianca.md
@@ -1,0 +1,121 @@
+---
+title: "Pipeline de incidente graduado por confiança — porta única, redação cross-tenant, auto-resolve só não-valor"
+status: proposed
+date: "2026-06-17"
+decisores: [Wagner (aprova), Claude Code (autor)]
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0080-trust-tiers-operacional-audit-findings
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0070-jira-style-task-management-current-md-removed
+origem: "Wagner 2026-06-17: duas frentes (sensor determinístico + atendimento autônomo que enriquece ticket e processa incidente), ancoradas no caso Guilherme (incidente num_uf 2026-06-05). Review adversário apontou que o desenho ingênuo (sensor cria mcp_task FORJA) abre 3ª porta de triagem, mistura confiança, vaza Tier 0 e promete auto-resolve onde a Regra Mestre proíbe."
+---
+
+# Pipeline de incidente graduado por confiança
+
+## Contexto
+
+Dois esforços convergem para o mesmo ecossistema:
+
+- **Frente 1 (sensor):** detecção determinística de incidente. Primeiro sensor já no
+  `main` — `sells_value_sanity` no `jana:health-check` (PR #2907), invariante dura
+  `final_total ≤ total_before_tax + tax + shipping`. Nasceu do incidente **Guilherme**
+  (`num_uf` 2026-06-05): valor de venda corrompido só foi pego 8 dias depois, quando o
+  cliente reportou no WhatsApp — apesar de a lógica de detecção já existir em
+  `SellsFinalTotalAuditCommand`.
+- **Frente 2 (atendimento autônomo):** cliente reporta no WhatsApp → o sistema enriquece
+  o ticket e processa o incidente. Mercado 2026 (Sierra/Decagon/Resolve AI) trata isso
+  como *vertical AI agent embutido no produto* com confidence+HITL+ação. Dossiê:
+  [`memory/sessions/2026-06-17-arte-atendimento-autonomo-incidente.md`](../../sessions/2026-06-17-arte-atendimento-autonomo-incidente.md).
+
+O desenho ingênuo — "o sensor cria um `mcp_task project=FORJA` em triagem" — **quebra em
+seis pontos** (review adversário):
+
+1. **Triagem duplicada.** Já existem dois pipelines: `clients_feedbacks`
+   (tenant-scoped, com dedup por signature, `severity_nng`, `persona`, `dev_task_requested`)
+   e a Triagem da Forja (`mcp_tasks project=FORJA`, cross-tenant). Criar uma 3ª fonte viola
+   "não duplicar info entre sistemas".
+2. **Confiança misturada.** Sensor determinístico (certeza matemática) e relato de cliente
+   (`untrusted_external_data`, pode estar errado ou ser abuso) cairiam com o mesmo peso.
+3. **Vazamento Tier 0.** `mcp_tasks` é cross-tenant (visível a Felipe/Maiara/Luiz); o
+   incidente carrega `business_id` + valor BRL + PII. Jogar isso cru no store cross-tenant
+   repete o vetor que custou `git filter-repo` em 5.033 commits (2026-06-08).
+4. **"Autônomo" sem agente.** Se o "[AN]" da triagem é humano, não há automação — é um Jira
+   mais bonito. O ADS Dual-Brain (confidence→policy→HITL) não está plugado.
+5. **Auto-resolve proibido no caso-bandeira.** A Regra Mestre Tier 0 proíbe mexer em valor
+   sem dupla-confirmação + antes→depois + humano. O incidente de valor (o mais limpo de
+   diagnosticar) é justamente o que NÃO se resolve sozinho.
+6. **Idempotência.** 1 bug → N vendas afetadas não pode virar N tickets; e "resolvido" não
+   é "o check passou hoje" (o bug para de gerar novas, mas as linhas corrompidas ficam).
+
+## Decisão proposta
+
+Tratar o ecossistema como **um pipeline de incidente graduado por confiança**, com seis
+invariantes:
+
+### 1. Porta única (store canônico)
+Estender **`clients_feedbacks`** como o store único de incidente — já é tenant-scoped, já
+tem dedup por signature, severity, persona e `dev_task_requested`. A **Triagem da Forja
+apenas LÊ/espelha** os itens aprovados (não cria um terceiro pipeline). Proibido criar
+`mcp_task` de incidente direto do sensor.
+
+### 2. Origem + confiança carimbadas
+Cada item ganha `origem ∈ {sensor, cliente, métrica}` + `trust ∈ {alto, baixo}` (alinhado
+ADR 0080). **Sensor determinístico = trust alto** → entra com diagnóstico anexado.
+**Relato de cliente (WhatsApp) = trust baixo** → é *nota* até corroboração
+(sensor/métrica/humano). Conteúdo NL de cliente nunca dispara ação automatizada sem HITL.
+
+### 3. Redação na fronteira cross-tenant
+Dado de incidente fica **tenant-scoped**. O que cruza pra store/visão cross-tenant (Forja,
+MCP) é **redigido**: estrutura sim (`16 vendas, biz=4, invariante de desconto, deploy
+27/05`), valor BRL e PII **não** (`[redacted Tier 0]`). Pareia com a proibição de valores
+BRL em git/MCP.
+
+### 4. Auto-resolve só fora de valor/estoque
+- **Valor/estoque** (Regra Mestre Tier 0): pipeline para em **detectar + enriquecer +
+  propor**. Correção sempre humana, via `sells:final-total-audit` (dupla-confirmação).
+- **Operacional não-valor** (mídia órfã, job preso, canal Baileys caído): candidato a
+  **self-healing real** (auto-resolve), com verificação pós-ação.
+
+### 5. Autonomia explícita (agente propõe, humano aprova)
+Separar no schema o que o **agente** faz (enriquecer: correlacionar vendas/deploy/invariante
+— há fato determinístico) do que o **humano** faz (aprovar). A decisão roteia pelo **ADS
+Dual-Brain** (confidence→policy→HITL) — que precisa ser plugado ANTES de qualquer rótulo
+"autônomo".
+
+### 6. Idempotência por signature
+**1 incidente = 1 item** por signature (reusa `computeSignature`/`findDuplicateWithin90d`).
+Re-disparo bumpa recorrência, não cria novo. Critério de "resolvido" = **dado subjacente
+corrigido**, não "check verde hoje".
+
+## Consequências
+
+**Positivas**
+- Uma fonte de verdade de incidente; Forja vira leitura, não 3º pipeline.
+- Sensor (Frente 1) e WhatsApp (Frente 2) entram pela mesma porta com confiança distinta.
+- Tier 0 protegido por construção (redação na fronteira).
+- Honestidade de produto: "auto-triage + auto-enrich" no valor; "self-healing" só no
+  operacional. Sem vender o que a Regra Mestre proíbe.
+
+**Custos / riscos**
+- Estender `clients_feedbacks` (origem/trust/redação) + a Forja Triagem ler dali = trabalho
+  de schema + UI. Menor que manter 2-3 pipelines em drift.
+- ADS precisa ser plugado pra a parte "agente enriquece" sair do papel (hoje aspiracional).
+
+## Alternativas rejeitadas
+
+- **Sensor cria `mcp_task project=FORJA` direto** (proposta inicial do autor): rejeitada —
+  abre 3ª porta, mistura confiança e vaza Tier 0 (pontos 1-3 do contexto).
+- **Auto-corrigir valor quando confidence alto:** rejeitada — viola Regra Mestre Tier 0
+  (origem deste incidente). Inegociável.
+- **Pipeline novo dedicado (tabela nova):** rejeitada — `clients_feedbacks` já cobre 80%;
+  criar tabela nova é o anti-padrão "não duplicar".
+
+## Próximos passos (se aceita)
+
+1. Migration: `clients_feedbacks` + `origem`, `trust`, flag `valor_redigido`.
+2. Sensor `sells_value_sanity` cria `clients_feedbacks` (origem=sensor, trust=alto,
+   diagnóstico redigido) em vez de só logar — com dedup por signature.
+3. Forja Triagem lê os aprovados de `clients_feedbacks` (espelho, read-only).
+4. Plugar ADS no roteamento de enriquecimento (confidence→HITL).
+5. Catálogo de incidentes operacionais **não-valor** elegíveis a auto-resolve.


### PR DESCRIPTION
## O que é

ADR **proposta** (`status: proposed`) que define como tratar o ecossistema das duas frentes discutidas com o Wagner — **sensor determinístico** (Frente 1, já mergeado no #2907) + **atendimento autônomo que enriquece ticket e processa incidente** (Frente 2) — ancorado no caso **Guilherme** (incidente `num_uf` 2026-06-05).

Nasceu de um **review adversário**: o desenho ingênuo ("sensor cria `mcp_task project=FORJA`") quebra em 6 pontos — triagem duplicada, confiança misturada, vazamento Tier 0, "autônomo" sem agente, auto-resolve proibido em valor, e idempotência.

## Decisão proposta (6 invariantes)

1. **Porta única** — estende `clients_feedbacks` (já tenant-scoped + dedup); Forja Triagem só **espelha** aprovados. Sem 3º pipeline.
2. **Origem + confiança carimbadas** — sensor=trust alto (auto-cria c/ diagnóstico); cliente WhatsApp=trust baixo (nota até corroborar).
3. **Redação na fronteira cross-tenant** — estrutura cruza, valor BRL/PII não (pareia c/ proibição de BRL em git/MCP).
4. **Auto-resolve só fora de valor/estoque** — valor para em detect+enrich+propõe (Regra Mestre Tier 0); self-healing real só no operacional (mídia/job/canal).
5. **Autonomia explícita** — agente enriquece+propõe, humano aprova; roteia pelo ADS (confidence→HITL), que precisa ser plugado antes.
6. **Idempotência por signature** — 1 incidente = 1 item; "resolvido" = dado corrigido, não check verde.

## Status

`proposed` — **aguarda aceite textual do Wagner**. Nenhum código de pipeline foi escrito; esta PR só adiciona o doc de decisão. Se aceita, vira ADR canon numerada + os 5 próximos passos listados no doc.

## Refs

- Dossiê: `memory/sessions/2026-06-17-arte-atendimento-autonomo-incidente.md`
- Incidente: `memory/sessions/2026-06-05-veiculo-na-venda-e-incidente-numuf-valor-inflado.md`
- Frente 1 mergeada: #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UU84hYmosfD9kACLysYDKS

---
_Generated by [Claude Code](https://claude.ai/code/session_01UU84hYmosfD9kACLysYDKS)_