### PR TITLE
fix(deploy): boot smoke console gate + dump-autoload no force-rebuild (ADR 0216, reincidência 2026-06-17)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -248,6 +248,21 @@ jobs:
             composer dump-autoload -o --classmap-authoritative --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry 2>&1 | tail -10
           "
 
+      - name: Boot smoke CONSOLE — falha o deploy AGORA se o artisan não bootar (ADR 0216 + incidente 2026-06-17)
+        # Gate DURO logo após o composer/dump-autoload, AINDA em maintenance ON e ANTES do migrate.
+        # Pega o modo de falha que o smoke web /login NÃO vê: um ServiceProvider que registra
+        # commands() dentro de runningInConsole() (ex. TeamMcpServiceProvider → handoff:stale-alert,
+        # PR #2906) referencia uma classe nova; se ela ficou fora do classmap-authoritative, TODO
+        # `php artisan` crasha com BindingResolutionException — incl. o `schedule:run` que o cron do
+        # Hostinger dispara a cada minuto — enquanto a WEB segue 200 (boot() só registra o comando
+        # quando runningInConsole). Resultado: deploy "verde" sobre um scheduler 100% quebrado, downtime
+        # silencioso no console até o próximo deploy bem-sucedido (mesmo padrão da ADR 0216, que checava
+        # só a web via curl /). `php artisan about` constrói o console Application → dispara
+        # resolveCommands() → instancia cada comando registrado → reproduz o crash AQUI, no ato, falhando
+        # o deploy antes de expor o cron quebrado. set -o pipefail: senão o exit do `about` é mascarado
+        # pelo `| tail` e o gate fica decorativo.
+        run: /tmp/ssh_exec.sh "set -o pipefail && cd $RDIR && php artisan about 2>&1 | tail -40"
+
       - name: Artisan migrate (se necessário)
         if: ${{ inputs.skip_migrate != 'true' }}
         # set -o pipefail: senão migrate --force que falha tem exit mascarado pelo | tail → deploy verde com schema drift.

--- a/.github/workflows/force-clean-rebuild-trigger.yml
+++ b/.github/workflows/force-clean-rebuild-trigger.yml
@@ -103,6 +103,22 @@ jobs:
             git log --oneline -1
           "
 
+      - name: Composer dump-autoload (registra classes novas — ADR 0216)
+        # CAUSA RAIZ catalogada (ADR 0216, reincidência 2026-06-17): este workflow fazia
+        # `git reset --hard` mas NÃO regenerava o autoload do Composer. Quando um PR adiciona
+        # CLASSE NOVA em app/, Modules/ ou database/ (ex. comando artisan, Service, Observer,
+        # Middleware), o classmap-authoritative de prod não a conhece → `php artisan` crasha
+        # com BindingResolutionException já nos steps seguintes (package:discover/config:cache),
+        # deixando prod com caches stale. Espelha o `dump-autoload` do deploy.yml pra que os dois
+        # caminhos de deploy produzam o MESMO estado de autoloader. set -o pipefail: senão o exit
+        # do composer é mascarado pelo `| tail` (deploy verde com classmap stale, incidente 2026-05-26).
+        run: |
+          /tmp/ssh_exec.sh "
+            set -o pipefail &&
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            composer dump-autoload -o --classmap-authoritative --no-scripts --no-interaction --ignore-platform-req=ext-opentelemetry 2>&1 | tail -10
+          "
+
       - name: npm ci (force)
         run: |
           /tmp/ssh_exec.sh "


### PR DESCRIPTION
## Contexto — incidente 2026-06-17 (reincidência da ADR 0216)

PR #2906 (`feat(teammcp): handoff:stale-alert`) adicionou `HandoffStaleAlertCommand`, registrado em `TeamMcpServiceProvider::boot()` dentro de `if ($this->app->runningInConsole())` + um `$schedule->command('handoff:stale-alert')` em `app/Console/Kernel.php`.

Com a classe **fora do `classmap-authoritative`** de prod, **todo `php artisan`** crashou com `BindingResolutionException: Target class [...] does not exist` — incluindo o `schedule:run` que o **cron do Hostinger dispara a cada minuto** (40+ comandos agendados: backup, conciliação Inter, jana:health-check, governance snapshots…). A **web seguiu 200** porque o comando só é registrado em `runningInConsole()`. Foi corrigido manualmente via `composer dump-autoload -o --no-scripts && php artisan optimize:clear`.

### Por que os smokes existentes não pegaram

| Gate | Cobre | Cego a |
|---|---|---|
| `deploy.yml` smoke `/login` (200/302) | quebra **web** | quebra **console-only** |
| ADR 0216 probe `curl /` | quebra **web** | quebra **console-only** |
| `deploy.yml` `php artisan --version` (linha ~421) | console | roda **no fim, após o site já estar live**; deploy cancelado nunca chega lá |

Forense dos runs de 2026-06-17: o deploy do #2906 (`27703637589`) **falhou no "Pré-deploy check"** (SSH flaky Hostinger) e **pulou git pull + composer**; #2907 cancelou; #2908 rodou limpo. Janela de console quebrado entre `git reset --hard` (arquivo aterrissa) e o `composer dump-autoload` do próximo deploy bem-sucedido, com o cron firando no meio.

> ⚠️ A premissa original do incidente ("deploy.yml não regenera o autoload") está incorreta: o `deploy.yml` **já** roda `composer install --optimize-autoloader` + `composer dump-autoload -o --classmap-authoritative` (linhas 246–248), após o `git reset --hard` e antes do migrate.

## Mudanças

1. **`deploy.yml`** — gate DURO `php artisan about` logo após o composer/dump-autoload, **ainda em maintenance ON e antes do migrate**. `about` constrói o console Application → dispara `resolveCommands()` → instancia cada comando registrado → **reproduz o crash no ato** e falha o deploy antes de expor o cron quebrado.
2. **`force-clean-rebuild-trigger.yml`** — faltava `composer dump-autoload` após o `git pull` (**violava a ADR 0216** — reproduzia o incidente se usado pós-classe-nova). Adicionado, espelhando o `deploy.yml`.

## Fora de escopo (decisão Wagner)

- **`--classmap-authoritative`**: mantido (escolha deliberada de perf). É o que transforma "classmap stale" de _perf-miss_ em _crash duro_ — `--optimize` puro mantém fallback PSR-4 e a classe nova carregaria mesmo sem dump (alinhado à ADR 0216 e ao seu recovery manual). O gate de boot cobre a recorrência; dropar para `--optimize` fica como decisão sua + emenda à ADR 0216.
- **Cron/scheduler do Laravel**: o schedule vive em `app/Console/Kernel.php`, mas o `* * * * * php artisan schedule:run` é entrada de **cron do cPanel Hostinger** (não versionada). Confirmar lá — é onde o boot quebrado dói.

Refs: [ADR 0216](memory/decisions/0216-deploy-webhook-rodar-composer-dump-autoload.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)