### PR TITLE
fix(forja): instrumenta ForjaMcpService com OtelHelper::span — recupera TeamMcp 78→79 (D9.a)

### DIFF
--- a/CODE_NOTES.md
+++ b/CODE_NOTES.md
@@ -59,6 +59,12 @@ Não recriado nada da Fase 0.
   (skill `tela-smoke-pos-merge`, rota `/forja/mcp`) + os gates de CI (conformance/foundation/pageheader/
   a11y/visual-regression).
 
+### Pós-push (CI verde)
+- **PHPStan**: removidos `is_array($h->files_json)`/`is_string($h->sig)` redundantes (casts/`@property` — larastan resolve como sempre-true).
+- **Casos G-6** (ADR 0264): `last_run` de `Cockpit.casos.md` bumpado + UC-FORJA-12.
+- **Base atualizada**: merge de `origin/main` (PR #2914 entrou depois do branch — subiu o baseline TeamMcp 75→79 + OTel no GitMainResolver). Minha query repo-wide de `CoworkHandoff` é consistente com o novo `CoworkHandoffCrossTenantTest`.
+- **Module Grade D9.a** (ADR 0155): `ForjaMcpService` instrumentado com `OtelHelper::span` (observability real, igual GitMainResolver) — sem isso o service novo diluía a razão `services-com-OTel` e derrubava TeamMcp 79→78.
+
 ### Arquivos
 - `Modules/TeamMcp/Services/Forja/ForjaMcpService.php` (novo)
 - `Modules/TeamMcp/Http/Controllers/ForjaController.php` (mcp() + import; removido renderTab órfão)

--- a/Modules/TeamMcp/Services/Forja/ForjaMcpService.php
+++ b/Modules/TeamMcp/Services/Forja/ForjaMcpService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\TeamMcp\Services\Forja;
 
+use App\Util\OtelHelper;
 use Modules\TeamMcp\Entities\CoworkHandoff;
 use Modules\TeamMcp\Entities\McpIngestHeartbeat;
 
@@ -21,6 +22,9 @@ use Modules\TeamMcp\Entities\McpIngestHeartbeat;
  * sem dado fantasma. Tier 0 (ADR 0093): `cowork_handoffs`/`mcp_ingest_heartbeat`
  * são REPO-WIDE (artefato do repo, não de tenant) — sem business_id por design,
  * igual {@see \Modules\TeamMcp\Mcp\Tools\HandoffPendingTool}.
+ *
+ * Observability (ADR 0155 D9.a): cada leitura roda dentro de `OtelHelper::span`
+ * (zero-cost quando OTel off), igual {@see \Modules\TeamMcp\Services\GitMainResolver}.
  */
 class ForjaMcpService
 {
@@ -44,16 +48,18 @@ class ForjaMcpService
     {
         $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — cowork_handoffs é repo-wide (ADR 0093/0283), sem tenant por design
 
-        return CoworkHandoff::query()
-            ->where('status', '!=', 'superseded')
-            ->orderByDesc('version')
-            ->get()
-            ->unique('slug')               // maior version por slug (lista já vem version desc)
-            ->sortByDesc(fn (CoworkHandoff $h) => optional($h->created_at)->getTimestamp() ?? 0)
-            ->take(self::LIMIT)
-            ->map(fn (CoworkHandoff $h): array => $this->serialize($h))
-            ->values()
-            ->all();
+        return OtelHelper::span('teammcp.forja.handoffs', [], function () {
+            return CoworkHandoff::query()
+                ->where('status', '!=', 'superseded')
+                ->orderByDesc('version')
+                ->get()
+                ->unique('slug')               // maior version por slug (lista já vem version desc)
+                ->sortByDesc(fn (CoworkHandoff $h) => optional($h->created_at)->getTimestamp() ?? 0)
+                ->take(self::LIMIT)
+                ->map(fn (CoworkHandoff $h): array => $this->serialize($h))
+                ->values()
+                ->all();
+        });
     }
 
     /**
@@ -66,16 +72,18 @@ class ForjaMcpService
     {
         $tenancy = 'business_id'; // marker NoMissingTenantScopeRule — mcp_ingest_heartbeat é repo-wide (ADR 0093), sem tenant por design
 
-        $hb = McpIngestHeartbeat::query()->orderByDesc('last_ingest_at')->first();
-        $last = $hb?->last_ingest_at;
+        return OtelHelper::span('teammcp.forja.heartbeat', [], function () {
+            $hb = McpIngestHeartbeat::query()->orderByDesc('last_ingest_at')->first();
+            $last = $hb?->last_ingest_at;
 
-        return [
-            'last_ingest_at'    => optional($last)->toIso8601String(),
-            'last_ingest_human' => $last !== null ? $last->diffForHumans() : null,
-            'host'              => $hb?->host,
-            // "transporte sem sinal": sem heartbeat OU mudo além do teto.
-            'silent'            => $last === null || $last->lt(now()->subMinutes(self::HEARTBEAT_SILENT_MINUTES)),
-        ];
+            return [
+                'last_ingest_at'    => optional($last)->toIso8601String(),
+                'last_ingest_human' => $last !== null ? $last->diffForHumans() : null,
+                'host'              => $hb?->host,
+                // "transporte sem sinal": sem heartbeat OU mudo além do teto.
+                'silent'            => $last === null || $last->lt(now()->subMinutes(self::HEARTBEAT_SILENT_MINUTES)),
+            ];
+        });
     }
 
     /**


### PR DESCRIPTION
## Follow-up de [#2913](https://github.com/wagnerra23/oimpresso.com/pull/2913) — recupera o grade do TeamMcp

#2913 (aba MCP da Forja projetando `cowork_handoffs`) mergeou com a **module-grades-gate vermelha**: TeamMcp caiu **79→78**. Causa: o `ForjaMcpService` novo entrou **sem OTel**, diluindo a razão **D9.a "Services com OTel"** da rubrica (ADR 0155):

- antes: 8/12 services com OTel → `round(8/12·4)` = **3**
- com o service novo sem OTel: 8/13 → `round(8/13·4)` = **2**  ← o −1

Como o merge não aplicou label `module-grades-allowed-regression` e o baseline em `main` segue **79**, ficou uma **regressão latente** que travaria a próxima PR.

### Fix (real, não gaming)
Instrumenta `handoffs()` e `heartbeat()` com `OtelHelper::span` — observability de verdade (trace span por leitura, zero-cost quando OTel off), **exatamente o padrão que o #2914 aplicou no `GitMainResolver`**. Volta a razão pra 9/13 → `round(9/13·4)` = **3** → TeamMcp **79**.

Detalhe larastan: closures sem return-type explícito pra o genérico `span<T>` inferir o tipo do corpo (preserva `@return list<...>`/`array<string,mixed>` sem regressão de tipagem).

Refs: ADR 0155 (D9.a) · ADR 0283 (Fase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)