### PR TITLE
fix(teammcp): A2 guard ignora docblock ao grep Cache::flush (HandoffAckTool)

### DIFF
--- a/Modules/TeamMcp/Tests/Feature/HandoffToolsTest.php
+++ b/Modules/TeamMcp/Tests/Feature/HandoffToolsTest.php
@@ -251,7 +251,25 @@ it('ack rejected sem note → erro', function () {
     expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('pending');
 });
 
-it('HandoffAckTool NÃO usa Cache::flush() [A2 — grep no source]', function () {
+it('HandoffAckTool NÃO usa Cache::flush() no CÓDIGO (comentários removidos) [A2]', function () {
     $src = file_get_contents(dirname(__DIR__, 2) . '/Mcp/Tools/HandoffAckTool.php');
-    expect($src)->not->toContain('Cache::flush');
+
+    // A2 mira o CÓDIGO, não a prosa: o docblock do handler cita `Cache::flush()` de
+    // propósito (documenta por que NÃO o usa). Um grep cru na fonte casaria com esse
+    // comentário e o guard falharia sozinho. Tokeniza e descarta comentários/docblocks
+    // antes de procurar a chamada — ainda morde se alguém escrever Cache::flush() de
+    // verdade no handler (vira tokens T_STRING/T_DOUBLE_COLON, que sobram no código).
+    $codeOnly = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)) {
+            if ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT) {
+                continue;
+            }
+            $codeOnly .= $token[1];
+        } else {
+            $codeOnly .= $token;
+        }
+    }
+
+    expect($codeOnly)->not->toContain('Cache::flush');
 });


### PR DESCRIPTION
## Problema

O teste `it('HandoffAckTool NÃO usa Cache::flush() [A2 — grep no source]')` em [`HandoffToolsTest.php`](Modules/TeamMcp/Tests/Feature/HandoffToolsTest.php) lia a **fonte crua** do handler com `file_get_contents` e fazia `expect($src)->not->toContain('Cache::flush')`.

Mas o docblock do handler ([`HandoffAckTool.php:29`](Modules/TeamMcp/Mcp/Tools/HandoffAckTool.php#L29)) cita `Cache::flush()` **de propósito** — documenta a defesa A2 ("este handler NÃO usa cache, logo NÃO há `Cache::flush()`"). O grep cru casava com o **comentário**, então o teste falhava sozinho mesmo com o handler correto. **Self-defeating.**

Teste e comentário nasceram no mesmo PR (#2905, ADR 0283 Fase 0). A falha ficou **latente** porque nenhum workflow roda a suite Feature geral — só gates de domínio (module-grade, e2e, financeiro-pest…). Mas `php artisan test Modules/TeamMcp/Tests/Feature` estava **vermelho** por causa disso.

## Fix

Tokeniza a fonte via `token_get_all` e descarta `T_COMMENT`/`T_DOC_COMMENT` **antes** do grep — mira o **código**, não a prosa. Continua um guard A2 honesto: se alguém escrever `Cache::flush()` de verdade no handler, vira tokens `T_STRING`/`T_DOUBLE_COLON` que sobram no código e o teste **morde**.

Mudança é **só no arquivo de teste** (+20/-2). O handler não foi tocado.

## Verificação (CT 100 · origin/main · oimpresso/mcp PHP 8.4 · sqlite :memory:)

| Estado | Resultado |
|---|---|
| **RED** (antes do fix) | `1 failed, 8 passed` — falha exatamente no A2 `Cache::flush` |
| **GREEN** (depois do fix) | `9 passed (21 assertions)` |
| **Neg-control** (`Cache::flush()` real injetado no handler) | `1 failed` — guard **morde** o código real |

🤖 Generated with [Claude Code](https://claude.com/claude-code)