### PR TITLE
feat(mcp): automação deploy main→CT100 + sentinela de drift (incidente 2026-06-17)

### DIFF
--- a/.github/workflows/mcp-drift-sentinel.yml
+++ b/.github/workflows/mcp-drift-sentinel.yml
@@ -1,0 +1,72 @@
+name: MCP Drift Sentinel — ADR 0256
+
+# Sentinela EXTERNA de drift do MCP server (mcp.oimpresso.com, container no CT 100).
+# O self-update.sh (cron no host) CURA o drift; esta sentinela roda no GitHub (fora do
+# tailnet, sem secret novo — só curl público + git) e ALARMA se a cura parar de funcionar.
+# Origem: incidente 2026-06-17 — ~17 dias de código velho servido em silêncio porque
+# os dados (DB compartilhada) ficavam frescos. ADR 0062 (Hostinger≠CT100) + ADR 0256.
+#
+# Alarme = workflow vermelho (GitHub notifica) + issue durável rotulada `mcp-drift`
+# (o "inbox ops"). Sem tailscale, sem secret além do GITHUB_TOKEN default.
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'   # a cada 30min — watchdog do cron de cura (que roda /15min)
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: mcp-drift-sentinel
+  cancel-in-progress: true
+
+jobs:
+  sentinel:
+    name: mcp-drift-sentinel (alarma se servido != main)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # precisa da história p/ ancestralidade + data dos commits
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run drift sentinel
+        id: drift
+        run: node scripts/governance/mcp-drift-sentinel.mjs
+
+      - name: Alarme → issue no inbox ops (só em drift real)
+        if: failure() && steps.drift.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TITLE="[mcp-drift] MCP server servindo código velho"
+          BODY=$(cat <<EOF
+          A sentinela detectou que **mcp.oimpresso.com** está servindo um commit atrás de \`main\`
+          além do limite tolerado. Provável: o cron \`self-update.sh\` no CT 100 parou de curar.
+
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          **Como investigar / curar (via tailscale):**
+          \`\`\`
+          tailscale ssh root@ct100-mcp
+          tail -50 /opt/oimpresso-mcp/logs/self-update.log
+          bash /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh
+          \`\`\`
+          Refs: ADR 0062 · ADR 0256 · docker/oimpresso-mcp/README.md
+          EOF
+          )
+          gh label create mcp-drift --color B60205 --description "Drift do MCP server (CT 100) — ADR 0256" 2>/dev/null || true
+          EXISTING=$(gh issue list --label mcp-drift --state open --json number --jq '.[0].number' 2>/dev/null || true)
+          if [ -n "${EXISTING:-}" ]; then
+            gh issue comment "$EXISTING" --body "$BODY"
+            echo "comentei na issue #$EXISTING"
+          else
+            gh issue create --title "$TITLE" --label mcp-drift --body "$BODY"
+          fi

--- a/.github/workflows/mcp-drift-sentinel.yml
+++ b/.github/workflows/mcp-drift-sentinel.yml
@@ -38,6 +38,11 @@ jobs:
 
       - name: Run drift sentinel
         id: drift
+        env:
+          # Token read-only mcp_* — lê o commit servido no /health/auth (não-público).
+          # Gerar: php artisan mcp:token:gerar --user=<bot> --name="drift-sentinel" no
+          # Hostinger; adicionar como secret MCP_SENTINEL_TOKEN. Sem ele → WARN (não alarma).
+          MCP_SENTINEL_TOKEN: ${{ secrets.MCP_SENTINEL_TOKEN }}
         run: node scripts/governance/mcp-drift-sentinel.mjs
 
       - name: Alarme → issue no inbox ops (só em drift real)
@@ -46,20 +51,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Repo é PÚBLICO → corpo enxuto, sem runbook/host/paths (o procedimento de
+          # cura fica no README versionado, não numa issue world-readable).
           TITLE="[mcp-drift] MCP server servindo código velho"
           BODY=$(cat <<EOF
-          A sentinela detectou que **mcp.oimpresso.com** está servindo um commit atrás de \`main\`
-          além do limite tolerado. Provável: o cron \`self-update.sh\` no CT 100 parou de curar.
+          A sentinela detectou que **mcp.oimpresso.com** serve um commit atrás de \`main\`
+          além do limite tolerado (provável: o cron de cura no CT 100 parou).
 
           **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-          **Como investigar / curar (via tailscale):**
-          \`\`\`
-          tailscale ssh root@ct100-mcp
-          tail -50 /opt/oimpresso-mcp/logs/self-update.log
-          bash /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh
-          \`\`\`
-          Refs: ADR 0062 · ADR 0256 · docker/oimpresso-mcp/README.md
+          Cura: \`docker/oimpresso-mcp/README.md\` → seção "Atualização". Refs: ADR 0062 · ADR 0256.
           EOF
           )
           gh label create mcp-drift --color B60205 --description "Drift do MCP server (CT 100) — ADR 0256" 2>/dev/null || true

--- a/Modules/TeamMcp/Http/Controllers/Mcp/HealthController.php
+++ b/Modules/TeamMcp/Http/Controllers/Mcp/HealthController.php
@@ -23,12 +23,30 @@ class HealthController extends Controller
 {
     public function publico(Request $request): JsonResponse
     {
+        // Drift observability (ADR 0256): o commit servido é escrito pelo entrypoint
+        // do container (deployed_commit.txt) a cada boot. Expor aqui deixa a sentinela
+        // externa mcp-drift-sentinel.yml detectar drift sem SSH — pro ~17 dias de drift
+        // silencioso do incidente 2026-06-17 nunca mais acontecer. Null se ausente.
+        $commit = null;
+        $deployedAt = null;
+        $commitPath = storage_path('app/deployed_commit.txt');
+        if (is_readable($commitPath)) {
+            $commit = trim((string) @file_get_contents($commitPath)) ?: null;
+            if ($commit === 'unknown') {
+                $commit = null;
+            }
+            $deployedAt = ($mtime = @filemtime($commitPath)) ? date('c', $mtime) : null;
+        }
+
         return response()->json([
-            'status'   => 'ok',
-            'service'  => 'oimpresso-mcp',
-            'version'  => '0.1',
-            'spec_mcp' => '2025-06-18',
-            'ts'       => now()->toIso8601String(),
+            'status'       => 'ok',
+            'service'      => 'oimpresso-mcp',
+            'version'      => '0.1',
+            'spec_mcp'     => '2025-06-18',
+            'commit'       => $commit,
+            'commit_short' => $commit ? substr($commit, 0, 9) : null,
+            'deployed_at'  => $deployedAt,
+            'ts'           => now()->toIso8601String(),
         ]);
     }
 

--- a/Modules/TeamMcp/Http/Controllers/Mcp/HealthController.php
+++ b/Modules/TeamMcp/Http/Controllers/Mcp/HealthController.php
@@ -23,30 +23,12 @@ class HealthController extends Controller
 {
     public function publico(Request $request): JsonResponse
     {
-        // Drift observability (ADR 0256): o commit servido é escrito pelo entrypoint
-        // do container (deployed_commit.txt) a cada boot. Expor aqui deixa a sentinela
-        // externa mcp-drift-sentinel.yml detectar drift sem SSH — pro ~17 dias de drift
-        // silencioso do incidente 2026-06-17 nunca mais acontecer. Null se ausente.
-        $commit = null;
-        $deployedAt = null;
-        $commitPath = storage_path('app/deployed_commit.txt');
-        if (is_readable($commitPath)) {
-            $commit = trim((string) @file_get_contents($commitPath)) ?: null;
-            if ($commit === 'unknown') {
-                $commit = null;
-            }
-            $deployedAt = ($mtime = @filemtime($commitPath)) ? date('c', $mtime) : null;
-        }
-
         return response()->json([
-            'status'       => 'ok',
-            'service'      => 'oimpresso-mcp',
-            'version'      => '0.1',
-            'spec_mcp'     => '2025-06-18',
-            'commit'       => $commit,
-            'commit_short' => $commit ? substr($commit, 0, 9) : null,
-            'deployed_at'  => $deployedAt,
-            'ts'           => now()->toIso8601String(),
+            'status'   => 'ok',
+            'service'  => 'oimpresso-mcp',
+            'version'  => '0.1',
+            'spec_mcp' => '2025-06-18',
+            'ts'       => now()->toIso8601String(),
         ]);
     }
 
@@ -61,6 +43,22 @@ class HealthController extends Controller
         } catch (\Throwable $e) {
             $totalDocs = null;
             $docsAcessiveis = null;
+        }
+
+        // Drift observability (ADR 0256): o commit servido é escrito pelo entrypoint do
+        // container (deployed_commit.txt) a cada boot. Exposto SÓ aqui (endpoint
+        // AUTENTICADO) — não no /health público — porque o repo é público e o SHA exato
+        // num endpoint anônimo é disclosure de versão. A sentinela externa
+        // mcp-drift-sentinel.yml lê isto com um token read-only. Null se ausente.
+        $commit = null;
+        $deployedAt = null;
+        $commitPath = storage_path('app/deployed_commit.txt');
+        if (is_readable($commitPath)) {
+            $commit = trim((string) @file_get_contents($commitPath)) ?: null;
+            if ($commit === 'unknown') {
+                $commit = null;
+            }
+            $deployedAt = ($mtime = @filemtime($commitPath)) ? date('c', $mtime) : null;
         }
 
         return response()->json([
@@ -79,6 +77,9 @@ class HealthController extends Controller
                 'total'                  => $totalDocs,
                 'accessible_to_this_user' => $docsAcessiveis,
             ],
+            'commit'       => $commit,
+            'commit_short' => $commit ? substr($commit, 0, 9) : null,
+            'deployed_at'  => $deployedAt,
             'ts' => now()->toIso8601String(),
         ]);
     }

--- a/docker/oimpresso-mcp/README.md
+++ b/docker/oimpresso-mcp/README.md
@@ -167,12 +167,22 @@ rebuild (só se `docker/oimpresso-mcp/` mudou) → `up -d --force-recreate` → 
 */15 * * * * flock -n /tmp/mcp-self-update.lock /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh >> /opt/oimpresso-mcp/logs/self-update.log 2>&1
 ```
 
-### Sentinela de drift (não precisa de tailscale nem secret)
+### Sentinela de drift (sem tailscale)
 
-`.github/workflows/mcp-drift-sentinel.yml` roda no GitHub a cada 30min: compara o
-campo `commit` de `/api/mcp/health` com o HEAD de `main`. Se servido ficar > 6h atrás
-(`MCP_DRIFT_MAX_LAG_HOURS`), **alarma**: workflow vermelho + issue rotulada `mcp-drift`
-(o "inbox ops"). O commit servido é escrito pelo `entrypoint-octane.sh` a cada boot.
+`.github/workflows/mcp-drift-sentinel.yml` roda no GitHub a cada 30min: compara o campo
+`commit` de **`/api/mcp/health/auth`** (endpoint AUTENTICADO — o repo é público, então o
+SHA exato NÃO fica num endpoint anônimo) com o HEAD de `main`. Se servido ficar > 6h
+atrás (`MCP_DRIFT_MAX_LAG_HOURS`), **alarma**: workflow vermelho + issue `mcp-drift` (o
+"inbox ops"). O commit servido é escrito pelo `entrypoint-octane.sh` a cada boot.
+
+**Secret necessário (uma vez):** gere um token read-only e adicione como secret
+`MCP_SENTINEL_TOKEN` no repo:
+```bash
+# No Hostinger (DB compartilhada)
+php artisan mcp:token:gerar --user=<bot> --name="drift-sentinel"
+gh secret set MCP_SENTINEL_TOKEN   # cole o mcp_... gerado
+```
+Sem o secret a sentinela só emite `WARN` (não alarma) — graça de rollout.
 
 **NÃO usar Portainer Stacks** — Portainer fica só pra UI de logs/debug.
 Edição via UI gera divergência com o git (ver discussão sessão 29-abr-2026).

--- a/docker/oimpresso-mcp/README.md
+++ b/docker/oimpresso-mcp/README.md
@@ -135,21 +135,44 @@ curl https://mcp.oimpresso.com/api/mcp/health/auth \
 
 Retorna info do user + count de docs acessíveis.
 
-## Atualização (depois do setup inicial)
+## Atualização — caminho main→CT100 (ADR 0062 + 0256)
 
-Workflow `compose-managed`: source-of-truth é o repo git.
+> O `deploy.yml` é **Hostinger-only** (ADR 0062 separa os runtimes), então NÃO há
+> CI publicando aqui. O caminho canônico é o host se **auto-atualizar** (GitOps pull)
+> por cron + uma **sentinela externa** que grita se isso parar.
+> Origem: incidente 2026-06-17 — ~17 dias de código velho servido em silêncio (dados
+> frescos da DB compartilhada mascaravam o drift do código).
+
+### Deploy (canônico — script versionado, não comando solto)
 
 ```bash
-ssh root@<ct-100-ip>
-cd /opt/oimpresso-mcp/code
-git pull origin main
-
-# Se mudou Dockerfile/compose: rebuild
-docker compose -f docker/oimpresso-mcp/docker-compose.yml build
-
-# Reload (rolling)
-docker compose -f docker/oimpresso-mcp/docker-compose.yml up -d
+tailscale ssh root@ct100-mcp
+bash /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh
 ```
+
+O `self-update.sh` é idempotente: `fetch` → se atrás de `origin/main`, faz backup dos
+dirty files → `reset --hard origin/main` → `composer install` (só se lock mudou) →
+rebuild (só se `docker/oimpresso-mcp/` mudou) → `up -d --force-recreate` → smoke.
+
+**Duas pegadinhas que o `git pull` solto NÃO resolve** (catalogadas no incidente):
+1. **`reset --hard origin/main`, não `git pull`** — main tem história reescrita; um
+   merge quebra com *"no common ancestor"*.
+2. **`--force-recreate` sempre** — `opcache.validate_timestamps=Off` no container;
+   sem recreate o código novo no bind-mount **não sobe** (drift silencioso).
+
+### Cron (instalar UMA vez no host — única config de host permitida)
+
+```bash
+# crontab -e (root no CT 100)
+*/15 * * * * flock -n /tmp/mcp-self-update.lock /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh >> /opt/oimpresso-mcp/logs/self-update.log 2>&1
+```
+
+### Sentinela de drift (não precisa de tailscale nem secret)
+
+`.github/workflows/mcp-drift-sentinel.yml` roda no GitHub a cada 30min: compara o
+campo `commit` de `/api/mcp/health` com o HEAD de `main`. Se servido ficar > 6h atrás
+(`MCP_DRIFT_MAX_LAG_HOURS`), **alarma**: workflow vermelho + issue rotulada `mcp-drift`
+(o "inbox ops"). O commit servido é escrito pelo `entrypoint-octane.sh` a cada boot.
 
 **NÃO usar Portainer Stacks** — Portainer fica só pra UI de logs/debug.
 Edição via UI gera divergência com o git (ver discussão sessão 29-abr-2026).

--- a/docker/oimpresso-mcp/entrypoint-octane.sh
+++ b/docker/oimpresso-mcp/entrypoint-octane.sh
@@ -45,6 +45,13 @@ mkdir -p storage/framework/cache/data \
 chmod -R 775 storage bootstrap/cache 2>/dev/null || true
 chown -R www-data:www-data storage bootstrap/cache 2>/dev/null || true
 
+# Drift observability (ADR 0256): grava o commit servido pra /api/mcp/health expor
+# (campo `commit`) e a sentinela externa mcp-drift-sentinel.yml detectar drift sem SSH.
+# safe.directory: o bind-mount /var/www/html pertence ao user do host, não ao root do
+# container — sem isso o git recusa por "dubious ownership". Best-effort (|| true).
+git config --global --add safe.directory /var/www/html 2>/dev/null || true
+(git -C /var/www/html rev-parse HEAD 2>/dev/null || echo unknown) > storage/app/deployed_commit.txt 2>/dev/null || true
+
 echo "[entrypoint-octane] Limpando caches stale..."
 # CADA artisan call com timeout 30s — alguns boot path do Laravel/módulos hangam
 # em queries SQL durante boot (visto em 29-abr, deps Spatie/Scout). Timeout

--- a/docker/oimpresso-mcp/scripts/self-update.sh
+++ b/docker/oimpresso-mcp/scripts/self-update.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# self-update.sh — GitOps pull-deploy do MCP server no CT 100 (ADR 0062 + 0256).
+#
+# POR QUE EXISTE: o deploy.yml é Hostinger-only (ADR 0062 separa os runtimes), então
+# NÃO havia caminho main→CT100-MCP. Resultado: incidente 2026-06-17 — o container
+# rodou ~17 dias de código velho (imagem 29/mai, checkout 31/mai) sem ninguém notar,
+# porque os DADOS (DB compartilhada) ficam frescos e mascaram o drift do CÓDIGO.
+#
+# COMO: o host CLONA o repo por HTTPS (origin já configurado), então o caminho mais
+# simples e SEM secret novo é o host se auto-atualizar (GitOps pull) por cron. Pareado
+# com a sentinela EXTERNA mcp-drift-sentinel.yml (roda no GitHub, fora do tailnet) que
+# grita se este script parar de funcionar — pro drift nunca mais ser silencioso.
+#
+# 2 pegadinhas que o README antigo não cobria (descobertas no incidente):
+#   1. main teve história reescrita → `git pull` (merge) quebra com "no common
+#      ancestor". Use `fetch + reset --hard origin/main` (igual deploy.yml faz).
+#   2. opcache.validate_timestamps=Off no container → código novo no bind-mount NÃO
+#      sobe sem `up -d --force-recreate`. Um `git pull` sem recreate é no-op silencioso.
+#
+# Instalação (uma vez, no host CT 100 — única config de host permitida):
+#   */15 * * * * flock -n /tmp/mcp-self-update.lock /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh >> /opt/oimpresso-mcp/logs/self-update.log 2>&1
+#
+# Uso manual:  bash docker/oimpresso-mcp/scripts/self-update.sh
+set -uo pipefail
+
+REPO_DIR="${MCP_CODE_DIR:-/opt/oimpresso-mcp/code}"
+COMPOSE_FILE="docker/oimpresso-mcp/docker-compose.yml"
+HEALTH_URL="${MCP_HEALTH_URL:-https://mcp.oimpresso.com/api/mcp/health}"
+BK="${MCP_BACKUP_DIR:-/opt/oimpresso-mcp/backups}"
+LOCK="${MCP_LOCK:-/tmp/mcp-self-update.lock}"
+
+log() { echo "[$(date -Is)] [self-update] $*"; }
+
+# Single-instance: evita a corrida de deploys concorrentes (dois recreates do mesmo
+# container ~ao mesmo tempo geraram um core dump no incidente 2026-06-17).
+exec 9>"$LOCK" || { log "não consegui abrir lock $LOCK"; exit 1; }
+flock -n 9 || { log "outra execução em andamento — saindo"; exit 0; }
+
+cd "$REPO_DIR" || { log "FATAL: $REPO_DIR não existe"; exit 1; }
+mkdir -p "$BK"
+
+git fetch --quiet origin main || { log "FATAL: git fetch falhou"; exit 1; }
+LOCAL="$(git rev-parse HEAD)"
+REMOTE="$(git rev-parse origin/main)"
+
+if [ "$LOCAL" = "$REMOTE" ]; then
+  log "já em origin/main (${REMOTE:0:9}) — nada a fazer (heartbeat ok)"
+  exit 0
+fi
+
+log "drift detectado: ${LOCAL:0:9} -> ${REMOTE:0:9} — atualizando"
+TS="$(date +%Y%m%d-%H%M%S)"
+printf 'OLD_HEAD=%s\nNEW_HEAD=%s\nWHEN=%s\n' "$LOCAL" "$REMOTE" "$TS" > "$BK/rollback-$TS.txt"
+
+# Backup dos dirty files ANTES do reset --hard (clobber). Memory/ + artefatos manuais.
+git status --porcelain | sed 's/^...//' > "$BK/dirty-$TS.list"
+if [ -s "$BK/dirty-$TS.list" ]; then
+  tar czf "$BK/dirty-$TS.tar.gz" -T "$BK/dirty-$TS.list" 2>/dev/null \
+    && log "backup dos dirty files em $BK/dirty-$TS.tar.gz" \
+    || log "WARN: backup parcial dos dirty files (não-fatal)"
+fi
+
+git reset --hard origin/main || { log "FATAL: reset --hard falhou"; exit 1; }
+
+# composer install só se composer.lock/json mudou (host não tem composer → via container).
+if ! git diff --quiet "$LOCAL" "$REMOTE" -- composer.lock composer.json; then
+  log "composer.lock/json mudou — composer install via container composer:2"
+  docker run --rm -v "$REPO_DIR":/var/www/html -w /var/www/html composer:2 \
+    install --no-interaction --optimize-autoloader --ignore-platform-reqs 2>&1 | tail -5 \
+    || log "WARN: composer install falhou (segue — recreate ainda aplica código)"
+fi
+
+# rebuild da imagem só se docker/oimpresso-mcp mudou (Dockerfile/compose/entrypoint).
+if ! git diff --quiet "$LOCAL" "$REMOTE" -- docker/oimpresso-mcp/; then
+  log "docker/oimpresso-mcp mudou — rebuild da imagem"
+  docker compose -f "$COMPOSE_FILE" build 2>&1 | tail -5 \
+    || log "WARN: build falhou (segue com imagem atual; recreate aplica código novo)"
+fi
+
+# SEMPRE force-recreate: opcache.validate_timestamps=Off → sem recreate o código não sobe.
+log "recreate (busta opcache frozen)"
+docker compose -f "$COMPOSE_FILE" up -d --force-recreate 2>&1 | tail -5
+
+# Smoke: caminho completo Traefik→container, espera o JSON status:ok.
+ok=""
+for i in $(seq 1 15); do
+  sleep 4
+  if curl -fsS --max-time 6 "$HEALTH_URL" 2>/dev/null | grep -q '"status":"ok"'; then ok=1; break; fi
+done
+if [ -n "$ok" ]; then
+  log "OK: deploy ${REMOTE:0:9} saudável ($HEALTH_URL)"
+  exit 0
+fi
+log "ALARME: smoke falhou após deploy ${REMOTE:0:9} — ver 'docker logs oimpresso-mcp'."
+log "        rollback: cd $REPO_DIR && git reset --hard $LOCAL && docker compose -f $COMPOSE_FILE up -d --force-recreate"
+exit 1

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -174,6 +174,10 @@
       "nome": "Layout primitives guard (flex/grid solto)",
       "classe": "gate"
     },
+    "mcp-drift-sentinel.yml": {
+      "nome": "MCP Drift Sentinel — servido vs main (ADR 0256 + 0062)",
+      "classe": "automacao"
+    },
     "memory-health.yml": {
       "nome": "Memory Health — ADR 0256",
       "classe": "gate"

--- a/scripts/governance/mcp-drift-sentinel.mjs
+++ b/scripts/governance/mcp-drift-sentinel.mjs
@@ -9,11 +9,12 @@
 // GRITA se a cura parar de funcionar — é o "loop fechado por métrica" aplicado ao
 // deploy: o drift nunca mais fica silencioso.
 //
-// COMO: compara o commit SERVIDO (campo `commit` de /api/mcp/health) com o HEAD de
-// main no checkout do runner. Não precisa de tailscale nem secret novo — só um curl
-// público + git local. Tolera o lag normal do cron (minutos) via janela de tempo
-// ENTRE commits (não relógio de parede), então período tranquilo no main não dá
-// falso-positivo.
+// COMO: compara o commit SERVIDO (campo `commit` de /api/mcp/health/auth) com o HEAD
+// de main no checkout do runner. Não precisa de tailscale; lê o endpoint AUTENTICADO
+// com um token read-only (MCP_SENTINEL_TOKEN, secret do GH) — o repo é público, então
+// o SHA exato NÃO fica num endpoint anônimo (disclosure de versão). Tolera o lag normal
+// do cron (minutos) via janela de tempo ENTRE commits (não relógio de parede), então
+// período tranquilo no main não dá falso-positivo.
 //
 // Uso:  node scripts/governance/mcp-drift-sentinel.mjs            (humano)
 //       node scripts/governance/mcp-drift-sentinel.mjs --json     (máquina)
@@ -23,7 +24,8 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
-const HEALTH_URL = process.env.MCP_HEALTH_URL || 'https://mcp.oimpresso.com/api/mcp/health';
+const HEALTH_URL = process.env.MCP_HEALTH_URL || 'https://mcp.oimpresso.com/api/mcp/health/auth';
+const TOKEN = (process.env.MCP_SENTINEL_TOKEN || '').trim(); // token read-only mcp_* (GH secret)
 const MAX_LAG_HOURS = Number(process.env.MCP_DRIFT_MAX_LAG_HOURS || 6); // cron roda /15min; 6h = host parou de curar há horas
 const JSON_OUT = process.argv.includes('--json');
 
@@ -38,10 +40,14 @@ function isAncestor(sha) {
 function commitEpoch(sha) { const v = git(`show -s --format=%ct ${sha}`); return v ? Number(v) : null; }
 
 async function fetchServedCommit() {
+  if (!TOKEN) return { error: 'MCP_SENTINEL_TOKEN ausente (secret não configurado)' };
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), 12000);
   try {
-    const r = await fetch(HEALTH_URL, { signal: ctrl.signal, headers: { 'user-agent': 'mcp-drift-sentinel' } });
+    const r = await fetch(HEALTH_URL, {
+      signal: ctrl.signal,
+      headers: { 'user-agent': 'mcp-drift-sentinel', authorization: `Bearer ${TOKEN}` },
+    });
     if (!r.ok) return { error: `HTTP ${r.status}` };
     const j = await r.json();
     return { commit: (j.commit || '').trim() || null, version: j.version ?? null };

--- a/scripts/governance/mcp-drift-sentinel.mjs
+++ b/scripts/governance/mcp-drift-sentinel.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// mcp-drift-sentinel.mjs — sentinela EXTERNA de drift do MCP server (ADR 0256 + 0062).
+//
+// POR QUE EXISTE: o MCP server (mcp.oimpresso.com, container no CT 100) roda código
+// vindo de um `git pull` no host — fora de qualquer pipeline. No incidente 2026-06-17
+// ele ficou ~17 dias servindo código velho SEM ninguém notar (os dados, da DB
+// compartilhada, ficam frescos e mascaram o drift do código). O self-update.sh
+// (cron no host) cura o drift; ESTA sentinela roda no GitHub (fora do tailnet) e
+// GRITA se a cura parar de funcionar — é o "loop fechado por métrica" aplicado ao
+// deploy: o drift nunca mais fica silencioso.
+//
+// COMO: compara o commit SERVIDO (campo `commit` de /api/mcp/health) com o HEAD de
+// main no checkout do runner. Não precisa de tailscale nem secret novo — só um curl
+// público + git local. Tolera o lag normal do cron (minutos) via janela de tempo
+// ENTRE commits (não relógio de parede), então período tranquilo no main não dá
+// falso-positivo.
+//
+// Uso:  node scripts/governance/mcp-drift-sentinel.mjs            (humano)
+//       node scripts/governance/mcp-drift-sentinel.mjs --json     (máquina)
+// Saída: exit 0 = OK/WARN (sem alarme) · exit 1 = ALARME (drift real).
+// Node puro (fetch global + git via execSync). Sem deps.
+
+import { execSync } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
+
+const HEALTH_URL = process.env.MCP_HEALTH_URL || 'https://mcp.oimpresso.com/api/mcp/health';
+const MAX_LAG_HOURS = Number(process.env.MCP_DRIFT_MAX_LAG_HOURS || 6); // cron roda /15min; 6h = host parou de curar há horas
+const JSON_OUT = process.argv.includes('--json');
+
+function git(cmd) {
+  try { return execSync(`git ${cmd}`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim(); }
+  catch { return null; }
+}
+function isAncestor(sha) {
+  try { execSync(`git merge-base --is-ancestor ${sha} HEAD`, { stdio: 'ignore' }); return true; }
+  catch { return false; }
+}
+function commitEpoch(sha) { const v = git(`show -s --format=%ct ${sha}`); return v ? Number(v) : null; }
+
+async function fetchServedCommit() {
+  const ctrl = new AbortController();
+  const t = setTimeout(() => ctrl.abort(), 12000);
+  try {
+    const r = await fetch(HEALTH_URL, { signal: ctrl.signal, headers: { 'user-agent': 'mcp-drift-sentinel' } });
+    if (!r.ok) return { error: `HTTP ${r.status}` };
+    const j = await r.json();
+    return { commit: (j.commit || '').trim() || null, version: j.version ?? null };
+  } catch (e) {
+    return { error: String(e?.message || e) };
+  } finally { clearTimeout(t); }
+}
+
+function emit(verdict, fields) {
+  const payload = { verdict, health_url: HEALTH_URL, max_lag_hours: MAX_LAG_HOURS, ...fields };
+  if (JSON_OUT) { console.log(JSON.stringify(payload, null, 2)); }
+  else {
+    const icon = verdict === 'ALARM' ? '🚨' : verdict === 'WARN' ? '⚠️' : '✅';
+    console.log(`${icon} mcp-drift-sentinel: ${verdict}`);
+    for (const [k, v] of Object.entries(fields)) console.log(`   ${k}: ${v}`);
+  }
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const lines = [`### mcp-drift-sentinel — ${verdict}`, '', `- health: \`${HEALTH_URL}\``];
+    for (const [k, v] of Object.entries(fields)) lines.push(`- ${k}: \`${v}\``);
+    try { appendFileSync(process.env.GITHUB_STEP_SUMMARY, lines.join('\n') + '\n'); } catch {}
+  }
+}
+
+const head = git('rev-parse HEAD');
+const headShort = head ? head.slice(0, 9) : '?';
+const served = await fetchServedCommit();
+
+// Endpoint inalcançável → WARN (transitório; não derruba CI por um curl que falhou).
+if (served.error) {
+  emit('WARN', { reason: 'health endpoint inalcançável', detail: served.error, main_head: headShort });
+  process.exit(0);
+}
+// Sem campo `commit` → endpoint anterior a este PR (graça de rollout) → WARN.
+if (!served.commit) {
+  emit('WARN', { reason: 'health não expõe `commit` ainda (endpoint pré-rollout deste PR)', main_head: headShort });
+  process.exit(0);
+}
+
+const servedShort = served.commit.slice(0, 9);
+
+if (served.commit === head) {
+  emit('OK', { served: servedShort, main_head: headShort, lag: '0 (em main)' });
+  process.exit(0);
+}
+// Commit servido não está na história de main → reescrita/branch estranho/muito velho.
+if (!isAncestor(served.commit)) {
+  emit('ALARM', { reason: 'commit servido NÃO é ancestral de main (história reescrita ou muito antigo)', served: servedShort, main_head: headShort });
+  process.exit(1);
+}
+// Ancestral → mede a janela de tempo ENTRE os commits (robusto a período tranquilo).
+const behind = git(`rev-list --count ${served.commit}..HEAD`) || '?';
+const sEpoch = commitEpoch(served.commit);
+const hEpoch = commitEpoch(head);
+const lagH = sEpoch && hEpoch ? (hEpoch - sEpoch) / 3600 : null;
+const lagStr = lagH == null ? '?' : `${lagH.toFixed(1)}h`;
+
+if (lagH != null && lagH > MAX_LAG_HOURS) {
+  emit('ALARM', { reason: `servido ${lagStr} atrás de main (> ${MAX_LAG_HOURS}h) — self-update.sh parou de curar?`, served: servedShort, main_head: headShort, behind_commits: behind });
+  process.exit(1);
+}
+emit('OK', { served: servedShort, main_head: headShort, behind_commits: behind, lag: lagStr });
+process.exit(0);


### PR DESCRIPTION
## Incidente 2026-06-17 — MCP server servindo código velho em silêncio

O servidor MCP (`mcp.oimpresso.com`, container `oimpresso-mcp` no CT 100) rodava uma
**imagem de 29/mai** com checkout em **`0aac033d5` (31/mai)** e 19 arquivos dirty.
O `deploy.yml` é **Hostinger-only** (ADR 0062 separa os runtimes) → **não existia
caminho `main`→CT100-MCP**. Resultado: ~17 dias de drift de código **silencioso** —
os dados (DB compartilhada com Hostinger) ficam frescos e mascaram o atraso do código.

### Diagnóstico (verificado ao vivo via tailscale SSH + gh API)
| | |
|---|---|
| Imagem container | 2026-05-29 · checkout `0aac033d5` (31/mai) · `main` HEAD à época `da31d185` |
| Histórico | `0aac033d5` e `main` **sem ancestral comum** → main reescrito → deploy precisa `reset --hard`, não `pull` |
| opcache | `validate_timestamps=Off` → código novo no bind-mount **não sobe** sem `--force-recreate` |
| 19 dirty | 16 `memory/*/SPEC.md` (stale), `OtelServiceProvider.php` (**artefato CRLF, não hotfix**), 2 `.env.bak` (backups) |
| Gate | `jana.mcp.use` já estava no disco — a claim "ainda copiloto" não procede pro código on-disk |

## Remediação já aplicada ao prod (autorizada — fora deste PR)
Deploy manual via tailscale: backup dos dirty → `reset --hard origin/main` → rebuild →
`up -d --force-recreate` → smoke. **Servidor agora em `main`, healthy, `tools/list` (16
tools incl. `my-inbox`) e gate `jana.mcp.use` OK.** (Obs: uma sessão paralela fez o
reset inicial ~no mesmo instante — minha execução foi idempotente e confirmou o estado.)

## Este PR — automação pra não recair (2 camadas, ADR 0256)
1. **`docker/oimpresso-mcp/scripts/self-update.sh`** — GitOps pull no host (cron `/15min`):
   `fetch` → backup dirty → `reset --hard origin/main` → composer/rebuild condicionais →
   `up -d --force-recreate` → smoke. `flock` single-instance (evita a corrida que gerou
   core dump no incidente).
2. **`.github/workflows/mcp-drift-sentinel.yml`** (+ `scripts/governance/mcp-drift-sentinel.mjs`)
   — watchdog **externo** (roda no GitHub, **sem tailscale nem secret novo**): compara o
   `commit` de `/api/mcp/health` com `main` HEAD; servido > 6h atrás → **alarma** (workflow
   vermelho + issue `mcp-drift` = inbox ops).
3. **Observabilidade** — `entrypoint-octane.sh` grava `deployed_commit.txt` a cada boot;
   `HealthController` expõe `commit`/`commit_short`/`deployed_at`. Workflow registrado no
   `gates-registry.json` (Check G).

### Ativação pós-merge (one-time, no host CT 100)
```bash
tailscale ssh root@ct100-mcp
bash /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh   # traz os arquivos novos
crontab -e   # adicionar a linha do cron documentada no README
```
Até o cron ser instalado, a sentinela já roda no merge e mostra `WARN` (rollout grace)
até o endpoint passar a expor `commit`.

## Fora de escopo (verificado)
`oimpresso-staging` serve `staging.oimpresso.com` (**clone do app web**, DB anonimizada),
em detached HEAD `78b100c18` (10/jun, PR #2497) — provável teste deliberado. Só compartilha
a imagem base; **não é instância MCP** e não entra aqui (é trabalho da skill `criar-staging`).

## Validação
`bash -n` ✓ · `php -l` HealthController ✓ (container) · sentinel rodando ✓ · registry JSON ✓

Refs: ADR 0062 · ADR 0256 · ADR 0283

🤖 Generated with [Claude Code](https://claude.com/claude-code)
