### PR TITLE
fix(mcp): git na imagem octane pra /health/auth expor o commit servido

### DIFF
--- a/docker/oimpresso-mcp/Dockerfile.octane
+++ b/docker/oimpresso-mcp/Dockerfile.octane
@@ -28,6 +28,12 @@ RUN install-php-extensions \
         sockets \
         opentelemetry
 
+# git: o entrypoint-octane usa `git rev-parse HEAD` pra gravar o commit servido
+# (storage/app/deployed_commit.txt → /api/mcp/health/auth) — drift observability
+# (ADR 0256), lido pela sentinela mcp-drift-sentinel.yml. A base FrankenPHP-alpine
+# NÃO traz git; sem isto o entrypoint grava "unknown" → /health/auth sem commit.
+RUN apk add --no-cache git
+
 # OPcache + JIT em produção pra acelerar boot inicial e código quente
 COPY php.ini /usr/local/etc/php/conf.d/zz-mcp-overrides.ini
 


### PR DESCRIPTION
Follow-up do #2917. O entrypoint grava `deployed_commit.txt` via `git rev-parse HEAD`, mas a imagem octane (FrankenPHP alpine) não tem git → gravava `unknown` → `/api/mcp/health/auth` sem `commit` → sentinela em WARN permanente.

**Fix:** `apk add --no-cache git` no `Dockerfile.octane`. No próximo deploy o `self-update.sh` detecta `docker/` mudado → rebuild → recreate → entrypoint grava o SHA real.

Verificado ao vivo: hoje `git` ausente no container + entrypoint baked era o antigo (imagem de 14:34, pré-PR). Refs: ADR 0256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)