### PR TITLE
feat(teammcp): handoff zero-paste sync Cowork→repo (PR-6 · ADR 0283)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -25,6 +25,11 @@ Modules/Jana/Tests/Feature/TaskRegistry/AcceptanceRefTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
 Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php
 Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
+# Loop de Handoff Zero-Paste (ADR 0283): PR-6a submit (novo) + PR-1 ingest
+# (regressão do refactor que extraiu HandoffIngestService). Sintéticas em
+# beforeEach → sqlite-safe (sem migration MySQL-only).
+Modules/TeamMcp/Tests/Feature/HandoffSubmitToolTest.php
+Modules/TeamMcp/Tests/Feature/HandoffIngestTest.php
 tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php

--- a/.github/workflows/handoff-sign-submit.yml
+++ b/.github/workflows/handoff-sign-submit.yml
@@ -1,0 +1,140 @@
+name: Handoff Sign & Submit (on-push · loop zero-paste)
+
+# PR-6b Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — o TRANSPORTE.
+#
+# Fecha o "primeiro hop": um .md commitado em prototipo-ui/handoffs/ vira `pending`
+# SEM o [W] computar HMAC nem colar nada. Pra cada handoff novo/alterado no push,
+# a Action assina (sig = HMAC-SHA256(body, HANDOFF_SECRET), segredo SÓ no repo
+# secret) e chama o tool MCP handoff-submit (PR-6a) → pending → aparece na Forja.
+#
+# Por que on-push e não zero-toque puro: o Cowork é read-only no GitHub e não
+# expõe um endpoint estável de handoffs pendentes — então o 1º hop SEMPRE precisa
+# de um gatilho fora do Cowork. Isto é o piso real até existir um publisher
+# Cowork→repo (chip de follow-up). NÃO faz auto-merge (ADR 0283 — merge é o
+# 1-clique do [W]).
+#
+# ADVISORY de nascença (ADR 0271/0275): não está no branch protection. O job
+# `selftest` (controle-negativo do assinador) roda SEMPRE, sem segredo/rede/DB. O
+# job `submit` só roda no push pra main e degrada pra skip-as-pass se os secrets
+# ainda não existirem (o [W] os configura UMA vez).
+#
+# [W] faz UMA VEZ:
+#   - secret HANDOFF_SECRET   (= o do .env do servidor; o HMAC tem que bater)
+#   - secret HANDOFF_SUBMIT_TOKEN  (token MCP scope jana.mcp.handoff.submit via McpTokenIssuer)
+#   - (opcional) var MCP_ENDPOINT_URL  (default https://mcp.oimpresso.com/api/mcp)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'prototipo-ui/handoffs/*.md'
+  pull_request:
+    paths:
+      - 'bin/sign-handoff.php'
+      - '.github/workflows/handoff-sign-submit.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: handoff-sign-submit-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  selftest:
+    name: sign-handoff self-test (controle-negativo · sem segredo/rede)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+      - name: O assinador morde? (determinismo · CRLF→LF · sig-bate · parse · envelope)
+        run: php bin/sign-handoff.php --self-test
+
+  submit:
+    name: sign & submit handoffs alterados → pending
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # histórico pro diff before...after
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+
+      - name: Assina e submete cada handoff novo/alterado
+        env:
+          HANDOFF_SECRET: ${{ secrets.HANDOFF_SECRET }}
+          SUBMIT_TOKEN: ${{ secrets.HANDOFF_SUBMIT_TOKEN }}
+          MCP_ENDPOINT: ${{ vars.MCP_ENDPOINT_URL || 'https://mcp.oimpresso.com/api/mcp' }}
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # Skip-as-pass enquanto o [W] não configurou os secrets (advisory).
+          if [ -z "${HANDOFF_SECRET}" ] || [ -z "${SUBMIT_TOKEN}" ]; then
+            echo "ℹ️  HANDOFF_SECRET/HANDOFF_SUBMIT_TOKEN ainda não configurados — skip-as-pass."
+            echo "    Configure-os (Settings → Secrets) pra ligar o transporte zero-paste (ADR 0283)."
+            exit 0
+          fi
+
+          # Diff do push. Primeiro push/force (before=000…) → compara com o pai.
+          BASE="${BEFORE_SHA}"
+          if [ -z "${BASE}" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
+            BASE="${AFTER_SHA}^"
+          fi
+
+          # Só handoffs que AINDA existem (added/modified; deletados são ignorados).
+          mapfile -t FILES < <(git diff --name-only --diff-filter=AM "${BASE}" "${AFTER_SHA}" -- 'prototipo-ui/handoffs/*.md' | sort -u)
+
+          if [ "${#FILES[@]}" -eq 0 ]; then
+            echo "Nenhum handoff novo/alterado neste push — nada a submeter."
+            exit 0
+          fi
+
+          fail=0
+          for f in "${FILES[@]}"; do
+            [ -f "$f" ] || continue
+            echo "── $f ──"
+
+            # Assina (HMAC) e monta o envelope JSON-RPC do tools/call handoff-submit.
+            if ! body="$(php bin/sign-handoff.php --file="$f")"; then
+              echo "🔴 falha ao assinar $f"; fail=1; continue
+            fi
+
+            # POST stateless no endpoint MCP (Mcp::web é síncrono — JSON de volta).
+            resp="$(mktemp)"
+            code="$(curl -sS -o "$resp" -w '%{http_code}' -X POST "${MCP_ENDPOINT}" \
+              -H "Authorization: Bearer ${SUBMIT_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              -H 'Accept: application/json, text/event-stream' \
+              --data-binary "$body" || echo "000")"
+
+            # isError no resultado JSON-RPC (tool errou: sig inválida, sem scope…).
+            is_err="$(jq -r '.result.isError // (.error != null)' "$resp" 2>/dev/null || echo "true")"
+
+            if [ "$code" != "200" ] || [ "$is_err" = "true" ]; then
+              echo "🔴 submit falhou (HTTP $code · isError=$is_err):"
+              jq -r '.result.content[0].text // .error.message // .' "$resp" 2>/dev/null || cat "$resp"
+              fail=1
+            else
+              echo "🟢 submetido → pending:"
+              jq -r '.result.content[0].text // empty' "$resp" 2>/dev/null || true
+            fi
+            rm -f "$resp"
+          done
+
+          if [ "$fail" -ne 0 ]; then
+            echo ""
+            echo "❌ Um ou mais handoffs não entraram. Confira HANDOFF_SECRET (tem que bater o do servidor),"
+            echo "   o scope do HANDOFF_SUBMIT_TOKEN (jana.mcp.handoff.submit) e o MCP_ENDPOINT_URL."
+            exit 1
+          fi
+          echo "✅ Todos os handoffs do push viraram pending (sem auto-merge — merge é o 1-clique do [W])."

--- a/Modules/Jana/Database/Seeders/McpScopesSeeder.php
+++ b/Modules/Jana/Database/Seeders/McpScopesSeeder.php
@@ -229,6 +229,16 @@ class McpScopesSeeder extends Seeder
             'business_required' => false,
             'admin_only'        => false,
         ],
+        [
+            'slug'              => 'jana.mcp.handoff.submit',
+            'nome'              => 'Submeter handoff de design assinado (handoff-submit)',
+            'descricao'         => 'Permite handoff-submit (PR-6a, ADR 0283) — landing-pad HTTP que cria pending em cowork_handoffs a partir de um handoff ASSINADO (HMAC), sem SSH/commit. Mutação: sig inválida é recusada (A1), conteúdo idêntico é no-op, append-only por slug/version. SEM auto-merge. Só o ator-transporte (a GitHub Action on-push) — emitir token com este scope via McpTokenIssuer e guardá-lo como repo secret HANDOFF_SUBMIT_TOKEN.',
+            'resources_pattern' => null,
+            'tools_pattern'     => 'handoff-submit',
+            'is_destructive'    => false,
+            'business_required' => false,
+            'admin_only'        => false,
+        ],
     ];
 
     public function run(): void

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -159,6 +159,11 @@ class OimpressoMcpServer extends Server
         // brief-fetch numa sessão de UI, fora dos 15 essenciais da página 1).
         \Modules\TeamMcp\Mcp\Tools\HandoffPendingTool::class,
         \Modules\TeamMcp\Mcp\Tools\HandoffAckTool::class,
+        // PR-6a Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — landing-pad HTTP
+        // assinado: a GitHub Action on-push assina (HMAC) e chama handoff-submit →
+        // pending, sem [W] no transporte. Scope fino jana.mcp.handoff.submit (A7);
+        // reusa HandoffIngestService (mesma validação do PR-1). Sem auto-merge.
+        \Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/TeamMcp/Console/Commands/HandoffIngestCommand.php
+++ b/Modules/TeamMcp/Console/Commands/HandoffIngestCommand.php
@@ -6,7 +6,7 @@ namespace Modules\TeamMcp\Console\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Schema;
-use Modules\TeamMcp\Entities\CoworkHandoff;
+use Modules\TeamMcp\Services\HandoffIngestService;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
 
@@ -57,6 +57,11 @@ final class HandoffIngestCommand extends Command
         {--detail : Imprime o motivo de cada rejeição/skip}';
 
     protected $description = 'Ingere handoffs de design assinados (HMAC) → cowork_handoffs pending. Rejeita sem sig válida. Append-only por slug/version.';
+
+    public function __construct(private readonly HandoffIngestService $ingestService)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
@@ -121,7 +126,9 @@ final class HandoffIngestCommand extends Command
     }
 
     /**
-     * Processa um arquivo: parse frontmatter, valida HMAC, aplica append-only.
+     * Processa um arquivo: parse frontmatter, delega a validação/persistência ao
+     * {@see HandoffIngestService} (mesma lógica do tool HTTP) e traduz o desfecho
+     * pra stats + output PT-BR. O service é a fonte única — aqui só há I/O de arquivo.
      *
      * @param  array<string,int>  $stats  acumulador (by-ref)
      */
@@ -129,75 +136,59 @@ final class HandoffIngestCommand extends Command
     {
         [$fm, $body] = $this->parseFrontmatter((string) file_get_contents($file));
 
-        // A1: assinatura obrigatória — rejeita unsigned/forjado (timing-safe).
-        $expected = hash_hmac('sha256', $body, $secret);
-        $provided = (string) ($fm['sig'] ?? '');
-        if ($provided === '' || ! hash_equals($expected, $provided)) {
-            $stats['rejeitado']++;
-            $this->warn('REJEITADO (sig inválida): ' . basename($file));
-
-            return;
-        }
-
         $slug = (string) ($fm['handoff_id'] ?? $fm['slug'] ?? '');
-        if ($slug === '') {
-            $stats['rejeitado']++;
-            $this->warn('REJEITADO (sem handoff_id): ' . basename($file));
+        $base = basename($file);
 
-            return;
-        }
-
-        $hash = hash('sha256', $body);
-        $existing = CoworkHandoff::where('slug', $slug)->orderByDesc('version')->first();
-
-        // Re-ingest idêntico = no-op (dedup por source_hash).
-        if ($existing && $existing->source_hash === $hash) {
-            $stats['sem_mudanca']++;
-            if ($detail) {
-                $this->line("sem mudança: {$slug} v{$existing->version}");
-            }
-
-            return;
-        }
-
-        $version = $existing ? ((int) $existing->version + 1) : 1;
-        $isRevisao = (bool) $existing;
-        $supersede = $existing && $existing->status === 'applied';
-
-        if ($dryRun) {
-            $stats[$isRevisao ? 'revisao' : 'novo']++;
-            $this->line(sprintf(
-                '[plano] %s v%d (%s)%s',
-                $slug,
-                $version,
-                $isRevisao ? 'revisão' : 'novo',
-                $supersede ? ' + supersede anterior' : '',
-            ));
-
-            return;
-        }
-
-        // A6: revisão de algo já aplicado = lápide na anterior (append-only).
-        if ($existing !== null && $existing->status === 'applied') {
-            CoworkHandoff::where('id', $existing->id)->update(['status' => 'superseded']);
-        }
-
-        CoworkHandoff::create([
+        $result = $this->ingestService->ingest([
             'slug'            => $slug,
-            'version'         => $version,
-            'tela'            => (string) ($fm['tela'] ?? ''),
-            'status'          => 'pending',
-            'audited_against' => $fm['audited_against'] ?? null,
             'body_md'         => $body,
-            'files_json'      => (array) ($fm['files'] ?? []),
-            'source_hash'     => $hash,
-            'sig'             => $provided,
+            'sig'             => (string) ($fm['sig'] ?? ''),
+            'files'           => (array) ($fm['files'] ?? []),
+            'tela'            => (string) ($fm['tela'] ?? ''),
             'created_by'      => (string) ($fm['created_by'] ?? 'CC'),
-            'created_at'      => now(),
-        ]);
+            'audited_against' => $fm['audited_against'] ?? null,
+        ], $secret, $dryRun);
 
-        $stats[$isRevisao ? 'revisao' : 'novo']++;
-        $this->info(($isRevisao ? "revisão {$slug} v{$version}" : "novo {$slug} v{$version}") . ' → pending');
+        switch ($result['outcome']) {
+            case 'rejected':
+                $stats['rejeitado']++;
+                // A1: sig inválida (default) ou handoff_id ausente.
+                $this->warn($result['reason'] === 'slug'
+                    ? "REJEITADO (sem handoff_id): {$base}"
+                    : "REJEITADO (sig inválida): {$base}");
+
+                return;
+
+            case 'no_op':
+                $stats['sem_mudanca']++;
+                if ($detail) {
+                    $this->line("sem mudança: {$slug} v{$result['version']}");
+                }
+
+                return;
+
+            default: // 'created' | 'revised'
+                $isRevisao = $result['outcome'] === 'revised';
+                $stats[$isRevisao ? 'revisao' : 'novo']++;
+
+                if ($dryRun) {
+                    $this->line(sprintf(
+                        '[plano] %s v%d (%s)%s',
+                        $slug,
+                        $result['version'],
+                        $isRevisao ? 'revisão' : 'novo',
+                        $result['supersede'] ? ' + supersede anterior' : '',
+                    ));
+
+                    return;
+                }
+
+                $this->info(($isRevisao
+                    ? "revisão {$slug} v{$result['version']}"
+                    : "novo {$slug} v{$result['version']}") . ' → pending');
+
+                return;
+        }
     }
 
     /**

--- a/Modules/TeamMcp/Mcp/Tools/HandoffSubmitTool.php
+++ b/Modules/TeamMcp/Mcp/Tools/HandoffSubmitTool.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Entities\Mcp\McpAuditLog;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
+use Modules\TeamMcp\Entities\McpIngestHeartbeat;
+use Modules\TeamMcp\Services\HandoffIngestService;
+use Throwable;
+
+/**
+ * Tool MCP handoff-submit — PR-6a Loop de Handoff Zero-Paste (Fase 0 · ADR 0283).
+ *
+ * **Landing-pad ASSINADO por HTTP:** recebe um handoff de design (Cowork→Code) e
+ * cria 'pending' em `cowork_handoffs`, SEM depender de SSH no CT 100 nem de commit
+ * no repo. Fecha o "primeiro hop" do loop zero-paste — o gatilho é uma GitHub
+ * Action on-push ({@see .github/workflows/handoff-sign-submit.yml}) que assina e
+ * chama este tool, sem o [W] colar nada nem computar HMAC.
+ *
+ * Reusa {@see HandoffIngestService} — MESMA validação HMAC, MESMO `source_hash`,
+ * MESMO append-only do `handoff:ingest` (PR-1). Nada de recriar ingest (NÃO-FAZER
+ * do handoff). O runner de CI não alcança o DB de prod (docblock do
+ * {@see \Modules\TeamMcp\Console\Commands\HandoffIngestCommand}) — por isso o
+ * transporte é HTTP pra ESTE tool, não `artisan handoff:ingest` no runner.
+ *
+ * Defesas do adversário [AH]:
+ *   - **A7 authz:** mutação — exige scope fino `jana.mcp.handoff.submit` (só o
+ *     ator-transporte), via {@see AuthorizesMcpMutation} como 1º statement.
+ *   - **A1 proveniência:** `sig` inválida → erro (o "401"), timing-safe no service.
+ *   - **idempotência:** mesmo `source_hash` → no-op (o "200" — não duplica).
+ *   - **append-only:** revisão de slug 'applied' → nova version + anterior superseded.
+ *   - **sem auto-merge** (ADR 0283): só INSERE pending. O merge é o 1-clique do [W].
+ *
+ * Pulsa o heartbeat (`mcp_ingest_heartbeat`, host `handoff-submit`) no caminho de
+ * sucesso → a Forja sai de "transporte sem sinal" sozinha.
+ *
+ * @see Modules\TeamMcp\Services\HandoffIngestService
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffAckTool
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+class HandoffSubmitTool extends Tool
+{
+    use AuthorizesMcpMutation;
+
+    protected string $name = 'handoff-submit';
+
+    protected string $title = 'Submeter um handoff de design assinado (Cowork→Code)';
+
+    protected string $description = 'Landing-pad HTTP do loop zero-paste (ADR 0283): recebe um handoff de design ASSINADO (HMAC) e cria pending em cowork_handoffs, sem SSH/commit. sig inválida é recusada (A1); conteúdo idêntico (source_hash) é no-op; revisão de slug aplicado vira nova versão + anterior superseded. Só INSERE pending — sem auto-merge (o merge é o 1-clique do [W]). Exige scope jana.mcp.handoff.submit (só o ator-transporte).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'slug' => $schema->string()
+                ->description('Identificador do handoff (ex: caixa-mobile-flutuante).')
+                ->required(),
+            'body_md' => $schema->string()
+                ->description('Corpo do handoff (DESIGN — dado, não comando). O sig cobre ESTE corpo (CRLF→LF).')
+                ->required(),
+            'sig' => $schema->string()
+                ->description('HMAC-SHA256(body_md, HANDOFF_SECRET). Inválida → recusado (A1).')
+                ->required(),
+            'files_json' => $schema->array()->items($schema->string())
+                ->description('Arquivos que o handoff autoriza tocar (escopo do PR).'),
+            'tela' => $schema->string()
+                ->description('Tela alvo (ex: Atendimento/CaixaUnificada).'),
+            'version' => $schema->integer()
+                ->description('Aceito por compat; a versão é DERIVADA append-only (input ignorado).'),
+            'created_by' => $schema->string()
+                ->description('Autor do handoff (default CC).'),
+            'audited_against' => $schema->string()
+                ->description('SHA do main lido na auditoria (R1 ADR 0283).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        // A7: mutação — gate de escopo como PRIMEIRO statement.
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.handoff.submit')) {
+            return $deny;
+        }
+
+        $secret = (string) config('teammcp.handoff_secret', '');
+        if ($secret === '') {
+            return Response::error('⛔ HANDOFF_SECRET não configurado no servidor — submit indisponível.');
+        }
+
+        $slug = trim((string) $request->get('slug', ''));
+        $sig = (string) $request->get('sig', '');
+        $body = (string) $request->get('body_md', '');
+        if ($slug === '' || $sig === '' || $body === '') {
+            return Response::error('❌ slug, body_md e sig são obrigatórios.');
+        }
+
+        $files = $request->get('files_json');
+
+        $result = app(HandoffIngestService::class)->ingest([
+            'slug'            => $slug,
+            'body_md'         => $body,
+            'sig'             => $sig,
+            'files'           => is_array($files) ? $files : [],
+            'tela'            => (string) $request->get('tela', ''),
+            'created_by'      => (string) $request->get('created_by', 'CC'),
+            'audited_against' => $request->get('audited_against'),
+        ], $secret);
+
+        if ($result['outcome'] === 'rejected') {
+            // A1: sig inválida (ou slug vazio) — "401". Não insere, não pulsa heartbeat.
+            $this->audit($request, $slug, 0, 'rejected');
+
+            return Response::error($result['reason'] === 'slug'
+                ? '❌ slug ausente — handoff recusado.'
+                : '⛔ assinatura inválida — handoff recusado (A1). sig precisa bater HMAC-SHA256(body_md, HANDOFF_SECRET).');
+        }
+
+        // Sucesso (created/revised/no_op): transporte vivo → pulsa o heartbeat.
+        $this->bumpHeartbeat();
+        $this->audit($request, $slug, $result['version'], $result['outcome']);
+
+        $payload = [
+            'ok'      => true,
+            'slug'    => $slug,
+            'version' => $result['version'],
+            'outcome' => $result['outcome'], // created | revised | no_op
+            'hint'    => $result['outcome'] === 'no_op'
+                ? 'idempotente: conteúdo idêntico já estava pending — nada duplicado.'
+                : 'pending criado — aparece na Forja e no handoff-pending. O merge é o 1-clique do [W] (sem auto-merge).',
+        ];
+
+        return Response::text((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /** Pulsa o heartbeat do ingest (host marker) — best-effort, não trava a resposta. */
+    private function bumpHeartbeat(): void
+    {
+        try {
+            $hb = McpIngestHeartbeat::firstOrNew(['host' => 'handoff-submit']);
+            $hb->last_ingest_at = now();
+            $hb->msgs_acc = (int) ($hb->msgs_acc ?? 0) + 1;
+            $hb->save();
+        } catch (Throwable) {
+            // best-effort — o heartbeat é sinal, não bloqueio.
+        }
+    }
+
+    /** Audit best-effort (slug/outcome) — espelha HandoffAckTool::audit. */
+    private function audit(Request $request, string $slug, int $version, string $outcome): void
+    {
+        try {
+            $user = $request->user();
+            McpAuditLog::registrar([
+                'user_id'          => $user !== null ? (int) $user->getAuthIdentifier() : 0,
+                'endpoint'         => 'tools/call',
+                'tool_or_resource' => 'handoff-submit',
+                'status'           => $outcome === 'rejected' ? 'denied' : 'ok',
+                'payload_summary'  => [
+                    'slug'    => $slug,
+                    'version' => $version,
+                    'outcome' => $outcome,
+                ],
+            ]);
+        } catch (Throwable) {
+            // best-effort
+        }
+    }
+}

--- a/Modules/TeamMcp/Services/HandoffIngestService.php
+++ b/Modules/TeamMcp/Services/HandoffIngestService.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Services;
+
+use Modules\TeamMcp\Entities\CoworkHandoff;
+
+/**
+ * HandoffIngestService — PR-6 Loop de Handoff Zero-Paste (Fase 0 · ADR 0283).
+ *
+ * Núcleo COMPARTILHADO de validação + persistência de um handoff de design,
+ * extraído de {@see \Modules\TeamMcp\Console\Commands\HandoffIngestCommand}
+ * (PR-1) pra ser reusado pelo landing-pad HTTP
+ * {@see \Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool} (PR-6a). MESMA checagem HMAC,
+ * MESMO `source_hash`, MESMO append-only — uma fonte só de verdade pra ingest,
+ * venha de arquivo (command, server-side) ou de HTTP (tool, on-push).
+ *
+ * **Contrato do `body` assinado** (idêntico ao command): `sig = HMAC-SHA256(body, secret)`
+ * com CRLF normalizado pra LF ANTES do HMAC — determinístico cross-OS
+ * ({@see lição CRLF em writes}). `source_hash = sha256(body)` (mesma normalização).
+ *
+ * **Append-only** (A6 · {@see ADR 0130}/0003): revisão de um slug já 'applied' vira
+ * NOVA version 'pending' + a anterior 'superseded'. Re-ingest idêntico (mesmo
+ * `source_hash`) é no-op. NUNCA delete.
+ *
+ * Stateless e SEM efeito colateral além do insert/update em `cowork_handoffs`. NÃO
+ * faz auto-merge (ADR 0283); NÃO toca o heartbeat — quem chama decide (o
+ * {@see \Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool} pulsa; o command não, igual
+ * ao comportamento original do PR-1).
+ *
+ * @see Modules\TeamMcp\Console\Commands\HandoffIngestCommand
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+final class HandoffIngestService
+{
+    /**
+     * Valida a assinatura e aplica o handoff (append-only). Determinístico e
+     * idempotente: mesmo `source_hash` → no-op.
+     *
+     * @param  array{
+     *     slug?: string, body_md?: string, sig?: string, files?: array<mixed>,
+     *     tela?: string, created_by?: string, audited_against?: string|null
+     * }  $input  campos do handoff (já fora do frontmatter)
+     * @param  string  $secret  HANDOFF_SECRET (HMAC) — o caller garante não-vazio
+     * @param  bool  $dryRun  valida e calcula o plano, mas NÃO persiste
+     * @return array{
+     *     outcome: 'rejected'|'no_op'|'created'|'revised',
+     *     reason: string|null, version: int, supersede: bool
+     * }
+     */
+    public function ingest(array $input, string $secret, bool $dryRun = false): array
+    {
+        // Normaliza CRLF→LF: o HMAC e o source_hash têm que bater cross-OS.
+        $body = str_replace("\r\n", "\n", (string) ($input['body_md'] ?? ''));
+
+        // A1: assinatura obrigatória — rejeita unsigned/forjado (timing-safe).
+        $sig = (string) ($input['sig'] ?? '');
+        $expected = hash_hmac('sha256', $body, $secret);
+        if ($sig === '' || ! hash_equals($expected, $sig)) {
+            return ['outcome' => 'rejected', 'reason' => 'sig', 'version' => 0, 'supersede' => false];
+        }
+
+        $slug = (string) ($input['slug'] ?? '');
+        if ($slug === '') {
+            return ['outcome' => 'rejected', 'reason' => 'slug', 'version' => 0, 'supersede' => false];
+        }
+
+        $hash = hash('sha256', $body);
+        $existing = CoworkHandoff::where('slug', $slug)->orderByDesc('version')->first();
+
+        // Re-ingest idêntico = no-op (dedup por source_hash).
+        if ($existing !== null && $existing->source_hash === $hash) {
+            return ['outcome' => 'no_op', 'reason' => null, 'version' => (int) $existing->version, 'supersede' => false];
+        }
+
+        $version = $existing !== null ? ((int) $existing->version + 1) : 1;
+        $isRevisao = $existing !== null;
+        $supersede = $existing !== null && $existing->status === 'applied';
+
+        if ($dryRun) {
+            return ['outcome' => $isRevisao ? 'revised' : 'created', 'reason' => null, 'version' => $version, 'supersede' => $supersede];
+        }
+
+        // A6: revisão de algo já aplicado = lápide na anterior (append-only).
+        if ($existing !== null && $existing->status === 'applied') {
+            CoworkHandoff::where('id', $existing->id)->update(['status' => 'superseded']);
+        }
+
+        CoworkHandoff::create([
+            'slug'            => $slug,
+            'version'         => $version,
+            'tela'            => (string) ($input['tela'] ?? ''),
+            'status'          => 'pending',
+            'audited_against' => $input['audited_against'] ?? null,
+            'body_md'         => $body,
+            'files_json'      => (array) ($input['files'] ?? []),
+            'source_hash'     => $hash,
+            'sig'             => $sig,
+            'created_by'      => (string) ($input['created_by'] ?? 'CC'),
+            'created_at'      => now(),
+        ]);
+
+        return ['outcome' => $isRevisao ? 'revised' : 'created', 'reason' => null, 'version' => $version, 'supersede' => $supersede];
+    }
+}

--- a/Modules/TeamMcp/Tests/Feature/HandoffSubmitToolTest.php
+++ b/Modules/TeamMcp/Tests/Feature/HandoffSubmitToolTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Request as McpRequest;
+use Laravel\Mcp\Response as McpResponse;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+use Modules\TeamMcp\Entities\McpIngestHeartbeat;
+use Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-6a Loop de Handoff Zero-Paste (Fase 0 · ADR 0283) — GUARD do tool
+ * handoff-submit (landing-pad HTTP assinado).
+ *
+ * Provas (critério de aceite + adversário [AH]):
+ *   1. sig válida + scope → cria pending com campos certos + pulsa heartbeat
+ *   2. sig inválida → erro (A1), NÃO insere, NÃO pulsa heartbeat
+ *   3. re-submit idêntico (mesmo source_hash) → no-op, não duplica (idempotência)
+ *   4. revisão de 'applied' → nova version pending + anterior superseded (A6)
+ *   5. sem scope jana.mcp.handoff.submit → erro (A7), NÃO muta
+ *   6. campos obrigatórios faltando → erro
+ *
+ * Harness espelha HandoffToolsTest (user via auth userResolver + tabela sintética),
+ * com nomes ÚNICOS pra não colidir com HandoffIngestTest/HandoffToolsTest no mesmo
+ * processo Pest. A assinatura usa a MESMA definição de body do service (corpo
+ * CRLF→LF) — contrato self-consistente.
+ *
+ * Tier 0 ({@see ADR 0093}): cowork_handoffs/mcp_ingest_heartbeat sem business_id.
+ *
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool
+ * @see Modules\TeamMcp\Services\HandoffIngestService
+ */
+
+const HANDOFF_SUBMIT_SECRET = 'segredo-de-teste-hmac-pr6';
+
+/** Tabelas sintéticas (espelham as migrations; sqlite-friendly). */
+function mkSubmitTables(): void
+{
+    foreach (['cowork_handoffs', 'mcp_ingest_heartbeat'] as $t) {
+        if (Schema::hasTable($t)) {
+            Schema::drop($t);
+        }
+    }
+
+    Schema::create('cowork_handoffs', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('slug', 120);
+        $t->unsignedInteger('version')->default(1);
+        $t->string('tela', 160)->default('');
+        $t->string('status', 16)->default('pending');
+        $t->string('audited_against', 40)->nullable();
+        $t->longText('body_md');
+        $t->json('files_json');
+        $t->char('source_hash', 64);
+        $t->char('sig', 64);
+        $t->string('created_by', 40)->default('CC');
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('applied_at')->nullable();
+        $t->string('applied_by', 60)->nullable();
+        $t->text('pr_url')->nullable();
+        $t->json('gate_status')->nullable();
+        $t->unique(['slug', 'version']);
+        $t->index('status');
+    });
+
+    Schema::create('mcp_ingest_heartbeat', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('host', 500)->unique();
+        $t->timestamp('last_ingest_at')->nullable();
+        $t->string('last_session_uuid', 36)->nullable();
+        $t->unsignedBigInteger('msgs_acc')->default(0);
+        $t->timestamps();
+    });
+}
+
+/** Assina o corpo igual ao service (CRLF→LF antes do HMAC). */
+function signSubmitBody(string $body, string $secret = HANDOFF_SUBMIT_SECRET): string
+{
+    return hash_hmac('sha256', str_replace("\r\n", "\n", $body), $secret);
+}
+
+/** User-stub MCP (Authenticatable + can() injetável). */
+function mkSubmitUser(bool $granted): Authenticatable
+{
+    return new class($granted) implements Authenticatable
+    {
+        public function __construct(private bool $granted) {}
+
+        public function can($abilities, $arguments = []): bool
+        {
+            return $this->granted;
+        }
+
+        public function getAuthIdentifierName()
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier()
+        {
+            return 9;
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword()
+        {
+            return '';
+        }
+
+        public function getRememberToken()
+        {
+            return '';
+        }
+
+        public function setRememberToken($value) {}
+
+        public function getRememberTokenName()
+        {
+            return 'remember_token';
+        }
+    };
+}
+
+function actSubmitUser(?Authenticatable $user): void
+{
+    app('auth')->resolveUsersUsing(fn ($guard = null) => $user);
+}
+
+function submitRespArray(McpResponse $response): array
+{
+    return json_decode((string) $response->content(), true) ?: [];
+}
+
+/** Payload base de um submit válido (corpo + sig coerentes). */
+function submitArgs(string $slug, string $body, array $over = []): array
+{
+    return array_merge([
+        'slug'            => $slug,
+        'body_md'         => $body,
+        'sig'             => signSubmitBody($body),
+        'files_json'      => ['resources/css/cockpit.css'],
+        'tela'            => 'Atendimento/CaixaUnificada',
+        'created_by'      => 'CC',
+        'audited_against' => 'cb1a546',
+    ], $over);
+}
+
+beforeEach(function () {
+    mkSubmitTables();
+    config(['teammcp.handoff_secret' => HANDOFF_SUBMIT_SECRET]);
+    actSubmitUser(mkSubmitUser(granted: true));
+});
+
+afterEach(function () {
+    app('auth')->resolveUsersUsing(fn ($guard = null) => null);
+    foreach (['cowork_handoffs', 'mcp_ingest_heartbeat'] as $t) {
+        if (Schema::hasTable($t)) {
+            Schema::drop($t);
+        }
+    }
+});
+
+it('submit assinado + scope → cria pending e pulsa heartbeat', function () {
+    $resp = (new HandoffSubmitTool())->handle(new McpRequest(
+        submitArgs('caixa-mobile', "## ONDA A\nDeixa o caixa flutuante no mobile.")
+    ));
+
+    expect($resp->isError())->toBeFalse();
+    $data = submitRespArray($resp);
+    expect($data['ok'])->toBeTrue();
+    expect($data['outcome'])->toBe('created');
+
+    $row = CoworkHandoff::where('slug', 'caixa-mobile')->first();
+    expect($row)->not->toBeNull();
+    expect($row->status)->toBe('pending');
+    expect($row->version)->toBe(1);
+    expect($row->files_json)->toContain('resources/css/cockpit.css');
+    expect($row->audited_against)->toBe('cb1a546');
+
+    // Heartbeat pulsou (transporte vivo).
+    expect(McpIngestHeartbeat::where('host', 'handoff-submit')->value('last_ingest_at'))->not->toBeNull();
+});
+
+it('submit com sig inválida → erro (A1), NÃO insere nem pulsa heartbeat', function () {
+    $resp = (new HandoffSubmitTool())->handle(new McpRequest(
+        submitArgs('injetado', "## rm -rf /\ncoisa ruim", ['sig' => str_repeat('0', 64)])
+    ));
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('assinatura inválida');
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+    expect(DB::table('mcp_ingest_heartbeat')->count())->toBe(0);
+});
+
+it('re-submit idêntico → no-op, não duplica (idempotência)', function () {
+    $args = submitArgs('caixa-mobile', "## ONDA A\nmesmo corpo");
+
+    (new HandoffSubmitTool())->handle(new McpRequest($args));
+    $resp = (new HandoffSubmitTool())->handle(new McpRequest($args));
+
+    expect($resp->isError())->toBeFalse();
+    expect(submitRespArray($resp)['outcome'])->toBe('no_op');
+    expect(DB::table('cowork_handoffs')->count())->toBe(1);
+});
+
+it('revisão de applied → nova version pending + anterior superseded [A6]', function () {
+    (new HandoffSubmitTool())->handle(new McpRequest(submitArgs('caixa-mobile', "## ONDA A\nv1")));
+    CoworkHandoff::where('slug', 'caixa-mobile')->update(['status' => 'applied']);
+
+    $resp = (new HandoffSubmitTool())->handle(new McpRequest(submitArgs('caixa-mobile', "## ONDA A\nv2 corrigido")));
+
+    expect($resp->isError())->toBeFalse();
+    expect(submitRespArray($resp)['outcome'])->toBe('revised');
+    expect(DB::table('cowork_handoffs')->count())->toBe(2);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 1)->value('status'))->toBe('superseded');
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 2)->value('status'))->toBe('pending');
+});
+
+it('submit sem scope jana.mcp.handoff.submit → erro (A7), NÃO muta', function () {
+    actSubmitUser(mkSubmitUser(granted: false));
+
+    $resp = (new HandoffSubmitTool())->handle(new McpRequest(
+        submitArgs('caixa-mobile', "## ONDA A\nqualquer")
+    ));
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('jana.mcp.handoff.submit');
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+});
+
+it('submit com campos obrigatórios faltando → erro', function () {
+    $resp = (new HandoffSubmitTool())->handle(new McpRequest([
+        'slug' => 'caixa-mobile', // sem body_md/sig
+    ]));
+
+    expect($resp->isError())->toBeTrue();
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+});

--- a/bin/sign-handoff.php
+++ b/bin/sign-handoff.php
@@ -1,0 +1,229 @@
+<?php
+
+/**
+ * ASSINADOR de handoff (HMAC) → payload do tool handoff-submit — PR-6b Loop
+ * Zero-Paste (Fase 0 · ADR 0283).
+ *
+ * O "transporte" do loop zero-paste: a GitHub Action on-push
+ * ({@see .github/workflows/handoff-sign-submit.yml}) roda este script pra CADA
+ * handoff novo/alterado em `prototipo-ui/handoffs/*.md`, computando
+ * `sig = HMAC-SHA256(body, HANDOFF_SECRET)` e emitindo o envelope JSON-RPC do
+ * `tools/call` handoff-submit. A Action faz POST no endpoint MCP → pending. O [W]
+ * nunca computa HMAC; o segredo vive só no repo secret/servidor (NÃO versionado).
+ *
+ * **Contrato do `body`** (idêntico ao HandoffIngestService/Command, PR-1): o arquivo
+ * é `---\n<yaml>\n---\n<body>`; o `sig` cobre só o `<body>`, com CRLF→LF antes do
+ * HMAC — determinístico cross-OS ({@see lição CRLF em writes}).
+ *
+ * Dependency-free de propósito (igual {@see bin/check-handoff-scope.php}): roda no
+ * runner com só `php`, SEM `composer install` (sem vendor/autoload). Por isso o
+ * frontmatter é parseado com regex nativo, não Symfony\Yaml.
+ *
+ * Uso:
+ *   HANDOFF_SECRET=… php bin/sign-handoff.php --file=prototipo-ui/handoffs/<slug>.md
+ *       → imprime no stdout o JSON-RPC do tools/call handoff-submit (pronto pro POST)
+ *   php bin/sign-handoff.php --self-test   # controle-negativo, sem segredo/rede/DB
+ *
+ * Exit: 0 OK/selftest-verde · 1 erro (self-test vermelho, arquivo/segredo ausente).
+ */
+
+declare(strict_types=1);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Núcleo testável (puro) — sem I/O, sem env.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Separa frontmatter (raw) e corpo, normalizando CRLF→LF ANTES de tudo.
+ *
+ * @return array{0: string, 1: string} [frontmatterRaw, body] — fm vazio se ausente.
+ */
+function handoffSplit(string $raw): array
+{
+    $raw = str_replace("\r\n", "\n", $raw);
+    if (! preg_match('/^---\n(.*?)\n---\n(.*)$/s', $raw, $m)) {
+        return ['', $raw];
+    }
+
+    return [$m[1], $m[2]];
+}
+
+/** `sig = HMAC-SHA256(body, secret)` — body normalizado (idempotente). */
+function handoffSign(string $body, string $secret): string
+{
+    return hash_hmac('sha256', str_replace("\r\n", "\n", $body), $secret);
+}
+
+/** Lê um escalar do frontmatter raw (1ª ocorrência), sem aspas. */
+function handoffScalar(string $fm, string $key): ?string
+{
+    if (preg_match('/^' . preg_quote($key, '/') . ':\s*(.+?)\s*$/m', $fm, $m)) {
+        return trim($m[1], " \t\"'");
+    }
+
+    return null;
+}
+
+/**
+ * Parser do `files:` — inline `[a, b]` ou bloco YAML `- a`. MESMA lógica do
+ * {@see bin/check-handoff-scope.php} (consistência: o que assina = o que o
+ * scope-guard valida).
+ *
+ * @return list<string>
+ */
+function handoffFiles(string $fm): array
+{
+    $files = [];
+
+    if (preg_match('/^files:\s*\[(.*?)\]/m', $fm, $im)) {
+        foreach (explode(',', $im[1]) as $f) {
+            $f = trim($f, " \t\"'");
+            if ($f !== '') {
+                $files[] = $f;
+            }
+        }
+
+        return $files;
+    }
+
+    if (preg_match('/^files:\s*\n((?:[ \t]+-[ \t]*.+\n?)+)/m', $fm, $bm)) {
+        foreach (preg_split('/\n/', $bm[1]) as $line) {
+            if (preg_match('/^[ \t]+-[ \t]*"?(.+?)"?[ \t]*$/', $line, $lm)) {
+                $files[] = trim($lm[1]);
+            }
+        }
+    }
+
+    return $files;
+}
+
+/**
+ * Monta os `arguments` do tool handoff-submit a partir do conteúdo de um handoff.
+ *
+ * @return array<string,mixed>
+ */
+function handoffArguments(string $raw, string $secret): array
+{
+    [$fm, $body] = handoffSplit($raw);
+
+    return [
+        'slug'            => handoffScalar($fm, 'handoff_id') ?? handoffScalar($fm, 'slug') ?? '',
+        'body_md'         => $body,
+        'sig'             => handoffSign($body, $secret),
+        'files_json'      => handoffFiles($fm),
+        'tela'            => handoffScalar($fm, 'tela') ?? '',
+        'created_by'      => handoffScalar($fm, 'created_by') ?? 'CC',
+        'audited_against' => handoffScalar($fm, 'audited_against'),
+    ];
+}
+
+/**
+ * Envelope JSON-RPC 2.0 do `tools/call` handoff-submit (o body do POST).
+ *
+ * @param  array<string,mixed>  $arguments
+ * @return array<string,mixed>
+ */
+function handoffRpcEnvelope(array $arguments): array
+{
+    return [
+        'jsonrpc' => '2.0',
+        'id'      => 1,
+        'method'  => 'tools/call',
+        'params'  => ['name' => 'handoff-submit', 'arguments' => $arguments],
+    ];
+}
+
+function optValue(array $args, string $key): ?string
+{
+    foreach ($args as $a) {
+        if (str_starts_with($a, "--{$key}=")) {
+            return substr($a, strlen("--{$key}="));
+        }
+    }
+
+    return null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+$args = array_slice($argv, 1);
+
+// ── self-test: controle-negativo, ZERO segredo real/rede/DB ──
+if (in_array('--self-test', $args, true)) {
+    $fails = [];
+    $secret = 'selftest-secret';
+
+    // 1) DETERMINISMO: assinar o mesmo corpo 2× dá a MESMA sig.
+    $a = handoffSign("## corpo\nlinha", $secret);
+    $b = handoffSign("## corpo\nlinha", $secret);
+    if ($a !== $b) {
+        $fails[] = 'DETERMINISMO falhou: ' . $a . ' != ' . $b;
+    }
+
+    // 2) CRLF: CRLF e LF do MESMO corpo produzem a MESMA sig (normalização).
+    if (handoffSign("a\r\nb", $secret) !== handoffSign("a\nb", $secret)) {
+        $fails[] = 'CRLF falhou: \r\n e \n deviam dar a mesma sig.';
+    }
+
+    // 3) SIG-BATE: a sig do helper bate com hash_hmac cru sobre o body normalizado.
+    $body = "## ONDA A\nteste";
+    if (handoffSign($body, $secret) !== hash_hmac('sha256', $body, $secret)) {
+        $fails[] = 'SIG-BATE falhou: contrato HMAC divergente.';
+    }
+
+    // 4) PARSE: inline e bloco YAML produzem a mesma lista de files + slug/tela.
+    $inlineRaw = "---\nhandoff_id: caixa\ntela: Atendimento/Caixa\nfiles: [a.css, b.tsx]\ncreated_by: CC\n---\n## body\nx";
+    $blockRaw  = "---\nhandoff_id: caixa\ntela: Atendimento/Caixa\nfiles:\n  - a.css\n  - b.tsx\ncreated_by: CC\n---\n## body\nx";
+    $ai = handoffArguments($inlineRaw, $secret);
+    $ab = handoffArguments($blockRaw, $secret);
+    if ($ai['files_json'] !== ['a.css', 'b.tsx'] || $ab['files_json'] !== ['a.css', 'b.tsx']) {
+        $fails[] = 'PARSE files falhou: inline=' . json_encode($ai['files_json']) . ' block=' . json_encode($ab['files_json']);
+    }
+    if ($ai['slug'] !== 'caixa' || $ai['tela'] !== 'Atendimento/Caixa') {
+        $fails[] = 'PARSE scalar falhou: slug=' . $ai['slug'] . ' tela=' . $ai['tela'];
+    }
+    // inline e bloco têm o MESMO body → MESMA sig.
+    if ($ai['sig'] !== $ab['sig']) {
+        $fails[] = 'PARSE body falhou: sig inline != bloco (body divergiu).';
+    }
+
+    // 5) ENVELOPE: forma JSON-RPC do tools/call.
+    $env = handoffRpcEnvelope($ai);
+    if (($env['method'] ?? null) !== 'tools/call' || ($env['params']['name'] ?? null) !== 'handoff-submit') {
+        $fails[] = 'ENVELOPE falhou: ' . json_encode($env);
+    }
+
+    if ($fails !== []) {
+        fwrite(STDERR, "sign-handoff SELF-TEST 🔴\n" . implode("\n", $fails) . "\n");
+        exit(1);
+    }
+    echo "sign-handoff SELF-TEST 🟢 (determinismo · CRLF→LF · sig-bate · parse inline+bloco · envelope)\n";
+    exit(0);
+}
+
+// ── modo real: assina UM arquivo e emite o envelope JSON-RPC ──
+$file = optValue($args, 'file');
+if ($file === null || $file === '') {
+    fwrite(STDERR, "✗ Uso: HANDOFF_SECRET=… php bin/sign-handoff.php --file=prototipo-ui/handoffs/<slug>.md\n");
+    exit(1);
+}
+
+$secret = (string) getenv('HANDOFF_SECRET');
+if ($secret === '') {
+    fwrite(STDERR, "✗ HANDOFF_SECRET ausente no ambiente — sem segredo não há como assinar.\n");
+    exit(1);
+}
+
+$raw = @file_get_contents($file);
+if ($raw === false) {
+    fwrite(STDERR, "✗ Não consegui ler: {$file}\n");
+    exit(1);
+}
+
+$arguments = handoffArguments($raw, $secret);
+if ($arguments['slug'] === '') {
+    fwrite(STDERR, "✗ {$file}: frontmatter sem handoff_id/slug — não dá pra submeter.\n");
+    exit(1);
+}
+
+echo json_encode(handoffRpcEnvelope($arguments), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+exit(0);

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -258,6 +258,10 @@
       "nome": "Handoff Scope Guard (files_json · escopo duro do handoff de design, ADR 0283 Fase 0)",
       "classe": "gate"
     },
+    "handoff-sign-submit.yml": {
+      "nome": "Handoff Sign & Submit (on-push · assina HMAC + POST handoff-submit → pending; advisory · PR-6b ADR 0283)",
+      "classe": "automacao"
+    },
     "scorer-sync-gate.yml": {
       "nome": "Scorer sync (regex score-mechanized.mjs ↔ UiDeterministicScorer.php)",
       "classe": "gate"


### PR DESCRIPTION
## PR-6 — Sync Cowork→repo (handoff zero-paste · ADR 0283)

Fecha o **último hop** do loop de handoff zero-paste. Hoje a Fase 0/1 já existe no `main` (ingest assinado, `cowork_handoffs`, tools `handoff-pending`/`handoff-ack`, Forja). Faltava **o que assina e dispara sem o [W] no meio** — um handoff só virava `pending` se alguém rodasse `php artisan handoff:ingest` com o arquivo na pasta.

**Resultado:** um `.md` commitado em `prototipo-ui/handoffs/` é assinado pela Action, vira `pending` via endpoint, e aparece na Forja — **sem o [W] colar nada nem computar HMAC**. Heartbeat pulsa.

> Auditado contra o `main` fresco (`92ed49e8d`) — R1/§10.4 do handoff. Branch novo a partir do `origin/main` (a branch ativa do worktree estava 329/67 diverged de main).

### PR-6a — `handoff-submit` (landing-pad HTTP assinado)
- **`HandoffIngestService`** (novo): núcleo único de validação HMAC + `source_hash` + append-only, extraído de `HandoffIngestCommand` (PR-1). O command passa a **delegar** — comportamento preservado (guard: `HandoffIngestTest`).
- **`HandoffSubmitTool`** (`handoff-submit`): mutação com scope fino **`jana.mcp.handoff.submit`** (A7); `sig` inválida → recusa (A1, timing-safe); `source_hash` igual → no-op idempotente; revisão de slug `applied` → nova version + anterior `superseded`. Audita em `mcp_audit_log`, pulsa `mcp_ingest_heartbeat`. **Só insere pending — sem auto-merge** (ADR 0283).
- Registrado no `OimpressoMcpServer` + scope seedado no `McpScopesSeeder`.
- **Pest** `HandoffSubmitToolTest` (6 provas) + adiciona `submit`/`ingest` ao `ci-sqlite-pest.list`.

### PR-6b — Transporte: GitHub Action on-push
- **`bin/sign-handoff.php`**: assina (`HMAC-SHA256(body, HANDOFF_SECRET)`, CRLF→LF) e monta o envelope JSON-RPC do `tools/call`. Dependency-free + `--self-test` (sem segredo/rede/DB) ✅ rodado local.
- **`handoff-sign-submit.yml`**: `selftest` roda sempre; `submit` (push em `main`, paths `prototipo-ui/handoffs/*.md`) assina + faz POST stateless no endpoint MCP (`Mcp::web` é síncrono — confirmado no vendor: `tools/call` sem handshake). **Skip-as-pass** enquanto os secrets não existirem. Advisory de nascença.

### ⚙️ [W] faz UMA VEZ (não consigo fazer — secrets)
- Secret **`HANDOFF_SECRET`** = o mesmo do `.env` do servidor (o HMAC tem que bater).
- Emitir token scope `jana.mcp.handoff.submit` (via `McpTokenIssuer`) → secret **`HANDOFF_SUBMIT_TOKEN`**.
- (opcional) var `MCP_ENDPOINT_URL` (default `https://mcp.oimpresso.com/api/mcp`).

### ✅ Verificação
- `php -l` limpo em todos os arquivos · `bin/sign-handoff.php --self-test` 🟢 (local).
- Pest **não roda local** (Windows sem DB / o vendor do main aponta pra outro worktree) → roda em CI via `ci.yml` (alvos agora no `ci-sqlite-pest.list`).
- Fim-a-fim (pós-merge + secrets): commitar `.md` em `prototipo-ui/handoffs/` → Action assina + submete → `handoff-pending` lista o slug → Forja mostra `pending` + heartbeat pulsa.

### NÃO-FAZER (respeitado)
❌ Auto-merge (é o 1-clique do [W]) · ❌ secret no Cowork/Code/versionado · ❌ recriar ingest/tabela/tools · ❌ prometer zero-toque sem publisher Cowork→repo (chip).

### Follow-ups (chips)
- Gap 3 — Levers `re-disparar`/`devolver`/`supersede` (tools MCP + front).
- Gap 2 — Gate `conflito` (ack `gate_status` vs required checks reais via GitHub API).
- Publisher Cowork→repo (zero-toque real).

**Não fazer merge** — review do [W] + 1-clique (ADR 0283). Implementa a 0283 já aceita; sem ADR nova.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
