### PR TITLE
feat(mcp): /api/mcp/version com token dedicado pro drift sentinel (least-privilege)

### DIFF
--- a/.github/workflows/mcp-drift-sentinel.yml
+++ b/.github/workflows/mcp-drift-sentinel.yml
@@ -39,10 +39,10 @@ jobs:
       - name: Run drift sentinel
         id: drift
         env:
-          # Token read-only mcp_* — lê o commit servido no /health/auth (não-público).
-          # Gerar: php artisan mcp:token:gerar --user=<bot> --name="drift-sentinel" no
-          # Hostinger; adicionar como secret MCP_SENTINEL_TOKEN. Sem ele → WARN (não alarma).
-          MCP_SENTINEL_TOKEN: ${{ secrets.MCP_SENTINEL_TOKEN }}
+          # Token DEDICADO do /api/mcp/version — sem user, sem RBAC; vazar revela só o SHA.
+          # Gerar: openssl rand -hex 32 → por em MCP_DRIFT_TOKEN no .env do host MCP +
+          # `gh secret set MCP_DRIFT_TOKEN`. Sem ele → WARN (não alarma).
+          MCP_DRIFT_TOKEN: ${{ secrets.MCP_DRIFT_TOKEN }}
         run: node scripts/governance/mcp-drift-sentinel.mjs
 
       - name: Alarme → issue no inbox ops (só em drift real)

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -159,6 +159,11 @@ return [
         // Setar em .env: COPILOTO_MCP_SYNC_TOKEN=...
         'sync_webhook_token' => env('COPILOTO_MCP_SYNC_TOKEN'),
 
+        // === Drift sentinel (ADR 0256) — token dedicado do endpoint /api/mcp/version ===
+        // A sentinela externa (mcp-drift-sentinel.yml) lê o commit servido com este token.
+        // SEM user/RBAC: se vazar, só revela o SHA. Setar em .env: MCP_DRIFT_TOKEN=...
+        'drift_token' => env('MCP_DRIFT_TOKEN'),
+
         // === Audit log governança ===
         // Quanto tempo manter audit log antes de purgar (LGPD: mínimo 1 ano)
         'audit_retention_days' => env('COPILOTO_MCP_AUDIT_RETENTION_DAYS', 365),

--- a/Modules/Jana/Http/routes.php
+++ b/Modules/Jana/Http/routes.php
@@ -254,6 +254,11 @@ Route::group(
         Route::get('/health', 'HealthController@publico')
             ->name('jana.mcp.health');
 
+        // Drift sentinel (ADR 0256): token DEDICADO MCP_DRIFT_TOKEN checado no
+        // controller (sem mcp.auth/RBAC/user) — vazar revela só o SHA do commit.
+        Route::get('/version', 'HealthController@versao')
+            ->name('jana.mcp.version');
+
         // Autenticados via McpAuth
         Route::group(['middleware' => 'mcp.auth'], function () {
             Route::get('/health/auth', 'HealthController@autenticado')

--- a/Modules/TeamMcp/Http/Controllers/Mcp/HealthController.php
+++ b/Modules/TeamMcp/Http/Controllers/Mcp/HealthController.php
@@ -10,9 +10,11 @@ use Modules\Jana\Entities\Mcp\McpMemoryDocument;
 /**
  * MEM-MCP-1.b (ADR 0053) — Endpoint de health do MCP server.
  *
- * 2 variantes:
+ * 3 variantes:
  *   GET /api/mcp/health           — público, retorna status básico
- *   GET /api/mcp/health/auth      — exige Bearer mcp_*, retorna user info
+ *   GET /api/mcp/health/auth      — exige Bearer mcp_*, retorna user info + commit
+ *   GET /api/mcp/version          — Bearer MCP_DRIFT_TOKEN (dedicado, sem user/RBAC),
+ *                                   retorna só o commit servido (drift sentinel)
  *
  * Usado por:
  *   - Smoke teste pós-deploy
@@ -45,22 +47,6 @@ class HealthController extends Controller
             $docsAcessiveis = null;
         }
 
-        // Drift observability (ADR 0256): o commit servido é escrito pelo entrypoint do
-        // container (deployed_commit.txt) a cada boot. Exposto SÓ aqui (endpoint
-        // AUTENTICADO) — não no /health público — porque o repo é público e o SHA exato
-        // num endpoint anônimo é disclosure de versão. A sentinela externa
-        // mcp-drift-sentinel.yml lê isto com um token read-only. Null se ausente.
-        $commit = null;
-        $deployedAt = null;
-        $commitPath = storage_path('app/deployed_commit.txt');
-        if (is_readable($commitPath)) {
-            $commit = trim((string) @file_get_contents($commitPath)) ?: null;
-            if ($commit === 'unknown') {
-                $commit = null;
-            }
-            $deployedAt = ($mtime = @filemtime($commitPath)) ? date('c', $mtime) : null;
-        }
-
         return response()->json([
             'status' => 'authenticated',
             'user'   => [
@@ -77,10 +63,59 @@ class HealthController extends Controller
                 'total'                  => $totalDocs,
                 'accessible_to_this_user' => $docsAcessiveis,
             ],
+            ...$this->deployedCommit(),
+            'ts' => now()->toIso8601String(),
+        ]);
+    }
+
+    /**
+     * Drift observability (ADR 0256) — endpoint DEDICADO pra sentinela externa.
+     *
+     * Auth por token PRÓPRIO (config copiloto.mcp.drift_token / env MCP_DRIFT_TOKEN),
+     * NÃO por token mcp_* de usuário: sem user, sem RBAC jana.mcp.use, sem query no DB.
+     * Blast radius se o token vazar = revela só o SHA do commit servido. É por isso que
+     * a sentinela usa ESTE endpoint, não o /health/auth (que carrega permissão de tool).
+     */
+    public function versao(Request $request): JsonResponse
+    {
+        $expected = (string) config('copiloto.mcp.drift_token', '');
+        if ($expected === '') {
+            return response()->json(['error' => 'Misconfigured'], 500);
+        }
+        $provided = (string) $request->bearerToken();
+        if ($provided === '' || ! hash_equals($expected, $provided)) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        return response()->json([
+            'service' => 'oimpresso-mcp',
+            ...$this->deployedCommit(),
+            'ts' => now()->toIso8601String(),
+        ]);
+    }
+
+    /**
+     * Lê o commit servido (escrito pelo entrypoint-octane a cada boot em
+     * storage/app/deployed_commit.txt). Retorna chaves prontas pro response JSON.
+     * "unknown" (git indisponível no boot) vira null.
+     */
+    private function deployedCommit(): array
+    {
+        $commit = null;
+        $deployedAt = null;
+        $commitPath = storage_path('app/deployed_commit.txt');
+        if (is_readable($commitPath)) {
+            $commit = trim((string) @file_get_contents($commitPath)) ?: null;
+            if ($commit === 'unknown') {
+                $commit = null;
+            }
+            $deployedAt = ($mtime = @filemtime($commitPath)) ? date('c', $mtime) : null;
+        }
+
+        return [
             'commit'       => $commit,
             'commit_short' => $commit ? substr($commit, 0, 9) : null,
             'deployed_at'  => $deployedAt,
-            'ts' => now()->toIso8601String(),
-        ]);
+        ];
     }
 }

--- a/docker/oimpresso-mcp/.env.example
+++ b/docker/oimpresso-mcp/.env.example
@@ -35,3 +35,7 @@ QUEUE_CONNECTION=sync
 # MCP-specific
 COPILOTO_MCP_SYNC_TOKEN=GERAR_VIA_OPENSSL_RAND_HEX_32
 COPILOTO_MCP_AUDIT_RETENTION_DAYS=365
+
+# Drift sentinel (ADR 0256) — token dedicado do endpoint /api/mcp/version (sem user/RBAC).
+# Mesmo valor vai no secret GH MCP_DRIFT_TOKEN. Gerar: openssl rand -hex 32
+MCP_DRIFT_TOKEN=GERAR_VIA_OPENSSL_RAND_HEX_32

--- a/docker/oimpresso-mcp/README.md
+++ b/docker/oimpresso-mcp/README.md
@@ -172,17 +172,22 @@ rebuild (só se `docker/oimpresso-mcp/` mudou) → `up -d --force-recreate` → 
 ### Sentinela de drift (sem tailscale)
 
 `.github/workflows/mcp-drift-sentinel.yml` roda no GitHub a cada 30min: compara o campo
-`commit` de **`/api/mcp/health/auth`** (endpoint AUTENTICADO — o repo é público, então o
-SHA exato NÃO fica num endpoint anônimo) com o HEAD de `main`. Se servido ficar > 6h
-atrás (`MCP_DRIFT_MAX_LAG_HOURS`), **alarma**: workflow vermelho + issue `mcp-drift` (o
-"inbox ops"). O commit servido é escrito pelo `entrypoint-octane.sh` a cada boot.
+`commit` de **`/api/mcp/version`** com o HEAD de `main`. Esse endpoint é protegido por um
+token DEDICADO (`MCP_DRIFT_TOKEN`) checado direto no controller — **sem user, sem RBAC
+`jana.mcp.use`, sem query no DB**: se o token vazar, só revela o SHA do commit (blast
+radius zero). Por isso a sentinela usa ele, não o `/health/auth` (que carrega permissão
+de tool). Se servido ficar > 6h atrás (`MCP_DRIFT_MAX_LAG_HOURS`), **alarma**: workflow
+vermelho + issue `mcp-drift` (o "inbox ops"). O commit servido é escrito pelo
+`entrypoint-octane.sh` a cada boot (precisa de git na imagem — ver Dockerfile.octane).
 
-**Secret necessário (uma vez):** gere um token read-only e adicione como secret
-`MCP_SENTINEL_TOKEN` no repo:
+**Setup (uma vez):** gere o token, ponha no `.env` do host MCP e no secret do repo:
 ```bash
-# No Hostinger (DB compartilhada)
-php artisan mcp:token:gerar --user=<bot> --name="drift-sentinel"
-gh secret set MCP_SENTINEL_TOKEN   # cole o mcp_... gerado
+TOKEN=$(openssl rand -hex 32)
+# no host CT 100: adicionar ao .env do compose
+echo "MCP_DRIFT_TOKEN=$TOKEN" >> /opt/oimpresso-mcp/code/docker/oimpresso-mcp/.env
+gh secret set MCP_DRIFT_TOKEN --body "$TOKEN"
+# recriar o container pra o config:cache pegar o .env novo
+bash /opt/oimpresso-mcp/code/docker/oimpresso-mcp/scripts/self-update.sh   # ou docker compose up -d --force-recreate
 ```
 Sem o secret a sentinela só emite `WARN` (não alarma) — graça de rollout.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6436,7 +6436,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 79
+			count: 80
 			path: Modules/Jana/Config/config.php
 
 		-

--- a/scripts/governance/mcp-drift-sentinel.mjs
+++ b/scripts/governance/mcp-drift-sentinel.mjs
@@ -9,12 +9,12 @@
 // GRITA se a cura parar de funcionar — é o "loop fechado por métrica" aplicado ao
 // deploy: o drift nunca mais fica silencioso.
 //
-// COMO: compara o commit SERVIDO (campo `commit` de /api/mcp/health/auth) com o HEAD
-// de main no checkout do runner. Não precisa de tailscale; lê o endpoint AUTENTICADO
-// com um token read-only (MCP_SENTINEL_TOKEN, secret do GH) — o repo é público, então
-// o SHA exato NÃO fica num endpoint anônimo (disclosure de versão). Tolera o lag normal
-// do cron (minutos) via janela de tempo ENTRE commits (não relógio de parede), então
-// período tranquilo no main não dá falso-positivo.
+// COMO: compara o commit SERVIDO (campo `commit` de /api/mcp/version) com o HEAD de main
+// no checkout do runner. Não precisa de tailscale; lê o endpoint DEDICADO com o token
+// próprio MCP_DRIFT_TOKEN (secret do GH) — sem user, sem RBAC, sem disclosure pública
+// (repo é público). Vazar o token só revela o SHA. Tolera o lag normal do cron (minutos)
+// via janela de tempo ENTRE commits (não relógio de parede), então período tranquilo no
+// main não dá falso-positivo.
 //
 // Uso:  node scripts/governance/mcp-drift-sentinel.mjs            (humano)
 //       node scripts/governance/mcp-drift-sentinel.mjs --json     (máquina)
@@ -24,8 +24,8 @@
 import { execSync } from 'node:child_process';
 import { appendFileSync } from 'node:fs';
 
-const HEALTH_URL = process.env.MCP_HEALTH_URL || 'https://mcp.oimpresso.com/api/mcp/health/auth';
-const TOKEN = (process.env.MCP_SENTINEL_TOKEN || '').trim(); // token read-only mcp_* (GH secret)
+const HEALTH_URL = process.env.MCP_HEALTH_URL || 'https://mcp.oimpresso.com/api/mcp/version';
+const TOKEN = (process.env.MCP_DRIFT_TOKEN || '').trim(); // token dedicado (GH secret) — sem user/RBAC
 const MAX_LAG_HOURS = Number(process.env.MCP_DRIFT_MAX_LAG_HOURS || 6); // cron roda /15min; 6h = host parou de curar há horas
 const JSON_OUT = process.argv.includes('--json');
 
@@ -40,7 +40,7 @@ function isAncestor(sha) {
 function commitEpoch(sha) { const v = git(`show -s --format=%ct ${sha}`); return v ? Number(v) : null; }
 
 async function fetchServedCommit() {
-  if (!TOKEN) return { error: 'MCP_SENTINEL_TOKEN ausente (secret não configurado)' };
+  if (!TOKEN) return { error: 'MCP_DRIFT_TOKEN ausente (secret não configurado)' };
   const ctrl = new AbortController();
   const t = setTimeout(() => ctrl.abort(), 12000);
   try {


### PR DESCRIPTION
Follow-up de segurança dos #2917/#2919. A sentinela lia `/health/auth` com um token `mcp_*` de **user 1** → carrega `jana.mcp.use` (acesso a tools se vazasse do GH secret).

**Fix (least-privilege):** endpoint dedicado `GET /api/mcp/version` protegido por `MCP_DRIFT_TOKEN` próprio, `hash_equals` no controller — **sem user, sem RBAC, sem DB**. Vazar = revela só o SHA (blast radius 0). Espelha o padrão já usado no `/sync-memory` (token shared-secret).

- `HealthController::versao()` + helper `deployedCommit()` (DRY)
- rota pública `/api/mcp/version` (fora do `mcp.auth`)
- `config copiloto.mcp.drift_token` + `.env.example` + README
- sentinela → `/version` + `MCP_DRIFT_TOKEN`

Pós-merge eu revogo o token user-1 e removo o secret `MCP_SENTINEL_TOKEN`. Validado: `php -l` nos 3 PHP + sentinela roda. Refs: ADR 0256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)