### PR TITLE
feat(teammcp): levers handoff re-disparar/devolver/supersede (PR-7 · ADR 0283)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -30,6 +30,9 @@ Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
 # beforeEach → sqlite-safe (sem migration MySQL-only).
 Modules/TeamMcp/Tests/Feature/HandoffSubmitToolTest.php
 Modules/TeamMcp/Tests/Feature/HandoffIngestTest.php
+# PR-7 levers (re-disparar/devolver/supersede) — append-only sobre cowork_handoffs.
+# Tabela sintética em beforeEach → sqlite-safe.
+Modules/TeamMcp/Tests/Feature/HandoffLeverToolTest.php
 tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php

--- a/Modules/Jana/Database/Seeders/McpScopesSeeder.php
+++ b/Modules/Jana/Database/Seeders/McpScopesSeeder.php
@@ -239,6 +239,16 @@ class McpScopesSeeder extends Seeder
             'business_required' => false,
             'admin_only'        => false,
         ],
+        [
+            'slug'              => 'jana.mcp.handoff.lever',
+            'nome'              => 'Operar levers de handoff (handoff-lever)',
+            'descricao'         => 'Permite handoff-lever (PR-7, ADR 0283) — as levers re-disparar/devolver/supersede sobre cowork_handoffs. Mutação GOVERNADA e append-only: re-disparar re-arma um pending parado, devolver manda um rejected de volta pro [CC], supersede dá lápide num pending|applied (NUNCA delete). Recusa lever fora do estado esperado (o "409") e drift de versão (A4). SEM auto-merge (o merge é o 1-clique do [W]). Ator-Code/operador — emitir token com este scope via McpTokenIssuer; o cockpit Forja (web) chama a MESMA mutação via HandoffLeverService gated por copiloto.mcp.usage.all.',
+            'resources_pattern' => null,
+            'tools_pattern'     => 'handoff-lever',
+            'is_destructive'    => false,
+            'business_required' => false,
+            'admin_only'        => false,
+        ],
     ];
 
     public function run(): void

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -164,6 +164,11 @@ class OimpressoMcpServer extends Server
         // pending, sem [W] no transporte. Scope fino jana.mcp.handoff.submit (A7);
         // reusa HandoffIngestService (mesma validação do PR-1). Sem auto-merge.
         \Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool::class,
+        // PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283) — as 3 levers do loop
+        // (re-disparar/devolver/supersede) que estavam disabled na Forja. Mutação
+        // GOVERNADA append-only (scope fino jana.mcp.handoff.lever A7), reusa
+        // HandoffLeverService (mesma regra do endpoint web do cockpit). Sem auto-merge.
+        \Modules\TeamMcp\Mcp\Tools\HandoffLeverTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/TeamMcp/Http/Controllers/ForjaController.php
+++ b/Modules/TeamMcp/Http/Controllers/ForjaController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Jana\Entities\Mcp\McpAuditLog;
 use Modules\Jana\Entities\Mcp\McpCcSession;
 use Modules\Jana\Entities\Mcp\McpMemoryDocument;
 use Modules\Jana\Entities\Mcp\McpProject;
@@ -20,6 +21,7 @@ use Modules\TeamMcp\Services\Forja\ForjaBacklogService;
 use Modules\TeamMcp\Services\Forja\ForjaChangelogService;
 use Modules\TeamMcp\Services\Forja\ForjaMcpService;
 use Modules\TeamMcp\Services\Forja\ForjaQuadroService;
+use Modules\TeamMcp\Services\HandoffLeverService;
 
 /**
  * ForjaController — cockpit do cowork loop (/forja).
@@ -128,6 +130,102 @@ class ForjaController extends Controller
                 'heartbeat' => Inertia::defer(fn () => $svc->heartbeat()),
             ],
         ));
+    }
+
+    /**
+     * POST /forja/handoff/{slug}/lever — opera uma lever do loop de handoff
+     * (re-disparar/devolver/supersede) sobre cowork_handoffs. Fecha o Gap 3 do
+     * adversário: as levers da aba MCP deixam de ser `disabled "em breve"`.
+     *
+     * MESMA mutação GOVERNADA do tool MCP `handoff-lever` — ambos delegam pra
+     * {@see HandoffLeverService} (fonte única, append-only · ADR 0283). Aqui o ator
+     * é o [W] na sessão web (gate copiloto.mcp.usage.all no __construct); lá é o
+     * agente via scope fino jana.mcp.handoff.lever. SEM auto-merge: o merge segue o
+     * 1-clique do [W] no GitHub. Audit em mcp_audit_log (best-effort).
+     *
+     * Delega 100% ao service (sem Eloquent direto aqui) — repo-wide por design
+     * (cowork_handoffs sem business_id, Tier 0 ADR 0093), igual mcp()/dossier().
+     */
+    public function handoffLever(Request $request, string $slug): JsonResponse
+    {
+        $action = trim((string) $request->input('action', ''));
+        if (! in_array($action, HandoffLeverService::ACTIONS, true)) {
+            return response()->json(['error' => 'Ação inválida.'], 422);
+        }
+
+        $versionInput = $request->input('version');
+        $expected = ($versionInput !== null && $versionInput !== '') ? (int) $versionInput : null;
+
+        $result = app(HandoffLeverService::class)->apply($action, $slug, $expected);
+
+        $this->auditHandoffLever($request, $action, $slug, $result);
+
+        if ($result['outcome'] === 'rejected') {
+            $status = match ($result['reason']) {
+                'not_found'  => 404,
+                'stale_view' => 409,
+                default      => 422,
+            };
+
+            return response()->json([
+                'error'  => $this->leverErrorMessage($action, (string) $result['reason'], (int) $result['version']),
+                'reason' => $result['reason'],
+            ], $status);
+        }
+
+        return response()->json([
+            'ok'                 => true,
+            'action'             => $action,
+            'slug'               => $result['slug'],
+            'version'            => (int) $result['version'],
+            'outcome'            => $result['outcome'],
+            'superseded_version' => $result['superseded_version'],
+        ]);
+    }
+
+    /** Mensagem de recusa legível (espelha HandoffLeverTool::rejectMessage). */
+    private function leverErrorMessage(string $action, string $reason, int $version): string
+    {
+        return match ($reason) {
+            'not_found'  => 'Handoff não encontrado.',
+            'stale_view' => "A fila mudou — a versão atual é v{$version}. Recarregue antes de operar.",
+            'state'      => match ($action) {
+                're-disparar' => 're-disparar só vale pra um handoff pendente (parado).',
+                'devolver'    => 'devolver só vale pra um handoff rejeitado.',
+                'supersede'   => 'supersede só vale pra um handoff pendente ou aplicado.',
+                default       => 'Lever fora do estado esperado.',
+            },
+            default      => 'Ação inválida.',
+        };
+    }
+
+    /**
+     * Audit best-effort da lever no mcp_audit_log (origem web/cockpit) — espelha
+     * HandoffLeverTool::audit; não trava a resposta.
+     *
+     * @param  array{outcome:string,reason:string|null,slug:string,version:int,superseded_version:int|null}  $result
+     */
+    private function auditHandoffLever(Request $request, string $action, string $slug, array $result): void
+    {
+        try {
+            $user = $request->user();
+            McpAuditLog::registrar([
+                'user_id'          => $user !== null ? (int) $user->getAuthIdentifier() : 0,
+                'endpoint'         => 'web/forja',
+                'tool_or_resource' => 'handoff-lever',
+                'status'           => $result['outcome'] === 'rejected' ? 'denied' : 'ok',
+                'payload_summary'  => [
+                    'action'  => $action,
+                    'slug'    => $slug,
+                    'version' => (int) $result['version'],
+                    'outcome' => $result['outcome'],
+                    'reason'  => $result['reason'],
+                    'origin'  => 'forja-web',
+                ],
+            ]);
+        } catch (\Throwable) {
+            // best-effort
+        }
     }
 
     // ---------- Triagem · payload ----------

--- a/Modules/TeamMcp/Http/routes.php
+++ b/Modules/TeamMcp/Http/routes.php
@@ -91,6 +91,12 @@ Route::group(
         Route::get('/mcp',       'ForjaController@mcp')->name('forja.mcp');
         // Saúde foi fundida no Scorecard real (/team-mcp/scorecard) — sem rota própria.
 
+        // PR-7 (ADR 0283 · Fase 2) — levers do loop de handoff (re-disparar/devolver/
+        // supersede) da aba MCP. Mesma mutação governada do tool MCP handoff-lever
+        // (HandoffLeverService é a fonte única). 3 segmentos → não colide com /{taskId}/*.
+        Route::post('/handoff/{slug}/lever', 'ForjaController@handoffLever')
+            ->where('slug', '[A-Za-z0-9_\-]+')->name('forja.handoff.lever');
+
         // Triagem (aba 1) — dossiê do Analista (read-only) + ações [W] aprova.
         // Espelha /project-mgmt/triage/{id}/{dossier,aprovar,rejeitar,fundir} (PR-5a).
         // taskId aceita FORJA-150/identifier ou US-XXX legacy.

--- a/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
+++ b/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Entities\Mcp\McpAuditLog;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
+use Modules\TeamMcp\Services\HandoffLeverService;
+use Throwable;
+
+/**
+ * Tool MCP handoff-lever — PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283).
+ *
+ * As 3 levers do loop (re-disparar/devolver/supersede) que estavam `disabled`
+ * ("em breve") na Forja. Tira o [W] da operação manual do banco: a lever roteia
+ * por uma mutação GOVERNADA (scope fino + audit + idempotência + append-only),
+ * sem auto-merge (o merge segue o 1-clique do [W] no GitHub).
+ *
+ * Reusa {@see HandoffLeverService} — MESMA mutação que o endpoint web do cockpit
+ * ({@see \Modules\TeamMcp\Http\Controllers\ForjaController::handoffLever}) chama.
+ * Nada de duplicar a regra append-only (espelha o par
+ * `handoff:ingest`/`handoff-submit` sobre {@see \Modules\TeamMcp\Services\HandoffIngestService}).
+ *
+ * Defesas do adversário [AH]:
+ *   - **A7 authz:** mutação — exige scope fino `jana.mcp.handoff.lever`, via
+ *     {@see AuthorizesMcpMutation} como 1º statement.
+ *   - **append-only (A6):** supersede = lápide (`superseded`); re-disparar/devolver
+ *     criam NOVA versão pending. NUNCA delete.
+ *   - **idempotência/estado (o "409"):** lever fora do estado esperado é recusada
+ *     (re-disparar só em pending; devolver só em rejected; supersede só em
+ *     pending|applied) — não muta.
+ *   - **A4 drift:** `version` opcional = a versão que o operador viu; se a fila
+ *     andou, recusa ("recarregue") em vez de operar na versão errada.
+ *   - **A2 cache:** NÃO usa cache (logo NÃO há `Cache::flush()`) — a Forja lê
+ *     `cowork_handoffs` direto, sem o flush-global que derrubava o ERP.
+ *
+ * @see Modules\TeamMcp\Services\HandoffLeverService
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffAckTool
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+class HandoffLeverTool extends Tool
+{
+    use AuthorizesMcpMutation;
+
+    protected string $name = 'handoff-lever';
+
+    protected string $title = 'Operar uma lever de handoff (re-disparar/devolver/supersede)';
+
+    protected string $description = 'Opera uma lever do loop de handoff (ADR 0283) sobre cowork_handoffs, append-only e sem auto-merge. action: re-disparar (pending parado/stale → lápide + novo pending), devolver (rejected → novo pending pro [CC] retrabalhar), supersede (pending|applied → lápide, sem substituta). Recusa lever fora do estado esperado (o "409") e drift de versão (A4). Exige scope jana.mcp.handoff.lever (mutação, A7).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'action' => $schema->string()
+                ->description("Lever: 're-disparar' (re-arma um pending parado), 'devolver' (manda um rejected de volta pro [CC]) ou 'supersede' (lápide num pending|applied).")
+                ->required(),
+            'slug' => $schema->string()
+                ->description('slug do handoff a operar.')
+                ->required(),
+            'version' => $schema->integer()
+                ->description('A4 drift guard: a versão que você viu na fila. Omitir = opera na maior versão atual.'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        // A7: mutação — gate de escopo como PRIMEIRO statement.
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.handoff.lever')) {
+            return $deny;
+        }
+
+        $action = (string) $request->get('action', '');
+        if (! in_array($action, HandoffLeverService::ACTIONS, true)) {
+            return Response::error('❌ action inválida — use: ' . implode(' | ', HandoffLeverService::ACTIONS) . '.');
+        }
+
+        $slug = trim((string) $request->get('slug', ''));
+        if ($slug === '') {
+            return Response::error('❌ slug é obrigatório.');
+        }
+
+        $versionInput = $request->get('version');
+        $expected = ($versionInput !== null && $versionInput !== '') ? (int) $versionInput : null;
+
+        $result = app(HandoffLeverService::class)->apply($action, $slug, $expected);
+
+        if ($result['outcome'] === 'rejected') {
+            $this->audit($request, $action, $slug, (int) $result['version'], 'rejected', $result['reason']);
+
+            return Response::error($this->rejectMessage($action, (string) $result['reason'], (int) $result['version']));
+        }
+
+        $this->audit($request, $action, $slug, (int) $result['version'], $result['outcome'], null);
+
+        $payload = [
+            'ok'                 => true,
+            'action'             => $action,
+            'slug'               => $slug,
+            'version'            => (int) $result['version'],
+            'outcome'            => $result['outcome'], // redisparado | devolvido | superseded
+            'superseded_version' => $result['superseded_version'],
+            'hint'               => 'append-only aplicado; sem auto-merge (o merge é o 1-clique do [W]). Reflete na Forja na hora.',
+        ];
+
+        return Response::text((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /** Mensagem de recusa legível por motivo (o "409"/"422"/"404" do mundo HTTP). */
+    private function rejectMessage(string $action, string $reason, int $version): string
+    {
+        return match ($reason) {
+            'not_found'  => "⚠️ handoff não encontrado (slug inexistente).",
+            'stale_view' => "⚠️ a fila mudou — a versão atual é v{$version}. Recarregue a Forja antes de operar (A4 drift).",
+            'state'      => match ($action) {
+                're-disparar' => '⚠️ re-disparar só vale pra um handoff pendente (parado). Estado atual não permite.',
+                'devolver'    => '⚠️ devolver só vale pra um handoff rejeitado.',
+                'supersede'   => '⚠️ supersede só vale pra um handoff pendente ou aplicado (o atual já é lápide/rejeitado).',
+                default       => '⚠️ lever fora do estado esperado.',
+            },
+            default      => '❌ action inválida.',
+        };
+    }
+
+    /** Audit best-effort (action/slug/outcome) — espelha HandoffAckTool::audit, não trava a resposta. */
+    private function audit(Request $request, string $action, string $slug, int $version, string $outcome, ?string $reason): void
+    {
+        try {
+            $user = $request->user();
+            McpAuditLog::registrar([
+                'user_id'          => $user !== null ? (int) $user->getAuthIdentifier() : 0,
+                'endpoint'         => 'tools/call',
+                'tool_or_resource' => 'handoff-lever',
+                // Convenção do mcp_audit_log: status = ok|denied (espelha HandoffSubmitTool).
+                'status'           => $outcome === 'rejected' ? 'denied' : 'ok',
+                'payload_summary'  => [
+                    'action'  => $action,
+                    'slug'    => $slug,
+                    'version' => $version,
+                    'outcome' => $outcome,
+                    'reason'  => $reason,
+                ],
+            ]);
+        } catch (Throwable) {
+            // best-effort
+        }
+    }
+}

--- a/Modules/TeamMcp/Services/HandoffLeverService.php
+++ b/Modules/TeamMcp/Services/HandoffLeverService.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Services;
+
+use Illuminate\Support\Facades\DB;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+
+/**
+ * HandoffLeverService — PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283).
+ *
+ * Núcleo COMPARTILHADO das 3 levers do loop (re-disparar/devolver/supersede),
+ * extraído pra ser a fonte ÚNICA de verdade tanto da tool MCP
+ * {@see \Modules\TeamMcp\Mcp\Tools\HandoffLeverTool} (ator-agente, scope fino)
+ * quanto do endpoint web do cockpit
+ * {@see \Modules\TeamMcp\Http\Controllers\ForjaController::handoffLever} (ator-[W],
+ * gate copiloto.mcp.usage.all). Mesmo padrão de {@see HandoffIngestService}, que
+ * o `handoff:ingest` (command) e o `handoff-submit` (tool) já compartilham — uma
+ * mutação só, dois invólucros de autorização/auditoria.
+ *
+ * **APPEND-ONLY** ({@see ADR 0130}/0003 · entity {@see CoworkHandoff}): NUNCA delete.
+ * Toda lever é uma transição de estado no plano (slug, version):
+ *   - **re-disparar** (pending parado/"stale"): lápide na versão atual (`superseded`)
+ *     + clone fresco `pending` (version+1). Re-arma o relógio de staleness sem
+ *     sobrescrever `created_at` da versão original (esta vira histórico).
+ *   - **devolver** (rejected→[CC]): NOVA versão `pending` (version+1) com o mesmo
+ *     corpo, pro [CC] retrabalhar. A versão `rejected` FICA como histórico (terminal,
+ *     NÃO vira `superseded` — espelha {@see HandoffIngestService} que só dá lápide
+ *     em `applied`).
+ *   - **supersede** (pending|applied→lápide): marca a versão atual `superseded`.
+ *     SEM substituta aqui — o replacement chega depois via `handoff-submit` (Cowork).
+ *
+ * Sem auto-merge (ADR 0283): nenhuma lever abre/mergeia PR. Stateless e SEM efeito
+ * colateral além de cowork_handoffs — NÃO audita (quem chama audita, com o ator
+ * certo) e NÃO toca o heartbeat (que é sinal do transporte de INGEST, não de
+ * operação manual do [W] — pulsá-lo aqui pintaria "transporte ok" falso).
+ *
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffLeverTool
+ * @see Modules\TeamMcp\Http\Controllers\ForjaController
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+final class HandoffLeverService
+{
+    /** Levers válidas (espelha leverFor() do front ForjaMcp.tsx). */
+    public const ACTIONS = ['re-disparar', 'devolver', 'supersede'];
+
+    /**
+     * Aplica a lever sobre a versão MAIS RECENTE do slug (a que a Forja projeta).
+     *
+     * @param  string  $action  uma de {@see self::ACTIONS}
+     * @param  string  $slug  slug do handoff
+     * @param  int|null  $expectedVersion  versão que o operador viu (drift guard A4);
+     *                                      null = aceita a maior sem checar
+     * @return array{
+     *     outcome: 'rejected'|'redisparado'|'devolvido'|'superseded',
+     *     reason: string|null, slug: string, version: int, superseded_version: int|null
+     * }
+     *   reason (quando rejected) ∈ not_found | stale_view | state | action
+     */
+    public function apply(string $action, string $slug, ?int $expectedVersion = null): array
+    {
+        $slug = trim($slug);
+        if ($slug === '') {
+            return $this->reject('not_found', $slug, 0);
+        }
+        if (! in_array($action, self::ACTIONS, true)) {
+            return $this->reject('action', $slug, 0);
+        }
+
+        $latest = CoworkHandoff::query()
+            ->where('slug', $slug)
+            ->orderByDesc('version')
+            ->first();
+
+        if ($latest === null) {
+            return $this->reject('not_found', $slug, 0);
+        }
+
+        // A4 drift guard: a fila que o operador viu mudou desde o render.
+        if ($expectedVersion !== null && (int) $latest->version !== $expectedVersion) {
+            return $this->reject('stale_view', $slug, (int) $latest->version);
+        }
+
+        return match ($action) {
+            're-disparar' => $this->reDisparar($latest),
+            'devolver'    => $this->devolver($latest),
+            'supersede'   => $this->supersede($latest),
+            // Inalcançável (action já validado acima); default explícito = match
+            // exaustivo pro phpstan (codebase usa match-com-default).
+            default       => $this->reject('action', $slug, (int) $latest->version),
+        };
+    }
+
+    /** stale (pending) → lápide + clone fresco pending (append-only). */
+    private function reDisparar(CoworkHandoff $latest): array
+    {
+        if ($latest->status !== 'pending') {
+            return $this->reject('state', $latest->slug, (int) $latest->version);
+        }
+
+        $newVersion = (int) $latest->version + 1;
+
+        // Duas escritas (lápide + clone) numa transação — sem versão órfã se a 2ª falhar.
+        DB::transaction(function () use ($latest, $newVersion): void {
+            CoworkHandoff::query()->where('id', $latest->id)->update(['status' => 'superseded']);
+            $this->cloneAsPending($latest, $newVersion);
+        });
+
+        return [
+            'outcome'            => 'redisparado',
+            'reason'             => null,
+            'slug'               => $latest->slug,
+            'version'            => $newVersion,
+            'superseded_version' => (int) $latest->version,
+        ];
+    }
+
+    /** rejected → nova versão pending pro [CC] retrabalhar (rejected fica histórico). */
+    private function devolver(CoworkHandoff $latest): array
+    {
+        if ($latest->status !== 'rejected') {
+            return $this->reject('state', $latest->slug, (int) $latest->version);
+        }
+
+        $newVersion = (int) $latest->version + 1;
+        $this->cloneAsPending($latest, $newVersion);
+
+        return [
+            'outcome'            => 'devolvido',
+            'reason'             => null,
+            'slug'               => $latest->slug,
+            'version'            => $newVersion,
+            'superseded_version' => null,
+        ];
+    }
+
+    /** pending|applied → lápide (sem substituta; replacement vem do Cowork depois). */
+    private function supersede(CoworkHandoff $latest): array
+    {
+        if (! in_array($latest->status, ['pending', 'applied'], true)) {
+            return $this->reject('state', $latest->slug, (int) $latest->version);
+        }
+
+        CoworkHandoff::query()->where('id', $latest->id)->update(['status' => 'superseded']);
+
+        return [
+            'outcome'            => 'superseded',
+            'reason'             => null,
+            'slug'               => $latest->slug,
+            'version'            => (int) $latest->version,
+            'superseded_version' => (int) $latest->version,
+        ];
+    }
+
+    /**
+     * Clona um handoff numa nova versão `pending` (re-emite o MESMO design). Mantém
+     * created_by/source_hash/sig do original (autoria do design e proveniência
+     * preservadas); `created_at` fresco re-arma o relógio de staleness na leitura.
+     */
+    private function cloneAsPending(CoworkHandoff $src, int $version): void
+    {
+        CoworkHandoff::create([
+            'slug'            => $src->slug,
+            'version'         => $version,
+            'tela'            => $src->tela,
+            'status'          => 'pending',
+            'audited_against' => $src->audited_against,
+            'body_md'         => $src->body_md,
+            'files_json'      => $src->files_json,
+            'source_hash'     => $src->source_hash,
+            'sig'             => $src->sig,
+            'created_by'      => $src->created_by,
+            'created_at'      => now(),
+        ]);
+    }
+
+    /**
+     * @return array{outcome: 'rejected', reason: string, slug: string, version: int, superseded_version: null}
+     */
+    private function reject(string $reason, string $slug, int $version): array
+    {
+        return [
+            'outcome'            => 'rejected',
+            'reason'             => $reason,
+            'slug'               => $slug,
+            'version'            => $version,
+            'superseded_version' => null,
+        ];
+    }
+}

--- a/Modules/TeamMcp/Tests/Feature/HandoffLeverToolTest.php
+++ b/Modules/TeamMcp/Tests/Feature/HandoffLeverToolTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Request as McpRequest;
+use Laravel\Mcp\Response as McpResponse;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+use Modules\TeamMcp\Mcp\Tools\HandoffLeverTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283) — GUARD do tool handoff-lever
+ * (levers re-disparar/devolver/supersede sobre cowork_handoffs).
+ *
+ * Provas (critério de aceite + adversário [AH]):
+ *   1. sem scope jana.mcp.handoff.lever → erro (A7), NÃO muta
+ *   2. action inválida → erro
+ *   3. re-disparar (pending) → lápide na atual + novo pending v+1 (append-only)
+ *   4. re-disparar fora de pending → erro (estado/"409"), NÃO muta
+ *   5. devolver (rejected) → novo pending v+1; rejected FICA como histórico
+ *   6. devolver fora de rejected → erro
+ *   7. supersede (pending) → status superseded; (applied) idem
+ *   8. supersede em rejected/superseded → erro
+ *   9. drift: version divergente → erro (stale_view A4), NÃO muta
+ *  10. append-only: nada é deletado (contagem só cresce/preserva lápides)
+ *
+ * Harness espelha HandoffToolsTest/HandoffSubmitToolTest (user via auth userResolver
+ * + tabela sintética sqlite-friendly), com nomes ÚNICOS pra não colidir com os
+ * outros testes de handoff no mesmo processo Pest.
+ *
+ * Tier 0 ({@see ADR 0093}): cowork_handoffs sem business_id por design.
+ *
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffLeverTool
+ * @see Modules\TeamMcp\Services\HandoffLeverService
+ */
+
+/** Tabela sintética cowork_handoffs (espelha a migration; sqlite-friendly). */
+function mkLeverTable(): void
+{
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+    Schema::create('cowork_handoffs', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('slug', 120);
+        $t->unsignedInteger('version')->default(1);
+        $t->string('tela', 160)->default('');
+        $t->string('status', 16)->default('pending');
+        $t->string('audited_against', 40)->nullable();
+        $t->longText('body_md');
+        $t->json('files_json');
+        $t->char('source_hash', 64);
+        $t->char('sig', 64);
+        $t->string('created_by', 40)->default('CC');
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('applied_at')->nullable();
+        $t->string('applied_by', 60)->nullable();
+        $t->text('pr_url')->nullable();
+        $t->json('gate_status')->nullable();
+        $t->unique(['slug', 'version']);
+        $t->index('status');
+    });
+}
+
+/** Insere um handoff (default pending v1) — over sobrescreve status/version etc. */
+function mkLeverHandoff(string $slug, array $over = []): CoworkHandoff
+{
+    return CoworkHandoff::create(array_merge([
+        'slug'            => $slug,
+        'version'         => 1,
+        'tela'            => 'Atendimento/CaixaUnificada',
+        'status'          => 'pending',
+        'audited_against' => 'cb1a546',
+        'body_md'         => "## ONDA A\nDeixa o caixa flutuante.",
+        'files_json'      => ['resources/css/cockpit.css'],
+        'source_hash'     => str_repeat('a', 64),
+        'sig'             => str_repeat('b', 64),
+        'created_by'      => 'CC',
+        'created_at'      => now()->subDays(5), // "parado" (stale na leitura)
+    ], $over));
+}
+
+/** User-stub MCP (Authenticatable + can() injetável). */
+function mkLeverUser(bool $granted): Authenticatable
+{
+    return new class($granted) implements Authenticatable
+    {
+        public function __construct(private bool $granted) {}
+
+        public function can($abilities, $arguments = []): bool
+        {
+            return $this->granted;
+        }
+
+        public function getAuthIdentifierName()
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier()
+        {
+            return 11;
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword()
+        {
+            return '';
+        }
+
+        public function getRememberToken()
+        {
+            return '';
+        }
+
+        public function setRememberToken($value) {}
+
+        public function getRememberTokenName()
+        {
+            return 'remember_token';
+        }
+    };
+}
+
+function actLeverUser(?Authenticatable $user): void
+{
+    app('auth')->resolveUsersUsing(fn ($guard = null) => $user);
+}
+
+function leverRespArray(McpResponse $response): array
+{
+    return json_decode((string) $response->content(), true) ?: [];
+}
+
+function callLever(array $args): McpResponse
+{
+    return (new HandoffLeverTool())->handle(new McpRequest($args));
+}
+
+beforeEach(function () {
+    mkLeverTable();
+    actLeverUser(mkLeverUser(granted: true));
+});
+
+afterEach(function () {
+    app('auth')->resolveUsersUsing(fn ($guard = null) => null);
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+});
+
+it('NEGA caller sem jana.mcp.handoff.lever e NÃO muta [A7]', function () {
+    mkLeverHandoff('caixa-mobile');
+    actLeverUser(mkLeverUser(granted: false));
+
+    $resp = callLever(['action' => 'supersede', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('jana.mcp.handoff.lever');
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('pending');
+});
+
+it('action inválida → erro', function () {
+    mkLeverHandoff('caixa-mobile');
+
+    $resp = callLever(['action' => 'deletar', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('action inválida');
+});
+
+it('re-disparar (pending parado) → lápide na atual + novo pending v+1 [append-only]', function () {
+    mkLeverHandoff('caixa-mobile');
+
+    $resp = callLever(['action' => 're-disparar', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeFalse();
+    expect(leverRespArray($resp)['outcome'])->toBe('redisparado');
+    // v1 vira lápide; v2 pending fresco. Nada deletado: 2 linhas.
+    expect(DB::table('cowork_handoffs')->count())->toBe(2);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 1)->value('status'))->toBe('superseded');
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 2)->value('status'))->toBe('pending');
+});
+
+it('re-disparar fora de pending → erro (estado), NÃO muta', function () {
+    mkLeverHandoff('caixa-mobile', ['status' => 'applied']);
+
+    $resp = callLever(['action' => 're-disparar', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeTrue();
+    expect(DB::table('cowork_handoffs')->count())->toBe(1);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('applied');
+});
+
+it('devolver (rejected) → novo pending v+1; rejected fica histórico', function () {
+    mkLeverHandoff('caixa-mobile', ['status' => 'rejected']);
+
+    $resp = callLever(['action' => 'devolver', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeFalse();
+    expect(leverRespArray($resp)['outcome'])->toBe('devolvido');
+    expect(DB::table('cowork_handoffs')->count())->toBe(2);
+    // O rejeitado NÃO vira superseded (terminal/histórico — espelha HandoffIngestService).
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 1)->value('status'))->toBe('rejected');
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 2)->value('status'))->toBe('pending');
+});
+
+it('devolver fora de rejected → erro', function () {
+    mkLeverHandoff('caixa-mobile'); // pending
+
+    $resp = callLever(['action' => 'devolver', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeTrue();
+    expect(DB::table('cowork_handoffs')->count())->toBe(1);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('pending');
+});
+
+it('supersede (pending) → status superseded [lápide]', function () {
+    mkLeverHandoff('caixa-mobile');
+
+    $resp = callLever(['action' => 'supersede', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeFalse();
+    expect(leverRespArray($resp)['outcome'])->toBe('superseded');
+    // Append-only: a linha continua existindo, só vira lápide.
+    expect(DB::table('cowork_handoffs')->count())->toBe(1);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('superseded');
+});
+
+it('supersede (applied) → status superseded', function () {
+    mkLeverHandoff('caixa-mobile', ['status' => 'applied']);
+
+    $resp = callLever(['action' => 'supersede', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeFalse();
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('superseded');
+});
+
+it('supersede em rejected → erro (estado)', function () {
+    mkLeverHandoff('caixa-mobile', ['status' => 'rejected']);
+
+    $resp = callLever(['action' => 'supersede', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeTrue();
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('rejected');
+});
+
+it('drift: version divergente → erro (stale_view A4), NÃO muta', function () {
+    mkLeverHandoff('caixa-mobile'); // v1 pending
+
+    $resp = callLever(['action' => 'supersede', 'slug' => 'caixa-mobile', 'version' => 2]);
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('fila mudou');
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->value('status'))->toBe('pending');
+});
+
+it('slug inexistente → erro (not_found), NÃO cria nada', function () {
+    $resp = callLever(['action' => 'supersede', 'slug' => 'nao-existe']);
+
+    expect($resp->isError())->toBeTrue();
+    expect(DB::table('cowork_handoffs')->count())->toBe(0);
+});
+
+it('opera na MAIOR versão do slug', function () {
+    mkLeverHandoff('caixa-mobile', ['version' => 1, 'status' => 'superseded']);
+    mkLeverHandoff('caixa-mobile', ['version' => 2, 'status' => 'pending']);
+
+    $resp = callLever(['action' => 'supersede', 'slug' => 'caixa-mobile']);
+
+    expect($resp->isError())->toBeFalse();
+    expect(leverRespArray($resp)['version'])->toBe(2);
+    expect(CoworkHandoff::where('slug', 'caixa-mobile')->where('version', 2)->value('status'))->toBe('superseded');
+});
+
+it('HandoffLeverTool NÃO usa Cache::flush() no CÓDIGO [A2]', function () {
+    $src = file_get_contents(dirname(__DIR__, 2) . '/Mcp/Tools/HandoffLeverTool.php');
+
+    // Tokeniza e descarta comentários/docblocks antes de procurar a chamada
+    // (espelha o guard A2 de HandoffToolsTest) — morde só Cache::flush() real no código.
+    $codeOnly = '';
+    foreach (token_get_all($src) as $token) {
+        if (is_array($token)) {
+            if ($token[0] === T_COMMENT || $token[0] === T_DOC_COMMENT) {
+                continue;
+            }
+            $codeOnly .= $token[1];
+        } else {
+            $codeOnly .= $token;
+        }
+    }
+
+    expect($codeOnly)->not->toContain('Cache::flush');
+});

--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaMcp.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaMcp.tsx
@@ -1,10 +1,12 @@
 // Forja — aba MCP do cockpit.
 //
 // DUAS CAMADAS:
-//   1. HANDOFFS (REAL · Fase 1 ADR 0283) — seção do topo: projeta os handoffs de
+//   1. HANDOFFS (REAL · Fase 1+2 ADR 0283) — seção do topo: projeta os handoffs de
 //      design (Cowork→Code, F1→F3) de `cowork_handoffs` via props deferidas
 //      (`handoffs`/`heartbeat`). Status/gate/sig REAIS; sem auto-merge (o merge é
-//      o 1-clique do [W]). As levers roteiam pelas tools MCP — Fase 2 (TODO).
+//      o 1-clique do [W]). As levers (re-disparar/devolver/supersede) POSTam em
+//      /forja/handoff/{slug}/lever → HandoffLeverService (mesma mutação governada
+//      do tool MCP handoff-lever, append-only · Fase 2 PR-7).
 //   2. CONTRATO/TOKENS/AUDITORIA (MOCKADO por design) — vitrine do contrato; o
 //      enforce real é do servidor TeamMcp ([CL]). Default = read + propose;
 //      merge e constituicao.edit NEGADOS no contrato, não por convenção.
@@ -15,7 +17,7 @@
 //
 // Tier 0 (ADR 0081): NUNCA exibir/logar token raw — só o nome lógico do token.
 
-import { Deferred } from '@inertiajs/react';
+import { Deferred, router } from '@inertiajs/react';
 import {
   AlertTriangle,
   ExternalLink,
@@ -32,7 +34,22 @@ import {
   Workflow,
 } from 'lucide-react';
 import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/Components/ui/alert-dialog';
 import { cn } from '@/Lib/utils';
+
+// CSRF do POST das levers (mesmo helper do ForjaDossier).
+function csrf(): string {
+  return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+}
 
 // --- Contrato de ferramentas (estático, do protótipo aprovado) ----------------
 
@@ -170,12 +187,45 @@ const HANDOFF_FILTERS: { key: 'todos' | HandoffItem['status']; label: string }[]
   { key: 'stale', label: 'parado' },
 ];
 
-// Lever por status (roteamento via tool MCP auditada — NÃO [W] operando). SEM merge.
-function leverFor(status: HandoffItem['status']): { label: string; Icon: LucideIcon } | null {
-  if (status === 'stale') return { label: 're-disparar', Icon: RefreshCw };
-  if (status === 'rejected') return { label: 'devolver ao [CC]', Icon: Undo2 };
-  if (status === 'pending' || status === 'applied') return { label: 'supersede', Icon: Layers };
+// Lever por status (roteamento via mutação governada — NÃO [W] operando o banco).
+// SEM merge. `action` = a action que o backend HandoffLeverService espera.
+type LeverAction = 're-disparar' | 'devolver' | 'supersede';
+interface Lever {
+  label: string;
+  action: LeverAction;
+  Icon: LucideIcon;
+  destructive: boolean;
+}
+
+function leverFor(status: HandoffItem['status']): Lever | null {
+  if (status === 'stale') return { label: 're-disparar', action: 're-disparar', Icon: RefreshCw, destructive: false };
+  if (status === 'rejected') return { label: 'devolver ao [CC]', action: 'devolver', Icon: Undo2, destructive: false };
+  if (status === 'pending' || status === 'applied') return { label: 'supersede', action: 'supersede', Icon: Layers, destructive: true };
   return null;
+}
+
+// Texto do confirm por lever (append-only · ADR 0283; nada é deletado).
+function leverConfirm(lever: Lever, h: HandoffItem): { title: string; description: string; confirmLabel: string } {
+  const ref = `${h.slug} v${h.version}`;
+  if (lever.action === 're-disparar') {
+    return {
+      title: `Re-disparar ${ref}?`,
+      description: 'Re-arma o handoff parado: cria uma nova versão pendente e marca a atual como substituída (lápide). Append-only — nada é deletado. Sem auto-merge.',
+      confirmLabel: 'Re-disparar',
+    };
+  }
+  if (lever.action === 'devolver') {
+    return {
+      title: `Devolver ${ref} ao [CC]?`,
+      description: 'Cria uma nova versão pendente pro [CC] retrabalhar. A versão rejeitada fica como histórico. Sem auto-merge.',
+      confirmLabel: 'Devolver',
+    };
+  }
+  return {
+    title: `Supersede ${ref}?`,
+    description: 'Marca esta versão como substituída (lápide) — sai da fila ativa. Append-only: nada é deletado; a substituta chega depois pelo Cowork.',
+    confirmLabel: 'Supersede',
+  };
 }
 
 function HandoffsSkeleton() {
@@ -216,7 +266,15 @@ function HeartbeatLine({ heartbeat }: { heartbeat?: HeartbeatInfo }) {
   );
 }
 
-function HandoffRow({ h }: { h: HandoffItem }) {
+function HandoffRow({
+  h,
+  busy,
+  onLever,
+}: {
+  h: HandoffItem;
+  busy: boolean;
+  onLever: (h: HandoffItem, lever: Lever) => void;
+}) {
   const status = HANDOFF_STATUS[h.status] ?? HANDOFF_STATUS.pending;
   const gate = HANDOFF_GATE[h.gate] ?? HANDOFF_GATE.na;
   const lever = leverFor(h.status);
@@ -293,18 +351,25 @@ function HandoffRow({ h }: { h: HandoffItem }) {
         <span className="tabular-nums">{h.created_at_human ?? '—'}</span>
         <span className="text-muted-foreground/70">por {h.created_by}</span>
 
-        {/* Lever (roteamento via MCP — Fase 2 · ADR 0283). SEM merge. Disabled =
-            surface-only: NÃO simula sucesso até o endpoint existir. */}
+        {/* Lever (mutação governada via HandoffLeverService — Fase 2 · ADR 0283).
+            SEM merge. Append-only. Pede confirmação antes de operar. */}
         {lever ? (
           <button
             type="button"
-            disabled
+            disabled={busy}
+            onClick={() => onLever(h, lever)}
             data-testid="forja-handoff-lever"
-            title="Roteia via tool MCP — Fase 2 (ADR 0283)"
-            className="ml-auto inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-dashed px-2 py-0.5 text-[11px] font-medium text-muted-foreground opacity-70"
+            data-lever={lever.action}
+            title={`${lever.label} — mutação governada e auditada (ADR 0283), sem auto-merge`}
+            className={cn(
+              'ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors',
+              busy ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+              lever.destructive
+                ? 'border-destructive/30 text-destructive-fg hover:bg-destructive-soft'
+                : 'border-border text-foreground hover:bg-muted',
+            )}
           >
             <lever.Icon size={11} /> {lever.label}
-            <span className="opacity-80">· em breve</span>
           </button>
         ) : null}
       </div>
@@ -316,10 +381,42 @@ function HandoffsSection({ handoffs, heartbeat }: { handoffs?: HandoffItem[]; he
   const items = handoffs ?? [];
   const [filter, setFilter] = useState<'todos' | HandoffItem['status']>('todos');
 
+  // Lever em confirmação + estado da mutação (busy/erro). A mutação roteia pelo
+  // endpoint web /forja/handoff/{slug}/lever, que delega ao HandoffLeverService —
+  // a MESMA mutação governada do tool MCP handoff-lever (ADR 0283). Sem auto-merge.
+  const [pending, setPending] = useState<{ h: HandoffItem; lever: Lever } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function runLever(h: HandoffItem, lever: Lever) {
+    setBusy(true);
+    setError(null);
+    fetch(`/forja/handoff/${encodeURIComponent(h.slug)}/lever`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-CSRF-TOKEN': csrf() },
+      body: JSON.stringify({ action: lever.action, version: h.version }),
+    })
+      .then(async (r) => {
+        const d = await r.json().catch(() => ({}));
+        setBusy(false);
+        if (!r.ok) {
+          setError(d?.error ?? `Erro ${r.status}`);
+          return;
+        }
+        // Reflete na hora: recarrega só as props deferidas da seção (sem cache).
+        router.reload({ only: ['handoffs', 'heartbeat'] });
+      })
+      .catch(() => {
+        setBusy(false);
+        setError('Erro de rede.');
+      });
+  }
+
   const countFor = (key: 'todos' | HandoffItem['status']) =>
     key === 'todos' ? items.length : items.filter((h) => h.status === key).length;
 
   const visible = filter === 'todos' ? items : items.filter((h) => h.status === filter);
+  const confirm = pending ? leverConfirm(pending.lever, pending.h) : null;
 
   return (
     <section data-testid="forja-mcp-handoffs" className="inline-flex w-full flex-col gap-3">
@@ -371,13 +468,51 @@ function HandoffsSection({ handoffs, heartbeat }: { handoffs?: HandoffItem[]; he
         <>
           <div className="inline-flex w-full flex-col divide-y overflow-hidden rounded-lg border">
             {visible.map((h) => (
-              <HandoffRow key={`${h.slug}-${h.version}`} h={h} />
+              <HandoffRow
+                key={`${h.slug}-${h.version}`}
+                h={h}
+                busy={busy}
+                onLever={(hh, lever) => setPending({ h: hh, lever })}
+              />
             ))}
           </div>
           {/* Heartbeat de rodapé — leitura "viva" mesmo com a fila cheia. */}
           <HeartbeatLine heartbeat={heartbeat} />
         </>
       )}
+
+      {/* Erro da última lever (recusa do "409"/drift OU rede). */}
+      {error ? (
+        <div
+          data-testid="forja-handoff-lever-error"
+          className="inline-flex w-full items-start gap-2 rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-xs text-destructive-fg"
+        >
+          <AlertTriangle size={13} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      {/* Confirmação antes de operar (espelha o AlertDialog do ForjaDossier). */}
+      <AlertDialog open={pending !== null} onOpenChange={(o) => { if (!o && !busy) setPending(null); }}>
+        <AlertDialogContent data-testid="forja-handoff-lever-confirm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirm?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirm?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              variant={pending?.lever.destructive ? 'destructive' : 'default'}
+              onClick={() => {
+                if (pending) runLever(pending.h, pending.lever);
+                setPending(null);
+              }}
+            >
+              {confirm?.confirmLabel ?? 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }


### PR DESCRIPTION
Liga as 3 levers da Forja (aba MCP) que estavam `disabled "em breve"` — **backend governado + fiação do front**. Follow-up de #2921 (PR-6, handoff-submit + transporte). Fecha o **Gap 3 do adversário** do loop zero-paste.

## Por que empilhado em #2921 (não em `main`)
Toca exatamente os 4 arquivos de governança que a PR-6 também toca (`ci-sqlite-pest.list`, `McpScopesSeeder.php`, `OimpressoMcpServer.php` $tools, e — neste caso — nenhum workflow). Branch off `main` daria conflito garantido; empilhado em `feat/handoff-zero-paste-pr6` o diff fica limpo e **retargeta sozinho pra `main` quando a PR-6 mergear**. **Mergear esta exige a #2921 antes.**

## O que entra
- **`HandoffLeverService`** — fonte **única** da mutação **append-only**, igual o par `HandoffIngestService` (command + tool compartilham). Semântica das levers (`status` enum `pending|applied|rejected|stale|superseded`, NUNCA delete):
  - **re-disparar** (pending parado/"stale"): lápide na atual (`superseded`) + **clone fresco** `pending` (version+1) — re-arma o relógio de staleness sem sobrescrever `created_at`.
  - **devolver** (rejected→[CC]): **novo** `pending` (version+1) pro [CC] retrabalhar; o `rejected` fica **histórico** (terminal, não vira lápide — espelha o `HandoffIngestService`, que só dá lápide em `applied`).
  - **supersede** (pending|applied): **lápide** (`superseded`), sem substituta aqui — o replacement chega depois pelo Cowork via `handoff-submit`.
- **`handoff-lever`** (tool MCP) — espelha `HandoffAckTool`: scope fino **`jana.mcp.handoff.lever`** (A7) como 1º statement, audit em `mcp_audit_log`, **idempotência de estado** (lever fora do estado esperado = o "409", não muta) e **drift guard** de versão (A4 — `version` que o operador viu). Registrado no `OimpressoMcpServer` + scope semeado no `McpScopesSeeder` (`firstOrCreate`, padrão `jana.mcp.handoff.*`).
- **`ForjaController@handoffLever`** (`POST /forja/handoff/{slug}/lever`) — a **mesma** mutação via o service (browser não é cliente MCP), gate `copiloto.mcp.usage.all` do cockpit, audit `mcp_audit_log` (origem `forja-web`). Delega 100% ao service (sem Eloquent direto → não trip o `NoMissingTenantScopeRule`).
- **Front `ForjaMcp.tsx`** — levers ativas (eram `disabled`), confirm via `AlertDialog` (espelha `ForjaDossier`), POST com CSRF + `router.reload({ only: ['handoffs','heartbeat'] })`. **Sem botão de merge.**
- **Pest `HandoffLeverToolTest`** na lane sqlite (adicionado ao `.github/ci-sqlite-pest.list`, senão não roda) — cobre authz (A7), estado/"409", append-only (lápide + clone, nada deletado), drift (A4), maior-versão e o guard A2 (`Cache::flush()` ausente do código).

## Tier 0 / ADR 0283
`cowork_handoffs` é **repo-wide** (sem `business_id`, ADR 0093) — consistente com os irmãos. **Sem auto-merge**: as levers só mutam a fila; o merge segue o **1-clique do [W]** no GitHub (ADR 0283).

## Não-mexido
- **`scripts/governance/gates-registry.json`** inalterado — não adiciono workflow novo (só um teste numa lane existente). O memory-health enforce exige registro só de `*.yml` novo.
- **`SCOPE.md`** inalterado — `scope-guard` é controller-**file**-level e `ForjaController` + `cowork_handoffs` já estão declarados.
- Sem ADR novo — é a Fase 2 da ADR 0283 já aceita (responsabilidade de numerar é do [CL] sob OK do [W]).

## Verificação
Sem PHP/`vendor`/DB no ambiente local (backend no CT 100/Hostinger) → a lane **sqlite-pest** roda o `HandoffLeverToolTest` no CI; smoke visual da aba é pós-merge (`tela-smoke-pos-merge`) por [W]. **Não auto-mergear.**

Refs: ADR-0283 Fase 2 PR-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)