### PR TITLE
feat(teammcp): handoff-lever — liga as levers da fila (PR-7 · ADR 0283)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -26,10 +26,11 @@ Modules/Jana/Tests/Feature/TaskRegistry/TaskUpdateAtomicTest.php
 Modules/TeamMcp/Tests/Feature/IngestHeartbeatTest.php
 Modules/TeamMcp/Tests/Feature/IngestLivenessTest.php
 # Loop de Handoff Zero-Paste (ADR 0283): PR-6a submit (novo) + PR-1 ingest
-# (regressão do refactor que extraiu HandoffIngestService). Sintéticas em
-# beforeEach → sqlite-safe (sem migration MySQL-only).
+# (regressão do refactor que extraiu HandoffIngestService) + PR-7 levers
+# (re-disparar/devolver/supersede). Sintéticas em beforeEach → sqlite-safe.
 Modules/TeamMcp/Tests/Feature/HandoffSubmitToolTest.php
 Modules/TeamMcp/Tests/Feature/HandoffIngestTest.php
+Modules/TeamMcp/Tests/Feature/HandoffLeverToolTest.php
 tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php

--- a/Modules/Jana/Database/Seeders/McpScopesSeeder.php
+++ b/Modules/Jana/Database/Seeders/McpScopesSeeder.php
@@ -239,6 +239,16 @@ class McpScopesSeeder extends Seeder
             'business_required' => false,
             'admin_only'        => false,
         ],
+        [
+            'slug'              => 'jana.mcp.handoff.lever',
+            'nome'              => 'Rotear estado de handoff na fila (handoff-lever)',
+            'descricao'         => 'Permite handoff-lever (PR-7, ADR 0283) — liga as levers da fila cowork_handoffs: re-disparar (pending parado re-arma), devolver (rejected reabre pra pending) e supersede (pending/applied vira obsoleto, append-only). Mutação auditada e idempotente (só morde no status de origem). SEM auto-merge — o merge segue 1-clique do [W]. Emitir token com este scope via McpTokenIssuer pro ator que gerencia a fila.',
+            'resources_pattern' => null,
+            'tools_pattern'     => 'handoff-lever',
+            'is_destructive'    => false,
+            'business_required' => false,
+            'admin_only'        => false,
+        ],
     ];
 
     public function run(): void

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -164,6 +164,11 @@ class OimpressoMcpServer extends Server
         // pending, sem [W] no transporte. Scope fino jana.mcp.handoff.submit (A7);
         // reusa HandoffIngestService (mesma validação do PR-1). Sem auto-merge.
         \Modules\TeamMcp\Mcp\Tools\HandoffSubmitTool::class,
+        // PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283) — liga as levers da
+        // fila (re-disparar/devolver/supersede) que o front só PINTA hoje. Mutação
+        // auditada+idempotente da fila cowork_handoffs; scope fino jana.mcp.handoff.lever.
+        // Sem auto-merge (o merge segue 1-clique do [W]).
+        \Modules\TeamMcp\Mcp\Tools\HandoffLeverTool::class,
     ];
 
     /** @var array<int, class-string<\Laravel\Mcp\Server\Resource>> */

--- a/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
+++ b/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
@@ -157,6 +157,9 @@ class HandoffLeverTool extends Tool
             ],
             // Obsoleto: sai da lista ativa (ForjaMcpService exclui superseded).
             'supersede' => ['status' => 'superseded'],
+            // Inalcançável: handle() já validou action contra ORIGINS antes de
+            // chamar. Arm exigido pelo PHPStan (match exaustivo).
+            default => throw new \InvalidArgumentException("action inválida: {$action}"),
         };
     }
 

--- a/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
+++ b/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Entities\Mcp\McpAuditLog;
+use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+use Throwable;
+
+/**
+ * Tool MCP handoff-lever — PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283).
+ *
+ * Liga as 3 levers que o front da Forja só PINTA hoje (`ForjaMcp.tsx` —
+ * `disabled "em breve"`): o gerenciamento da fila de design-handoffs sai do
+ * "[W] mexe no banco à mão" e passa por uma tool MCP auditada, scopeada e
+ * idempotente. NÃO há auto-merge — o merge do PR continua sendo o 1-clique do
+ * [W] no GitHub (ADR 0283). As levers só roteiam ESTADO da fila:
+ *
+ *   - **re-disparar** (handoff `stale` = `pending` velho > 3d): re-arma o handoff
+ *     na fila ativa. `status` segue `pending`; só a freshness reseta.
+ *   - **devolver** (handoff `rejected`): reabre pro [CC] retrabalhar — volta a
+ *     `pending` e limpa os artefatos do ack (pr_url/gate_status/applied_*).
+ *   - **supersede** (handoff `pending`|`applied`): marca obsoleto — sai da lista
+ *     ativa da Forja (que já exclui `superseded`). Append-only: a linha FICA.
+ *
+ * **Freshness sem coluna nova:** a Forja deriva `stale` de `created_at < now-3d`
+ * ({@see \Modules\TeamMcp\Services\Forja\ForjaMcpService::displayStatus}). re-disparar
+ * e devolver re-armam tocando `created_at = now()` — ele passa a valer "entrou na
+ * fila ativa" (o ingest original sobrevive em `mcp_audit_log` + git). Escolha
+ * deliberada pra manter o PR cirúrgico (zero migration, zero toque em ForjaMcpService).
+ *
+ * Defesas do adversário [AH] (espelha {@see HandoffAckTool}):
+ *   - **A7 authz:** mutação — exige scope fino `jana.mcp.handoff.lever`, via
+ *     {@see AuthorizesMcpMutation} como 1º statement.
+ *   - **idempotência:** a lever só morde no `status` de origem certo. Lever num
+ *     handoff fora do estado-origem → erro (o "409"): não muta em dobro.
+ *   - **sem cache:** este handler NÃO cacheia (logo NÃO há `Cache::flush()` que
+ *     derrubava o ERP inteiro — A2).
+ *
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffAckTool
+ * @see Modules\TeamMcp\Services\Forja\ForjaMcpService
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+class HandoffLeverTool extends Tool
+{
+    use AuthorizesMcpMutation;
+
+    protected string $name = 'handoff-lever';
+
+    protected string $title = 'Rotear estado de um handoff na fila (re-disparar/devolver/supersede)';
+
+    protected string $description = 'Liga as levers da fila de design-handoffs (Fase 2 · ADR 0283), auditadas e idempotentes. re-disparar re-arma um handoff parado (pending velho). devolver reabre um rejected pro [CC] (volta a pending, limpa o ack). supersede marca pending/applied como obsoleto (sai da lista ativa, append-only: a linha fica). SEM auto-merge — o merge segue sendo o 1-clique do [W]. Exige scope jana.mcp.handoff.lever.';
+
+    /** action → status(es) de origem em que a lever morde. */
+    private const ORIGINS = [
+        're-disparar' => ['pending'],
+        'devolver'    => ['rejected'],
+        'supersede'   => ['pending', 'applied'],
+    ];
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'slug' => $schema->string()
+                ->description('slug do handoff alvo')
+                ->required(),
+            'action' => $schema->string()
+                ->description("Lever: 're-disparar' (pending parado → re-arma), 'devolver' (rejected → reabre pending), 'supersede' (pending|applied → obsoleto).")
+                ->required(),
+            'version' => $schema->integer()
+                ->description('Versão alvo (default: a maior no status de origem da lever).'),
+            'note' => $schema->string()
+                ->description('Motivo da lever — só auditado (não muda o body do handoff).'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        // A7: mutação — gate de escopo como PRIMEIRO statement.
+        if ($deny = $this->authorizeMcpMutation($request, 'jana.mcp.handoff.lever')) {
+            return $deny;
+        }
+
+        $slug = trim((string) $request->get('slug', ''));
+        if ($slug === '') {
+            return Response::error('❌ slug é obrigatório.');
+        }
+
+        $action = (string) $request->get('action', '');
+        if (! array_key_exists($action, self::ORIGINS)) {
+            return Response::error("❌ action deve ser 're-disparar', 'devolver' ou 'supersede'.");
+        }
+
+        $origins = self::ORIGINS[$action];
+
+        // Acha a versão no status de origem (default: a maior). Idempotência: só
+        // morde no estado-origem certo — lever fora dele é "409".
+        $query = CoworkHandoff::query()->where('slug', $slug)->whereIn('status', $origins);
+        $version = $request->get('version');
+        if ($version !== null && $version !== '') {
+            $query->where('version', (int) $version);
+        }
+        $row = $query->orderByDesc('version')->first();
+
+        if ($row === null) {
+            $estados = implode('/', $origins);
+            return Response::error(
+                "⚠️ '{$slug}' não tem versão em '{$estados}' pra '{$action}'. As levers são idempotentes: só mordem no estado de origem."
+            );
+        }
+
+        $from = (string) $row->status;
+        $changes = $this->changesFor($action);
+        $row->update($changes);
+        $to = (string) $changes['status'];
+
+        $this->audit($request, $slug, (int) $row->version, $action, $from, $to, $request->get('note'));
+
+        $payload = [
+            'ok'          => true,
+            'slug'        => $slug,
+            'version'     => (int) $row->version,
+            'action'      => $action,
+            'from_status' => $from,
+            'to_status'   => $to,
+        ];
+
+        return Response::text((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+
+    /**
+     * O patch de cada lever. re-disparar/devolver re-armam a freshness via
+     * `created_at = now()` (sem coluna nova — ver doc da classe); supersede é
+     * terminal e não mexe na freshness.
+     *
+     * @return array<string,mixed>
+     */
+    private function changesFor(string $action): array
+    {
+        return match ($action) {
+            // Re-arma na fila ativa: status segue pending, freshness reseta.
+            're-disparar' => ['status' => 'pending', 'created_at' => now()],
+            // Reabre pro [CC]: volta a pending fresco e limpa os artefatos do ack.
+            'devolver' => [
+                'status'      => 'pending',
+                'created_at'  => now(),
+                'applied_at'  => null,
+                'applied_by'  => null,
+                'pr_url'      => null,
+                'gate_status' => null,
+            ],
+            // Obsoleto: sai da lista ativa (ForjaMcpService exclui superseded).
+            'supersede' => ['status' => 'superseded'],
+        };
+    }
+
+    private function agentId(): string
+    {
+        // Headers HTTP (X-MCP-Agent-Id, povoados pelo McpAuthMiddleware) vêm pelo
+        // helper global request() — o Laravel\Mcp\Request não tem header(). Mesmo
+        // padrão de HandoffAckTool/TasksClaimTool.
+        $id = request()->header('X-MCP-Agent-Id');
+
+        return is_string($id) && $id !== '' ? $id : 'unknown';
+    }
+
+    /** Audit best-effort (slug/action/transição) — não trava a resposta. */
+    private function audit(Request $request, string $slug, int $version, string $action, string $from, string $to, mixed $note): void
+    {
+        try {
+            $user = $request->user();
+            McpAuditLog::registrar([
+                'user_id'          => $user !== null ? (int) $user->getAuthIdentifier() : 0,
+                'endpoint'         => 'tools/call',
+                'tool_or_resource' => 'handoff-lever',
+                'status'           => 'ok',
+                'payload_summary'  => [
+                    'slug'    => $slug,
+                    'version' => $version,
+                    'action'  => $action,
+                    'from'    => $from,
+                    'to'      => $to,
+                    'actor'   => $this->agentId(),
+                    'note'    => is_string($note) ? mb_substr($note, 0, 200) : null,
+                ],
+            ]);
+        } catch (Throwable) {
+            // best-effort
+        }
+    }
+}

--- a/Modules/TeamMcp/Tests/Feature/HandoffLeverToolTest.php
+++ b/Modules/TeamMcp/Tests/Feature/HandoffLeverToolTest.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Mcp\Request as McpRequest;
+use Laravel\Mcp\Response as McpResponse;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+use Modules\TeamMcp\Mcp\Tools\HandoffLeverTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283) — GUARD do tool
+ * handoff-lever (re-disparar / devolver / supersede).
+ *
+ * Provas (critério de aceite + adversário [AH]):
+ *   1. supersede em pending → status superseded (sai da lista ativa, append-only)
+ *   2. devolver em rejected → volta a pending + limpa o ack (pr_url/gate/applied_*)
+ *   3. re-disparar em pending velho (stale) → re-arma created_at (un-stale)
+ *   4. idempotência: lever fora do status de origem → erro, NÃO muta
+ *   5. sem scope jana.mcp.handoff.lever → erro (A7), NÃO muta
+ *   6. action inválida → erro
+ *
+ * Harness espelha HandoffSubmitToolTest (user via auth userResolver + tabela
+ * sintética sqlite-friendly), com nomes ÚNICOS pra não colidir no mesmo processo Pest.
+ *
+ * Tier 0 ({@see ADR 0093}): cowork_handoffs sem business_id.
+ *
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffLeverTool
+ */
+
+/** Tabela sintética (espelha a migration; sqlite-friendly). */
+function mkLeverTable(): void
+{
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+
+    Schema::create('cowork_handoffs', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('slug', 120);
+        $t->unsignedInteger('version')->default(1);
+        $t->string('tela', 160)->default('');
+        $t->string('status', 16)->default('pending');
+        $t->string('audited_against', 40)->nullable();
+        $t->longText('body_md');
+        $t->json('files_json');
+        $t->char('source_hash', 64);
+        $t->char('sig', 64);
+        $t->string('created_by', 40)->default('CC');
+        $t->timestamp('created_at')->nullable();
+        $t->timestamp('applied_at')->nullable();
+        $t->string('applied_by', 60)->nullable();
+        $t->text('pr_url')->nullable();
+        $t->json('gate_status')->nullable();
+        $t->unique(['slug', 'version']);
+        $t->index('status');
+    });
+}
+
+/** Insere um handoff direto (sem passar pelo ingest) pra montar o cenário. */
+function mkLeverHandoff(string $slug, array $over = []): CoworkHandoff
+{
+    return CoworkHandoff::create(array_merge([
+        'slug'        => $slug,
+        'version'     => 1,
+        'tela'        => 'Atendimento/CaixaUnificada',
+        'status'      => 'pending',
+        'body_md'     => "## ONDA A\nDeixa o caixa flutuante no mobile.",
+        'files_json'  => ['resources/css/cockpit.css'],
+        'source_hash' => str_repeat('a', 64),
+        'sig'         => str_repeat('b', 64),
+        'created_by'  => 'CC',
+        'created_at'  => now(),
+    ], $over));
+}
+
+/** User-stub MCP (Authenticatable + can() injetável). */
+function mkLeverUser(bool $granted): Authenticatable
+{
+    return new class($granted) implements Authenticatable
+    {
+        public function __construct(private bool $granted) {}
+
+        public function can($abilities, $arguments = []): bool
+        {
+            return $this->granted;
+        }
+
+        public function getAuthIdentifierName()
+        {
+            return 'id';
+        }
+
+        public function getAuthIdentifier()
+        {
+            return 7;
+        }
+
+        public function getAuthPasswordName()
+        {
+            return 'password';
+        }
+
+        public function getAuthPassword()
+        {
+            return '';
+        }
+
+        public function getRememberToken()
+        {
+            return '';
+        }
+
+        public function setRememberToken($value) {}
+
+        public function getRememberTokenName()
+        {
+            return 'remember_token';
+        }
+    };
+}
+
+function actLeverUser(?Authenticatable $user): void
+{
+    app('auth')->resolveUsersUsing(fn ($guard = null) => $user);
+}
+
+function leverRespArray(McpResponse $response): array
+{
+    return json_decode((string) $response->content(), true) ?: [];
+}
+
+beforeEach(function () {
+    mkLeverTable();
+    actLeverUser(mkLeverUser(granted: true));
+});
+
+afterEach(function () {
+    actLeverUser(null);
+    if (Schema::hasTable('cowork_handoffs')) {
+        Schema::drop('cowork_handoffs');
+    }
+});
+
+it('supersede em pending → status superseded', function () {
+    mkLeverHandoff('caixa-lever');
+
+    $resp = (new HandoffLeverTool())->handle(new McpRequest([
+        'slug' => 'caixa-lever', 'action' => 'supersede',
+    ]));
+
+    expect($resp->isError())->toBeFalse();
+    $data = leverRespArray($resp);
+    expect($data['ok'])->toBeTrue();
+    expect($data['from_status'])->toBe('pending');
+    expect($data['to_status'])->toBe('superseded');
+    expect(CoworkHandoff::where('slug', 'caixa-lever')->value('status'))->toBe('superseded');
+});
+
+it('devolver em rejected → volta a pending e limpa o ack', function () {
+    mkLeverHandoff('caixa-lever', [
+        'status'      => 'rejected',
+        'applied_at'  => now(),
+        'applied_by'  => 'CC',
+        'pr_url'      => 'https://github.com/x/y/pull/1',
+        'gate_status' => ['conformance' => false, 'critique_score' => 40, 'a11y' => false],
+    ]);
+
+    $resp = (new HandoffLeverTool())->handle(new McpRequest([
+        'slug' => 'caixa-lever', 'action' => 'devolver', 'note' => 'refaz o header',
+    ]));
+
+    expect($resp->isError())->toBeFalse();
+    expect(leverRespArray($resp)['to_status'])->toBe('pending');
+
+    $row = CoworkHandoff::where('slug', 'caixa-lever')->first();
+    expect($row->status)->toBe('pending');
+    expect($row->pr_url)->toBeNull();
+    expect($row->gate_status)->toBeNull();
+    expect($row->applied_at)->toBeNull();
+    expect($row->applied_by)->toBeNull();
+});
+
+it('re-disparar em pending velho → re-arma created_at (un-stale)', function () {
+    // 10 dias atrás = stale (ForjaMcpService usa > 3d).
+    mkLeverHandoff('caixa-lever', ['created_at' => now()->subDays(10)]);
+
+    $resp = (new HandoffLeverTool())->handle(new McpRequest([
+        'slug' => 'caixa-lever', 'action' => 're-disparar',
+    ]));
+
+    expect($resp->isError())->toBeFalse();
+    expect(leverRespArray($resp)['to_status'])->toBe('pending');
+
+    $row = CoworkHandoff::where('slug', 'caixa-lever')->first();
+    expect($row->status)->toBe('pending');
+    // Re-armado: created_at fresco (não mais > 3d).
+    expect($row->created_at->gt(now()->subMinute()))->toBeTrue();
+});
+
+it('idempotência: lever fora do status de origem → erro, NÃO muta', function () {
+    mkLeverHandoff('caixa-lever', ['status' => 'superseded']);
+
+    // devolver só morde em 'rejected'; superseded não é origem de nada.
+    $resp = (new HandoffLeverTool())->handle(new McpRequest([
+        'slug' => 'caixa-lever', 'action' => 'devolver',
+    ]));
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('idempotentes');
+    expect(CoworkHandoff::where('slug', 'caixa-lever')->value('status'))->toBe('superseded');
+});
+
+it('sem scope jana.mcp.handoff.lever → erro (A7), NÃO muta', function () {
+    mkLeverHandoff('caixa-lever');
+    actLeverUser(mkLeverUser(granted: false));
+
+    $resp = (new HandoffLeverTool())->handle(new McpRequest([
+        'slug' => 'caixa-lever', 'action' => 'supersede',
+    ]));
+
+    expect($resp->isError())->toBeTrue();
+    expect((string) $resp->content())->toContain('jana.mcp.handoff.lever');
+    expect(CoworkHandoff::where('slug', 'caixa-lever')->value('status'))->toBe('pending');
+});
+
+it('action inválida → erro', function () {
+    mkLeverHandoff('caixa-lever');
+
+    $resp = (new HandoffLeverTool())->handle(new McpRequest([
+        'slug' => 'caixa-lever', 'action' => 'merge',
+    ]));
+
+    expect($resp->isError())->toBeTrue();
+    expect(CoworkHandoff::where('slug', 'caixa-lever')->value('status'))->toBe('pending');
+});


### PR DESCRIPTION
## Por quê
Fecha o **Gap 3 do adversário [AH]** (Fase 2 do loop de handoff zero-paste). As 3 levers que a Forja só **pinta** hoje (`ForjaMcp.tsx` — botão `disabled "em breve"`) ganham uma tool MCP real. O gerenciamento da fila `cowork_handoffs` sai do *"[W] mexe no banco à mão"* e passa por mutação **auditada, scopeada e idempotente**. **SEM auto-merge** — o merge segue sendo o 1-clique do [W] (ADR 0283).

Sequência: [#2921](https://github.com/wagnerra23/oimpresso.com/pull/2921) entregou PR-6 (handoff-submit + Action on-push). Este é o resíduo "levers" que ficou como Fase 2.

## O que muda
- **`HandoffLeverTool` (`handoff-lever`)** — espelha `HandoffAckTool`:
  - `re-disparar` (`pending` parado/stale → re-arma a freshness)
  - `devolver` (`rejected` → reabre pra `pending` + limpa o ack: `pr_url`/`gate_status`/`applied_*`)
  - `supersede` (`pending`|`applied` → `superseded`, append-only — a linha **fica**, só sai da lista ativa)
  - Scope fino **`jana.mcp.handoff.lever`** (A7, 1º statement via `AuthorizesMcpMutation`); idempotente (só morde no status de origem → "409" fora dele); audita em `mcp_audit_log`.
- Registra a tool no `OimpressoMcpServer` + seed do scope no `McpScopesSeeder`.
- **`HandoffLeverToolTest`** (6 provas) + entrada no `ci-sqlite-pest.list` (a lane que roda os testes TeamMcp).

## Decisões de escopo
- **Re-arm sem coluna nova:** a Forja deriva `stale` de `created_at < now-3d`. `re-disparar`/`devolver` re-armam tocando `created_at = now()` (passa a valer "entrou na fila ativa"; o ingest original sobrevive em `mcp_audit_log` + git). → **zero migration, zero toque em `ForjaMcpService`** (PR cirúrgico, sem colisão com o trabalho do gate `conflito` que mexe no mesmo serviço).
- **Front segue surface-only de propósito:** ADR 0283 diz que as levers roteiam via tool MCP auditada, **NÃO [W] operando no web**. Ligar o botão exige uma ponte web→scope-MCP que não existe — fica como follow-up separado.

## Teste
- `php -l` limpo nos 4 arquivos PHP.
- Pest local não roda neste ambiente (worktree sem `vendor`; árvore principal com autoload corrompido de outro worktree). Coberto pela **lane sqlite do CI** (`HandoffLeverToolTest` no allowlist), espelhando o harness já-verde do `HandoffSubmitToolTest`.

Refs: ADR 0283