### PR TITLE
feat(handoff): publisher Cowork→repo — fecha o 1º hop zero-paste (PR-7 · ADR 0285)

### DIFF
--- a/.github/scripts/cowork-inbox.py
+++ b/.github/scripts/cowork-inbox.py
@@ -17,6 +17,11 @@ Anything else, or any denied substring, is SKIPPED.
 
 If any processed file is "review" tier, this script writes `review_required=true` to $GITHUB_OUTPUT
 so the workflow opens the PR for review instead of auto-merging.
+
+PUBLISHER Cowork→repo (PR-7 · ADR 0285): files landed under prototipo-ui/handoffs/*.md are also
+emitted as `handoffs=<space-separated>` to $GITHUB_OUTPUT, so the workflow can sign+submit them to
+the MCP handoff-submit tool INLINE (the auto-merge done via GITHUB_TOKEN does NOT trigger the on-push
+handoff-sign-submit.yml). This closes the "first hop" without [W] committing by hand.
 """
 import os
 import re
@@ -27,6 +32,7 @@ INBOX = Path("cowork-inbox")
 ALLOWED_PREFIXES = ("prototipo-ui/", "memory/", "docs/")       # auto-merge once green
 ALLOWED_PREFIXES_REVIEW = ("resources/js/",)                   # code -> human review, never auto-merge
 DENY_SUBSTRINGS = ("..", ".github/", ".claude/")               # never reachable, even via review tier
+HANDOFFS_DIR = "prototipo-ui/handoffs/"                         # publisher target (ADR 0285) -> sign+submit
 MAX_SIZE_BYTES = 1_000_000
 SKIP_FILES = {"README.md", ".gitkeep"}
 
@@ -52,11 +58,11 @@ def classify_path(path: str) -> tuple[str | None, str | None]:
     return None, f"path {path!r} not in whitelist {ALLOWED_PREFIXES + ALLOWED_PREFIXES_REVIEW}"
 
 
-def process_file(filepath: Path) -> tuple[str, str | None]:
-    """Return (log_message, tier). tier is the written file's tier, or None when skipped."""
+def process_file(filepath: Path) -> tuple[str, str | None, str | None]:
+    """Return (log_message, tier, dest). tier/dest are None when the file is skipped."""
     size = filepath.stat().st_size
     if size > MAX_SIZE_BYTES:
-        return f"SKIP {filepath} (size {size} > {MAX_SIZE_BYTES})", None
+        return f"SKIP {filepath} (size {size} > {MAX_SIZE_BYTES})", None, None
 
     content = filepath.read_text(encoding="utf-8")
     headers = parse_headers(content)
@@ -66,14 +72,14 @@ def process_file(filepath: Path) -> tuple[str, str | None]:
     append_to = headers.get("append-to")
 
     if target and append_to:
-        return f"SKIP {filepath} (both target and append-to set)", None
+        return f"SKIP {filepath} (both target and append-to set)", None, None
     if not target and not append_to:
-        return f"SKIP {filepath} (no target/append-to header)", None
+        return f"SKIP {filepath} (no target/append-to header)", None, None
 
     dest = target or append_to
     tier, err = classify_path(dest)
     if tier is None:
-        return f"SKIP {filepath} ({err})", None
+        return f"SKIP {filepath} ({err})", None, None
 
     dest_path = Path(dest)
     dest_path.parent.mkdir(parents=True, exist_ok=True)
@@ -89,22 +95,31 @@ def process_file(filepath: Path) -> tuple[str, str | None]:
         action = "APPEND"
 
     filepath.unlink()
-    return f"{action} [{tier}] {filepath} -> {dest}", tier
+    return f"{action} [{tier}] {filepath} -> {dest}", tier, dest
 
 
-def emit_review_flag(review_required: bool) -> None:
-    value = "true" if review_required else "false"
+def emit_output(key: str, value: str) -> None:
     gh_output = os.environ.get("GITHUB_OUTPUT")
     if gh_output:
         with open(gh_output, "a", encoding="utf-8") as fh:
-            fh.write(f"review_required={value}\n")
-    print(f"review_required={value}")
+            fh.write(f"{key}={value}\n")
+    print(f"{key}={value}")
+
+
+def emit_review_flag(review_required: bool) -> None:
+    emit_output("review_required", "true" if review_required else "false")
+
+
+def is_handoff(dest: str | None) -> bool:
+    """A landed file is a publisher handoff (ADR 0285) iff it lives in prototipo-ui/handoffs/*.md."""
+    return bool(dest) and dest.startswith(HANDOFFS_DIR) and dest.endswith(".md")
 
 
 def main() -> int:
     if not INBOX.exists():
         print("cowork-inbox/ does not exist; nothing to do")
         emit_review_flag(False)
+        emit_output("handoffs", "")
         return 0
 
     files = sorted(
@@ -113,21 +128,27 @@ def main() -> int:
     if not files:
         print("inbox empty; nothing to do")
         emit_review_flag(False)
+        emit_output("handoffs", "")
         return 0
 
     print(f"Found {len(files)} file(s) in inbox")
     tiers: list[str] = []
+    handoffs: list[str] = []
     for f in files:
         try:
-            result, tier = process_file(f)
+            result, tier, dest = process_file(f)
             print(f"  {result}")
             if tier is not None:
                 tiers.append(tier)
+            if is_handoff(dest):
+                handoffs.append(dest)
         except Exception as e:
             print(f"  ERROR processing {f}: {e}", file=sys.stderr)
             return 1
 
     emit_review_flag(any(t == "review" for t in tiers))
+    # Publisher (ADR 0285): handoffs landed -> workflow signs+submits them to handoff-submit.
+    emit_output("handoffs", " ".join(handoffs))
     return 0
 
 

--- a/.github/workflows/cowork-inbox.yml
+++ b/.github/workflows/cowork-inbox.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           python-version: '3.12'
 
+      # PHP pro assinador (bin/sign-handoff.php) do publisher de handoff (ADR 0285).
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+
       - name: Configure git
         run: |
           git config user.name "cowork-inbox[bot]"
@@ -64,6 +69,23 @@ jobs:
             --body "Auto-processed by \`.github/workflows/cowork-inbox.yml\` from push ${GITHUB_SHA::7}." \
             --base main \
             --head "$BRANCH"
+
+      # PUBLISHER Cowork→repo (PR-7 · ADR 0285): fecha o 1º hop SEM [W] commitar à mão.
+      # Os handoffs já pousaram em prototipo-ui/handoffs/*.md (no working tree); assina+submete
+      # INLINE porque o auto-merge via GITHUB_TOKEN NÃO dispara o on-push do handoff-sign-submit.yml.
+      # Reusa bin/submit-handoff.sh (fonte única do transporte) — skip-as-pass sem os secrets.
+      - name: Assina & submete handoffs pousados → pending (publisher · ADR 0285)
+        if: steps.process.outputs.handoffs != ''
+        env:
+          HANDOFFS: ${{ steps.process.outputs.handoffs }}
+          HANDOFF_SECRET: ${{ secrets.HANDOFF_SECRET }}
+          SUBMIT_TOKEN: ${{ secrets.HANDOFF_SUBMIT_TOKEN }}
+          MCP_ENDPOINT: ${{ vars.MCP_ENDPOINT_URL || 'https://mcp.oimpresso.com/api/mcp' }}
+        run: |
+          set -euo pipefail
+          # Paths são slug-only (sem espaço): word-split intencional em args.
+          # shellcheck disable=SC2086
+          bash bin/submit-handoff.sh $HANDOFFS
 
       - name: Merge (doc/memory) or request review (code)
         if: steps.process.outputs.changed == 'true'

--- a/.github/workflows/handoff-sign-submit.yml
+++ b/.github/workflows/handoff-sign-submit.yml
@@ -53,6 +53,8 @@ jobs:
           php-version: '8.4'
       - name: O assinador morde? (determinismo · CRLF→LF · sig-bate · parse · envelope)
         run: php bin/sign-handoff.php --self-test
+      - name: O transporte morde? (skip-as-pass · vazio · arquivo inexistente · sem rede)
+        run: bash bin/submit-handoff.sh --self-test
 
   submit:
     name: sign & submit handoffs alterados → pending
@@ -78,13 +80,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Skip-as-pass enquanto o [W] não configurou os secrets (advisory).
-          if [ -z "${HANDOFF_SECRET}" ] || [ -z "${SUBMIT_TOKEN}" ]; then
-            echo "ℹ️  HANDOFF_SECRET/HANDOFF_SUBMIT_TOKEN ainda não configurados — skip-as-pass."
-            echo "    Configure-os (Settings → Secrets) pra ligar o transporte zero-paste (ADR 0283)."
-            exit 0
-          fi
-
           # Diff do push. Primeiro push/force (before=000…) → compara com o pai.
           BASE="${BEFORE_SHA}"
           if [ -z "${BASE}" ] || ! git cat-file -e "${BASE}^{commit}" 2>/dev/null; then
@@ -99,42 +94,6 @@ jobs:
             exit 0
           fi
 
-          fail=0
-          for f in "${FILES[@]}"; do
-            [ -f "$f" ] || continue
-            echo "── $f ──"
-
-            # Assina (HMAC) e monta o envelope JSON-RPC do tools/call handoff-submit.
-            if ! body="$(php bin/sign-handoff.php --file="$f")"; then
-              echo "🔴 falha ao assinar $f"; fail=1; continue
-            fi
-
-            # POST stateless no endpoint MCP (Mcp::web é síncrono — JSON de volta).
-            resp="$(mktemp)"
-            code="$(curl -sS -o "$resp" -w '%{http_code}' -X POST "${MCP_ENDPOINT}" \
-              -H "Authorization: Bearer ${SUBMIT_TOKEN}" \
-              -H 'Content-Type: application/json' \
-              -H 'Accept: application/json, text/event-stream' \
-              --data-binary "$body" || echo "000")"
-
-            # isError no resultado JSON-RPC (tool errou: sig inválida, sem scope…).
-            is_err="$(jq -r '.result.isError // (.error != null)' "$resp" 2>/dev/null || echo "true")"
-
-            if [ "$code" != "200" ] || [ "$is_err" = "true" ]; then
-              echo "🔴 submit falhou (HTTP $code · isError=$is_err):"
-              jq -r '.result.content[0].text // .error.message // .' "$resp" 2>/dev/null || cat "$resp"
-              fail=1
-            else
-              echo "🟢 submetido → pending:"
-              jq -r '.result.content[0].text // empty' "$resp" 2>/dev/null || true
-            fi
-            rm -f "$resp"
-          done
-
-          if [ "$fail" -ne 0 ]; then
-            echo ""
-            echo "❌ Um ou mais handoffs não entraram. Confira HANDOFF_SECRET (tem que bater o do servidor),"
-            echo "   o scope do HANDOFF_SUBMIT_TOKEN (jana.mcp.handoff.submit) e o MCP_ENDPOINT_URL."
-            exit 1
-          fi
-          echo "✅ Todos os handoffs do push viraram pending (sem auto-merge — merge é o 1-clique do [W])."
+          # bin/submit-handoff.sh = fonte única do sign+POST (reusada pelo publisher
+          # cowork-inbox.yml, ADR 0285). Skip-as-pass interno se faltar secret.
+          bash bin/submit-handoff.sh "${FILES[@]}"

--- a/bin/submit-handoff.sh
+++ b/bin/submit-handoff.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Transporte do loop de handoff zero-paste (Fase 0 · ADR 0283/0285) — sign + POST.
+#
+# Fonte ÚNICA do "assina (HMAC via bin/sign-handoff.php) → POST no tool MCP
+# handoff-submit → pending". Reusada por DOIS caminhos de transporte:
+#   1) handoff-sign-submit.yml — commit MANUAL de [W] em prototipo-ui/handoffs/ (o push dispara).
+#   2) cowork-inbox.yml         — PUBLISHER Cowork→repo (PR-7 · ADR 0285): o Cowork dropa em
+#      cowork-inbox/, a Action pousa em prototipo-ui/handoffs/ e chama ISTO inline —
+#      porque o auto-merge feito com GITHUB_TOKEN NÃO dispara o on-push do (1)
+#      (regra do GitHub: eventos do GITHUB_TOKEN não disparam outros workflows).
+#
+# O segredo vive SÓ no servidor/CI (HANDOFF_SECRET) — o Cowork nunca assina
+# (proibição ADR 0283). NÃO faz auto-merge: só cria pending. O merge do CÓDIGO é
+# o 1-clique de [W].
+#
+# Uso:
+#   HANDOFF_SECRET=… SUBMIT_TOKEN=… [MCP_ENDPOINT=…] bash bin/submit-handoff.sh <file.md> [<file.md> …]
+#   bash bin/submit-handoff.sh --self-test     # controle-negativo (sem segredo/rede/php)
+#
+# Degrada pra skip-as-pass (exit 0) enquanto os secrets não existirem (advisory,
+# ADR 0271/0275). Exit: 0 OK/skip/selftest-verde · 1 falha de submit (sig/scope/rede)
+# ou self-test vermelho.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIGNER="${SCRIPT_DIR}/sign-handoff.php"
+MCP_ENDPOINT="${MCP_ENDPOINT:-https://mcp.oimpresso.com/api/mcp}"
+
+# Assina (bin/sign-handoff.php) e submete UM arquivo. Ecoa status. Retorna 0/1.
+submit_one() {
+  local f="$1"
+  if [ ! -f "$f" ]; then
+    echo "ℹ️  $f não existe no working tree — pulado."
+    return 0
+  fi
+  echo "── $f ──"
+
+  local body
+  if ! body="$(php "$SIGNER" --file="$f")"; then
+    echo "🔴 falha ao assinar $f"
+    return 1
+  fi
+
+  # POST stateless no endpoint MCP (Mcp::web é síncrono — JSON de volta).
+  local resp code is_err
+  resp="$(mktemp)"
+  code="$(curl -sS -o "$resp" -w '%{http_code}' -X POST "${MCP_ENDPOINT}" \
+    -H "Authorization: Bearer ${SUBMIT_TOKEN}" \
+    -H 'Content-Type: application/json' \
+    -H 'Accept: application/json, text/event-stream' \
+    --data-binary "$body" || echo "000")"
+
+  # isError no resultado JSON-RPC (tool errou: sig inválida, sem scope…).
+  is_err="$(jq -r '.result.isError // (.error != null)' "$resp" 2>/dev/null || echo "true")"
+
+  if [ "$code" != "200" ] || [ "$is_err" = "true" ]; then
+    echo "🔴 submit falhou (HTTP $code · isError=$is_err):"
+    jq -r '.result.content[0].text // .error.message // .' "$resp" 2>/dev/null || cat "$resp"
+    rm -f "$resp"
+    return 1
+  fi
+  echo "🟢 submetido → pending:"
+  jq -r '.result.content[0].text // empty' "$resp" 2>/dev/null || true
+  rm -f "$resp"
+  return 0
+}
+
+run() {
+  # Skip-as-pass enquanto [W] não configurou os secrets (advisory).
+  if [ -z "${HANDOFF_SECRET:-}" ] || [ -z "${SUBMIT_TOKEN:-}" ]; then
+    echo "ℹ️  HANDOFF_SECRET/SUBMIT_TOKEN ainda não configurados — skip-as-pass."
+    echo "    Configure-os (Settings → Secrets) pra ligar o transporte zero-paste (ADR 0283/0285)."
+    return 0
+  fi
+
+  if [ "$#" -eq 0 ]; then
+    echo "Nenhum handoff pra submeter — nada a fazer."
+    return 0
+  fi
+
+  local fail=0 f
+  for f in "$@"; do
+    submit_one "$f" || fail=1
+  done
+
+  if [ "$fail" -ne 0 ]; then
+    echo ""
+    echo "❌ Um ou mais handoffs não entraram. Confira HANDOFF_SECRET (tem que bater o do servidor),"
+    echo "   o scope do SUBMIT_TOKEN (jana.mcp.handoff.submit) e o MCP_ENDPOINT."
+    return 1
+  fi
+  echo "✅ Handoffs submetidos → pending (sem auto-merge — merge é o 1-clique do [W])."
+  return 0
+}
+
+# Controle-negativo: exercita os 3 guard-rails SEM tocar php/curl/rede.
+self_test() {
+  local fails=() out rc self="${BASH_SOURCE[0]}"
+
+  # 1) sem segredo → skip-as-pass (exit 0), antes de qualquer rede.
+  set +e
+  out="$(HANDOFF_SECRET='' SUBMIT_TOKEN='' bash "$self" dummy.md 2>&1)"; rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] || ! grep -q 'skip-as-pass' <<<"$out"; then
+    fails+=("SKIP-AS-PASS falhou: rc=$rc | $out")
+  fi
+
+  # 2) com segredo fake, sem arquivos → exit 0 "nada a fazer" (sem rede).
+  set +e
+  out="$(HANDOFF_SECRET='x' SUBMIT_TOKEN='y' bash "$self" 2>&1)"; rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] || ! grep -q 'nada a fazer' <<<"$out"; then
+    fails+=("VAZIO falhou: rc=$rc | $out")
+  fi
+
+  # 3) com segredo fake + arquivo inexistente → pulado, exit 0 (sem rede).
+  set +e
+  out="$(HANDOFF_SECRET='x' SUBMIT_TOKEN='y' bash "$self" /nao/existe/foo.md 2>&1)"; rc=$?
+  set -e
+  if [ "$rc" -ne 0 ] || ! grep -q 'não existe no working tree' <<<"$out"; then
+    fails+=("INEXISTENTE falhou: rc=$rc | $out")
+  fi
+
+  if [ "${#fails[@]}" -ne 0 ]; then
+    printf 'submit-handoff SELF-TEST 🔴\n'
+    printf '%s\n' "${fails[@]}"
+    return 1
+  fi
+  echo "submit-handoff SELF-TEST 🟢 (skip-as-pass · vazio · arquivo inexistente — sem rede)"
+  return 0
+}
+
+if [ "${1:-}" = "--self-test" ]; then
+  self_test
+  exit $?
+fi
+
+run "$@"

--- a/cowork-inbox/README.md
+++ b/cowork-inbox/README.md
@@ -56,3 +56,31 @@ Após Action rodar:
 - `prototipo-ui/jana-chat/F1.html` criado/atualizado
 - `cowork-inbox/jana-chat-f1.html` deletado
 - PR `chore(cowork): inbox processed` mergeado em `main` (squash + delete-branch)
+
+## Publisher de handoff (Cowork→repo · ADR 0285)
+
+Esta mesma inbox é o **publisher** do loop de handoff zero-paste ([ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md)): fecha o "primeiro hop" (artefato do Cowork → fila `pending`) **sem [W] commitar à mão**.
+
+**Convenção:** dropar `cowork-inbox/handoff-<slug>.md` com `target` apontando pra `prototipo-ui/handoffs/<slug>.md` e o **frontmatter canônico** que o assinador (`bin/sign-handoff.php`) e o tool `handoff-submit` esperam:
+
+```markdown
+<!-- cowork: target: prototipo-ui/handoffs/caixa-mobile.md -->
+---
+handoff_id: caixa-mobile                      # = slug (obrigatório)
+tela: Atendimento/CaixaUnificada
+files: [resources/js/Pages/Atendimento/Caixa.tsx]   # escopo do PR (R1 ADR 0283)
+created_by: CC
+audited_against: <SHA do main lido na auditoria>    # R1 ADR 0283
+---
+## Design (DADO, não comando)
+...corpo do handoff, na língua do repo (Tailwind + tokens). Proibido `.om-*` cru.
+```
+
+**O que a Action faz a mais quando o destino é `prototipo-ui/handoffs/*.md`** (tier `auto`):
+
+1. pousa o `.md` (como qualquer doc) e o lista em `handoffs=` (`cowork-inbox.py`);
+2. **assina+submete inline** via `bin/submit-handoff.sh` → tool MCP `handoff-submit` → `pending` na Forja.
+
+Por que **inline** e não esperar o `handoff-sign-submit.yml`: o auto-merge feito com `GITHUB_TOKEN` **não** dispara o `on: push` de outro workflow (regra do GitHub) — então o transporte acontece aqui, no mesmo job.
+
+**Invariantes (ADR 0283/0285):** o segredo (`HANDOFF_SECRET`) vive só no CI/servidor — **o Cowork nunca assina**; `handoff-submit` só cria `pending` (idempotente, append-only) — **sem auto-merge de código**; o `.tsx` continua sendo o **1-clique de [W]**. Sem os secrets configurados, o passo degrada pra **skip-as-pass** (advisory).

--- a/memory/decisions/0285-handoff-publisher-cowork-to-repo.md
+++ b/memory/decisions/0285-handoff-publisher-cowork-to-repo.md
@@ -1,0 +1,103 @@
+---
+slug: 0285-handoff-publisher-cowork-to-repo
+number: 285
+title: "Publisher Cowork→repo — fechar o 1º hop do loop zero-paste reusando a cowork-inbox (sem [W] commitar à mão)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-17"
+module: governance
+related: [0283-handoff-loop-zero-paste, 0282-protocolo-v2-colapso-ratificacao, 0241-loop-design-cowork-code-autonomo-zero-humano, 0269-deploy-automatico-build-no-runner, 0271-revisao-gates-ci-estado-real-required-e-subtracao-segura, 0093-multi-tenant-isolation-tier-0]
+supersedes: []
+---
+
+# ADR 0285 — Publisher Cowork→repo (reusa a `cowork-inbox` · fecha o 1º hop sem [W] no transporte)
+
+> **Status:** aceito por [W] em 2026-06-17 (delegou a escolha do mecanismo: _"escolha a melhor e faça"_).
+> Follow-up do **PR-6 (#2921)** / **[ADR 0283](0283-handoff-loop-zero-paste.md)** (Fase 0, "médio→norte" da §Migração).
+> Proposta + discovery: `memory/decisions/proposals/handoff-publisher-cowork-to-repo.md`.
+
+## Contexto
+
+Pós-PR-6 o **transporte** do handoff já é mecânico: um `.md` commitado em `prototipo-ui/handoffs/*.md`
+no push pra `main` → a Action `handoff-sign-submit.yml` assina (HMAC) e chama o tool MCP `handoff-submit`
+→ `pending`. **Mas o "primeiro hop" (artefato do Cowork → o `.md` no repo) ainda exigia [W] commitar
+à mão**, porque "o Cowork é read-only no GitHub e não expõe endpoint estável de pendentes" (cabeçalho da
+própria Action). O chip de follow-up pedia um **publisher Cowork→repo**.
+
+**Discovery (verificado no repo):** o relay já existe. `cowork-inbox/README.md` diz textual: _"Cowork tem
+write GitHub mas não pode aplicar patch no repo: ele cria o arquivo aqui via `github_import_files`, Action
+faz o resto."_ A Action `cowork-inbox.yml` pousa qualquer arquivo dropado em `cowork-inbox/**` no destino
+(whitelist em `cowork-inbox.py:30` já libera `prototipo-ui/` como tier `auto`) e auto-mergeia doc-only.
+Faltava **fiação** — não um relay novo.
+
+**O furo real (verificado):** o auto-merge da `cowork-inbox.yml` é feito com `GITHUB_TOKEN`, e **eventos do
+`GITHUB_TOKEN` não disparam outros workflows** (regra anti-recursão do GitHub). Logo o commit que pousa o
+handoff em `main` **não** dispara o `on: push` do `handoff-sign-submit.yml` — o handoff nunca viraria
+`pending`. (`handoff-sign-submit.yml` não tem `workflow_run`; não há PAT/App de bot no repo — o `grokwr2`
+ainda é bootstrap planejado.)
+
+## Decisão
+
+**Reusar a `cowork-inbox` como publisher** (a "Opção B" do chip — relay autenticado — já materializada),
+fechando a fiação **inline**:
+
+1. **Convenção:** o Cowork dropa `cowork-inbox/handoff-<slug>.md` com `<!-- cowork: target:
+   prototipo-ui/handoffs/<slug>.md -->` + o frontmatter canônico (`handoff_id`/`tela`/`files`/`created_by`/
+   `audited_against`) que o assinador e o `handoff-submit` esperam.
+2. **Detecção:** `cowork-inbox.py` emite `handoffs=<...>` (`$GITHUB_OUTPUT`) com os `.md` pousados em
+   `prototipo-ui/handoffs/`.
+3. **Transporte inline:** a `cowork-inbox.yml` ganha um passo que **assina+submete** esses handoffs ali
+   mesmo (mesmo job, working tree quente) — **não** espera um `on: push` que o `GITHUB_TOKEN` não dispara.
+4. **DRY:** o sign+POST vira `bin/submit-handoff.sh` (fonte única), reusado pela `cowork-inbox.yml` **e**
+   pela `handoff-sign-submit.yml` (que continua servindo o commit MANUAL de [W]). Self-test
+   (controle-negativo, sem rede) roda no job `selftest`.
+
+### Mecanismo: por que inline, e não as outras opções
+- **(a) PAT/App de bot no merge** (faria o push de auto-merge disparar downstream) — **adiada como NORTE**:
+  exige [W] provisionar um secret de bot (`grokwr2`, bootstrap Tier-0 humano). Quando existir, também
+  destrava o zero-humano de `AUTOMACAO-LOOP-AUTONOMO.md §3`. Não bloqueia este PR.
+- **(b) `workflow_run` chaining** — **descartada**: o `cowork-inbox.yml` _completa antes_ do auto-merge
+  acontecer (auto-merge espera os checks), então o `.md` ainda não está no `main` quando o evento
+  dispararia → o signer não acharia o arquivo. Timing fura.
+- **(c) inline (escolhida):** sem secret novo, sem timing, fonte única do transporte, testável.
+
+## Consequências
+- **Positiva:** [W] sai do **transporte** do artefato (não clona/commita/pusha/cola/computa HMAC); o
+  Cowork dropa 1 arquivo e o handoff vira `pending` sozinho. DRY (um `submit-handoff.sh`). 2 caminhos de
+  transporte (commit manual de [W] **e** publisher Cowork) convergem na mesma fila idempotente.
+- **Negativa/limite honesto:** enquanto o Cowork for **sessão interativa**, "zero-toque REAL" não existe —
+  há sempre **um** ato em-Cowork (importar/publicar o arquivo). O publisher mata o transporte manual, não
+  o ato de publicar. É o análogo do "1-clique de merge é o ótimo real" do 0283.
+- **Custo:** a `cowork-inbox.yml` passa a precisar de PHP (setup-php). Trivial.
+
+## Guardrails (invariantes do ADR 0283 PRESERVADOS)
+- **Sem auto-merge de CÓDIGO.** Só auto-mergeia o `.md` inerte (popula `pending`); o `.tsx` segue
+  **1-clique de [W]**. `cowork-inbox.py` já manda `resources/js/**` pra tier **review** (nunca auto-merge).
+- **Segredo nunca no Cowork.** Quem assina é a Action (`HANDOFF_SECRET` no CI/servidor). Sem os secrets →
+  **skip-as-pass** (advisory).
+- **Append-only + idempotente** no `handoff-submit` (`source_hash` no-op; revisão → nova `version`).
+- **Não toca prod.** `deploy.yml` ignora `prototipo-ui/**`/`**.md`/`cowork-inbox/**` (E5 do 0283).
+- **Multi-tenant Tier 0:** infra de governança; zero dado de negócio trafega.
+
+## O que este ADR NÃO faz (continua BLOQUEADO)
+- **Não** reabre o auto-merge de **Camada-4 render-only** do `.tsx` — segue bloqueado até os **5 controles
+  de conteúdo** do ADR 0283 existirem e passarem fixture no `gate-selftest`. O publisher é **upstream e
+  ortogonal**: entrega o handoff na fila; o merge do código é decisão de [W].
+- **Não** promove gate a required nem trata `multi-tenant-gate` como rede pra `.tsx` (E2 = teatro, 0283).
+
+## Responsabilidades
+| Papel | Faz |
+|---|---|
+| **[W]** | (1×) configura `HANDOFF_SECRET`/`HANDOFF_SUBMIT_TOKEN`; (norte) provisiona bot p/ opção (a); clica o merge do código |
+| **[CC]/Cowork** | dropa `cowork-inbox/handoff-<slug>.md` repo-nativo+auditado (R1); nunca assina; nunca `.om-*` cru |
+| **[CL]** | mantém `submit-handoff.sh`/workflows; liga gates; numera ADR sob OK de [W] |
+
+## Histórico
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-06-17 | [CC] | discovery + proposta: relay já existe (`cowork-inbox`); furo real = `GITHUB_TOKEN` não dispara downstream |
+| 2026-06-17 | [W] | **aceito** — delegou o mecanismo ("escolha a melhor e faça"); [CL] implementa inline + `submit-handoff.sh` (PR-7) |

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **289** arquivos · **274** números únicos · máx **0284**
-- **ADRs ATIVOS (lifecycle ativo): 249** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 227 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 249 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **290** arquivos · **275** números únicos · máx **0285**
+- **ADRs ATIVOS (lifecycle ativo): 250** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 228 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 250 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (289)
+## Todas as ADRs (290)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -321,3 +321,4 @@ _(íntegra)_
 | 0282 | aceito | ativo | decision | Protocolo v2 (colapso) — ratificação: 6→2 papéis · 7→3 fases · memória=git SSOT  |
 | 0283 | aceito | ativo | decision | Loop de handoff zero-paste — repo fonte única, gate de conteúdo, sem auto-merge  |
 | 0284 | aceito | ativo | decision | Pipeline de incidente graduado por confiança — porta única, redação cross-tenant |
+| 0285 | aceito | ativo | decision | Publisher Cowork→repo — fechar o 1º hop do loop zero-paste reusando a cowork-inb |

--- a/memory/decisions/proposals/handoff-publisher-cowork-to-repo.md
+++ b/memory/decisions/proposals/handoff-publisher-cowork-to-repo.md
@@ -1,0 +1,87 @@
+---
+title: "Publisher Cowork→repo — fechar o 1º hop do loop zero-paste sem [W] commitar à mão (PR-7)"
+status: decided
+date: "2026-06-17"
+proposal_id: handoff-publisher-cowork-to-repo
+proposed_by: claude-code
+decided_by: wagner
+decided_at: "2026-06-17"
+parent_adr: "0283-handoff-loop-zero-paste"
+resulting_adr: "0285-handoff-publisher-cowork-to-repo"
+related_adrs:
+  - 0283-handoff-loop-zero-paste
+  - 0282-protocolo-v2-colapso-ratificacao
+  - 0241-loop-design-cowork-code-autonomo-zero-humano
+  - 0269-deploy-automatico-build-no-runner
+  - 0271-revisao-gates-ci-estado-real-required-e-subtracao-segura
+origem: "Follow-up do PR-6 (#2921). [W]: 'caramba escolha a melhor e faça termine conclua' → mecanismo delegado a [CC]."
+---
+
+> ✅ **DECIDED 2026-06-17 — aceito por [W]** (delegou o mecanismo: _"escolha a melhor e faça"_).
+> Formalizado em **[ADR 0285](../0285-handoff-publisher-cowork-to-repo.md)** (fonte única da decisão).
+> Este doc fica como registro do **discovery** + alternativas avaliadas.
+
+# Publisher Cowork→repo — discovery + design (PR-7, follow-up do PR-6)
+
+## 0. O gap (o "primeiro hop")
+Pós-PR-6: `.md` em `prototipo-ui/handoffs/*.md` no push → `handoff-sign-submit.yml` assina + POST
+`handoff-submit` → `pending`. **O que faltava:** alguém pôr o artefato do Cowork em
+`prototipo-ui/handoffs/<slug>.md` e commitar. Hoje = [W] à mão.
+
+## 1. Discovery — o que JÁ EXISTE (o achado central)
+**O publisher é WIRING de coisa que já existe, não greenfield.** A premissa "Cowork é read-only no
+GitHub" é parcialmente falsa:
+
+| Peça | Estado | Evidência |
+|---|---|---|
+| Cowork **cria arquivo** (não dá push/patch) | ✅ | `cowork-inbox/README.md` — _"cria via `github_import_files`, Action faz o resto"_ |
+| **Relay** Cowork→repo (a "Opção B" do chip) | ✅ **já existe** | `.github/workflows/cowork-inbox.yml` |
+| Pousar em `prototipo-ui/` (tier auto-merge) | ✅ | `.github/scripts/cowork-inbox.py:27-30` |
+| Assinatura só no servidor (Cowork não vê segredo) | ✅ | `bin/sign-handoff.php` + `HandoffSubmitTool` |
+| `handoff-submit` só cria `pending` (sem auto-merge) | ✅ | `Modules/TeamMcp/Mcp/Tools/HandoffSubmitTool.php` |
+| Pousar `.md` não dispara deploy (E5 do 0283) | ✅ | `deploy.yml` `paths-ignore`: `prototipo-ui/**`, `**.md`, `cowork-inbox/**` |
+
+## 2. O gap REAL de engenharia
+Encadear `cowork-inbox → handoff-sign-submit` **quebra**: o auto-merge da `cowork-inbox.yml` usa
+`GITHUB_TOKEN`, e **eventos do `GITHUB_TOKEN` não disparam outros workflows** → o `on: push` do signer
+não acende. Verificado: signer só tem `push`/`pull_request`/`workflow_dispatch` (sem `workflow_run`); não
+há PAT/App de bot (o `grokwr2` é bootstrap planejado); `prototipo-ui/handoffs/` nunca existiu (loop nunca
+rodou ponta-a-ponta).
+
+## 3. As 3 opções do chip → realidade
+- **A — push via API** ("se/quando o Cowork ganhar git write"): parcial — já dá, sem push (Cowork *cria*).
+- **B — relay autenticado**: ✅ **escolhida** — o relay já é o `cowork-inbox`.
+- **C — polling de manifesto estável**: ❌ — Cowork não expõe endpoint estável (URLs efêmeras ~1h); pull
+  inferior ao push quando A/B funcionam.
+
+## 4. Decisão (mecanismo) — ver ADR 0285
+**Reusar `cowork-inbox` como publisher**, fechando a fiação **inline** (a `cowork-inbox.yml` assina+submete
+o handoff que acabou de pousar, no mesmo job). Alternativas de fiação avaliadas:
+- **(a) PAT/App de bot** → adiada como **norte** (precisa [W] provisionar secret; destrava `grokwr2`).
+- **(b) `workflow_run`** → descartada (timing: o `cowork-inbox.yml` completa **antes** do auto-merge; o
+  `.md` ainda não está no `main`).
+- **(c) inline** → **escolhida** (sem secret novo, sem timing, DRY via `bin/submit-handoff.sh`, testável).
+
+## 5. Entregue no PR-7
+1. `bin/submit-handoff.sh` — fonte única do sign+POST + self-test (controle-negativo, sem rede).
+2. `.github/scripts/cowork-inbox.py` — emite `handoffs=` dos `.md` pousados em `prototipo-ui/handoffs/`.
+3. `.github/workflows/cowork-inbox.yml` — setup-php + passo inline de sign+submit.
+4. `.github/workflows/handoff-sign-submit.yml` — refatorado pra reusar `submit-handoff.sh` (DRY) + self-test.
+5. `cowork-inbox/README.md` — seção "Publisher de handoff (ADR 0285)" com a convenção.
+6. `memory/decisions/0285-handoff-publisher-cowork-to-repo.md`.
+
+## 6. Guardrails 0283 preservados / o que fica BLOQUEADO
+Sem auto-merge de código (só o `.md` inerte); segredo server-side; append-only; não toca prod. **Auto-merge
+Camada-4 render-only do `.tsx` continua bloqueado** até os 5 controles de conteúdo do 0283. O publisher é
+upstream e ortogonal.
+
+## 7. Residual honesto
+Enquanto o Cowork for sessão interativa, há sempre **um** ato de publicar em-Cowork. O publisher mata o
+**transporte manual**, não o clique de publicar. Norte (zero-toque real) = opção (a) + Cowork com gatilho
+autônomo.
+
+## 8. Histórico
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-06-17 | [CC] | discovery + design; achado: relay já existe; furo = `GITHUB_TOKEN` não dispara downstream |
+| 2026-06-17 | [W] | **decided** — "escolha a melhor e faça"; → ADR 0285 + PR-7 |


### PR DESCRIPTION
**Follow-up do PR-6 (#2921)** · formaliza **[ADR 0285](memory/decisions/0285-handoff-publisher-cowork-to-repo.md)** (aceito por [W]: _"escolha a melhor e faça"_).
Base = `feat/handoff-zero-paste-pr6` (stack: depende de `bin/sign-handoff.php` + `handoff-submit` do PR-6).

## O que fecha
O **1º hop** do loop zero-paste: o artefato do Cowork chega em `prototipo-ui/handoffs/*.md` e vira `pending` **sem [W] commitar à mão**.

**Achado do discovery:** o relay já existia — `cowork-inbox` ("Cowork tem write GitHub mas não pode aplicar patch: cria via `github_import_files`, Action faz o resto"). Faltava **fiação**, não um relay novo.

**Furo real:** o auto-merge da `cowork-inbox.yml` usa `GITHUB_TOKEN`, e **eventos do `GITHUB_TOKEN` não disparam outros workflows** → o `on: push` do `handoff-sign-submit.yml` não acende. Por isso o transporte é feito **inline**, no mesmo job.

## Fluxo
```
Cowork → cowork-inbox/handoff-<slug>.md (header target: prototipo-ui/handoffs/<slug>.md)
  → cowork-inbox.yml pousa + auto-mergeia (doc) + assina+submete INLINE (bin/submit-handoff.sh)
  → handoff-submit → pending na Forja
  → [CC]/[CL] pega via handoff-pending → PR do código (.tsx)
  → [W] 1-clique mergeia o CÓDIGO  (inalterado — ADR 0283)
```

## Mudanças
- **`bin/submit-handoff.sh`** (novo) — fonte única do sign+POST, reusada pelos 2 caminhos de transporte; `--self-test` (controle-negativo, sem rede/php).
- **`.github/scripts/cowork-inbox.py`** — emite `handoffs=` dos `.md` pousados em `prototipo-ui/handoffs/`.
- **`.github/workflows/cowork-inbox.yml`** — `setup-php` + passo inline de sign+submit.
- **`.github/workflows/handoff-sign-submit.yml`** — refatora pra reusar `submit-handoff.sh` (DRY) + roda o self-test do transporte.
- **`cowork-inbox/README.md`** — seção "Publisher de handoff (ADR 0285)" + convenção do frontmatter.

## Mecanismo (alternativas avaliadas)
- **(a) PAT/App de bot no merge** → adiada como **norte** (precisa [W] provisionar secret; destrava `grokwr2`).
- **(b) `workflow_run`** → descartada (timing: `cowork-inbox` completa antes do auto-merge; o `.md` ainda não está no `main`).
- **(c) inline** → **escolhida** (sem secret novo, sem timing, DRY, testável).

## Invariantes ADR 0283 preservados
- ✅ Sem auto-merge de **código** — só o `.md` inerte popula `pending`; o `.tsx` segue **1-clique de [W]** (`resources/js/**` já é tier review em `cowork-inbox.py`).
- ✅ Segredo **server-side** (`HANDOFF_SECRET` no CI) — o Cowork nunca assina.
- ✅ Append-only + idempotente (`handoff-submit`). ✅ Não toca prod (`deploy.yml` ignora esses paths).
- 🔒 **Auto-merge Camada-4 render-only do `.tsx` segue BLOQUEADO** até os 5 controles de conteúdo do 0283. Este PR é **upstream e ortogonal**.

## [W] faz UMA VEZ (pra ligar de verdade)
Sem isto, tudo degrada pra **skip-as-pass** (advisory — não quebra CI):
- secret `HANDOFF_SECRET` (= o do `.env` do servidor MCP)
- secret `HANDOFF_SUBMIT_TOKEN` (token MCP scope `jana.mcp.handoff.submit`)
- (opcional) var `MCP_ENDPOINT_URL`

## Residual honesto
Enquanto o Cowork for sessão interativa, há sempre **um** ato de publicar em-Cowork. O publisher mata o **transporte manual** ([W] não clona/commita/pusha/cola/computa HMAC), não o clique de publicar. Norte (zero-toque real) = opção (a) + Cowork com gatilho autônomo.

## Verificação local
- `bash bin/submit-handoff.sh --self-test` 🟢
- `cowork-inbox.py` scratch run: handoff pousa em `prototipo-ui/handoffs/`, emitido em `handoffs=`, doc/código roteados certo, inbox esvaziada 🟢
- `node scripts/governance/adr-index-generate.mjs --check` 🟢 · YAML/py syntax 🟢

> Nota: o loop nunca rodou ponta-a-ponta (`prototipo-ui/handoffs/` é criado no 1º pouso) — o caminho `cowork-inbox.yml` (`on: push main`) não roda em PR, então a validação ponta-a-ponta acontece no 1º handoff real. PR um pouco acima de 300 linhas por incluir ADR+proposta (governança) + o script compartilhado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
