### PR TITLE
feat(teammcp): fia os botões de lever da Forja ao handoff-lever (PR-7b · ADR 0283)

### DIFF
--- a/Modules/TeamMcp/Http/Controllers/ForjaController.php
+++ b/Modules/TeamMcp/Http/Controllers/ForjaController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Jana\Entities\Mcp\McpAuditLog;
 use Modules\Jana\Entities\Mcp\McpCcSession;
 use Modules\Jana\Entities\Mcp\McpMemoryDocument;
 use Modules\Jana\Entities\Mcp\McpProject;
@@ -20,6 +21,7 @@ use Modules\TeamMcp\Services\Forja\ForjaBacklogService;
 use Modules\TeamMcp\Services\Forja\ForjaChangelogService;
 use Modules\TeamMcp\Services\Forja\ForjaMcpService;
 use Modules\TeamMcp\Services\Forja\ForjaQuadroService;
+use Modules\TeamMcp\Services\HandoffLeverService;
 
 /**
  * ForjaController — cockpit do cowork loop (/forja).
@@ -128,6 +130,82 @@ class ForjaController extends Controller
                 'heartbeat' => Inertia::defer(fn () => $svc->heartbeat()),
             ],
         ));
+    }
+
+    /**
+     * POST /forja/handoff/{slug}/lever — opera uma lever do loop de handoff
+     * (re-disparar/devolver/supersede) a partir dos botões da aba MCP da Forja,
+     * que eram `disabled "em breve"` (Fase 2 · ADR 0283).
+     *
+     * MESMA mutação GOVERNADA do tool MCP `handoff-lever` (#2924) — ambos delegam
+     * pra {@see HandoffLeverService} (fonte única, in-place, idempotente por estado
+     * de origem). Aqui o ator é o [W] na sessão web (gate copiloto.mcp.usage.all no
+     * __construct); lá é o agente via scope fino jana.mcp.handoff.lever. SEM
+     * auto-merge. Audit em mcp_audit_log (origem forja-web).
+     *
+     * Delega 100% ao service (sem Eloquent direto aqui) — cowork_handoffs é repo-wide
+     * (Tier 0 ADR 0093/0283), igual mcp()/dossier().
+     */
+    public function handoffLever(Request $request, string $slug): JsonResponse
+    {
+        $action = trim((string) $request->input('action', ''));
+        if (! array_key_exists($action, HandoffLeverService::ORIGINS)) {
+            return response()->json(['error' => 'Ação inválida.'], 422);
+        }
+
+        $versionInput = $request->input('version');
+        $expected = ($versionInput !== null && $versionInput !== '') ? (int) $versionInput : null;
+
+        $result = app(HandoffLeverService::class)->apply($slug, $action, $expected);
+
+        if ($result === null) {
+            // "409": não há versão no estado de origem — lever idempotente.
+            $estados = implode('/', HandoffLeverService::ORIGINS[$action]);
+            $this->auditHandoffLever($request, $slug, 0, $action, null, null);
+
+            return response()->json([
+                'error' => "Este handoff não está em '{$estados}' — a lever '{$action}' não se aplica. Recarregue a fila.",
+            ], 409);
+        }
+
+        $this->auditHandoffLever($request, $slug, $result['version'], $action, $result['from'], $result['to']);
+
+        return response()->json([
+            'ok'          => true,
+            'slug'        => $slug,
+            'version'     => $result['version'],
+            'action'      => $action,
+            'from_status' => $result['from'],
+            'to_status'   => $result['to'],
+        ]);
+    }
+
+    /**
+     * Audit best-effort da lever no mcp_audit_log (origem web/cockpit) — espelha
+     * HandoffLeverTool::audit; não trava a resposta.
+     */
+    private function auditHandoffLever(Request $request, string $slug, int $version, string $action, ?string $from, ?string $to): void
+    {
+        try {
+            $user = $request->user();
+            McpAuditLog::registrar([
+                'user_id'          => $user !== null ? (int) $user->getAuthIdentifier() : 0,
+                'endpoint'         => 'web/forja',
+                'tool_or_resource' => 'handoff-lever',
+                'status'           => $to === null ? 'denied' : 'ok',
+                'payload_summary'  => [
+                    'slug'    => $slug,
+                    'version' => $version,
+                    'action'  => $action,
+                    'from'    => $from,
+                    'to'      => $to,
+                    'note'    => is_string($request->input('note')) ? mb_substr((string) $request->input('note'), 0, 200) : null,
+                    'origin'  => 'forja-web',
+                ],
+            ]);
+        } catch (\Throwable) {
+            // best-effort
+        }
     }
 
     // ---------- Triagem · payload ----------

--- a/Modules/TeamMcp/Http/routes.php
+++ b/Modules/TeamMcp/Http/routes.php
@@ -91,6 +91,13 @@ Route::group(
         Route::get('/mcp',       'ForjaController@mcp')->name('forja.mcp');
         // Saúde foi fundida no Scorecard real (/team-mcp/scorecard) — sem rota própria.
 
+        // PR-7b (ADR 0283 · Fase 2) — levers do loop de handoff (re-disparar/devolver/
+        // supersede) dos botões da aba MCP. Mesma mutação governada do tool MCP
+        // handoff-lever (HandoffLeverService é a fonte única). 3 segmentos → não
+        // colide com /{taskId}/* (2 segmentos).
+        Route::post('/handoff/{slug}/lever', 'ForjaController@handoffLever')
+            ->where('slug', '[A-Za-z0-9_\-]+')->name('forja.handoff.lever');
+
         // Triagem (aba 1) — dossiê do Analista (read-only) + ações [W] aprova.
         // Espelha /project-mgmt/triage/{id}/{dossier,aprovar,rejeitar,fundir} (PR-5a).
         // taskId aceita FORJA-150/identifier ou US-XXX legacy.

--- a/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
+++ b/Modules/TeamMcp/Mcp/Tools/HandoffLeverTool.php
@@ -10,17 +10,17 @@ use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
 use Modules\Jana\Entities\Mcp\McpAuditLog;
 use Modules\Jana\Mcp\Tools\Concerns\AuthorizesMcpMutation;
-use Modules\TeamMcp\Entities\CoworkHandoff;
+use Modules\TeamMcp\Services\HandoffLeverService;
 use Throwable;
 
 /**
  * Tool MCP handoff-lever — PR-7 Loop de Handoff Zero-Paste (Fase 2 · ADR 0283).
  *
- * Liga as 3 levers que o front da Forja só PINTA hoje (`ForjaMcp.tsx` —
- * `disabled "em breve"`): o gerenciamento da fila de design-handoffs sai do
- * "[W] mexe no banco à mão" e passa por uma tool MCP auditada, scopeada e
- * idempotente. NÃO há auto-merge — o merge do PR continua sendo o 1-clique do
- * [W] no GitHub (ADR 0283). As levers só roteiam ESTADO da fila:
+ * Liga as 3 levers que o front da Forja só PINTAVA (`ForjaMcp.tsx`): o gerenciamento
+ * da fila de design-handoffs sai do "[W] mexe no banco à mão" e passa por uma
+ * mutação auditada, scopeada e idempotente. NÃO há auto-merge — o merge do PR
+ * continua sendo o 1-clique do [W] no GitHub (ADR 0283). As levers só roteiam
+ * ESTADO da fila:
  *
  *   - **re-disparar** (handoff `stale` = `pending` velho > 3d): re-arma o handoff
  *     na fila ativa. `status` segue `pending`; só a freshness reseta.
@@ -29,11 +29,11 @@ use Throwable;
  *   - **supersede** (handoff `pending`|`applied`): marca obsoleto — sai da lista
  *     ativa da Forja (que já exclui `superseded`). Append-only: a linha FICA.
  *
- * **Freshness sem coluna nova:** a Forja deriva `stale` de `created_at < now-3d`
- * ({@see \Modules\TeamMcp\Services\Forja\ForjaMcpService::displayStatus}). re-disparar
- * e devolver re-armam tocando `created_at = now()` — ele passa a valer "entrou na
- * fila ativa" (o ingest original sobrevive em `mcp_audit_log` + git). Escolha
- * deliberada pra manter o PR cirúrgico (zero migration, zero toque em ForjaMcpService).
+ * **Fonte única (PR-7b):** a mutação vive em {@see HandoffLeverService} — MESMO
+ * núcleo que o endpoint web do cockpit
+ * ({@see \Modules\TeamMcp\Http\Controllers\ForjaController::handoffLever}) chama
+ * pros botões do front. Nada de duplicar a regra (espelha o par
+ * `handoff:ingest`/`handoff-submit` sobre {@see \Modules\TeamMcp\Services\HandoffIngestService}).
  *
  * Defesas do adversário [AH] (espelha {@see HandoffAckTool}):
  *   - **A7 authz:** mutação — exige scope fino `jana.mcp.handoff.lever`, via
@@ -43,8 +43,8 @@ use Throwable;
  *   - **sem cache:** este handler NÃO cacheia (logo NÃO há `Cache::flush()` que
  *     derrubava o ERP inteiro — A2).
  *
+ * @see Modules\TeamMcp\Services\HandoffLeverService
  * @see Modules\TeamMcp\Mcp\Tools\HandoffAckTool
- * @see Modules\TeamMcp\Services\Forja\ForjaMcpService
  * @see memory/decisions/0283-handoff-loop-zero-paste.md
  */
 class HandoffLeverTool extends Tool
@@ -56,13 +56,6 @@ class HandoffLeverTool extends Tool
     protected string $title = 'Rotear estado de um handoff na fila (re-disparar/devolver/supersede)';
 
     protected string $description = 'Liga as levers da fila de design-handoffs (Fase 2 · ADR 0283), auditadas e idempotentes. re-disparar re-arma um handoff parado (pending velho). devolver reabre um rejected pro [CC] (volta a pending, limpa o ack). supersede marca pending/applied como obsoleto (sai da lista ativa, append-only: a linha fica). SEM auto-merge — o merge segue sendo o 1-clique do [W]. Exige scope jana.mcp.handoff.lever.';
-
-    /** action → status(es) de origem em que a lever morde. */
-    private const ORIGINS = [
-        're-disparar' => ['pending'],
-        'devolver'    => ['rejected'],
-        'supersede'   => ['pending', 'applied'],
-    ];
 
     public function schema(JsonSchema $schema): array
     {
@@ -93,74 +86,37 @@ class HandoffLeverTool extends Tool
         }
 
         $action = (string) $request->get('action', '');
-        if (! array_key_exists($action, self::ORIGINS)) {
+        if (! array_key_exists($action, HandoffLeverService::ORIGINS)) {
             return Response::error("❌ action deve ser 're-disparar', 'devolver' ou 'supersede'.");
         }
 
-        $origins = self::ORIGINS[$action];
-
-        // Acha a versão no status de origem (default: a maior). Idempotência: só
-        // morde no estado-origem certo — lever fora dele é "409".
-        $query = CoworkHandoff::query()->where('slug', $slug)->whereIn('status', $origins);
         $version = $request->get('version');
-        if ($version !== null && $version !== '') {
-            $query->where('version', (int) $version);
-        }
-        $row = $query->orderByDesc('version')->first();
+        $expected = ($version !== null && $version !== '') ? (int) $version : null;
 
-        if ($row === null) {
-            $estados = implode('/', $origins);
+        // Mutação governada — núcleo compartilhado com o endpoint web da Forja.
+        $result = app(HandoffLeverService::class)->apply($slug, $action, $expected);
+
+        if ($result === null) {
+            // "409": não há versão no estado de origem — lever é idempotente.
+            $estados = implode('/', HandoffLeverService::ORIGINS[$action]);
+
             return Response::error(
                 "⚠️ '{$slug}' não tem versão em '{$estados}' pra '{$action}'. As levers são idempotentes: só mordem no estado de origem."
             );
         }
 
-        $from = (string) $row->status;
-        $changes = $this->changesFor($action);
-        $row->update($changes);
-        $to = (string) $changes['status'];
-
-        $this->audit($request, $slug, (int) $row->version, $action, $from, $to, $request->get('note'));
+        $this->audit($request, $slug, $result['version'], $action, $result['from'], $result['to'], $request->get('note'));
 
         $payload = [
             'ok'          => true,
             'slug'        => $slug,
-            'version'     => (int) $row->version,
+            'version'     => $result['version'],
             'action'      => $action,
-            'from_status' => $from,
-            'to_status'   => $to,
+            'from_status' => $result['from'],
+            'to_status'   => $result['to'],
         ];
 
         return Response::text((string) json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
-    }
-
-    /**
-     * O patch de cada lever. re-disparar/devolver re-armam a freshness via
-     * `created_at = now()` (sem coluna nova — ver doc da classe); supersede é
-     * terminal e não mexe na freshness.
-     *
-     * @return array<string,mixed>
-     */
-    private function changesFor(string $action): array
-    {
-        return match ($action) {
-            // Re-arma na fila ativa: status segue pending, freshness reseta.
-            're-disparar' => ['status' => 'pending', 'created_at' => now()],
-            // Reabre pro [CC]: volta a pending fresco e limpa os artefatos do ack.
-            'devolver' => [
-                'status'      => 'pending',
-                'created_at'  => now(),
-                'applied_at'  => null,
-                'applied_by'  => null,
-                'pr_url'      => null,
-                'gate_status' => null,
-            ],
-            // Obsoleto: sai da lista ativa (ForjaMcpService exclui superseded).
-            'supersede' => ['status' => 'superseded'],
-            // Inalcançável: handle() já validou action contra ORIGINS antes de
-            // chamar. Arm exigido pelo PHPStan (match exaustivo).
-            default => throw new \InvalidArgumentException("action inválida: {$action}"),
-        };
     }
 
     private function agentId(): string

--- a/Modules/TeamMcp/Services/HandoffLeverService.php
+++ b/Modules/TeamMcp/Services/HandoffLeverService.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\TeamMcp\Services;
+
+use App\Util\OtelHelper;
+use Modules\TeamMcp\Entities\CoworkHandoff;
+
+/**
+ * HandoffLeverService — PR-7b Loop de Handoff Zero-Paste (Fase 2 · ADR 0283).
+ *
+ * Núcleo COMPARTILHADO das 3 levers do loop (re-disparar/devolver/supersede),
+ * extraído do {@see \Modules\TeamMcp\Mcp\Tools\HandoffLeverTool} (PR-7 #2924) pra
+ * ser a fonte ÚNICA tanto da tool MCP (ator-agente, scope fino) quanto do endpoint
+ * web do cockpit ({@see \Modules\TeamMcp\Http\Controllers\ForjaController::handoffLever},
+ * ator-[W] na Forja) — o browser NÃO é cliente MCP, então as levers do front
+ * roteiam por aqui. Mesmo padrão de {@see HandoffIngestService} (command + tool).
+ *
+ * Semântica IN-PLACE (definida no #2924), idempotente por estado de origem
+ * ({@see self::ORIGINS}):
+ *   - **re-disparar** (pending parado/"stale"): re-arma a freshness — `status`
+ *     segue `pending`, `created_at = now()` (a Forja deriva stale de created_at).
+ *   - **devolver** (rejected): reabre pro [CC] — volta a `pending` fresco e limpa
+ *     os artefatos do ack (pr_url/gate_status/applied_*).
+ *   - **supersede** (pending|applied): marca `superseded` — sai da lista ativa.
+ *     Append-only: a linha FICA (NUNCA delete).
+ *
+ * Sem auto-merge (ADR 0283). Stateless e SEM efeito colateral além de
+ * cowork_handoffs — NÃO audita (quem chama audita, com o ator certo). Observability
+ * (ADR 0155 D9.a): roda dentro de `OtelHelper::span` (zero-cost quando OTel off),
+ * igual {@see \Modules\TeamMcp\Services\Forja\ForjaMcpService}/{@see GitMainResolver}.
+ *
+ * @see Modules\TeamMcp\Mcp\Tools\HandoffLeverTool
+ * @see Modules\TeamMcp\Http\Controllers\ForjaController
+ * @see memory/decisions/0283-handoff-loop-zero-paste.md
+ */
+final class HandoffLeverService
+{
+    /** action → status(es) de origem em que a lever morde (canônico, #2924). */
+    public const ORIGINS = [
+        're-disparar' => ['pending'],
+        'devolver'    => ['rejected'],
+        'supersede'   => ['pending', 'applied'],
+    ];
+
+    /**
+     * Resolve a versão alvo no status de origem da lever e aplica o patch in-place.
+     *
+     * @param  string  $slug  slug do handoff
+     * @param  string  $action  uma de {@see self::ORIGINS}
+     * @param  int|null  $version  versão alvo (default: a maior no status de origem)
+     * @return array{version:int, from:string, to:string}|null  null = action inválida
+     *         OU não há versão no estado de origem (idempotência — não muta)
+     */
+    public function apply(string $slug, string $action, ?int $version = null): ?array
+    {
+        $slug = trim($slug);
+        if ($slug === '' || ! array_key_exists($action, self::ORIGINS)) {
+            return null;
+        }
+
+        return OtelHelper::span('teammcp.handoff.lever', ['handoff.action' => $action], function () use ($slug, $action, $version): ?array {
+            $query = CoworkHandoff::query()
+                ->where('slug', $slug)
+                ->whereIn('status', self::ORIGINS[$action]);
+            if ($version !== null) {
+                $query->where('version', $version);
+            }
+
+            $row = $query->orderByDesc('version')->first();
+            if ($row === null) {
+                return null;
+            }
+
+            $from = (string) $row->status;
+            $changes = $this->changesFor($action);
+            $row->update($changes);
+
+            return ['version' => (int) $row->version, 'from' => $from, 'to' => (string) $changes['status']];
+        });
+    }
+
+    /**
+     * O patch de cada lever (semântica in-place do #2924). re-disparar/devolver
+     * re-armam a freshness via `created_at = now()`; supersede é terminal.
+     *
+     * @return array<string,mixed>
+     */
+    public function changesFor(string $action): array
+    {
+        return match ($action) {
+            // Re-arma na fila ativa: status segue pending, freshness reseta.
+            're-disparar' => ['status' => 'pending', 'created_at' => now()],
+            // Reabre pro [CC]: volta a pending fresco e limpa os artefatos do ack.
+            'devolver' => [
+                'status'      => 'pending',
+                'created_at'  => now(),
+                'applied_at'  => null,
+                'applied_by'  => null,
+                'pr_url'      => null,
+                'gate_status' => null,
+            ],
+            // Obsoleto: sai da lista ativa (ForjaMcpService exclui superseded).
+            'supersede' => ['status' => 'superseded'],
+            // action inválida (apply() já barra antes; defesa em profundidade pro match).
+            default => throw new \InvalidArgumentException("action inválida: {$action}"),
+        };
+    }
+}

--- a/resources/js/Pages/team-mcp/Forja/_components/ForjaMcp.tsx
+++ b/resources/js/Pages/team-mcp/Forja/_components/ForjaMcp.tsx
@@ -4,7 +4,9 @@
 //   1. HANDOFFS (REAL · Fase 1 ADR 0283) — seção do topo: projeta os handoffs de
 //      design (Cowork→Code, F1→F3) de `cowork_handoffs` via props deferidas
 //      (`handoffs`/`heartbeat`). Status/gate/sig REAIS; sem auto-merge (o merge é
-//      o 1-clique do [W]). As levers roteiam pelas tools MCP — Fase 2 (TODO).
+//      o 1-clique do [W]). As levers (re-disparar/devolver/supersede) POSTam em
+//      /forja/handoff/{slug}/lever → HandoffLeverService (mesma mutação governada
+//      do tool MCP handoff-lever, Fase 2 · PR-7b).
 //   2. CONTRATO/TOKENS/AUDITORIA (MOCKADO por design) — vitrine do contrato; o
 //      enforce real é do servidor TeamMcp ([CL]). Default = read + propose;
 //      merge e constituicao.edit NEGADOS no contrato, não por convenção.
@@ -15,7 +17,7 @@
 //
 // Tier 0 (ADR 0081): NUNCA exibir/logar token raw — só o nome lógico do token.
 
-import { Deferred } from '@inertiajs/react';
+import { Deferred, router } from '@inertiajs/react';
 import {
   AlertTriangle,
   ExternalLink,
@@ -32,7 +34,22 @@ import {
   Workflow,
 } from 'lucide-react';
 import { useState } from 'react';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/Components/ui/alert-dialog';
 import { cn } from '@/Lib/utils';
+
+// CSRF do POST das levers (mesmo helper do ForjaDossier).
+function csrf(): string {
+  return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
+}
 
 // --- Contrato de ferramentas (estático, do protótipo aprovado) ----------------
 
@@ -117,7 +134,8 @@ const RESULTADO_TONE: Record<Resultado, string> = {
 // ════════════════════════════════════════════════════════════════════════════
 // Projeção de `cowork_handoffs` (ForjaMcpService). body_md é DESIGN (dado), não
 // comando — aqui só se MOSTRA. SEM botão de merge (Tier 0 / 0283: o merge é o
-// 1-clique do [W] no GitHub). As levers roteiam pelas tools MCP — Fase 2 (TODO).
+// 1-clique do [W] no GitHub). As levers POSTam em /forja/handoff/{slug}/lever →
+// HandoffLeverService (mesma mutação do tool MCP handoff-lever, Fase 2 · PR-7b).
 
 export interface HandoffItem {
   slug: string;
@@ -170,12 +188,46 @@ const HANDOFF_FILTERS: { key: 'todos' | HandoffItem['status']; label: string }[]
   { key: 'stale', label: 'parado' },
 ];
 
-// Lever por status (roteamento via tool MCP auditada — NÃO [W] operando). SEM merge.
-function leverFor(status: HandoffItem['status']): { label: string; Icon: LucideIcon } | null {
-  if (status === 'stale') return { label: 're-disparar', Icon: RefreshCw };
-  if (status === 'rejected') return { label: 'devolver ao [CC]', Icon: Undo2 };
-  if (status === 'pending' || status === 'applied') return { label: 'supersede', Icon: Layers };
+// Lever por status (mutação governada via HandoffLeverService — NÃO [W] operando o
+// banco). SEM merge. `action` = a action que o backend espera (semântica in-place
+// do tool handoff-lever #2924).
+type LeverAction = 're-disparar' | 'devolver' | 'supersede';
+interface Lever {
+  label: string;
+  action: LeverAction;
+  Icon: LucideIcon;
+  destructive: boolean;
+}
+
+function leverFor(status: HandoffItem['status']): Lever | null {
+  if (status === 'stale') return { label: 're-disparar', action: 're-disparar', Icon: RefreshCw, destructive: false };
+  if (status === 'rejected') return { label: 'devolver ao [CC]', action: 'devolver', Icon: Undo2, destructive: false };
+  if (status === 'pending' || status === 'applied') return { label: 'supersede', action: 'supersede', Icon: Layers, destructive: true };
   return null;
+}
+
+// Texto do confirm por lever (semântica in-place · ADR 0283; append-only no supersede).
+function leverConfirm(lever: Lever, h: HandoffItem): { title: string; description: string; confirmLabel: string } {
+  const ref = `${h.slug} v${h.version}`;
+  if (lever.action === 're-disparar') {
+    return {
+      title: `Re-disparar ${ref}?`,
+      description: 'Re-arma o handoff parado: volta pro topo da fila ativa (freshness renovada). O status segue pendente. Sem auto-merge.',
+      confirmLabel: 'Re-disparar',
+    };
+  }
+  if (lever.action === 'devolver') {
+    return {
+      title: `Devolver ${ref} ao [CC]?`,
+      description: 'Reabre o handoff rejeitado pro [CC] retrabalhar: volta a pendente e limpa o ack (PR/gate/aplicado). Sem auto-merge.',
+      confirmLabel: 'Devolver',
+    };
+  }
+  return {
+    title: `Supersede ${ref}?`,
+    description: 'Marca esta versão como obsoleta (substituída) — sai da fila ativa. Append-only: nada é deletado; a substituta chega depois pelo Cowork.',
+    confirmLabel: 'Supersede',
+  };
 }
 
 function HandoffsSkeleton() {
@@ -216,7 +268,15 @@ function HeartbeatLine({ heartbeat }: { heartbeat?: HeartbeatInfo }) {
   );
 }
 
-function HandoffRow({ h }: { h: HandoffItem }) {
+function HandoffRow({
+  h,
+  busy,
+  onLever,
+}: {
+  h: HandoffItem;
+  busy: boolean;
+  onLever: (h: HandoffItem, lever: Lever) => void;
+}) {
   const status = HANDOFF_STATUS[h.status] ?? HANDOFF_STATUS.pending;
   const gate = HANDOFF_GATE[h.gate] ?? HANDOFF_GATE.na;
   const lever = leverFor(h.status);
@@ -293,18 +353,25 @@ function HandoffRow({ h }: { h: HandoffItem }) {
         <span className="tabular-nums">{h.created_at_human ?? '—'}</span>
         <span className="text-muted-foreground/70">por {h.created_by}</span>
 
-        {/* Lever (roteamento via MCP — Fase 2 · ADR 0283). SEM merge. Disabled =
-            surface-only: NÃO simula sucesso até o endpoint existir. */}
+        {/* Lever (mutação governada via HandoffLeverService — Fase 2 · ADR 0283).
+            SEM merge. Pede confirmação antes de operar. */}
         {lever ? (
           <button
             type="button"
-            disabled
+            disabled={busy}
+            onClick={() => onLever(h, lever)}
             data-testid="forja-handoff-lever"
-            title="Roteia via tool MCP — Fase 2 (ADR 0283)"
-            className="ml-auto inline-flex cursor-not-allowed items-center gap-1 rounded-md border border-dashed px-2 py-0.5 text-[11px] font-medium text-muted-foreground opacity-70"
+            data-lever={lever.action}
+            title={`${lever.label} — mutação governada e auditada (ADR 0283), sem auto-merge`}
+            className={cn(
+              'ml-auto inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-medium transition-colors',
+              busy ? 'cursor-not-allowed opacity-50' : 'cursor-pointer',
+              lever.destructive
+                ? 'border-destructive/30 text-destructive-fg hover:bg-destructive-soft'
+                : 'border-border text-foreground hover:bg-muted',
+            )}
           >
             <lever.Icon size={11} /> {lever.label}
-            <span className="opacity-80">· em breve</span>
           </button>
         ) : null}
       </div>
@@ -316,10 +383,42 @@ function HandoffsSection({ handoffs, heartbeat }: { handoffs?: HandoffItem[]; he
   const items = handoffs ?? [];
   const [filter, setFilter] = useState<'todos' | HandoffItem['status']>('todos');
 
+  // Lever em confirmação + estado da mutação (busy/erro). POSTa em
+  // /forja/handoff/{slug}/lever → HandoffLeverService (a MESMA mutação governada
+  // do tool MCP handoff-lever, ADR 0283). Sem auto-merge.
+  const [pending, setPending] = useState<{ h: HandoffItem; lever: Lever } | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function runLever(h: HandoffItem, lever: Lever) {
+    setBusy(true);
+    setError(null);
+    fetch(`/forja/handoff/${encodeURIComponent(h.slug)}/lever`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json', 'X-CSRF-TOKEN': csrf() },
+      body: JSON.stringify({ action: lever.action, version: h.version }),
+    })
+      .then(async (r) => {
+        const d = await r.json().catch(() => ({}));
+        setBusy(false);
+        if (!r.ok) {
+          setError(d?.error ?? `Erro ${r.status}`);
+          return;
+        }
+        // Reflete na hora: recarrega só as props deferidas da seção (sem cache).
+        router.reload({ only: ['handoffs', 'heartbeat'] });
+      })
+      .catch(() => {
+        setBusy(false);
+        setError('Erro de rede.');
+      });
+  }
+
   const countFor = (key: 'todos' | HandoffItem['status']) =>
     key === 'todos' ? items.length : items.filter((h) => h.status === key).length;
 
   const visible = filter === 'todos' ? items : items.filter((h) => h.status === filter);
+  const confirm = pending ? leverConfirm(pending.lever, pending.h) : null;
 
   return (
     <section data-testid="forja-mcp-handoffs" className="inline-flex w-full flex-col gap-3">
@@ -371,13 +470,51 @@ function HandoffsSection({ handoffs, heartbeat }: { handoffs?: HandoffItem[]; he
         <>
           <div className="inline-flex w-full flex-col divide-y overflow-hidden rounded-lg border">
             {visible.map((h) => (
-              <HandoffRow key={`${h.slug}-${h.version}`} h={h} />
+              <HandoffRow
+                key={`${h.slug}-${h.version}`}
+                h={h}
+                busy={busy}
+                onLever={(hh, lever) => setPending({ h: hh, lever })}
+              />
             ))}
           </div>
           {/* Heartbeat de rodapé — leitura "viva" mesmo com a fila cheia. */}
           <HeartbeatLine heartbeat={heartbeat} />
         </>
       )}
+
+      {/* Erro da última lever (recusa do "409"/drift OU rede). */}
+      {error ? (
+        <div
+          data-testid="forja-handoff-lever-error"
+          className="inline-flex w-full items-start gap-2 rounded-md border border-destructive/20 bg-destructive-soft px-3 py-2 text-xs text-destructive-fg"
+        >
+          <AlertTriangle size={13} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      ) : null}
+
+      {/* Confirmação antes de operar (espelha o AlertDialog do ForjaDossier). */}
+      <AlertDialog open={pending !== null} onOpenChange={(o) => { if (!o && !busy) setPending(null); }}>
+        <AlertDialogContent data-testid="forja-handoff-lever-confirm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>{confirm?.title}</AlertDialogTitle>
+            <AlertDialogDescription>{confirm?.description}</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              variant={pending?.lever.destructive ? 'destructive' : 'default'}
+              onClick={() => {
+                if (pending) runLever(pending.h, pending.lever);
+                setPending(null);
+              }}
+            >
+              {confirm?.confirmLabel ?? 'Confirmar'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </section>
   );
 }


### PR DESCRIPTION
Fecha o **Step 3** que o **#2924** deixou aberto. O #2924 entregou o tool MCP `handoff-lever` (scope + test), mas tocou só 5 arquivos — **não tocou o front**. Os botões **re-disparar / devolver / supersede** da aba MCP da Forja seguem `disabled "em breve"`, e o browser não é cliente MCP, então faltava a ponte web. Este PR liga os botões.

## O que entra
- **`HandoffLeverService`** (novo) — extrai a mutação **in-place** do tool #2924 pra ser a **fonte única** do tool MCP **e** do endpoint web. Mesma semântica canônica do #2924:
  - `re-disparar` (pending parado) → re-arma `created_at` (volta pro topo da fila), status segue `pending`.
  - `devolver` (rejected) → volta a `pending` + limpa o ack (`pr_url`/`gate_status`/`applied_*`).
  - `supersede` (pending|applied) → `superseded` (sai da fila ativa; append-only, a linha fica).
  - Idempotente por estado de origem (`ORIGINS`); instrumentado com `OtelHelper::span` (ADR 0155 D9.a — não dilui o module-grade como service novo; mesma lição do `GitMainResolver`).
- **`HandoffLeverTool`** — passa a **delegar** pro service. Comportamento idêntico → o `HandoffLeverToolTest` mergeado (do #2924) **continua verde** (mesmas mensagens, mesmo payload `from_status`/`to_status`, mesmo audit).
- **`ForjaController@handoffLever`** (`POST /forja/handoff/{slug}/lever`) — mesma mutação via o service, gate `copiloto.mcp.usage.all` do cockpit, audit `mcp_audit_log` (origem `forja-web`). Delega 100% ao service (sem Eloquent direto → não trip o `NoMissingTenantScopeRule`).
- **`ForjaMcp.tsx`** — botões **ativos** (eram `disabled`), confirm via `AlertDialog` (espelha `ForjaDossier`), POST com CSRF + `router.reload({ only: ['handoffs','heartbeat'] })`. Copy alinhada à semântica **in-place** do #2924. Sem botão de merge.

## Por que um PR separado (e não no #2924)
O #2924 (paralelo) mergeou enquanto eu trabalhava; meu PR #2923 (que tinha tudo, mas com semântica append-only divergente) fechou sozinho quando a branch do PR-6 foi deletada. Este PR re-baseia no `main` atual e entrega **só** o delta que faltava (o front + a ponte web), reusando o tool do #2924 como canônico.

## Tier 0 / ADR 0283
`cowork_handoffs` é repo-wide (sem `business_id`). **Sem auto-merge** — o merge do PR de design segue o 1-clique do [W] (ADR 0283).

## Cobertura / verificação
Sem PHP/`vendor`/DB local (backend no CT 100/Hostinger). O `HandoffLeverToolTest` mergeado exercita o `HandoffLeverService` através do tool delegante (extração behavior-preserving); a lane **sqlite-pest** valida no CI. Smoke visual da aba é pós-merge (`tela-smoke-pos-merge`) por [W]. **Não auto-mergear.**

Refs: ADR-0283 Fase 2 PR-7b · complementa #2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)