### PR TITLE
fix(sells): exibe desconto da venda no drawer (Resumo de valores)

### DIFF
--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -97,6 +97,8 @@ interface SaleDetail {
   total_paid: number;
   tax_amount: number;
   discount_amount: number;
+  /** 'fixed' = R$ direto · 'percentage' = % sobre o subtotal. Espelha Create/Edit.tsx. */
+  discount_type: 'fixed' | 'percentage' | null;
   shipping_charges: number;
   payment_status: string;
   shipping_status: string | null;
@@ -142,6 +144,9 @@ function getCsrfToken(): string {
 
 const formatBRL = (value: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+const formatPercent = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { maximumFractionDigits: 2 }).format(value) + '%';
 
 const formatDate = (iso: string) => {
   const d = new Date(iso);
@@ -287,6 +292,19 @@ export default function SaleSheet({
   };
 
   const saldoDevedor = data ? data.final_total - data.total_paid : 0;
+
+  // Resumo de valores — espelha a fórmula canônica de Sells/Create.tsx:
+  //   subtotalProdutos = Σ (qty × unit_price − desconto_linha)  [já vem pronto em l.subtotal]
+  //   descontoVenda    = type==='percentage' ? subtotal×amount/100 : amount  ('fixed')
+  // Display-only: o Total exibido é sempre o final_total autoritativo do backend (nunca recalculado).
+  const subtotalProdutos = data
+    ? data.lines.reduce((sum, l) => sum + l.subtotal, 0)
+    : 0;
+  const descontoVenda = data
+    ? data.discount_type === 'percentage'
+      ? (subtotalProdutos * data.discount_amount) / 100
+      : data.discount_amount
+    : 0;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -471,6 +489,51 @@ export default function SaleSheet({
                   </div>
                 )}
               </Section>
+
+              {/* Resumo de valores — subtotal · desconto · frete · impostos · total.
+                  Desconto da venda (discount_amount) antes só aparecia no Editar — agora visível
+                  no drawer. Frete/Impostos só viram linha quando > 0. Total = final_total do backend. */}
+              {data.lines.length > 0 && (
+                <Section title="Resumo de valores" icon={Receipt}>
+                  <div className="rounded-md border border-border divide-y divide-border text-sm">
+                    <div className="flex items-center justify-between px-3 py-2">
+                      <span className="text-muted-foreground">Subtotal</span>
+                      <span className="tabular-nums text-foreground">{formatBRL(subtotalProdutos)}</span>
+                    </div>
+                    {descontoVenda > 0 && (
+                      <div className="flex items-center justify-between px-3 py-2">
+                        <span className="text-muted-foreground">
+                          Desconto
+                          {data.discount_type === 'percentage' && data.discount_amount > 0 && (
+                            <span className="ml-1 text-xs text-muted-foreground">
+                              ({formatPercent(data.discount_amount)})
+                            </span>
+                          )}
+                        </span>
+                        <span className="tabular-nums text-success">− {formatBRL(descontoVenda)}</span>
+                      </div>
+                    )}
+                    {data.shipping_charges > 0 && (
+                      <div className="flex items-center justify-between px-3 py-2">
+                        <span className="text-muted-foreground">Frete</span>
+                        <span className="tabular-nums text-foreground">+ {formatBRL(data.shipping_charges)}</span>
+                      </div>
+                    )}
+                    {data.tax_amount > 0 && (
+                      <div className="flex items-center justify-between px-3 py-2">
+                        <span className="text-muted-foreground">Impostos</span>
+                        <span className="tabular-nums text-foreground">+ {formatBRL(data.tax_amount)}</span>
+                      </div>
+                    )}
+                    <div className="flex items-center justify-between px-3 py-2.5 bg-muted/30">
+                      <span className="font-medium text-foreground">Total</span>
+                      <span className="tabular-nums font-semibold text-foreground text-base">
+                        {formatBRL(data.final_total)}
+                      </span>
+                    </div>
+                  </div>
+                </Section>
+              )}
 
               {/* Histórico de pagamentos + ação rápida */}
               <section>


### PR DESCRIPTION
## Problema

No drawer **SaleSheet** (Vendas → clicar numa venda), o desconto de venda **não aparecia**. O operador via os subtotais dos produtos e o KPI "Valor", mas não entendia a diferença entre a soma dos produtos e o total — o desconto ficava invisível (só aparecia ao entrar em **Editar**).

Reportado por Wagner numa venda da ROTA LIVRE (biz=4): produtos somavam mais que o total, e o desconto fixo de venda não era exibido em lugar nenhum do drawer.

## Causa

O backend (`SellController@sheetData`) **já enviava** `discount_amount`, `discount_type`, `tax_amount`, `shipping_charges` e o `subtotal` por linha — mas o `SaleSheet.tsx` nunca renderizava esses campos. Não havia seção de totais. (O `Show.tsx` também não exibe o desconto de venda.)

## Solução (1 arquivo · +63 linhas · puramente aditivo)

`resources/js/Pages/Sells/_components/SaleSheet.tsx`:

- Bloco **"Resumo de valores"** abaixo de Produtos: **Subtotal · Desconto · Frete · Impostos · Total**.
- Frete e Impostos só viram linha quando `> 0`.
- `discount_type` declarado na interface `SaleDetail` (backend já enviava).
- `descontoVenda` **espelha a fórmula canônica** de `Sells/Create.tsx`: `type==='percentage' ? subtotal×amount/100 : amount`. Quando percentual, anexa o `%` ao label.
- **Display-only:** o Total exibido é o `final_total` autoritativo do backend — nada é recalculado nem gravado.

## Tier 0 — cálculo de valor (proibicoes.md §REGRA MESTRE)

- **Dupla conferência** (2 caminhos independentes): caminho 1 = fórmula de entrada (`subtotal − desconto + frete + impostos`); caminho 2 = resíduo (`Σ subtotal − final_total`). Os dois caminhos batem no mesmo desconto.
- **Sem escrita no banco** — mudança puramente de exibição. Nenhum `final_total`/`discount_amount`/pagamento é tocado.
- **Impacto antes→depois** apresentado ao Wagner (mockup visual aprovado) antes do merge.

## Verificação

- [ ] CI build verde (Vite/TS)
- [ ] Smoke Chrome MCP em prod pós-merge: abrir drawer da venda e conferir Subtotal/Desconto/Total reconciliando

<!-- no-ui-smoke: smoke Chrome MCP será feito pós-merge em prod (drawer só renderiza com dado real) -->