### PR TITLE
fix(jana): McpAuthMiddleware seta user no auth manager — destrava mutações MCP (PR-7c · ADR 0283/0081)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -39,6 +39,9 @@ tests/Feature/Form
 tests/Feature/Services/FeatureFlagServiceTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/FsmTransitionGuardTest.php
 Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
+# PR-7c — guard do fix de auth-manager resolver no McpAuthMiddleware (ADR 0283/0081).
+# Source-ratchet (sem DB) → sqlite-safe.
+Modules/Jana/Tests/Feature/Mcp/McpAuthUserResolverTest.php
 Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
 tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/ClaimlessMutationWarningTest.php

--- a/Modules/Jana/Http/Middleware/McpAuthMiddleware.php
+++ b/Modules/Jana/Http/Middleware/McpAuthMiddleware.php
@@ -92,6 +92,15 @@ class McpAuthMiddleware
         $request->attributes->set('mcp_user', $user);
         $request->setUserResolver(fn () => $user);
 
+        // PR-7c FIX (ADR 0283/0081): laravel/mcp `Request::user()` resolve via o auth
+        // MANAGER (`auth()->userResolver()` → guard()->user()), NÃO via o resolver do
+        // request HTTP acima. Sem isto, `$request->user()` dentro das Tools é null e
+        // TODA mutação scopeada (handoff-ack/submit/lever, tasks-claim, lgpd-esquecer)
+        // cai em "autenticação ausente" no HTTP real — bug mascarado pelos testes, que
+        // stubam justamente o manager (`app('auth')->resolveUsersUsing`). setUser é
+        // guard-scoped (Octane faz flush entre requests) — sem vazamento cross-request.
+        app('auth')->setUser($user);
+
         // Continua a request
         $response = $next($request);
 

--- a/Modules/Jana/Tests/Feature/Mcp/McpAuthUserResolverTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/McpAuthUserResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-7c GUARD (ADR 0283/0081) — o McpAuthMiddleware TEM que setar o user no auth
+ * MANAGER, não só no resolver do request HTTP.
+ *
+ * Por quê: laravel/mcp `Laravel\Mcp\Request::user()` resolve via
+ * `Container::make('auth')->userResolver()` (→ guard()->user()), NÃO via o
+ * `$request->setUserResolver()` do request HTTP. Sem `app('auth')->setUser($user)`,
+ * `$request->user()` dentro das Tools é null e TODA mutação scopeada
+ * (handoff-ack/submit/lever, tasks-claim, lgpd-esquecer) cai em "autenticação
+ * ausente" no HTTP real.
+ *
+ * Bug PROVADO em prod 2026-06-17 (cert e2e contra o MCP vivo): ANTES do fix
+ * HTTP 200 + "⛔ ...autenticação ausente"; DEPOIS HTTP 200 + pending criado.
+ *
+ * Os testes das tools stubam `app('auth')->resolveUsersUsing` (o manager), então
+ * NUNCA exerceram o caminho real do middleware → o bug ficou invisível ("a suite
+ * mente"). Este guard tokeniza a fonte (descarta comentários/docblocks, pra não
+ * casar com a prosa) e exige que o handle() sete o manager. Ratchet anti-remoção —
+ * espelha o guard A2 (Cache::flush) de HandoffToolsTest.
+ *
+ * @see Modules/Jana/Http/Middleware/McpAuthMiddleware.php
+ */
+it('McpAuthMiddleware seta o user no auth MANAGER (setUser), não só no request resolver', function () {
+    $src = file_get_contents(dirname(__DIR__, 3) . '/Http/Middleware/McpAuthMiddleware.php');
+
+    // Tokeniza e descarta comentários/docblocks — o guard mira o CÓDIGO, não a prosa.
+    $codeOnly = '';
+    foreach (token_get_all($src) as $t) {
+        if (is_array($t)) {
+            if ($t[0] === T_COMMENT || $t[0] === T_DOC_COMMENT) {
+                continue;
+            }
+            $codeOnly .= $t[1];
+        } else {
+            $codeOnly .= $t;
+        }
+    }
+    $codeOnly = preg_replace('/\s+/', '', (string) $codeOnly);
+
+    // Os dois resolvers têm que coexistir: o do request (helpers HTTP/controllers)
+    // E o do auth manager (que laravel/mcp Request::user() — e as Tools — leem).
+    expect($codeOnly)->toContain('setUserResolver');
+    expect($codeOnly)->toContain('->setUser($user)');
+});


### PR DESCRIPTION
## O bug (Tier-0, mascarado por teste)
`McpAuthMiddleware` autenticava o token e fazia só **`$request->setUserResolver()`** (resolver do request HTTP). Mas o pacote `laravel/mcp` resolve o usuário das Tools via o **auth MANAGER**:

```php
// vendor/laravel/mcp/src/Request.php
public function user(...) { return call_user_func(Container::make('auth')->userResolver(), $guard); }
```

Como o middleware nunca setava o manager, no **HTTP real** `$request->user()` dentro das Tools era `null` → **toda mutação scopeada** (`handoff-ack`/`submit`/`lever`, `tasks-claim`, `lgpd-esquecer`) caía em `⛔ ...autenticação ausente` via `AuthorizesMcpMutation`.

Os testes das tools stubam `app('auth')->resolveUsersUsing` (o manager) — exatamente o que faltava no prod — então **nunca exerceram o caminho real do middleware**. Bug invisível: *"a suite mente"*.

## O fix
```php
$request->setUserResolver(fn () => $user);   // já existia (helpers HTTP/controllers)
app('auth')->setUser($user);                 // FIX: o manager (o que laravel/mcp lê)
```
`setUser` é **guard-scoped** (Octane faz flush entre requests) — sem vazamento cross-request.

## Provado e2e contra o MCP vivo (2026-06-17)
Cert via `Http::withToken(...)->post('/api/mcp', tools/call handoff-submit)`:
- **ANTES** do fix: `HTTP 200` + `"⛔ ...autenticação ausente"`.
- **DEPOIS** do fix: `HTTP 200` + `{"ok":true,"outcome":"created"}` (pending criado).

Esse era o *"verde mas morto"* real do loop zero-paste — somado a 2 itens de config que também corrigi no CT 100 (fora deste PR): `McpScopesSeeder` não tinha rodado pós-#2924 (scopes `jana.mcp.handoff.*` inexistentes) e `HANDOFF_SECRET` do servidor estava vazio. Ambos ajustados; `HANDOFF_SECRET` (server↔repo) e `HANDOFF_SUBMIT_TOKEN` agora setados e casados.

## Live vs durável
Já apliquei o **hotfix no CT 100** (bind-mount `/opt/oimpresso-mcp/code` + `docker restart`) pra destravar agora. **Este PR torna durável no `main`** — senão o próximo `git pull` de deploy reverte o hotfix.

## Teste
`McpAuthUserResolverTest` (source-ratchet, sqlite-safe) na lane: exige que `handle()` sete o auth manager (`->setUser($user)`) além do request resolver — ratchet anti-remoção (a prova comportamental é o cert e2e acima). Espelha o guard A2 (`Cache::flush`) de `HandoffToolsTest`.

Refs: ADR-0283 Fase 2 PR-7c

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Infra Contract

**Runtime:** `McpAuthMiddleware` passa a setar o auth manager (`app('auth')->setUser($user)`) em cada request autenticado de `/api/mcp`. Guard-scoped; Octane faz flush entre requests (sem vazamento cross-request). Sem migração, sem schema, sem nova dependência.

**Validação prod (CT 100 · container `oimpresso-mcp` · 2026-06-17):** hotfix no bind-mount `/opt/oimpresso-mcp/code` + `docker restart`; cert e2e contra o MCP vivo (`POST /api/mcp` → `tools/call` `handoff-submit`, token user-5 + body assinado):

```
ANTES:  POST /api/mcp  ->  < HTTP/1.1 200  ->  {"isError":true, "text":"⛔ ...autenticacao ausente"}
DEPOIS: POST /api/mcp  ->  < HTTP/1.1 200  ->  {"ok":true,"slug":"test-loop-vivo","outcome":"created"}  (pending criado)
```

**Rollback:** `git revert` deste commit + `git pull` em `/opt/oimpresso-mcp/code` + `docker restart oimpresso-mcp` — 1 linha, reversível, sem efeito em schema/dados.
