### PR TITLE
docs(loop): reconciliar playbook merge com enforce_admins:true (ADR 0271)

### DIFF
--- a/prototipo-ui/AUTOMACAO-LOOP-AUTONOMO.md
+++ b/prototipo-ui/AUTOMACAO-LOOP-AUTONOMO.md
@@ -4,6 +4,13 @@
 > **Tipo:** doc VIVO. Cada Onda apêndice no §5 (custo-benefício). Evolui até zero intervenção.
 > **Princípio:** o humano sai do **loop**, não da **supervisão** — transparência (Constituição v2 §7) + reversível (revert) + gate automático no lugar do gate humano. Nunca bypassa segurança (Tier 0 fica humano).
 
+> **⚠️ Atualização de enforcement (2026-06-17 — reconciliação de drift).** O estado da branch protection da `main` mudou desde a redação original. Desde **2026-06-11 ([ADR 0271](../memory/decisions/0271-revisao-gates-ci-estado-real-required-e-subtracao-segura.md))** a `main` roda **`enforce_admins:true`** + `required_approving_review_count:0` + `strict:false` + **18 required checks** (verificado via `gh api .../branches/main/protection` em 2026-06-17). Três consequências pra este playbook:
+> 1. **`gh pr merge --admin` está MORTO** — com `enforce_admins:true` o admin não bypassa mais a proteção.
+> 2. **Hoje o merge é `gh pr merge --squash` NORMAL** — `reviews:0` + os 18 checks verdes já fecham o PR (sem `--admin`, sem aprovação humana).
+> 3. O alvo **zero-humano** segue sendo o bot `grokwr2`, agora **bloqueado por [ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md)** ("sem auto-merge até a rede existir") + token ainda não provisionado.
+>
+> A [ADR 0241](../memory/decisions/0241-loop-design-cowork-code-autonomo-zero-humano.md) §4 (linha ~82) descreve o mecanismo `--admin`/`enforce_admins:false` — isso reflete o estado **pré-0271** (2026-05-31). É canon append-only: não se edita; o estado vivo está aqui (§3 atualizado abaixo).
+
 ## 1. O loop (1 módulo = 1 ciclo)
 
 | # | Passo | Quem | Custo | Gate |
@@ -14,7 +21,7 @@
 | 4 | `lint:baseline:write` + `:check` (delta ≤ 0) | [CL] | baixo | baseline cai |
 | 5 | commit + push + `gh pr create` | [CL] | trivial | — |
 | 6 | **CI (gate automático — §2)** | GitHub Actions | ~3-4 min | **substitui o humano** |
-| 7 | merge se CI verde (§3) | [CL] | trivial | branch protection |
+| 7 | merge se CI verde — `gh pr merge --squash` (§3) | [CL] | trivial | branch protection (reviews=0 + 18 checks) |
 | 8 | sync placar (`ds:report --write` + SYNC_LOG + HANDOFF) | [CL] | baixo | — |
 | 9 | próximo módulo da fila | [CL] | — | — |
 
@@ -34,29 +41,41 @@ A suite CI já cobre o que o humano fazia — **incluindo o gate visual [W2]**:
 
 **Regra de decisão:** *todos os checks required verdes → merge.* Vermelho → [CL] corrige (causa clara) **ou** escala (ambíguo / Tier 0).
 
-## 3. Merge — o único ponto que ainda toca "humano" (e como tirá-lo)
+## 3. Merge — estado atual da branch protection (pós-ADR 0271)
 
-Branch protection `main`: **1 approving review** + `strict` (up-to-date) + `enforce_admins:false`. GitHub **proíbe self-approve** → o autor (`wagnerra23`) não aprova o próprio PR. Esse é o ÚNICO bloqueio real ao zero-humano.
+**Branch protection `main` hoje** (verificado via `gh api repos/wagnerra23/oimpresso.com/branches/main/protection` em 2026-06-17; ligado por [ADR 0271](../memory/decisions/0271-revisao-gates-ci-estado-real-required-e-subtracao-segura.md) em 2026-06-11):
+
+- **`enforce_admins: true`** — admin **não** bypassa mais a proteção
+- **`required_approving_review_count: 0`** — nenhuma aprovação exigida (`require_code_owner_reviews:true` está setado, mas é **no-op**: não há `CODEOWNERS` atribuindo donos a path algum)
+- `required_status_checks.strict: false` — não exige rebase/up-to-date pra mergear
+- `required_linear_history: true` · `allow_force_pushes: false` · `allow_deletions: false`
+- **18 required checks** — todos verdes ⇒ merge liberado
+
+**Consequência direta:** como `reviews:0` e os 18 checks ficam verdes, um **`gh pr merge <n> --squash` NORMAL fecha o PR** — sem aprovação humana e sem `--admin`. O squash respeita `required_linear_history`. Não existe mais bloqueio de self-approve (não há review a dar).
 
 | Mecanismo | Custo | Auditoria | Status |
 |---|---|---|---|
-| Wagner aprova+mergeia manual | alto (humano no loop) | ✅ | era o padrão |
-| `gh --admin` (wagnerra23 é admin) | trivial | atribuído a conta real, **sem registro de review** | **interim (Wagner autorizou 2026-05-31)** |
-| Chrome dirige GitHub UI como Wagner | alto (pixels) + cria approve "do Wagner" que foi do Claude | ⚠️ registro enganoso | **descartado** |
-| 🎯 Bot `grokwr2` auto-approve+merge (Action) | ~zero/ciclo | ✅ approve real de conta ≠ autor | **alvo da evolução** |
+| Wagner aprova+mergeia manual | alto (humano no loop) | ✅ | não é mais necessário (`reviews:0`) |
+| `gh pr merge --squash` normal (checks verdes) | trivial | ✅ conta real; gate = CI | **ATUAL (`reviews:0` + 18 checks)** |
+| `gh pr merge --admin` | — | — | **❌ MORTO pós-0271** — `enforce_admins:true` não deixa o admin bypassar |
+| Chrome dirige GitHub UI como Wagner | alto (pixels) + approve "do Wagner" que foi do Claude | ⚠️ registro enganoso | **descartado** |
+| 🎯 Bot `grokwr2` auto-approve+merge (Action) | ~zero/ciclo | ✅ approve real de conta ≠ autor | **alvo zero-humano — BLOQUEADO** ([ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md)) |
 
-**Decisão atual (custo-benefício):** `gh --admin` — mais barato + atribuição honesta + CI verde é o gate. **NÃO** Chrome (caro + registro falso de approve de Wagner).
+**Decisão atual (custo-benefício):** `gh pr merge --squash` normal — mais barato, atribuição honesta, CI verde é o gate. `--admin` é ao mesmo tempo **desnecessário** (não há review a bypassar) e **inoperante** (`enforce_admins:true`).
 
-**🔑 Único bootstrap humano p/ zero intervenção:** Wagner provisiona o token do `grokwr2` (collaborator com push, conta ≠ autor) como secret → uma Action aprova+mergeia quando todos os checks passam. Aí o `--admin` sai e fica auditável **sem humano**.
+**🔑 Alvo zero-humano (ainda pendente — 2 bloqueios):** o merge *totalmente* autônomo (sem [CL] disparando o `gh pr merge`) segue dependendo do bot `grokwr2` (collaborator ≠ autor) aprovar+mergear via Action:
+1. **Bootstrap do token** `grokwr2` como secret — pendente com Wagner (1×).
+2. **[ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md) (aceita 2026-06-17): auto-merge fica BLOQUEADO** até os 5 controles de gate de **conteúdo** existirem e passarem fixture no `gate-selftest`. Pra `.tsx` num ERP multi-tenant, humano-no-merge é **estrutural** (Fase 0 = 1-clique de Wagner é o ótimo atual). A rede de gates precisa existir antes de reabrir o auto-merge — é o "sem auto-merge até a rede existir".
 
 ## 4. Lista ENCOLHENDO de intervenção humana
 
-- ❌ ~~Wagner mergeia cada PR~~ → automático (`--admin` agora / bot depois)
+- ❌ ~~Wagner aprova cada PR~~ → `required_reviews:0` ([ADR 0271](../memory/decisions/0271-revisao-gates-ci-estado-real-required-e-subtracao-segura.md)) — aprovação não é mais exigida
+- 🟡 **Merge:** hoje **[CL] roda `gh pr merge --squash`** (checks verdes). ~~`--admin`~~ está morto (`enforce_admins:true`). Merge **totalmente** sem [CL] ainda pendente (bot `grokwr2`, ver §3)
 - ❌ ~~Wagner aprova screenshot [W2]~~ → PR UI Judge + visual-regression
 - ❌ ~~Wagner responde Tipo 1 vs Tipo 2~~ → regra documentada (PR-C-WORKLIST §EMENDA)
 - ❌ ~~Wagner roda o sync do placar~~ → `ds:report --write` automático
-- ⏳ Bootstrap único restante: token `grokwr2` (1×)
-- ✅ FICA humano (Tier 0): ADR novo · mudança multi-tenant · segredos/Vaultwarden · lógica de lint/tooling · decisão de produto
+- ⏳ Bootstrap restante: token `grokwr2` (1×) **+** os 5 controles de conteúdo da [ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md) antes de reabrir auto-merge
+- ✅ FICA humano (Tier 0): ADR novo · mudança multi-tenant · segredos/Vaultwarden · lógica de lint/tooling · decisão de produto · **merge de `.tsx`** (humano-no-merge estrutural — [ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md))
 
 ## 5. Custo-benefício — log (apêndice por Onda)
 
@@ -75,8 +94,8 @@ Branch protection `main`: **1 approving review** + `strict` (up-to-date) + `enfo
 **Bottleneck humano eliminado nesta Onda:** merge + sync + handoff + dúvidas de classificação.
 
 ## 6. Próximos passos (evolução)
-1. **[bootstrap Wagner]** token `grokwr2` → mata o `--admin`.
-2. **[CL]** `.github/workflows/ds-automerge.yml` (label `ds-auto` + todos checks green → `grokwr2` approve + squash merge).
+1. **[bootstrap Wagner]** token `grokwr2` (1×) → habilita o bot auto-approve+merge. (O `--admin` já está morto via `enforce_admins:true`; o token agora **habilita o bot**, não substitui o `--admin`.) **Gated por [ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md)** — auto-merge só reabre depois dos 5 controles de conteúdo.
+2. **[CL]** `.github/workflows/ds-automerge.yml` (label `ds-auto` + todos checks green → `grokwr2` approve + squash merge) — **não criar até** os 5 controles da [ADR 0283](../memory/decisions/0283-handoff-loop-zero-paste.md) passarem `gate-selftest`.
 3. **[CL]** auto-advance: ao fechar o sync, disparar o próximo módulo da fila sem novo pedido.
 4. **[decisão Wagner]** excluir `Components/ui` + `_Showcase` do ui:lint R1 (evita baseline-absorb futuro).
 5. **[CL]** `ds:report` ciente de fase (Fase A done vs Tipo-2/Fase D pendente).


### PR DESCRIPTION
## Por quê

O playbook do loop autônomo (`prototipo-ui/AUTOMACAO-LOOP-AUTONOMO.md`) estava **defasado** quanto à branch protection real da `main`. Documentava `enforce_admins:false` + merge via `gh pr merge --admin`. Esse caminho **morreu** quando a ADR 0271 (2026-06-11) ligou `enforce_admins:true` — com admin enforcement, `--admin` não bypassa mais a proteção.

## Estado real (verificado via `gh api repos/wagnerra23/oimpresso.com/branches/main/protection` em 2026-06-17)

- `enforce_admins: true`
- `required_approving_review_count: 0` (`require_code_owner_reviews:true` mas **no-op** — não há `CODEOWNERS`)
- `required_status_checks.strict: false`
- `required_linear_history: true` · `allow_force_pushes: false` · `allow_deletions: false`
- **18 required checks**

**Realidade:** como `reviews:0` e os 18 checks ficam verdes, um **`gh pr merge <n> --squash` NORMAL** já fecha o PR — sem `--admin`, sem aprovação humana.

## O que muda (docs-only, dentro de `prototipo-ui/`)

- **§3** reescrito: tabela de mecanismos com `--admin` marcado **❌ MORTO pós-0271**; merge atual = `--squash` normal.
- **§4 / §1 (row 7) / §6**: refletem o novo enforcement.
- **Pointer no topo**: estado vivo fica no doc; **ADR 0241 §4 (linha ~82)** descreve o mecanismo `--admin`/`enforce_admins:false` **pré-0271** (canon append-only — **não editado**).
- Alvo zero-humano (bot `grokwr2`) segue **BLOQUEADO por ADR 0283** ("sem auto-merge até a rede de gates de conteúdo existir") + token ainda não provisionado.

## Fora de escopo (não tocado)

- ❌ `.github/workflows/` · branch protection real
- ❌ ADR 0241 / ADR 0271 (canon append-only)

## Follow-up sugerido (decisão de Wagner)

Como a ADR 0241 §82 ficou canon-stale (afirma `enforce_admins:false` sobre o repo vivo), pode merecer uma **emenda-ADR** em `memory/decisions/proposals/` com `supersedes_partially: [0241]` reconciliando 0271 (enforcement) + 0283 (auto-merge block). **Não incluído aqui** pra manter 1 PR = 1 intent (`commit-discipline`). Posso abrir se quiser.

**Sem auto-merge — Wagner revisa.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)