### PR TITLE
docs(handoff): land Fase 2 error-dedup design handoff (Cowork→git SSOT)

### DIFF
--- a/prototipo-ui/handoffs/erros-dedup.md
+++ b/prototipo-ui/handoffs/erros-dedup.md
@@ -1,0 +1,34 @@
+<!-- cowork: target: prototipo-ui/handoffs/erros-dedup.md -->
+---
+handoff_id: erros-dedup
+tela: Plataforma/ErrorHandling
+files: [app/Support/Errors/ErrorGrouper.php, database/migrations/xxxx_create_error_groups_table.php, app/Exceptions/Handler.php]
+created_by: CC
+audited_against: 0f98814eb4f8
+---
+## Onda E-2 (Fase 2 · Absorver) — Deduplicação + rate-limit de alertas
+
+**Depende de:** E-1 (classificação na origem já carimba `dedupKey`). **Objetivo:** 1000 ocorrências do
+mesmo erro = **1 sinal com contador**, nunca 1000 pings. Sem isto, qualquer canal se mata sozinho.
+
+**§10.4:** validar contra o `main`; main vence. Reusar `Cache` + DB; NÃO `Cache::flush`.
+
+### Design
+- Tabela `error_groups`: `dedup_key (unique) · severity · audience · first_seen · last_seen · count ·
+  status (open/muted/resolved) · sample_payload (sem PII)`. Tier-0: repo-wide, sem business_id no scope
+  de leitura de governança (mas `dedup_key` inclui o business afetado).
+- `ErrorGrouper::record(Classification $c)`: upsert por `dedup_key` (incrementa `count`, atualiza
+  `last_seen`). Janela de decaimento: grupo sem ocorrência há N dias → arquiva.
+- **Rate-limit do alerta** (no Handler, S0): dispara `S0Alert` no máx **1×/grupo/janela** (ex. 15min)
+  via `Cache::add(dedup_key, ...)`. Reincidência dentro da janela só incrementa o contador.
+- O alerta carrega o `count` ("3ª vez em 10min") e link pro grupo.
+
+### NÃO FAZER
+- ❌ Alertar por ocorrência. ❌ `Cache::flush`. ❌ PII no `sample_payload`. ❌ tocar a régua da E-1.
+
+### PRONTO QUANDO (Pest)
+- 1000 exceções iguais → 1 linha em `error_groups` com `count=1000`.
+- `S0Alert` dispara 1× na janela por `dedup_key`; reincidência só incrementa.
+- Grupo sem ocorrência há N dias → arquivado.
+
+> Cowork read-only no git — DESIGN; código é PR revisado do [CL].


### PR DESCRIPTION
## O que

Aterrissa em git o handoff de **design** `erros-dedup` (Cowork→Code) no alvo que o próprio handoff declara: `prototipo-ui/handoffs/erros-dedup.md`. **Só o doc** — DESIGN (dado), nada de código.

## Onda E-2 (Fase 2 · Absorver) — resumo do handoff

Dedup + rate-limit de alertas do **Plano Sustentável de Erros**: 1000 ocorrências do mesmo erro = **1 sinal com contador**, nunca 1000 pings.
- Tabela `error_groups` (`dedup_key` unique · severity · audience · first/last_seen · count · status · sample_payload sem PII).
- `ErrorGrouper::record()` faz upsert por `dedup_key`; grupo sem ocorrência há N dias → arquiva.
- Rate-limit do `S0Alert` no Handler: 1×/grupo/janela (15min) via `Cache::add`; reincidência só incrementa o `count`.

**Depende de** E-1 (#2936, mergeado hoje) que já carimba `dedupKey` na origem.

## Transporte (Forma A · PROTOCOL.md §10.1 + ADR 0283)

URL `claudeusercontent.com` expira ~1h → **fetch → commit em git = SSOT**. Espelha exatamente o #2936 (E-1). Validado pelo gate §10.4 (base ancorada em `origin/main` fresco, sem duplicar/mutar canon).

## Escopo / segurança

- 📄 **Design (dado), não código** — Cowork read-only no git.
- 🔒 **Sem auto-merge** (ADR 0283: auto-merge bloqueado · [W] clica o merge, Fase 0). O **código** da Fase 2 vem em **PR separado revisado** (toca `app/`+migration → review humano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)