### PR TITLE
feat(errors): Fase 1 — régua de severidade na origem + cano do S0 (E-1)

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -2,6 +2,8 @@
 
 namespace App\Exceptions;
 
+use App\Support\Errors\ErrorClassifier;
+use App\Support\Errors\ErrorReporter;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Throwable;
 
@@ -43,8 +45,29 @@ class Handler extends ExceptionHandler
      */
     public function register()
     {
-        $this->reportable(function (Throwable $e) {
-            //
+        // Fase 1 · Plano Sustentável de Erros (E-1): carimba todo erro na origem
+        // (severidade/público/dono/dedupKey) → audita → só o S0 alerta 1 humano.
+        // Estende o Handler do projeto (não substitui). ErrorReporter é resiliente.
+        // @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+        $reporter = app(ErrorReporter::class);
+
+        $this->reportable(function (Throwable $e) use ($reporter) {
+            try {
+                $reporter->report($e, request());
+            } catch (Throwable) {
+                // Reporter nunca pode derrubar o tratamento de erro — engole e segue.
+            }
+        });
+
+        // render() pro operador: mensagem de recuperação, NUNCA o trace.
+        $this->renderable(function (Throwable $e, $request) {
+            $c = (new ErrorClassifier)->classify($e, $request);
+
+            if (! ErrorReporter::shouldRenderOperatorMessage($c, $request)) {
+                return null; // cai no tratamento padrão do framework.
+            }
+
+            return response()->json(['message' => $c->operatorMessage], 500);
         });
     }
 }

--- a/app/Notifications/S0Alert.php
+++ b/app/Notifications/S0Alert.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Support\Errors\Classification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+/**
+ * S0Alert — o ÚNICO alerta que interrompe 1 humano (Fase 1 · E-1).
+ *
+ * Disparado pelo {@see \App\Support\Errors\ErrorReporter} só pra severidade S0,
+ * rate-limited por dedupKey. Payload enxuto, **sem PII e sem trace** (LGPD) —
+ * só o quê/onde (dedupKey)/quando.
+ *
+ * Mesmo transporte do {@see SellsSmokeFailedNotification}: HTTP POST direto
+ * (sem channel), pra funcionar com qualquer webhook Slack-compatible / push /
+ * WhatsApp de 1 pessoa (`config('errors.s0_channel')`).
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+class S0Alert extends Notification
+{
+    use Queueable;
+
+    public function __construct(public Classification $classification) {}
+
+    /** Sem channel — usamos HTTP direto (ver ErrorReporter::dispatchS0Alert). */
+    public function via(object $notifiable): array
+    {
+        return [];
+    }
+
+    /**
+     * Payload Slack-compatible (Block Kit). Sem PII, sem trace.
+     *
+     * @return array<string, mixed>
+     */
+    public function toWebhookPayload(): array
+    {
+        $c = $this->classification;
+        $title = "🚨 S0 — {$c->owner} (interrompe humano)";
+
+        return [
+            'text' => $title,
+            'blocks' => [
+                [
+                    'type' => 'header',
+                    'text' => ['type' => 'plain_text', 'text' => $title, 'emoji' => true],
+                ],
+                [
+                    'type' => 'section',
+                    'text' => [
+                        'type' => 'mrkdwn',
+                        'text' => "*Severidade:* {$c->severity->value}\n"
+                            ."*Dono:* {$c->owner}\n"
+                            ."*Grupo (dedup):* `{$c->dedupKey}`",
+                    ],
+                ],
+                [
+                    'type' => 'context',
+                    'elements' => [[
+                        'type' => 'mrkdwn',
+                        'text' => '*Ambiente:* '.app()->environment()
+                            .' | *Quando:* '.now()->format('Y-m-d H:i:s').' BRT',
+                    ]],
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Support/Errors/Audience.php
+++ b/app/Support/Errors/Audience.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+/**
+ * Audience — quem precisa ver o erro (Fase 1 · E-1).
+ *
+ * Separa o canal do operador (recuperação, NUNCA trace) do construtor (trace/diagnóstico).
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+enum Audience: string
+{
+    /** Usuário do ERP — vê mensagem de recuperação humana, nunca o trace. */
+    case OPERADOR = 'operador';
+
+    /** Time técnico — vê o trace/diagnóstico no canal construtor. */
+    case CONSTRUTOR = 'construtor';
+
+    /** Ambos os públicos. */
+    case AMBOS = 'ambos';
+}

--- a/app/Support/Errors/Classification.php
+++ b/app/Support/Errors/Classification.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+/**
+ * Classification — o carimbo de um erro na origem (Fase 1 · E-1).
+ *
+ * Imutável. NUNCA carrega trace nem PII — o `operatorMessage` é texto humano
+ * genérico de recuperação, o `dedupKey` é um hash (Fase 2 agrupa por ele).
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+final readonly class Classification
+{
+    public function __construct(
+        public Severity $severity,
+        public Audience $audience,
+        /** Dono do erro (ex: 'plataforma', 'fiscal', 'cobranca', 'app'). */
+        public string $owner,
+        /** hash(classe + local + business_id) — Fase 2 agrupa; aqui já carimba. */
+        public string $dedupKey,
+        /** Texto de recuperação pro operador. NUNCA o trace. */
+        public string $operatorMessage,
+    ) {}
+
+    /**
+     * Campos seguros pra log/auditoria — sem trace, sem PII (LGPD).
+     *
+     * @return array{severity: string, audience: string, owner: string, dedup_key: string}
+     */
+    public function toAuditArray(): array
+    {
+        return [
+            'severity'  => $this->severity->value,
+            'audience'  => $this->audience->value,
+            'owner'     => $this->owner,
+            'dedup_key' => $this->dedupKey,
+        ];
+    }
+}

--- a/app/Support/Errors/ClassifiedError.php
+++ b/app/Support/Errors/ClassifiedError.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+use Throwable;
+
+/**
+ * ClassifiedError — exceção de domínio que se auto-classifica (Fase 1 · E-1).
+ *
+ * Caminho confiável: o código que LANÇA conhece a severidade melhor que um
+ * classificador genérico. O {@see ErrorClassifier} respeita estes valores —
+ * exceto {@see CrossTenantViolation}, que é sempre S0 e tem prioridade.
+ *
+ * As exceções de domínio do Mapa de Severidade (fiscal, cobrança, OS, ...)
+ * graduam pra cá conforme [W] for preenchendo o Mapa.
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+interface ClassifiedError extends Throwable
+{
+    public function severity(): Severity;
+
+    public function audience(): Audience;
+
+    public function owner(): string;
+
+    /** Texto humano de recuperação pro operador. NUNCA o trace. */
+    public function operatorMessage(): string;
+}

--- a/app/Support/Errors/CrossTenantViolation.php
+++ b/app/Support/Errors/CrossTenantViolation.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+use Throwable;
+
+/**
+ * CrossTenantViolation — marcador Tier 0 IRREVOGÁVEL (ADR 0093).
+ *
+ * Qualquer exceção que sinalize acesso/escrita a dado de `business_id` alheio
+ * implementa esta interface. O {@see ErrorClassifier} classifica TODA
+ * CrossTenantViolation como **S0** — é o "S0 silencioso" do Mapa: o operador
+ * só vê uma negação genérica, mas o construtor é alertado na hora.
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ * @see ADR 0093 (Multi-tenant Tier 0)
+ */
+interface CrossTenantViolation extends Throwable
+{
+}

--- a/app/Support/Errors/ErrorClassifier.php
+++ b/app/Support/Errors/ErrorClassifier.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Validation\ValidationException;
+use PDOException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Throwable;
+
+/**
+ * ErrorClassifier — o coração da Fase 1: carimba todo erro na origem.
+ *
+ * `classify()` devolve `{severity, audience, owner, dedupKey, operatorMessage}`.
+ * Regras na ordem (primeira que casar vence), espelhando o Mapa de Severidade [W]:
+ *
+ *   1. CrossTenantViolation        → S0 (Tier 0, o "S0 silencioso")
+ *   2. ClassifiedError             → severidade auto-declarada pelo domínio
+ *   3. Banco indisponível (conexão)→ S0
+ *   4. Exceções esperadas/tratadas → S3 (ruído conhecido, sem alerta)
+ *   5. default                     → S3
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+class ErrorClassifier
+{
+    public function classify(Throwable $e, ?Request $request = null): Classification
+    {
+        $dedupKey = $this->dedupKey($e);
+
+        // 1. Cross-tenant — Tier 0, sempre S0 (ADR 0093). Operador só vê negação genérica.
+        if ($e instanceof CrossTenantViolation) {
+            return new Classification(
+                Severity::S0,
+                Audience::CONSTRUTOR,
+                'plataforma',
+                $dedupKey,
+                'Você não tem acesso a esse recurso.',
+            );
+        }
+
+        // 2. Domínio se auto-classifica (caminho confiável — quem lança sabe).
+        if ($e instanceof ClassifiedError) {
+            return new Classification(
+                $e->severity(),
+                $e->audience(),
+                $e->owner(),
+                $dedupKey,
+                $e->operatorMessage(),
+            );
+        }
+
+        // 3. Banco indisponível (conexão caiu) → S0. NÃO todo QueryException — só conexão.
+        if ($this->isDatabaseUnavailable($e)) {
+            return new Classification(
+                Severity::S0,
+                Audience::CONSTRUTOR,
+                'plataforma',
+                $dedupKey,
+                'Sistema temporariamente indisponível. Já fomos avisados — tente em instantes.',
+            );
+        }
+
+        // 4. Exceções esperadas/tratadas → S3 (ruído conhecido, sem alerta).
+        if ($this->isExpected($e)) {
+            return new Classification(
+                Severity::S3,
+                Audience::OPERADOR,
+                'app',
+                $dedupKey,
+                $this->operatorMessageFor($e),
+            );
+        }
+
+        // 5. default → S3 (bug ainda não graduado; vai pro dashboard, não alerta).
+        return new Classification(
+            Severity::S3,
+            Audience::OPERADOR,
+            'app',
+            $dedupKey,
+            'Algo deu errado. Tente novamente — se persistir, chame o suporte.',
+        );
+    }
+
+    /**
+     * dedupKey = hash(classe + local + business_id) — Fase 2 agrupa; aqui já carimba.
+     * `local` = arquivo:linha de origem (não vaza PII — é caminho de código).
+     */
+    public function dedupKey(Throwable $e): string
+    {
+        $local = $e->getFile().':'.$e->getLine();
+
+        return sha1(get_class($e).'|'.$local.'|'.$this->businessId());
+    }
+
+    /**
+     * Detecta banco indisponível (conexão), não erro de query qualquer.
+     * Olha a cadeia de `getPrevious()` por PDOException com SQLSTATE classe 08
+     * (connection exception) ou mensagem de conexão recusada/servidor fora.
+     */
+    private function isDatabaseUnavailable(Throwable $e): bool
+    {
+        $connectionStates = ['08001', '08003', '08004', '08006', '08S01'];
+        $cursor = $e;
+
+        while ($cursor !== null) {
+            if ($cursor instanceof PDOException) {
+                $sqlState = is_array($cursor->errorInfo) ? ($cursor->errorInfo[0] ?? null) : (string) $cursor->getCode();
+                if ($sqlState !== null && in_array($sqlState, $connectionStates, true)) {
+                    return true;
+                }
+                $msg = $cursor->getMessage();
+                if (str_contains($msg, 'Connection refused')
+                    || str_contains($msg, 'server has gone away')
+                    || str_contains($msg, 'could not find driver')
+                    || str_contains($msg, "Can't connect")) {
+                    return true;
+                }
+            }
+            $cursor = $cursor->getPrevious();
+        }
+
+        return false;
+    }
+
+    private function isExpected(Throwable $e): bool
+    {
+        return $e instanceof ValidationException
+            || $e instanceof AuthenticationException
+            || $e instanceof AuthorizationException
+            || $e instanceof ModelNotFoundException
+            || $e instanceof TokenMismatchException
+            || $e instanceof HttpExceptionInterface;
+    }
+
+    private function operatorMessageFor(Throwable $e): string
+    {
+        return match (true) {
+            $e instanceof ValidationException => 'Confira os campos destacados e tente de novo.',
+            $e instanceof AuthenticationException => 'Sua sessão expirou. Entre novamente.',
+            $e instanceof AuthorizationException => 'Você não tem permissão para isso.',
+            $e instanceof ModelNotFoundException => 'Não encontramos o que você procurou.',
+            default => 'Não foi possível concluir agora. Tente novamente.',
+        };
+    }
+
+    /**
+     * business_id do contexto — mesmo padrão de {@see \App\Util\OtelHelper::spanBiz}.
+     * session() não existe em CLI/queue/Unit sem TestCase → try/catch + fallback 0.
+     */
+    private function businessId(): int
+    {
+        try {
+            $bizId = session()->get('user.business_id');
+        } catch (Throwable) {
+            $bizId = null;
+        }
+        $bizId ??= optional(auth()->user())->business_id ?? 0;
+
+        return (int) $bizId;
+    }
+}

--- a/app/Support/Errors/ErrorReporter.php
+++ b/app/Support/Errors/ErrorReporter.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+use App\Notifications\S0Alert;
+use App\Util\OtelHelper;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Throwable;
+
+/**
+ * ErrorReporter — os efeitos colaterais do report() (Fase 1 · E-1).
+ *
+ * Mantém o Handler magro (estende, não substitui): classifica → audita
+ * (mcp_audit_log + log estruturado + span OTel) → dispara S0 (rate-limited).
+ *
+ * Resiliente por contrato: NUNCA deve lançar — um reporter que quebra derruba
+ * o próprio tratamento de erro. Todo caminho de falha cai em log.
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+class ErrorReporter
+{
+    public function __construct(
+        private ErrorClassifier $classifier = new ErrorClassifier(),
+    ) {}
+
+    /** Classifica + audita + (só S0) alerta. Devolve a Classification (útil pro render()). */
+    public function report(Throwable $e, ?Request $request = null): Classification
+    {
+        $c = $this->classifier->classify($e, $request);
+
+        // Auditoria — todas as severidades vão pro log/dashboard (OTel + mcp_audit_log).
+        $this->audit($c, $e);
+
+        // Só o S0 interrompe humano — cano do alerta, rate-limited por dedupKey.
+        if ($c->severity->interrompeHumano()) {
+            $this->dispatchS0Alert($c);
+        }
+
+        return $c;
+    }
+
+    /**
+     * Log estruturado + span OTel + insert guarded em mcp_audit_log. Sem trace/PII.
+     * Nunca lança — uma auditoria que falha (ex: DB fora) NÃO pode bloquear o S0Alert.
+     */
+    private function audit(Classification $c, Throwable $e): void
+    {
+        try {
+            $context = $c->toAuditArray() + [
+                'exception' => get_class($e),
+                'local'     => basename($e->getFile()).':'.$e->getLine(),
+            ];
+
+            Log::channel('single')->log(
+                $c->severity === Severity::S0 ? 'critical' : 'error',
+                'error.classified',
+                $context,
+            );
+
+            // Zero-cost se OTel ausente (PII filtrado pelo próprio helper).
+            OtelHelper::span('error.classified', $context, fn () => null);
+
+            $this->writeAuditLog($c, $e);
+        } catch (Throwable) {
+            // Auditoria é best-effort — segue pro alerta mesmo se o log/DB falhar.
+        }
+    }
+
+    /** Reusa o writer canônico do mcp_audit_log (ver UserLockoutService::auditMcp). */
+    private function writeAuditLog(Classification $c, Throwable $e): void
+    {
+        try {
+            if (! Schema::hasTable('mcp_audit_log')) {
+                return;
+            }
+
+            DB::table('mcp_audit_log')->insert([
+                'request_id'       => (string) Str::uuid(),
+                'user_id'          => optional(auth()->user())->id,
+                'business_id'      => optional(auth()->user())->business_id,
+                'ts'               => now(),
+                'endpoint'         => 'exception',
+                'tool_or_resource' => get_class($e),
+                'status'           => $c->severity->value,
+                'payload_summary'  => json_encode($c->toAuditArray() + [
+                    'local' => basename($e->getFile()).':'.$e->getLine(),
+                ]),
+                'created_at'       => now(),
+            ]);
+        } catch (Throwable $ex) {
+            Log::warning('error.audit_failed', ['error' => $ex->getMessage()]);
+        }
+    }
+
+    /**
+     * Dispara S0Alert no máx 1×/dedupKey/janela (Cache::add, NUNCA Cache::flush).
+     * Reincidência na janela só não repete (Fase 2 incrementa contador).
+     * Sem webhook configurado → degrada pra log (skip, sem crash).
+     */
+    public function dispatchS0Alert(Classification $c): void
+    {
+        $windowMin = (int) config('errors.s0_window_minutes', 15);
+
+        // Rate-limit: Cache::add devolve false se a chave já existe na janela.
+        // Fail-open: cache indisponível → melhor alertar que silenciar um S0.
+        try {
+            $fresh = Cache::add('error_s0:'.$c->dedupKey, true, now()->addMinutes($windowMin));
+        } catch (Throwable) {
+            $fresh = true;
+        }
+        if (! $fresh) {
+            return;
+        }
+
+        $webhook = config('errors.s0_channel');
+        if (empty($webhook)) {
+            Log::channel('single')->critical('error.s0.no_webhook', $c->toAuditArray());
+
+            return;
+        }
+
+        try {
+            Http::timeout(5)->post((string) $webhook, (new S0Alert($c))->toWebhookPayload());
+        } catch (Throwable $ex) {
+            Log::channel('single')->warning('error.s0.webhook_failed', [
+                'error'     => $ex->getMessage(),
+                'dedup_key' => $c->dedupKey,
+            ]);
+        }
+    }
+
+    /**
+     * O render() pro operador só assume falhas inesperadas (S0/S1) em requests
+     * JSON/Inertia. Web puro usa a página de erro padrão (que já esconde trace em
+     * prod); em debug o construtor mantém o trace. Nunca vaza trace pro cliente.
+     */
+    public static function shouldRenderOperatorMessage(Classification $c, Request $request): bool
+    {
+        if (config('app.debug')) {
+            return false;
+        }
+
+        if (! ($request->expectsJson() || $request->header('X-Inertia'))) {
+            return false;
+        }
+
+        return in_array($c->severity, [Severity::S0, Severity::S1], true);
+    }
+}

--- a/app/Support/Errors/Severity.php
+++ b/app/Support/Errors/Severity.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+/**
+ * Severity — a régua S0–S3 do Plano Sustentável de Erros (Fase 1 · E-1).
+ *
+ * Princípio: só o **S0** interrompe 1 humano (o "cano do alerta"). O resto vai
+ * pra log/dashboard (OTel + mcp_audit_log que já existem). Crawl, não boil-the-ocean.
+ *
+ * Fonte da régua: Mapa de Severidade do Oimpresso (rascunho [W]).
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+enum Severity: string
+{
+    /** Crítico — interrompe humano. Pagamento fora · conciliação · cross-tenant · ERP/auth/DB fora · backup destrutivo. */
+    case S0 = 'S0';
+
+    /** Alto — o dono precisa ver. Emissão fiscal falhou · Baileys off · OS travada · boleto falhou p/ 1. */
+    case S1 = 'S1';
+
+    /** Médio — recuperável, só dashboard. Erro-rate subindo · cert a vencer · webhook atrasado · gate vermelho. */
+    case S2 = 'S2';
+
+    /** Baixo/ruído — esperado/tratado. ValidationException, exceções conhecidas. **Default**. */
+    case S3 = 'S3';
+
+    /**
+     * SLA-alvo (minutos) pra primeira resposta humana. 0 = sem SLA (só dashboard/log).
+     * Informativo nesta fase — o enforcement de SLA é Fase 2/3.
+     */
+    public function slaMinutes(): int
+    {
+        return match ($this) {
+            self::S0 => 15,
+            self::S1 => 240,
+            self::S2 => 1440,
+            self::S3 => 0,
+        };
+    }
+
+    /** Só o S0 interrompe 1 humano. Todas as outras vão pra log/dashboard sem alertar. */
+    public function interrompeHumano(): bool
+    {
+        return $this === self::S0;
+    }
+}

--- a/config/errors.php
+++ b/config/errors.php
@@ -1,0 +1,25 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Canal do S0 (Fase 1 · Plano Sustentável de Erros)
+    |--------------------------------------------------------------------------
+    |
+    | 1 webhook/destino pro ÚNICO alerta que interrompe humano — push, destino
+    | Slack-compatible, ou WhatsApp de 1 pessoa. [W] seta UMA vez no .env.
+    | Sem env → degrada pra log (skip, sem crash). Payload sem PII (LGPD).
+    |
+    | @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+    */
+    's0_channel' => env('ERROR_S0_WEBHOOK'),
+
+    /*
+    | Janela (minutos) do rate-limit do S0Alert: no máx 1 alerta por grupo
+    | (dedupKey) por janela, via Cache::add. Reincidência só não repete.
+    | A Fase 2 (E-2) endurece isto com contador persistente em error_groups.
+    */
+    's0_window_minutes' => (int) env('ERROR_S0_WINDOW_MINUTES', 15),
+
+];

--- a/tests/Feature/Errors/ErrorClassifierTest.php
+++ b/tests/Feature/Errors/ErrorClassifierTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — ErrorClassifier (Fase 1 · E-1, a régua na origem).
+ *
+ * Cobre "PRONTO QUANDO" do handoff:
+ *  - mapeia cada exceção-exemplo do Mapa pra severity+audience corretos (tabelado)
+ *  - detector cross-tenant → S0 (Tier-0)
+ *  - operatorMessage nunca vaza trace
+ *  - só o S0 interrompe humano
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+
+use App\Support\Errors\Audience;
+use App\Support\Errors\ClassifiedError;
+use App\Support\Errors\Classification;
+use App\Support\Errors\CrossTenantViolation;
+use App\Support\Errors\ErrorClassifier;
+use App\Support\Errors\Severity;
+use Illuminate\Validation\ValidationException;
+
+// ── Fixtures: exceções-exemplo do Mapa de Severidade ──────────────────
+
+class FakeCrossTenant extends RuntimeException implements CrossTenantViolation {}
+
+class FakeFiscalFail extends RuntimeException implements ClassifiedError
+{
+    public function severity(): Severity { return Severity::S1; }
+
+    public function audience(): Audience { return Audience::CONSTRUTOR; }
+
+    public function owner(): string { return 'fiscal'; }
+
+    public function operatorMessage(): string { return 'Não consegui emitir a NF-e agora — salvei como rascunho.'; }
+}
+
+class FakeCertExpiring extends RuntimeException implements ClassifiedError
+{
+    public function severity(): Severity { return Severity::S2; }
+
+    public function audience(): Audience { return Audience::AMBOS; }
+
+    public function owner(): string { return 'plataforma'; }
+
+    public function operatorMessage(): string { return 'Certificado a vencer.'; }
+}
+
+// ── Tabela: exceção → [severity esperada, audience esperada] ──────────
+
+dataset('mapa', [
+    'cross-tenant (S0 silencioso)' => [fn () => new FakeCrossTenant('biz alheio'), Severity::S0, Audience::CONSTRUTOR],
+    'banco indisponível (S0)'      => [fn () => new PDOException('SQLSTATE[08006] [2002] Connection refused'), Severity::S0, Audience::CONSTRUTOR],
+    'emissão fiscal (S1)'          => [fn () => new FakeFiscalFail, Severity::S1, Audience::CONSTRUTOR],
+    'certificado a vencer (S2)'    => [fn () => new FakeCertExpiring, Severity::S2, Audience::AMBOS],
+    'validação (S3 default)'       => [fn () => ValidationException::withMessages(['x' => 'inválido']), Severity::S3, Audience::OPERADOR],
+    'genérica (S3 default)'        => [fn () => new RuntimeException('boom'), Severity::S3, Audience::OPERADOR],
+]);
+
+it('classifica cada exceção-exemplo do Mapa pra severity+audience corretos', function (Closure $make, Severity $sev, Audience $aud) {
+    $c = (new ErrorClassifier)->classify($make());
+
+    expect($c)->toBeInstanceOf(Classification::class)
+        ->and($c->severity)->toBe($sev)
+        ->and($c->audience)->toBe($aud);
+})->with('mapa');
+
+it('cross-tenant é sempre S0 e não vaza detalhe técnico pro operador', function () {
+    $c = (new ErrorClassifier)->classify(new FakeCrossTenant('SELECT ... business_id=99'));
+
+    expect($c->severity)->toBe(Severity::S0)
+        ->and($c->owner)->toBe('plataforma')
+        ->and($c->operatorMessage)->not->toContain('SELECT')
+        ->and($c->operatorMessage)->not->toContain('business_id');
+});
+
+it('dedupKey é estável pra mesma exceção e muda entre classes', function () {
+    $clf = new ErrorClassifier;
+    $a = new RuntimeException('x');
+
+    expect($clf->dedupKey($a))->toBe($clf->dedupKey($a))
+        ->and($clf->dedupKey(new LogicException('x')))->not->toBe($clf->dedupKey($a));
+});
+
+it('operatorMessage nunca contém o trace nem a mensagem técnica', function () {
+    $c = (new ErrorClassifier)->classify(new RuntimeException('SQLSTATE secret stacktrace'));
+
+    expect($c->operatorMessage)->not->toContain('SQLSTATE')
+        ->and($c->operatorMessage)->not->toContain('stacktrace');
+});
+
+it('só o S0 interrompe humano', function () {
+    expect(Severity::S0->interrompeHumano())->toBeTrue()
+        ->and(Severity::S1->interrompeHumano())->toBeFalse()
+        ->and(Severity::S2->interrompeHumano())->toBeFalse()
+        ->and(Severity::S3->interrompeHumano())->toBeFalse();
+});

--- a/tests/Feature/Errors/ErrorReporterS0Test.php
+++ b/tests/Feature/Errors/ErrorReporterS0Test.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — ErrorReporter: cano do S0 + rate-limit + render() (Fase 1 · E-1).
+ *
+ * Cobre "PRONTO QUANDO" do handoff:
+ *  - S0 dispara S0Alert UMA vez por dedupKey na janela (rate-limit)
+ *  - S2/S3 NÃO disparam
+ *  - sem ERROR_S0_WEBHOOK → degrada pra log, sem exceção
+ *  - render() pro operador devolve operatorMessage e NÃO vaza trace
+ *
+ * Sem dependência de MySQL: mcp_audit_log write é guarded por Schema::hasTable
+ * (ausente no sqlite de teste → skip), OTel é no-op, e usamos Http::fake + Cache.
+ *
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+
+use App\Exceptions\Handler;
+use App\Support\Errors\Audience;
+use App\Support\Errors\ClassifiedError;
+use App\Support\Errors\ErrorClassifier;
+use App\Support\Errors\ErrorReporter;
+use App\Support\Errors\Severity;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class FakeS0Payment extends RuntimeException implements ClassifiedError
+{
+    public function severity(): Severity { return Severity::S0; }
+
+    public function audience(): Audience { return Audience::CONSTRUTOR; }
+
+    public function owner(): string { return 'pagamento'; }
+
+    public function operatorMessage(): string { return 'Pagamento indisponível agora — tente em instantes.'; }
+}
+
+class FakeS3Noise extends RuntimeException implements ClassifiedError
+{
+    public function severity(): Severity { return Severity::S3; }
+
+    public function audience(): Audience { return Audience::OPERADOR; }
+
+    public function owner(): string { return 'app'; }
+
+    public function operatorMessage(): string { return 'Tente novamente.'; }
+}
+
+beforeEach(function () {
+    config(['errors.s0_channel' => 'https://hooks.slack.com/services/T1/B2/secret']);
+    config(['errors.s0_window_minutes' => 15]);
+    Http::fake(['hooks.slack.com/*' => Http::response(['ok' => true], 200)]);
+});
+
+it('exceção S0 dispara S0Alert UMA vez por dedupKey na janela', function () {
+    $reporter = new ErrorReporter;
+    $e = new FakeS0Payment('gateway fora');
+
+    $reporter->report($e);
+    $reporter->report($e); // reincidência na mesma janela — NÃO repete
+
+    Http::assertSentCount(1);
+    Http::assertSent(fn ($req) => str_contains($req->url(), 'hooks.slack.com')
+        && str_contains($req->data()['text'], 'S0'));
+});
+
+it('S3 (ruído) NÃO dispara alerta', function () {
+    (new ErrorReporter)->report(new FakeS3Noise('ruído conhecido'));
+
+    Http::assertNothingSent();
+});
+
+it('sem ERROR_S0_WEBHOOK degrada pra log, sem exceção e sem HTTP', function () {
+    config(['errors.s0_channel' => null]);
+    $reporter = new ErrorReporter;
+
+    expect(fn () => $reporter->report(new FakeS0Payment('x')))->not->toThrow(Throwable::class);
+    Http::assertNothingSent();
+});
+
+it('render() pro operador devolve operatorMessage e NÃO vaza trace (JSON)', function () {
+    config(['app.debug' => false]);
+
+    $request = Request::create('/api/x', 'GET', server: ['HTTP_ACCEPT' => 'application/json']);
+    $handler = app(Handler::class);
+
+    $response = $handler->render($request, new FakeS0Payment('segredo-trace-xyz'));
+    $body = $response->getContent();
+
+    expect($response->getStatusCode())->toBe(500)
+        ->and(json_decode($body, true)['message'])->toBe('Pagamento indisponível agora — tente em instantes.')
+        ->and($body)->not->toContain('segredo-trace-xyz')
+        ->and($body)->not->toContain('FakeS0Payment');
+});
+
+it('render() não assume erros esperados (deixa o framework tratar)', function () {
+    config(['app.debug' => false]);
+
+    $request = Request::create('/api/x', 'GET', server: ['HTTP_ACCEPT' => 'application/json']);
+    $c = (new ErrorClassifier)->classify(new RuntimeException('qualquer'), $request);
+
+    // RuntimeException genérica = S3 → render() NÃO assume.
+    expect(ErrorReporter::shouldRenderOperatorMessage($c, $request))->toBeFalse();
+});


### PR DESCRIPTION
## O que

Código da **Fase 1 do Plano Sustentável de Erros** (E-1). Aterrissa o design landed em #2936 (`prototipo-ui/handoffs/erros-fase1-classificacao.md`). É a **dependência da E-2** (dedup, design em #2938).

**Régua na origem:** todo erro nasce carimbado com `severidade (S0–S3) + público + dono + dedupKey`. **Só o S0 interrompe 1 humano**; o resto vai pra log/dashboard (OTel + `mcp_audit_log`). Crawl, não boil-the-ocean.

## Peças

| Camada | Arquivo |
|---|---|
| Vocabulário | `app/Support/Errors/{Severity,Audience}.php` (enums) |
| Carimbo | `Classification.php` (DTO `readonly`, sem trace/PII) |
| Contratos | `CrossTenantViolation` (marcador Tier-0) · `ClassifiedError` (domínio se auto-classifica) |
| Coração | `ErrorClassifier::classify()` — ordem: cross-tenant **S0** → domínio → DB-down **S0** → esperadas **S3** → default **S3** |
| Cano | `ErrorReporter` — audita + dispara `S0Alert` rate-limited (`Cache::add`, **nunca** `Cache::flush`) |
| Canal | `S0Alert` (webhook Slack-compatible, sem PII) + `config/errors.php` (`ERROR_S0_WEBHOOK`) |
| Wiring | `Handler.php` — **estende** (`reportable`+`renderable`), não substitui |

## Reuso (não inventei stack)
- `business_id` resolvido igual `OtelHelper::spanBiz` (`session('user.business_id')` → auth → 0).
- Writer do `mcp_audit_log` reusa o pattern canônico (`UserLockoutService::auditMcp`, colunas reais + `Schema::hasTable` guard) — **sem inventar schema** (Tier 0).
- Webhook reusa o pattern do `SellsSmokeFailedNotification` (HTTP POST direto, graceful).

## PRONTO QUANDO (Pest · `tests/Feature/Errors/`)
- ✅ classifica cada exceção-exemplo do Mapa → severity+audience (tabelado, 4 severidades)
- ✅ cross-tenant → S0 (Tier-0)
- ✅ S0 dispara `S0Alert` **1×/dedupKey/janela**; reincidência não repete
- ✅ S3 **não** dispara
- ✅ sem `ERROR_S0_WEBHOOK` → degrada pra log, sem exceção
- ✅ `render()` pro operador devolve `operatorMessage` e **não** vaza trace

> Sem PHP local (CT 100 only) — a suíte roda no CI (`PHP / Pest (Unit)`), que é o teste real.

## Resiliência
`ErrorReporter` nunca lança: auditoria é best-effort e o S0 é **fail-open** (DB/cache fora → ainda alerta, que é justo o momento em que o DB-down S0 acontece).

## Escopo / fora de escopo
- ❌ **UX de recuperação** nas 3 telas (NF-e/Pagamento/OS) — é UI (`.tsx`/Blade), vai em **PR separado** pelo protocolo UI (não misturo `app/` backend com tela).
- 🔢 +823 linhas (≈500 prod + tests/docblocks) — acima do alvo de 300 do `commit-discipline`, mas é **1 unidade coesa** (a Fase 1 é atômica no handoff). Posso fatiar em régua vs cano se preferir.

## Ação [W]
Setar `ERROR_S0_WEBHOOK` no `.env` **uma vez** (push/Slack/WhatsApp de 1 pessoa). Sem isso, degrada pra log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)