### PR TITLE
feat(errors): Fase 2 — dedup de erros + rate-limit por contador (E-2)

### DIFF
--- a/app/Console/Commands/ArchiveStaleErrorGroupsCommand.php
+++ b/app/Console/Commands/ArchiveStaleErrorGroupsCommand.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Support\Errors\ErrorGrouper;
+use Illuminate\Console\Command;
+
+/**
+ * errors:archive-stale-groups — janela de decaimento dos grupos de erro (Fase 2 · E-2).
+ *
+ * Arquiva grupos abertos sem ocorrência há N dias (default config
+ * `errors.group_decay_days`). Plataforma/governança — NÃO é business-scoped
+ * (error_groups é repo-wide; o dedup_key já carrega o business).
+ *
+ * Agendado daily 04:00 (app/Console/Kernel.php).
+ *
+ * @see prototipo-ui/handoffs/erros-dedup.md
+ */
+class ArchiveStaleErrorGroupsCommand extends Command
+{
+    protected $signature = 'errors:archive-stale-groups
+        {--days= : Dias sem ocorrência pra arquivar (default config errors.group_decay_days)}
+        {--detail : Log detalhado}';
+
+    protected $description = 'Arquiva grupos de erro abertos sem ocorrência há N dias (decaimento E-2).';
+
+    public function handle(ErrorGrouper $grouper): int
+    {
+        $days = (int) ($this->option('days') ?: config('errors.group_decay_days', 14));
+
+        $archived = $grouper->archiveStale($days);
+
+        $this->info("error_groups: {$archived} grupo(s) arquivado(s) (sem ocorrência há ≥{$days}d).");
+
+        if ($this->option('detail')) {
+            $this->line("Janela de decaimento: {$days} dias (config errors.group_decay_days).");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -18,6 +18,13 @@ class Kernel extends ConsoleKernel
         $env = config('app.env');
         $email = config('mail.username');
 
+        // Erros (Fase 2 · E-2) — janela de decaimento: arquiva grupos de erro abertos
+        // sem ocorrência há N dias (config errors.group_decay_days). Plataforma, não
+        // business-scoped. @see prototipo-ui/handoffs/erros-dedup.md
+        $schedule->command('errors:archive-stale-groups')
+            ->dailyAt('04:00')
+            ->withoutOverlapping();
+
         if ($env === 'live') {
             //Scheduling backup, specify the time when the backup will get cleaned & time when it will run.
             

--- a/app/Models/ErrorGroup.php
+++ b/app/Models/ErrorGroup.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * ErrorGroup — grupo de erros deduplicado por dedupKey (Fase 2 · E-2).
+ *
+ * Tabela de PLATAFORMA (governança repo-wide). NÃO usa HasBusinessScope de
+ * propósito: o `dedup_key` já carrega o business afetado e a leitura é
+ * cross-tenant — mesma natureza de `mcp_audit_log`. @see ErrorGrouper.
+ *
+ * @see prototipo-ui/handoffs/erros-dedup.md
+ *
+ * @property int $count
+ * @property string $status
+ * @property array<string,mixed>|null $sample_payload
+ */
+class ErrorGroup extends Model
+{
+    public const STATUS_OPEN = 'open';
+
+    public const STATUS_MUTED = 'muted';
+
+    public const STATUS_RESOLVED = 'resolved';
+
+    public const STATUS_ARCHIVED = 'archived';
+
+    protected $table = 'error_groups';
+
+    protected $guarded = ['id'];
+
+    protected $casts = [
+        'count'          => 'integer',
+        'first_seen'     => 'datetime',
+        'last_seen'      => 'datetime',
+        'sample_payload' => 'array',
+    ];
+
+    /** Grupos abertos sem ocorrência há $days dias — candidatos a arquivar. */
+    public function scopeStale(Builder $query, int $days): Builder
+    {
+        return $query->where('status', self::STATUS_OPEN)
+            ->where('last_seen', '<', now()->subDays($days));
+    }
+}

--- a/app/Notifications/S0Alert.php
+++ b/app/Notifications/S0Alert.php
@@ -25,7 +25,7 @@ class S0Alert extends Notification
 {
     use Queueable;
 
-    public function __construct(public Classification $classification) {}
+    public function __construct(public Classification $classification, public ?int $count = null) {}
 
     /** Sem channel — usamos HTTP direto (ver ErrorReporter::dispatchS0Alert). */
     public function via(object $notifiable): array
@@ -56,6 +56,7 @@ class S0Alert extends Notification
                         'type' => 'mrkdwn',
                         'text' => "*Severidade:* {$c->severity->value}\n"
                             ."*Dono:* {$c->owner}\n"
+                            .($this->count !== null ? "*Ocorrências:* {$this->count} no grupo\n" : '')
                             ."*Grupo (dedup):* `{$c->dedupKey}`",
                     ],
                 ],

--- a/app/Support/Errors/ErrorGrouper.php
+++ b/app/Support/Errors/ErrorGrouper.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+use App\Models\ErrorGroup;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
+
+/**
+ * ErrorGrouper — deduplica erros por dedupKey (Fase 2 · E-2 "Absorver").
+ *
+ * `record()` faz upsert por `dedup_key` com incremento atômico de `count`:
+ * 1000 ocorrências do mesmo erro = 1 linha com count=1000, nunca 1000 alertas.
+ *
+ * Resiliente por contrato: NUNCA lança — DB fora não pode derrubar o report/alerta
+ * da E-1 (justo o cenário do S0 "banco indisponível"). Falha → null + log.
+ *
+ * NÃO toca a régua da E-1 (ErrorClassifier) — só absorve o que ela carimbou.
+ *
+ * @see prototipo-ui/handoffs/erros-dedup.md
+ */
+class ErrorGrouper
+{
+    /**
+     * Registra 1 ocorrência. Upsert por dedup_key + incremento atômico de count.
+     *
+     * @param  array<string, mixed>  $sample  Amostra SEM PII (ex: ['exception' => ..., 'local' => ...]).
+     */
+    public function record(Classification $c, array $sample = []): ?ErrorGroup
+    {
+        if (! Schema::hasTable('error_groups')) {
+            return null;
+        }
+
+        try {
+            $now = now();
+
+            // Incremento atômico se o grupo já existe.
+            $affected = DB::table('error_groups')
+                ->where('dedup_key', $c->dedupKey)
+                ->update([
+                    'count'      => DB::raw('count + 1'),
+                    'last_seen'  => $now,
+                    'updated_at' => $now,
+                ]);
+
+            if ($affected === 0) {
+                // Primeira ocorrência — insere. A unique de dedup_key trata corrida.
+                try {
+                    DB::table('error_groups')->insert([
+                        'dedup_key'      => $c->dedupKey,
+                        'severity'       => $c->severity->value,
+                        'audience'       => $c->audience->value,
+                        'owner'          => $c->owner,
+                        'count'          => 1,
+                        'status'         => ErrorGroup::STATUS_OPEN,
+                        'first_seen'     => $now,
+                        'last_seen'      => $now,
+                        'sample_payload' => $sample === [] ? null : json_encode($sample),
+                        'created_at'     => $now,
+                        'updated_at'     => $now,
+                    ]);
+                } catch (QueryException) {
+                    // Corrida: outra ocorrência inseriu antes → incrementa.
+                    DB::table('error_groups')
+                        ->where('dedup_key', $c->dedupKey)
+                        ->update([
+                            'count'      => DB::raw('count + 1'),
+                            'last_seen'  => $now,
+                            'updated_at' => $now,
+                        ]);
+                }
+            }
+
+            $group = ErrorGroup::query()->where('dedup_key', $c->dedupKey)->first();
+
+            // Reincidência reabre grupo arquivado/resolvido.
+            if ($group !== null && in_array($group->status, [ErrorGroup::STATUS_ARCHIVED, ErrorGroup::STATUS_RESOLVED], true)) {
+                $group->status = ErrorGroup::STATUS_OPEN;
+                $group->save();
+            }
+
+            return $group;
+        } catch (Throwable $e) {
+            Log::warning('error.group_record_failed', ['error' => $e->getMessage()]);
+
+            return null;
+        }
+    }
+
+    /** Arquiva grupos abertos sem ocorrência há $days dias. Devolve quantos arquivou. */
+    public function archiveStale(int $days): int
+    {
+        if (! Schema::hasTable('error_groups')) {
+            return 0;
+        }
+
+        try {
+            return ErrorGroup::query()->stale($days)->update(['status' => ErrorGroup::STATUS_ARCHIVED]);
+        } catch (Throwable $e) {
+            Log::warning('error.archive_stale_failed', ['error' => $e->getMessage()]);
+
+            return 0;
+        }
+    }
+}

--- a/app/Support/Errors/ErrorReporter.php
+++ b/app/Support/Errors/ErrorReporter.php
@@ -30,9 +30,10 @@ class ErrorReporter
 {
     public function __construct(
         private ErrorClassifier $classifier = new ErrorClassifier(),
+        private ErrorGrouper $grouper = new ErrorGrouper(),
     ) {}
 
-    /** Classifica + audita + (só S0) alerta. Devolve a Classification (útil pro render()). */
+    /** Classifica + audita + dedup + (só S0) alerta. Devolve a Classification (útil pro render()). */
     public function report(Throwable $e, ?Request $request = null): Classification
     {
         $c = $this->classifier->classify($e, $request);
@@ -40,9 +41,16 @@ class ErrorReporter
         // Auditoria — todas as severidades vão pro log/dashboard (OTel + mcp_audit_log).
         $this->audit($c, $e);
 
-        // Só o S0 interrompe humano — cano do alerta, rate-limited por dedupKey.
+        // Fase 2 (E-2): deduplica em error_groups (1000 iguais = 1 linha + contador).
+        // Resiliente (null se DB fora) — não bloqueia o alerta da E-1.
+        $group = $this->grouper->record($c, [
+            'exception' => get_class($e),
+            'local'     => basename($e->getFile()).':'.$e->getLine(),
+        ]);
+
+        // Só o S0 interrompe humano — rate-limited; o alerta carrega o contador do grupo.
         if ($c->severity->interrompeHumano()) {
-            $this->dispatchS0Alert($c);
+            $this->dispatchS0Alert($c, $group?->count);
         }
 
         return $c;
@@ -106,7 +114,7 @@ class ErrorReporter
      * Reincidência na janela só não repete (Fase 2 incrementa contador).
      * Sem webhook configurado → degrada pra log (skip, sem crash).
      */
-    public function dispatchS0Alert(Classification $c): void
+    public function dispatchS0Alert(Classification $c, ?int $count = null): void
     {
         $windowMin = (int) config('errors.s0_window_minutes', 15);
 
@@ -129,7 +137,7 @@ class ErrorReporter
         }
 
         try {
-            Http::timeout(5)->post((string) $webhook, (new S0Alert($c))->toWebhookPayload());
+            Http::timeout(5)->post((string) $webhook, (new S0Alert($c, $count))->toWebhookPayload());
         } catch (Throwable $ex) {
             Log::channel('single')->warning('error.s0.webhook_failed', [
                 'error'     => $ex->getMessage(),

--- a/config/errors.php
+++ b/config/errors.php
@@ -22,4 +22,10 @@ return [
     */
     's0_window_minutes' => (int) env('ERROR_S0_WINDOW_MINUTES', 15),
 
+    /*
+    | Janela de decaimento (dias) dos grupos de erro (Fase 2 · E-2): grupo aberto
+    | sem ocorrência há N dias → arquivado pelo cron errors:archive-stale-groups.
+    */
+    'group_decay_days' => (int) env('ERROR_GROUP_DECAY_DAYS', 14),
+
 ];

--- a/database/migrations/2026_06_17_120000_create_error_groups_table.php
+++ b/database/migrations/2026_06_17_120000_create_error_groups_table.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * error_groups — agrupamento de erros por dedupKey (Fase 2 · E-2 "Absorver").
+ *
+ * 1000 ocorrências do mesmo erro = 1 linha com contador, nunca 1000 pings.
+ *
+ * Tabela de PLATAFORMA/governança: **repo-wide, SEM business_id** no scope de
+ * leitura — o `dedup_key` (hash classe+local+business) já carrega o business
+ * afetado, e a leitura é cross-tenant (mesma natureza de `mcp_audit_log` e
+ * `feature_flag_audits`). Decisão arquitetural autorizada pelo handoff de design
+ * `erros-dedup` (#2938) — documentada no PR body.
+ *
+ * Idempotente (Schema::hasTable guard) + down() reversível.
+ *
+ * @see prototipo-ui/handoffs/erros-dedup.md
+ * @see ADR 0093 (multi-tenant — exceção repo-wide documentada)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('error_groups')) {
+            return;
+        }
+
+        Schema::create('error_groups', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('dedup_key', 64)->unique();        // hash(classe+local+business)
+            $table->string('severity', 4)->index();           // S0..S3
+            $table->string('audience', 16);                   // operador/construtor/ambos
+            $table->string('owner', 60)->nullable();
+            $table->unsignedBigInteger('count')->default(1);
+            $table->string('status', 16)->default('open')->index(); // open/muted/resolved/archived
+            $table->timestamp('first_seen')->nullable();
+            $table->timestamp('last_seen')->nullable();
+            $table->json('sample_payload')->nullable();        // amostra SEM PII (LGPD)
+            $table->timestamps();
+
+            $table->index(['status', 'last_seen'], 'eg_status_lastseen_idx');
+            $table->index(['severity', 'last_seen'], 'eg_sev_lastseen_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('error_groups');
+    }
+};

--- a/tests/Feature/Errors/ErrorGrouperTest.php
+++ b/tests/Feature/Errors/ErrorGrouperTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — ErrorGrouper: dedup + contador + decaimento (Fase 2 · E-2).
+ *
+ * Cobre "PRONTO QUANDO" do handoff erros-dedup:
+ *  - 1000 exceções iguais → 1 linha em error_groups com count=1000
+ *  - S0Alert dispara 1× na janela por dedup_key; reincidência só incrementa o contador
+ *  - grupo sem ocorrência há N dias → arquivado (e reincidência reabre)
+ *  - o alerta carrega o count
+ *
+ * Sem MySQL: a tabela de plataforma é criada sob demanda no beforeEach (mesmo
+ * pattern do tests/Pest.php · RecurringBilling).
+ *
+ * @see prototipo-ui/handoffs/erros-dedup.md
+ */
+
+use App\Models\ErrorGroup;
+use App\Notifications\S0Alert;
+use App\Support\Errors\Audience;
+use App\Support\Errors\Classification;
+use App\Support\Errors\ClassifiedError;
+use App\Support\Errors\ErrorClassifier;
+use App\Support\Errors\ErrorGrouper;
+use App\Support\Errors\ErrorReporter;
+use App\Support\Errors\Severity;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+
+class GrpS0Exception extends RuntimeException implements ClassifiedError
+{
+    public function severity(): Severity { return Severity::S0; }
+
+    public function audience(): Audience { return Audience::CONSTRUTOR; }
+
+    public function owner(): string { return 'pagamento'; }
+
+    public function operatorMessage(): string { return 'Pagamento indisponível.'; }
+}
+
+function mkClassification(string $key, Severity $sev = Severity::S1): Classification
+{
+    return new Classification($sev, Audience::CONSTRUTOR, 'plataforma', $key, 'Mensagem de recuperação.');
+}
+
+beforeEach(function () {
+    if (! Schema::hasTable('error_groups')) {
+        Schema::create('error_groups', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('dedup_key', 64)->unique();
+            $t->string('severity', 4)->index();
+            $t->string('audience', 16);
+            $t->string('owner', 60)->nullable();
+            $t->unsignedBigInteger('count')->default(1);
+            $t->string('status', 16)->default('open')->index();
+            $t->timestamp('first_seen')->nullable();
+            $t->timestamp('last_seen')->nullable();
+            $t->json('sample_payload')->nullable();
+            $t->timestamps();
+        });
+    }
+});
+
+it('1000 exceções iguais viram 1 linha com count=1000', function () {
+    $grouper = new ErrorGrouper;
+    $c = mkClassification('grp-1000');
+
+    for ($i = 0; $i < 1000; $i++) {
+        $grouper->record($c, ['exception' => 'RuntimeException', 'local' => 'X.php:10']);
+    }
+
+    expect(ErrorGroup::where('dedup_key', 'grp-1000')->count())->toBe(1)
+        ->and(ErrorGroup::where('dedup_key', 'grp-1000')->first()->count)->toBe(1000);
+});
+
+it('record devolve o grupo com count corrente e amostra sem PII', function () {
+    $grouper = new ErrorGrouper;
+    $g1 = $grouper->record(mkClassification('grp-a'), ['exception' => 'X', 'local' => 'A.php:1']);
+    $g2 = $grouper->record(mkClassification('grp-a'));
+
+    expect($g1->count)->toBe(1)
+        ->and($g2->count)->toBe(2)
+        ->and($g1->sample_payload)->toBe(['exception' => 'X', 'local' => 'A.php:1']);
+});
+
+it('grupo sem ocorrência há N dias é arquivado; reincidência reabre', function () {
+    $grouper = new ErrorGrouper;
+    $grouper->record(mkClassification('grp-stale'));
+
+    ErrorGroup::where('dedup_key', 'grp-stale')->update(['last_seen' => now()->subDays(20)]);
+
+    expect($grouper->archiveStale(14))->toBe(1)
+        ->and(ErrorGroup::where('dedup_key', 'grp-stale')->first()->status)->toBe('archived');
+
+    // reincidência reabre o grupo arquivado.
+    $reopened = $grouper->record(mkClassification('grp-stale'));
+    expect($reopened->status)->toBe('open');
+});
+
+it('archiveStale não toca grupos recentes', function () {
+    $grouper = new ErrorGrouper;
+    $grouper->record(mkClassification('grp-fresh'));
+
+    expect($grouper->archiveStale(14))->toBe(0)
+        ->and(ErrorGroup::where('dedup_key', 'grp-fresh')->first()->status)->toBe('open');
+});
+
+it('S0 repetido: 1 alerta na janela, mas o grupo conta as 2 ocorrências', function () {
+    config(['errors.s0_channel' => 'https://hooks.slack.com/services/T1/B2/secret']);
+    Http::fake(['hooks.slack.com/*' => Http::response(['ok' => true], 200)]);
+
+    $reporter = new ErrorReporter;
+    $e = new GrpS0Exception('gateway fora');
+
+    $reporter->report($e);
+    $reporter->report($e); // reincidência na janela
+
+    Http::assertSentCount(1); // rate-limit: 1 alerta por dedup_key/janela
+
+    $key = (new ErrorClassifier)->dedupKey($e);
+    expect(ErrorGroup::where('dedup_key', $key)->first()->count)->toBe(2);
+});
+
+it('S0Alert carrega o contador de ocorrências no payload', function () {
+    $c = mkClassification('grp-count', Severity::S0);
+    $payload = (new S0Alert($c, 42))->toWebhookPayload();
+
+    expect(json_encode($payload))->toContain('42')
+        ->and(json_encode($payload))->toContain('Ocorrências');
+});


### PR DESCRIPTION
## O que

Código da **Fase 2 do Plano Sustentável de Erros** (E-2 · "Absorver"). Aterrissa o design landed em #2938 (`prototipo-ui/handoffs/erros-dedup.md`).

**1000 ocorrências do mesmo erro = 1 sinal com contador, nunca 1000 pings.** Sem isto, qualquer canal de alerta se mata sozinho.

## ⚠️ Empilhado sobre a E-1 (#2939)
Base deste PR = `feat/erros-fase1-classificacao` (E-1, a dependência ainda aberta). O diff mostra **só o delta da E-2**. Quando #2939 mergear, o GitHub re-targeta este PR pra `main` automaticamente. **Mergear a E-1 primeiro.**

## Peças
| Camada | Arquivo |
|---|---|
| Tabela | `migrations/..._create_error_groups_table.php` — `dedup_key` unique + `count` + `status` + `sample_payload` |
| Model | `app/Models/ErrorGroup.php` + `scopeStale()` |
| Absorver | `ErrorGrouper::record()` — upsert **atômico** por `dedup_key` (incrementa `count`, atualiza `last_seen`, reabre arquivado) |
| Integração | `ErrorReporter` chama `record()` e passa o `count` pro `S0Alert` — **não toca a régua da E-1** |
| Alerta | `S0Alert` carrega o contador ("N no grupo") |
| Decaimento | `errors:archive-stale-groups` + Kernel daily 04:00 (grupo sem ocorrência há N dias → arquivado) |

## Decisão arquitetural — tabela de plataforma (sem `business_id`)
`error_groups` é **repo-wide / governança**, igual a `mcp_audit_log` e `feature_flag_audits`: **sem `business_id`** no scope de leitura. O `dedup_key = hash(classe+local+business)` **já carrega o business afetado**, e a leitura é cross-tenant. Autorizado pelo handoff #2938; é a exceção repo-wide que a regra de migrations prevê documentar no PR. O model **não** usa `HasBusinessScope` de propósito.

## PRONTO QUANDO (Pest · `tests/Feature/Errors/ErrorGrouperTest.php`)
- ✅ 1000 exceções iguais → 1 linha com `count=1000`
- ✅ S0 repetido → **1 alerta na janela** (`Cache::add`) mas o grupo **conta as 2**
- ✅ grupo sem ocorrência há N dias → **arquivado**; reincidência **reabre**
- ✅ `S0Alert` carrega o `count`

> Tabela criada sob demanda no `beforeEach` (sqlite-safe, pattern do `Pest.php`). A suíte real roda no CI.

## Resiliência / Tier 0
`ErrorGrouper` nunca lança (DB fora → `null` + log, não bloqueia o S0 da E-1). Rate-limit via `Cache::add` (**nunca** `Cache::flush`). `sample_payload` **sem PII** (LGPD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)