### PR TITLE
feat(governance): gate de frescor visual_source (Catraca Viva F0)

### DIFF
--- a/.github/workflows/ui-architecture-gate.yml
+++ b/.github/workflows/ui-architecture-gate.yml
@@ -9,6 +9,7 @@ name: UI architecture gate
 #   - AppShellUsageGateTest      (A1) toda tela Inertia usa AppShellV2
 #   - CockpitAccentCanonTest     (A2) accent = roxo canon 295 (não azul 220)
 #   - CoreScreensIntegrityTest   (B)  telas-núcleo: page + AppShellV2 + charter
+#   - CharterVisualSourceGateTest (C) visual_source de charter aponta pra arquivo vivo (frescor de design · Catraca Viva Fase 0)
 #
 # NOTA: NoHardcodeBusinessIdInModulesTest (guard Tier 0 business_id) NÃO está aqui
 # de propósito — hoje ele false-positiva no padrão legítimo `=== 0` (no-tenant guard).
@@ -84,4 +85,5 @@ jobs:
             tests/Feature/Architecture/AppShellUsageGateTest.php \
             tests/Feature/Architecture/CockpitAccentCanonTest.php \
             tests/Feature/Architecture/CoreScreensIntegrityTest.php \
+            tests/Feature/Architecture/CharterVisualSourceGateTest.php \
             --no-coverage

--- a/resources/js/Pages/Jana/Cockpit.charter.md
+++ b/resources/js/Pages/Jana/Cockpit.charter.md
@@ -7,7 +7,7 @@ status_detail: spec-ahead-of-impl
 last_validated: "2026-05-15"
 parent_module: Jana
 parent_adr: memory/decisions/0035-stack-ai-canonica-wagner-2026-04-26.md
-visual_source: prototipo-ui/_cowork-export-2026-05-15/chat-jana.jsx
+visual_source: prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.jsx
 visual_critique: prototipo-ui/_cowork-export-2026-05-15/CRITIQUE-chat-jana-vs-amendment.md
 related_adrs: [35, 39, 94, 104, 107, 110, 114]
 related_charters:

--- a/tests/Feature/Architecture/CharterVisualSourceGateTest.php
+++ b/tests/Feature/Architecture/CharterVisualSourceGateTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Gate de FRESCOR de design — todo `visual_source:` de charter aponta pra arquivo
+ * que EXISTE no repo.
+ *
+ * Origem: sessão 2026-06-17/18 (auditoria adversarial do loop design→código). Furo
+ * provado: `visual_source` não era validado por gate NENHUM (`git grep visual_source`
+ * em PHP/CI = 0) e 5 de 8 charters apontavam pra arquivo morto/`_BACKUP-NAO-USAR`.
+ * É o medo do Wagner — "pegar a versão errada do design" — sem defesa. Este teste
+ * transforma o campo decorativo em catraca que MORDE.
+ *
+ * Plano: "Catraca Viva", Fase 0 (gate-semente). Prova o método M4/M5 num caso real:
+ *   - MORDE: falha o CI (roda no ui-architecture-gate.yml, required ADR 0263).
+ *   - AUTO-TESTA: caso negativo in-band (fixtures/dead-visual-source.charter.md) prova
+ *     que o gate acusa um path morto — senão é teatro (lição: self-test da conformance
+ *     que "rodava via ci.yml" mas o ci.yml não rodava vitest).
+ *   - VIGIA: allowlist explícita e versionada (revisável em PR), não skip silencioso.
+ *
+ * Filesystem-puro (sem DB, sem browser). Rápido.
+ *
+ * @see Modules/Jana/Services/CharterHealthChecker.php (charterRefsBroken — advisory; este MORDE)
+ * @see tests/Feature/Architecture/AppShellUsageGateTest.php (mesmo padrão estrutural)
+ */
+
+// Charters cujo `visual_source` aponta pra protótipo ARQUIVADO (sem fonte viva), com
+// motivo explícito. NÃO é "skip" — é débito documentado e congelado: charter NOVO com
+// path morto falha mesmo assim. [CC]/[W] decide repoint (promover protótipo pra fora do
+// _BACKUP) ou remover o campo. Allowlist só ENCOLHE (mesma filosofia de ratchet).
+const CHARTER_VSOURCE_ALLOWLIST = [
+    'RecurringBilling/Index.charter.md'
+        => 'protótipo recurring arquivado em _BACKUP-NAO-USAR pós-implementação; sem fonte viva — [CC] decidir repoint/remover',
+    'RecurringBilling/Planos/Index.charter.md'
+        => 'idem recurring (protótipo arquivado)',
+    'RecurringBilling/Faturas/Index.charter.md'
+        => 'idem recurring (protótipo arquivado)',
+    'RecurringBilling/Configuracoes/Index.charter.md'
+        => 'idem recurring (protótipo arquivado)',
+];
+
+function charterGateRepoRoot(): string
+{
+    // tests/Feature/Architecture -> repo root (3 níveis acima). Sem base_path()
+    // (estrutural de filesystem, não precisa do app bootstrapado).
+    return dirname(__DIR__, 3);
+}
+
+/**
+ * Extrai o PATH do campo `visual_source:` do frontmatter (1º token; o valor costuma
+ * ter texto descritivo depois — "· função…", "(tab Faturas)"). Devolve null se o
+ * charter não declara `visual_source` ou se o valor não parece um path repo-relativo.
+ */
+function charterVisualSourcePath(string $charterAbs): ?string
+{
+    $content = @file_get_contents($charterAbs);
+    if ($content === false) {
+        return null;
+    }
+    // Só frontmatter (entre os dois `---`).
+    if (! preg_match('/^---\R(.*?)\R---/s', $content, $fm)) {
+        return null;
+    }
+    if (! preg_match('/^visual_source:\s*["\']?(\S+)/m', $fm[1], $m)) {
+        return null;
+    }
+    $path = rtrim($m[1], "\"'");
+
+    // Repo-relativo? (não-URL, contém "/"). Senão não dá pra verificar — não acusa.
+    if (preg_match('#^https?://#', $path) || ! str_contains($path, '/')) {
+        return null;
+    }
+
+    return $path;
+}
+
+/**
+ * Devolve o motivo da violação (string) ou null se o `visual_source` está OK / ausente.
+ * Um charter viola quando o path declarado NÃO existe no repo.
+ */
+function charterVisualSourceViolation(string $charterAbs, string $repoRoot): ?string
+{
+    $path = charterVisualSourcePath($charterAbs);
+    if ($path === null) {
+        return null; // sem visual_source verificável — fora do escopo
+    }
+
+    if (! is_file($repoRoot.'/'.ltrim($path, '/'))) {
+        return "visual_source morto: {$path}";
+    }
+
+    return null;
+}
+
+/** @return list<string> caminhos relativos a resources/js/Pages (sep "/") */
+function charterFilesUnderPages(string $repoRoot): array
+{
+    $dir = $repoRoot.'/resources/js/Pages';
+    if (! is_dir($dir)) {
+        return [];
+    }
+
+    $out = [];
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS)
+    );
+    foreach ($it as $file) {
+        if (! $file->isFile() || ! str_ends_with($file->getPathname(), '.charter.md')) {
+            continue;
+        }
+        $out[] = str_replace('\\', '/', substr($file->getPathname(), strlen($dir) + 1));
+    }
+    sort($out);
+
+    return $out;
+}
+
+it('todo visual_source de charter aponta pra arquivo que existe (exceto allowlist arquivada)', function () {
+    $root = charterGateRepoRoot();
+    $charters = charterFilesUnderPages($root);
+
+    // Sanidade: o crawler tem que achar um volume realista de charters.
+    expect(count($charters))->toBeGreaterThan(20);
+
+    $violations = [];
+    foreach ($charters as $rel) {
+        if (array_key_exists($rel, CHARTER_VSOURCE_ALLOWLIST)) {
+            continue;
+        }
+        $why = charterVisualSourceViolation($root.'/resources/js/Pages/'.$rel, $root);
+        if ($why !== null) {
+            $violations[] = "{$rel} → {$why}";
+        }
+    }
+
+    sort($violations);
+
+    expect($violations)->toBe([], sprintf(
+        "Charter(s) com visual_source apontando pra arquivo inexistente (%d). "
+        ."Repoint pro protótipo vigente, OU (se arquivado sem fonte viva) adicione à "
+        ."allowlist com motivo em %s:\n  - %s",
+        count($violations),
+        'tests/Feature/Architecture/CharterVisualSourceGateTest.php',
+        implode("\n  - ", $violations)
+    ));
+});
+
+it('MORDE: acusa um visual_source morto (fixture negativa — anti-teatro)', function () {
+    // Self-test in-band: a MESMA lógica do gate real, apontada pra um charter-fixture
+    // cujo visual_source é intencionalmente morto. Se isto NÃO acusar, o gate virou
+    // teatro (gate-selftest.mjs é node-only e não roda Pest → o self-test vive aqui).
+    $fixture = __DIR__.'/fixtures/dead-visual-source.charter.md';
+    expect(is_file($fixture))->toBeTrue('fixture negativa sumiu — self-test perdeu o dente');
+
+    $why = charterVisualSourceViolation($fixture, charterGateRepoRoot());
+
+    expect($why)->not->toBeNull('o gate NÃO acusou um visual_source comprovadamente morto — parou de morder');
+    expect($why)->toContain('__intencionalmente_inexistente__');
+});

--- a/tests/Feature/Architecture/fixtures/dead-visual-source.charter.md
+++ b/tests/Feature/Architecture/fixtures/dead-visual-source.charter.md
@@ -1,0 +1,12 @@
+---
+page: /fixture/dead-visual-source
+component: resources/js/Pages/Fixture/Dead.tsx
+status: live
+visual_source: prototipo-ui/__intencionalmente_inexistente__.jsx
+---
+
+# Fixture NEGATIVA — charter com `visual_source` morto
+
+> NÃO é uma tela real. Existe só pra **provar que o gate morde** (self-test in-band do
+> `CharterVisualSourceGateTest`). O `visual_source` acima aponta de propósito pra um
+> arquivo que não existe. Se o gate parar de acusar este arquivo, ele virou teatro.


### PR DESCRIPTION
## O que / por quê

Auditoria adversarial (2026-06-17/18) provou: **`visual_source` de charter não era validado por gate nenhum** (`git grep visual_source` em PHP/CI = 0) e **5 de 8 charters apontavam pra arquivo morto/`_BACKUP-NAO-USAR`**. Era o medo do Wagner — *"pegar a versão errada do design"* — sem defesa.

Este é o **gate-semente** do plano **Catraca Viva** (sistema imune do loop design→código). Prova o método num caso real: um gate que **morde**, **se auto-testa** e **tem vigia**.

## Como passa a Regra dos 3

| Critério | Como |
|---|---|
| **Morde** | Pest `CharterVisualSourceGateTest` plugado no `ui-architecture-gate.yml` (**required**, ADR 0263). Falha o CI quando um `visual_source` aponta pra arquivo inexistente. |
| **Auto-testa** | Caso negativo in-band (`fixtures/dead-visual-source.charter.md`) prova que o gate acusa um path morto. Anti-teatro — `gate-selftest.mjs` é node-only e não roda Pest, então o self-test vive no próprio teste. |
| **Vigia** | Allowlist **explícita e versionada** (revisável em PR), não skip silencioso. Só encolhe. |

## Débito resolvido (os 5 quebrados)

- **Jana/Cockpit** → `visual_source` repointado do export morto pro snapshot vivo (`cowork-2026-05-26.../chat-jana.jsx`).
- **4× RecurringBilling** → protótipo `recurring-page.jsx` arquivado em `_BACKUP-NAO-USAR` (sem fonte viva) → **allowlist documentada**. [CC]/W decide repoint (promover protótipo) ou remover o campo.

## Validação (red→green)

Sem PHP local no worktree → lógica validada via node (mesma regex/existência); Pest real roda no CI:
- **[A]** com allowlist: **0 violações** (verde).
- **[B]** sem allowlist: os **4 recurring** são pegos, e o Jana **saiu** da lista (repoint funcionou) — gate não é vácuo.
- **[C]** fixture negativa: **acusada** (morde).

## Fora de escopo (v1)
- `visual_critique` (mesmo charter Jana também tem ref morta) — candidato à próxima iteração do gate.
- Regra "não sourcear de `_BACKUP`" (hoje só checa existência) — Fase 1/2.

Plano completo: Catraca Viva, Fase 0. Próximas fases: gate de tela órfã/morta, calibrar ratchet, pipeline de graduação, adversário permanente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)