### PR TITLE
feat(governance): gate de tela órfã/morta (Catraca Viva F1)

### DIFF
--- a/.github/workflows/ui-architecture-gate.yml
+++ b/.github/workflows/ui-architecture-gate.yml
@@ -10,6 +10,7 @@ name: UI architecture gate
 #   - CockpitAccentCanonTest     (A2) accent = roxo canon 295 (não azul 220)
 #   - CoreScreensIntegrityTest   (B)  telas-núcleo: page + AppShellV2 + charter
 #   - CharterVisualSourceGateTest (C) visual_source de charter aponta pra arquivo vivo (frescor de design · Catraca Viva Fase 0)
+#   - OrphanRenderGateTest        (D) Inertia::render aponta pra page viva (anti tela órfã/morta · Catraca Viva Fase 1)
 #
 # NOTA: NoHardcodeBusinessIdInModulesTest (guard Tier 0 business_id) NÃO está aqui
 # de propósito — hoje ele false-positiva no padrão legítimo `=== 0` (no-tenant guard).
@@ -86,4 +87,5 @@ jobs:
             tests/Feature/Architecture/CockpitAccentCanonTest.php \
             tests/Feature/Architecture/CoreScreensIntegrityTest.php \
             tests/Feature/Architecture/CharterVisualSourceGateTest.php \
+            tests/Feature/Architecture/OrphanRenderGateTest.php \
             --no-coverage

--- a/tests/Feature/Architecture/OrphanRenderGateTest.php
+++ b/tests/Feature/Architecture/OrphanRenderGateTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Gate de TELA ÓRFÃ/MORTA — todo `Inertia::render('X')` tem uma page viva
+ * (resources/js/Pages/X.tsx|.jsx).
+ *
+ * Origem: sessão 2026-06-17/18 (auditoria adversarial). Furo provado: NÃO havia
+ * defesa contra render órfão / tela morta. O único teste capaz (AppShellUsageGateTest)
+ * dá `continue` quando a page não existe (linha ~115) — cego POR DESIGN pro caso. Dois
+ * renders apontam pra page inexistente em prod: `Atendimento/Inbox/Index` e
+ * `Financeiro/Boletos/Index` (telas substituídas no cutover, controllers nunca limpos).
+ * Render sem page = 500 em runtime se a rota for atingida, OU dead code silencioso.
+ *
+ * Plano: "Catraca Viva", Fase 1. Fecha o ponto cego do AppShellUsageGateTest sem
+ * mexer nele (responsabilidade única: aquele checa AppShellV2, este checa existência).
+ *
+ * Regra dos 3:
+ *   - MORDE: roda no ui-architecture-gate.yml (required, ADR 0263); falha em render órfão.
+ *   - AUTO-TESTA: caso negativo in-band (target sintético inexistente) prova o dente.
+ *   - VIGIA: allowlist explícita versionada (não skip silencioso).
+ *
+ * Filesystem-puro (sem DB/browser). Funções com nomes próprios (orphan*) pra não
+ * colidir com AppShellUsageGateTest no mesmo suite.
+ *
+ * @see tests/Feature/Architecture/AppShellUsageGateTest.php (o `continue` que este cobre)
+ */
+
+// Render targets ÓRFÃOS conhecidos (controller renderiza page que não existe mais), com
+// motivo + ação. NÃO é skip: target NOVO órfão falha mesmo assim. Limpeza do dead code
+// rastreada fora (1 PR = 1 intent). Allowlist só ENCOLHE.
+const ORPHAN_RENDER_ALLOWLIST = [
+    'Atendimento/Inbox/Index'
+        => 'InboxController::index órfão pós-cutover Caixa Unificada V4 (ADR 0135); /inbox é 301 → caixa-unificada. Limpar dead code: task spawn_37d7a9e6',
+    'Financeiro/Boletos/Index'
+        => 'BoletoController::index órfão; /financeiro/boletos é 301 → /financeiro/cobranca (hotfix 2026-05-19). Limpar dead code: task separada',
+];
+
+function orphanGateRepoRoot(): string
+{
+    // tests/Feature/Architecture -> repo root (3 níveis acima).
+    return dirname(__DIR__, 3);
+}
+
+/**
+ * Alvos de `Inertia::render('X/Y')` / `inertia('X/Y')` em app/ e Modules/.
+ *
+ * @return list<string>
+ */
+function orphanRenderTargets(): array
+{
+    $roots = [orphanGateRepoRoot().'/app', orphanGateRepoRoot().'/Modules'];
+    $targets = [];
+
+    foreach ($roots as $root) {
+        if (! is_dir($root)) {
+            continue;
+        }
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+        );
+        foreach ($it as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+            $code = file_get_contents($file->getPathname());
+            if ($code === false || ! str_contains($code, 'nertia')) {
+                continue;
+            }
+            if (preg_match_all("/(?:Inertia::render|inertia)\(\s*'([A-Za-z0-9_\/]+)'/", $code, $m)) {
+                foreach ($m[1] as $t) {
+                    $targets[$t] = true;
+                }
+            }
+        }
+    }
+
+    return array_keys($targets);
+}
+
+/**
+ * Um render target é órfão quando NÃO existe page (.tsx nem .jsx) correspondente.
+ * Inertia::render('X') exige resources/js/Pages/X.{tsx,jsx} — sem ela, 500 em runtime.
+ */
+function orphanRenderViolation(string $target, string $repoRoot): bool
+{
+    $base = $repoRoot.'/resources/js/Pages/'.$target;
+
+    return ! is_file($base.'.tsx') && ! is_file($base.'.jsx');
+}
+
+it('todo Inertia::render aponta pra uma page viva (sem tela órfã/morta, exceto allowlist)', function () {
+    $root = orphanGateRepoRoot();
+    $targets = orphanRenderTargets();
+
+    // Sanidade: o crawler tem que achar um volume realista de telas.
+    expect(count($targets))->toBeGreaterThan(100);
+
+    $violations = [];
+    foreach ($targets as $target) {
+        if (array_key_exists($target, ORPHAN_RENDER_ALLOWLIST)) {
+            continue;
+        }
+        if (orphanRenderViolation($target, $root)) {
+            $violations[] = $target;
+        }
+    }
+
+    sort($violations);
+
+    expect($violations)->toBe([], sprintf(
+        "Inertia::render apontando pra page inexistente (%d) — tela órfã/morta. "
+        ."Crie a page, remova o render morto, OU (se transição conhecida) adicione à "
+        ."allowlist com motivo em %s:\n  - %s",
+        count($violations),
+        'tests/Feature/Architecture/OrphanRenderGateTest.php',
+        implode("\n  - ", $violations)
+    ));
+});
+
+it('MORDE: acusa um render sem page (target sintético — anti-teatro)', function () {
+    // Self-test in-band: a MESMA lógica, apontada pra um target que comprovadamente
+    // não tem page. Se NÃO acusar, o gate virou teatro.
+    $synthetic = 'Fixture/__RenderSemPageInexistente__';
+
+    expect(orphanRenderViolation($synthetic, orphanGateRepoRoot()))
+        ->toBeTrue('o gate NÃO acusou um render sem page — parou de morder');
+
+    // E um target real e vivo NÃO pode ser falso-positivo.
+    expect(orphanRenderViolation('Home/Index', orphanGateRepoRoot()))
+        ->toBeFalse('falso-positivo: Home/Index tem page viva e foi acusado');
+});


### PR DESCRIPTION
## O que / por quê

Auditoria adversarial provou: **nenhuma defesa contra render órfão / tela morta**. O único teste capaz (`AppShellUsageGateTest`) faz `continue` quando a page não existe (linha ~115) — **cego por design**. 2 renders apontam pra page inexistente em prod (telas substituídas em cutover, controllers nunca limpos).

Fase 1 do plano **Catraca Viva** (segue a Fase 0 / #2941, já mergeada). Fecha o ponto cego **sem mexer** no `AppShellUsageGateTest` (responsabilidade única: aquele checa AppShellV2, este checa existência).

## Regra dos 3

| Critério | Como |
|---|---|
| **Morde** | `OrphanRenderGateTest` no `ui-architecture-gate` (**required**, ADR 0263) — falha em `Inertia::render('X')` sem `resources/js/Pages/X.{tsx,jsx}` |
| **Auto-testa** | caso negativo in-band (target sintético) **+** guard anti-falso-positivo (`Home/Index` não pode ser acusado) |
| **Vigia** | allowlist explícita versionada dos 2 órfãos conhecidos, com motivo + ação |

## Os 2 órfãos (allowlist documentada)

- `Atendimento/Inbox/Index` ← `InboxController::index` — órfão pós-cutover Caixa Unificada V4 (ADR 0135); `/inbox` é 301 → caixa-unificada.
- `Financeiro/Boletos/Index` ← `BoletoController::index` — `/financeiro/boletos` é 301 → `/financeiro/cobranca` (hotfix 2026-05-19).

Limpeza do dead code (remover os 2 métodos) **rastreada fora** (task spawn_37d7a9e6) — **1 PR = 1 intent**.

## Validação

Node scan: **225 alvos** de `Inertia::render`, **exatamente 2 órfãos**, ambos allowlisted → **0 violações**. Pest real roda no CI (rebaseado sobre `main` pós-merge do #2941; diff = só 2 arquivos da F1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)