### PR TITLE
fix(whatsapp): caixa unificada — filtro media_inbound_24h lê messages, não whatsapp_messages legacy

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -436,16 +436,17 @@ class CaixaUnificadaController extends Controller
             $convQuery->whereNull('contact_id');
         }
 
-        // mediaInbound24h: convs com mensagem inbound type=image/video/audio/document nas 24h
+        // mediaInbound24h: convs com mensagem inbound type=image/video/audio/document nas 24h.
+        // Lê da relação Conversation::messages (tabela `messages` do schema novo polimórfico,
+        // ADR 0135) — NÃO da tabela legacy `whatsapp_messages`, que não recebe os dados do
+        // schema novo: o join cross-schema `whatsapp_messages.conversation_id = conversations.id`
+        // não casava nenhuma row e o filtro voltava sempre vazio. Mesmo padrão correto do
+        // InboxController::index.
         if ($mediaInbound24h) {
-            $convQuery->whereExists(function ($q) {
-                $q->select(\DB::raw(1))
-                    ->from('whatsapp_messages')
-                    ->whereColumn('whatsapp_messages.conversation_id', 'conversations.id')
-                    ->where('direction', 'inbound')
-                    ->whereIn('type', ['image', 'video', 'audio', 'document'])
-                    ->where('created_at', '>=', now()->subHours(24));
-            });
+            $convQuery->whereHas('messages', fn ($q) => $q
+                ->where('direction', 'inbound')
+                ->whereIn('type', ['image', 'video', 'audio', 'document'])
+                ->where('created_at', '>=', now()->subHours(24)));
         }
 
         // inboundAging: aguardando resposta há mais de N horas

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -988,3 +988,65 @@ it('R-WA-CAIXA-UNIF-013 — customerContext agrega Saldo+Histórico do contact (
     expect((int) $props2['customerContext']['sells_count'])->toBe(0);
     expect((float) $props2['customerContext']['saldo_aberto'])->toBe(0.0);
 });
+
+// ============================================================================
+// 14. Filtro media_inbound_24h — schema novo (`messages`), NÃO legacy
+// ============================================================================
+
+/**
+ * R-WA-CAIXA-UNIF-014 — o filtro `?media_inbound_24h=1` deve casar mensagens da relação
+ * Conversation::messages (tabela `messages` do schema novo polimórfico, ADR 0135).
+ *
+ * BUG (pré-fix): o controller fazia `->from('whatsapp_messages')` (tabela LEGACY) e
+ * juntava `whatsapp_messages.conversation_id = conversations.id`. Como o schema novo grava
+ * em `messages`, o join cross-schema nunca casava e o filtro voltava SEMPRE vazio.
+ *
+ * red-first: contra o código antigo este teste FALHA de forma barulhenta — o schema
+ * sintético sequer cria `whatsapp_messages`, então a query estoura "no such table". É o
+ * discriminador do bug, não tautológico.
+ */
+function cuctMakeInboundMsg(int $businessId, int $convId, string $type, ?string $createdAt = null): void
+{
+    // DB::table direto pra controlar `created_at` (Eloquent reseta pra now()).
+    $ts = $createdAt ?? now()->toDateTimeString();
+    \DB::table('messages')->insert([
+        'business_id' => $businessId,
+        'conversation_id' => $convId,
+        'direction' => 'inbound',
+        'provider' => 'whatsapp_whatsmeow',
+        'type' => $type,
+        'status' => 'received',
+        'created_at' => $ts,
+        'updated_at' => $ts,
+    ]);
+}
+
+it('R-WA-CAIXA-UNIF-014 — media_inbound_24h filtra pela relação messages (schema novo), não whatsapp_messages legacy', function () {
+    $ch = cuctMakeChannel(1, 'caixa-unif-014-uuid');
+    cuctSetUserAndGrant(1, 10, [$ch->id]);
+
+    // Conv A — mídia inbound recente (< 24h) → DEVE aparecer no filtro
+    $convMedia = cuctMakeConv(1, $ch->id);
+    cuctMakeInboundMsg(1, $convMedia->id, 'image');
+
+    // Conv B — só texto inbound recente → NÃO aparece (filtra por type de mídia)
+    $convText = cuctMakeConv(1, $ch->id);
+    cuctMakeInboundMsg(1, $convText->id, 'text');
+
+    // Conv C — mídia inbound, mas há 25h (fora da janela 24h) → NÃO aparece
+    $convOld = cuctMakeConv(1, $ch->id);
+    cuctMakeInboundMsg(1, $convOld->id, 'audio', now()->subHours(25)->toDateTimeString());
+
+    // Sem filtro: as 3 convs aparecem (controle)
+    $all = cuctResolveDefer(
+        cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest())['conversations']
+    );
+    expect($all['data'])->toHaveCount(3);
+
+    // Com filtro: só a conv com mídia inbound nas últimas 24h
+    $filtered = cuctResolveDefer(
+        cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest(['media_inbound_24h' => '1']))['conversations']
+    );
+    expect($filtered['data'])->toHaveCount(1)
+        ->and($filtered['data'][0]['id'])->toBe($convMedia->id);
+});


### PR DESCRIPTION
## Contexto

Auditoria adversarial do *dead code* do `InboxController` legacy (cutover Caixa Unificada V4) revelou um **bug de produção** no controller canônico `CaixaUnificadaController`.

## Bug

O filtro `?media_inbound_24h=1` da Caixa Unificada fazia `whereExists` na tabela **legacy** `whatsapp_messages`, juntando `whatsapp_messages.conversation_id = conversations.id`:

```php
$convQuery->whereExists(function ($q) {
    $q->select(\DB::raw(1))
        ->from('whatsapp_messages')                                   // ❌ tabela legacy
        ->whereColumn('whatsapp_messages.conversation_id', 'conversations.id')
        ...
});
```

O schema novo polimórfico (ADR 0135) grava mensagens em **`messages`** (via `Conversation::messages`), não em `whatsapp_messages`. O join cross-schema **nunca casa** nenhuma row do schema novo → o filtro de mídia voltava **sempre vazio** em produção.

`InboxController::index` (legacy) já fazia certo, com `whereHas('messages')`.

## Fix

Troca pela relação Eloquent — mesmo padrão correto do legacy, e ainda respeita global scopes (defense-in-depth Tier 0):

```php
$convQuery->whereHas('messages', fn ($q) => $q
    ->where('direction', 'inbound')
    ->whereIn('type', ['image', 'video', 'audio', 'document'])
    ->where('created_at', '>=', now()->subHours(24)));
```

## Teste

`R-WA-CAIXA-UNIF-014` cobre 3 cenários (mídia recente incluída · texto recente excluído · mídia 25h atrás excluída) — valida type-filter + janela 24h + tabela correta.

**red-first:** contra o código antigo o teste falha de forma barulhenta — o schema sqlite sintético sequer cria `whatsapp_messages`, então a query estoura `no such table`. Não é tautológico.

## Validação

⚠️ Sem PHP/vendor no ambiente local — validação depende da **CI (lane sqlite)**. Os testes da Caixa Unificada `markTestSkipped` fora de sqlite.

## Escopo

PR pequeno, 1 intent (2 arquivos, +72/−9). É a **etapa 1** de um trabalho maior: a remoção do `InboxController::index` dead-code (etapa 2) é uma migração de testes pro `CaixaUnificadaController` — fica pra PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)