### PR TITLE
chore(cowork): land erros-autoresolucao handoff (publisher push-perm fallback)

### DIFF
--- a/prototipo-ui/handoffs/erros-autoresolucao.md
+++ b/prototipo-ui/handoffs/erros-autoresolucao.md
@@ -1,4 +1,3 @@
-<!-- cowork: target: prototipo-ui/handoffs/erros-autoresolucao.md -->
 ---
 handoff_id: erros-autoresolucao
 tela: Plataforma/ErrorHandling


### PR DESCRIPTION
O publisher `cowork-inbox.yml` processou o handoff E-3 corretamente (rename + strip), mas **falhou no push**: `GITHUB_TOKEN` (GitHub App) não tem `workflows` permission e o ref toca `.github/workflows/ui-architecture-gate.yml`. Run: https://github.com/wagnerra23/oimpresso.com/actions/runs/27754012023

Este PR finaliza o 1º hop à mão (strip_headers + move `cowork-inbox/` → `prototipo-ui/handoffs/`). ⚠️ O **sign+submit → pending na Forja** (ADR 0285) NÃO rodou (precisa de `HANDOFF_SECRET` no CI) — registrar separadamente. Doc-only.