### PR TITLE
feat(errors): Fase 2 — auto-resolução (retry/backoff/dead-letter) (E-3)

### DIFF
--- a/app/Jobs/ReprocessJob.php
+++ b/app/Jobs/ReprocessJob.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Support\Errors\AutoResolver;
+use App\Support\Errors\Classification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * ReprocessJob — reprocessador idempotente da auto-resolução (Fase 2 · E-3).
+ *
+ * Genérico por design: executa uma AÇÃO de domínio resolvível pelo container
+ * (`__invoke(array $params): void`) com retry + backoff exponencial da fila e,
+ * ao esgotar, dead-letter via {@see AutoResolver}. Casos do Mapa:
+ *   - SEFAZ fora → reemite a NF-e quando voltar (operador vê "enfileirado").
+ *   - Webhook de pagamento atrasado → reprocessa (dedup por id externo).
+ *   - Baileys desconectou → tenta reconectar N×; mensagens enfileiram.
+ *
+ * Idempotência (OBRIGATÓRIA — não duplicar NF-e/cobrança):
+ *   1. Fast-path: marca `reprocess_done:<idempotencyKey>` no Cache após o sucesso;
+ *      uma re-execução (entrega dupla / retry após sucesso não-ack) faz short-circuit.
+ *   2. Garantia DURÁVEL é da própria AÇÃO (dedup por id externo — ex: unique no DB).
+ *      O Cache é só o atalho barato; a ação NÃO pode confiar só nele.
+ *
+ * Sem retry infinito: `$tries` é o teto (config); esgotou → {@see failed()} promove S1.
+ *
+ * Em prod, aponte `errors.auto_resolve.connection` pra a conexão `reprocess`
+ * (retry_after alto · @see config/queue.php) — senão o worker pode reclamar um job
+ * em backoff e re-executá-lo antes do tempo, furando a idempotência.
+ *
+ * @see prototipo-ui/handoffs/erros-autoresolucao.md
+ */
+class ReprocessJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /** Teto de tentativas — sem retry infinito (config errors.auto_resolve.max_attempts). */
+    public int $tries;
+
+    public int $timeout = 120;
+
+    /**
+     * @param  class-string  $actionClass  invocável resolvível: __invoke(array $params): void
+     * @param  array<string,mixed>  $params  args serializáveis (ids/strings, NÃO models)
+     * @param  string  $idempotencyKey  id externo — chave de dedup do efeito
+     */
+    public function __construct(
+        public readonly Classification $classification,
+        public readonly string $actionClass,
+        public readonly array $params,
+        public readonly string $idempotencyKey,
+    ) {
+        $this->tries = max(1, (int) config('errors.auto_resolve.max_attempts', 5));
+
+        if ($conn = config('errors.auto_resolve.connection')) {
+            $this->onConnection((string) $conn);
+        }
+        if ($queue = config('errors.auto_resolve.queue')) {
+            $this->onQueue((string) $queue);
+        }
+    }
+
+    /**
+     * Backoff exponencial (segundos) entre tentativas — fonte única: {@see AutoResolver}.
+     *
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        return app(AutoResolver::class)->backoff();
+    }
+
+    public function handle(AutoResolver $resolver): void
+    {
+        $doneKey = 'reprocess_done:'.$this->idempotencyKey;
+
+        // Idempotência (fast-path): já concluído → não reaplica o efeito.
+        try {
+            if (Cache::has($doneKey)) {
+                Log::channel('single')->info('error.reprocess.skipped_idempotent', [
+                    'idempotency_key' => $this->idempotencyKey,
+                    'dedup_key' => $this->classification->dedupKey,
+                ]);
+
+                return;
+            }
+        } catch (Throwable) {
+            // Cache indisponível → segue; a ação tem o dedup durável por id externo.
+        }
+
+        // Executa a ação de domínio. Se lançar, a fila reagenda com backoff até esgotar $tries.
+        $action = app($this->actionClass);
+        $action($this->params);
+
+        // Sucesso: fecha a janela de duplicação ANTES da métrica (que nunca lança).
+        try {
+            Cache::put($doneKey, true, now()->addDay());
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('error.reprocess.done_marker_failed', [
+                'idempotency_key' => $this->idempotencyKey,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        $resolver->recordResolved($this->classification, $this->attemptsSafe());
+    }
+
+    /**
+     * Dead-letter: a fila esgotou $tries. Promove pra S1 e para (sem retry infinito).
+     * Laravel chama isto uma vez, após a última tentativa falhar.
+     */
+    public function failed(Throwable $e): void
+    {
+        app(AutoResolver::class)->deadLetter($this->classification, $e, $this->attemptsSafe());
+    }
+
+    /** attempts() depende do job da fila; em execução direta (teste) devolve 1. */
+    private function attemptsSafe(): int
+    {
+        try {
+            return $this->job !== null ? max(1, $this->attempts()) : 1;
+        } catch (Throwable) {
+            return 1;
+        }
+    }
+}

--- a/app/Support/Errors/AutoResolver.php
+++ b/app/Support/Errors/AutoResolver.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Errors;
+
+use App\Jobs\ReprocessJob;
+use App\Util\OtelHelper;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use RuntimeException;
+use Throwable;
+
+/**
+ * AutoResolver — a política de auto-resolução (Fase 2 · E-3).
+ *
+ * "O erro que se resolve sozinho não acorda ninguém." Decide o que é recuperável
+ * (whitelist S1/S2 por dono), enfileira o reprocesso ({@see ReprocessJob}) com
+ * backoff exponencial, registra o "% auto-resolvido" e — quando o retry esgota —
+ * faz o dead-letter: promove pra S1 (vira problema de humano) e FECHA o auto-loop.
+ *
+ * Invariantes (handoff):
+ *   - S0 NUNCA auto-resolve (dinheiro/dado/segurança = humano sempre · ADR 0284 §4).
+ *   - Sem retry infinito (dead-letter promove pra S1 e para).
+ *   - Idempotência é obrigatória — garantida pelo {@see ReprocessJob} + ação de domínio.
+ *
+ * NUNCA lança em caminho de métrica/promoção — um resolvedor que quebra agrava o
+ * próprio erro que tentava absorver.
+ *
+ * @see prototipo-ui/handoffs/erros-autoresolucao.md
+ * @see prototipo-ui/handoffs/erros-fase1-classificacao.md
+ */
+final class AutoResolver
+{
+    public function __construct(
+        /** Reusa o pipeline E-1/E-2 (classify → audita → dedup) pra promover o dead-letter. */
+        private ErrorReporter $reporter = new ErrorReporter(),
+    ) {}
+
+    /**
+     * Recuperável por retry automático? Whitelist: S1/S2 + dono na lista.
+     * S0 nunca (Tier 0); S3 é ruído conhecido — não vale auto-retry.
+     */
+    public function canRetry(Classification $c): bool
+    {
+        if (! (bool) config('errors.auto_resolve.enabled', true)) {
+            return false;
+        }
+
+        // S0 NUNCA auto-resolve. Inegociável (Regra Mestre Tier 0 · ADR 0284 §4).
+        if ($c->severity === Severity::S0) {
+            return false;
+        }
+
+        // Só os recuperáveis do Mapa (S1/S2). S3 = ruído, não entra no loop.
+        if (! in_array($c->severity, [Severity::S1, Severity::S2], true)) {
+            return false;
+        }
+
+        return in_array($c->owner, $this->whitelistOwners(), true);
+    }
+
+    /**
+     * Ponto de entrada do domínio: se recuperável, enfileira o reprocesso idempotente
+     * e devolve true (operador vê "enfileirado", não erro). Caso contrário, false —
+     * o chamador segue pro tratamento humano (E-1/E-2).
+     *
+     * @param  class-string  $actionClass  invocável resolvível pelo container: __invoke(array $params): void
+     * @param  array<string,mixed>  $params  args serializáveis (ids, não models)
+     * @param  string  $idempotencyKey  id externo — dedup do efeito (não duplicar NF-e/cobrança)
+     */
+    public function attempt(Classification $c, string $actionClass, array $params, string $idempotencyKey): bool
+    {
+        if (! $this->canRetry($c)) {
+            return false;
+        }
+
+        ReprocessJob::dispatch($c, $actionClass, $params, $idempotencyKey);
+
+        return true;
+    }
+
+    /** Teto de tentativas — sem retry infinito. */
+    public function maxAttempts(): int
+    {
+        return max(1, (int) config('errors.auto_resolve.max_attempts', 5));
+    }
+
+    /**
+     * Backoff exponencial (segundos) entre as tentativas: base · 2^(n-1), saturado no teto.
+     * Devolve maxAttempts-1 esperas (entre N tentativas há N-1 intervalos).
+     *
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        $base = max(1, (int) config('errors.auto_resolve.backoff_base_seconds', 30));
+        $cap = max($base, (int) config('errors.auto_resolve.backoff_max_seconds', 900));
+
+        $waits = [];
+        for ($n = 1; $n < $this->maxAttempts(); $n++) {
+            $waits[] = (int) min($cap, $base * (2 ** ($n - 1)));
+        }
+
+        return $waits !== [] ? $waits : [$base];
+    }
+
+    /**
+     * Auto-resolução bem-sucedida — registra (alimenta o "% auto-resolvido") SEM alerta.
+     */
+    public function recordResolved(Classification $c, int $attempts): void
+    {
+        $this->recordMetric($c, 'auto_resolved', $attempts);
+    }
+
+    /**
+     * Dead-letter: o retry esgotou. Promove pra S1 (problema de humano — dashboard/dono,
+     * sem paging, coerente com a régua E-1) e fecha o auto-loop. Best-effort, nunca lança.
+     */
+    public function deadLetter(Classification $c, Throwable $last, int $attempts): void
+    {
+        $this->recordMetric($c, 'auto_dead_letter', $attempts);
+
+        try {
+            // O ErrorReporter é resiliente por contrato (nunca lança).
+            $this->reporter->report($this->promoteToS1($c, $last));
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('error.auto_dead_letter.promote_failed', [
+                'dedup_key' => $c->dedupKey,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /** Constrói uma exceção S1 auto-classificada a partir do erro recuperável esgotado. */
+    private function promoteToS1(Classification $c, Throwable $last): ClassifiedError
+    {
+        return new class($c->owner, $c->operatorMessage, $c->dedupKey, $last) extends RuntimeException implements ClassifiedError
+        {
+            public function __construct(
+                private readonly string $ownerName,
+                private readonly string $opMsg,
+                string $dedup,
+                Throwable $previous,
+            ) {
+                parent::__construct('auto-resolução esgotada ('.$dedup.')', 0, $previous);
+            }
+
+            public function severity(): Severity
+            {
+                return Severity::S1;
+            }
+
+            public function audience(): Audience
+            {
+                return Audience::CONSTRUTOR;
+            }
+
+            public function owner(): string
+            {
+                return $this->ownerName;
+            }
+
+            public function operatorMessage(): string
+            {
+                return $this->opMsg;
+            }
+        };
+    }
+
+    /**
+     * Métrica de auto-resolução — log estruturado + span OTel + insert guarded em
+     * mcp_audit_log (mesma porta da auditoria E-1). O painel computa o "% auto-resolvido"
+     * (auto_resolved ÷ (auto_resolved + auto_dead_letter)). Sem trace/PII. Nunca lança.
+     */
+    private function recordMetric(Classification $c, string $outcome, int $attempts): void
+    {
+        $ctx = $c->toAuditArray() + ['outcome' => $outcome, 'attempts' => $attempts];
+
+        try {
+            Log::channel('single')->log(
+                $outcome === 'auto_resolved' ? 'info' : 'warning',
+                'error.'.$outcome,
+                $ctx,
+            );
+
+            OtelHelper::span('error.'.$outcome, $ctx, fn () => null);
+
+            $this->writeAuditLog($c, $outcome, $attempts);
+        } catch (Throwable) {
+            // Métrica é best-effort — nunca derruba a absorção do erro.
+        }
+    }
+
+    /** Insert guarded em mcp_audit_log (espelha {@see ErrorReporter::writeAuditLog}). */
+    private function writeAuditLog(Classification $c, string $outcome, int $attempts): void
+    {
+        try {
+            if (! Schema::hasTable('mcp_audit_log')) {
+                return;
+            }
+
+            DB::table('mcp_audit_log')->insert([
+                'request_id' => (string) Str::uuid(),
+                'user_id' => optional(auth()->user())->id,
+                'business_id' => optional(auth()->user())->business_id,
+                'ts' => now(),
+                'endpoint' => 'auto_resolve',
+                'tool_or_resource' => $c->owner,
+                'status' => $outcome,
+                'payload_summary' => json_encode($c->toAuditArray() + ['attempts' => $attempts]),
+                'created_at' => now(),
+            ]);
+        } catch (Throwable $e) {
+            Log::warning('error.auto_resolve.audit_failed', ['error' => $e->getMessage()]);
+        }
+    }
+
+    /** @return list<string> donos/domínios recuperáveis (whitelist). */
+    private function whitelistOwners(): array
+    {
+        return array_values(array_filter((array) config('errors.auto_resolve.whitelist_owners', [])));
+    }
+}

--- a/config/errors.php
+++ b/config/errors.php
@@ -28,4 +28,39 @@ return [
     */
     'group_decay_days' => (int) env('ERROR_GROUP_DECAY_DAYS', 14),
 
+    /*
+    |--------------------------------------------------------------------------
+    | Auto-resolução (Fase 2 · E-3) — retry / backoff / dead-letter
+    |--------------------------------------------------------------------------
+    |
+    | Os S1/S2 recuperáveis do Mapa (SEFAZ fora, webhook atrasado, Baileys off)
+    | se resolvem sozinhos sem acordar ninguém — sobe o "% auto-resolvido".
+    | S0 NUNCA auto-resolve (dinheiro/dado/segurança = humano · ADR 0284 §4).
+    | Sem retry infinito: esgotou → promove pra S1 e para.
+    |
+    | @see prototipo-ui/handoffs/erros-autoresolucao.md
+    */
+    'auto_resolve' => [
+        'enabled' => (bool) env('ERROR_AUTO_RESOLVE_ENABLED', true),
+
+        // Teto de tentativas — sem retry infinito (dead-letter promove pra S1).
+        'max_attempts' => (int) env('ERROR_AUTO_RESOLVE_MAX_ATTEMPTS', 5),
+
+        // Backoff exponencial: base · 2^(n-1), saturado no teto (segundos).
+        'backoff_base_seconds' => (int) env('ERROR_AUTO_RESOLVE_BACKOFF_BASE_SECONDS', 30),
+        'backoff_max_seconds' => (int) env('ERROR_AUTO_RESOLVE_BACKOFF_MAX_SECONDS', 900),
+
+        // Whitelist de donos/domínios recuperáveis (S1/S2). Fora disto → humano.
+        'whitelist_owners' => array_values(array_filter(array_map(
+            'trim',
+            explode(',', (string) env('ERROR_AUTO_RESOLVE_OWNERS', 'fiscal,cobranca,whatsapp,ingest'))
+        ))),
+
+        // Fila/conexão do reprocesso. Vazio → default do app. Em prod, aponte a
+        // conexão pra 'reprocess' (retry_after alto · @see config/queue.php) pra o
+        // worker não reclamar um job em backoff e duplicar efeito.
+        'connection' => env('ERROR_AUTO_RESOLVE_CONNECTION') ?: null,
+        'queue' => env('ERROR_AUTO_RESOLVE_QUEUE') ?: null,
+    ],
+
 ];

--- a/config/queue.php
+++ b/config/queue.php
@@ -71,6 +71,22 @@ return [
             'after_commit' => false,
         ],
 
+        /*
+        | Conexão dedicada ao reprocesso da auto-resolução (Fase 2 · E-3).
+        | retry_after ALTO (> backoff_max + timeout do ReprocessJob) pra o worker
+        | NUNCA reclamar um job em backoff exponencial e re-executá-lo — duplicar
+        | NF-e/cobrança é proibido (idempotência). after_commit: o efeito externo
+        | só roda depois do commit do dado de origem.
+        | @see config/errors.php ('auto_resolve') · prototipo-ui/handoffs/erros-autoresolucao.md
+        */
+        'reprocess' => [
+            'driver' => 'database',
+            'table' => 'jobs',
+            'queue' => env('REPROCESS_QUEUE', 'reprocess'),
+            'retry_after' => (int) env('REPROCESS_RETRY_AFTER', 1200),
+            'after_commit' => true,
+        ],
+
     ],
 
     /*

--- a/tests/Feature/Errors/AutoResolverTest.php
+++ b/tests/Feature/Errors/AutoResolverTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — AutoResolver + ReprocessJob: retry · fallback · reprocesso (Fase 2 · E-3).
+ *
+ * Cobre "PRONTO QUANDO" do handoff erros-autoresolucao:
+ *  - erro recuperável → resolvido por retry SEM disparar alerta; % auto-resolvido registrado
+ *  - retry é idempotente (não duplica efeito — dedup por id externo)
+ *  - após N falhas → dead-letter promove pra S1 e PARA (sem retry infinito)
+ *  - S0 NUNCA auto-resolve (dinheiro/dado/segurança = humano · ADR 0284 §4)
+ *
+ * Sem MySQL: as tabelas de plataforma (error_groups, mcp_audit_log) são criadas sob
+ * demanda no beforeEach (mesmo pattern do ErrorGrouperTest).
+ *
+ * @see prototipo-ui/handoffs/erros-autoresolucao.md
+ */
+
+use App\Jobs\ReprocessJob;
+use App\Models\ErrorGroup;
+use App\Support\Errors\Audience;
+use App\Support\Errors\AutoResolver;
+use App\Support\Errors\Classification;
+use App\Support\Errors\Severity;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+
+/** Ação de reprocesso de teste — conta quantas vezes o efeito foi aplicado. */
+class FakeReprocessAction
+{
+    public static int $count = 0;
+
+    public function __invoke(array $params): void
+    {
+        self::$count++;
+    }
+}
+
+/** Ação que sempre falha — alimenta o caminho de dead-letter. */
+class FakeFailingAction
+{
+    public function __invoke(array $params): void
+    {
+        throw new RuntimeException('domínio ainda fora');
+    }
+}
+
+function mkAR(string $key, Severity $sev = Severity::S1, string $owner = 'cobranca'): Classification
+{
+    return new Classification($sev, Audience::CONSTRUTOR, $owner, $key, 'Tente novamente em instantes.');
+}
+
+beforeEach(function () {
+    FakeReprocessAction::$count = 0;
+
+    config([
+        'errors.auto_resolve.enabled' => true,
+        'errors.auto_resolve.max_attempts' => 5,
+        'errors.auto_resolve.whitelist_owners' => ['cobranca', 'fiscal', 'whatsapp'],
+        'errors.auto_resolve.connection' => null,
+        'errors.auto_resolve.queue' => null,
+    ]);
+
+    if (! Schema::hasTable('error_groups')) {
+        Schema::create('error_groups', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('dedup_key', 64)->unique();
+            $t->string('severity', 4)->index();
+            $t->string('audience', 16);
+            $t->string('owner', 60)->nullable();
+            $t->unsignedBigInteger('count')->default(1);
+            $t->string('status', 16)->default('open')->index();
+            $t->timestamp('first_seen')->nullable();
+            $t->timestamp('last_seen')->nullable();
+            $t->json('sample_payload')->nullable();
+            $t->timestamps();
+        });
+    }
+
+    if (! Schema::hasTable('mcp_audit_log')) {
+        Schema::create('mcp_audit_log', function ($t) {
+            $t->bigIncrements('id');
+            $t->string('request_id', 64)->nullable();
+            $t->unsignedBigInteger('user_id')->nullable();
+            $t->unsignedBigInteger('business_id')->nullable();
+            $t->timestamp('ts')->nullable();
+            $t->string('endpoint')->nullable();
+            $t->string('tool_or_resource')->nullable();
+            $t->string('status', 32)->nullable();
+            $t->text('payload_summary')->nullable();
+            $t->timestamp('created_at')->nullable();
+        });
+    }
+});
+
+it('canRetry: S1/S2 com dono na whitelist sim; S0/S3/dono-fora não', function () {
+    $r = new AutoResolver;
+
+    expect($r->canRetry(mkAR('a', Severity::S1, 'cobranca')))->toBeTrue()
+        ->and($r->canRetry(mkAR('b', Severity::S2, 'fiscal')))->toBeTrue()
+        // S0 NUNCA — inegociável (Tier 0).
+        ->and($r->canRetry(mkAR('c', Severity::S0, 'cobranca')))->toBeFalse()
+        // S3 é ruído — não entra no loop.
+        ->and($r->canRetry(mkAR('d', Severity::S3, 'cobranca')))->toBeFalse()
+        // dono fora da whitelist → humano.
+        ->and($r->canRetry(mkAR('e', Severity::S1, 'plataforma')))->toBeFalse();
+});
+
+it('canRetry: desligado por config → não auto-resolve nada', function () {
+    config(['errors.auto_resolve.enabled' => false]);
+
+    expect((new AutoResolver)->canRetry(mkAR('x', Severity::S1, 'cobranca')))->toBeFalse();
+});
+
+it('attempt: recuperável enfileira ReprocessJob; S0 não enfileira nada', function () {
+    Queue::fake();
+    $r = new AutoResolver;
+
+    expect($r->attempt(mkAR('q1', Severity::S1, 'cobranca'), FakeReprocessAction::class, [], 'q1'))->toBeTrue();
+    Queue::assertPushed(ReprocessJob::class, 1);
+
+    // S0 nunca auto-resolve — nada é enfileirado.
+    expect($r->attempt(mkAR('q2', Severity::S0, 'cobranca'), FakeReprocessAction::class, [], 'q2'))->toBeFalse();
+    Queue::assertPushed(ReprocessJob::class, 1); // continua 1
+});
+
+it('erro recuperável resolve por retry SEM alerta e registra % auto-resolvido', function () {
+    config(['errors.s0_channel' => 'https://hooks.slack.com/services/T/B/secret']);
+    Http::fake();
+
+    $c = mkAR('resolved-1', Severity::S1, 'cobranca');
+    (new ReprocessJob($c, FakeReprocessAction::class, ['cobranca_id' => 7], 'ext-resolved-1'))
+        ->handle(app(AutoResolver::class));
+
+    // efeito aplicado…
+    expect(FakeReprocessAction::$count)->toBe(1)
+        // …registrado como auto-resolvido (alimenta o painel)…
+        ->and(DB::table('mcp_audit_log')->where('status', 'auto_resolved')->where('tool_or_resource', 'cobranca')->exists())->toBeTrue();
+
+    // …e NENHUM alerta disparado (o erro que se resolve sozinho não acorda ninguém).
+    Http::assertNothingSent();
+});
+
+it('retry é idempotente — efeito aplicado UMA vez por id externo', function () {
+    $c = mkAR('idem-1', Severity::S1, 'fiscal');
+    $key = 'ext-idem-1';
+    Cache::forget('reprocess_done:'.$key);
+
+    // 2 execuções com o mesmo id externo (ex: entrega dupla / retry após sucesso).
+    (new ReprocessJob($c, FakeReprocessAction::class, ['nfe_id' => 9], $key))->handle(app(AutoResolver::class));
+    (new ReprocessJob($c, FakeReprocessAction::class, ['nfe_id' => 9], $key))->handle(app(AutoResolver::class));
+
+    expect(FakeReprocessAction::$count)->toBe(1); // não duplicou NF-e
+});
+
+it('dead-letter: esgotou tentativas → promove pra S1 e PARA (sem retry infinito)', function () {
+    $c = mkAR('dl-1', Severity::S1, 'whatsapp');
+    $job = new ReprocessJob($c, FakeFailingAction::class, [], 'ext-dl-1');
+
+    // Limites duros: $tries finito e backoff com tries-1 esperas (a fila para sozinha).
+    expect($job->tries)->toBe(5)
+        ->and($job->backoff())->toHaveCount(4);
+
+    // Laravel chama failed() uma vez, depois da última tentativa.
+    $job->failed(new RuntimeException('domínio ainda fora'));
+
+    expect(ErrorGroup::where('severity', 'S1')->exists())->toBeTrue()
+        ->and(DB::table('mcp_audit_log')->where('status', 'auto_dead_letter')->exists())->toBeTrue();
+});
+
+it('backoff é exponencial e saturado no teto', function () {
+    config([
+        'errors.auto_resolve.max_attempts' => 6,
+        'errors.auto_resolve.backoff_base_seconds' => 30,
+        'errors.auto_resolve.backoff_max_seconds' => 240,
+    ]);
+
+    // 30, 60, 120, 240 (cap), 240 (cap) — 5 esperas pra 6 tentativas.
+    expect((new AutoResolver)->backoff())->toBe([30, 60, 120, 240, 240]);
+});


### PR DESCRIPTION
## Onda E-3 (Fase 2 · Absorver) — Auto-resolução: retry · fallback · reprocesso

Implementa o handoff `prototipo-ui/handoffs/erros-autoresolucao.md` (landed em #2945). O erro recuperável (S1/S2 do Mapa: SEFAZ fora, webhook atrasado, Baileys off) **se resolve sozinho sem acordar ninguém** — sobe o `% auto-resolvido`. Reusa a fila/jobs Laravel existentes. **Depende de E-1 + E-2 (ambos já em main).**

### O quê (escopo do handoff: 4 arquivos + teste)
- **`app/Support/Errors/AutoResolver.php`** — política: `canRetry()` (whitelist S1/S2 por dono, **NUNCA S0** · ADR 0284 §4), `attempt()` (enfileira), `backoff()` exponencial saturado, `recordResolved()` + `deadLetter()`.
- **`app/Jobs/ReprocessJob.php`** — reprocessador idempotente (dedup por id externo: cache fast-path + dedup durável da ação), `$tries` finito, `backoff()`, `failed()` → dead-letter. **Sem retry infinito.**
- **`config/errors.php`** — bloco `auto_resolve`.
- **`config/queue.php`** — conexão `reprocess` (`retry_after` alto + `after_commit`): o worker não reclama job em backoff e duplica NF-e/cobrança.
- **`tests/Feature/Errors/AutoResolverTest.php`** — Pest.

### Decisões
- **Dead-letter promove pra S1 reusando `ErrorReporter`** (classify→audita→dedup) — zero modificação no E-1/E-2. S1 vai pro dashboard/dono, sem paging (coerente com a régua E-1).
- **`% auto-resolvido`** via Log + span OTel + `mcp_audit_log` (`status` ∈ `auto_resolved`/`auto_dead_letter`).
- **Idempotência**: garantia durável é da ação de domínio (id externo); cache é só o atalho.

### NÃO FAZER (respeitado)
- ❌ Retry sem idempotência · ❌ Retry infinito · ❌ Auto-resolver S0.

### PRONTO QUANDO (Pest · 7 testes / 19 asserts · verde local)
- ✅ recuperável → retry **sem** alerta; `% auto-resolvido` registrado.
- ✅ retry idempotente (efeito 1×).
- ✅ N falhas → dead-letter promove S1 e **para**.
- ✅ S0 **nunca** auto-resolve.

> Adoção por domínio (NFe/webhook/Baileys chamarem `AutoResolver::attempt`) é follow-up (toca código de domínio = outro handoff). Aqui entra o PRIMITIVO testado.
> Código do loop Cowork→CC; **review humano** (toca `app/`, nunca auto-merge).