### PR TITLE
fix(ci): cowork-inbox usa COWORK_BOT_PAT (escopo workflows) no push/PR/merge

### DIFF
--- a/.github/workflows/cowork-inbox.yml
+++ b/.github/workflows/cowork-inbox.yml
@@ -20,9 +20,26 @@ jobs:
     # Loop guard: skip the commit this very workflow produces.
     if: "${{ !contains(github.event.head_commit.message, 'chore(cowork): inbox processed') }}"
     steps:
+      # PAT obrigatório (ADR 0283/0285): o branch novo carrega os .github/workflows/* do main.
+      # O GITHUB_TOKEN (GitHub App) NÃO tem o escopo `workflows` (não-concedível via permissions:),
+      # então o push do branch é rejeitado: "refusing to allow a GitHub App to create or update
+      # workflow ... without `workflows` permission". O COWORK_BOT_PAT (fine-grained: contents:write
+      # + pull_requests:write + workflows:write) é quem empurra o branch, abre e mergeia o PR.
+      - name: Preflight — COWORK_BOT_PAT presente
+        env:
+          COWORK_BOT_PAT: ${{ secrets.COWORK_BOT_PAT }}
+        run: |
+          if [ -z "${COWORK_BOT_PAT}" ]; then
+            echo "::error title=COWORK_BOT_PAT ausente::Configure um PAT fine-grained (contents:write + pull_requests:write + workflows:write) em Settings → Secrets → Actions → COWORK_BOT_PAT. O GITHUB_TOKEN não serve: sem o escopo 'workflows', o push de um branch que contém .github/workflows/* é rejeitado pelo GitHub."
+            exit 1
+          fi
+          echo "✓ COWORK_BOT_PAT presente."
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
+          # Persistido pro `git push origin $BRANCH` autenticar com o PAT (não o GITHUB_TOKEN).
+          token: ${{ secrets.COWORK_BOT_PAT }}
 
       - uses: actions/setup-python@v5
         with:
@@ -41,7 +58,7 @@ jobs:
       - name: Process inbox
         id: process
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COWORK_BOT_PAT }}
         run: |
           set -euo pipefail
 
@@ -90,7 +107,7 @@ jobs:
       - name: Merge (doc/memory) or request review (code)
         if: steps.process.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.COWORK_BOT_PAT }}
         run: |
           set -euo pipefail
           BRANCH="${{ steps.process.outputs.branch }}"


### PR DESCRIPTION
## Problema

O workflow `cowork-inbox.yml` (publisher do loop zero-paste · ADR 0283/0285) falha no step **Process inbox** desde ~18/jun, quebrando o pouso de todo handoff novo. O python (`cowork-inbox.py`) roda OK (rename `cowork-inbox/*.md` → `prototipo-ui/handoffs/*.md`), mas o `git push origin "$BRANCH"` é **rejeitado**:

```
! [remote rejected] cowork/inbox-8a943bc (refusing to allow a GitHub App to create or
  update workflow `.github/workflows/ui-architecture-gate.yml` without `workflows` permission)
```

**Causa raiz:** o step usa `GH_TOKEN: secrets.GITHUB_TOKEN` (token de GitHub App). O branch novo é criado a partir do `main` e portanto **carrega os `.github/workflows/*` do main na sua árvore**. Ao criar/empurrar esse ref novo, o GitHub trata como "criar/alterar workflow", e o `GITHUB_TOKEN` **não tem o escopo `workflows`** — escopo que **não é concedível** via bloco `permissions:`. Quebrou quando o `ui-architecture-gate.yml` entrou no main em **18/jun** ([#2943](https://github.com/wagnerra23/oimpresso.com/pull/2943) Catraca Viva F1); os handoffs E-1/E-2 (17/jun) pousaram OK porque o gate ainda não existia.

Run que falhou: https://github.com/wagnerra23/oimpresso.com/actions/runs/27754012023 (PR #2942, handoff `erros-autoresolucao`).

## O que mudou (só `cowork-inbox.yml`)

1. **`actions/checkout`** ganha `token: ${{ secrets.COWORK_BOT_PAT }}` → o `git push origin "$BRANCH"` autentica com o PAT (não o `GITHUB_TOKEN`).
2. **Process inbox** `GH_TOKEN` → `secrets.COWORK_BOT_PAT` (push + `gh pr create`).
3. **Merge (doc/memory) or request review** `GH_TOKEN` → `secrets.COWORK_BOT_PAT` (`gh pr merge --auto`). Bônus já documentado no design (`bin/submit-handoff.sh`): merge via PAT (≠ `GITHUB_TOKEN`) é o que faz o push em `main` **disparar** os workflows on-push downstream.
4. **Preflight** novo que **falha claro** se o secret não existir, em vez de quebrar no meio do push.

## O que NÃO mudou (e por quê)

- **`bin/cowork-postman.sh`** — roda numa sessão Claude Code local com o `gh auth` do usuário (que **tem** o escopo `workflow`), nunca com `GITHUB_TOKEN`. Já comenta "PAT-merge (não GITHUB_TOKEN)". `--self-test` 🟢.
- **`bin/submit-handoff.sh`** — só assina (HMAC via `sign-handoff.php`) e dá POST no MCP; não faz `git push`/`gh pr`. Já degrada skip-as-pass sem os secrets. `--self-test` 🟢.

## ⚠️ AÇÃO MANUAL OBRIGATÓRIA (Wagner — não dá pra fazer via código)

Criar o secret **`COWORK_BOT_PAT`** em **Settings → Secrets and variables → Actions**:

- **Fine-grained PAT** com escopo neste repo: **Contents: Read and write**, **Pull requests: Read and write**, **Workflows: Read and write**.
- (Clássico equivalente: `repo` + `workflow`.)

Sem o secret, o **Preflight** falha com mensagem explícita apontando o que configurar (não fica mais quebrando no `git push`).

## Como smoke-testar (depois do secret)

1. Dropar um handoff de teste em `cowork-inbox/handoff-smoke.md` (ou rodar `bin/cowork-postman.sh --slug smoke --tela X --files a.tsx --file ./h.md`) e mergear na main.
2. Conferir o run do `cowork-inbox`: push do branch deve passar, PR auto-criado e auto-mergeado (doc-only).
3. Conferir que o handoff aparece como **pending** na Forja (depende dos secrets `HANDOFF_SECRET` + `HANDOFF_SUBMIT_TOKEN`).

## Pendência relacionada (fora deste PR)

`prototipo-ui/handoffs/erros-autoresolucao.md` (já no main via #2945) **não** foi sign+submetido ao `handoff-submit` do MCP, então **não está pending na Forja**. Re-trigger não resolve (inbox vazio). Submeter manualmente de uma sessão com MCP conectado + secrets:

```bash
HANDOFF_SECRET=… SUBMIT_TOKEN=… bash bin/submit-handoff.sh prototipo-ui/handoffs/erros-autoresolucao.md
```

ou via o tool MCP `handoff-submit` direto.

Refs: ADR 0283, ADR 0285

🤖 Generated with [Claude Code](https://claude.com/claude-code)
