### PR TITLE
fix(ci): deploy failsafe boot-gated — 503 gracioso em vez de 500 quando código não boota

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -411,15 +411,25 @@ jobs:
           fi
           echo "✅ Smoke OK (frontend_changed=$FRONTEND_CHANGED)"
 
-      - name: Failsafe — nunca deixar o site preso em maintenance (always)
-        # Lição do 1º auto-deploy (2026-06-10): um step falhou DEPOIS do `php artisan
-        # down` e ANTES do `up`, deixando o site em 503 preso até intervenção manual.
-        # Auto-deploy roda sem supervisão → o invariante é "nunca ficar em maintenance".
-        # Este step roda SEMPRE (inclusive em falha) e garante o site no ar. Em sucesso
-        # é no-op (já está up). Fallback remove o flag na unha se o artisan estiver quebrado.
+      - name: Failsafe — site no ar SÓ se bootar; senão mantém maintenance (503 gracioso)
+        # Lição 2026-06-10: um step falhou entre `down` e `up`, deixando o site preso em 503
+        # até intervenção manual → invariante "nunca ficar preso em maintenance".
+        # Lição 2026-06-18: o failsafe forçava `up` INCONDICIONALMENTE, inclusive com código
+        # que NÃO boota — classmap autoritativo stale após deploy interrompido entre
+        # `git reset --hard` e `composer dump-autoload` → 500 em TODA rota por ~1h (web+console+cron),
+        # sem nada no laravel.log (falha antes do logger). Invariante corrigido: nunca preso em
+        # maintenance A MENOS que o código não boote — nesse caso 503 gracioso > 500, e o deploy
+        # falha (vermelho) + alerta pra investigar. `php artisan about` reproduz o boot do app
+        # (constrói o Handler + resolve binds) = mesmo gate do boot-smoke console.
         if: always()
         run: |
-          /tmp/ssh_exec.sh "cd $RDIR && php artisan up 2>&1 || rm -f storage/framework/down storage/framework/maintenance.php 2>&1 || true; echo 'maintenance OFF (failsafe)'"
+          if /tmp/ssh_exec.sh "cd $RDIR && php artisan about > /dev/null 2>&1"; then
+            /tmp/ssh_exec.sh "cd $RDIR && php artisan up 2>&1 || rm -f storage/framework/down storage/framework/maintenance.php 2>&1 || true; echo 'maintenance OFF (boot OK)'"
+          else
+            /tmp/ssh_exec.sh "cd $RDIR && php artisan down --retry=60 --refresh=60 2>&1 || true; echo 'MANTIDO EM MAINTENANCE (503) — codigo nao boota'"
+            echo "::error::Codigo deployado NAO boota (php artisan about falhou). Site mantido em MAINTENANCE (503 gracioso) em vez de servir 500. Recuperar no prod: 'composer dump-autoload -o --classmap-authoritative --no-scripts --ignore-platform-req=ext-opentelemetry' + reset OPcache, OU re-deploy. Ver Tail laravel.log abaixo."
+            exit 1
+          fi
 
       - name: Tail laravel.log (sempre — diagnose + post-mortem)
         if: always()


### PR DESCRIPTION
## Contexto — incidente 2026-06-18 (~1h de prod 500)

Pós-mortem da queda: um auto-deploy foi **interrompido/falhou entre `git reset --hard origin/main` e `composer dump-autoload`**. Resultado: prod com código novo (que referencia `App\Support\Errors\ErrorReporter` no `App\Exceptions\Handler::register()`) mas com o **classmap `--classmap-authoritative` stale** (sem a classe nova) → `BindingResolutionException` na construção do exception handler → **500 em TODA rota** (web + console + cron), corpo vazio, **nada no `laravel.log`** (falha antes do logger).

## Por que o failsafe piorou

O passo `Failsafe — nunca deixar o site preso em maintenance (always)` rodava `php artisan up` **incondicionalmente** (`if: always()`). Então mesmo com o código sem bootar, ele **tirava o site do maintenance e expunha o 500**, em vez de deixar o 503 gracioso. O invariante "nunca preso em maintenance" (lição de 2026-06-10) atropelava "nunca servir 500".

## Fix

Failsafe **boot-gated**:
- `php artisan about` bootou? → `php artisan up` (site no ar). ✅
- não bootou? → mantém `php artisan down` (**503 "voltamos já"**) + `::error::` + **deploy vermelho**. ⛔

`php artisan about` reproduz o boot real do app (constrói o Handler + resolve binds) — é o mesmo gate do boot-smoke console. **503 gracioso >> 500 quebrado**, e o deploy vermelho alerta o time na hora em vez de degradar silencioso.

## O que NÃO muda

- Deploy de sucesso: `up` normal (no-op se já up).
- Invariante de 2026-06-10 preservado: o site só fica em maintenance quando o código **genuinamente não boota** — que é exatamente quando ficar em maintenance é o certo.

## Diagnóstico que confirmou a causa (no prod, via SSH)

`ErrorReporter.php` estava no disco + no git HEAD, mas `grep -c` no `vendor/composer/autoload_classmap.php` = **0**. `composer dump-autoload -o --classmap-authoritative` (regenerou, 19.849 classes) + `optimize:clear` + reset OPcache + reciclar workers `lsphp` → prod voltou a **200**.

## Follow-up (separado, maior)

Deploy por **release atômico** (symlink swap): montar a release nova numa pasta, rodar composer/dump-autoload/migrate lá, e só então trocar o symlink `current` atomicamente. Um deploy interrompido **nunca toca** o que está no ar. Mapeado, não incluído aqui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)