### PR TITLE
fix(ci): deconflita insertAuditLog() global que matava o full-suite CT100 (FV-F3)

### DIFF
--- a/Modules/Arquivos/Tests/Feature/AuditLogCommandTest.php
+++ b/Modules/Arquivos/Tests/Feature/AuditLogCommandTest.php
@@ -38,7 +38,7 @@ uses(Tests\TestCase::class);
  *
  * @param array<string,mixed> $overrides
  */
-function insertAuditLog(array $overrides = []): int
+function insertArquivosAuditLog(array $overrides = []): int
 {
     $defaults = [
         'arquivo_id'  => 9901,
@@ -90,7 +90,7 @@ it('command arquivos:audit-log está registrado no artisan', function () {
 
 it('modo default lista logs das últimas 24h ordenado desc por created_at', function () {
     // Row recente (dentro da janela padrão de 24h).
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9901,
         'business_id' => 1,
         'action'      => 'upload',
@@ -98,7 +98,7 @@ it('modo default lista logs das últimas 24h ordenado desc por created_at', func
     ]);
 
     // Row fora da janela (25h atrás) — não deve aparecer.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9902,
         'business_id' => 1,
         'action'      => 'download',
@@ -129,7 +129,7 @@ it('modo default lista logs das últimas 24h ordenado desc por created_at', func
 
 it('--business=1 filtra logs e não vaza biz=2', function () {
     // Row biz=1 — deve aparecer.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9903,
         'business_id' => 1,
         'action'      => 'classify',
@@ -137,7 +137,7 @@ it('--business=1 filtra logs e não vaza biz=2', function () {
     ]);
 
     // Row biz=2 — NÃO deve aparecer com --business=1.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9904,
         'business_id' => 2,
         'action'      => 'classify',
@@ -170,7 +170,7 @@ it('--business=1 filtra logs e não vaza biz=2', function () {
 
 it('--action=signed_url_issued filtra apenas essa action', function () {
     // Row com action signed_url_issued — deve aparecer.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9905,
         'business_id' => 1,
         'action'      => 'signed_url_issued',
@@ -179,7 +179,7 @@ it('--action=signed_url_issued filtra apenas essa action', function () {
     ]);
 
     // Row com outra action — não deve aparecer com --action=signed_url_issued.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9906,
         'business_id' => 1,
         'action'      => 'soft_delete',
@@ -208,7 +208,7 @@ it('--action=signed_url_issued filtra apenas essa action', function () {
 it('--top-files agrega acessos e retorna total_acessos correto', function () {
     // Insere 4 logs pro mesmo arquivo (arquivo_id=9910).
     foreach (range(1, 4) as $i) {
-        insertAuditLog([
+        insertArquivosAuditLog([
             'arquivo_id'  => 9910,
             'business_id' => 1,
             'action'      => 'upload',
@@ -217,7 +217,7 @@ it('--top-files agrega acessos e retorna total_acessos correto', function () {
     }
 
     // Insere 1 log pra outro arquivo (arquivo_id=9911) — deve aparecer com count=1.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9911,
         'business_id' => 1,
         'action'      => 'upload',
@@ -247,7 +247,7 @@ it('--top-files agrega acessos e retorna total_acessos correto', function () {
 
 it('--suspicious detecta signed_url_issued sem user_id como padrão suspeito', function () {
     // Row suspeita: signed_url_issued SEM user_id (URL vazada / acesso anônimo).
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9920,
         'business_id' => 1,
         'action'      => 'signed_url_issued',
@@ -256,7 +256,7 @@ it('--suspicious detecta signed_url_issued sem user_id como padrão suspeito', f
     ]);
 
     // Row normal: signed_url_issued COM user_id — não deve ser flagrada.
-    insertAuditLog([
+    insertArquivosAuditLog([
         'arquivo_id'  => 9921,
         'business_id' => 1,
         'action'      => 'signed_url_issued',

--- a/Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php
@@ -119,7 +119,7 @@ it('mcp_task_events: DELETE estoura QueryException 45000 (append-only)', functio
 
 // ─── mcp_audit_log (dívida histórica — nunca teve teste) ──────────────────────
 
-function insertAuditLog(): int
+function insertMcpAuditLog(): int
 {
     // user_id é FK NOT NULL → usa o primeiro user semeado pela lane (biz=1).
     $userId = (int) DB::table('users')->min('id');
@@ -140,14 +140,14 @@ function insertAuditLog(): int
 }
 
 it('mcp_audit_log: INSERT é permitido (append)', function () {
-    $id = insertAuditLog();
+    $id = insertMcpAuditLog();
 
     expect($id)->toBeGreaterThan(0)
         ->and(DB::table('mcp_audit_log')->where('id', $id)->exists())->toBeTrue();
 })->group('immutability', 'governance', 'ci');
 
 it('mcp_audit_log: UPDATE estoura QueryException 45000 (append-only)', function () {
-    $id = insertAuditLog();
+    $id = insertMcpAuditLog();
 
     try {
         DB::table('mcp_audit_log')->where('id', $id)->update(['status' => 'error']);
@@ -161,7 +161,7 @@ it('mcp_audit_log: UPDATE estoura QueryException 45000 (append-only)', function 
 })->group('immutability', 'governance', 'ci');
 
 it('mcp_audit_log: DELETE estoura QueryException 45000 (append-only)', function () {
-    $id = insertAuditLog();
+    $id = insertMcpAuditLog();
 
     try {
         DB::table('mcp_audit_log')->where('id', $id)->delete();

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -223,8 +223,27 @@ for attempt in $(seq 1 12); do
       exec php -d memory_limit=2G vendor/bin/pest --log-junit /artifacts/junit.xml --colors=never
     ' \
     2>&1 | tee "$RUN_DIR/pest-out.txt" || PEST_EXIT=$?
+  # Detector 1 — Pest loader: uses(TestCase) file-level dentro de pasta ja vinculada
+  # ("can not be used. The folder [/workspace/...]").
   BLOCKER=$(grep -oP 'can not be used\. The folder \[/workspace/\K[^]]+' "$RUN_DIR/pest-out.txt" | head -1 || true)
+  # Detector 2 — PHP "Cannot redeclare" fatal no LOAD (helper/classe/const global com
+  # mesmo nome em 2 arquivos do escopo ->in()). PHP morre ANTES do 1o teste (exit 255 +
+  # junit.xml 0 bytes) e o detector 1 NAO pega. A mensagem nomeia o arquivo SENDO
+  # CARREGADO em "... in /workspace/<F> on line N"; quarentenar ESSE deixa a declaracao
+  # "previously declared in <outro>" sobreviver. Caso real 2026-06-16..18 (3 nights sem
+  # floor): insertAuditLog() em Jana/ImmutabilityTriggersTest vs Arquivos/AuditLogCommandTest.
+  # O loop re-tenta e pega colisao em cadeia (1 arquivo por volta, ate 12).
+  if [ -z "$BLOCKER" ] && grep -qE 'Cannot (re)?declare' "$RUN_DIR/pest-out.txt"; then
+    BLOCKER=$(grep -E 'Cannot (re)?declare' "$RUN_DIR/pest-out.txt" \
+      | grep -oP 'in /workspace/\K[^ ]+(?= on line)' | head -1 || true)
+  fi
   [ -z "$BLOCKER" ] && break
+  # Sanity: extracao errada de path NAO deve matar o run sob set -e — so quarentena o
+  # arquivo que realmente existe no clone.
+  if [ ! -f "$CODE/$BLOCKER" ]; then
+    echo "LOADER-BLOCKER ($attempt): '$BLOCKER' detectado mas inexistente no clone — sem quarentena; abortando loop"
+    break
+  fi
   echo "LOADER-BLOCKER ($attempt): $BLOCKER — movido pro lado no clone, registrado"
   echo "$BLOCKER" >> "$RUN_DIR/loader-blockers.txt"
   mkdir -p "$CODE/.loader-quarantine/$(dirname "$BLOCKER")"


### PR DESCRIPTION
## Problema

O nightly **CT100 full-suite** (FV-F3, `/opt/oimpresso-fullsuite/ct100-fullsuite.sh`) produziu **junit.xml de 0 bytes + pest exit 255** nas corridas de **2026-06-16, 06-17 e 06-18** — 3 dias sem floor measurement válido.

**Causa-raiz** (confirmada em `origin/main`): dois arquivos de teste declaram `function insertAuditLog()` no **escopo global**:

| Arquivo | Tabela alvo |
|---|---|
| `Modules/Arquivos/Tests/Feature/AuditLogCommandTest.php:41` | `arquivos_audit_log` |
| `Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php:122` | `mcp_audit_log` |

Quando o Pest carrega o repo inteiro, o PHP estoura `Fatal error: Cannot redeclare insertAuditLog()` **no LOAD, antes de rodar 1 teste** → exit 255 → junit vazio. O auto-quarantine do harness só pegava a mensagem `can not be used. The folder [...]` (colisão de pasta `uses()` do Pest), **não** o fatal `Cannot redeclare` — por isso não se recuperava. Colisão introduzida por #2848 (team-mcp Forja).

## Fix

**1. Renomeia os helpers globais** — não são duplicatas (tabelas/schemas distintos), então nomes únicos por domínio em vez de helper compartilhado, espelhando o `insertAuditLogHc` que o `HealthCheckCommandTest` já usa:
- `insertAuditLog` → `insertArquivosAuditLog` (Arquivos)
- `insertAuditLog` → `insertMcpAuditLog` (Jana)

**2. Endurece `scripts/tests/ct100-fullsuite.sh`** (defesa em profundidade): novo **Detector 2** no loop loader-blocker que reconhece o fatal `Cannot redeclare`, extrai o arquivo *sendo carregado* (`... in /workspace/<F> on line N`) e o põe em quarentena no clone descartável — o loop re-tenta pra colisão em cadeia, com sanity-check de existência pra não morrer sob `set -e`. Precedente: #2263.

## Diligência — é a única colisão real?

Varredura repo-wide de declarações globais duplicadas em `Tests/**` confirma que `insertAuditLog` é a **única colisão global real**:
- `pgEnsureSchema` (PaymentGateway ×2) → `if (! function_exists(...))`-guarded ✅
- `setBizSession` "duplicado" (Governance) → fixture dentro de heredoc `<<<'PHP'`, não é declaração real ✅
- `MultiTenantIsolationTest` (Financeiro/Ponto) → namespaces distintos (FQCN diferente) ✅

Sem isso, fixar só `insertAuditLog` deixaria o próximo nightly morrer numa colisão diferente — não é o caso.

## Verificação

- `bash -n scripts/tests/ct100-fullsuite.sh` → OK
- Lógica do Detector 2 validada (perl + `grep -oP` sob `C.UTF-8`): extrai o arquivo carregado (não o "previously declared"), cobre fatal de função **e** de classe, e **não** quarentena em warning comum.
- Renames consistentes: 11 ocorrências (1 decl + 10 calls) em Arquivos, 4 (1 decl + 3 calls) em Jana, zero `insertAuditLog(` global remanescente.
- **Pós-merge:** copiar `scripts/tests/ct100-fullsuite.sh` → `/opt/oimpresso-fullsuite/` no CT100 (ver `RUNBOOK-ct100-fullsuite.md`) e confirmar que o próximo nightly gera `summary.json` coerente.

Refs: FV-F3

🤖 Generated with [Claude Code](https://claude.com/claude-code)