### PR TITLE
fix(ct100): nightly não morre por função global duplicada + quarentena pega redeclare/parse

### DIFF
--- a/Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php
@@ -119,7 +119,7 @@ it('mcp_task_events: DELETE estoura QueryException 45000 (append-only)', functio
 
 // ─── mcp_audit_log (dívida histórica — nunca teve teste) ──────────────────────
 
-function insertAuditLog(): int
+function insertImmutableAuditLog(): int
 {
     // user_id é FK NOT NULL → usa o primeiro user semeado pela lane (biz=1).
     $userId = (int) DB::table('users')->min('id');
@@ -140,14 +140,14 @@ function insertAuditLog(): int
 }
 
 it('mcp_audit_log: INSERT é permitido (append)', function () {
-    $id = insertAuditLog();
+    $id = insertImmutableAuditLog();
 
     expect($id)->toBeGreaterThan(0)
         ->and(DB::table('mcp_audit_log')->where('id', $id)->exists())->toBeTrue();
 })->group('immutability', 'governance', 'ci');
 
 it('mcp_audit_log: UPDATE estoura QueryException 45000 (append-only)', function () {
-    $id = insertAuditLog();
+    $id = insertImmutableAuditLog();
 
     try {
         DB::table('mcp_audit_log')->where('id', $id)->update(['status' => 'error']);
@@ -161,7 +161,7 @@ it('mcp_audit_log: UPDATE estoura QueryException 45000 (append-only)', function 
 })->group('immutability', 'governance', 'ci');
 
 it('mcp_audit_log: DELETE estoura QueryException 45000 (append-only)', function () {
-    $id = insertAuditLog();
+    $id = insertImmutableAuditLog();
 
     try {
         DB::table('mcp_audit_log')->where('id', $id)->delete();

--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -224,6 +224,20 @@ for attempt in $(seq 1 12); do
     ' \
     2>&1 | tee "$RUN_DIR/pest-out.txt" || PEST_EXIT=$?
   BLOCKER=$(grep -oP 'can not be used\. The folder \[/workspace/\K[^]]+' "$RUN_DIR/pest-out.txt" | head -1 || true)
+  # US-GOV-018 hardening (2026-06-18): fatais de LOAD que zeram a suite inteira (junit 0
+  # bytes / pest exit 255) ANTES de 1 teste rodar — o detector de folder acima NAO os pega,
+  # entao 1 arquivo envenenado matava o nightly inteiro (06-16/17/18: redeclare insertAuditLog).
+  #  (a) "Cannot redeclare <fn>() (previously declared in /workspace/<PATH>:N)" — funcao
+  #      global duplicada entre 2 test files (Pest carrega tudo no mesmo escopo global).
+  #  (b) "Parse error ... in /workspace/<PATH> on line N" — arquivo com sintaxe quebrada.
+  # Quarentena o arquivo ofensor (registrado em loader-blockers.txt) e re-tenta, em vez de
+  # quebrar o run. Consertar o arquivo e das lanes de burn-down, nao desta.
+  if [ -z "$BLOCKER" ]; then
+    BLOCKER=$(grep -oP 'Cannot redeclare.*previously declared in /workspace/\K[^:)]+' "$RUN_DIR/pest-out.txt" | head -1 || true)
+  fi
+  if [ -z "$BLOCKER" ]; then
+    BLOCKER=$(grep -oP 'Parse error[^\n]* in /workspace/\K[^ ]+(?= on line)' "$RUN_DIR/pest-out.txt" | head -1 || true)
+  fi
   [ -z "$BLOCKER" ] && break
   echo "LOADER-BLOCKER ($attempt): $BLOCKER — movido pro lado no clone, registrado"
   echo "$BLOCKER" >> "$RUN_DIR/loader-blockers.txt"


### PR DESCRIPTION
## Por quê
O nightly full-suite — **único sinal vivo do scorecard SDD** — morreu **3 noites seguidas** (06-16/17/18): `junit.xml` 0 bytes + pest exit 255 por `Cannot redeclare function insertAuditLog()`, declarada global em `AuditLogCommandTest.php:41` **e** `ImmutabilityTriggersTest.php:122` (Pest carrega tudo no mesmo escopo global). E **nenhuma catraca ficou vermelha** — porque a métrica fica `not_yet_measured`, que nunca regride.

Diagnóstico: avaliação adversarial SDD 2026-06-18 (`sdd-avaliador-processo`, 8 agents), caminho crítico **passo 1**.

## O que muda
- **Fix 1 — a colisão:** renomeia o helper da Jana `insertAuditLog` → `insertImmutableAuditLog` (3 chamadas, menor blast radius que as 10 do Arquivos). Segue a convenção `insertAuditLogHc` que o próprio módulo Arquivos já usa em `HealthCheckCommandTest` pra evitar exatamente isto.
- **Fix 2 — defesa em profundidade:** o quarantine do `ct100-fullsuite.sh` só pegava colisão de *folder* do Pest. Agora também captura fatais de **LOAD** (`Cannot redeclare` e `Parse error`), quarentena o arquivo ofensor (registra em `loader-blockers.txt`) e re-tenta — em vez de zerar o run inteiro. Cap de 12 tentativas mantido.

## Validação
- `php -l` no teste renomeado → **No syntax errors detected**
- 0 token `insertAuditLog` cru restante na Jana
- `bash -n ct100-fullsuite.sh` → OK
- regex de extração validada via PCRE (extrai o 1º declarante / o arquivo quebrado)

## ⚠️ Dependência operacional (pós-merge)
1. O nightly roda contra o checkout de `main` no CT100 → **Fix 1 só vale após merge + CT100 atualizar main**.
2. O `ct100-fullsuite.sh` tem cópia em `/opt/oimpresso-fullsuite/` no CT100 (drift repo↔CT100 já flagrado no audit) → **Fix 2 exige copiar o script atualizado pra lá** antes da nightly de hoje 02:00 BRT.

Refs: US-GOV-018