### PR TITLE
fix(ci): ct100-fullsuite quarentena fatal de "Parse error" no load (FV-F3)

### DIFF
--- a/scripts/tests/ct100-fullsuite.sh
+++ b/scripts/tests/ct100-fullsuite.sh
@@ -237,6 +237,14 @@ for attempt in $(seq 1 12); do
     BLOCKER=$(grep -E 'Cannot (re)?declare' "$RUN_DIR/pest-out.txt" \
       | grep -oP 'in /workspace/\K[^ ]+(?= on line)' | head -1 || true)
   fi
+  # Detector 3 — PHP "Parse error" no LOAD: arquivo com sintaxe quebrada tambem zera a
+  # suite (exit 255 + junit.xml 0 bytes) ANTES do 1o teste e nao cai em 1 nem 2. Mensagem:
+  # "PHP Parse error: ... in /workspace/<F> on line N" — mesmo formato de cauda do detector 2.
+  # (Salvo de #2954, sessao paralela 2026-06-18 — #2953 cobriu redeclare, este cobre parse.)
+  if [ -z "$BLOCKER" ] && grep -qE 'Parse error' "$RUN_DIR/pest-out.txt"; then
+    BLOCKER=$(grep -E 'Parse error' "$RUN_DIR/pest-out.txt" \
+      | grep -oP 'in /workspace/\K[^ ]+(?= on line)' | head -1 || true)
+  fi
   [ -z "$BLOCKER" ] && break
   # Sanity: extracao errada de path NAO deve matar o run sob set -e — so quarentena o
   # arquivo que realmente existe no clone.


### PR DESCRIPTION
Follow-up de #2953, salvando a parte complementar da sessão paralela #2954 (fechada como superseded).

## Contexto

#2953 endureceu o `ct100-fullsuite.sh` pra auto-quarentenar fatais de **`Cannot redeclare`** no load (Detector 2). Mas há outra classe de fatal-de-load que zera a suite inteira do mesmo jeito (exit 255 + `junit.xml` 0 bytes, **antes** de 1 teste rodar) e que nem o Detector 1 (pasta Pest) nem o 2 (redeclare) pegam: um arquivo de teste com **sintaxe quebrada**.

## Fix

**Detector 3** no loop loader-blocker: reconhece `PHP Parse error: ... in /workspace/<F> on line N` (mesma cauda do Detector 2), quarentena o arquivo ofensor no clone descartável (registrado em `loader-blockers.txt`) e re-tenta. Herda o sanity-check de existência já presente, então não morre sob `set -e` com extração ruim.

## Verificação

- `bash -n scripts/tests/ct100-fullsuite.sh` → OK
- Lógica validada (perl + `grep -oP`): extrai o arquivo do parse-error; **não** dispara em warning comum.

Crédito da abordagem: #2954 (sessão paralela). Aquele PR renomeava só o lado Jana e quarentenava o arquivo "previously declared"; #2953 já cobriu o redeclare (ambos os lados + classe + sanity-check), então só o detector de parse-error sobrou como valor novo — é o que este PR traz.

Refs: FV-F3

🤖 Generated with [Claude Code](https://claude.com/claude-code)