### PR TITLE
feat(whatsapp): banner "canal caiu — religar" na Caixa + whatsmeow:health-probe (US-WA-308/309)

### DIFF
--- a/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
+++ b/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Services\Drivers\WhatsmeowState;
+use Modules\Whatsapp\Services\WhatsmeowReconciler;
+
+/**
+ * whatsmeow:health-probe — detecta sessão whatsmeow caída e converge channel_health.
+ *
+ * **Lacuna fechada (incidente 2026-06-18, US-WA-308).** O reconciler de 5min
+ * (`whatsapp:channels-reconcile`) é Baileys-only; canais `whatsapp_whatsmeow` só
+ * sabiam de queda via webhook `Disconnected`/`LoggedOut`. Mas o WuzAPI NÃO assina
+ * `LoggedOut` por default ("Skipping webhook. Not subscribed for this type=LoggedOut"),
+ * então um "logged out from another device" nunca chega ao app → `channel_health`
+ * fica `healthy` eternamente e a Caixa Unificada não avisa. Foi exatamente o que
+ * deixou o canal 11 (biz=1) caído ~3h sem ninguém ver.
+ *
+ * Este probe consulta o estado REAL do daemon (`Reconciler.reconcile()` →
+ * `/session/status`) pra cada canal whatsmeow ATIVO e converge o DB:
+ *   - LOGGED_OUT / NOT_EXISTS  → `markDisconnectedInDb` (sessão morreu → re-parear)
+ *   - BANNED                   → `markDisconnectedInDb(banDetected: true)`
+ *   - PAIRED                   → `markPairedInDb` (só re-marca se estava unhealthy)
+ *   - DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → NÃO toca o
+ *     health (queda transitória do daemon ou pareamento em curso não é logout —
+ *     evita falso-positivo; `whatsapp:daemon-source-drift-check` cobre daemon down).
+ *
+ * Idempotente (convergente, não acumulativo). Multi-tenant Tier 0 (ADR 0093):
+ * varre cross-business (cron sem session), cada row carrega seu `business_id` e o
+ * Reconciler nunca atravessa fronteira de tenant.
+ *
+ * @see Modules\Whatsapp\Services\WhatsmeowReconciler
+ * @see Modules\Whatsapp\Http\Controllers\Api\WhatsmeowWebhookController (caminho webhook)
+ * @see memory/requisitos/Whatsapp/SPEC.md (US-WA-308)
+ */
+class WhatsmeowHealthProbeCommand extends Command
+{
+    protected $signature = 'whatsmeow:health-probe {--detail : Loga o estado observado de cada canal}';
+
+    protected $description = 'Sonda o daemon e marca channel_health quando a sessão whatsmeow cai (incidente 2026-06-18).';
+
+    public function handle(WhatsmeowReconciler $reconciler): int
+    {
+        // SUPERADMIN: cron sem session — Tier 0 garantido pelo business_id de cada row
+        $channels = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('type', Channel::TYPE_WHATSAPP_WHATSMEOW)
+            ->where('status', 'active')
+            ->get();
+
+        if ($channels->isEmpty()) {
+            $this->info('Nenhum canal whatsmeow ativo pra sondar.');
+
+            return self::SUCCESS;
+        }
+
+        $flipped = 0;
+
+        foreach ($channels as $channel) {
+            $state = $reconciler->reconcile($channel);
+            $healthBefore = (string) $channel->channel_health;
+
+            if (in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)) {
+                if ($healthBefore !== 'disconnected') {
+                    $reconciler->markDisconnectedInDb($channel, "health-probe: {$state->value}");
+                    $flipped++;
+                }
+            } elseif ($state === WhatsmeowState::BANNED) {
+                if ($healthBefore !== 'banned') {
+                    $reconciler->markDisconnectedInDb($channel, 'health-probe: banned', banDetected: true);
+                    $flipped++;
+                }
+            } elseif ($state === WhatsmeowState::PAIRED) {
+                if ($healthBefore !== 'healthy') {
+                    $jid = is_array($channel->config_json) ? ($channel->config_json['whatsmeow_jid'] ?? null) : null;
+                    $reconciler->markPairedInDb($channel, is_string($jid) ? $jid : null);
+                    $flipped++;
+                }
+            }
+            // DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → não muta health
+
+            if ($this->option('detail')) {
+                $this->line(sprintf(
+                    '  ch#%d %-22s biz=%d · %s → health=%s',
+                    $channel->id,
+                    "'{$channel->label}'",
+                    $channel->business_id,
+                    $state->value,
+                    $channel->channel_health,
+                ));
+            }
+        }
+
+        Log::info('whatsmeow.health_probe.done', [
+            'event' => 'whatsmeow.health_probe.done',
+            'probed' => $channels->count(),
+            'flipped' => $flipped,
+        ]);
+
+        $this->info("Sondados {$channels->count()} canal(is) whatsmeow · {$flipped} mudou de estado.");
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -177,6 +177,12 @@ class CaixaUnificadaController extends Controller
             'customerContext' => $customerContext,
             'centrifugoConfig' => $centrifugoConfig,
 
+            // US-WA-308 (incidente 2026-06-18) — canais ATIVOS com saúde != healthy,
+            // eager (query trivial na tabela channels) pro banner "canal caiu —
+            // religar" aparecer no first-paint sem esperar o defer de
+            // availableAccounts. Tier 0 ADR 0093 + ACL canal=fila (US-WA-069).
+            'unhealthyChannels' => $this->buildUnhealthyChannelsPayload($businessId, $userId),
+
             // US-WA-301 (ADR 0267) — filas agora vêm do DB (seed lazy do config
             // na 1ª visita; fallback config se DB vazio). Shape QueueConfig compat.
             'queues' => $this->getQueuesConfig($businessId),
@@ -628,6 +634,41 @@ class CaixaUnificadaController extends Controller
             'channel_health' => $ch->channel_health,
             'count' => (int) ($convCounts[$ch->id] ?? 0),
         ])->all();
+    }
+
+    /**
+     * US-WA-308 (incidente 2026-06-18) — canais ATIVOS cuja sessão caiu, pro banner
+     * "canal desconectado — religar" no topo da Caixa Unificada.
+     *
+     * Eager (custo trivial: tabela `channels`, poucas rows) pra o aviso aparecer no
+     * first-paint — diferente de `availableAccounts` (deferred). Tier 0 ADR 0093 +
+     * ACL canal=fila (US-WA-069): só canais que o user pode ver. `degraded` entra
+     * junto de `disconnected`/`banned` porque já significa "não confiável agora".
+     *
+     * @return array<int, array{id: int, label: string, type: string, channel_health: string, last_health_message: ?string, last_health_check_at: ?string}>
+     */
+    protected function buildUnhealthyChannelsPayload(int $businessId, int $userId): array
+    {
+        $query = Channel::query()
+            ->where('business_id', $businessId)
+            ->where('status', 'active')
+            ->whereIn('channel_health', ['disconnected', 'banned', 'degraded']);
+        if (! $this->canSeeAllChannels()) {
+            $query->whereIn('id', $this->allowedChannelIdsSubquery($businessId, $userId));
+        }
+
+        return $query
+            ->orderBy('label')
+            ->get(['id', 'label', 'type', 'channel_health', 'last_health_message', 'last_health_check_at'])
+            ->map(fn (Channel $ch) => [
+                'id' => $ch->id,
+                'label' => $ch->label,
+                'type' => $ch->type,
+                'channel_health' => $ch->channel_health,
+                'last_health_message' => $ch->last_health_message,
+                'last_health_check_at' => optional($ch->last_health_check_at)->toIso8601String(),
+            ])
+            ->all();
     }
 
     /**

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -35,6 +35,7 @@ use Modules\Whatsapp\Console\Commands\RetryRecentMediaDownloadsCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
 use Modules\Whatsapp\Console\Commands\SlaScanCommand;
 use Modules\Whatsapp\Console\Commands\WebhookCanaryCommand;
+use Modules\Whatsapp\Console\Commands\WhatsmeowHealthProbeCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
@@ -108,6 +109,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 SlaScanCommand::class,                  // CYCLE-07 PR-2 — scan SLA policies + alertas escalation
                 MetricsAggregateCommand::class,         // US-WA-021/041 — snapshot diário métricas (CYCLE-07 PR-3)
                 ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
+                WhatsmeowHealthProbeCommand::class,      // US-WA-308 — detecta queda sessão whatsmeow (cron 3min, incidente 2026-06-18)
                 ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
                 CleanupWebhookNoncesCommand::class,     // US-WA-082 — purga nonces >24h (replay protection cleanup)
                 CleanupStaleJobsCommand::class,         // US-WA-084 — purga jobs presos da fila whatsapp-history (>6h)

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -429,6 +429,43 @@ it('R-WA-CAIXA-UNIF-013 — canal whatsmeow ativo vira chip ativo com count real
     expect($none['data'])->toHaveCount(0);
 });
 
+/**
+ * R-WA-CAIXA-UNIF-014 — US-WA-308 (incidente 2026-06-18): canal ATIVO com saúde
+ * caída entra no payload eager `unhealthyChannels` (banner "religar" no topo da
+ * Caixa); canal saudável NÃO entra; e o Tier 0 (ADR 0093) impede vazar canal caído
+ * de OUTRO business.
+ *
+ * red-first: sem o payload `unhealthyChannels` (ou filtrando health errado) o
+ * pluck/firstWhere não acha o canal → falha; é o discriminador, não tautológico.
+ */
+it('R-WA-CAIXA-UNIF-014 — canal ativo deslogado entra em unhealthyChannels + Tier 0', function () {
+    // biz=1 canal caído (logout) — DEVE aparecer
+    $down = cuctMakeChannel(1, 'caixa-unif-014-down');
+    $down->forceFill(['channel_health' => 'disconnected', 'last_health_message' => 'whatsmeow disconnected: logged_out'])->save();
+
+    // biz=1 canal saudável — NÃO deve aparecer
+    $ok = cuctMakeChannel(1, 'caixa-unif-014-ok');
+    $ok->forceFill(['channel_health' => 'healthy'])->save();
+
+    // biz=99 canal caído — Tier 0 impede vazar pra biz=1
+    $cross = cuctMakeChannel(99, 'caixa-unif-014-cross');
+    $cross->forceFill(['channel_health' => 'disconnected'])->save();
+
+    cuctSetUserAndGrant(1, 10, [$down->id, $ok->id]);
+
+    $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
+    $unhealthy = cuctResolveDefer($props['unhealthyChannels']); // eager — array direto
+
+    $ids = collect($unhealthy)->pluck('id')->all();
+    expect($ids)->toContain($down->id)
+        ->and($ids)->not->toContain($ok->id)
+        ->and($ids)->not->toContain($cross->id);
+
+    $row = collect($unhealthy)->firstWhere('id', $down->id);
+    expect($row['channel_health'])->toBe('disconnected')
+        ->and($row['label'])->toBe('Suporte');
+});
+
 // ============================================================================
 // 2. Cross-tenant Tier 0 (ADR 0093) — biz=99 NUNCA vaza pra biz=1
 // ============================================================================

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -750,6 +750,21 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // whatsmeow:health-probe (3 em 3 min) — fecha a lacuna que o reconciler
+        // Baileys-only NÃO cobre (incidente 2026-06-18, US-WA-308): canal whatsmeow
+        // "logged out from another device" sem webhook LoggedOut → channel_health
+        // ficava 'healthy' e a Caixa não avisava (linha caída ~3h sem ninguém ver).
+        // Probe consulta /session/status REAL e converge disconnected/banned/healthy.
+        $schedule->command('whatsmeow:health-probe')
+            ->everyThreeMinutes()
+            ->withoutOverlapping(3)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsmeow:health-probe FALHOU — queda de canal whatsmeow pode ficar invisível'
+                );
+            });
+
         // Worker da fila `whatsapp-history` (Wagner request 2026-05-14 02h):
         // "recebe tudo de maneira rapida... depois sincroniza com o banco,
         // sempre guarda para não perder". Cron everyMinute pra processar

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -3,7 +3,7 @@ page: /atendimento/caixa-unificada
 component: resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
 owner: wagner
 status: live
-last_validated: "2026-06-16"
+last_validated: "2026-06-18"
 cutover_at: "2026-05-15"
 supersedes: resources/js/Pages/Atendimento/Inbox/Index.charter.md
 parent_module: Whatsapp
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 15
+charter_version: 16
 permissao: whatsapp.access
 ---
 
@@ -282,6 +282,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + draft auditável` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL canal fail-loud` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-014 — canal ativo deslogado entra em unhealthyChannels + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-013 — canal whatsmeow ativo vira chip ativo com count real (PARTE 4)` | mesmo arquivo |
 
 ---
@@ -327,6 +328,7 @@ Após Wagner aprovar canary 7d:
 
 | Data | Autor | Mudança |
 |---|---|---|
+| 2026-06-18 | Claude (incidente WhatsApp atendimento) | **US-WA-308/309 banner "canal caiu — religar".** Origem: canal 11 (biz=1) deslogou "logged out from another device" às 07:50 sem webhook `LoggedOut` (WuzAPI não assina) → `channel_health` ficou `healthy`, a Caixa não avisou, linha caída ~3h sem ninguém ver. Fix: (1) prop eager `unhealthyChannels` no `CaixaUnificadaController` (ACL + Tier 0) + `ChannelHealthBanner` no topo da Caixa (clique → `/atendimento/canais/{id}` re-parear, QR já existente); (2) comando `whatsmeow:health-probe` (cron 3min, Kernel) que sonda `/session/status` real e converge disconnected/banned/healthy — fecha a lacuna do reconciler Baileys-only. Charter v16. Pest R-WA-CAIXA-UNIF-014. Sem dev server no worktree → build/typecheck/visual-regression no CI + screenshot [W] na prod (Wagner re-pareia e valida o fluxo real). |
 | 2026-06-16 | Claude Code [CL] (Caixa filtros 2-botões · Onda 2) | **Header da lista em 2 controles.** `ConversationListV4`: a fileira de 7 tabs + a fileira de power-filters (chips/selects) viram **Status** (DropdownMenu, 7-valor `?tab=`) + **Filtros** (botão funil `lucide Filter` + badge → Popover flutuante, não empurra a lista). Grupos do popover: Canal · Conta · Fila · Tags · Ordenar · Esperando há · Sem CRM · Janela 24h · Mídia 24h + "Limpar". **Atribuição omitida** — não há param backend (`CaixaUnificadaController` não filtra por assignee; só a tab "Minhas" + picker da sidebar) → não inventei grupo morto (anti M-AP-2). Contrato backend intacto (mesmos params na querystring; `buildQuery` agora carrega channel/account_id/queue → filtros persistem na navegação). Index.tsx passa accounts/channelTypeFilter/accountFilter/queues/queueFilter pra lista. Charter v15. **Verificado:** `tsc --noEmit` limpo nos 2 arquivos (só erros pré-existentes de `preserveScroll`) + `vite build:inertia` verde (4431 módulos, ConversationListV4 bundlou). Sem screenshot local (sem dev server no worktree) — visual-regression CI + revisão [W]. |
 | 2026-06-16 | Claude Code [CL] (Caixa filtros 2-botões · Onda 1) | **Faixa de canais removida.** Direção [W] 2026-06-16: a faixa horizontal `ChannelChipsRow` acima da shell (comprimia 1280px) sai; Canal/Conta viram grupos do popover **Filtros** da lista (Onda 2). Onda 1: removida a faixa + `ChannelChipsRow.tsx` (dead-code, único consumidor era esta tela); `availableChannels`/`availableAccounts` (props), URL-sync `?channel=`/`?account_id=` e os demais consumidores (Thread/Sidebar/Drawers/Nova-conversa) **intactos**. Charter v14. PR off origin/main; CI verifica build/typecheck (worktree sem node_modules). Onda 2 adiciona os grupos no popover Filtros + Status em DropdownMenu. |
 | 2026-06-16 | Claude Code (brief [CC] PARTE 4) | **Fix chips de canal — WhatsApp LIVE sumia.** `buildAvailableChannelsPayload` listava o WhatsApp como `whatsapp_baileys` (provider deletado, ADR 0202); o Channel ativo real é `whatsapp_whatsmeow` (WuzAPI/whatsmeow, ADR 0204), então `$activeTypesCount[id]` nunca casava → TODOS os chips caíam em 'em_breve' e o canal vivo (de onde as conversas chegam) ficava escondido. Row trocada pra `whatsapp_whatsmeow` (label/short "WhatsApp", hue 145 verde, glyph W); `?channel=whatsapp_whatsmeow` filtra via whereHas channel.type. Helper Pest e R-WA-CAIXA-UNIF-001 seedavam o type morto (mascaravam o bug) → migrados pro LIVE; novo R-WA-CAIXA-UNIF-013 (regressão: chip 'ativo' + count real + filtro). Tier 0 multi-tenant preservado. Completa a PARTE 4 que o item dark-mode abaixo deixou pra PR backend. Charter v12. PR próprio off origin/main. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -50,6 +50,7 @@ import QueuesSheet from './_components/QueuesSheet';
 import ConversationListV4 from './_components/ConversationListV4';
 import ConversationThreadV4 from './_components/ConversationThreadV4';
 import ContextSidebarV4 from './_components/ContextSidebarV4';
+import ChannelHealthBanner from './_components/ChannelHealthBanner';
 import type {
   AccountItem,
   AssigneeItem,
@@ -64,6 +65,7 @@ import type {
   Paginated,
   QueueConfig,
   CustomerContext,
+  UnhealthyChannel,
 } from './_components/helpers';
 
 interface Props {
@@ -102,6 +104,8 @@ interface Props {
   messages: CaixaUnifMessage[] | null;
   customerContext: CustomerContext | null;
   centrifugoConfig: CentrifugoConfig | null;
+  /** US-WA-308 — canais ativos com sessão caída (banner "religar"). Eager. */
+  unhealthyChannels?: UnhealthyChannel[];
   queues: Record<string, QueueConfig>;
   defaultQueue: string;
 }
@@ -111,7 +115,7 @@ export default function CaixaUnificadaIndex({
   queuesAdmin, canManageQueues,
   businessId: _businessId,
   statusFilter, channelTypeFilter, accountFilter, queueFilter, q,
-  thread, messages, customerContext, centrifugoConfig,
+  thread, messages, customerContext, centrifugoConfig, unhealthyChannels,
   queues, defaultQueue: _defaultQueue,
   within24h, unlinked, mediaInbound24h, inboundAging, orderBy, activeTagIds,
 }: Props) {
@@ -413,6 +417,9 @@ export default function CaixaUnificadaIndex({
           </button>
         </div>
       </div>
+
+      {/* US-WA-308 — banner "canal caiu — religar" (incidente 2026-06-18) */}
+      <ChannelHealthBanner channels={unhealthyChannels ?? []} />
 
       {/* Polish V2 §5 — tabs mobile (abaixo de lg; desktop 3-col intacto) */}
       <InboxMobileTabs

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
@@ -14,8 +14,8 @@ import type { UnhealthyChannel } from './helpers';
  * já existe em `/atendimento/canais/{id}`.
  *
  * Lê o prop EAGER `unhealthyChannels` (não-deferred) pra aparecer no first-paint.
- * Layout via primitivos `<Stack>`/`<Inline>` (ADR 0253); cor de status via token
- * semântico `text-destructive` (ds/no-adhoc-status-text).
+ * Layout via primitivos `<Stack>`/`<Inline>` (ADR 0253); cor 100% semântica via
+ * token `destructive` (ds/no-adhoc-status-text + ui:lint R1) — auto dark-mode.
  */
 const HEALTH_LABEL: Record<string, string> = {
   disconnected: 'desconectado',
@@ -39,7 +39,7 @@ export default function ChannelHealthBanner({ channels }: { channels: UnhealthyC
             key={ch.id}
             gap={3}
             role="alert"
-            className="rounded-md border border-red-300 bg-red-50 px-3.5 py-2.5 dark:border-red-900/60 dark:bg-red-950/40"
+            className="rounded-md border border-destructive/30 bg-destructive/10 px-3.5 py-2.5"
             data-testid={`caixa-unif-health-banner-${ch.id}`}
           >
             <AlertTriangle size={18} className="shrink-0 text-destructive" aria-hidden />
@@ -54,7 +54,7 @@ export default function ChannelHealthBanner({ channels }: { channels: UnhealthyC
             </div>
             <a
               href={route('atendimento.channels.show', ch.id)}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-red-300 bg-white px-3 py-1.5 text-[12.5px] font-medium text-destructive transition-colors hover:bg-red-100 dark:border-red-900/60 dark:bg-transparent dark:hover:bg-red-950"
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-destructive/40 bg-background px-3 py-1.5 text-[12.5px] font-medium text-destructive transition-colors hover:bg-destructive/10"
               data-testid={`caixa-unif-health-banner-religar-${ch.id}`}
             >
               <QrCode size={15} aria-hidden />

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
@@ -1,0 +1,63 @@
+import { AlertTriangle, QrCode } from 'lucide-react';
+
+import type { UnhealthyChannel } from './helpers';
+
+/**
+ * ChannelHealthBanner — banner "canal caiu — religar" no topo da Caixa Unificada.
+ *
+ * US-WA-308 (incidente 2026-06-18): canal whatsmeow deslogou ("401: logged out
+ * from another device") e o app nunca soube → `channel_health` ficou `healthy` e
+ * a tela não avisava. Agora o `whatsmeow:health-probe` (cron 3min) converge o
+ * health real e este banner o exibe — com clique direto pro re-parear (QR) que
+ * já existe em `/atendimento/canais/{id}`.
+ *
+ * Lê o prop EAGER `unhealthyChannels` (não-deferred) pra aparecer no first-paint.
+ */
+const HEALTH_LABEL: Record<string, string> = {
+  disconnected: 'desconectado',
+  banned: 'bloqueado pela Meta',
+  degraded: 'instável',
+};
+
+export default function ChannelHealthBanner({ channels }: { channels: UnhealthyChannel[] }) {
+  if (!channels || channels.length === 0) return null;
+
+  return (
+    <div className="shrink-0 flex flex-col gap-1 px-1" data-testid="caixa-unif-health-banner">
+      {channels.map((ch) => {
+        const label = HEALTH_LABEL[ch.channel_health] ?? 'desconectado';
+        const caiu = ch.last_health_check_at
+          ? new Date(ch.last_health_check_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })
+          : null;
+
+        return (
+          <div
+            key={ch.id}
+            role="alert"
+            className="flex items-center gap-3 rounded-md border border-red-300 bg-red-50 px-3.5 py-2.5 dark:border-red-900/60 dark:bg-red-950/40"
+            data-testid={`caixa-unif-health-banner-${ch.id}`}
+          >
+            <AlertTriangle size={18} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />
+            <div className="min-w-0 flex-1 leading-tight">
+              <p className="text-[13px] font-semibold text-red-700 dark:text-red-300">
+                WhatsApp {ch.label} {label}
+              </p>
+              <p className="text-[12px] text-red-700/80 dark:text-red-300/80">
+                Novas mensagens não estão entrando até você religar
+                {caiu ? ` · caiu às ${caiu}` : ''}.
+              </p>
+            </div>
+            <a
+              href={route('atendimento.channels.show', ch.id)}
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-red-300 bg-white px-3 py-1.5 text-[12.5px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-900/60 dark:bg-transparent dark:text-red-300 dark:hover:bg-red-950"
+              data-testid={`caixa-unif-health-banner-religar-${ch.id}`}
+            >
+              <QrCode size={15} aria-hidden />
+              Religar agora
+            </a>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
@@ -14,7 +14,8 @@ import type { UnhealthyChannel } from './helpers';
  * já existe em `/atendimento/canais/{id}`.
  *
  * Lê o prop EAGER `unhealthyChannels` (não-deferred) pra aparecer no first-paint.
- * Layout via primitivos `<Stack>`/`<Inline>` (ADR 0253).
+ * Layout via primitivos `<Stack>`/`<Inline>` (ADR 0253); cor de status via token
+ * semântico `text-destructive` (ds/no-adhoc-status-text).
  */
 const HEALTH_LABEL: Record<string, string> = {
   disconnected: 'desconectado',
@@ -41,19 +42,19 @@ export default function ChannelHealthBanner({ channels }: { channels: UnhealthyC
             className="rounded-md border border-red-300 bg-red-50 px-3.5 py-2.5 dark:border-red-900/60 dark:bg-red-950/40"
             data-testid={`caixa-unif-health-banner-${ch.id}`}
           >
-            <AlertTriangle size={18} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />
+            <AlertTriangle size={18} className="shrink-0 text-destructive" aria-hidden />
             <div className="min-w-0 flex-1 leading-tight">
-              <p className="text-[13px] font-semibold text-red-700 dark:text-red-300">
+              <p className="text-[13px] font-semibold text-destructive">
                 WhatsApp {ch.label} {label}
               </p>
-              <p className="text-[12px] text-red-700/80 dark:text-red-300/80">
+              <p className="text-[12px] text-destructive/80">
                 Novas mensagens não estão entrando até você religar
                 {caiu ? ` · caiu às ${caiu}` : ''}.
               </p>
             </div>
             <a
               href={route('atendimento.channels.show', ch.id)}
-              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-red-300 bg-white px-3 py-1.5 text-[12.5px] font-medium text-red-700 transition-colors hover:bg-red-100 dark:border-red-900/60 dark:bg-transparent dark:text-red-300 dark:hover:bg-red-950"
+              className="inline-flex shrink-0 items-center gap-1.5 rounded-md border border-red-300 bg-white px-3 py-1.5 text-[12.5px] font-medium text-destructive transition-colors hover:bg-red-100 dark:border-red-900/60 dark:bg-transparent dark:hover:bg-red-950"
               data-testid={`caixa-unif-health-banner-religar-${ch.id}`}
             >
               <QrCode size={15} aria-hidden />

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangle, QrCode } from 'lucide-react';
 
+import { Inline, Stack } from '@/Components/layout';
+
 import type { UnhealthyChannel } from './helpers';
 
 /**
@@ -12,6 +14,7 @@ import type { UnhealthyChannel } from './helpers';
  * já existe em `/atendimento/canais/{id}`.
  *
  * Lê o prop EAGER `unhealthyChannels` (não-deferred) pra aparecer no first-paint.
+ * Layout via primitivos `<Stack>`/`<Inline>` (ADR 0253).
  */
 const HEALTH_LABEL: Record<string, string> = {
   disconnected: 'desconectado',
@@ -23,7 +26,7 @@ export default function ChannelHealthBanner({ channels }: { channels: UnhealthyC
   if (!channels || channels.length === 0) return null;
 
   return (
-    <div className="shrink-0 flex flex-col gap-1 px-1" data-testid="caixa-unif-health-banner">
+    <Stack gap={1} className="shrink-0 px-1" data-testid="caixa-unif-health-banner">
       {channels.map((ch) => {
         const label = HEALTH_LABEL[ch.channel_health] ?? 'desconectado';
         const caiu = ch.last_health_check_at
@@ -31,10 +34,11 @@ export default function ChannelHealthBanner({ channels }: { channels: UnhealthyC
           : null;
 
         return (
-          <div
+          <Inline
             key={ch.id}
+            gap={3}
             role="alert"
-            className="flex items-center gap-3 rounded-md border border-red-300 bg-red-50 px-3.5 py-2.5 dark:border-red-900/60 dark:bg-red-950/40"
+            className="rounded-md border border-red-300 bg-red-50 px-3.5 py-2.5 dark:border-red-900/60 dark:bg-red-950/40"
             data-testid={`caixa-unif-health-banner-${ch.id}`}
           >
             <AlertTriangle size={18} className="shrink-0 text-red-600 dark:text-red-400" aria-hidden />
@@ -55,9 +59,9 @@ export default function ChannelHealthBanner({ channels }: { channels: UnhealthyC
               <QrCode size={15} aria-hidden />
               Religar agora
             </a>
-          </div>
+          </Inline>
         );
       })}
-    </div>
+    </Stack>
   );
 }

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -59,6 +59,19 @@ export interface AccountItem {
 }
 
 /**
+ * US-WA-308 — canal ATIVO cuja sessão caiu (banner "religar" no topo da Caixa).
+ * Prop eager `unhealthyChannels` — health convergido pelo cron `whatsmeow:health-probe`.
+ */
+export interface UnhealthyChannel {
+  id: number;
+  label: string;
+  type: string;
+  channel_health: string;
+  last_health_message: string | null;
+  last_health_check_at: string | null;
+}
+
+/**
  * Fila — derivada (não persiste em DB). Heurística tag → fila no Controller.
  */
 export interface QueueDerived {


### PR DESCRIPTION
## Incidente (origem)

Wagner reportou que o atendimento WhatsApp **não avisa na tela quando o canal cai**. Investigação confirmou incidente vivo: o canal 11 ("Suporte", biz=1) **deslogou às 07:50 BRT de 18/06** — `Logged out: "401: logged out from another device"` no daemon WuzAPI (CT100) — e o app **nunca soube**: o WuzAPI **não assina o evento `LoggedOut`** (log: `Skipping webhook. Not subscribed for this type=LoggedOut`), então `channels.channel_health` ficou `healthy`, a Caixa Unificada não mostrou nada, e a linha ficou **caída ~3h sem ninguém perceber**. O reconciler de 5min (`whatsapp:channels-reconcile`) é **Baileys-only** e não cobre whatsmeow.

Mensagens históricas (49k) intactas; nada real perdido na janela noturna (só Stories/recibos).

## O que este PR faz

1. **Detecção** — `whatsmeow:health-probe` (cron 3min) sonda `/session/status` real via `WhatsmeowReconciler` e converge `channel_health` (disconnected/banned/healthy). Não toca health em `DAEMON_UNREACHABLE`/pareamento em curso (evita falso-positivo).
2. **Aviso na tela** — prop eager `unhealthyChannels` (ACL canal=fila + Tier 0 ADR 0093) + `ChannelHealthBanner` (primitivos Stack/Inline) no topo da Caixa. "Religar agora" → `/atendimento/canais/{id}` (QR de re-parear já existente).
3. Pest `R-WA-CAIXA-UNIF-014` + charter v16.

## Infra Contract

Mudança em runtime crítico é **aditiva e artisan-only**: `WhatsappServiceProvider` registra o comando `whatsmeow:health-probe` e `app/Console/Kernel.php` adiciona 1 entrada de schedule (cron 3min). **Não toca rota, middleware, routing nem bootstrap HTTP** — nenhum comportamento de request muda.

### 1. Artisan Contract — comando + output esperado

```bash
$ php artisan whatsmeow:health-probe --detail
  ch#11 'Suporte'             biz=1 · logged_out → health=disconnected
  ch#12 'Jana'                biz=1 · paired → health=healthy
Sondados 2 canal(is) whatsmeow · 1 mudou de estado.
```
(o estado real depende da sessão no momento; o ponto é o canal deslogado virar `disconnected`.)

### 2. Regression adjacent — o que NÃO muda

- Crons whatsapp existentes intactos: `whatsapp:channels-reconcile`, `whatsapp:health-check-all`, `queue:work --queue=whatsapp` (mesmas entradas/cadência).
- `GET /atendimento/caixa-unificada` continua 200 — o banner é só um prop eager novo.

### 3. Environment delta — Pest local NÃO prova prod

- O comando fala com o daemon WuzAPI real (`/session/status`); Pest local não tem o daemon.
- Pest do controller está em quarentena (Onda 2 SDD floor) → R-WA-CAIXA-UNIF-014 documenta o contrato mas não roda no CI agora.
- **Declarado:** Pest local + build CI NÃO provam o fluxo. Validação é na prod: rodar o comando + Wagner ver o banner + clicar + escanear.

### 4. Smoke prod pós-deploy (preencher após merge + deploy)

```bash
# (timestamp + saída real de `php artisan whatsmeow:health-probe --detail` na prod)
```
| Caso | Esperado | Observado | OK |
|---|---|---|---|
| health-probe marca ch#11 | `logged_out → disconnected` | _(pós-deploy)_ | ⬜ |
| Banner aparece na Caixa | barra vermelha + "Religar" | _(pós-deploy, screenshot [W])_ | ⬜ |
| Re-parear → reconecta | `Connected → healthy` → banner some | _(pós-deploy)_ | ⬜ |

## Plano de teste (validação real em prod — Wagner)

1. Deploy.
2. `php artisan whatsmeow:health-probe` → canal 11 vira `disconnected`.
3. Abrir a Caixa → **ver o banner vermelho**.
4. Clicar **Religar** → QR → escanear no celular.
5. Reconectar → webhook `Connected` → `healthy` → **banner some** + linha restaurada.

## Notas

- Sem dev server no worktree (off origin/main, sem node_modules) → build/typecheck/visual-regression no CI + screenshot [W] na prod (padrão do projeto).
- Fast-follow (não neste PR): assinar `LoggedOut` no provisionamento WuzAPI (detecção real-time) — resto da US-WA-308; matar o cron Baileys morto (US-WA-310).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
