### PR TITLE
fix(sdd): mata o comentário factualmente falso do full_suite no scorecard

### DIFF
--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -116,7 +116,7 @@ function buildScorecard() {
         detail: an,
       },
       full_suite_pass_rate: notYet('up', '100% não-quarentenado',
-        'nightly MySQL diagnóstica (FV-F3) — nenhum run full-repo MySQL jamais foi salvo'),
+        'nightly MySQL diagnóstica (FV-F3) roda no CT100 (15+ runs reais; último OK 2026-06-15) — o que falta é o transporte CT100→scorecard publicar governance/nightly-floor.json. Ver ADR 0279 / proposal #2765'),
       n_quarantine: {
         status: 'measured', value: q.files, unit: 'arquivos de teste',
         direction: 'down', target: 0,


### PR DESCRIPTION
## Por quê
O `source` de `full_suite_pass_rate` em `sdd-scorecard.mjs` dizia **"nenhum run full-repo MySQL jamais foi salvo"** — factualmente falso. O nightly FV-F3 roda no CT100 há **15+ runs** (último OK **2026-06-15**, junit de 15 MB). O **ADR 0279** já declarara esse comentário falso; o avaliador adversarial de **2026-06-18** reconfirmou que persistia em `main` (risco sistêmico #2 — *"mede mas não governa"*).

## O que muda
- 1 string. A métrica **segue `not_yet_measured`** (correto — o transporte CT100→scorecard ainda não existe), mas o `source` agora diz a verdade: os runs existem; o que falta é publicar `governance/nightly-floor.json`.
- Aponta pro **ADR 0279** + **proposal #2765**, onde a forma do artefato (write-side) será decidida.
- **Sem mudança de lógica/medição.** `node --check` OK.

## Fora de escopo (de propósito)
read-side (ler `nightly-floor.json`) + write-side ficam pro PR que fechar o **#2765** — a forma do artefato é decisão de governança pendente, não invento aqui.

Refs: US-GOV-018, ADR 0279