### PR TITLE
feat(sdd): read-side do floor MEDIR→GOVERNAR (ADR 0279 PR-1 · US-GOV-023)

### DIFF
--- a/.github/workflows/sdd-scorecard.yml
+++ b/.github/workflows/sdd-scorecard.yml
@@ -30,6 +30,8 @@ on:
       - 'scripts/governance/knowledge-drift.mjs'
       - 'governance/sdd-scorecard.json'
       - 'governance/sdd-scorecard-baseline.json'
+      - 'governance/nightly-floor.json'        # floor publicado pelo write-side CT100 (ADR 0279)
+      - 'scripts/governance/sdd-floor-read.test.mjs'
       - '.github/workflows/sdd-scorecard.yml'
   schedule:
     - cron: '50 9 * * *' # 06:50 BRT diário (pós-nightly)
@@ -51,6 +53,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Read-side do floor — meta-teste (hard · ADR 0279 PR-1 · US-GOV-023)
+        run: node scripts/governance/sdd-floor-read.test.mjs
 
       - name: Medir — agregador escreve governance/sdd-scorecard.json
         run: |

--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -43,9 +43,9 @@
     "full_suite_pass_rate": {
       "status": "not_yet_measured",
       "value": null,
-      "direction": "up",
-      "target": "100% não-quarentenado",
-      "source": "nightly MySQL diagnóstica (FV-F3) — nenhum run full-repo MySQL jamais foi salvo",
+      "direction": "down",
+      "target": 0,
+      "source": "governance/nightly-floor.json ainda não publicado pelo write-side CT100 (ADR 0279 PR-2 — precisa de credencial de push no CT100). A nightly FV-F3 roda (15+ runs reais); falta o transporte.",
       "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
     },
     "n_quarantine": {
@@ -86,8 +86,8 @@
       "target": 100,
       "source": "scripts/governance/knowledge-drift.mjs --json (BRIEFING.md presente por módulo)",
       "detail": {
-        "with_door": 69,
-        "modules": 69
+        "with_door": 70,
+        "modules": 70
       }
     },
     "recall_eval_violations": {

--- a/scripts/governance/sdd-floor-read.test.mjs
+++ b/scripts/governance/sdd-floor-read.test.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Meta-teste do read-side do floor (ADR 0279 / US-GOV-023, PR-1).
+// Importa measureFullSuiteFloor de sdd-scorecard.mjs (guard isMain garante que o
+// import NÃO dispara o scorecard inteiro) e prova os 2+1 lados:
+//   A) arquivo ausente            → not_yet_measured (fallback honesto, zero-risco)
+//   B) governance/nightly-floor.json válido → measured (value = floor_count, desce p/ 0)
+//   C) arquivo presente malformado → not_yet_measured (graceful, não estoura)
+// Uso: node scripts/governance/sdd-floor-read.test.mjs
+import { measureFullSuiteFloor } from './sdd-scorecard.mjs';
+import { writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+let fails = 0;
+const ok = (cond, msg) => { if (cond) console.log(`  ✓ ${msg}`); else { console.error(`  ✗ ${msg}`); fails++; } };
+
+// ── A: ausente → notYet ─────────────────────────────────────────────────────
+const absent = measureFullSuiteFloor(join(tmpdir(), `floor-inexistente-${process.pid}.json`));
+ok(absent.status === 'not_yet_measured', 'arquivo ausente → not_yet_measured');
+ok(absent.value === null, 'ausente → value null (não mente 0)');
+
+// ── B: válido → measured ────────────────────────────────────────────────────
+const okPath = join(tmpdir(), `floor-ok-${process.pid}.json`);
+writeFileSync(okPath, JSON.stringify({
+  floor_count: 1280, floor_files_hash: 'deadbeef',
+  runs: [{ sha: 'a1', ts: '2026-06-19T05:00Z', failed: 448, errors: 832, skipped: 1985 }],
+  computed_at: '2026-06-19T05:10Z', intersection_of: 2,
+}));
+try {
+  const m = measureFullSuiteFloor(okPath);
+  ok(m.status === 'measured', 'json válido → measured');
+  ok(m.value === 1280, 'value === floor_count (1280)');
+  ok(m.direction === 'down' && m.target === 0, 'floor DESCE pra 0');
+  ok(m.detail.intersection_of === 2, 'detail preserva intersection_of');
+} finally { rmSync(okPath, { force: true }); }
+
+// ── C: malformado → notYet (graceful) ───────────────────────────────────────
+const badPath = join(tmpdir(), `floor-bad-${process.pid}.json`);
+writeFileSync(badPath, 'isto não é json {');
+try {
+  ok(measureFullSuiteFloor(badPath).status === 'not_yet_measured', 'json malformado → not_yet_measured (graceful)');
+} finally { rmSync(badPath, { force: true }); }
+
+// ── D: sem floor_count numérico → notYet ────────────────────────────────────
+const noCountPath = join(tmpdir(), `floor-nocount-${process.pid}.json`);
+writeFileSync(noCountPath, JSON.stringify({ runs: [] }));
+try {
+  ok(measureFullSuiteFloor(noCountPath).status === 'not_yet_measured', 'sem floor_count → not_yet_measured');
+} finally { rmSync(noCountPath, { force: true }); }
+
+console.log(fails === 0 ? '\n  floor read-side (ADR 0279 PR-1): OK\n' : `\n  floor read-side: ${fails} FALHA(S)\n`);
+process.exit(fails === 0 ? 0 : 1);

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -24,9 +24,10 @@
 //                                                        # SDD_RATCHET_ARM=1 trata todas como armadas (simulação/selftest).
 // Node puro (fs + execSync). Sem deps, sem DB, sem PHP. Idioma: clone de knowledge-drift.mjs.
 
-import { readdirSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, existsSync, writeFileSync, realpathSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const ROOT = process.cwd();
 const OUT = join(ROOT, 'governance', 'sdd-scorecard.json');
@@ -91,6 +92,38 @@ const notYet = (direction, target, source) => ({
   baseline_rule: '1ª medição real da fonte, nunca do plano (anti-stale)',
 });
 
+// ── fonte: floor do nightly CT100 (ADR 0279 — transporte Opção A · US-GOV-023) ─
+// Read-side do elo MEDIR→GOVERNAR. Lê governance/nightly-floor.json, que o write-side
+// (PR-2) escreve no CT100 via git-push [skip ci]. O artefato carrega floor_count =
+// INTERSEÇÃO dos arquivos-que-falham entre ≥2 runs (def US-GOV-018) + counts por run.
+// O schema NÃO traz passed/total, então a métrica mede o FLOOR (arquivos-que-falham,
+// DESCE pra 0); o nome histórico full_suite_pass_rate fica só pra casar a chave do
+// baseline. Fallback not_yet_measured se ausente/inválido — ZERO-RISCO até a 1ª escrita
+// do CT100 (nunca "mente 0"). Quando o write-side publicar, vira measured sozinha.
+export function measureFullSuiteFloor(floorPath = join(ROOT, 'governance', 'nightly-floor.json')) {
+  if (!existsSync(floorPath)) {
+    return notYet('down', 0,
+      'governance/nightly-floor.json ainda não publicado pelo write-side CT100 (ADR 0279 PR-2 — precisa de credencial de push no CT100). A nightly FV-F3 roda (15+ runs reais); falta o transporte.');
+  }
+  let f;
+  try { f = JSON.parse(readFileSync(floorPath, 'utf8')); }
+  catch { return notYet('down', 0, 'governance/nightly-floor.json presente mas JSON inválido — write-side corrige; fallback honesto.'); }
+  if (typeof f.floor_count !== 'number') {
+    return notYet('down', 0, 'governance/nightly-floor.json sem floor_count numérico (schema ADR 0279) — fallback honesto.');
+  }
+  return {
+    status: 'measured', value: f.floor_count, unit: 'arquivos-que-falham (interseção ≥2 runs · ADR 0279)',
+    direction: 'down', target: 0,
+    source: 'governance/nightly-floor.json (transporte CT100→scorecard · ADR 0279 Opção A · US-GOV-023)',
+    detail: {
+      floor_files_hash: f.floor_files_hash ?? null,
+      runs: Array.isArray(f.runs) ? f.runs : [],
+      computed_at: f.computed_at ?? null,
+      intersection_of: f.intersection_of ?? null,
+    },
+  };
+}
+
 function buildScorecard() {
   const kd = measureKnowledgeDrift();
   const an = measureAnchors();
@@ -115,8 +148,7 @@ function buildScorecard() {
         source: 'scripts/governance/anchor-lint.mjs --json .summary.anchor_coverage_pct (fonte única — ADR 0273 §2)',
         detail: an,
       },
-      full_suite_pass_rate: notYet('up', '100% não-quarentenado',
-        'nightly MySQL diagnóstica (FV-F3) roda no CT100 (15+ runs reais; último OK 2026-06-15) — o que falta é o transporte CT100→scorecard publicar governance/nightly-floor.json. Ver ADR 0279 / proposal #2765'),
+      full_suite_pass_rate: measureFullSuiteFloor(),
       n_quarantine: {
         status: 'measured', value: q.files, unit: 'arquivos de teste',
         direction: 'down', target: 0,
@@ -175,16 +207,23 @@ function ratchet(current) {
   return 1;
 }
 
-// ── main ────────────────────────────────────────────────────────────────────
-const scorecard = buildScorecard();
-const body = JSON.stringify(scorecard, null, 2) + '\n';
+// ── main (só quando executado direto; importável p/ teste sem rodar) ────────
+const isMain = (() => {
+  try { return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url); }
+  catch { return false; }
+})();
 
-if (MODE_JSON) { process.stdout.write(body); process.exit(0); }
-if (MODE_RATCHET) process.exit(ratchet(scorecard));
+if (isMain) {
+  const scorecard = buildScorecard();
+  const body = JSON.stringify(scorecard, null, 2) + '\n';
 
-writeFileSync(OUT, body, 'utf8');
-const measured = Object.entries(scorecard.metrics).filter(([, m]) => m.status === 'measured');
-const pending = Object.keys(scorecard.metrics).length - measured.length;
-console.log(`\n  SDD SCORECARD → governance/sdd-scorecard.json\n`);
-for (const [name, m] of measured) console.log(`  ✓ ${name.padEnd(22)} ${String(m.value).padStart(6)} ${m.unit}  (meta: ${m.target}, ${m.direction === 'up' ? 'sobe' : 'desce'})`);
-console.log(`  … ${pending} métricas not_yet_measured (fonte futura declarada no JSON — baseline na 1ª medição real)\n`);
+  if (MODE_JSON) { process.stdout.write(body); process.exit(0); }
+  if (MODE_RATCHET) process.exit(ratchet(scorecard));
+
+  writeFileSync(OUT, body, 'utf8');
+  const measured = Object.entries(scorecard.metrics).filter(([, m]) => m.status === 'measured');
+  const pending = Object.keys(scorecard.metrics).length - measured.length;
+  console.log(`\n  SDD SCORECARD → governance/sdd-scorecard.json\n`);
+  for (const [name, m] of measured) console.log(`  ✓ ${name.padEnd(22)} ${String(m.value).padStart(6)} ${m.unit}  (meta: ${m.target}, ${m.direction === 'up' ? 'sobe' : 'desce'})`);
+  console.log(`  … ${pending} métricas not_yet_measured (fonte futura declarada no JSON — baseline na 1ª medição real)\n`);
+}


### PR DESCRIPTION
## Por quê
Fecha o **PR-1** (read-side) do elo **MEDIR→GOVERNAR** (ADR 0279, Opção A) — o risco sistêmico #1 do audit adversarial (*"mede mas não governa"*). É o slice **seguro e testável local**; o write-side (PR-2) fica bloqueado noutra coisa (abaixo).

## O que muda
- **`measureFullSuiteFloor()`** em `sdd-scorecard.mjs`: lê `governance/nightly-floor.json` (schema ADR 0279: `{floor_count, floor_files_hash, runs, computed_at, intersection_of}`). Como o schema não traz passed/total, a métrica mede o **FLOOR** (arquivos-que-falham, desce→0); o nome `full_suite_pass_rate` fica só pra casar a chave do baseline.
- **Fallback `not_yet_measured`** se o arquivo está ausente/inválido/sem floor_count → **zero-risco** até a 1ª escrita do CT100 (nunca "mente 0"). Quando o write-side publicar, vira `measured` sozinha.
- **Guard `isMain`** (`realpathSync == fileURLToPath`): o módulo vira importável sem disparar o agregador inteiro.
- **`sdd-floor-read.test.mjs`**: meta-teste (ausente/válido/malformado/sem-floor_count) — step **HARD** novo no `sdd-scorecard.yml` (gate real, não advisory).
- **`sdd-scorecard.json` regenerado** (não hand-edit, ledger §C): mata a string falsa que ainda sobrava no JSON gerado; `front_door` detail 69→70 (value pct segue 100% → sem impacto no ratchet).

## Validação local
- `node --check` OK · meta-teste **8/8** · run direto produz `full_suite` notYet honesto.

## Fora de escopo — PR-2 (write-side) está BLOQUEADO
O passo no `ct100-fullsuite.sh` que computa+commita o floor precisa de **credencial de push no CT100** — verifiquei: o CT100 hoje **não tem** `gh` nem `GH_TOKEN` nem credential.helper (clona via https sem cred). Provisionar isso é **decisão de segredo (Vaultwarden)**, não código. Além disso o floor por interseção precisa de **≥2 nightlies válidos** — os 3 últimos morreram; recuperam a partir de hoje 02:00 BRT (fix #2953/#2955 + harness deployado).

Refs: ADR 0279, US-GOV-023