### PR TITLE
fix(deploy): ignora ext-sodium no composer (desbloqueia deploys do main)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -243,9 +243,9 @@ jobs:
           /tmp/ssh_exec.sh "
             set -o pipefail &&
             cd $RDIR &&
-            composer install --optimize-autoloader --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry 2>&1 | tail -20 &&
+            composer install --optimize-autoloader --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry --ignore-platform-req=ext-sodium 2>&1 | tail -20 &&
             echo '=== dump-autoload force ===' &&
-            composer dump-autoload -o --classmap-authoritative --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry 2>&1 | tail -10
+            composer dump-autoload -o --classmap-authoritative --no-interaction --no-scripts --ignore-platform-req=ext-opentelemetry --ignore-platform-req=ext-sodium 2>&1 | tail -10
           "
 
       - name: Boot smoke CONSOLE — falha o deploy AGORA se o artisan não bootar (ADR 0216 + incidente 2026-06-17)
@@ -427,7 +427,7 @@ jobs:
             /tmp/ssh_exec.sh "cd $RDIR && php artisan up 2>&1 || rm -f storage/framework/down storage/framework/maintenance.php 2>&1 || true; echo 'maintenance OFF (boot OK)'"
           else
             /tmp/ssh_exec.sh "cd $RDIR && php artisan down --retry=60 --refresh=60 2>&1 || true; echo 'MANTIDO EM MAINTENANCE (503) — codigo nao boota'"
-            echo "::error::Codigo deployado NAO boota (php artisan about falhou). Site mantido em MAINTENANCE (503 gracioso) em vez de servir 500. Recuperar no prod: 'composer dump-autoload -o --classmap-authoritative --no-scripts --ignore-platform-req=ext-opentelemetry' + reset OPcache, OU re-deploy. Ver Tail laravel.log abaixo."
+            echo "::error::Codigo deployado NAO boota (php artisan about falhou). Site mantido em MAINTENANCE (503 gracioso) em vez de servir 500. Recuperar no prod: 'composer dump-autoload -o --classmap-authoritative --no-scripts --ignore-platform-req=ext-opentelemetry --ignore-platform-req=ext-sodium' + reset OPcache, OU re-deploy. Ver Tail laravel.log abaixo."
             exit 1
           fi
 


### PR DESCRIPTION
## Outage — deploys do main quebrados hoje

O `composer install` do `deploy.yml` aborta: o `/usr/bin/php` 8.4.19 (CLI que o composer usa no Hostinger) **não tem `ext-sodium`**, e `lcobucci/jwt 5.6.0` (transitivo de `league/oauth2-server`) **exige** sodium → `Your lock file does not contain a compatible set of packages`. Os 2-3 últimos deploys do `main` falharam por isso (continuação do incidente classmap-stale de ~1h atrás).

**O app está de pé** (login 200) — o php do web (LiteSpeed) tem sodium; é só o check do CLI do composer que falha.

## Fix

Adiciona `--ignore-platform-req=ext-sodium` ao `composer install` + `dump-autoload` (mesmo padrão já usado pra `ext-opentelemetry`) + atualiza a dica de recovery. Auto-curável: ao entrar no main, o próximo deploy passa.

## Validação pós-deploy

Este merge dispara o `deploy.yml` já corrigido — se o `composer install` passar e `php artisan about` bootar, está validado. (Sem rota HTTP nova; mudança só no pipeline.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
