### PR TITLE
fix(sells): tamanho selecionado no popover não era adicionado à venda

### DIFF
--- a/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
@@ -368,7 +368,18 @@ export default function ProductSearchAutocomplete({
   // Click fora fecha dropdown
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+      const target = e.target as Element | null;
+      // Radix renderiza PopoverContent num Portal em document.body — FORA do
+      // containerRef. Sem este guard, o mousedown num item do popover de variação
+      // ("Escolha o tamanho") conta como "clique fora" e dispara setOpen(false) +
+      // setExpandedProductId(null) ANTES do onClick do <button> da variação rodar:
+      // o Popover desmonta e a seleção nunca chega em onSelect → a variação não é
+      // adicionada à venda (Larissa @ Rota Livre 2026-06-18: "ao selecionar o
+      // tamanho ele não é adicionado, está sendo preciso digitar o SKU"). Digitar
+      // o SKU funcionava porque cai no handler de teclado (Enter), sem clique no
+      // portal. Cobre também o popover de configurar-busca (mesmo wrapper Radix).
+      if (target?.closest('[data-radix-popper-content-wrapper]')) return;
+      if (containerRef.current && !containerRef.current.contains(target as Node)) {
         setOpen(false);
         setExpandedProductId(null);
       }

--- a/tests/product-variation-click.test.tsx
+++ b/tests/product-variation-click.test.tsx
@@ -1,0 +1,102 @@
+// Regressão — clicar/tocar num tamanho no popover "Escolha o tamanho" adiciona
+// a variação à venda (bug Larissa @ Rota Livre, 2026-06-18).
+//
+// Bug: o handler de "clique fora" (mousedown no document) tratava o mousedown num
+// item do popover de variação como clique-fora — porque o Radix PopoverContent é
+// renderizado num Portal em document.body, FORA do containerRef. Resultado:
+// setOpen(false)+setExpandedProductId(null) disparavam no mousedown, o Popover
+// desmontava, e o onClick do <button> da variação nunca rodava → onSelect não era
+// chamado. A operadora só conseguia adicionar digitando o SKU (caminho de teclado,
+// que não passa por clique no portal).
+//
+// Este teste reproduz o TOQUE real: mousedown (que borbulha pro document, onde o
+// handler de clique-fora vive) seguido de click. SEM o guard, o mousedown fecha o
+// popover e onSelect não é chamado; COM o guard, a variação é adicionada. O Pest
+// estrutural (tests/Feature/Sells/) não exercita esse encadeamento mousedown→click
+// dentro do portal.
+//
+// Mesma estratégia do product-keyboard-nav.test.tsx: timers reais + stub direto de
+// `fetch` + queries assíncronas (findBy/waitFor).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ProductSearchAutocomplete, {
+  type ProductSearchResult,
+} from '@/Pages/Sells/_components/ProductSearchAutocomplete';
+
+// Camiseta com 3 tamanhos (P/M/G) — o caso comum da Larissa (vestuário): produto
+// type='variable' com ≥2 variações, que abre o popover "Escolha o tamanho".
+const PRODUCTS: ProductSearchResult[] = [
+  { product_id: 2, variation_id: 21, name: 'Camiseta', type: 'variable', variation: 'P', sku: 'CAM-P', selling_price: 50, qty_available: 3, unit: 'un' },
+  { product_id: 2, variation_id: 22, name: 'Camiseta', type: 'variable', variation: 'M', sku: 'CAM-M', selling_price: 50, qty_available: 2, unit: 'un' },
+  { product_id: 2, variation_id: 23, name: 'Camiseta', type: 'variable', variation: 'G', sku: 'CAM-G', selling_price: 50, qty_available: 1, unit: 'un' },
+];
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => PRODUCTS,
+        }) as unknown as Response,
+    ),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderAutocomplete() {
+  const onSelect = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProductSearchAutocomplete locationId={1} onSelect={onSelect} />
+    </QueryClientProvider>,
+  );
+  return { onSelect };
+}
+
+describe('ProductSearchAutocomplete — seleção de variação por clique (regressão 2026-06-18)', () => {
+  it('clicar (mousedown+click) num tamanho no popover adiciona a variação à venda', async () => {
+    const { onSelect } = renderAutocomplete();
+    const input = screen.getByLabelText('Buscar produto') as HTMLInputElement;
+
+    // Abre o dropdown (debounce 250ms + fetch) com o grupo Camiseta multi-variação.
+    fireEvent.change(input, { target: { value: 'cam' } });
+    const options = await screen.findAllByRole('option', undefined, { timeout: 2000 });
+    const grupo = options.find((o) => o.textContent?.includes('Camiseta'));
+    expect(grupo).toBeTruthy();
+
+    // Abre o popover de tamanhos (Radix Portal em document.body).
+    fireEvent.click(grupo!);
+
+    // O tamanho M aparece no popover.
+    const mNome = await screen.findByText('M', { exact: true }, { timeout: 2000 });
+    const mBotao = mNome.closest('button');
+    expect(mBotao).toBeTruthy();
+
+    // TOQUE real: mousedown borbulha pro document (handler de clique-fora) e o
+    // click seleciona. É o mousedown que disparava o bug ao fechar o popover.
+    fireEvent.mouseDown(mBotao!);
+    fireEvent.click(mBotao!);
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(1));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ variation_id: 22, variation: 'M' }),
+    );
+  });
+});


### PR DESCRIPTION
## Sintoma (reportado por Wagner — vídeo Larissa @ Rota Livre, 2026-06-18)

> Quando seleciona o item → abre a aba de variação por tamanho → ao selecionar o produto do tamanho desejado ele **não é adicionado** na venda; está sendo preciso digitar o SKU.

Atinge produtos `type='variable'` com ≥2 tamanhos (o caso comum da Larissa, vestuário) na tela **Adicionar venda** (`Sells/Create`).

## Causa-raiz

`ProductSearchAutocomplete` tem um handler de **clique-fora** em `document` (`mousedown`) que fecha o dropdown quando o alvo não está dentro de `containerRef`:

```ts
if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
  setOpen(false); setExpandedProductId(null);
}
```

Mas o `PopoverContent` (Radix) é renderizado num **Portal em `document.body`** — fora de `containerRef`. Ao tocar um tamanho:

1. `mousedown` borbulha pro `document` → o handler vê o alvo "fora" → `setOpen(false)` + `setExpandedProductId(null)`;
2. React re-renderiza, o Popover **desmonta**;
3. o `onClick` do `<button>` da variação (que dispara em `click`, depois do `mouseup`) **nunca roda** → `onSelect` não é chamado → nada é adicionado.

Digitar o SKU funcionava porque cai no handler de **teclado** (Enter) → `handleSelectVariation` direto, sem clique no portal.

## Correção

Guard de uma linha: ignora `mousedown` originado dentro de qualquer popper Radix (`[data-radix-popper-content-wrapper]`). Cobre o popover de variação **e** o de configurar-busca.

## Teste (regressão)

`tests/product-variation-click.test.tsx` reproduz o toque real (`mousedown` → `click`) num tamanho no popover:
- **passa** com o guard;
- **falha** sem o guard (`onSelect` nunca chamado — provado removendo a linha);
- suíte do componente verde: **7/7** (`product-variation-click` + `product-keyboard-nav` G3 + `scanner-race` R7).

`tsc --noEmit`: sem erros no arquivo.

## Escopo

- `resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx` (+12/−1)
- `tests/product-variation-click.test.tsx` (novo)

Sem mudança visual/layout — fix de comportamento. Não mergeei: aguardando teu OK pra deploy.

Refs: cliente RotaLivre biz=4 (sinal qualificado — ADR 0105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)