### PR TITLE
fix(whatsapp): banner canal-caiu business-wide + probe detecta provision_pending (US-WA-308/309 follow-up)

### DIFF
--- a/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
+++ b/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
@@ -24,12 +24,14 @@ use Modules\Whatsapp\Services\WhatsmeowReconciler;
  *
  * Este probe consulta o estado REAL do daemon (`Reconciler.reconcile()` →
  * `/session/status`) pra cada canal whatsmeow ATIVO e converge o DB:
- *   - LOGGED_OUT / NOT_EXISTS  → `markDisconnectedInDb` (sessão morreu → re-parear)
+ *   - LOGGED_OUT / NOT_EXISTS / PROVISION_PENDING → `markDisconnectedInDb` (canal
+ *     ATIVO com sessão não conectada = caiu → re-parear). PROVISION_PENDING incluído
+ *     no fix 2026-06-18: o daemon retorna Connected=false (não LOGGED_OUT) quando a
+ *     sessão morre — era a razão do canal 11 caído não ser detectado.
  *   - BANNED                   → `markDisconnectedInDb(banDetected: true)`
  *   - PAIRED                   → `markPairedInDb` (só re-marca se estava unhealthy)
- *   - DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → NÃO toca o
- *     health (queda transitória do daemon ou pareamento em curso não é logout —
- *     evita falso-positivo; `whatsapp:daemon-source-drift-check` cobre daemon down).
+ *   - DAEMON_UNREACHABLE / QR_PENDING / ERROR → NÃO toca o health (daemon down ou
+ *     pareamento em curso não é queda do canal — `daemon-source-drift-check` cobre).
  *
  * Idempotente (convergente, não acumulativo). Multi-tenant Tier 0 (ADR 0093):
  * varre cross-business (cron sem session), cada row carrega seu `business_id` e o
@@ -66,7 +68,11 @@ class WhatsmeowHealthProbeCommand extends Command
             $state = $reconciler->reconcile($channel);
             $healthBefore = (string) $channel->channel_health;
 
-            if (in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)) {
+            // PROVISION_PENDING incluído (fix 2026-06-18): pra um canal ATIVO, o
+            // daemon WuzAPI retorna Connected=false → reconcile() devolve
+            // PROVISION_PENDING (não LOGGED_OUT). Era a razão do canal 11 caído não
+            // ser detectado. Active + sessão não conectada = caiu → disconnected.
+            if (in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS, WhatsmeowState::PROVISION_PENDING], true)) {
                 if ($healthBefore !== 'disconnected') {
                     $reconciler->markDisconnectedInDb($channel, "health-probe: {$state->value}");
                     $flipped++;
@@ -83,7 +89,8 @@ class WhatsmeowHealthProbeCommand extends Command
                     $flipped++;
                 }
             }
-            // DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → não muta health
+            // DAEMON_UNREACHABLE / QR_PENDING / ERROR → não muta (daemon down ou
+            // pareamento em curso, não é queda do canal — evita falso-positivo)
 
             if ($this->option('detail')) {
                 $this->line(sprintf(

--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -181,7 +181,7 @@ class CaixaUnificadaController extends Controller
             // eager (query trivial na tabela channels) pro banner "canal caiu —
             // religar" aparecer no first-paint sem esperar o defer de
             // availableAccounts. Tier 0 ADR 0093 + ACL canal=fila (US-WA-069).
-            'unhealthyChannels' => $this->buildUnhealthyChannelsPayload($businessId, $userId),
+            'unhealthyChannels' => $this->buildUnhealthyChannelsPayload($businessId),
 
             // US-WA-301 (ADR 0267) — filas agora vêm do DB (seed lazy do config
             // na 1ª visita; fallback config se DB vazio). Shape QueueConfig compat.
@@ -641,23 +641,22 @@ class CaixaUnificadaController extends Controller
      * "canal desconectado — religar" no topo da Caixa Unificada.
      *
      * Eager (custo trivial: tabela `channels`, poucas rows) pra o aviso aparecer no
-     * first-paint — diferente de `availableAccounts` (deferred). Tier 0 ADR 0093 +
-     * ACL canal=fila (US-WA-069): só canais que o user pode ver. `degraded` entra
-     * junto de `disconnected`/`banned` porque já significa "não confiável agora".
+     * first-paint — diferente de `availableAccounts` (deferred). Tier 0 ADR 0093
+     * (escopado por `business_id`). **Business-wide** (Wagner 2026-06-18): um alerta
+     * "seu WhatsApp caiu" aparece pra QUALQUER pessoa com acesso ao atendimento (a
+     * página já gateia por `whatsapp.access`), não só admin view-all — ainda mais
+     * porque o business pode não ter grants de canal. `degraded` entra junto.
      *
      * @return array<int, array{id: int, label: string, type: string, channel_health: string, last_health_message: ?string, last_health_check_at: ?string}>
      */
-    protected function buildUnhealthyChannelsPayload(int $businessId, int $userId): array
+    protected function buildUnhealthyChannelsPayload(int $businessId): array
     {
-        $query = Channel::query()
+        // SEM filtro ACL-de-canal de propósito (business-wide). Tier 0 preservado
+        // pelo `business_id`. A página já exige permissão `whatsapp.access`.
+        return Channel::query()
             ->where('business_id', $businessId)
             ->where('status', 'active')
-            ->whereIn('channel_health', ['disconnected', 'banned', 'degraded']);
-        if (! $this->canSeeAllChannels()) {
-            $query->whereIn('id', $this->allowedChannelIdsSubquery($businessId, $userId));
-        }
-
-        return $query
+            ->whereIn('channel_health', ['disconnected', 'banned', 'degraded'])
             ->orderBy('label')
             ->get(['id', 'label', 'type', 'channel_health', 'last_health_message', 'last_health_check_at'])
             ->map(fn (Channel $ch) => [

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -430,36 +430,39 @@ it('R-WA-CAIXA-UNIF-013 — canal whatsmeow ativo vira chip ativo com count real
 });
 
 /**
- * R-WA-CAIXA-UNIF-014 — US-WA-308 (incidente 2026-06-18): canal ATIVO com saúde
- * caída entra no payload eager `unhealthyChannels` (banner "religar" no topo da
- * Caixa); canal saudável NÃO entra; e o Tier 0 (ADR 0093) impede vazar canal caído
- * de OUTRO business.
+ * R-WA-CAIXA-UNIF-015 — US-WA-308/309 (incidente 2026-06-18): canal ATIVO com saúde
+ * caída entra no payload eager `unhealthyChannels` (banner "religar"), **business-wide**
+ * — aparece MESMO sem grant ACL no canal (Wagner 2026-06-18: alerta de queda é pra
+ * todos do business). Canal saudável NÃO entra; Tier 0 (ADR 0093) impede vazar canal
+ * caído de OUTRO business.
  *
- * red-first: sem o payload `unhealthyChannels` (ou filtrando health errado) o
- * pluck/firstWhere não acha o canal → falha; é o discriminador, não tautológico.
+ * red-first: o user NÃO tem grant em canal nenhum e `can()`=false (fake user) → com o
+ * filtro ACL antigo o canal caído sumiria (0 rows); business-wide mantém ele. É o
+ * discriminador da mudança, não tautológico.
  */
-it('R-WA-CAIXA-UNIF-014 — canal ativo deslogado entra em unhealthyChannels + Tier 0', function () {
-    // biz=1 canal caído (logout) — DEVE aparecer
-    $down = cuctMakeChannel(1, 'caixa-unif-014-down');
-    $down->forceFill(['channel_health' => 'disconnected', 'last_health_message' => 'whatsmeow disconnected: logged_out'])->save();
+it('R-WA-CAIXA-UNIF-015 — canal caído entra business-wide (sem grant) + saudável fora + Tier 0', function () {
+    // biz=1 caído, SEM grant pro user — DEVE aparecer (business-wide)
+    $down = cuctMakeChannel(1, 'caixa-unif-015-down');
+    $down->forceFill(['channel_health' => 'disconnected', 'last_health_message' => 'whatsmeow disconnected: provision_pending'])->save();
 
-    // biz=1 canal saudável — NÃO deve aparecer
-    $ok = cuctMakeChannel(1, 'caixa-unif-014-ok');
+    // biz=1 saudável — NÃO aparece
+    $ok = cuctMakeChannel(1, 'caixa-unif-015-ok');
     $ok->forceFill(['channel_health' => 'healthy'])->save();
 
-    // biz=99 canal caído — Tier 0 impede vazar pra biz=1
-    $cross = cuctMakeChannel(99, 'caixa-unif-014-cross');
+    // biz=99 caído — Tier 0 impede vazar pra biz=1
+    $cross = cuctMakeChannel(99, 'caixa-unif-015-cross');
     $cross->forceFill(['channel_health' => 'disconnected'])->save();
 
-    cuctSetUserAndGrant(1, 10, [$down->id, $ok->id]);
+    // user do biz=1 SEM grant em canal nenhum (fake user retorna can()=false)
+    cuctSetUserAndGrant(1, 10, []);
 
     $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
     $unhealthy = cuctResolveDefer($props['unhealthyChannels']); // eager — array direto
 
     $ids = collect($unhealthy)->pluck('id')->all();
-    expect($ids)->toContain($down->id)
-        ->and($ids)->not->toContain($ok->id)
-        ->and($ids)->not->toContain($cross->id);
+    expect($ids)->toContain($down->id)         // aparece mesmo sem grant (business-wide)
+        ->and($ids)->not->toContain($ok->id)    // saudável fora
+        ->and($ids)->not->toContain($cross->id); // Tier 0
 
     $row = collect($unhealthy)->firstWhere('id', $down->id);
     expect($row['channel_health'])->toBe('disconnected')

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 16
+charter_version: 17
 permissao: whatsapp.access
 ---
 
@@ -282,7 +282,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + draft auditável` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL canal fail-loud` | mesmo arquivo |
-| ✅ | `R-WA-CAIXA-UNIF-014 — canal ativo deslogado entra em unhealthyChannels + Tier 0` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-015 — canal caído entra business-wide (sem grant) + saudável fora + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-013 — canal whatsmeow ativo vira chip ativo com count real (PARTE 4)` | mesmo arquivo |
 
 ---
@@ -328,6 +328,7 @@ Após Wagner aprovar canary 7d:
 
 | Data | Autor | Mudança |
 |---|---|---|
+| 2026-06-18 | Claude (incidente WhatsApp · follow-up) | **Banner business-wide + probe detecta `provision_pending`.** (1) `buildUnhealthyChannelsPayload` perde o filtro ACL-de-canal (Wagner 2026-06-18: o alerta de queda é pra todos com `whatsapp.access`, não só admin view-all — o business pode não ter grants de canal). (2) `whatsmeow:health-probe` marca `disconnected` também em `PROVISION_PENDING` — o daemon WuzAPI retorna `Connected=false` (não `LOGGED_OUT`) quando a sessão morre, e era a razão do canal 11 caído não ser detectado pelo probe. Renomeia o Pest `014→015` (colisão com o teste media_inbound_24h). Charter v17. |
 | 2026-06-18 | Claude (incidente WhatsApp atendimento) | **US-WA-308/309 banner "canal caiu — religar".** Origem: canal 11 (biz=1) deslogou "logged out from another device" às 07:50 sem webhook `LoggedOut` (WuzAPI não assina) → `channel_health` ficou `healthy`, a Caixa não avisou, linha caída ~3h sem ninguém ver. Fix: (1) prop eager `unhealthyChannels` no `CaixaUnificadaController` (ACL + Tier 0) + `ChannelHealthBanner` no topo da Caixa (clique → `/atendimento/canais/{id}` re-parear, QR já existente); (2) comando `whatsmeow:health-probe` (cron 3min, Kernel) que sonda `/session/status` real e converge disconnected/banned/healthy — fecha a lacuna do reconciler Baileys-only. Charter v16. Pest R-WA-CAIXA-UNIF-014. Sem dev server no worktree → build/typecheck/visual-regression no CI + screenshot [W] na prod (Wagner re-pareia e valida o fluxo real). |
 | 2026-06-16 | Claude Code [CL] (Caixa filtros 2-botões · Onda 2) | **Header da lista em 2 controles.** `ConversationListV4`: a fileira de 7 tabs + a fileira de power-filters (chips/selects) viram **Status** (DropdownMenu, 7-valor `?tab=`) + **Filtros** (botão funil `lucide Filter` + badge → Popover flutuante, não empurra a lista). Grupos do popover: Canal · Conta · Fila · Tags · Ordenar · Esperando há · Sem CRM · Janela 24h · Mídia 24h + "Limpar". **Atribuição omitida** — não há param backend (`CaixaUnificadaController` não filtra por assignee; só a tab "Minhas" + picker da sidebar) → não inventei grupo morto (anti M-AP-2). Contrato backend intacto (mesmos params na querystring; `buildQuery` agora carrega channel/account_id/queue → filtros persistem na navegação). Index.tsx passa accounts/channelTypeFilter/accountFilter/queues/queueFilter pra lista. Charter v15. **Verificado:** `tsc --noEmit` limpo nos 2 arquivos (só erros pré-existentes de `preserveScroll`) + `vite build:inertia` verde (4431 módulos, ConversationListV4 bundlou). Sem screenshot local (sem dev server no worktree) — visual-regression CI + revisão [W]. |
 | 2026-06-16 | Claude Code [CL] (Caixa filtros 2-botões · Onda 1) | **Faixa de canais removida.** Direção [W] 2026-06-16: a faixa horizontal `ChannelChipsRow` acima da shell (comprimia 1280px) sai; Canal/Conta viram grupos do popover **Filtros** da lista (Onda 2). Onda 1: removida a faixa + `ChannelChipsRow.tsx` (dead-code, único consumidor era esta tela); `availableChannels`/`availableAccounts` (props), URL-sync `?channel=`/`?account_id=` e os demais consumidores (Thread/Sidebar/Drawers/Nova-conversa) **intactos**. Charter v14. PR off origin/main; CI verifica build/typecheck (worktree sem node_modules). Onda 2 adiciona os grupos no popover Filtros + Status em DropdownMenu. |


### PR DESCRIPTION
Follow-up do [#2956](https://github.com/wagnerra23/oimpresso.com/pull/2956) (US-WA-308/309), 2 correções descobertas validando na prod com o Wagner:

## 1. Banner business-wide

`buildUnhealthyChannelsPayload` **perde o filtro ACL-de-canal**. Descoberta: na prod o business 1 tem **ZERO grants de canal** — só conta admin `view-all-phones` enxergava o banner. Wagner (que usa a conta admin) viu; qualquer outra conta não veria. Um alerta "seu WhatsApp caiu" deve aparecer pra **todos com `whatsapp.access`** (a página já gateia por isso). Tier 0 mantido via `business_id`.

## 2. Probe detecta `provision_pending`

`whatsmeow:health-probe` agora marca `disconnected` também em `PROVISION_PENDING`. Na prod o `reconcile()` do canal 11 caído retornou `provision_pending` (o daemon WuzAPI devolve `Connected=false` quando a sessão morre, **não** `LOGGED_OUT`) — meu probe original só marcava em `LOGGED_OUT`/`NOT_EXISTS`, então **não detectava a queda real**. Pra um canal ATIVO, sessão não conectada = caiu.

`DAEMON_UNREACHABLE`/`QR_PENDING`/`ERROR` seguem sem flip (evita falso-positivo).

## Teste

- Pest `R-WA-CAIXA-UNIF-015` (renomeado de 014 — colidia com o teste `media_inbound_24h`): canal caído entra `unhealthyChannels` **sem grant** (prova business-wide) + saudável fora + Tier 0.
- Pós-deploy: `php artisan whatsmeow:health-probe --detail` deve marcar ch#11 (`provision_pending → disconnected`) e o banner aparecer pra qualquer conta. O deploy reseta o OPcache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
