### PR TITLE
fix(jana): remove nome morto 'Copiloto' do peso_real (ADR 0088)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -691,7 +691,8 @@ return [
                 'NfeBrasil'        => 82,
 
                 // Tier 2 — diferencial, sem cliente pagante dedicado ainda.
-                'Copiloto'          => 65,
+                // 'Copiloto' removido: módulo renomeado pra Jana (ADR 0088). O nome morto
+                // pesava o recall (audit SDD 2026-06-18 risco KL); o peso vivo é a linha Jana.
                 'Jana'              => 62,
                 'LaravelAI'         => 62,
                 'Whatsapp'          => 60,


### PR DESCRIPTION
Dent no **passo 6 (KL)** do SDD. O audit adversarial (risco KL) flagrou `peso_real.modules` listando `'Copiloto' => 65` (módulo **renomeado pra Jana**, ADR 0088) ao lado de `'Jana' => 62` — nome morto pesando o recall. Inerte hoje (`retrieval_enabled=false`), vira defeito quando a flag ligar. Removida a entrada morta + comentário de rastreabilidade; peso vivo = linha Jana.

Seguro: `PesoRealRetrievalTest` não asserta a chave; `RelevanciaMetaInfererTest` usa 'Copiloto' como fixture própria (não lê config). `php -l` OK. Verifica via lane Jana Pest MySQL.

Refs: ADR 0088, audit SDD 2026-06-18