### PR TITLE
feat(sdd): A5 batch 1 — 16 anchors reais (coverage 5.4→7.5%)

### DIFF
--- a/governance/sdd-verification-ledger.json
+++ b/governance/sdd-verification-ledger.json
@@ -32,7 +32,7 @@
       "amostra_pct": 100,
       "itens_verificados": 25,
       "erros_confirmados": 0,
-      "error_rate_pct": 0.0,
+      "error_rate_pct": 0,
       "pii_scan": true,
       "pii_hits": 0,
       "evidencia": "refutador G5 sessao fresca 2026-06-15 — cobre PR #2750 (13 redirects FUNDIR) + PR #2751 (4 lapides + 5 wishes + 3 portas leves). 25/25 conferidos contra E1 + emenda #2748 + existencia das pastas-alvo.",
@@ -49,7 +49,7 @@
       "amostra_pct": 100,
       "itens_verificados": 71,
       "erros_confirmados": 0,
-      "error_rate_pct": 0.0,
+      "error_rate_pct": 0,
       "pii_scan": true,
       "pii_hits": 0,
       "veredito": "aprovado",
@@ -66,11 +66,28 @@
       "amostra_pct": 100,
       "itens_verificados": 38,
       "erros_confirmados": 0,
-      "error_rate_pct": 0.0,
+      "error_rate_pct": 0,
       "pii_scan": true,
       "pii_hits": 0,
       "veredito": "aprovado",
       "evidencia": "refutador G5 sessao fresca 2026-06-15 — reparticao cluster Estoque (34 docs move R100 + 4 stubs)"
+    },
+    {
+      "pr": 2970,
+      "lote_id": "SA-A5-batch1-pg-pmg-kb",
+      "data": "2026-06-18",
+      "tipo": "anchors",
+      "gerador": "opus-4.8 (workflow A5 — agente Explore)",
+      "refutador": "opus-4.8 (workflow A5 — refutador G5 Explore adversarial)",
+      "sessao_fresca": true,
+      "amostra_pct": 100,
+      "itens_verificados": 16,
+      "erros_confirmados": 0,
+      "error_rate_pct": 0,
+      "pii_scan": true,
+      "pii_hits": 0,
+      "evidencia": "A5 motor (workflow wf_52d3c190-19c): gerador propos anchors (path real do codigo por US, existsSync-guarded); refutador G5 adversarial reverificou cada path (test -f + leu o arquivo, default=mentira se incerto) — 23 confirmados real / 0 mentira / 0 incerto. Aplicados 16 (headings US-XXX-NNN reconhecidos pelo anchor-lint: US-PG x3, US-TR x7, US-KB x6); 7 PMG-00x confirmados mas heading nao-canonico (PMG- nao US-) fora do lote. Verificado live: anchor-lint coverage 5.4->7.5%, anchored_ok 19->35, dead 15->15 (zero novo), orphan 5->5 (zero novo).",
+      "veredito": "aprovado"
     }
   ]
 }

--- a/memory/requisitos/KB/SPEC.md
+++ b/memory/requisitos/KB/SPEC.md
@@ -23,6 +23,8 @@ Cérebro consultável da empresa sobre TODO conhecimento (ADRs, sessions, charte
 ## 2. User Stories canônicas
 
 ### US-KB-001 — Bridge canon dos 143 ADRs (ONDA 1, ✅ LIVE)
+
+**Implementado em:** `Modules/KB/Jobs/KbBridgeFromMcpJob.php` · `Modules/KB/Services/KbBridgeStateService.php` · `Modules/KB/Services/KbEdgeAutoDeriver.php` · `Modules/KB/Entities/KbNode.php` · `Modules/KB/Entities/KbEdge.php` · `Modules/KB/Entities/KbBridgeState.php` · `Modules/KB/Observers/KbNodeObserver.php` · `Modules/KB/Tests/Feature/Http/KbNodeControllerTest.php` · `Modules/KB/Tests/Unit/KbBridgeFromMcpJobTest.php` · verificado@98cae0a (2026-06-18)
 **Como** Wagner governance,
 **quero** ver os 143 ADRs do projeto como nós navegáveis no grafo KB,
 **para** poder consultar dependências (supersedes/related/charter-of) sem grep cego em filesystem.
@@ -35,6 +37,8 @@ Critérios:
 - Multi-tenant Tier 0: cada business vê seus próprios ADRs (business_id global scope)
 
 ### US-KB-002 — Artigo editável (Larissa Cowork, ONDA 3 parcial)
+
+**Implementado em:** `Modules/KB/Entities/KbNode.php` · `Modules/KB/Entities/KbNodeVersion.php` · `Modules/KB/Services/KbArticleService.php` · `Modules/KB/Http/Controllers/KbNodeController.php` · `Modules/KB/Observers/KbNodeObserver.php` · `resources/js/Pages/kb/Index.tsx` · `resources/js/Pages/kb/_components/BlockRenderer.tsx` · `Modules/KB/Tests/Feature/Http/KbNodeControllerTest.php` · `Modules/KB/Tests/Unit/KbArticleServiceUnitTest.php` · `Modules/KB/Tests/Feature/LgpdComplianceTest.php` · verificado@98cae0a (2026-06-18)
 **Como** Larissa operadora gráfica,
 **quero** criar artigo "Como trocar tinta Roland VS-540" com blocks (h1/p/img/code),
 **para** consolidar SOP do balcão sem depender de Wagner editar manualmente git.
@@ -47,6 +51,8 @@ Critérios:
 - Soft-delete pra reversibilidade
 
 ### US-KB-003 — Pergunta IA RAG sobre grafo (ONDA 4, ✅ LIVE)
+
+**Implementado em:** `Modules/KB/Services/KbRagService.php` · `Modules/KB/Services/KbBgeRerankerService.php` · `Modules/KB/Services/KbCorpusBuilder.php` · `Modules/KB/Services/Dtos/RagResult.php` · `Modules/KB/Http/Controllers/KbAiController.php` · `Modules/KB/Tests/Feature/KbRagServiceMultiTenantTest.php` · `Modules/KB/Tests/Unit/KbBgeRerankerServiceTest.php` · `Modules/KB/Tests/Unit/KbBgeRerankerServiceProdTest.php` · `Modules/KB/Tests/Feature/KbRagasEvalTest.php` · verificado@98cae0a (2026-06-18)
 **Como** Wagner ou Larissa,
 **quero** perguntar "qual ADR rege multi-tenant aqui?" e receber resposta com citações,
 **para** descobrir conhecimento sem precisar memorizar 143 slugs ADR.
@@ -59,6 +65,8 @@ Critérios:
 - Multi-tenant: pergunta de biz=1 nunca recupera nós de biz=4
 
 ### US-KB-004 — Trilha de aprendizado Larissa (ONDA 3+5)
+
+**Implementado em:** `Modules/KB/Entities/KbPath.php` · `Modules/KB/Entities/KbPathStep.php` · `Modules/KB/Http/Controllers/KbPathController.php` · `resources/js/Pages/kb/_components/PathsDialog.tsx` · `Modules/KB/Tests/Feature/Http/KbPathControllerTest.php` · `Modules/KB/Database/Factories/KbPathFactory.php` · `Modules/KB/Database/Factories/KbPathStepFactory.php` · verificado@98cae0a (2026-06-18)
 **Como** Larissa,
 **quero** trilha "Como abrir OS no balcão" com 7 passos em ordem,
 **para** treinar Mateus novo funcionário sem retrabalho de explicar oralmente.
@@ -70,6 +78,8 @@ Critérios:
 - Visualização tri-pane Cockpit V2 (Cowork [CC])
 
 ### US-KB-005 — Troubleshooter Q→Sim/Não→Fix (ONDA 3)
+
+**Implementado em:** `Modules/KB/Entities/KbDecisionTree.php` · `Modules/KB/Entities/KbDecisionTreeStep.php` · `Modules/KB/Http/Controllers/KbDecisionTreeController.php` · `Modules/KB/Observers/KbDecisionTreeStepObserver.php` · `resources/js/Pages/kb/_components/TroubleshooterDialog.tsx` · `Modules/KB/Tests/Feature/Http/KbDecisionTreeControllerTest.php` · `Modules/KB/Tests/Unit/KbDecisionTreeStepTest.php` · `Modules/KB/Database/Factories/KbDecisionTreeFactory.php` · `Modules/KB/Database/Factories/KbDecisionTreeStepFactory.php` · verificado@98cae0a (2026-06-18)
 **Como** Mateus operando Roland VS-540,
 **quero** decision-tree "Roland não imprime?" com bifurcações até Fix,
 **para** resolver problema sem ligar pra Wagner.
@@ -80,6 +90,8 @@ Critérios:
 - Fix pode linkar artigo kb_node via `yes_fix_node_id` → edge `fix-of-decision`
 
 ### US-KB-006 — Visualização-grafo Cytoscape (ONDA 5)
+
+**Implementado em:** `Modules/KB/Http/Controllers/Admin/GraphController.php` · `resources/js/Pages/kb/Graph.tsx` · `resources/js/Pages/kb/_components/GraphCanvas.tsx` · `resources/js/Pages/kb/_components/GraphFilters.tsx` · `resources/js/Pages/kb/_components/GraphLegend.tsx` · `resources/js/Pages/kb/_components/GraphNodeDetail.tsx` · `Modules/KB/Entities/KbEdge.php` · verificado@98cae0a (2026-06-18)
 **Como** Wagner,
 **quero** ver os 143 ADRs num grafo navegável (Cytoscape.js) com edges supersedes/related,
 **para** entender dependências arquiteturais visualmente.

--- a/memory/requisitos/PaymentGateway/SPEC.md
+++ b/memory/requisitos/PaymentGateway/SPEC.md
@@ -29,6 +29,8 @@ owner: wagner
 
 ### US-PG-001 · [SEC P0] Encrypted cast config_json (drift ADR 0170 §G) + rewrap command + 3 Pest
 
+**Implementado em:** `Modules/PaymentGateway/Models/PaymentGatewayCredential.php` · `Modules/PaymentGateway/Console/Commands/RewrapCredentialsCommand.php` · `Modules/PaymentGateway/Tests/Feature/EncryptedCredentialCastTest.php` · verificado@98cae0a (2026-06-18)
+
 > owner: — · priority: p0 · estimate: 8h · status: todo · type: story
 > blocked_by: —
 
@@ -55,6 +57,8 @@ protected $casts = [
 **Refs:** ADR 0170 §G, [Laravel 12 Encrypted Casts](https://laravel-news.com/eloquent-encrypted-casting), [PCI-DSS 4.0](https://www.upguard.com/blog/pci-compliance)
 
 ### US-PG-002 · [SEC P0] HMAC validation 4 webhooks legacy (espelhar Pagarme/InterPix) + WebhookProcessor refactor + 8 Pest
+
+**Implementado em:** `Modules/PaymentGateway/Http/Controllers/Webhooks/WebhookProcessor.php` · `Modules/PaymentGateway/Http/Controllers/Webhooks/AsaasWebhookController.php` · `Modules/PaymentGateway/Http/Controllers/Webhooks/InterWebhookController.php` · `Modules/PaymentGateway/Http/Controllers/Webhooks/C6WebhookController.php` · `Modules/PaymentGateway/Http/Controllers/Webhooks/BcbPixWebhookController.php` · `Modules/PaymentGateway/Tests/Feature/WebhookSignatureValidationTest.php` · verificado@98cae0a (2026-06-18)
 
 > owner: — · priority: p0 · estimate: 12h · status: todo · type: story
 > blocked_by: —
@@ -122,6 +126,8 @@ if ($timestamp && abs(now()->timestamp - Carbon::parse($timestamp)->timestamp) >
 **Refs:** Audit dossier inline 2026-05-25 §PR-0 Doc-1/2/3
 
 ### US-PG-005 · Registrar URL de webhook PIX no Inter (PUT /pix/v2/webhook)
+
+**Implementado em:** `Modules/PaymentGateway/Services/Drivers/InterDriver.php` · `Modules/PaymentGateway/Console/Commands/RegisterInterWebhookCommand.php` · `Modules/PaymentGateway/Tests/Feature/InterDriverRegisterWebhookTest.php` · verificado@98cae0a (2026-06-18)
 
 > owner: eliana · priority: p2 · status: todo · type: story
 > blocked_by: US-PG-006, US-PG-007

--- a/memory/requisitos/ProjectMgmt/SPEC.md
+++ b/memory/requisitos/ProjectMgmt/SPEC.md
@@ -207,6 +207,8 @@ Module Jira-style já em prod desde 2026-05-04 (PRs #91/#92). Redesign UI em **4
 
 ## Onda 2 — Triage + Inbox (US-TR-301..308 · SPEC-UI-FASE7)
 
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/TriageController.php` · `resources/js/Pages/ProjectMgmt/Triage/Index.tsx` · verificado@98cae0a (2026-06-18)
+
 > Superfícies humanas das tools MCP `triage` e `my-inbox`. Telas: `resources/js/Pages/ProjectMgmt/{Triage,Inbox}/Index.tsx`.
 > **PR #1940 — code-complete, segue DRAFT** aguardando gate visual do Wagner (ADR 0107/0114; Chrome MCP off).
 > Fonte funcional: [`TaskRegistry/SPEC-UI-FASE7.md`](../TaskRegistry/SPEC-UI-FASE7.md). RUNBOOK: [`RUNBOOK-index.md`](RUNBOOK-index.md). Visual: [`projectmgmt-index-visual-comparison.md`](projectmgmt-index-visual-comparison.md) (status draft).
@@ -219,11 +221,15 @@ Como membro do time, vejo uma tela **Triage** (`/project-mgmt/triage`) com todas
 
 ### US-TR-302 · Triage — atribuir owner + prioridade inline
 
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/TriageController.php` · `resources/js/Pages/ProjectMgmt/Triage/Index.tsx` · verificado@98cae0a (2026-06-18)
+
 > owner: wagner · priority: p1 · estimate: codável · status: review · type: feature
 
 Na Triage, atribuo **owner + prioridade inline** sem abrir a task: select inline → `PATCH /triage/{taskId}/assign` (reusa `TaskCrudService::update`, mesma via da tool `tasks-update`) → UI otimista + rollback em erro; gera `mcp_task_events` + notifica o novo owner.
 
 ### US-TR-303 · Triage — mover cycle/epic
+
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/TriageController.php` · `resources/js/Pages/ProjectMgmt/Triage/Index.tsx` · verificado@98cae0a (2026-06-18)
 
 > owner: wagner · priority: p2 · estimate: codável · status: review · type: feature
 
@@ -231,11 +237,15 @@ Na Triage, movo a task pra um **cycle/epic** opcionalmente (dropdowns na mesma l
 
 ### US-TR-304 · Inbox — lista de não-lidas
 
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/InboxController.php` · `resources/js/Pages/ProjectMgmt/Inbox/Index.tsx` · verificado@98cae0a (2026-06-18)
+
 > owner: wagner · priority: p1 · estimate: codável · status: review · type: feature
 
 Como membro, vejo uma tela **Inbox** (`/project-mgmt/inbox`) com minhas notificações: lê `mcp_inbox_notifications WHERE user_id=me` (não-lidas por default), **agrupado por tipo**. Paridade com a tool MCP `my-inbox`. Implementado em [`Inbox/Index.tsx`](../../../resources/js/Pages/ProjectMgmt/Inbox/Index.tsx) + [`InboxController`](../../../Modules/ProjectMgmt/Http/Controllers/InboxController.php).
 
 ### US-TR-305 · Inbox — marcar lido (individual + todas)
+
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/InboxController.php` · `resources/js/Pages/ProjectMgmt/Inbox/Index.tsx` · verificado@98cae0a (2026-06-18)
 
 > owner: wagner · priority: p1 · estimate: codável · status: review · type: feature
 
@@ -243,11 +253,15 @@ No Inbox, **marco como lido** individual (`PATCH /inbox/{id}/read`) e "marcar to
 
 ### US-TR-306 · Inbox — deep-link pra task/DetailSheet
 
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/InboxController.php` · `resources/js/Pages/ProjectMgmt/Inbox/Index.tsx` · verificado@98cae0a (2026-06-18)
+
 > owner: wagner · priority: p1 · estimate: codável · status: review · type: feature
 
 No Inbox, clico (ou Enter) numa notificação e vou direto pra **task** no Board com o `DetailSheet` aberto (`/project-mgmt/board?task=ID`), marcando lido no caminho.
 
 ### US-TR-307 · Operador não-técnico usa sem treino
+
+**Implementado em:** `Modules/ProjectMgmt/Http/Controllers/BoardController.php` · `Modules/ProjectMgmt/Http/Controllers/TriageController.php` · `Modules/ProjectMgmt/Http/Controllers/InboxController.php` · `resources/js/Pages/ProjectMgmt/Board/Index.tsx` · `resources/js/Pages/ProjectMgmt/Triage/Index.tsx` · `resources/js/Pages/ProjectMgmt/Inbox/Index.tsx` · verificado@98cae0a (2026-06-18)
 
 > owner: wagner · priority: p2 · estimate: codável · status: review · type: feature
 


### PR DESCRIPTION
**Passo 4 do SDD (motor de cobertura de anchors) — PRIMEIRA execução real.** Risco SA do audit (anchor_coverage parado em 5%, motor A5 nunca rodou, 0 entries tipo:anchors no ledger).

## Como
Workflow gerador→refutador G5 (`wf_52d3c190-19c`, 6 agents): por US, acha o código que implementa (existsSync-guarded); **refutador adversarial** reverifica cada path (`test -f` + lê o arquivo, default=mentira se incerto). **23 confirmados / 0 mentira.**

## Aplicado (16, só headings US-XXX-NNN que o anchor-lint reconhece)
- PaymentGateway: US-PG-001/002/005 · ProjectMgmt: US-TR-301..307 · KB: US-KB-001..006
- 7 `PMG-00x` confirmados-real mas heading `#### PMG-` (não `US-PMG-`) → fora deste lote (fix de convenção à parte)

## Verificado live (anchor-lint)
coverage **5.4→7.5%** · anchored_ok **19→35** · dead **15→15 (zero novo)** · orphan **5→5 (zero novo)**. Safe-by-construction (anchor só se path existe). Módulos livres do #2611.

Refs: ADR 0273, ADR 0276, audit SDD 2026-06-18