### PR TITLE
feat(whatsapp): Caixa — notas internas por-mensagem · port inbox-cur (PR-2)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -33,6 +33,8 @@ import InboxTranscriptDialog from './InboxTranscriptDialog';
 import CaptureFeedbackSheet, { type CaptureFeedbackInput } from '@/Pages/Whatsapp/_components/CaptureFeedbackSheet';
 import MediaFullscreenModal from '@/Pages/Whatsapp/_components/MediaFullscreenModal';
 import type { ReadyTemplate } from '@/Pages/Whatsapp/_components/helpers';
+import MsgComments from './MsgComments';
+import { useMsgComments } from './useMsgComments';
 
 interface Props {
   thread: CaixaUnifThread;
@@ -106,6 +108,9 @@ export default function ConversationThreadV4({
 
   const isPreview = thread.preview_only;
   const isBlocked = thread.is_blocked;
+
+  // Notas internas por-mensagem (port inbox-cur) — localStorage per-user, "só equipe vê".
+  const msgComments = useMsgComments(thread.id);
 
   return (
     // Fix scroll incident 2026-05-28: era <main> sem h-full → <main> aninhado dentro
@@ -297,7 +302,7 @@ export default function ConversationThreadV4({
               // bolha vira no-op e as enviadas (outbound) encostavam à esquerda junto
               // das recebidas. Stack faz inbound→esquerda, outbound→direita.
               // gap={0}: espaçamento vem do `gap-1` do container + `my-3` do dia.
-              <Stack key={m.id} gap={0}>
+              <Stack key={m.id} gap={0} className="group/msg">
                 {showDay && (
                   <div className="text-center my-3">
                     <span className="bg-card border rounded-full px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-[0.08em] text-muted-foreground">
@@ -435,6 +440,14 @@ export default function ConversationThreadV4({
                     </small>
                   </div>
                   </div>
+                )}
+                {!m.is_internal_note && (
+                  <MsgComments
+                    side={m.direction}
+                    comments={msgComments.forMsg(i)}
+                    onAdd={(t) => msgComments.add(i, t)}
+                    onRemove={(idx) => msgComments.remove(i, idx)}
+                  />
                 )}
               </Stack>
             );

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/MsgComments.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/MsgComments.tsx
@@ -1,0 +1,81 @@
+// MsgComments — notas internas por-mensagem abaixo da bolha (port inbox-cur MsgCommentWrap).
+// "+" hover-revealed via `group/msg` no Stack da mensagem → resting state da Caixa = diff=0
+// (Caixa é o ouro). Notas em localStorage per-user (useMsgComments). "só equipe vê".
+
+import { useState } from 'react';
+import { MessageSquarePlus, X } from 'lucide-react';
+import { Inline, Stack } from '@/Components/layout';
+import { cn } from '@/Lib/utils';
+import type { MsgComment } from './useMsgComments';
+
+interface Props {
+  side: 'inbound' | 'outbound';
+  comments: MsgComment[];
+  onAdd: (text: string) => void;
+  onRemove: (i: number) => void;
+}
+
+export default function MsgComments({ side, comments, onAdd, onRemove }: Props) {
+  const [open, setOpen] = useState(false);
+  const [text, setText] = useState('');
+  const submit = () => { const t = text.trim(); if (!t) return; onAdd(t); setText(''); setOpen(false); };
+  const hasAny = comments.length > 0;
+
+  return (
+    <Stack
+      gap={1}
+      align={side === 'inbound' ? 'start' : 'end'}
+      className={cn('mt-0.5 max-w-[68%]', side === 'inbound' ? 'self-start' : 'self-end')}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className={cn(
+          'inline-flex items-center gap-1 text-[10px] font-medium text-muted-foreground hover:text-foreground transition-opacity',
+          hasAny || open ? 'opacity-100' : 'opacity-0 group-hover/msg:opacity-100',
+        )}
+        data-testid="caixa-unif-msg-comment-add"
+      >
+        <MessageSquarePlus size={11} aria-hidden />
+        {hasAny ? `${comments.length} nota${comments.length > 1 ? 's' : ''} da equipe` : 'Anotar (só equipe)'}
+      </button>
+
+      {(hasAny || open) && (
+        <Stack gap={1} className="w-full rounded-md border border-dashed border-warning/40 bg-warning-soft px-2 py-1.5">
+          {comments.map((c, i) => (
+            <Stack key={i} gap={0}>
+              <Inline gap={1} align="center" className="text-[9.5px] text-warning-fg/80">
+                <b className="font-semibold">{c.author}</b>
+                <span className="font-mono">{c.when}</span>
+                <button type="button" onClick={() => onRemove(i)} className="ml-auto hover:text-destructive-fg" aria-label="Remover nota">
+                  <X size={10} aria-hidden />
+                </button>
+              </Inline>
+              <p className="text-[11.5px] text-foreground whitespace-pre-wrap">{c.text}</p>
+            </Stack>
+          ))}
+          {open && (
+            <Stack gap={1}>
+              <textarea
+                autoFocus
+                value={text}
+                onChange={e => setText(e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); submit(); }
+                  if (e.key === 'Escape') { setOpen(false); setText(''); }
+                }}
+                placeholder="Anotar essa mensagem… (⌘↵ envia)"
+                rows={2}
+                className="w-full resize-none rounded border bg-card px-2 py-1 text-[11.5px]"
+              />
+              <Inline gap={2} align="center" justify="end">
+                <button type="button" onClick={() => { setOpen(false); setText(''); }} className="text-[10.5px] text-muted-foreground hover:text-foreground">Cancelar</button>
+                <button type="button" onClick={submit} disabled={!text.trim()} className="text-[10.5px] font-semibold text-warning-fg disabled:opacity-40">Comentar</button>
+              </Inline>
+            </Stack>
+          )}
+        </Stack>
+      )}
+    </Stack>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/useMsgComments.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/useMsgComments.ts
@@ -1,0 +1,50 @@
+// useMsgComments — notas internas por-mensagem (port inbox-cur `useMsgComments`).
+// localStorage per-user (SEM DB — mesmo anti-hook de useInboxFavs; charter §Anti-hooks:
+// "favoritos localStorage SEM DB"). Escopo: { [convId]: { [msgIdx]: MsgComment[] } }.
+// DB compartilhado entre a equipe = US futura (decisão registrada no charter 2026-06-18).
+
+import { useEffect, useState } from 'react';
+
+export interface MsgComment {
+  author: string;
+  text: string;
+  when: string;
+}
+
+const LS_KEY = 'oimpresso.inbox.msgComments';
+type Store = Record<string, Record<string, MsgComment[]>>;
+
+export function useMsgComments(convId: number | null) {
+  const [store, setStore] = useState<Store>(() => {
+    try { return JSON.parse(localStorage.getItem(LS_KEY) || '{}'); } catch { return {}; }
+  });
+  useEffect(() => {
+    try { localStorage.setItem(LS_KEY, JSON.stringify(store)); } catch { /* quota/private mode */ }
+  }, [store]);
+
+  const key = convId == null ? null : String(convId);
+
+  const forMsg = (msgIdx: number): MsgComment[] => (key ? store[key]?.[String(msgIdx)] ?? [] : []);
+
+  const add = (msgIdx: number, text: string) => {
+    if (!key) return;
+    const when = new Date().toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+    setStore(prev => {
+      const conv = prev[key] ?? {};
+      const list = conv[String(msgIdx)] ?? [];
+      return { ...prev, [key]: { ...conv, [String(msgIdx)]: [...list, { author: 'você', text, when }] } };
+    });
+  };
+
+  const remove = (msgIdx: number, i: number) => {
+    if (!key) return;
+    setStore(prev => {
+      const conv = { ...(prev[key] ?? {}) };
+      const list = (conv[String(msgIdx)] ?? []).filter((_, idx) => idx !== i);
+      if (list.length) conv[String(msgIdx)] = list; else delete conv[String(msgIdx)];
+      return { ...prev, [key]: conv };
+    });
+  };
+
+  return { forMsg, add, remove };
+}


### PR DESCRIPTION
## O quê (PR-2 da série inbox-cur)
Porta **notas internas por-mensagem** (`MsgCommentWrap`/`useMsgComments` do protótipo Cowork). Cada bolha ganha um **"+" hover-revealed** que abre uma nota interna ("só equipe vê") ancorada naquela mensagem.

- `_components/useMsgComments.ts` — hook localStorage per-user (`oimpresso.inbox.msgComments`), **sem DB** (mesmo anti-hook dos favoritos; DB compartilhado = US futura, registrado no charter).
- `_components/MsgComments.tsx` — lista + form abaixo da bolha, primitivos `Stack`/`Inline`, tokens semânticos.
- `ConversationThreadV4.tsx` — `group/msg` na mensagem + `<MsgComments>` (não em notas internas).

## Caixa = ouro
O "+" só aparece **no hover** (`group-hover/msg`) → **resting state da Caixa = diff=0**. Sem nota = nada muda na bolha.

## Checks
- `tsc --noEmit`: **0 erros** · `layout-primitives-guard`: **✅** · **sem R1** (cor crua) nos 3 arquivos.
- Validação visual = screenshot na prod pós-deploy ([W], ADR 0114).

## Série
PR-1 (Guia: troubleshooters+trilhas) = #2971. PR-3 (linkify `#os`/`#fila`) = próximo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)