### PR TITLE
feat(whatsapp): Caixa — Reconectar canal via QR in-place (port Cowork · piloto da catraca)

### DIFF
--- a/prototipo-ui/contrato/caixa-unificada.contract.json
+++ b/prototipo-ui/contrato/caixa-unificada.contract.json
@@ -1,0 +1,14 @@
+{
+  "_nota": "Primeiro contrato de tela ATIVO (piloto da catraca Contrato de Tela). Cobre o feature QR/Reconectar portado do design Cowork. Roda no CI advisory via contrato-de-tela.yml; promove a required quando estável. Ver RUNBOOK-contrato-de-tela.md.",
+  "tela": "Atendimento/CaixaUnificada",
+  "fonte": "prototipo-ui (Cowork 'comunicacao-visual' · inbox-page.jsx — Modal Reconectar canal / QR re-pareamento)",
+  "alvo": ["resources/js/Pages/Atendimento/CaixaUnificada"],
+  "secoes": [
+    { "id": "reconnect-cta", "copy": ["Reconectar canal"] },
+    { "id": "reconnect-modal", "copy": ["Reconectar canal", "Ver todos os canais"] },
+    { "id": "reconnect-qr", "copy": ["Já escaneei"], "estados": ["loading", "qr", "pairing", "error"] },
+    { "id": "reconnect-meta", "copy": ["Canal via API oficial da Meta — sem QR", "Reautenticar"] },
+    { "id": "reconnect-ok", "copy": ["Canal reconectado!"] }
+  ],
+  "ordem": ["reconnect-cta", "reconnect-modal"]
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -47,6 +47,13 @@ permissao: whatsapp.access
 | 2026-06-18 | **PENDENTE** | **Saúde de canal Onda 2/3** (handoff `CHANNEL-HEALTH-BANNER`, validado vs main): composer pausa em canal `disconnected`/`banned` + thread mostra `● fora do ar`; drawer Canais conserta `HEALTH_LABELS` stale + botão Reconectar. Banner US-WA-308 já é live. |
 | 2026-06-18 | **RECUSADO** | **`workspace-3` como padrão universal.** Só primitivo opcional pras telas mestre→corpo→aside (CRM, OS, atendimento). Forçar em cadastro/dashboard = anti-padrão (decisão [W], confirmada pelo design). |
 | 2026-06-18 | **RECUSADO** | **Trocar Cowork por Figma como ponte.** Figma só vale pro design SYSTEM e só com designer humano (não há). Caminho: DS-como-contrato + gerar-na-stack. Ver `memory/sessions/2026-06-18-arte-ponte-design-producao.md`. |
+| 2026-06-18 | **APLICADO** | **Reconectar canal via QR in-place** (port do design Cowork · `inbox-page.jsx` "Modal Reconectar"). O botão "Reconectar" do banner de saúde abre modal com o **QR REAL do backend** (reusa `atendimento.channels.connect`/`status`, gate `whatsapp.settings.manage` — NÃO a matriz fake do protótipo). Canal Meta Cloud = sem QR (token/webhook). **1º piloto da catraca Contrato de Tela** (contrato abaixo · gate ✅ passou). |
+
+---
+
+## Contrato visual (catraca Contrato de Tela)
+
+Contrato declarado em `prototipo-ui/contrato/caixa-unificada.contract.json` — âncoras `data-contract` + copy literal + ordem, checados pelo gate `contrato-de-tela.yml` (advisory na adoção · doc `memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md`). Seções cobertas: `reconnect-cta`, `reconnect-modal`, `reconnect-qr`, `reconnect-meta`, `reconnect-ok`. Ao tocar essas seções, manter as âncoras + a copy literal (senão o gate acusa).
 
 ---
 

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -490,6 +490,7 @@ export default function CaixaUnificadaIndex({
             availableTags={availableTags ?? []}
             activeTagIds={activeTagIds ?? []}
             unhealthyChannels={unhealthyChannels ?? []}
+            canManageChannels={canManageQueues ?? false}
           />
         </Deferred>
         </div>

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ChannelHealthBanner.tsx
@@ -7,6 +7,7 @@ import { Inline, Stack } from '@/Components/layout';
 import { cn } from '@/Lib/utils';
 
 import type { AccountItem, ChannelCatalogItem, UnhealthyChannel } from './helpers';
+import ReconnectModal from './ReconnectModal';
 
 /**
  * ChannelHealthBanner — banner "canal caiu — reconectar" no topo da LISTA da Caixa.
@@ -63,10 +64,13 @@ interface Props {
   channels: UnhealthyChannel[];
   accounts?: AccountItem[];
   catalog?: ChannelCatalogItem[];
+  /** whatsapp.settings.manage — habilita o QR de re-pareamento in-place (senão navega pra a página do canal). */
+  canManageChannels?: boolean;
 }
 
-export default function ChannelHealthBanner({ channels, accounts = [], catalog = [] }: Props) {
+export default function ChannelHealthBanner({ channels, accounts = [], catalog = [], canManageChannels = false }: Props) {
   const [dismissed, setDismissed] = useState(false);
+  const [reconnectCh, setReconnectCh] = useState<UnhealthyChannel | null>(null);
   if (dismissed || !channels || channels.length === 0) return null;
 
   // Enriquecimento (count + short) a partir do que a lista já tem em mãos.
@@ -83,7 +87,11 @@ export default function ChannelHealthBanner({ channels, accounts = [], catalog =
       : 'bg-warning-soft text-warning-fg border-warning/40';
   const iconWrap = worst === 'err' ? 'bg-destructive/15' : 'bg-warning/20';
 
-  const reconnect = (id: number) => router.visit(route('atendimento.channels.show', id));
+  // QR in-place pra quem pode gerenciar canal; fallback navega pra a página (paridade anterior).
+  const reconnect = (c: UnhealthyChannel) => {
+    if (canManageChannels) setReconnectCh(c);
+    else router.visit(route('atendimento.channels.show', c.id));
+  };
   const c0 = channels[0]!;
   const c0Count = countOf(c0);
   const totalConvs = channels.reduce((sum, c) => sum + countOf(c), 0);
@@ -141,7 +149,8 @@ export default function ChannelHealthBanner({ channels, accounts = [], catalog =
         <div className="pl-[34px]">
           <button
             type="button"
-            onClick={() => reconnect(c0.id)}
+            onClick={() => reconnect(c0)}
+            data-contract="reconnect-cta"
             className={cn(
               'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11.5px] font-semibold transition-colors',
               worst === 'err'
@@ -178,7 +187,7 @@ export default function ChannelHealthBanner({ channels, accounts = [], catalog =
                 </span>
                 <button
                   type="button"
-                  onClick={() => reconnect(c.id)}
+                  onClick={() => reconnect(c)}
                   className="shrink-0 font-semibold underline underline-offset-2 hover:opacity-80"
                   data-testid={`caixa-unif-health-reconnect-${c.id}`}
                 >
@@ -188,6 +197,15 @@ export default function ChannelHealthBanner({ channels, accounts = [], catalog =
             );
           })}
         </Stack>
+      )}
+      {reconnectCh && (
+        <ReconnectModal
+          channelId={reconnectCh.id}
+          channelType={reconnectCh.type}
+          label={reconnectCh.label}
+          handle={accounts.find((a) => a.id === reconnectCh.id)?.handle ?? null}
+          onClose={() => setReconnectCh(null)}
+        />
       )}
     </Stack>
   );

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -80,6 +80,8 @@ interface Props {
   activeTagIds?: number[];
   // US-WA-308 (redesign Cowork) — canais ativos com saúde caída (eager, first-paint)
   unhealthyChannels?: UnhealthyChannel[];
+  /** whatsapp.settings.manage — habilita o QR de re-pareamento in-place no banner de saúde. */
+  canManageChannels?: boolean;
 }
 
 const TABS: { id: CaixaUnifTab; label: string; statKey?: keyof CaixaUnifStats; title?: string }[] = [
@@ -100,6 +102,7 @@ export default function ConversationListV4({
   inboundAging = null, orderBy = 'last_message',
   availableTags = [], activeTagIds = [],
   unhealthyChannels = [],
+  canManageChannels = false,
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
   const tab = status as CaixaUnifTab;
@@ -466,7 +469,7 @@ export default function ConversationListV4({
       </div>
 
       {/* US-WA-308 (redesign Cowork) — banner saúde de canal no topo da lista, fiel ao protótipo */}
-      <ChannelHealthBanner channels={unhealthyChannels} accounts={accounts} catalog={channels} />
+      <ChannelHealthBanner channels={unhealthyChannels} accounts={accounts} catalog={channels} canManageChannels={canManageChannels} />
 
       {/* Lista */}
       {conversations.data.length === 0 ? (

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ReconnectModal.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ReconnectModal.tsx
@@ -1,0 +1,179 @@
+// ReconnectModal — re-parear canal via QR, in-place na Caixa (port inbox-cur "Modal Reconectar").
+// Resposta ao [W]: clicar "Reconectar" mostra o QR pra re-parear (Baileys/whatsmeow/Z-API).
+// Canal Meta Cloud = token, NÃO tem QR (mostra mensagem de credencial/webhook).
+//
+// REUSA os endpoints que já existem (zero backend novo · gate can:whatsapp.settings.manage):
+//   POST atendimento.channels.connect → { ok, qr_png_data_url (PNG real), pairing_code, state }
+//   GET  atendimento.channels.status  → { state }  (poll 3s até 'connected')
+// O QR é o PNG REAL rasterizado pelo daemon — não a matriz fake do protótipo.
+
+import { useEffect, useState } from 'react';
+import { router } from '@inertiajs/react';
+import { Loader2, RefreshCw, ScanLine, ShieldAlert } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/Components/ui/dialog';
+import { Inline, Stack } from '@/Components/layout';
+
+interface Props {
+  channelId: number;
+  /** Tipo/provider do canal — só 'meta_cloud'/'wa_meta' não tem QR. Default = QR (banner é Baileys/whatsmeow). */
+  channelType?: string;
+  label: string;
+  handle?: string | null;
+  onClose: () => void;
+  /** Chamado quando o canal volta a 'connected' (a tela recarrega a saúde). */
+  onReconnected?: () => void;
+}
+
+const csrf = () =>
+  (document.querySelector('meta[name=csrf-token]') as HTMLMetaElement | null)?.content || '';
+
+export default function ReconnectModal({ channelId, channelType, label, handle, onClose, onReconnected }: Props) {
+  // Meta Cloud usa token (sem QR). Demais (baileys/whatsmeow/zapi) re-pareiam por QR.
+  const isQR = channelType !== 'meta_cloud' && channelType !== 'wa_meta';
+
+  const [loading, setLoading] = useState(isQR);
+  const [qrImage, setQrImage] = useState<string | null>(null);
+  const [pairingCode, setPairingCode] = useState<string | null>(null);
+  const [state, setState] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const connected = state === 'connected';
+
+  // 1) connect → QR PNG real (só pra canais QR)
+  useEffect(() => {
+    if (!isQR) return;
+    let alive = true;
+    (async () => {
+      setLoading(true); setError(null);
+      try {
+        const r = await fetch(route('atendimento.channels.connect', channelId), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest', 'X-CSRF-TOKEN': csrf() },
+          credentials: 'same-origin',
+        });
+        const data = await r.json();
+        if (!alive) return;
+        if (!r.ok || !data.ok) {
+          setError(data.error || 'Falha ao iniciar o re-pareamento.');
+        } else {
+          setQrImage(data.qr_png_data_url || null);
+          setPairingCode(data.pairing_code || null);
+          setState(data.state || null);
+          if (!data.qr_png_data_url && !data.pairing_code && data.state !== 'connected') {
+            setError(data.message || 'O canal respondeu sem QR nem código.');
+          }
+        }
+      } catch (e) {
+        if (alive) setError('Erro de rede ao falar com o canal.');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [channelId, isQR]);
+
+  // 2) poll status até conectar
+  useEffect(() => {
+    if (!isQR || connected) return;
+    const t = setInterval(async () => {
+      try {
+        const r = await fetch(route('atendimento.channels.status', channelId), {
+          headers: { 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin',
+        });
+        const data = await r.json();
+        setState(data.state);
+        if (data.state === 'connected') {
+          setTimeout(() => { onReconnected?.(); router.reload({ only: ['unhealthyChannels', 'conversations'] }); onClose(); }, 1500);
+        }
+      } catch { /* engole — próximo tick tenta de novo */ }
+    }, 3000);
+    return () => clearInterval(t);
+  }, [channelId, isQR, connected, onClose, onReconnected]);
+
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="sm:max-w-sm" data-testid="caixa-unif-reconnect-modal" data-contract="reconnect-modal">
+        <DialogHeader>
+          <DialogTitle>Reconectar canal</DialogTitle>
+          <DialogDescription>
+            {label}{handle ? <span className="font-mono"> · {handle}</span> : null}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!isQR ? (
+          <Stack gap={2} align="center" className="py-2 text-center" data-contract="reconnect-meta">
+            <span className="grid place-items-center h-10 w-10 rounded-full bg-warning-soft text-warning-fg">
+              <ShieldAlert size={20} aria-hidden />
+            </span>
+            <b className="text-[13px] font-semibold">Canal via API oficial da Meta — sem QR</b>
+            <p className="text-[12px] text-muted-foreground leading-relaxed">
+              Este canal usa token da Cloud API. A queda costuma ser token expirado ou webhook fora do ar —
+              verifique a credencial e o webhook na página do canal.
+            </p>
+          </Stack>
+        ) : connected ? (
+          <Stack gap={2} align="center" className="py-4 text-center" data-contract="reconnect-ok">
+            <span className="grid place-items-center h-10 w-10 rounded-full bg-success-soft text-success-fg">
+              <RefreshCw size={20} aria-hidden />
+            </span>
+            <b className="text-[13px] font-semibold text-success-fg">Canal reconectado!</b>
+            <p className="text-[12px] text-muted-foreground">As mensagens novas voltam a chegar.</p>
+          </Stack>
+        ) : (
+          <Stack gap={2} align="center" className="py-1 text-center" data-contract="reconnect-qr">
+            {loading ? (
+              <Inline gap={2} align="center" className="py-8 text-muted-foreground">
+                <Loader2 size={16} className="animate-spin" aria-hidden /> <span className="text-[12px]">Gerando QR…</span>
+              </Inline>
+            ) : error ? (
+              <p className="py-6 text-[12px] text-destructive-fg">{error}</p>
+            ) : qrImage ? (
+              <>
+                <img src={qrImage} alt="QR code pra parear o WhatsApp" width={232} height={232} className="rounded-md border bg-card" />
+                <Inline gap={1} align="center" className="text-[11.5px] text-muted-foreground">
+                  <ScanLine size={13} aria-hidden /> WhatsApp → Aparelhos conectados → Conectar aparelho
+                </Inline>
+              </>
+            ) : pairingCode ? (
+              <Stack gap={1} align="center" className="py-4">
+                <span className="text-[11px] text-muted-foreground">Código de pareamento</span>
+                <b className="font-mono text-2xl tracking-[0.3em]">{pairingCode}</b>
+              </Stack>
+            ) : (
+              <p className="py-6 text-[12px] text-muted-foreground">Sem QR disponível no momento.</p>
+            )}
+          </Stack>
+        )}
+
+        <Inline gap={2} align="center" justify="end" className="pt-1">
+          <button
+            type="button"
+            onClick={() => router.visit(route('atendimento.channels.show', channelId))}
+            className="mr-auto text-[11.5px] font-medium text-muted-foreground hover:text-foreground"
+          >
+            Ver todos os canais
+          </button>
+          <button type="button" onClick={onClose} className="rounded-md border px-3 py-1.5 text-[11.5px] font-medium text-muted-foreground hover:bg-muted">
+            Cancelar
+          </button>
+          {!connected && (
+            <button
+              type="button"
+              onClick={() => { if (isQR) { onReconnected?.(); router.reload({ only: ['unhealthyChannels'] }); } onClose(); }}
+              className="rounded-md border border-primary bg-primary px-3 py-1.5 text-[11.5px] font-semibold text-primary-foreground hover:bg-primary/90"
+              data-testid="caixa-unif-reconnect-confirm"
+            >
+              {isQR ? 'Já escaneei' : 'Reautenticar'}
+            </button>
+          )}
+        </Inline>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ReconnectModal.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ReconnectModal.tsx
@@ -68,7 +68,7 @@ export default function ReconnectModal({ channelId, channelType, label, handle, 
             setError(data.message || 'O canal respondeu sem QR nem código.');
           }
         }
-      } catch (e) {
+      } catch {
         if (alive) setError('Erro de rede ao falar com o canal.');
       } finally {
         if (alive) setLoading(false);


### PR DESCRIPTION
## O quê
Porta o **"Modal Reconectar canal"** do design Cowork (`inbox-page.jsx`) — a resposta ao seu comentário *"clicar Reconectar mostra o QR"*. O botão **"Reconectar canal"** do banner de saúde passa a abrir um **modal in-place** com o QR de re-pareamento, em vez de navegar pra a página do canal.

- **QR REAL do backend** — reusa `atendimento.channels.connect` (retorna `qr_png_data_url` PNG rasterizado + pairing code) + poll `atendimento.channels.status` até `connected`. **Zero backend novo.** Gate `whatsapp.settings.manage` (managers; demais navegam — fallback).
- **NÃO** porta a matriz fake do protótipo (o próprio comentário do design diz "QR fake · só protótipo").
- **Canal Meta Cloud** = sem QR → mensagem de token/webhook (fiel ao design).
- Additivo: o modal só abre quando há canal caído → **resting state da Caixa = intacto** (ouro).

## 🔬 1º piloto da catraca Contrato de Tela
Esta tela é a **primeira instrumentada** com o contrato:
- Âncoras `data-contract` nos componentes (`reconnect-cta`, `reconnect-modal`, `reconnect-qr`, `reconnect-meta`, `reconnect-ok`).
- Contrato declarado: `prototipo-ui/contrato/caixa-unificada.contract.json` + `## Contrato visual` no charter.
- **Rodei a catraca local: 5/5 seções OK + ordem coerente → ✅ passou.** Quando o PR da catraca (#2973) mergear, ela roda **automática neste PR** (advisory).

## Checks
`tsc --noEmit` **0 erros** · `layout-primitives-guard` **✅** · **sem R1** (cor crua) nos 3 .tsx · validação visual = screenshot na prod pós-deploy ([W], ADR 0114).

## Série inbox-cur/canal
Guia #2971 ✅ · Notas #2972 · Catraca #2973 · **QR (este)**. Próximo: estender o "Reconectar" pro drawer + composer (Onda 2/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)