### PR TITLE
fix(whatsapp): tela do QR fecha sozinha ao parear o canal

### DIFF
--- a/Modules/Whatsapp/Services/WhatsmeowReconciler.php
+++ b/Modules/Whatsapp/Services/WhatsmeowReconciler.php
@@ -74,6 +74,18 @@ final class WhatsmeowReconciler
             return WhatsmeowState::NOT_EXISTS;
         }
 
+        // 2b. Blindagem (Wagner 2026-06-18): a própria lista /admin/users já traz
+        // connected/loggedIn por sessão. Usa como fonte PRIMÁRIA de "pareado" —
+        // não depende do user_token salvo em config_json, que pode ter ficado
+        // stale e fazer /session/status retornar 401, travando o fechamento
+        // automático da tela do QR. Só decide PAIRED aqui; demais estados seguem
+        // o fluxo abaixo (token + /session/status) que distingue QR_PENDING etc.
+        $remoteConnected = (bool) ($remoteUser['connected'] ?? $remoteUser['Connected'] ?? false);
+        $remoteLoggedIn = (bool) ($remoteUser['loggedIn'] ?? $remoteUser['LoggedIn'] ?? false);
+        if ($remoteConnected && $remoteLoggedIn) {
+            return WhatsmeowState::PAIRED;
+        }
+
         // 3. Token user disponível pra consultar status?
         $cfg = $channel->config_json ?? [];
         $userToken = $cfg['whatsmeow_user_token'] ?? null;

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowReconcilerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowReconcilerTest.php
@@ -126,6 +126,28 @@ it('reconcile() retorna PAIRED quando Connected=true e LoggedIn=true', function 
     expect($state->isPaired())->toBeTrue();
 });
 
+it('reconcile() retorna PAIRED pela lista /admin/users mesmo sem token no DB (blindagem stale-token · Wagner 2026-06-18)', function () {
+    // A própria lista /admin/users traz connected/loggedIn por sessão. Quando
+    // ambos true, reconcile resolve PAIRED SEM depender do user_token salvo em
+    // config_json (que pode ter ficado stale e fazer /session/status dar 401,
+    // travando o fechamento automático da tela do QR).
+    Http::fake([
+        '*/admin/users' => Http::response([
+            'data' => [
+                ['name' => 'ch-aaaaaaaabbbbccccddddeeeeeeeeeeee', 'connected' => true, 'loggedIn' => true],
+            ],
+        ], 200),
+        // Guard: session/status NÃO deve decidir aqui (mesmo respondendo desconectado).
+        '*/session/status' => Http::response(['data' => ['Connected' => false, 'LoggedIn' => false]], 200),
+    ]);
+
+    $channel = whatsmeowChannelStub(['config_json' => []]); // token perdido no DB
+
+    $state = app(WhatsmeowReconciler::class)->reconcile($channel);
+
+    expect($state)->toBe(WhatsmeowState::PAIRED);
+});
+
 it('reconcile() retorna LOGGED_OUT quando channel era active e voltou pra Connected=true/LoggedIn=false', function () {
     Http::fake([
         '*/admin/users' => Http::response([

--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -253,11 +253,34 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
             setConnecting(null);
             router.reload({ only: ['channels'] });
           }, 800);
+        } else {
+          // Blindagem (Wagner 2026-06-18): mantém o card de status vivo enquanto
+          // o diálogo está aberto. Faz o canal recém-pareado pelo webhook
+          // 'Connected' aparecer como `active` na lista, alimentando o effect
+          // abaixo que fecha o diálogo mesmo se este poll perder a janela.
+          router.reload({ only: ['channels'], preserveState: true, preserveScroll: true });
         }
       } catch { /* swallow — daemon transitório */ }
     }, intervalMs);
     return () => clearInterval(interval);
   }, [connecting?.id]);
+
+  // Blindagem do fechamento (Wagner 2026-06-18 — "conectou mas não fechou a tela
+  // do QR"). Caminho independente do poll /whatsmeow-status: assim que o canal
+  // que está conectando aparecer ATIVO/saudável na lista (marcado pelo webhook
+  // 'Connected' OU por qualquer reload), fecha o diálogo. Cobre a janela frágil
+  // logo após o scan, quando o daemon emite 'days_to_sync_history' e o poll
+  // pode não pegar o instante `loggedIn=true`.
+  useEffect(() => {
+    if (!connecting) return;
+    const fresh = channels?.find((c) => c.id === connecting.id);
+    if (fresh && (fresh.status === 'active' || fresh.channel_health === 'healthy')) {
+      setQrState('paired');
+      setQrImage(null);
+      const t = setTimeout(() => setConnecting(null), 800);
+      return () => clearTimeout(t);
+    }
+  }, [channels, connecting?.id]);
 
   return (
     <div className="p-4 space-y-4">
@@ -376,7 +399,12 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
             )}
           </div>
 
-          <DialogFooter>
+          <DialogFooter className="flex-col items-stretch gap-2 sm:flex-col sm:space-x-0">
+            {qrImage && qrState !== 'paired' && qrState !== 'connected' && (
+              <p className="text-[11px] text-muted-foreground text-center">
+                Já apareceu "aparelho conectado" no celular? Pode fechar — a conexão conclui em segundo plano.
+              </p>
+            )}
             <Button variant="outline" onClick={() => { setConnecting(null); setQrImage(null); setPairingCode(null); }}>
               Fechar
             </Button>


### PR DESCRIPTION
## Problema
Wagner: _"conectou mas não fechou a tela do QR automático"_.

O pareamento whatsmeow (daemon WuzAPI no CT 100) **funciona** — diagnóstico ao vivo confirmou os 2 canais biz=1 com `connected:true, loggedIn:true` e infra/config limpa (token admin bate, daemon responde, nome/rota/permissão corretos). O problema era só a **tela do QR não fechar sozinha** depois de parear.

## Causa
O fechamento dependia **só** do poll de 2s detectar `loggedIn=true`. Logo após o scan o daemon emite `Failed to get days_to_sync_history` e há uma janela curta `connected mas ainda não loggedIn` — o poll perdia esse instante e a tela ficava travada aberta. Risco adicional: se o `whatsmeow_user_token` salvo em `config_json` ficar stale, o `/session/status` do `reconcile()` retorna 401 e a detecção de "pareado" nunca acontece.

## Correção — 3 caminhos independentes de fechamento
1. **Front** ([Channels/Index.tsx](resources/js/Pages/Atendimento/Channels/Index.tsx)): novo `useEffect` que observa a lista `channels` e fecha o diálogo assim que o canal vira `active`/`healthy` (cobre o webhook `Connected`).
2. **Front**: o poll passa a recarregar `channels` a cada tick (surfando o status marcado pelo webhook + mantendo o card vivo) + dica "pode fechar com segurança".
3. **Backend** ([WhatsmeowReconciler.php](Modules/Whatsapp/Services/WhatsmeowReconciler.php)): `reconcile()` lê `connected/loggedIn` direto da lista `/admin/users` (token admin) como fonte **primária** de `PAIRED` — não depende mais do `user_token` possivelmente stale.

## Escopo / risco
- 2 arquivos, +41/−1. Sem mudança de schema, sem Tier 0, multi-tenant intacto (reconcile já escopado por channel).
- Não inclui o rename de label "Caixa Unificada → Atendimento" (intenção separada — segue em PR próprio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)