### PR TITLE
fix(whatsapp): ESLint ratchet — deps do effect de auto-close (#2979 follow-up)

### DIFF
--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -280,7 +280,7 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
       const t = setTimeout(() => setConnecting(null), 800);
       return () => clearTimeout(t);
     }
-  }, [channels, connecting?.id]);
+  }, [channels, connecting]);
 
   return (
     <div className="p-4 space-y-4">


### PR DESCRIPTION
Follow-up do #2979. Troca `[channels, connecting?.id]` por `[channels, connecting]` no effect de fechamento automático da tela do QR — satisfaz react-hooks/exhaustive-deps sem aviso novo (comportamento idêntico) e zera o ESLint ratchet que ficou +1 acima do baseline após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)