### PR TITLE
fix(caixa): Reconectar não pinta "sessão ativa" como erro vermelho

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ReconnectModal.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ReconnectModal.tsx
@@ -19,6 +19,8 @@ import {
 } from '@/Components/ui/dialog';
 import { Inline, Stack } from '@/Components/layout';
 
+import { isSessionActive } from './reconnectState';
+
 interface Props {
   channelId: number;
   /** Tipo/provider do canal — só 'meta_cloud'/'wa_meta' não tem QR. Default = QR (banner é Baileys/whatsmeow). */
@@ -42,7 +44,7 @@ export default function ReconnectModal({ channelId, channelType, label, handle, 
   const [pairingCode, setPairingCode] = useState<string | null>(null);
   const [state, setState] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const connected = state === 'connected';
+  const connected = isSessionActive({ state });
 
   // 1) connect → QR PNG real (só pra canais QR)
   useEffect(() => {
@@ -64,7 +66,8 @@ export default function ReconnectModal({ channelId, channelType, label, handle, 
           setQrImage(data.qr_png_data_url || null);
           setPairingCode(data.pairing_code || null);
           setState(data.state || null);
-          if (!data.qr_png_data_url && !data.pairing_code && data.state !== 'connected') {
+          // Canal já pareado (connect → 'paired'/'paired:true') ou conectado = SUCESSO, não erro.
+          if (!isSessionActive(data) && !data.qr_png_data_url && !data.pairing_code) {
             setError(data.message || 'O canal respondeu sem QR nem código.');
           }
         }
@@ -88,7 +91,7 @@ export default function ReconnectModal({ channelId, channelType, label, handle, 
         });
         const data = await r.json();
         setState(data.state);
-        if (data.state === 'connected') {
+        if (isSessionActive(data)) {
           setTimeout(() => { onReconnected?.(); router.reload({ only: ['unhealthyChannels', 'conversations'] }); onClose(); }, 1500);
         }
       } catch { /* engole — próximo tick tenta de novo */ }

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts
@@ -1,0 +1,27 @@
+// reconnectState — contrato de "sessão já ativa" do fluxo Reconectar (Camada 1).
+//
+// Bug 2026-06-18 (verificado ao vivo no daemon CT 100: canal logado + recebendo
+// mensagens, webhook 200): o endpoint `connect` sinaliza canal já ativo com
+// `state:'paired'` (+ `paired:true`), enquanto o `status` usa `state:'connected'`.
+// O ReconnectModal só reconhecia 'connected' → a verdade "Canal já pareado —
+// sessão ativa" caía no ramo de ERRO (texto vermelho `destructive-fg`) com o botão
+// "Já escaneei" fantasma. Aqui os dois vocabulários ficam unificados num único
+// predicado puro, testável e travado por vitest (a catraca que faltou no #2974).
+
+export interface ReconnectResponse {
+  ok?: boolean;
+  state?: string | null;
+  paired?: boolean;
+}
+
+/**
+ * true quando a sessão já está ativa/logada — é SUCESSO, não erro.
+ *
+ * Aceita os dois vocabulários do backend de propósito:
+ *   - `connect` (ChannelsController::whatsmeowPairedResponse) → `state:'paired'` + `paired:true`
+ *   - `status`  (ChannelsController::statusWhatsmeow)          → `state:'connected'`
+ */
+export function isSessionActive(data: ReconnectResponse | null | undefined): boolean {
+  if (!data) return false;
+  return data.paired === true || data.state === 'paired' || data.state === 'connected';
+}

--- a/tests/reconnect-session-active.test.ts
+++ b/tests/reconnect-session-active.test.ts
@@ -1,0 +1,31 @@
+// Contrato do fluxo Reconectar da Caixa/Atendimento (Camada 1 · bug 2026-06-18).
+//
+// Regressão travada: o `connect` devolve `state:'paired'` (+ `paired:true`) e o
+// `status` devolve `state:'connected'`. O ReconnectModal só aceitava 'connected',
+// então a verdade "Canal já pareado — sessão ativa" virava ERRO vermelho com botão
+// "Já escaneei" fantasma. `isSessionActive` unifica os dois vocabulários — este
+// teste é a catraca que impede a divergência de voltar (faltou no #2974).
+//
+// Nota: usa só expect/toBe (sem jest-dom — ver tests/js/setup.ts).
+
+import { describe, it, expect } from 'vitest';
+
+import { isSessionActive } from '@/Pages/Atendimento/CaixaUnificada/_components/reconnectState';
+
+describe('isSessionActive — sessão já ativa = sucesso (não erro)', () => {
+  it("aceita o vocabulário do connect ('paired'/paired:true) E do status ('connected')", () => {
+    expect(isSessionActive({ ok: true, state: 'paired', paired: true })).toBe(true);
+    expect(isSessionActive({ state: 'paired' })).toBe(true);
+    expect(isSessionActive({ paired: true })).toBe(true);
+    expect(isSessionActive({ state: 'connected' })).toBe(true);
+  });
+
+  it('mantém QR/desconectado/nulo como NÃO-sucesso (segue mostrando QR ou erro real)', () => {
+    expect(isSessionActive({ state: 'qr_required' })).toBe(false);
+    expect(isSessionActive({ state: 'disconnected' })).toBe(false);
+    expect(isSessionActive({ state: null })).toBe(false);
+    expect(isSessionActive({})).toBe(false);
+    expect(isSessionActive(null)).toBe(false);
+    expect(isSessionActive(undefined)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Sintoma (Wagner, screenshot)
Na **Caixa/Atendimento**, o banner dizia *"WhatsApp · Suporte está fora do ar — 94 conversas afetadas"*, mas ao clicar **Reconectar** o modal mostrava em **vermelho** *"Canal já pareado — sessão ativa"* + botão "Já escaneei" fantasma. Contradição.

## Verificação ao vivo (daemon CT 100, 2026-06-18)
SSH read-only no WuzAPI: canal do incidente **logado**, **~48 msg/h recebidas**, webhook **151× 200** na última hora, **zero logout em 24h**. Ou seja:
- o **"fora do ar" do banner era falso-positivo** (probe — tratado na Camada 2, PR+ADR à parte);
- o **"sessão ativa" do modal era a verdade** — só estava pintado como erro.

## Causa raiz (contrato FE↔BE)
Dois vocabulários pra "conectado":
- `connect` (`whatsmeowPairedResponse`) → `state: 'paired'` (+ `paired: true`)
- `status` (`statusWhatsmeow`) → `state: 'connected'`

O modal só aceitava `'connected'`, então `'paired'` caía no ramo de `setError(...)` (`text-destructive-fg`).

## Fix
- `reconnectState.ts` — `isSessionActive()` puro unifica os dois vocabulários.
- `ReconnectModal.tsx` — usa o predicado em 3 pontos (`connected`, guard de erro do connect, poll). `'paired'` agora renderiza o verde "Canal reconectado", sem botão fantasma.
- `tests/reconnect-session-active.test.ts` — vitest trava o contrato (**a catraca que faltou no #2974**: o piloto valida presença do `data-contract`, não a semântica do `state`).

## Escopo
1 intent, 64 linhas, zero backend. **Camada 2** (probe cruzar `channel_health` com fluxo real de mensagens) vem em PR + ADR separados.

## Teste
`npx vitest run tests/reconnect-session-active.test.ts` → 2 passed (rodado no checkout principal; CI valida no pipeline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)