### PR TITLE
fix(whatsapp): health-probe corrobora channel_health com mensagem real (anti falso "fora do ar")

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -75,6 +75,10 @@ return [
         // 2026-06-16 (recebimento parado pós-#2726). Não-spoofável (TLS-only).
         'webhook_url_secret' => env('WHATSMEOW_WEBHOOK_URL_SECRET'),
         'request_timeout' => (int) env('WHATSMEOW_TIMEOUT', 15),
+        // Janela (min) de "inbound recente" que o health-probe usa como prova de
+        // "no ar" — suprime o falso "fora do ar" do loggedIn não-confiável do WuzAPI
+        // e auto-cura pra healthy (incidente 2026-06-18; martelo [W] = 10min).
+        'health_fresh_inbound_minutes' => (int) env('WHATSMEOW_HEALTH_FRESH_INBOUND_MINUTES', 10),
     ],
 
     /*

--- a/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
+++ b/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\Conversation;
 use Modules\Whatsapp\Services\Drivers\WhatsmeowState;
 use Modules\Whatsapp\Services\WhatsmeowReconciler;
 
@@ -31,6 +32,16 @@ use Modules\Whatsapp\Services\WhatsmeowReconciler;
  *     health (queda transitória do daemon ou pareamento em curso não é logout —
  *     evita falso-positivo; `whatsapp:daemon-source-drift-check` cobre daemon down).
  *
+ * **Saúde por mensagem real (Camada 2 · incidente 2026-06-18 inverso).** O flag
+ * `loggedIn` do WuzAPI é não-confiável: ele reportou caído num canal que recebia
+ * ~48 msg/h (sessão viva, webhook 200), e o banner mostrou "fora do ar" falso.
+ * Inbound recente (`whatsapp_conversations.last_inbound_at` < N min, default 10 ·
+ * config `whatsapp.whatsmeow.health_fresh_inbound_minutes`) é PROVA autoritativa de
+ * "no ar": no ramo caído o probe SUPRIME o falso `disconnected` e AUTO-CURA pra
+ * `healthy`. Ausência de inbound ≠ queda (canal pode estar quieto) → sem inbound
+ * recente, mantém o sinal do daemon (não cria falso-negativo). BANNED não é
+ * suprimível (mensagem pré-ban não invalida o ban). Decisão pura em `decideAction()`.
+ *
  * Idempotente (convergente, não acumulativo). Multi-tenant Tier 0 (ADR 0093):
  * varre cross-business (cron sem session), cada row carrega seu `business_id` e o
  * Reconciler nunca atravessa fronteira de tenant.
@@ -41,6 +52,18 @@ use Modules\Whatsapp\Services\WhatsmeowReconciler;
  */
 class WhatsmeowHealthProbeCommand extends Command
 {
+    /**
+     * Janela (min) de "inbound recente" que prova que o canal está no ar — martelo
+     * [W] 2026-06-18. Override: config `whatsapp.whatsmeow.health_fresh_inbound_minutes`.
+     */
+    private const FRESH_INBOUND_MINUTES = 10;
+
+    /** Ação que o probe toma sobre channel_health (resultado puro de decideAction). */
+    public const ACTION_NONE = 'none';
+    public const ACTION_DISCONNECTED = 'disconnected';
+    public const ACTION_BANNED = 'banned';
+    public const ACTION_PAIRED = 'paired';
+
     protected $signature = 'whatsmeow:health-probe {--detail : Loga o estado observado de cada canal}';
 
     protected $description = 'Sonda o daemon e marca channel_health quando a sessão whatsmeow cai (incidente 2026-06-18).';
@@ -61,38 +84,55 @@ class WhatsmeowHealthProbeCommand extends Command
         }
 
         $flipped = 0;
+        $suppressed = 0;
+        $freshMinutes = (int) config('whatsapp.whatsmeow.health_fresh_inbound_minutes', self::FRESH_INBOUND_MINUTES);
 
         foreach ($channels as $channel) {
             $state = $reconciler->reconcile($channel);
             $healthBefore = (string) $channel->channel_health;
 
-            if (in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)) {
-                if ($healthBefore !== 'disconnected') {
-                    $reconciler->markDisconnectedInDb($channel, "health-probe: {$state->value}");
-                    $flipped++;
-                }
-            } elseif ($state === WhatsmeowState::BANNED) {
-                if ($healthBefore !== 'banned') {
-                    $reconciler->markDisconnectedInDb($channel, 'health-probe: banned', banDetected: true);
-                    $flipped++;
-                }
-            } elseif ($state === WhatsmeowState::PAIRED) {
-                if ($healthBefore !== 'healthy') {
-                    $jid = is_array($channel->config_json) ? ($channel->config_json['whatsmeow_jid'] ?? null) : null;
-                    $reconciler->markPairedInDb($channel, is_string($jid) ? $jid : null);
-                    $flipped++;
-                }
+            // Só corrobora com mensagem real no ramo "caído" — é onde o loggedIn do WuzAPI mente.
+            $isDownState = in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true);
+            $freshInbound = $isDownState && $this->hasRecentInbound($channel, $freshMinutes);
+
+            $action = self::decideAction($state, $healthBefore, $freshInbound);
+
+            $jid = is_array($channel->config_json) ? ($channel->config_json['whatsmeow_jid'] ?? null) : null;
+            $jid = is_string($jid) ? $jid : null;
+
+            match ($action) {
+                self::ACTION_DISCONNECTED => $reconciler->markDisconnectedInDb($channel, "health-probe: {$state->value}"),
+                self::ACTION_BANNED => $reconciler->markDisconnectedInDb($channel, 'health-probe: banned', banDetected: true),
+                self::ACTION_PAIRED => $reconciler->markPairedInDb($channel, $jid),
+                default => null,
+            };
+
+            if ($action !== self::ACTION_NONE) {
+                $flipped++;
             }
-            // DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → não muta health
+
+            if ($freshInbound) {
+                $suppressed++;
+                Log::warning('whatsmeow.health_probe.false_disconnect_suppressed', [
+                    'event' => 'whatsmeow.health_probe.false_disconnect_suppressed',
+                    'channel_id' => $channel->id,
+                    'business_id' => $channel->business_id,
+                    'daemon_state' => $state->value,
+                    'health_before' => $healthBefore,
+                    'fresh_inbound_minutes' => $freshMinutes,
+                    'auto_recovered' => $action === self::ACTION_PAIRED,
+                ]);
+            }
 
             if ($this->option('detail')) {
                 $this->line(sprintf(
-                    '  ch#%d %-22s biz=%d · %s → health=%s',
+                    '  ch#%d %-22s biz=%d · %s → health=%s%s',
                     $channel->id,
                     "'{$channel->label}'",
                     $channel->business_id,
                     $state->value,
                     $channel->channel_health,
+                    $freshInbound ? ' (inbound recente — suprimido)' : '',
                 ));
             }
         }
@@ -101,10 +141,62 @@ class WhatsmeowHealthProbeCommand extends Command
             'event' => 'whatsmeow.health_probe.done',
             'probed' => $channels->count(),
             'flipped' => $flipped,
+            'false_disconnect_suppressed' => $suppressed,
         ]);
 
-        $this->info("Sondados {$channels->count()} canal(is) whatsmeow · {$flipped} mudou de estado.");
+        $this->info("Sondados {$channels->count()} canal(is) whatsmeow · {$flipped} mudou de estado · {$suppressed} falso-positivo suprimido.");
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Decisão PURA (sem DB/daemon) de como o probe converge channel_health.
+     *
+     * Isolada pra teste determinístico — a query de inbound fica no handle().
+     * `$freshInbound` só vem true no ramo caído: inbound recente prova "no ar" e
+     * troca o markDisconnected por auto-cura (markPaired). BANNED nunca é suprimido
+     * (mensagem pré-ban não invalida o ban). Idempotente: ACTION_NONE quando o DB
+     * já está no alvo.
+     *
+     * @param  bool  $freshInbound  Houve inbound recente (corrobora "no ar").
+     * @return self::ACTION_*
+     */
+    public static function decideAction(WhatsmeowState $state, string $healthBefore, bool $freshInbound): string
+    {
+        if (in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)) {
+            if ($freshInbound) {
+                // Falso "fora do ar": daemon diz caído, mas mensagens chegando.
+                return $healthBefore === 'healthy' ? self::ACTION_NONE : self::ACTION_PAIRED;
+            }
+
+            return $healthBefore === 'disconnected' ? self::ACTION_NONE : self::ACTION_DISCONNECTED;
+        }
+
+        if ($state === WhatsmeowState::BANNED) {
+            return $healthBefore === 'banned' ? self::ACTION_NONE : self::ACTION_BANNED;
+        }
+
+        if ($state === WhatsmeowState::PAIRED) {
+            return $healthBefore === 'healthy' ? self::ACTION_NONE : self::ACTION_PAIRED;
+        }
+
+        // DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → não muta.
+        return self::ACTION_NONE;
+    }
+
+    /**
+     * Houve mensagem recebida (inbound) neste canal nos últimos $minutes min?
+     *
+     * Sinal autoritativo-positivo de "no ar". Tier 0 (ADR 0093): escopado por
+     * channel_id (PK única por business → nunca cross-tenant); withoutGlobalScopes
+     * porque o probe roda em cron sem session de tenant.
+     */
+    private function hasRecentInbound(Channel $channel, int $minutes): bool
+    {
+        return Conversation::query()
+            ->withoutGlobalScopes()
+            ->where('channel_id', $channel->id)
+            ->where('last_inbound_at', '>=', now()->subMinutes($minutes))
+            ->exists();
     }
 }

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowHealthProbeDecisionTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowHealthProbeDecisionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Whatsapp\Console\Commands\WhatsmeowHealthProbeCommand as Probe;
+use Modules\Whatsapp\Services\Drivers\WhatsmeowState;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Camada 2 (incidente 2026-06-18 inverso) — decisão PURA do health-probe.
+ *
+ * O flag `loggedIn` do WuzAPI mentiu: marcou como "fora do ar" um canal que
+ * recebia ~48 msg/h (verificado ao vivo no daemon CT 100). `decideAction()`
+ * corrobora o estado do daemon com "inbound recente" SÓ no ramo caído — suprime o
+ * falso `disconnected` e auto-cura pra `healthy`. Determinístico, sem DB/daemon:
+ * é a catraca da regra (a query de inbound real fica fina no handle()).
+ */
+
+it('caído + inbound recente + já disconnected → AUTO-CURA (paired)', function () {
+    expect(Probe::decideAction(WhatsmeowState::LOGGED_OUT, 'disconnected', true))->toBe(Probe::ACTION_PAIRED);
+    expect(Probe::decideAction(WhatsmeowState::NOT_EXISTS, 'disconnected', true))->toBe(Probe::ACTION_PAIRED);
+});
+
+it('caído + inbound recente + já healthy → NÃO mexe (idempotente, sem churn)', function () {
+    expect(Probe::decideAction(WhatsmeowState::LOGGED_OUT, 'healthy', true))->toBe(Probe::ACTION_NONE);
+});
+
+it('caído SEM inbound recente → marca disconnected (queda real preservada)', function () {
+    expect(Probe::decideAction(WhatsmeowState::LOGGED_OUT, 'healthy', false))->toBe(Probe::ACTION_DISCONNECTED);
+    expect(Probe::decideAction(WhatsmeowState::NOT_EXISTS, 'healthy', false))->toBe(Probe::ACTION_DISCONNECTED);
+});
+
+it('caído SEM inbound + já disconnected → NÃO repete (idempotente)', function () {
+    expect(Probe::decideAction(WhatsmeowState::LOGGED_OUT, 'disconnected', false))->toBe(Probe::ACTION_NONE);
+});
+
+it('BANNED nunca é suprimido por mensagem (msg pré-ban não invalida o ban)', function () {
+    expect(Probe::decideAction(WhatsmeowState::BANNED, 'healthy', false))->toBe(Probe::ACTION_BANNED);
+    expect(Probe::decideAction(WhatsmeowState::BANNED, 'banned', false))->toBe(Probe::ACTION_NONE);
+});
+
+it('PAIRED converge healthy só se estava unhealthy', function () {
+    expect(Probe::decideAction(WhatsmeowState::PAIRED, 'disconnected', false))->toBe(Probe::ACTION_PAIRED);
+    expect(Probe::decideAction(WhatsmeowState::PAIRED, 'healthy', false))->toBe(Probe::ACTION_NONE);
+});
+
+it('estados transitórios (daemon down / pareando) não mutam health', function () {
+    foreach ([
+        WhatsmeowState::DAEMON_UNREACHABLE,
+        WhatsmeowState::QR_PENDING,
+        WhatsmeowState::PROVISION_PENDING,
+        WhatsmeowState::ERROR,
+    ] as $s) {
+        expect(Probe::decideAction($s, 'healthy', false))->toBe(Probe::ACTION_NONE);
+        expect(Probe::decideAction($s, 'disconnected', false))->toBe(Probe::ACTION_NONE);
+    }
+});

--- a/memory/decisions/0286-channel-health-corroborado-por-mensagem-real.md
+++ b/memory/decisions/0286-channel-health-corroborado-por-mensagem-real.md
@@ -1,0 +1,65 @@
+---
+slug: 0286-channel-health-corroborado-por-mensagem-real
+number: 286
+title: "channel_health de canal whatsmeow é corroborado por fluxo de mensagem real — inbound recente suprime o falso 'fora do ar' do loggedIn não-confiável do WuzAPI"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-18"
+module: whatsapp
+tags: [whatsapp, whatsmeow, health-probe, channel-health, incident, tier-0, caixa-unificada, atendimento]
+supersedes: []
+superseded_by: []
+related:
+  - 0206-state-machine-whatsmeow-reconciliacao
+  - 0093-multi-tenant-isolation-tier-0
+  - 0130-handoff-append-only-mcp-first
+---
+
+# ADR 0286 — `channel_health` corroborado por mensagem real
+
+## Contexto
+
+Incidente reportado por [W] em 2026-06-18 na Caixa/Atendimento (`/atendimento/caixa-unificada`): o banner mostrava **"WhatsApp · Suporte está fora do ar — 94 conversas afetadas"**, mas ao clicar **Reconectar** o modal respondia **"Canal já pareado — sessão ativa"**. Contradição na mesma tela.
+
+**Verificação ao vivo** (SSH read-only no daemon WuzAPI, CT 100): o canal estava **logado** (JID presente), **recebendo ~48 msg/h** (124 em 24h), **webhook entregando 200** (151× na última hora), **zero logout em 24h**. Ou seja: o canal estava **no ar o tempo todo** — quem mentia era o app.
+
+Diagnóstico de duas camadas:
+
+1. **Contrato de UI** (resolvido em PR separado): o `connect` sinaliza canal já ativo com `state:'paired'`, o `status` com `state:'connected'`; o `ReconnectModal` só reconhecia `'connected'` → a verdade caía no ramo de erro vermelho.
+2. **Heurística do probe** (este ADR): `WhatsmeowReconciler::reconcile()` tem o ramo `connected && !loggedIn → LOGGED_OUT` (pegajoso: `channel_health==='disconnected'` se auto-perpetua). O `whatsmeow:health-probe` ([ADR 0206](0206-state-machine-whatsmeow-reconciliacao.md), US-WA-308) marcava `disconnected` baseado **só** no `loggedIn` do WuzAPI — flag que o próprio docblock do probe admite ser não-confiável (WuzAPI não assina `LoggedOut`). Nunca cruzava com "tá chegando mensagem?".
+
+Observações de processo no mesmo incidente:
+
+- **Catraca não mordeu.** O reconnect foi entregue como "piloto da catraca" (#2974). A catraca valida **presença** dos marcadores `data-contract`, não a **semântica** (que `paired` ≡ `connected` nos dois lados). Contrato estruturalmente presente, comportamento quebrado — passou no gate.
+- **Memória superestimou verificação.** O handoff 2026-06-16 afirmava a Caixa "verificada na prod nos 2 temas"; a verificação não cobriu a semântica banner↔reconnect. Correção registrada abaixo (append-only, [ADR 0130](0130-handoff-append-only-mcp-first.md)).
+
+## Decisão
+
+**1. Inbound recente é prova autoritativa de "no ar".** O `whatsmeow:health-probe`, no ramo caído (`LOGGED_OUT`/`NOT_EXISTS`), consulta `whatsapp_conversations.last_inbound_at`. Se houve inbound dentro da janela (`whatsapp.whatsmeow.health_fresh_inbound_minutes`, **default 10 min**, martelo [W]):
+
+   - **Suprime** o `disconnected` (não marca "fora do ar");
+   - **Auto-cura**: se já estava `disconnected`, volta pra `healthy` (quebra o loop pegajoso sem esperar re-pareamento).
+
+**2. Ausência de inbound ≠ queda.** Canal pode estar legitimamente quieto. Sem inbound recente, mantém o sinal do daemon (marca `disconnected`) — a regra **não cria falso-negativo**.
+
+**3. `BANNED` não é suprimível.** Uma mensagem anterior ao ban não invalida o ban (P0, alerta humano).
+
+**4. Decisão pura isolada.** A lógica vive em `WhatsmeowHealthProbeCommand::decideAction(state, healthBefore, freshInbound)` — sem DB/daemon, travada por teste determinístico (`WhatsmeowHealthProbeDecisionTest`, 7 casos). A query de inbound fica fina no `handle()` (Tier 0: escopada por `channel_id`, único por business; `withoutGlobalScopes` porque o cron roda sem session — [ADR 0093](0093-multi-tenant-isolation-tier-0.md)).
+
+**5. Princípio derivado (catraca semântica).** Um gate de contrato de tela deve validar o **acordo de valores** entre backend e frontend (vocabulário de `state`), não só a presença do marcador `data-contract`. Endereçar na evolução da catraca (follow-up).
+
+## Consequências
+
+- ✅ O banner "fora do ar" deixa de disparar (e some sozinho) quando o canal está provadamente recebendo mensagens.
+- ✅ Auto-cura encerra o estado pegajoso `disconnected` sem intervenção humana.
+- ✅ Quedas reais (sem tráfego) continuam detectadas — sem regressão de cobertura.
+- ⚠️ Janela de 10 min: uma queda real logo após uma mensagem leva até ~10 min + 1 ciclo de cron pra ser declarada. Aceitável (martelo [W]); ajustável por env `WHATSMEOW_HEALTH_FRESH_INBOUND_MINUTES`.
+- 📝 **Correção de memória** (append-only): o handoff `2026-06-16-1545-caixa-unificada-dark-ondas` afirma a Caixa "verificada na prod"; a verificação **não** cobriu o contrato banner↔reconnect nem a semântica do `channel_health`. Este ADR é a fonte de verdade do estado real pós-2026-06-18.
+
+## Anchor
+
+**Implementado em:** `Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php` (`decideAction` + `hasRecentInbound`), `Modules/Whatsapp/Config/config.php` (`health_fresh_inbound_minutes`), `Modules/Whatsapp/Tests/Feature/WhatsmeowHealthProbeDecisionTest.php`.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **290** arquivos · **275** números únicos · máx **0285**
-- **ADRs ATIVOS (lifecycle ativo): 250** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 228 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 250 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **291** arquivos · **276** números únicos · máx **0286**
+- **ADRs ATIVOS (lifecycle ativo): 251** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 228 · proposto 37 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 251 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -29,7 +29,7 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
-## Todas as ADRs (290)
+## Todas as ADRs (291)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -322,3 +322,4 @@ _(íntegra)_
 | 0283 | aceito | ativo | decision | Loop de handoff zero-paste — repo fonte única, gate de conteúdo, sem auto-merge  |
 | 0284 | aceito | ativo | decision | Pipeline de incidente graduado por confiança — porta única, redação cross-tenant |
 | 0285 | aceito | ativo | decision | Publisher Cowork→repo — fechar o 1º hop do loop zero-paste reusando a cowork-inb |
+| 0286 | proposto | ativo | decision | channel_health de canal whatsmeow é corroborado por fluxo de mensagem real — inb |

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13016,7 +13016,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 54
+			count: 55
 			path: Modules/Whatsapp/Config/config.php
 
 		-


### PR DESCRIPTION
## Origem
Incidente 2026-06-18 (Caixa/Atendimento): banner "WhatsApp · Suporte está fora do ar — 94 conversas" enquanto o Reconectar dizia "sessão ativa". **Verificação ao vivo no daemon CT 100**: canal **logado**, **~48 msg/h**, webhook **151× 200**, **zero logout em 24h** → o "fora do ar" era **falso-positivo** do probe. (A camada de UI saiu em [caixa#2984](https://github.com/wagnerra23/oimpresso.com/pull/2984).)

## Causa
`whatsmeow:health-probe` marcava `channel_health=disconnected` baseado **só** no `loggedIn` do WuzAPI — flag que o próprio docblock admite ser não-confiável (WuzAPI não assina `LoggedOut`). Nunca cruzava com "está chegando mensagem?". O ramo `connected && !loggedIn → LOGGED_OUT` do reconciler é pegajoso (se auto-perpetua).

## Fix — saúde por mensagem real
- `decideAction(state, healthBefore, freshInbound)` **pura** (sem DB/daemon): no ramo caído, inbound recente (`whatsapp_conversations.last_inbound_at` < N min) **suprime** o `disconnected` e **auto-cura** pra `healthy`.
- Ausência de inbound **≠ queda** → sem tráfego mantém o sinal do daemon (**sem falso-negativo**). `BANNED` nunca suprimido.
- Janela configurável `whatsapp.whatsmeow.health_fresh_inbound_minutes` (default **10**, martelo [W]).
- Tier 0: `hasRecentInbound` escopado por `channel_id` (único por business) + `withoutGlobalScopes` (cron sem session).

## Teste
`WhatsmeowHealthProbeDecisionTest` — 7 casos cobrindo a matriz (suprime/auto-cura/queda-real/idempotente/banned/transitórios). Executado standalone: **11/11 OK**. `php -l` limpo nos 3 arquivos.

## ADR
[0286](memory/decisions/0286-channel-health-corroborado-por-mensagem-real.md) (**proposto** — ratifica no merge): registra a regra + o **furo da catraca semântica** (#2974 valida presença do `data-contract`, não o acordo de `state`) + **correção de memória** (handoff 16/jun dizia "verificado na prod"; não cobria isto).

🤖 Generated with [Claude Code](https://claude.com/claude-code)