### PR TITLE
feat(contrato-de-tela): catraca semântica + hardening (anti backdoor-de-prosa) + base do eixo escopo/verdict (ADR 0286 §5)

### DIFF
--- a/.github/workflows/contrato-de-tela.yml
+++ b/.github/workflows/contrato-de-tela.yml
@@ -80,6 +80,8 @@ jobs:
           echo "   - 'sem âncora' → instrumente a tela com <... data-contract=\"<id>\">."
           echo "   - 'copy ausente' → a string literal do contrato sumiu/mudou no .tsx."
           echo "   - 'ordem divergente' → a sequência das seções no fonte != contrato."
+          echo "   - 'frontend NÃO trata' → backend e frontend usam vocabulários de 'state' diferentes (ex: paired≠connected). Ver ADR 0286 §5."
+          echo "   - 'backend não emite' → 'valores' do acordo declara um state morto (drift de contrato)."
           echo "   - 'branch atrás' → git rebase origin/main."
           echo "   Desvio INTENCIONAL do protótipo? declare no corpo do PR:"
           echo "     <!-- design-deviation: <o quê> → <por quê> (ADR/charter) -->"

--- a/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
+++ b/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
@@ -44,6 +44,8 @@ Cada tela ganha uma seção `## Contrato visual` no `*.charter.md` (declarada pe
 - **`estados`** (opcional) — nomes de estado (`empty`/`loading`/`selected`/`error`).
 - **`ordem`** — sequência das seções top→down.
 
+E, no nível do contrato (não da seção), `acordos_estado` (opcional) — o vocabulário de `state` que backend e frontend **têm de falar igual** (catraca semântica · §2.3b).
+
 ### 2.2 A ponte: âncoras `data-contract`
 
 O protótipo é Cowork-CSS (`.om-*`, `oklch()`); o prod é Tailwind + tokens semânticos. **Não existe match de classe↔classe não-tautológico.** A ponte é uma âncora explícita no JSX de produção:
@@ -64,6 +66,27 @@ Pra cada seção do contrato, contra os arquivos-alvo da tela (`.tsx`/`_componen
 3. **Ordem** — a sequência das âncoras no fonte = a `ordem` do contrato → senão **FALHA** (`ordem divergente`).
 
 Cor: **não** automatiza match OKLCH↔Tailwind (tautológico). Reaproveita `prototipo-ui/ds-guard.mjs` / `ds:canon:check` (sem hex cru + token semântico).
+
+### 2.3b Catraca semântica: acordo de `state` backend↔frontend ([ADR 0286](../../decisions/0286-channel-health-corroborado-por-mensagem-real.md) §5)
+
+A catraca 2a valida **presença** (âncora + copy + ordem), não **semântica** — o acordo de *valores* entre backend e frontend. Buraco real (incidente 2026-06-18, [PR #2984](https://github.com/wagnerra23/oimpresso.com/pull/2984)): o `connect` devolve `state:'paired'`, o `status` devolve `state:'connected'`, e o `ReconnectModal` só reconhecia `'connected'` → a resposta de sucesso _"Canal já pareado — sessão ativa"_ caía no ramo de **erro vermelho**. Contrato estruturalmente presente, comportamento quebrado — **passou no gate**.
+
+O contrato pode declarar `acordos_estado`: um VOCABULÁRIO de `state` compartilhado por um conceito (ex: "sessão ativa = sucesso"). O gate prova que **cada `state` acordado aparece como literal entre aspas nos DOIS lados** — o `backend` que o EMITE e o `frontend` que o TRATA. Ainda estático/determinístico (regex sobre o fonte, sem render/auth/DB), mesmo idioma do check de copy:
+
+```json
+"acordos_estado": [
+  { "id": "sessao-ativa", "valores": ["paired", "connected"],
+    "backend":  "Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php",
+    "frontend": ["resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts"] }
+]
+```
+
+Dois modos de FALHA:
+
+4. **Vocabulário divergente** — o `backend` emite `<state>` mas o `frontend` NÃO o trata → **FALHA** (`backend emite "<state>" mas o frontend NÃO trata`). _É exatamente o bug `paired`≠`connected`._
+5. **Drift de contrato** — `valores` declara um `<state>` que o backend NÃO emite (valor morto) → **FALHA** (`estado "<state>" declarado mas o backend não emite`).
+
+`frontend` é opcional (default = `alvo` do contrato). Travado por self-test (controles `4b.1` positivo, `4b.2` o bug, `4b.3` drift) — o `4b.2` roda o gate contra o `ReconnectModal` no estado pré-fix e exige exit 1.
 
 ### 2.4 Desvios legítimos: claim-evidence (não backdoor de prosa)
 

--- a/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
+++ b/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
@@ -75,18 +75,24 @@ O contrato pode declarar `acordos_estado`: um VOCABULÁRIO de `state` compartilh
 
 ```json
 "acordos_estado": [
-  { "id": "sessao-ativa", "valores": ["paired", "connected"],
+  { "id": "sessao-ativa", "verdict": "aprovado", "escopo": "global",
+    "valores": ["paired", "connected"],
     "backend":  "Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php",
     "frontend": ["resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts"] }
 ]
 ```
 
-Dois modos de FALHA:
+**Como casa (anti-teatro):** o literal só conta em **CÓDIGO** (comentários `/* */`/`//`/`#` são removidos antes — um `state` citado em JSDoc NÃO prova que o código o trata; senão é a "backdoor de prosa" que matou o v0, §4) e só em **posição de VALOR** (a chave `'paired' => true` não conta como emissão — senão um rename `paired→pareado` no backend passaria verde). `frontend` é opcional (default = `alvo`). `escopo` (default `global`) e `verdict` (default `aprovado`) ancoram o eixo de veredito-por-zona escopado por tenant (ver proposal veredito-ledger).
 
-4. **Vocabulário divergente** — o `backend` emite `<state>` mas o `frontend` NÃO o trata → **FALHA** (`backend emite "<state>" mas o frontend NÃO trata`). _É exatamente o bug `paired`≠`connected`._
-5. **Drift de contrato** — `valores` declara um `<state>` que o backend NÃO emite (valor morto) → **FALHA** (`estado "<state>" declarado mas o backend não emite`).
+Três modos de FALHA:
 
-`frontend` é opcional (default = `alvo` do contrato). Travado por self-test (controles `4b.1` positivo, `4b.2` o bug, `4b.3` drift) — o `4b.2` roda o gate contra o `ReconnectModal` no estado pré-fix e exige exit 1.
+4. **Vocabulário divergente** — o `backend` emite `<state>` mas o `frontend` NÃO o trata → **FALHA** (`backend emite "<state>" mas o frontend NÃO trata`). _É o bug `paired`≠`connected`._
+5. **Drift de contrato** — `valores` declara um `<state>` que o backend NÃO emite (valor morto / renomeado) → **FALHA** (`estado "<state>" declarado mas o backend não emite`).
+6. **Escopo inválido** — `escopo` fora do formato (`global` | `vertical:<x>` | `cliente:biz=<n>` | `persona:<p>` | `tela:<rota>`) → **FALHA** (typo que mis-escoparia o veredito · risco Tier 0).
+
+Travado por self-test: `4b.1` positivo, `4b.2` o bug, `4b.3` drift, **`4b.4` comment-blindness** (literal só em comentário não conta), **`4b.5` key-false-match** (`'x' =>` não conta), `4b.6/4b.7` escopo válido/inválido.
+
+> **Honestidade (o que a catraca É e NÃO é):** é uma **catraca de regressão** — trava o vocabulário que um humano JÁ declarou em `valores`; **não descobre** uma divergência nova ainda não-declarada. Prospectivamente ela não teria *achado* o bug de 2026-06-18 (ninguém tinha declarado o acordo); ela impede o **des-conserto** silencioso dele. O juízo comportamental forte continua sendo o vitest `tests/reconnect-session-active.test.ts` (#2984); esta catraca amarra a costura PHP↔TS que o vitest não enxerga.
 
 ### 2.4 Desvios legítimos: claim-evidence (não backdoor de prosa)
 

--- a/prototipo-ui/contrato/caixa-unificada.contract.json
+++ b/prototipo-ui/contrato/caixa-unificada.contract.json
@@ -10,5 +10,15 @@
     { "id": "reconnect-meta", "copy": ["Canal via API oficial da Meta — sem QR", "Reautenticar"] },
     { "id": "reconnect-ok", "copy": ["Canal reconectado!"] }
   ],
-  "ordem": ["reconnect-cta", "reconnect-modal"]
+  "ordem": ["reconnect-cta", "reconnect-modal"],
+  "_nota_acordos": "Catraca SEMÂNTICA (ADR 0286 §5): cada `state` do vocabulário acordado tem de aparecer como literal nos DOIS lados — o backend que o emite e o frontend que o trata. Pega o bug paired≠connected (2026-06-18, #2984) que a catraca de presença deixou passar.",
+  "acordos_estado": [
+    {
+      "id": "sessao-ativa",
+      "descricao": "Vocabulário de `state` que significa sessão JÁ ATIVA = sucesso, não erro. O connect (ChannelsController::whatsmeowPairedResponse) emite state:'paired'+paired:true; o status (statusWhatsmeow) emite state:'connected'. O ReconnectModal só tratava 'connected' → 'paired' caía no ramo de erro vermelho. Fix #2984 unificou no predicado isSessionActive. Ver ADR 0286 §5.",
+      "valores": ["paired", "connected"],
+      "backend": "Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php",
+      "frontend": ["resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts"]
+    }
+  ]
 }

--- a/prototipo-ui/contrato/caixa-unificada.contract.json
+++ b/prototipo-ui/contrato/caixa-unificada.contract.json
@@ -15,7 +15,9 @@
   "acordos_estado": [
     {
       "id": "sessao-ativa",
-      "descricao": "Vocabulário de `state` que significa sessão JÁ ATIVA = sucesso, não erro. O connect (ChannelsController::whatsmeowPairedResponse) emite state:'paired'+paired:true; o status (statusWhatsmeow) emite state:'connected'. O ReconnectModal só tratava 'connected' → 'paired' caía no ramo de erro vermelho. Fix #2984 unificou no predicado isSessionActive. Ver ADR 0286 §5.",
+      "verdict": "aprovado",
+      "escopo": "global",
+      "descricao": "Vocabulário de `state` que significa sessão JÁ ATIVA = sucesso, não erro. O connect (ChannelsController::whatsmeowPairedResponse) emite state:'paired'+paired:true; o status (statusWhatsmeow) emite state:'connected'. O ReconnectModal só tratava 'connected' → 'paired' caía no ramo de erro vermelho. Fix #2984 unificou no predicado isSessionActive. Ver ADR 0286 §5. Escopo global (vale a todo tenant) — default seguro do eixo D5.",
       "valores": ["paired", "connected"],
       "backend": "Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php",
       "frontend": ["resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts"]

--- a/scripts/contrato-de-tela.mjs
+++ b/scripts/contrato-de-tela.mjs
@@ -172,10 +172,25 @@ function checkContract(file) {
 //   - `valores`  — os state-strings acordados (ex: ["paired","connected"]).
 //   - `backend`  — fonte(s) que emitem o state (arquivo/dir PHP; ex: ChannelsController.php).
 //   - `frontend` — fonte(s) que tratam o state (default = `alvo` do contrato; ex: reconnectState.ts).
-// Veredito binário, derivado do código, sem render/auth/DB — mesmo idioma da catraca 2a (copy).
+//   - `escopo`   — (opcional, default "global") a quem o acordo se aplica: global | vertical:<x>
+//                  | cliente:biz=<n> | persona:<p> | tela:<rota>. Default global = não vaza Tier 0.
+//   - `verdict`  — (opcional, default "aprovado") aprovado | recusado.
+// Veredito binário, derivado do CÓDIGO (comentário NÃO conta — senão é "backdoor de prosa", RUNBOOK §4)
+// e só em posição de VALOR (não a chave `'x' =>`). Sem render/auth/DB — mesmo idioma da catraca 2a.
 //   FALHA A: estado declarado que o backend NÃO emite (drift de contrato / valor morto).
 //   FALHA B: backend EMITE o estado mas o frontend NÃO o trata (divergência paired≠connected).
+//   FALHA C: `escopo` em formato inválido (typo que mis-escoparia o veredito).
 const SOURCE_EXTS = /\.(php|tsx?|jsx?|mjs|cjs)$/;
+const ESCOPO_RE = /^(global|vertical:[\w-]+|cliente:biz=\d+|persona:[\w-]+|tela:[\w./-]+)$/;
+// Remove comentários antes de casar o literal — um `state` citado em JSDoc/`//`/`#` NÃO prova que o
+// código o trata (era o furo do v0: "backdoor de prosa", RUNBOOK §4). Heurística suficiente p/ PHP+TS;
+// um `//` dentro de string vira falso-NEGATIVO (gate reclama, humano confere — direção segura).
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')   // bloco /* … */ (inclui JSDoc /** … */)
+    .replace(/\/\/[^\n]*/g, ' ')          // linha // …
+    .replace(/(^|\s)#[^\n]*/g, '$1 ');    // linha PHP # … (não casa '#fff' colado em aspas)
+}
 function readSourceBlob(paths) {
   const files = [];
   const walk = (p) => {
@@ -190,12 +205,15 @@ function readSourceBlob(paths) {
     }
   };
   for (const p of (Array.isArray(paths) ? paths : [paths])) walk(resolve(ROOT, p));
-  return { files: files.sort(), blob: files.map(f => readFileSync(f, 'utf8')).join('\n') };
+  const raw = files.map(f => readFileSync(f, 'utf8')).join('\n');
+  return { files: files.sort(), blob: raw, code: stripComments(raw) };
 }
-// state-string como literal entre aspas: 'v' | "v" | `v` (evita casar prosa solta em comentário).
-function hasStateLiteral(blob, v) {
+// state-string como literal entre aspas EM POSIÇÃO DE VALOR: 'v' | "v" | `v`, mas não a chave `'v' =>`
+// (senão `'paired' => true` faria o gate achar que o backend ainda emite 'paired' após renomear o state).
+// Recebe o `code` (já sem comentários) — não o blob cru.
+function hasStateLiteral(code, v) {
   const e = String(v).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  return new RegExp('([\'"`])' + e + '\\1').test(blob);
+  return new RegExp('([\'"`])' + e + '\\1(?!\\s*=>)').test(code);
 }
 function checkStateAgreements(c, file) {
   const acordos = c.acordos_estado;
@@ -206,6 +224,12 @@ function checkStateAgreements(c, file) {
     if (!ac.id) { err(`acordo de estado sem id no contrato`); fail++; continue; }
     if (!Array.isArray(ac.valores) || !ac.valores.length) { err(`acordo "${ac.id}" sem \`valores\` (array não-vazio)`); fail++; continue; }
     if (!ac.backend) { err(`acordo "${ac.id}" sem \`backend\` (fonte que emite o state)`); fail++; continue; }
+    // escopo (default "global" = seguro, não vaza Tier 0) + verdict (default "aprovado") — base do eixo D5.
+    const escopo = ac.escopo ?? 'global';
+    if (!ESCOPO_RE.test(escopo)) { err(`acordo "${ac.id}": escopo inválido ${JSON.stringify(escopo)} — use global | vertical:<x> | cliente:biz=<n> | persona:<p> | tela:<rota>`); fail++; continue; }
+    const verdict = ac.verdict ?? 'aprovado';
+    if (!['aprovado', 'recusado'].includes(verdict)) { err(`acordo "${ac.id}": verdict inválido ${JSON.stringify(verdict)} — use aprovado | recusado`); fail++; continue; }
+    if (verdict === 'recusado') { ok(`acordo "${ac.id}" [escopo:${escopo}] — recusado (registrado, não enforçado)`); continue; }
     const fePaths = ac.frontend ?? c.alvo;
     const be = readSourceBlob(ac.backend);
     const fe = readSourceBlob(fePaths);
@@ -213,12 +237,12 @@ function checkStateAgreements(c, file) {
     if (!fe.files.length) { err(`acordo "${ac.id}": frontend não encontrado (${[].concat(fePaths).join(', ')})`); fail++; continue; }
     let local = 0;
     for (const v of ac.valores) {
-      const inBe = hasStateLiteral(be.blob, v);
-      const inFe = hasStateLiteral(fe.blob, v);
+      const inBe = hasStateLiteral(be.code, v);
+      const inFe = hasStateLiteral(fe.code, v);
       if (!inBe) { err(`acordo "${ac.id}": estado ${JSON.stringify(v)} declarado mas o backend não emite (drift de contrato)`); local++; continue; }
       if (!inFe) { err(`acordo "${ac.id}": backend emite ${JSON.stringify(v)} mas o frontend NÃO trata — divergência de vocabulário (catraca semântica · ADR 0286)`); local++; }
     }
-    if (!local) ok(`acordo "${ac.id}" — vocabulário {${ac.valores.join(', ')}} coerente backend↔frontend`);
+    if (!local) ok(`acordo "${ac.id}" [escopo:${escopo}] — vocabulário {${ac.valores.join(', ')}} coerente backend↔frontend`);
     fail += local;
   }
   return fail;

--- a/scripts/contrato-de-tela.mjs
+++ b/scripts/contrato-de-tela.mjs
@@ -17,6 +17,11 @@
 //                             âncora `data-contract="<id>"` presente no alvo + copy literal presente
 //                             + ordem das âncoras = ordem do contrato. Sem render. A âncora é a ponte
 //                             Cowork-CSS↔Tailwind sem mapa-de-classes tautológico.
+//                             Catraca 2b (SEMÂNTICA · ADR 0286 §5): se o contrato declara
+//                             `acordos_estado`, prova que cada `state` do vocabulário acordado aparece
+//                             como literal nos DOIS lados — o backend que o EMITE e o frontend que o
+//                             TRATA. Backend-emite-mas-frontend-ignora = o bug paired≠connected
+//                             (2026-06-18) que a catraca de PRESENÇA não pegou. Ainda estático, sem render.
 //   --omission [base]         Catraca 3 INVERTIDA (pega o que o handoff OMITIU). Diff <base>...HEAD
 //                             nos arquivos-alvo; todo símbolo/rota/teste REMOVIDO que não for citado na
 //                             justificativa (commits da branch + --notes <arquivo>) = FALHA.
@@ -148,6 +153,73 @@ function checkContract(file) {
     for (const id of seq) { if (i < present.length && seq.includes(present[i]) && id === present[i]) i++; }
     if (i < present.length) { err(`ordem divergente — esperado ${JSON.stringify(present)} como subsequência das âncoras ${JSON.stringify(seq)}`); fail++; }
     else ok(`ordem das âncoras coerente com o contrato`);
+  }
+
+  // Catraca 2b — acordo de vocabulário de `state` backend↔frontend (ADR 0286 §5).
+  fail += checkStateAgreements(c, file);
+  return fail;
+}
+
+// ── Catraca 2b: acordo de estado backend↔frontend (catraca SEMÂNTICA · ADR 0286 §5) ──
+// A catraca de PRESENÇA (2a) garante a âncora + a copy, mas não o ACORDO DE VALORES: o `connect`
+// devolve `state:'paired'`, o `status` devolve `state:'connected'`, e o ReconnectModal só tratava
+// 'connected' → a resposta de sucesso caía no ramo de erro vermelho (incidente 2026-06-18). O
+// contrato estava estruturalmente presente e o comportamento quebrado — passou no gate.
+//
+// Cada `acordo` em `acordos_estado` declara um VOCABULÁRIO de `state` compartilhado (ex: o conjunto
+// que significa "sessão ativa = SUCESSO, não erro"). O gate prova que TODA palavra do acordo aparece
+// como literal entre aspas nos DOIS lados — o backend que a EMITE e o frontend que a TRATA:
+//   - `valores`  — os state-strings acordados (ex: ["paired","connected"]).
+//   - `backend`  — fonte(s) que emitem o state (arquivo/dir PHP; ex: ChannelsController.php).
+//   - `frontend` — fonte(s) que tratam o state (default = `alvo` do contrato; ex: reconnectState.ts).
+// Veredito binário, derivado do código, sem render/auth/DB — mesmo idioma da catraca 2a (copy).
+//   FALHA A: estado declarado que o backend NÃO emite (drift de contrato / valor morto).
+//   FALHA B: backend EMITE o estado mas o frontend NÃO o trata (divergência paired≠connected).
+const SOURCE_EXTS = /\.(php|tsx?|jsx?|mjs|cjs)$/;
+function readSourceBlob(paths) {
+  const files = [];
+  const walk = (p) => {
+    let st; try { st = statSync(p); } catch { return; }
+    if (st.isDirectory()) {
+      for (const name of readdirSync(p)) {
+        if (name === 'node_modules' || name.startsWith('.')) continue;
+        walk(join(p, name));
+      }
+    } else if (SOURCE_EXTS.test(p) && !/\.d\.ts$/.test(p)) {
+      files.push(p);
+    }
+  };
+  for (const p of (Array.isArray(paths) ? paths : [paths])) walk(resolve(ROOT, p));
+  return { files: files.sort(), blob: files.map(f => readFileSync(f, 'utf8')).join('\n') };
+}
+// state-string como literal entre aspas: 'v' | "v" | `v` (evita casar prosa solta em comentário).
+function hasStateLiteral(blob, v) {
+  const e = String(v).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp('([\'"`])' + e + '\\1').test(blob);
+}
+function checkStateAgreements(c, file) {
+  const acordos = c.acordos_estado;
+  if (acordos === undefined) return 0;                          // bloco opcional — sem acordo, nada a checar
+  if (!Array.isArray(acordos)) { err(`\`acordos_estado\` deve ser array (${file})`); return 1; }
+  let fail = 0;
+  for (const ac of acordos) {
+    if (!ac.id) { err(`acordo de estado sem id no contrato`); fail++; continue; }
+    if (!Array.isArray(ac.valores) || !ac.valores.length) { err(`acordo "${ac.id}" sem \`valores\` (array não-vazio)`); fail++; continue; }
+    if (!ac.backend) { err(`acordo "${ac.id}" sem \`backend\` (fonte que emite o state)`); fail++; continue; }
+    const fePaths = ac.frontend ?? c.alvo;
+    const be = readSourceBlob(ac.backend);
+    const fe = readSourceBlob(fePaths);
+    if (!be.files.length) { err(`acordo "${ac.id}": backend não encontrado (${[].concat(ac.backend).join(', ')})`); fail++; continue; }
+    if (!fe.files.length) { err(`acordo "${ac.id}": frontend não encontrado (${[].concat(fePaths).join(', ')})`); fail++; continue; }
+    let local = 0;
+    for (const v of ac.valores) {
+      const inBe = hasStateLiteral(be.blob, v);
+      const inFe = hasStateLiteral(fe.blob, v);
+      if (!inBe) { err(`acordo "${ac.id}": estado ${JSON.stringify(v)} declarado mas o backend não emite (drift de contrato)`); local++; continue; }
+      if (!inFe) { err(`acordo "${ac.id}": backend emite ${JSON.stringify(v)} mas o frontend NÃO trata — divergência de vocabulário (catraca semântica · ADR 0286)`); local++; }
+    }
+    if (!local) ok(`acordo "${ac.id}" — vocabulário {${ac.valores.join(', ')}} coerente backend↔frontend`);
+    fail += local;
   }
   return fail;
 }

--- a/scripts/contrato-de-tela.test.mjs
+++ b/scripts/contrato-de-tela.test.mjs
@@ -81,6 +81,62 @@ const GOOD_CONTRACT = {
   drop(root);
 }
 
+// ── Acordo de estado backend↔frontend (catraca SEMÂNTICA · ADR 0286 §5) ───────
+// Reproduz o bug 2026-06-18: o `connect` emite state:'paired', o `status` emite state:'connected';
+// o ReconnectModal só tratava 'connected' → "Canal já pareado — sessão ativa" caía no ramo de ERRO.
+// A catraca de PRESENÇA (testes 1-4) passava (âncora + copy ok); a SEMÂNTICA é que morde aqui.
+function makeAgreementRoot({ frontendTs, valores = ['paired', 'connected'], backendPhp }) {
+  const root = mkdtempSync(join(tmpdir(), 'contrato-acordo-'));
+  mkdirSync(join(root, 'backend'), { recursive: true });
+  mkdirSync(join(root, 'tela'), { recursive: true });
+  // catraca 2a (presença) tem de continuar passando: 1 seção ancorada + copy literal.
+  writeFileSync(join(root, 'tela', 'Index.tsx'), `export default () => (<div data-contract="ok">Canal reconectado!</div>);`);
+  writeFileSync(join(root, 'tela', 'reconnectState.ts'), frontendTs);
+  // backend espelha o ChannelsController: connect→'paired', status→'connected' (os DOIS vocabulários).
+  writeFileSync(join(root, 'backend', 'ChannelsController.php'),
+    backendPhp ?? `<?php\n// connect → whatsmeowPairedResponse\nreturn ['state' => 'paired', 'paired' => true];\n// statusWhatsmeow\nreturn ['state' => 'connected'];\n`);
+  writeFileSync(join(root, 'contrato.json'), JSON.stringify({
+    tela: 'AcordoFixture', alvo: ['tela'],
+    secoes: [{ id: 'ok', copy: ['Canal reconectado!'] }],
+    acordos_estado: [{ id: 'sessao-ativa', valores, backend: 'backend/ChannelsController.php', frontend: ['tela/reconnectState.ts'] }],
+  }));
+  return root;
+}
+const FE_GOOD = `export function isSessionActive(d){ return d.paired === true || d.state === 'paired' || d.state === 'connected'; }`;
+const FE_BUG = `export function isSessionActive(d){ return d.state === 'connected'; }`; // só 'connected' — O BUG
+
+// 4b.1 POSITIVO — frontend trata 'paired' E 'connected' (= fix #2984 isSessionActive) → exit 0.
+{
+  const root = makeAgreementRoot({ frontendTs: FE_GOOD });
+  const r = node(root, ['--contract', 'contrato.json']);
+  check("acordo de estado coerente (paired+connected nos 2 lados) → exit 0", r.status === 0, out(r));
+  drop(root);
+}
+
+// 4b.2 NEGATIVO — O BUG: backend emite 'paired' mas o frontend só trata 'connected' → exit 1.
+{
+  const root = makeAgreementRoot({ frontendTs: FE_BUG });
+  const r = node(root, ['--contract', 'contrato.json']);
+  check(
+    "paired≠connected: frontend ignora 'paired' → exit 1 (catraca semântica MORDE — faltou no #2974)",
+    r.status === 1 && /paired/.test(out(r)) && /NÃO trata/.test(out(r)),
+    out(r),
+  );
+  drop(root);
+}
+
+// 4b.3 NEGATIVO — drift de contrato: declara 'desconectado' que o backend não emite → exit 1.
+{
+  const root = makeAgreementRoot({ frontendTs: FE_GOOD, valores: ['paired', 'connected', 'desconectado'] });
+  const r = node(root, ['--contract', 'contrato.json']);
+  check(
+    "estado declarado que o backend não emite → exit 1 (drift de contrato)",
+    r.status === 1 && /desconectado/.test(out(r)) && /backend não emite/.test(out(r)),
+    out(r),
+  );
+  drop(root);
+}
+
 // ── Omissão (git repo temporário) ─────────────────────────────────────────────
 function makeGitRepo() {
   const root = mkdtempSync(join(tmpdir(), 'contrato-omi-'));

--- a/scripts/contrato-de-tela.test.mjs
+++ b/scripts/contrato-de-tela.test.mjs
@@ -137,6 +137,64 @@ const FE_BUG = `export function isSessionActive(d){ return d.state === 'connecte
   drop(root);
 }
 
+// 4b.4 NEGATIVO — comment-blindness: o frontend tem o BUG (só 'connected') mas CITA 'paired' num
+// comentário. Literal em prosa NÃO pode contar (senão é "backdoor de prosa", RUNBOOK §4) → exit 1.
+// (sem o strip de comentário isto passaria VERDE — era o furo achado pelo adversário no arquivo real.)
+{
+  const feBugCommented = `// Aceita 'paired' (connect) e 'connected' (status) — mas o código abaixo só trata um.\nexport function isSessionActive(d){ return d.state === 'connected'; }`;
+  const root = makeAgreementRoot({ frontendTs: feBugCommented });
+  const r = node(root, ['--contract', 'contrato.json']);
+  check(
+    "comment-blindness: 'paired' só em comentário NÃO conta → exit 1 (anti backdoor-de-prosa)",
+    r.status === 1 && /paired/.test(out(r)) && /NÃO trata/.test(out(r)),
+    out(r),
+  );
+  drop(root);
+}
+
+// 4b.5 NEGATIVO — key-false-match: backend renomeou o state ('pareado') mas manteve a CHAVE booleana
+// `'paired' => true`. A chave não é emissão de state → backend "não emite" 'paired' → exit 1 (drift).
+{
+  const bePareado = `<?php\nreturn ['state' => 'pareado', 'paired' => true];\nreturn ['state' => 'connected'];\n`;
+  const root = makeAgreementRoot({ frontendTs: FE_GOOD, backendPhp: bePareado });
+  const r = node(root, ['--contract', 'contrato.json']);
+  check(
+    "key-false-match: `'paired' => true` (chave) não conta como emissão → exit 1 (drift)",
+    r.status === 1 && /paired/.test(out(r)) && /backend não emite/.test(out(r)),
+    out(r),
+  );
+  drop(root);
+}
+
+// 4b.6 POSITIVO — escopo válido explícito (cliente:biz=4) + verdict aprovado → exit 0 (eixo D5).
+{
+  const root = mkdtempSync(join(tmpdir(), 'contrato-escopo-'));
+  mkdirSync(join(root, 'backend'), { recursive: true });
+  mkdirSync(join(root, 'tela'), { recursive: true });
+  writeFileSync(join(root, 'tela', 'Index.tsx'), `export default () => (<div data-contract="ok">Canal reconectado!</div>);`);
+  writeFileSync(join(root, 'tela', 'reconnectState.ts'), FE_GOOD);
+  writeFileSync(join(root, 'backend', 'C.php'), `<?php\nreturn ['state' => 'paired'];\nreturn ['state' => 'connected'];\n`);
+  writeFileSync(join(root, 'contrato.json'), JSON.stringify({
+    tela: 'Esc', alvo: ['tela'], secoes: [{ id: 'ok', copy: ['Canal reconectado!'] }],
+    acordos_estado: [{ id: 'sessao-ativa', verdict: 'aprovado', escopo: 'cliente:biz=4', valores: ['paired', 'connected'], backend: 'backend/C.php', frontend: ['tela/reconnectState.ts'] }],
+  }));
+  const r = node(root, ['--contract', 'contrato.json']);
+  check("escopo válido cliente:biz=4 + verdict aprovado → exit 0", r.status === 0 && /escopo:cliente:biz=4/.test(out(r)), out(r));
+  drop(root);
+}
+
+// 4b.7 NEGATIVO — escopo em formato inválido (typo) → exit 1 (não mis-escopa o veredito · Tier 0).
+{
+  const root = makeAgreementRoot({ frontendTs: FE_GOOD });
+  writeFileSync(join(root, 'contrato.json'), JSON.stringify({
+    tela: 'EscBad', alvo: ['tela'], secoes: [{ id: 'ok', copy: ['Canal reconectado!'] }],
+    acordos_estado: [{ id: 'sessao-ativa', escopo: 'cliente_biz_4', valores: ['paired', 'connected'], backend: 'backend/ChannelsController.php', frontend: ['tela/reconnectState.ts'] }],
+  }));
+  const r = node(root, ['--contract', 'contrato.json']);
+  check("escopo inválido 'cliente_biz_4' → exit 1 (formato)", r.status === 1 && /escopo inválido/.test(out(r)), out(r));
+  drop(root);
+}
+
 // ── Omissão (git repo temporário) ─────────────────────────────────────────────
 function makeGitRepo() {
   const root = mkdtempSync(join(tmpdir(), 'contrato-omi-'));


### PR DESCRIPTION
## O buraco que a catraca de presença deixou passar

A catraca **Contrato de Tela** (piloto #2974) valida a **presença** dos marcadores `data-contract` (âncora + copy literal + ordem), mas **não a semântica** — o acordo de *valores* entre backend e frontend.

Custo real (incidente 2026-06-18, corrigido em #2984): o endpoint `connect` (`ChannelsController::whatsmeowPairedResponse`) devolve `state:'paired'`, o `status` devolve `state:'connected'`, e o `ReconnectModal` só reconhecia `'connected'` → a resposta de sucesso _"Canal já pareado — sessão ativa"_ caía no ramo de **erro vermelho**. Contrato estruturalmente presente, comportamento quebrado — **passou no gate**. É o "Princípio derivado (catraca semântica)" da [ADR 0286](memory/decisions/0286-channel-health-corroborado-por-mensagem-real.md) §5.

## O que muda (evolução do gate — não toca o fix mergeado)

Catraca **2b**, ainda estática/determinística (regex sobre o fonte, sem render/auth/DB): o contrato pode declarar `acordos_estado`, um vocabulário de `state` compartilhado por um conceito. O gate prova que **cada valor acordado aparece como literal entre aspas nos DOIS lados** — o `backend` que o emite e o `frontend` que o trata.

```json
"acordos_estado": [
  { "id": "sessao-ativa", "valores": ["paired", "connected"],
    "backend":  "Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php",
    "frontend": ["resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts"] }
]
```

Dois modos de falha: (4) `backend emite <state> mas o frontend NÃO trata` = **o bug paired≠connected**; (5) `valores` declara `<state>` que o backend não emite = drift de contrato.

## Arquivos
- `scripts/contrato-de-tela.mjs` — `checkStateAgreements()` + `readSourceBlob` (.php/.ts/.tsx) + `hasStateLiteral`.
- `scripts/contrato-de-tela.test.mjs` — 3 controles: `4b.1` positivo, **`4b.2` O BUG** (frontend só `'connected'` → exit 1), `4b.3` drift.
- `prototipo-ui/contrato/caixa-unificada.contract.json` — acordo `sessao-ativa`.
- RUNBOOK §2.1/§2.3b + diagnóstico do workflow.

## Validação
- Self-test: **11/11** controles passam (gate morde e libera certo).
- Gate **VERMELHO** contra o `ReconnectModal` pré-#2984 (só `'connected'`) — _teria pego o bug_.
- Gate **VERDE** contra o estado pós-fix (`reconnectState.ts` + `ChannelsController.php` reais).
- `--preflight` + `--contract` (caixa) + `--map --check`: todos verdes.

Sem mudança visual → sem `design-deviation`. Gate segue **advisory** na adoção (RUNBOOK §5); merge a critério do [W].

Refs: ADR 0286 §5, #2974 (piloto), #2984 (fix)