### PR TITLE
docs(governance): REQ-001 — vocabulário de estado da zona saude-canal (1ª entrada do Design Request Ledger)

### DIFF
--- a/memory/governance/design-requests/LEDGER.md
+++ b/memory/governance/design-requests/LEDGER.md
@@ -18,6 +18,6 @@
 ## Índice (o "já processei?")
 | REQ | data | tela / arquétipo | status | delta (resumo) | resultado |
 |---|---|---|---|---|---|
-| _(vazio)_ | — | — | — | _o 1º pedido cria `REQ-001`_ | — |
+| [REQ-001](REQ-001.md) | 2026-06-18 | Atendimento/CaixaUnificada · detalhe | processing | zona `saude-canal`: vocabulário de estado `{paired, connected}` travado (backend↔frontend) | [#2986](https://github.com/wagnerra23/oimpresso.com/pull/2986) em review · base [#2984](https://github.com/wagnerra23/oimpresso.com/pull/2984) · [ADR 0286 §5](../../decisions/0286-channel-health-corroborado-por-mensagem-real.md) |
 
 > Atualizar esta tabela faz parte do "pronto" de cada REQ — espelha a regra **"índice = fonte única"** do [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md).

--- a/memory/governance/design-requests/REQ-001.md
+++ b/memory/governance/design-requests/REQ-001.md
@@ -1,0 +1,36 @@
+---
+req: REQ-001
+data: 2026-06-18
+tela: Atendimento/CaixaUnificada
+arquetipo: detalhe
+persona: eliana
+status: processing          # received | processing | done
+origem: ADR 0286 §5 (princípio derivado — catraca semântica) · incidente Caixa 2026-06-18 (banner "fora do ar" × reconnect "sessão ativa")
+---
+
+# REQ-001 — travar o vocabulário de estado da zona `saude-canal`
+
+> **Pedido:** travar o vocabulário de estado da zona `saude-canal` (`reconnect-*`): backend e frontend
+> falam o mesmo `{paired, connected}`. Sessão ativa = sucesso = `{paired, connected}` (não pode cair no
+> ramo de erro vermelho). É o **primeiro zone-invariant** do ledger — o acordo de valores que a catraca
+> de presença (`data-contract`) não cobria ([ADR 0286 §5](../../decisions/0286-channel-health-corroborado-por-mensagem-real.md)).
+
+## Delta manifest — o que mudou (ancorado por LINHA, não a tela toda)
+> Claude Design lê SÓ isto, não relê a tela inteira (TraceLLM: localized rewrite).
+> **Zona:** `saude-canal` · **invariante:** `acordos_estado.sessao-ativa` = `{paired, connected}` (sucesso, nunca erro vermelho).
+
+- **arquivo:** `Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php`  *(backend — emite o vocabulário)*
+  - seção: `whatsmeowPairedResponse` · linha ~`636` · mudança: `emite state:'paired' (+ paired:true) quando o canal já está ativo`
+  - seção: `statusWhatsmeow` · linha ~`517` / `541` · mudança: `emite state:'connected' no caminho de canal OK`
+- **arquivo:** `resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts`  *(frontend — trata o vocabulário)*
+  - seção: `isReconnectSuccess` (helper) · linha ~`26` · mudança: `sucesso ≡ data.paired === true || state === 'paired' || state === 'connected' (não só 'connected' → some o falso erro vermelho)`
+
+## Checkpoint — até onde fiz (granularidade = 1 seção, nunca no meio)
+- [x] `fix base` — done (PR #2984 mergeado: reconnect não pinta "sessão ativa" como erro vermelho)
+- [ ] `catraca semântica` (enforcement do acordo `{paired, connected}` backend↔frontend) — processing (PR #2986 em review)
+- [ ] `hardening` (cegueira-a-comentário achada por adversário no parser do gate) — untouched (pendente em #2986)
+
+## Resultado
+- **diff:** PR #2986 (em review; hardening pendente) · fix base #2984 · origem [ADR 0286 §5](../../decisions/0286-channel-health-corroborado-por-mensagem-real.md)   # retorna igual no retry (idempotente)
+- **grade pós:** — (catraca semântica ainda não mergeada; sem nota pós)
+- **golden:** arquétipo `detalhe` — invariante de vocabulário travado por gate estático (presença `data-contract` + acordo de valores `state`), não por olho humano. Juízo visual (cor/ícone) segue [ADR 0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md).


### PR DESCRIPTION
## O quê

Cria a **primeira entrada real** do **Design Request Ledger** (`memory/governance/design-requests/`). Até agora o ledger era um scaffold vazio — o mesmo rot-warning que um `SYNC_LOG` vazio. Esta é a **Onda 1** do plano veredito-ledger.

- `REQ-001.md` (a partir de `_TEMPLATE-REQ.md`, field-for-field) documentando o **1º zone-invariant**: o vocabulário de estado da zona `saude-canal` (`reconnect-*`) — **sessão ativa = sucesso = `{paired, connected}`**, backend e frontend falando o mesmo idioma.
- Linha correspondente no `LEDGER.md` (append-only; substitui o placeholder `_(vazio)_`).

## Delta manifest (ancorado por linha)

Zona `saude-canal` / invariante `acordos_estado.sessao-ativa`, ancorada em:
- `Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php` — emite `state:'paired'` (~636) e `state:'connected'` (~517/541).
- `resources/js/Pages/Atendimento/CaixaUnificada/_components/reconnectState.ts` — trata sucesso ≡ `{paired, connected}` (~26).

## Status honesto (um ledger que mente é pior que um vazio)

`status: processing`, **não `done`**. A enforcement — a **catraca semântica** que trava o acordo `{paired, connected}` backend↔frontend — está em **#2986 (em review, hardening pendente:** um adversário achou cegueira-a-comentário no parser do gate**)**, não mergeada. O fix base (#2984) está mergeado.

`resultado:` → #2986 (em review) · base #2984 · [ADR 0286 §5](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0286-channel-health-corroborado-por-mensagem-real.md) (princípio derivado: catraca deve validar o **acordo de valores**, não só a presença do marcador `data-contract`).

## Spec / proposta

Mecanismo definido em [`memory/decisions/proposals/design-request-ledger-incremental.md`](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/proposals/design-request-ledger-incremental.md) (idempotency key + delta manifest + checkpoint + resultado; append-only; file-based git — o Claude Design só lê arquivos, nunca o MCP). Status do mecanismo: scaffold pré-ADR.

## Verificação

- Sem lint dedicado a `design-requests` em `package.json` ou `.github/workflows/` (o `ds:ledger` é outro ledger — censo de conformidade DS, não pedidos de design).
- `REQ-001` frontmatter confere **field-for-field** com `_TEMPLATE-REQ.md` (mesmas chaves, mesma ordem); `status` e `arquetipo` dentro do enum do template.

Refs: proposal design-request-ledger-incremental · #2986 · #2984 · ADR 0286

🤖 Generated with [Claude Code](https://claude.com/claude-code)