### PR TITLE
feat(governance): status `recusado` first-class no adr.schema + seção Recusadas no índice

### DIFF
--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -29,6 +29,9 @@
 ## Integridade de supersessão (0 alertas)
 _(íntegra)_
 
+## Recusadas (0) — o NÃO consultável
+_(nenhuma — nenhum pedido recusado catalogado ainda)_
+
 ## Todas as ADRs (291)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|

--- a/memory/decisions/_schema.json
+++ b/memory/decisions/_schema.json
@@ -42,6 +42,7 @@
         "rascunho",
         "proposto",
         "aceito",
+        "recusado",
         "deprecated",
         "superseded"
       ]
@@ -166,6 +167,22 @@
       },
       "uniqueItems": true,
       "default": []
+    },
+    "rejected_at": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "Data da recusa (YYYY-MM-DD). Obrigatório quando status=recusado (proposal recusado-com-motivo, 2026-06-11)."
+    },
+    "rejected_via": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Rito do NÃO — mesmo padrão de accepted_via: 'Wagner DATA no chat: <palavras textuais>'. Obrigatório quando status=recusado."
+    },
+    "rejected_reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "1-3 frases: por que NÃO — e o que faria reabrir (sinal que faltou, coerente com ADR 0105). Obrigatório quando status=recusado."
     }
   },
   "allOf": [
@@ -195,6 +212,25 @@
             ]
           }
         }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "status": {
+            "const": "recusado"
+          }
+        },
+        "required": [
+          "status"
+        ]
+      },
+      "then": {
+        "required": [
+          "rejected_at",
+          "rejected_via",
+          "rejected_reason"
+        ]
       }
     }
   ],

--- a/scripts/governance/adr-index-generate.mjs
+++ b/scripts/governance/adr-index-generate.mjs
@@ -51,7 +51,7 @@ for (const file of readdirSync(join(ROOT, DIR)).sort()) {
   if (!m) continue;
   const [num, slug] = [m[1], `${m[1]}-${m[2]}`];
   const txt = readFileSync(join(ROOT, DIR, file), 'utf8');
-  let rec = { num, slug, title: '', status: '', lifecycle: '', kind: 'decision', supersedes: [], superseded_by: [], hasFrontmatter: false };
+  let rec = { num, slug, title: '', status: '', lifecycle: '', kind: 'decision', supersedes: [], superseded_by: [], rejected_at: '', rejected_reason: '', hasFrontmatter: false };
   if (txt.startsWith('---')) {
     const end = txt.indexOf('\n---', 3);
     const fm = end === -1 ? txt : txt.slice(0, end);
@@ -62,6 +62,8 @@ for (const file of readdirSync(join(ROOT, DIR)).sort()) {
     rec.kind = (field(fm, 'kind') || 'decision').toLowerCase();
     rec.supersedes = numbersFrom(fm, 'supersedes');
     rec.superseded_by = numbersFrom(fm, 'superseded_by');
+    rec.rejected_at = field(fm, 'rejected_at'); // o NÃO consultável (proposal recusado-com-motivo, 2026-06-11)
+    rec.rejected_reason = field(fm, 'rejected_reason');
   } else {
     // ADR formato-tabela legado (sem YAML frontmatter)
     rec.title = (txt.match(/^#\s*(.+)$/m) || [])[1] || slug;
@@ -85,6 +87,8 @@ const byStatus = tally(adrs, 'statusN');
 const byLifecycle = tally(adrs, 'lifecycleN');
 const ativos = adrs.filter((a) => a.lifecycleN === 'ativo').length;
 const semFrontmatter = adrs.filter((a) => !a.hasFrontmatter);
+// Recusadas: o NÃO consultável (proposal recusado-com-motivo, 2026-06-11) — anti-relitígio.
+const recusadas = adrs.filter((a) => a.statusN === 'recusado');
 
 // integridade de supersessão
 const exists = (n) => !!byNum[n];
@@ -119,6 +123,9 @@ ${collisions.length ? collisions.map(([n, v]) => `- **${n}** ×${v.length}: ${v.
 
 ## Integridade de supersessão (${supWarn.length} alertas)
 ${supWarn.length ? supWarn.map((w) => `- ⚠️ ${w}`).join('\n') : '_(íntegra)_'}
+
+## Recusadas (${recusadas.length}) — o NÃO consultável
+${recusadas.length ? recusadas.map((a) => `- **${a.num}** ${(a.title || a.slug).replace(/\|/g, '/').slice(0, 80)}${a.rejected_at ? ` · recusada ${a.rejected_at}` : ''}${a.rejected_reason ? ` — ${a.rejected_reason.replace(/\|/g, '/').slice(0, 120)}` : ''}`).join('\n') : '_(nenhuma — nenhum pedido recusado catalogado ainda)_'}
 
 ## Todas as ADRs (${adrs.length})
 | Nº | Status | Lifecycle | Kind | Título |

--- a/scripts/memory-schemas/adr.schema.json
+++ b/scripts/memory-schemas/adr.schema.json
@@ -38,7 +38,7 @@
     },
     "status": {
       "type": "string",
-      "enum": ["rascunho", "proposto", "aceito", "deprecated", "superseded"]
+      "enum": ["rascunho", "proposto", "aceito", "recusado", "deprecated", "superseded"]
     },
     "authority": {
       "type": "string",
@@ -98,6 +98,22 @@
       "items": { "type": "string", "pattern": "^[0-9]{4}-[a-z0-9-]+$" },
       "uniqueItems": true,
       "default": []
+    },
+    "rejected_at": {
+      "type": "string",
+      "format": "date",
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+      "description": "Data da recusa (YYYY-MM-DD). Obrigatório quando status=recusado (proposal recusado-com-motivo, 2026-06-11)."
+    },
+    "rejected_via": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Rito do NÃO — mesmo padrão de accepted_via: 'Wagner DATA no chat: <palavras textuais>'. Obrigatório quando status=recusado."
+    },
+    "rejected_reason": {
+      "type": "string",
+      "minLength": 1,
+      "description": "1-3 frases: por que NÃO — e o que faria reabrir (sinal que faltou, coerente com ADR 0105). Obrigatório quando status=recusado."
     }
   },
   "allOf": [
@@ -109,6 +125,12 @@
           "superseded_by": { "minItems": 1 },
           "lifecycle": { "enum": ["substituido", "arquivado"] }
         }
+      }
+    },
+    {
+      "if": { "properties": { "status": { "const": "recusado" } }, "required": ["status"] },
+      "then": {
+        "required": ["rejected_at", "rejected_via", "rejected_reason"]
       }
     }
   ]


### PR DESCRIPTION
## O que

Torna `recusado` um **status de primeira classe** no vocabulário de ADR — o NÃO consultável. Onda 1 do plano veredito-ledger (aprovado por Wagner 2026-06-18).

Implementa exatamente a proposal [`2026-06-11-recusado-com-motivo-status-primeira-classe.md`](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/proposals/2026-06-11-recusado-com-motivo-status-primeira-classe.md) §1-§3.

## Mudanças (governança/schema only — Tier 0: nenhum Module/runtime tocado)

1. **`scripts/memory-schemas/adr.schema.json`** (fonte única, ADR 0271)
   - enum `status` ganha `recusado`: `[rascunho, proposto, aceito, recusado, deprecated, superseded]`
   - bloco condicional `if/then` espelhando o de `superseded`: quando `status === "recusado"`, exige `rejected_at` + `rejected_via` + `rejected_reason`
   - 3 props novas (`rejected_at`: date; `rejected_via`: string; `rejected_reason`: string) — `rejected_reason` carrega o critério de reabertura (recusa condicional ao sinal, coerente com ADR 0105)
2. **`memory/decisions/_schema.json`** — espelho gerado, regenerado da fonte (não hand-edit divergente; mantém paridade exata)
3. **`scripts/governance/adr-index-generate.mjs`** — nova seção **"Recusadas"** no índice gerado (hoje só ativos/supersedidos), com data + motivo da recusa → `decisions-search` passa a responder "por que não temos X?"
4. **`memory/decisions/_INDEX-GENERATED.md`** — regenerado (`--check` em dia)

## Verificação (feita localmente antes do push)

- **Não-quebra provada**: 291 ADRs validados contra o schema HEAD vs o novo, com a **mesma stack do `memory-schema-gate`** (AJV draft-2020 + gray-matter). Resultado: **0 ADR novo quebrado** — as 190 falhas são pré-existentes e idênticas sob ambos os schemas (legacy debt append-only que o gate nunca re-avalia). Adicionar enum + required-condicional-só-quando-recusado é não-breaking por construção.
- **Casos sintéticos do `recusado`**: positivo completo → válido; negativo sem os 3 campos → bloqueado (exige rejected_at/via/reason); controle `aceito` → segue válido; paridade do espelho confirmada.
- **Gerador**: `--write` roda limpo (291 ADRs, 0 alertas de supersessão), `--check` exit 0 (sem drift); asserções do `governanceAdrScripts.spec.ts` (colisão, ativos, normalização accepted→aceito) re-verificadas funcionalmente + nova seção "Recusadas" renderiza data+motivo de um ADR recusado de fixture.
- **PHP `jana:validate-memory`** não rodável neste ambiente (sem php/vendor) — CI cobre. Validação AJV equivalente rodada no lugar.

Refs: ADR 0105, 0270, 0271

🤖 Generated with [Claude Code](https://claude.com/claude-code)