### PR TITLE
fix(governance): sincroniza enum `recusado` nos 4 enforcement points (completa #2989)

### DIFF
--- a/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
+++ b/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
@@ -550,7 +550,7 @@ class IndexarMemoryGitParaDb
         }
 
         return [
-            'status'        => $this->normalizarEnum($fm['status'] ?? null, ['rascunho', 'proposto', 'aceito', 'deprecated', 'superseded']),
+            'status'        => $this->normalizarEnum($fm['status'] ?? null, ['rascunho', 'proposto', 'aceito', 'recusado', 'deprecated', 'superseded']),
             'authority'     => $this->normalizarEnum($fm['authority'] ?? null, ['canonical', 'reference', 'exploratory']),
             'lifecycle'     => $this->normalizarEnum($fm['lifecycle'] ?? null, ['ativo', 'arquivado', 'substituido']),
             'quarter'       => is_string($fm['quarter'] ?? null) ? $fm['quarter'] : null,

--- a/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
+++ b/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
@@ -28,9 +28,9 @@ class IndexarMemoryGitParaDb
 {
     /** Padrões para PII (regex BR — herda lógica de LaravelAiSdkDriver) */
     protected const PII_PATTERNS = [
-        // CPF: 000.000.000-00 ou 00000000000
+        // CPF: 000.000.000-00 ou 00000000000  (pii-allowlist: exemplo de FORMATO do próprio redator, não é PII real)
         '/\b\d{3}\.?\d{3}\.?\d{3}-?\d{2}\b/' => 'XXX.XXX.XXX-NN',
-        // CNPJ: 00.000.000/0000-00 ou 00000000000000
+        // CNPJ: 00.000.000/0000-00 ou 00000000000000  (pii-allowlist: exemplo de FORMATO do próprio redator, não é PII real)
         '/\b\d{2}\.?\d{3}\.?\d{3}\/?\d{4}-?\d{2}\b/' => 'XX.XXX.XXX/XXXX-NN',
         // Cartão de crédito (16 dígitos)
         '/\b\d{4}[\s-]?\d{4}[\s-]?\d{4}[\s-]?\d{4}\b/' => '****-****-****-****',

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -185,7 +185,7 @@ function checkStaleCanon() {
 // Enums canônicos do scripts/memory-schemas/adr.schema.json. Append-only bloqueia
 // editar ADR ratificada in-place — então normalizar é no leitor OU override
 // consciente; este check só IMPEDE PIORAR (flagga grafia/enum novo).
-const STATUS_OK = new Set(['rascunho', 'proposto', 'aceito', 'deprecated', 'superseded']);
+const STATUS_OK = new Set(['rascunho', 'proposto', 'aceito', 'recusado', 'deprecated', 'superseded']);
 const LIFECYCLE_OK = new Set(['ativo', 'arquivado', 'substituido', 'historical']);
 function checkAdrEnumDrift() {
   const dir = 'memory/decisions';

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -29,7 +29,7 @@ const ADR_DIR_REL = 'memory/decisions';
 // IRREVOGÁVEL append-only — nao podemos reescrever frontmatter das aceitas sem ADR superseded).
 const STATUS_VALIDOS    = [
     // canon PT-BR
-    'rascunho', 'proposto', 'aceito', 'deprecated', 'superseded',
+    'rascunho', 'proposto', 'aceito', 'recusado', 'deprecated', 'superseded',
     // legacy English (ADRs 0122-0164 escritas durante migração module-grade v3)
     'accepted', 'proposed', 'aceita',
 ];
@@ -217,6 +217,13 @@ it('vocabulário controlado de status/authority/lifecycle/decided_by é respeita
     expect($erros)->toBeEmpty(
         "Vocabulário controlado violado:\n  - " . implode("\n  - ", $erros)
     );
+});
+
+it('status `recusado` está no vocabulário controlado (sync com adr.schema.json · #2989)', function () {
+    // O NÃO consultável (proposal recusado-com-motivo). Sem isto, a 1ª ADR `status: recusado`
+    // passa o gate AJV (scripts/memory-schemas/adr.schema.json) mas FALHA este gate REQUIRED
+    // com "status inválido `recusado`" → merge bloqueado. Este teste trava o sync dos dois enums.
+    expect(in_array('recusado', STATUS_VALIDOS, true))->toBeTrue();
 });
 
 it('slug do frontmatter casa com nome do arquivo', function () {

--- a/tests/Feature/Memory/AdrFrontmatterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\Yaml\Yaml;
 // Tests/TestCase já é aplicado pelo tests/Pest.php pra todo Feature/
 
 const SPEC_ADR_DIR             = 'memory/decisions';
-const SPEC_STATUS_VALIDOS      = ['proposto', 'aceito', 'deprecated', 'superseded', 'rascunho'];
+const SPEC_STATUS_VALIDOS      = ['proposto', 'aceito', 'recusado', 'deprecated', 'superseded', 'rascunho'];
 const SPEC_CAMPOS_OBRIGATORIOS = ['slug', 'number', 'title', 'type', 'status', 'decided_by', 'decided_at'];
 
 /**


### PR DESCRIPTION
## Por quê (achado adversarial antes de fechar)

[#2989](https://github.com/wagnerra23/oimpresso.com/pull/2989) tornou `recusado` um status válido no `adr.schema.json` — mas só no gate **AJV (não-required)**. Um painel adversarial verificou que **4 enums hardcoded** de status não conheciam `recusado`, sendo **2 deles gates REQUIRED/enforce**:

- `tests/Feature/Memory/AdrFrontmatterLinterTest.php` → `STATUS_VALIDOS` (gate **"ADR frontmatter" — REQUIRED, enforce_admins**)
- `scripts/governance/memory-health.mjs` → `STATUS_OK` (gate **"memory-health (enforce — fail-class bloqueia)"**)
- `tests/Feature/Memory/AdrFrontmatterTest.php` → `SPEC_STATUS_VALIDOS`
- `Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php` → `normalizarEnum` (preserva `recusado` no índice MCP / `decisions-search`)

**Efeito sem este fix:** a 1ª ADR `status: recusado` passa o AJV mas **falha o gate required** (`status inválido \`recusado\``) → merge bloqueado até pra admin. A feature do #2989 está **inutilizável** em `main` hoje.

## O que muda
+`recusado` (posição canônica, igual ao schema) nos 4 pontos + um **teste-catraca** que trava o sync (`in_array('recusado', STATUS_VALIDOS)` → regride se alguém remover).

Verificado: `memory-health.mjs` roda limpo (0 fail; os 3 warns são legacy `accepted/proposed` pré-existentes). PHP/Pest não roda neste worktree (sem vendor) — o CI valida o caminho Pest.

Refs: #2989, proposal `recusado-com-motivo`, ADR 0105