### PR TITLE
fix(contrato-de-tela): (A) claim honesta (menção≠handling) + 3 fixes do 2º painel adversarial

### DIFF
--- a/.github/workflows/contrato-de-tela.yml
+++ b/.github/workflows/contrato-de-tela.yml
@@ -19,6 +19,7 @@ on:
       - 'prototipo-ui/contrato/**'
       - '**/*.contract.json'
       - 'resources/js/Pages/**/*.tsx'
+      - 'resources/js/Pages/**/*.ts'
       - '.github/workflows/contrato-de-tela.yml'
 
 permissions:

--- a/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
+++ b/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
@@ -82,17 +82,17 @@ O contrato pode declarar `acordos_estado`: um VOCABULÁRIO de `state` compartilh
 ]
 ```
 
-**Como casa (anti-teatro):** o literal só conta em **CÓDIGO** (comentários `/* */`/`//`/`#` são removidos antes — um `state` citado em JSDoc NÃO prova que o código o trata; senão é a "backdoor de prosa" que matou o v0, §4) e só em **posição de VALOR** (a chave `'paired' => true` não conta como emissão — senão um rename `paired→pareado` no backend passaria verde). `frontend` é opcional (default = `alvo`). `escopo` (default `global`) e `verdict` (default `aprovado`) ancoram o eixo de veredito-por-zona escopado por tenant (ver proposal veredito-ledger).
+**Como casa (anti-teatro):** o literal só conta em **CÓDIGO** — comentários (`/* */`/`//`/`#`) são removidos antes, com strip **string-aware** (um `'http://x//y'` não é confundido com comentário) — e só em **posição de VALOR** (a chave `'paired' => true` não conta como emissão; senão um rename `paired→pareado` passaria verde). O gate prova **menção nos dois lados**, não *handling* (ver Honestidade abaixo). `frontend` é opcional (default = `alvo`). `escopo` (default `global`, sem `.` → sem path-traversal) e `verdict` (default `aprovado`) ancoram o eixo veredito-por-zona escopado por tenant (proposal veredito-ledger).
 
 Três modos de FALHA:
 
-4. **Vocabulário divergente** — o `backend` emite `<state>` mas o `frontend` NÃO o trata → **FALHA** (`backend emite "<state>" mas o frontend NÃO trata`). _É o bug `paired`≠`connected`._
+4. **Ignorância total** — o `backend` emite `<state>` mas o `frontend` NÃO o **menciona em código** → **FALHA** (`… o frontend NÃO menciona "<state>" em código`). _Pega a forma do bug `paired`≠`connected` (frontend totalmente sem o state) — não um handler errado que ainda menciona o state (isso é o vitest)._
 5. **Drift de contrato** — `valores` declara um `<state>` que o backend NÃO emite (valor morto / renomeado) → **FALHA** (`estado "<state>" declarado mas o backend não emite`).
-6. **Escopo inválido** — `escopo` fora do formato (`global` | `vertical:<x>` | `cliente:biz=<n>` | `persona:<p>` | `tela:<rota>`) → **FALHA** (typo que mis-escoparia o veredito · risco Tier 0).
+6. **Escopo inválido** — `escopo` fora do formato (`global` | `vertical:<x>` | `cliente:biz=<n>` | `persona:<p>` | `tela:<rota>`) → **FALHA** (typo/traversal que mis-escoparia o veredito · risco Tier 0).
 
-Travado por self-test: `4b.1` positivo, `4b.2` o bug, `4b.3` drift, **`4b.4` comment-blindness** (literal só em comentário não conta), **`4b.5` key-false-match** (`'x' =>` não conta), `4b.6/4b.7` escopo válido/inválido.
+Travado por self-test (17 controles): `4b.1` positivo, `4b.2` o bug, `4b.3` drift, **`4b.4` comment-blindness**, **`4b.5` key-false-match**, `4b.6/4b.7` escopo válido/inválido, **`4b.8` strip string-aware** (`//` em URL não come o state), **`4b.9` escopo path-traversal**.
 
-> **Honestidade (o que a catraca É e NÃO é):** é uma **catraca de regressão** — trava o vocabulário que um humano JÁ declarou em `valores`; **não descobre** uma divergência nova ainda não-declarada. Prospectivamente ela não teria *achado* o bug de 2026-06-18 (ninguém tinha declarado o acordo); ela impede o **des-conserto** silencioso dele. O juízo comportamental forte continua sendo o vitest `tests/reconnect-session-active.test.ts` (#2984); esta catraca amarra a costura PHP↔TS que o vitest não enxerga.
+> **Honestidade (o que a catraca É e NÃO é):** é uma **catraca de regressão** — trava o vocabulário que um humano JÁ declarou em `valores`; **não descobre** uma divergência nova ainda não-declarada. Prospectivamente ela não teria *achado* o bug de 2026-06-18 (ninguém tinha declarado o acordo); ela impede o **des-conserto** silencioso dele. **Limite conhecido (match léxico):** ela checa *menção*, não *handling* — um `'paired' | 'connected'` num tipo TS satisfaz o gate mesmo se o handler tratar só um. Quem prova o handling é o vitest `tests/reconnect-session-active.test.ts` (#2984); a catraca pega (a) drift/rename no **backend** e (b) **frontend totalmente ignorante** do state, e amarra a costura PHP↔TS que o vitest não enxerga.
 
 ### 2.4 Desvios legítimos: claim-evidence (não backdoor de prosa)
 

--- a/scripts/contrato-de-tela.mjs
+++ b/scripts/contrato-de-tela.mjs
@@ -175,21 +175,43 @@ function checkContract(file) {
 //   - `escopo`   — (opcional, default "global") a quem o acordo se aplica: global | vertical:<x>
 //                  | cliente:biz=<n> | persona:<p> | tela:<rota>. Default global = não vaza Tier 0.
 //   - `verdict`  — (opcional, default "aprovado") aprovado | recusado.
-// Veredito binário, derivado do CÓDIGO (comentário NÃO conta — senão é "backdoor de prosa", RUNBOOK §4)
-// e só em posição de VALOR (não a chave `'x' =>`). Sem render/auth/DB — mesmo idioma da catraca 2a.
-//   FALHA A: estado declarado que o backend NÃO emite (drift de contrato / valor morto).
-//   FALHA B: backend EMITE o estado mas o frontend NÃO o trata (divergência paired≠connected).
-//   FALHA C: `escopo` em formato inválido (typo que mis-escoparia o veredito).
+// HONESTO — o que prova e o que NÃO prova: derivado do CÓDIGO (comentário NÃO conta), em posição de
+// VALOR (não a chave `'x' =>`), o gate prova que o vocabulário é MENCIONADO nos dois lados. Pega
+// "backend renomeou/sumiu o state" (FALHA A) e "frontend totalmente ignorante do state" (FALHA B, a
+// forma do bug 2026-06-18). NÃO prova que o frontend TRATA o state certo — um `'paired' | 'connected'`
+// num tipo TS menciona sem tratar; o handling é coberto pelo vitest `reconnect-session-active.test.ts`
+// (#2984). Catraca = costura PHP↔TS + ratchet de regressão, não detector de handling. Sem render/auth/DB.
+//   FALHA A: estado declarado que o backend NÃO emite (drift de contrato / renomeado / valor morto).
+//   FALHA B: backend EMITE o estado mas o frontend NÃO o MENCIONA em código (ignorância total).
+//   FALHA C: `escopo` em formato inválido (typo que mis-escoparia o veredito · Tier 0).
 const SOURCE_EXTS = /\.(php|tsx?|jsx?|mjs|cjs)$/;
-const ESCOPO_RE = /^(global|vertical:[\w-]+|cliente:biz=\d+|persona:[\w-]+|tela:[\w./-]+)$/;
-// Remove comentários antes de casar o literal — um `state` citado em JSDoc/`//`/`#` NÃO prova que o
-// código o trata (era o furo do v0: "backdoor de prosa", RUNBOOK §4). Heurística suficiente p/ PHP+TS;
-// um `//` dentro de string vira falso-NEGATIVO (gate reclama, humano confere — direção segura).
+// `tela:` sem `.` → mata path-traversal (`tela:../../x`). vertical/persona = slug; cliente = biz=N.
+const ESCOPO_RE = /^(global|vertical:[\w-]+|cliente:biz=\d+|persona:[\w-]+|tela:[\w/-]+)$/;
+// Remove comentários antes de casar o literal (um `state` citado em JSDoc/`//`/`#` NÃO prova handling).
+// String-aware: caminha char-a-char respeitando aspas, então `'http://x//y'` NÃO é confundido com
+// comentário de linha (o falso-positivo achado pelo adversário). `#` só conta como comentário PHP em
+// início de token (preserva `this.#campo` e `'#fff'`).
 function stripComments(src) {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, ' ')   // bloco /* … */ (inclui JSDoc /** … */)
-    .replace(/\/\/[^\n]*/g, ' ')          // linha // …
-    .replace(/(^|\s)#[^\n]*/g, '$1 ');    // linha PHP # … (não casa '#fff' colado em aspas)
+  let out = '', i = 0, q = null;
+  const n = src.length;
+  while (i < n) {
+    const c = src[i], d = src[i + 1];
+    if (q) {                                    // dentro de string: copia (trata escape), detecta fecho
+      out += c;
+      if (c === '\\') { out += d ?? ''; i += 2; continue; }
+      if (c === q) q = null;
+      i++; continue;
+    }
+    if (c === '"' || c === "'" || c === '`') { q = c; out += c; i++; continue; }
+    if (c === '/' && d === '*') { const e = src.indexOf('*/', i + 2); out += ' '; i = e < 0 ? n : e + 2; continue; }
+    if (c === '/' && d === '/') { const e = src.indexOf('\n', i); out += ' '; i = e < 0 ? n : e; continue; }
+    if (c === '#') {                            // comentário PHP só em início de token (não `this.#x`/`'#fff'`)
+      const p = out.length ? out[out.length - 1] : '\n';
+      if (p === ' ' || p === '\n' || p === '\t' || p === '\r') { const e = src.indexOf('\n', i); out += ' '; i = e < 0 ? n : e; continue; }
+    }
+    out += c; i++;
+  }
+  return out;
 }
 function readSourceBlob(paths) {
   const files = [];
@@ -240,7 +262,7 @@ function checkStateAgreements(c, file) {
       const inBe = hasStateLiteral(be.code, v);
       const inFe = hasStateLiteral(fe.code, v);
       if (!inBe) { err(`acordo "${ac.id}": estado ${JSON.stringify(v)} declarado mas o backend não emite (drift de contrato)`); local++; continue; }
-      if (!inFe) { err(`acordo "${ac.id}": backend emite ${JSON.stringify(v)} mas o frontend NÃO trata — divergência de vocabulário (catraca semântica · ADR 0286)`); local++; }
+      if (!inFe) { err(`acordo "${ac.id}": backend emite ${JSON.stringify(v)} mas o frontend NÃO menciona ${JSON.stringify(v)} em código — divergência de vocabulário (catraca semântica · ADR 0286)`); local++; }
     }
     if (!local) ok(`acordo "${ac.id}" [escopo:${escopo}] — vocabulário {${ac.valores.join(', ')}} coerente backend↔frontend`);
     fail += local;

--- a/scripts/contrato-de-tela.test.mjs
+++ b/scripts/contrato-de-tela.test.mjs
@@ -119,7 +119,7 @@ const FE_BUG = `export function isSessionActive(d){ return d.state === 'connecte
   const r = node(root, ['--contract', 'contrato.json']);
   check(
     "paired≠connected: frontend ignora 'paired' → exit 1 (catraca semântica MORDE — faltou no #2974)",
-    r.status === 1 && /paired/.test(out(r)) && /NÃO trata/.test(out(r)),
+    r.status === 1 && /paired/.test(out(r)) && /NÃO menciona/.test(out(r)),
     out(r),
   );
   drop(root);
@@ -146,7 +146,7 @@ const FE_BUG = `export function isSessionActive(d){ return d.state === 'connecte
   const r = node(root, ['--contract', 'contrato.json']);
   check(
     "comment-blindness: 'paired' só em comentário NÃO conta → exit 1 (anti backdoor-de-prosa)",
-    r.status === 1 && /paired/.test(out(r)) && /NÃO trata/.test(out(r)),
+    r.status === 1 && /paired/.test(out(r)) && /NÃO menciona/.test(out(r)),
     out(r),
   );
   drop(root);
@@ -192,6 +192,28 @@ const FE_BUG = `export function isSessionActive(d){ return d.state === 'connecte
   }));
   const r = node(root, ['--contract', 'contrato.json']);
   check("escopo inválido 'cliente_biz_4' → exit 1 (formato)", r.status === 1 && /escopo inválido/.test(out(r)), out(r));
+  drop(root);
+}
+
+// 4b.8 POSITIVO — strip string-aware: `//` dentro de URL na MESMA linha do state NÃO vira comentário.
+// (regex naïve comia o resto da linha → falso-RED no `'state' => 'paired'`; o adversário pegou isso.)
+{
+  const beUrl = `<?php\nreturn ['url' => 'http://x//y/z', 'state' => 'paired'];\nreturn ['state' => 'connected'];\n`;
+  const root = makeAgreementRoot({ frontendTs: FE_GOOD, backendPhp: beUrl });
+  const r = node(root, ['--contract', 'contrato.json']);
+  check("strip string-aware: '//' em URL não come o state na mesma linha → exit 0", r.status === 0, out(r));
+  drop(root);
+}
+
+// 4b.9 NEGATIVO — escopo com path-traversal (`tela:../../etc/passwd`) → exit 1 (Tier 0).
+{
+  const root = makeAgreementRoot({ frontendTs: FE_GOOD });
+  writeFileSync(join(root, 'contrato.json'), JSON.stringify({
+    tela: 'EscTrav', alvo: ['tela'], secoes: [{ id: 'ok', copy: ['Canal reconectado!'] }],
+    acordos_estado: [{ id: 'sessao-ativa', escopo: 'tela:../../etc/passwd', valores: ['paired', 'connected'], backend: 'backend/ChannelsController.php', frontend: ['tela/reconnectState.ts'] }],
+  }));
+  const r = node(root, ['--contract', 'contrato.json']);
+  check("escopo path-traversal 'tela:../../etc/passwd' → exit 1", r.status === 1 && /escopo inválido/.test(out(r)), out(r));
   drop(root);
 }
 


### PR DESCRIPTION
Follow-up de [#2986](https://github.com/wagnerra23/oimpresso.com/pull/2986) (já mergeado). Aplica a **decisão (A)** do Wagner: manter a catraca semântica, com claim **honesta** + os bugs que o 2º painel adversarial reproduziu.

## Honestidade (match léxico ≠ handling)
O adversário mostrou que um tipo TS `'paired' | 'connected'` deixa o gate verde mesmo se o handler trata só um. Então a claim foi corrigida em mensagem + docstring + RUNBOOK: **o gate prova MENÇÃO em código nos 2 lados, NÃO handling.** Pega (a) drift/rename no backend e (b) frontend totalmente ignorante do state (a forma do bug 2026-06-18). Handling correto = vitest `reconnect-session-active.test.ts` (#2984). `"NÃO trata"` → `"NÃO menciona"`.

## 3 fixes (cada um com self-test novo)
1. **strip string-aware** (char-walker) → `'http://x//y'` não é confundido com `//` comentário (falso-RED reproduzido pelo adversário). **+4b.8**.
2. **`ESCOPO_RE`**: `tela:` sem `.` → mata path-traversal `tela:../../etc/passwd`. **+4b.9**.
3. **workflow `paths`**: + `resources/js/Pages/**/*.ts` — editar `reconnectState.ts` (a `.ts`) agora dispara o gate (antes só `.tsx`).

Self-test **17/17** (gate morde e libera certo); preflight + contrato real + `--map --check` verdes.

Refs: ADR 0286 §5, ADR 0093 (Tier 0), #2986, #2984