### PR TITLE
feat(whatsapp): Fase B — assina LoggedOut no WuzAPI (detecção de logout em segundos)

### DIFF
--- a/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
@@ -264,7 +264,12 @@ class WhatsmeowDriver implements DriverInterface
                 'name' => $userName,
                 'token' => $userToken,
                 'webhook' => $webhookUrl,
-                'events' => 'Message,ReadReceipt,Connected,Disconnected',
+                // LoggedOut assinado (Fase B · incidente 2026-06-18 / POC WAHA-GOWS Phase 2):
+                // o WuzAPI RECEBE "logged out from another device" mas só repassa o webhook
+                // se o tipo estiver assinado. Sem ele, logout remoto some → channel_health
+                // fica healthy eternamente (raiz do falso "fora do ar", ADR 0286). O app já
+                // roteia LoggedOut → handleDisconnected (WhatsmeowWebhookController).
+                'events' => 'Message,ReadReceipt,Connected,Disconnected,LoggedOut',
             ]);
 
         if (! $response->successful()) {
@@ -309,7 +314,7 @@ class WhatsmeowDriver implements DriverInterface
             // POST /session/connect (gera/refresh QR)
             $connectResponse = $this->client($userToken)
                 ->post('/session/connect', [
-                    'Subscribe' => ['Message', 'ReadReceipt', 'Connected', 'Disconnected'],
+                    'Subscribe' => ['Message', 'ReadReceipt', 'Connected', 'Disconnected', 'LoggedOut'],
                     'Immediate' => false,
                 ]);
 

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowSubscribeLoggedOutTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowSubscribeLoggedOutTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Services\Drivers\WhatsmeowDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * WhatsmeowSubscribeLoggedOutTest — Fase B (incidente 2026-06-18 / POC WAHA-GOWS Phase 2).
+ *
+ * O WuzAPI RECEBE o evento `LoggedOut` ("logged out from another device") mas só
+ * repassa via webhook se o user assinar o tipo — provado nos logs do daemon de prod:
+ *   INFO  Logged out  reason="401: logged out from another device"
+ *   WARN  Skipping webhook. Not subscribed for this type=LoggedOut
+ *         subscribedEvents=["Message","ReadReceipt","Connected","Disconnected"]
+ *
+ * Sem assinar, um logout remoto nunca chega ao app → channel_health fica `healthy`
+ * eternamente (raiz do falso "fora do ar", ADR 0286). Estes testes travam a
+ * assinatura de `LoggedOut` nos dois pontos: provisionamento (/admin/users) e
+ * conexão (/session/connect Subscribe). O app já roteia o webhook `LoggedOut`
+ * → handleDisconnected (WhatsmeowWebhookController).
+ *
+ * Trust L0 — NUNCA chama daemon real (Http::fake guard).
+ */
+beforeEach(function () {
+    config([
+        'whatsapp.whatsmeow.daemon_url' => 'https://whatsapp-whatsmeow.oimpresso.com',
+        'whatsapp.whatsmeow.api_key' => 'admin_token_fake_32_hex',
+        'whatsapp.whatsmeow.request_timeout' => 5,
+        'app.url' => 'https://oimpresso.com',
+    ]);
+});
+
+function loChannelStub(array $overrides = []): Channel
+{
+    $channel = new Channel(array_merge([
+        'id' => 1,
+        'business_id' => 99,
+        'channel_uuid' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+        'status' => 'setup',
+        'config_json' => [],
+    ], $overrides));
+    $channel->exists = true;
+
+    return $channel;
+}
+
+it('provisionSession assina LoggedOut no /admin/users (fecha o gap do logout remoto)', function () {
+    Http::fake([
+        '*/admin/users' => Http::response(['code' => 200, 'success' => true], 200),
+    ]);
+
+    app(WhatsmeowDriver::class)->provisionSession(loChannelStub(), 'biz-uuid-1234');
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), '/admin/users')
+            && str_contains($request->body(), 'LoggedOut');
+    });
+});
+
+it('connect assina LoggedOut no Subscribe do /session/connect', function () {
+    Http::fake([
+        '*/session/status' => Http::response(['data' => ['connected' => false, 'loggedIn' => false]], 200),
+        '*/session/connect' => Http::response(['code' => 200, 'success' => true], 200),
+        '*/session/qr' => Http::response(['data' => ['QRCode' => 'data:image/png;base64,AAAA']], 200),
+    ]);
+
+    $channel = loChannelStub(['config_json' => ['whatsmeow_user_token' => 'user_token_xyz']]);
+    app(WhatsmeowDriver::class)->connect($channel);
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), '/session/connect')
+            && str_contains($request->body(), 'LoggedOut');
+    });
+});


### PR DESCRIPTION
## Fase B — WuzAPI emite `LoggedOut` nativamente

Fecha a **raiz** que o POC WAHA-GOWS Phase 2 ([#2990](https://github.com/wagnerra23/oimpresso.com/pull/2990)) de-riscou: o WuzAPI não repassava o `LoggedOut`, então um *"logged out from another device"* nunca chegava ao app → `channel_health` ficava `healthy` eternamente (raiz do falso "fora do ar", ADR 0286).

### Achado decisivo: **não é fork**
Os logs do daemon de **produção** provam que o WuzAPI já recebe e entende o evento — só pula o webhook porque não estava assinado:
```
INFO  Logged out  reason="401: logged out from another device"
DEBUG Checking event subscription  eventType=LoggedOut
WARN  Skipping webhook. Not subscribed for this type=LoggedOut
      subscribedEvents=["Message","ReadReceipt","Connected","Disconnected"]
```

### Mudança (cirúrgica, não toca o daemon)
- `WhatsmeowDriver::provisionSession` — `events` += `LoggedOut` (canais novos).
- `WhatsmeowDriver::connect` — `Subscribe` += `LoggedOut`.
- Teste Pest travando a assinatura nos 2 pontos.

O app **já** roteia `LoggedOut → handleDisconnected` (`WhatsmeowWebhookController:170`); o `reason` real (com espaços) não casa os `banKeywords` (underscore) → vira `disconnected`, não `banned`. Detecção cai de **até 3 min + 10 min** (probe US-WA-308 + heurística de inbound) pra **segundos** (webhook).

### Follow-up (ops, gated — NÃO neste PR)
- **Re-subscribe dos canais já pareados**: WuzAPI não tem PATCH de eventos. Canais **novos** já nascem certos com este PR. Pros **vivos**, o candidato não-destrutivo é re-chamar `/session/connect` com o `Subscribe` novo (verificar persistência antes); backstop é o probe de 3 min (US-WA-308). Deploy + re-subscribe ficam no gate do Wagner.
- **Re-parear a Jana**: caiu no prod às 19:27 (efeito do POC Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
