### PR TITLE
feat(jana): Onda 3 (webhook) — trava cobertura MCP dos vereditos do ledger (read-only)

### DIFF
--- a/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
+++ b/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
@@ -289,7 +289,10 @@ class IndexarMemoryGitParaDb
             $arquivos[] = $info;
         }
 
-        // 4. Governance recursivo — CONSTITUTION, ENFORCEMENT, TRUST-TIERS, etc.
+        // 4. Governance recursivo — CONSTITUTION, ENFORCEMENT, TRUST-TIERS, design-requests/, etc.
+        //    Cobre `memory/governance/design-requests/` = o Design Request Ledger (vereditos · Onda 3):
+        //    REQ-NNN + LEDGER ficam consultáveis via memoria-search, READ-ONLY (git é SSOT · ADR 0061).
+        //    Travado por IndexarMemoryGitParaDbColetarTest (não regredir a cobertura dos vereditos).
         foreach ($this->coletarRecursivo("$base/memory/governance", $base, 'reference', 'governance') as $info) {
             $arquivos[] = $info;
         }

--- a/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitParaDbColetarTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitParaDbColetarTest.php
@@ -61,6 +61,11 @@ function coletarFixtureRepo(): string
         'memory/governance/CONSTITUTION.md'           => "# Constitution\ndoc",
         'memory/governance/_README.md'                => "# Readme gov\nignore",
 
+        // governance/design-requests/ — Design Request Ledger (vereditos · Onda 3)
+        'memory/governance/design-requests/LEDGER.md'        => "# Ledger\nREQ-001 | tela | done",
+        'memory/governance/design-requests/REQ-001.md'       => "# REQ-001\nvocabulário de estado",
+        'memory/governance/design-requests/_TEMPLATE-REQ.md' => "# Template\nignore",
+
         // audits/ raiz (subpasta NÃO recursada)
         'memory/audits/AUDITORIA-MEMORIA-2026-05-15.md' => "# Auditoria\ndoc",
         'memory/audits/2026-05-pre-sales/sensivel.md'   => "# Pre-sales\nsensivel",
@@ -176,6 +181,30 @@ it('coleta sprints/, governance/ e _DesignSystem/ recursivos + audits/ raiz', fu
             fn ($a) => str_contains($a['path'], 'audits/2026-05-pre-sales')
         );
         expect($temPreSales)->toBeFalse();
+    } finally {
+        coletarLimpar($base);
+    }
+});
+
+// ── (g2) design-requests/ (Design Request Ledger · vereditos · Onda 3) ──────
+
+it('coleta governance/design-requests/ (ledger de vereditos · Onda 3) e pula o _TEMPLATE', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $map = coletarSlugMap(coletarInvoke($base));
+
+        // o ledger e o REQ chegam ao MCP (consultáveis via memoria-search · read-only ADR 0061)
+        expect($map)->toHaveKey('governance-design-requests-ledger');
+        expect($map)->toHaveKey('governance-design-requests-req-001');
+        expect($map['governance-design-requests-req-001']['type'])->toBe('reference');
+        expect($map['governance-design-requests-req-001']['path'])
+            ->toBe('memory/governance/design-requests/REQ-001.md');
+
+        // o _TEMPLATE-REQ NÃO vaza pro índice
+        $temTemplate = collect($map)->contains(
+            fn ($a) => str_contains($a['path'], 'design-requests/_TEMPLATE')
+        );
+        expect($temTemplate)->toBeFalse();
     } finally {
         coletarLimpar($base);
     }


### PR DESCRIPTION
**Onda 3 (parte webhook)** do plano veredito-ledger. Objetivo: os vereditos (o NÃO `recusado`, o ledger REQ/LEDGER) consultáveis pelo time via MCP, **read-only** (git é SSOT · [ADR 0061](memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)).

## Achado honesto: já está coberto (sem código redundante)
- O coletor recursivo de `memory/governance/` (GAP #1, 2026-05-29) varre `design-requests/` → **REQ-NNN + LEDGER já chegam ao `memoria-search`**.
- Os ADRs `status: recusado` (o NÃO) já entram via o glob `memory/decisions/` + a normalização que o #2991 consertou.

Adicionar um glob dedicado seria **duplicação** (anti `reuse-check`). Então o deliverable real é **travar** o que já funciona, não re-implementar.

## O que entra
- **Teste-catraca** (`IndexarMemoryGitParaDbColetarTest`, hermético): prova que `design-requests/{LEDGER,REQ-001}` são coletados e o `_TEMPLATE-REQ` é pulado → um refactor futuro não derruba silenciosamente a busca dos vereditos.
- **Comentário** no indexer (item 4) tornando explícito que `governance/` cobre os vereditos, read-only.

## Adiado (de propósito)
A **herança de zona** (canon-de-zona + delta) fica para quando existir a **2ª tela** que a consuma — construir agora = infra especulativa sem consumidor (o "deixar amadurecer").

Refs: ADR 0061, proposal veredito-ledger, #2991