### PR TITLE
feat(whatsapp): Fase B parte 2 — comando re-subscribe LoggedOut nos canais existentes

### DIFF
--- a/Modules/Whatsapp/Console/Commands/WhatsmeowResubscribeEventsCommand.php
+++ b/Modules/Whatsapp/Console/Commands/WhatsmeowResubscribeEventsCommand.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Services\Drivers\WhatsmeowDriver;
+
+/**
+ * whatsapp:whatsmeow-resubscribe-events — Fase B: re-assina `LoggedOut` nos canais
+ * whatsmeow já provisionados (que nasceram antes da Fase B, sem `LoggedOut`).
+ *
+ * O WuzAPI só repassa o webhook de eventos **assinados** (coluna `users.events`).
+ * Canais provisionados antes da Fase B têm `events="Message,ReadReceipt,Connected,
+ * Disconnected"` → um logout remoto ("logged out from another device") nunca chega
+ * ao app e `channel_health` fica `healthy` eternamente (raiz do falso "fora do ar",
+ * ADR 0286). Este comando aplica o **mecanismo (D)** (`POST /webhook` → UPDATE
+ * `users.events` + refresh do cache no daemon) pra cada canal, incluindo `LoggedOut`,
+ * **SEM reconectar nem re-parear** (zero impacto na sessão viva). Idempotente.
+ *
+ * Migração **one-off** (não-recorrente): canais NOVOS já nascem com `LoggedOut`
+ * (`WhatsmeowDriver::provisionSession`). Mecanismo validado em canário 2026-06-18.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): varre cross-business (CLI sem session) via
+ * `withoutGlobalScope`; cada row carrega seu `business_id`; o driver nunca
+ * atravessa fronteira de tenant (usa o token do próprio canal).
+ *
+ * Uso:
+ *   php artisan whatsapp:whatsmeow-resubscribe-events --dry-run
+ *   php artisan whatsapp:whatsmeow-resubscribe-events
+ *   php artisan whatsapp:whatsmeow-resubscribe-events --business=1 --detail
+ *
+ * @see Modules\Whatsapp\Services\Drivers\WhatsmeowDriver::resubscribeEvents
+ * @see memory/sessions/2026-06-18-arte-whatsapp-naoficiais.md (POC WAHA-GOWS / Fase B)
+ */
+class WhatsmeowResubscribeEventsCommand extends Command
+{
+    protected $signature = 'whatsapp:whatsmeow-resubscribe-events
+                            {--business=all : Business ID ou "all" (default)}
+                            {--dry-run : Preview sem chamar o daemon}
+                            {--detail : Loga o resultado de cada canal}';
+
+    protected $description = 'Re-assina LoggedOut nos canais whatsmeow já provisionados (Fase B · mecanismo D, sem reconnect/re-pair).';
+
+    public function handle(WhatsmeowDriver $driver): int
+    {
+        $businessOption = (string) $this->option('business');
+        $dryRun = (bool) $this->option('dry-run');
+
+        // SUPERADMIN: migração cross-business — bypass scope explícito (ADR 0093).
+        $query = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('type', Channel::TYPE_WHATSAPP_WHATSMEOW);
+
+        if ($businessOption !== 'all') {
+            $bizId = (int) $businessOption;
+            if ($bizId <= 0) {
+                $this->error("--business='{$businessOption}' inválido. Use 'all' ou ID numérico.");
+
+                return self::FAILURE;
+            }
+            $query->where('business_id', $bizId);
+        }
+
+        $channels = $query->orderBy('business_id')->orderBy('id')->get();
+
+        if ($channels->isEmpty()) {
+            $this->info('Nenhum canal whatsmeow pra re-assinar.');
+
+            return self::SUCCESS;
+        }
+
+        $ok = 0;
+        $skipped = 0;
+        $failed = 0;
+        $rows = [];
+
+        foreach ($channels as $channel) {
+            $label = mb_strimwidth((string) $channel->label, 0, 24, '…');
+
+            if ($dryRun) {
+                $rows[] = [$channel->id, $channel->business_id, $label, '[dry-run]'];
+                $skipped++;
+                continue;
+            }
+
+            $result = $driver->resubscribeEvents($channel);
+            $reason = $result['reason'] ?? null;
+
+            if ($result['ok']) {
+                $ok++;
+                $outcome = 'ok';
+            } elseif (in_array($reason, ['no_token', 'no_webhook_url'], true)) {
+                // Canal ainda não provisionado no daemon — nada a re-assinar (nascerá certo).
+                $skipped++;
+                $outcome = "skip:{$reason}";
+            } else {
+                $failed++;
+                $outcome = 'falha:'.($result['status'] ?? '?');
+            }
+
+            $rows[] = [$channel->id, $channel->business_id, $label, $outcome];
+
+            if ($this->option('detail')) {
+                $this->line(sprintf('  ch#%d biz=%d "%s" → %s', $channel->id, $channel->business_id, $channel->label, $outcome));
+            }
+        }
+
+        $this->table(['ch_id', 'biz', 'label', 'resultado'], $rows);
+        $this->info("Canais: {$channels->count()} · ok: {$ok} · skip: {$skipped} · falha: {$failed}".($dryRun ? ' (dry-run)' : ''));
+
+        Log::info('whatsmeow.resubscribe_events.done', [
+            'event' => 'whatsmeow.resubscribe_events.done',
+            'total' => $channels->count(),
+            'ok' => $ok,
+            'skipped' => $skipped,
+            'failed' => $failed,
+            'dry_run' => $dryRun,
+            'business_filter' => $businessOption,
+        ]);
+
+        return $failed > 0 ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -36,6 +36,7 @@ use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
 use Modules\Whatsapp\Console\Commands\SlaScanCommand;
 use Modules\Whatsapp\Console\Commands\WebhookCanaryCommand;
 use Modules\Whatsapp\Console\Commands\WhatsmeowHealthProbeCommand;
+use Modules\Whatsapp\Console\Commands\WhatsmeowResubscribeEventsCommand;
 use Modules\Whatsapp\Entities\Message;
 use Modules\Whatsapp\Entities\WhatsappMessage;
 use Modules\Whatsapp\Events\OmnichannelMessageReceived;
@@ -110,6 +111,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 MetricsAggregateCommand::class,         // US-WA-021/041 — snapshot diário métricas (CYCLE-07 PR-3)
                 ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
                 WhatsmeowHealthProbeCommand::class,      // US-WA-308 — detecta queda sessão whatsmeow (cron 3min, incidente 2026-06-18)
+                WhatsmeowResubscribeEventsCommand::class, // Fase B — re-assina LoggedOut em canais já provisionados (one-off, mecanismo D)
                 ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
                 CleanupWebhookNoncesCommand::class,     // US-WA-082 — purga nonces >24h (replay protection cleanup)
                 CleanupStaleJobsCommand::class,         // US-WA-084 — purga jobs presos da fila whatsapp-history (>6h)

--- a/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
@@ -362,6 +362,38 @@ class WhatsmeowDriver implements DriverInterface
     }
 
     /**
+     * Re-assina os eventos do canal no daemon incluindo `LoggedOut` (Fase B · mecanismo D).
+     *
+     * Para canais já provisionados ANTES da Fase B (events sem LoggedOut). Usa o
+     * endpoint `POST /webhook` (UPDATE `users.events` no daemon + refresh do cache)
+     * — NÃO reconecta nem re-pareia, zero impacto na sessão viva. Idempotente
+     * (convergente). Mantém a webhook URL atual. Validado em canário 2026-06-18.
+     *
+     * @return array{ok: bool, status?: int, reason?: string}
+     */
+    public function resubscribeEvents(Channel $channel): array
+    {
+        $userToken = $this->resolveUserTokenFromChannel($channel);
+        if ($userToken === null) {
+            return ['ok' => false, 'reason' => 'no_token'];
+        }
+
+        $cfg = $channel->config_json ?? [];
+        $webhookUrl = (string) ($cfg['whatsmeow_webhook_url'] ?? '');
+        if ($webhookUrl === '') {
+            return ['ok' => false, 'reason' => 'no_webhook_url'];
+        }
+
+        $response = $this->client($userToken)->post('/webhook', [
+            'webhookurl' => $webhookUrl,
+            // Mesma lista canon de provisionSession/connect (inclui LoggedOut).
+            'events' => ['Message', 'ReadReceipt', 'Connected', 'Disconnected', 'LoggedOut'],
+        ]);
+
+        return ['ok' => $response->successful(), 'status' => $response->status()];
+    }
+
+    /**
      * Resolve user_token do channel (cifrado em config_json).
      *
      * Channel-based driver (ADR 0135). Recebe config como WhatsappBusinessConfig

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowResubscribeEventsCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowResubscribeEventsCommandTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+
+uses(Tests\TestCase::class);
+
+/**
+ * WhatsmeowResubscribeEventsCommandTest — Fase B (mecanismo D).
+ *
+ * Re-assina `LoggedOut` nos canais whatsmeow já provisionados via POST /webhook
+ * (UPDATE users.events no daemon), SEM reconnect/re-pair. Mocka o daemon via
+ * Http::fake. Schema sintético espelha HealthProbeChannelsCommandTest.
+ *
+ * @see Modules\Whatsapp\Console\Commands\WhatsmeowResubscribeEventsCommand
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('schema sintético manual incompatível com MySQL persistente.');
+    }
+
+    Schema::dropIfExists('channels');
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    config([
+        'whatsapp.whatsmeow.daemon_url' => 'https://whatsapp-whatsmeow.oimpresso.com',
+        'whatsapp.whatsmeow.api_key' => 'admin_token_fake',
+        'whatsapp.whatsmeow.request_timeout' => 5,
+    ]);
+});
+
+function makeWmChannel(int $bizId, bool $provisioned = true): Channel
+{
+    $cfg = $provisioned ? [
+        'whatsmeow_user_token' => 'tok-'.$bizId,
+        'whatsmeow_user_name' => 'ch-'.$bizId,
+        'whatsmeow_webhook_url' => "https://oimpresso.com/api/whatsapp/webhook/whatsmeow/biz-{$bizId}",
+    ] : [];
+
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'channel_uuid' => sprintf('rsub%04d-0000-0000-0000-%012d', $bizId, random_int(1, 999999)),
+        'label' => "Canal {$bizId}",
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+        'status' => 'active',
+        'config_json' => $cfg,
+    ]);
+}
+
+it('re-assina LoggedOut via POST /webhook (mecanismo D, sem reconnect)', function () {
+    makeWmChannel(1);
+    Http::fake(['*/webhook' => Http::response(['code' => 200, 'success' => true], 200)]);
+
+    $exit = \Artisan::call('whatsapp:whatsmeow-resubscribe-events', ['--business' => '1']);
+
+    expect($exit)->toBe(0);
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), '/webhook')
+            && str_contains($request->body(), 'LoggedOut');
+    });
+});
+
+it('multi-tenant Tier 0: --business=99 não toca biz=1', function () {
+    makeWmChannel(1);
+    makeWmChannel(99);
+    Http::fake(['*/webhook' => Http::response(['code' => 200], 200)]);
+
+    \Artisan::call('whatsapp:whatsmeow-resubscribe-events', ['--business' => '99']);
+
+    Http::assertSentCount(1);
+    Http::assertSent(fn ($r) => str_contains($r->body(), 'biz-99'));
+});
+
+it('--dry-run não chama o daemon', function () {
+    makeWmChannel(1);
+    Http::fake();
+
+    $exit = \Artisan::call('whatsapp:whatsmeow-resubscribe-events', ['--dry-run' => true]);
+
+    expect($exit)->toBe(0);
+    Http::assertNothingSent();
+});
+
+it('canal sem token é pulado (skip), comando não falha', function () {
+    makeWmChannel(1, provisioned: false);
+    Http::fake();
+
+    $exit = \Artisan::call('whatsapp:whatsmeow-resubscribe-events', ['--business' => '1']);
+
+    expect($exit)->toBe(0); // skip não é falha
+    Http::assertNothingSent();
+});


### PR DESCRIPTION
## Fase B (parte 2) — comando de re-subscribe pros canais existentes

Complementa [#2994](https://github.com/wagnerra23/oimpresso.com/pull/2994) (que faz canais **novos** nascerem com `LoggedOut`). Canais já provisionados **antes** da Fase B têm `events` sem `LoggedOut` → um logout remoto não chega ao app (raiz do falso "fora do ar", ADR 0286).

### O quê
- **`WhatsmeowDriver::resubscribeEvents(Channel)`** — mecanismo **(D)**: `POST /webhook` → `UPDATE users.events` no daemon + refresh do cache, **sem reconnect / re-pair** (zero impacto na sessão viva). Mecanismo validado em canário isolado (2026-06-18): `events` 4 → 5 sem derrubar sessão.
- **`whatsapp:whatsmeow-resubscribe-events {--business} {--dry-run} {--detail}`** — migração one-off, idempotente. Multi-tenant Tier 0 (ADR 0093): cross-business via `withoutGlobalScope`, token por canal.
- Teste Pest: re-assina / multi-tenant / dry-run / skip-sem-token.

### Como rodar (no gate do Wagner, pós-deploy)
```bash
php artisan whatsapp:whatsmeow-resubscribe-events --dry-run   # preview
php artisan whatsapp:whatsmeow-resubscribe-events             # aplica em todos
```

Canais **novos** já nascem certos via `provisionSession` (#2994); este comando cobre os **existentes** (Jana/Suporte).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
