### PR TITLE
fix(jana): `recusado` consultável no decisions-search + fecha landmine de corrupção

### DIFF
--- a/Modules/Jana/Console/Commands/McpAdrMigrarFrontmatterCommand.php
+++ b/Modules/Jana/Console/Commands/McpAdrMigrarFrontmatterCommand.php
@@ -47,6 +47,8 @@ class McpAdrMigrarFrontmatterCommand extends Command
         'proposed'    => 'proposto',
         'proposto'    => 'proposto',
         'proposta'    => 'proposto',
+        'recusado'    => 'recusado',   // o NÃO canônico — sem esta linha, normalizarStatus→null e o
+        'recusada'    => 'recusado',   // caller cai pro `?? 'aceito'`, CORROMPENDO um ADR recusado.
         'draft'       => 'rascunho',
         'rascunho'    => 'rascunho',
         'wip'         => 'rascunho',

--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -192,10 +192,13 @@ class McpMemoryDocument extends Model
         return $query->where(function ($q) {
             $q->whereNull('metadata')
               ->orWhereRaw("JSON_EXTRACT(metadata, '$.status') IS NULL")
-              ->orWhereRaw("JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.status')) IN (?, ?, ?)", [
+              ->orWhereRaw("JSON_UNQUOTE(JSON_EXTRACT(metadata, '$.status')) IN (?, ?, ?, ?)", [
                   'aceito',
                   'accepted',
                   'accepted-historical',
+                  // o NÃO é terminal-mas-VISÍVEL: `recusado` existe pra ser ACHADO (anti-relitígio),
+                  // senão a busca esconde a decisão que evita re-propor. Proposal recusado-com-motivo.
+                  'recusado',
               ]);
         });
     }

--- a/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
@@ -23,7 +23,7 @@ class DecisionsSearchTool extends Tool
 
     protected string $title = 'Buscar ADRs do projeto';
 
-    protected string $description = 'Busca full-text nas 90+ ADRs (decisões arquiteturais) do oimpresso. Retorna top 5 matches com slug, título e trecho relevante. Por padrão filtra ADRs ativas (aceito/accepted/accepted-historical) — use include_archived=true pra ver superseded/deprecated. Triagem 2026-05-06 ([_INDEX-LIFECYCLE](memory/decisions/_INDEX-LIFECYCLE.md)).';
+    protected string $description = 'Busca full-text nas 90+ ADRs (decisões arquiteturais) do oimpresso. Retorna top 5 matches com slug, título e trecho relevante. Por padrão retorna ADRs ativas (aceito/accepted/accepted-historical) + recusadas (o NÃO consultável — responde "por que não temos X?", anti-relitígio) — use include_archived=true pra ver superseded/deprecated. Triagem 2026-05-06 ([_INDEX-LIFECYCLE](memory/decisions/_INDEX-LIFECYCLE.md)).';
 
     public function schema(JsonSchema $schema): array
     {


### PR DESCRIPTION
Achado pelo **painel adversarial final** sobre as Ondas 1-3: o `recusado` (o NÃO) estava **quebrado de ponta a ponta na integração com o backend** — 2 furos vivos que minam o propósito da feature.

## 1. 🔴 `recusado` era invisível ao `decisions-search` (o 5º enforcement point)
`McpMemoryDocument::scopePorStatusAtivo` (a busca **default**) só retornava `{NULL, aceito, accepted, accepted-historical}`. Um ADR `status: recusado` **não aparecia** — e o propósito inteiro do `recusado` é ser **consultável** (*"o NÃO consultável"*, anti-relitígio: existe pra ser achado, senão a pessoa re-propõe o que já foi negado). A proposal `recusado-com-motivo` exige **"terminal-mas-VISÍVEL"**.
**Fix:** `+ 'recusado'` na IN-list + descrição da `DecisionsSearchTool` honesta (LLM/time sabe que recusadas voltam por default).

## 2. 🔴 Landmine de corrupção no migrar-frontmatter
`McpAdrMigrarFrontmatterCommand::STATUS_MAP` não tinha `recusado` → `normalizarStatus('recusado')` retornava null → o caller cai pro `?? 'aceito'` e **converteria um ADR `recusado` em `aceito`** (corrupção silenciosa). **Fix:** `+ 'recusado'/'recusada'`.

Completa a sincronização do enum `recusado`: o [#2991](https://github.com/wagnerra23/oimpresso.com/pull/2991) cobriu os 4 gates de **escrita**; o adversário final achou que os caminhos de **leitura** vivos do MCP ficaram de fora. Agora o NÃO funciona ponta-a-ponta.

Refs: #2991, #2989, proposal `recusado-com-motivo`, ADR 0105