### PR TITLE
fix(contrato-de-tela): catraca dispara em backend + hint honesto + motor de escopo dormente

### DIFF
--- a/.github/workflows/contrato-de-tela.yml
+++ b/.github/workflows/contrato-de-tela.yml
@@ -20,6 +20,10 @@ on:
       - '**/*.contract.json'
       - 'resources/js/Pages/**/*.tsx'
       - 'resources/js/Pages/**/*.ts'
+      # backends que a catraca semântica (2b) inspeciona — em sync com os campos `backend` dos
+      # *.contract.json. Sem isto, um rename de state:'paired' SÓ no backend não dispara o gate
+      # (blind-spot achado pelo painel adversarial final · ADR 0286 §5).
+      - 'Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php'
       - '.github/workflows/contrato-de-tela.yml'
 
 permissions:
@@ -81,7 +85,7 @@ jobs:
           echo "   - 'sem âncora' → instrumente a tela com <... data-contract=\"<id>\">."
           echo "   - 'copy ausente' → a string literal do contrato sumiu/mudou no .tsx."
           echo "   - 'ordem divergente' → a sequência das seções no fonte != contrato."
-          echo "   - 'frontend NÃO trata' → backend e frontend usam vocabulários de 'state' diferentes (ex: paired≠connected). Ver ADR 0286 §5."
+          echo "   - 'frontend NÃO menciona' → backend e frontend usam vocabulários de 'state' diferentes (ex: paired≠connected). Ver ADR 0286 §5."
           echo "   - 'backend não emite' → 'valores' do acordo declara um state morto (drift de contrato)."
           echo "   - 'branch atrás' → git rebase origin/main."
           echo "   Desvio INTENCIONAL do protótipo? declare no corpo do PR:"

--- a/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
+++ b/memory/requisitos/_DesignSystem/RUNBOOK-contrato-de-tela.md
@@ -90,7 +90,9 @@ Três modos de FALHA:
 5. **Drift de contrato** — `valores` declara um `<state>` que o backend NÃO emite (valor morto / renomeado) → **FALHA** (`estado "<state>" declarado mas o backend não emite`).
 6. **Escopo inválido** — `escopo` fora do formato (`global` | `vertical:<x>` | `cliente:biz=<n>` | `persona:<p>` | `tela:<rota>`) → **FALHA** (typo/traversal que mis-escoparia o veredito · risco Tier 0).
 
-Travado por self-test (17 controles): `4b.1` positivo, `4b.2` o bug, `4b.3` drift, **`4b.4` comment-blindness**, **`4b.5` key-false-match**, `4b.6/4b.7` escopo válido/inválido, **`4b.8` strip string-aware** (`//` em URL não come o state), **`4b.9` escopo path-traversal**.
+Travado por self-test (20 controles): `4b.1` positivo, `4b.2` o bug, `4b.3` drift, **`4b.4` comment-blindness**, **`4b.5` key-false-match**, `4b.6/4b.7` escopo válido/inválido, **`4b.8` strip string-aware** (`//` em URL não come o state), **`4b.9` escopo path-traversal**, **`O2.1-O2.3` resolução de escopo** (incl. o não-vazamento Tier 0).
+
+> **⚠️ Resolução de escopo (`--resolve`, Onda 2) está DORMENTE.** É invariante pré-cabeada: hoje nenhum contrato real tem veredito multi-escopo (só `global`) e nada consome a resolução pra gatear por tenant. Os campos `escopo`/`verdict` (validados, default seguro) ficam; o **motor** só vira load-bearing quando existir a 2ª tela escopada — mesmo critério que adiou a herança de zona.
 
 > **Honestidade (o que a catraca É e NÃO é):** é uma **catraca de regressão** — trava o vocabulário que um humano JÁ declarou em `valores`; **não descobre** uma divergência nova ainda não-declarada. Prospectivamente ela não teria *achado* o bug de 2026-06-18 (ninguém tinha declarado o acordo); ela impede o **des-conserto** silencioso dele. **Limite conhecido (match léxico):** ela checa *menção*, não *handling* — um `'paired' | 'connected'` num tipo TS satisfaz o gate mesmo se o handler tratar só um. Quem prova o handling é o vitest `tests/reconnect-session-active.test.ts` (#2984); a catraca pega (a) drift/rename no **backend** e (b) **frontend totalmente ignorante** do state, e amarra a costura PHP↔TS que o vitest não enxerga.
 

--- a/scripts/contrato-de-tela.mjs
+++ b/scripts/contrato-de-tela.mjs
@@ -275,6 +275,11 @@ function checkStateAgreements(c, file) {
 // O mais ESPECÍFICO vence (later-wins em empate), igual a herança da Constituição UI ("herda, nunca
 // contradiz") e o `resolutionOrder` do W3C DTCG. PROPRIEDADE TIER 0 (P0): um veredito `cliente:biz=4`
 // NÃO aplica a `biz=7` — escopo que não casa o contexto é IGNORADO, então NÃO vaza entre tenants.
+//
+// ⚠️ DORMENTE (invariante PRÉ-CABEADA, não load-bearing): hoje nenhum contrato real tem veredito
+// multi-escopo (o único é `global`) e NADA consome `--resolve` pra gatear por tenant — é infra +
+// trava P0 armada ANTES do consumidor. Honesto chamar de pré-cabeada, não "enforcement vivo". Vira
+// load-bearing quando a 2ª tela escopada existir (mesmo critério que adiou a herança de zona · #2995).
 const ESCOPO_SPEC = ['global', 'vertical:', 'persona:', 'cliente:biz=', 'tela:']; // índice = especificidade
 function escopoSpec(escopo) {
   if (escopo === 'global') return 0;


### PR DESCRIPTION
Os 3 itens **não-vivos** do painel adversarial final (os 2 vivos do `recusado` foram no [#2998](https://github.com/wagnerra23/oimpresso.com/pull/2998)).

1. 🔴→✅ **Blind-spot do CI (vivo):** o `paths:` do workflow não incluía o **backend** que a catraca 2b inspeciona (`ChannelsController.php`). Um rename `state:'paired'`→`'linked'` SÓ no backend — o **exato drift que a catraca existe pra pegar** — não disparava o gate, mergeando verde quebrado. Fix: + o backend do contrato no `paths:` (mantido em sync com os campos `backend` dos `*.contract.json`).
2. 🟡→✅ **Overclaim sobrevivente:** o hint do workflow dizia `'frontend NÃO trata'` — palavra "trata" (handling, que o (A) matou) **e uma msg que o gate nem emite**. Fix → `'frontend NÃO menciona'` (a real).
3. ⚖️→✅ **Motor de escopo (Onda 2) marcado DORMENTE** (código + RUNBOOK): é invariante **pré-cabeada** — nada consome `--resolve`, só existe veredito `global`. Os campos `escopo`/`verdict` (baratos, default seguro) ficam; o motor vira load-bearing na 2ª tela escopada (mesmo critério que adiou a herança de zona). **NÃO revertido** — testado, pronto, leak-free (200k fuzz) — só rotulado honesto. + corrige "17→20 controles".

Self-test 20/20, syntax OK, PII limpo. Refs: ADR 0286 §5.