### PR TITLE
fix(jana): `recusado` no filtro da busca híbrida Meili (completa #2998)

### DIFF
--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -143,7 +143,10 @@ class McpMemoryDocument extends Model
         $embedder = (string) config('copiloto.mcp_search.docs_embedder', 'qwen3_local');
         $ratio    = (float) config('copiloto.memoria.meilisearch.semantic_ratio', 0.6);
 
-        $filtros = ["status IN ['aceito','accepted','accepted-historical']"];
+        // `recusado` é terminal-mas-VISÍVEL (anti-relitígio) — simétrico ao scopePorStatusAtivo do
+        // caminho FULLTEXT. Sem isto, com docs_pipeline=true o recusado some da busca (índice tem,
+        // mas a query corta). shouldBeSearchable já NÃO exclui recusado do índice.
+        $filtros = ["status IN ['aceito','accepted','accepted-historical','recusado']"];
         if ($tipo !== null && $tipo !== '' && $tipo !== 'all') {
             $filtros[] = "type = '".addslashes($tipo)."'";
         }


### PR DESCRIPTION
Fecha um **12º furo** achado ao desenhar o plano de teste manual: o [#2998](https://github.com/wagnerra23/oimpresso.com/pull/2998) corrigiu o `recusado` no caminho **FULLTEXT** (`scopePorStatusAtivo`), mas há um **segundo** filtro no caminho **híbrido Meilisearch** (`buscarHybrid`, linha 146) que também escondia `recusado`:

`status IN ['aceito','accepted','accepted-historical']` → **+`'recusado'`**.

- Default `docs_pipeline=false` → usa FULLTEXT → meu fix do #2998 já funcionava.
- Mas com `JANA_MCP_SEARCH_PIPELINE_DOCS=true` o `decisions-search` usa `buscarHybrid` → recusado sumia de novo.
- `shouldBeSearchable` **não** exclui recusado do índice (o doc está indexado) — só o filtro da query o cortava.

Agora o `recusado` é consultável em **ambos** os caminhos de busca, em qualquer config. Refs: #2998.