### PR TITLE
feat(caixa): saúde de canal em tempo real — Caixa consome whatsmeow.* do Centrifugo (último elo Phase B)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -152,6 +152,24 @@ export default function CaixaUnificadaIndex({
     const sub = c.newSubscription(centrifugoConfig.channel);
 
     sub.on('publication', (ctx: { data: Record<string, unknown> }) => {
+      // US-WA-308 realtime — saúde de canal: o webhook publica `whatsmeow.*` em
+      // `data.event` (mensagens usam `data.type`). Queda/volta de sessão recarrega
+      // só a prop do banner "religar" (+ contas) — servidor segue source of truth,
+      // sem duplicar a lógica de channel_health no client. (Phase B · Centrifugo ADR 0058.)
+      const healthEvent = ctx.data?.event as string | undefined;
+      if (
+        healthEvent === 'whatsmeow.disconnected' ||
+        healthEvent === 'whatsmeow.ban_detected' ||
+        healthEvent === 'whatsmeow.paired'
+      ) {
+        router.reload({
+          only: ['unhealthyChannels', 'availableAccounts'],
+          preserveScroll: true,
+          preserveState: true,
+        });
+        return;
+      }
+
       const eventType = ctx.data?.type as string | undefined;
       if (eventType !== 'message.received' && eventType !== 'message.sent') return;
       const incomingConvId = ctx.data?.conversation_id as number | undefined;


### PR DESCRIPTION
## Caixa: saúde de canal em tempo real (último elo do Phase B)

Fecha o elo que faltava: o webhook já publicava `whatsmeow.disconnected/paired/ban_detected` no Centrifugo (`whatsapp:business:{id}`), mas a Caixa **só consumia `message.*`** (por `data.type`) e ignorava os eventos de saúde (que vêm em `data.event`). Resultado: queda de canal só aparecia no **refresh**.

### Mudança (wiring-only, 18 linhas)
No handler do Centrifugo da `CaixaUnificada/Index.tsx`: ao receber `whatsmeow.disconnected/paired/ban_detected`, faz `router.reload({ only: ['unhealthyChannels','availableAccounts'], preserveScroll, preserveState })`. O **servidor segue source of truth** — não duplico a lógica de `channel_health` no client; só recarrego a prop do banner "religar".

### Resultado
`logout remoto → webhook → channel_health → Centrifugo → TELA`, em segundos. Sem mudança de rótulo/visual (**REQ-001 intacta**) — é só *quando* o banner aparece, não *como*.

### Verificação
Realtime depende de evento do daemon de prod → não dá pra exercitar no preview local. **Smoke ao vivo pós-deploy**: derrubar um canal de teste → banner "religar" aparece sozinho, sem refresh.

> ⚠️ **Não auto-mergeei** — UI na zona `saude-canal` governada pela REQ-001 + gate visual (ADR 0114). Merge é seu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
