### PR TITLE
feat(whatsapp): probe detecta queda invisível (ADR 0287) + ADRs 0288/0289 + índice (roadmap saúde de canal)

### DIFF
--- a/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
+++ b/Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php
@@ -92,7 +92,9 @@ class WhatsmeowHealthProbeCommand extends Command
             $healthBefore = (string) $channel->channel_health;
 
             // Só corrobora com mensagem real no ramo "caído" — é onde o loggedIn do WuzAPI mente.
-            $isDownState = in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true);
+            // PROVISION_PENDING num canal que estava `healthy` = queda (connected=false), ADR 0287.
+            $isDownState = in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)
+                || ($state === WhatsmeowState::PROVISION_PENDING && $healthBefore === 'healthy');
             $freshInbound = $isDownState && $this->hasRecentInbound($channel, $freshMinutes);
 
             $action = self::decideAction($state, $healthBefore, $freshInbound);
@@ -163,7 +165,13 @@ class WhatsmeowHealthProbeCommand extends Command
      */
     public static function decideAction(WhatsmeowState $state, string $healthBefore, bool $freshInbound): string
     {
-        if (in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)) {
+        // Ramo "caído". PROVISION_PENDING (connected=false) entra AQUI só quando o
+        // canal estava `healthy` — sessão que estava no ar e caiu = queda real
+        // (ADR 0287); num canal nunca-pareado segue transitório (cai no NONE abaixo).
+        $isDown = in_array($state, [WhatsmeowState::LOGGED_OUT, WhatsmeowState::NOT_EXISTS], true)
+            || ($state === WhatsmeowState::PROVISION_PENDING && $healthBefore === 'healthy');
+
+        if ($isDown) {
             if ($freshInbound) {
                 // Falso "fora do ar": daemon diz caído, mas mensagens chegando.
                 return $healthBefore === 'healthy' ? self::ACTION_NONE : self::ACTION_PAIRED;
@@ -180,7 +188,7 @@ class WhatsmeowHealthProbeCommand extends Command
             return $healthBefore === 'healthy' ? self::ACTION_NONE : self::ACTION_PAIRED;
         }
 
-        // DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING / ERROR → não muta.
+        // DAEMON_UNREACHABLE / QR_PENDING / PROVISION_PENDING(nunca-pareado) / ERROR → não muta.
         return self::ACTION_NONE;
     }
 

--- a/Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php
@@ -206,7 +206,8 @@ class WhatsmeowWebhookController extends Controller
     private function handleDisconnected(Channel $channel, array $payload): JsonResponse
     {
         $reason = (string) ($payload['Data']['Reason'] ?? $payload['reason'] ?? 'unknown');
-        $banKeywords = ['banned', 'forbidden', 'logged_out', 'multidevice_mismatch'];
+        // 'logged_out' (re-pareável) NÃO é ban — vira `disconnected` (ADR 0287).
+        $banKeywords = ['banned', 'forbidden', 'multidevice_mismatch'];
         $banDetected = false;
         foreach ($banKeywords as $kw) {
             if (str_contains(strtolower($reason), $kw)) {

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowHealthProbeDecisionTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowHealthProbeDecisionTest.php
@@ -49,10 +49,21 @@ it('estados transitórios (daemon down / pareando) não mutam health', function 
     foreach ([
         WhatsmeowState::DAEMON_UNREACHABLE,
         WhatsmeowState::QR_PENDING,
-        WhatsmeowState::PROVISION_PENDING,
         WhatsmeowState::ERROR,
     ] as $s) {
         expect(Probe::decideAction($s, 'healthy', false))->toBe(Probe::ACTION_NONE);
         expect(Probe::decideAction($s, 'disconnected', false))->toBe(Probe::ACTION_NONE);
     }
+});
+
+it('PROVISION_PENDING num canal que estava healthy = QUEDA real (ADR 0287 — fim da queda invisível)', function () {
+    // connected=false num canal que estava no ar: a Jana sumiu sem o app marcar.
+    expect(Probe::decideAction(WhatsmeowState::PROVISION_PENDING, 'healthy', false))->toBe(Probe::ACTION_DISCONNECTED);
+    // inbound recente prova "no ar" → suprime o falso disconnected (corroboração ADR 0286).
+    expect(Probe::decideAction(WhatsmeowState::PROVISION_PENDING, 'healthy', true))->toBe(Probe::ACTION_NONE);
+});
+
+it('PROVISION_PENDING em canal nunca-pareado / já caído segue transitório (não marca)', function () {
+    expect(Probe::decideAction(WhatsmeowState::PROVISION_PENDING, 'never_checked', false))->toBe(Probe::ACTION_NONE);
+    expect(Probe::decideAction(WhatsmeowState::PROVISION_PENDING, 'disconnected', false))->toBe(Probe::ACTION_NONE);
 });

--- a/memory/decisions/0287-probe-whatsmeow-provision-pending-ativo-e-queda.md
+++ b/memory/decisions/0287-probe-whatsmeow-provision-pending-ativo-e-queda.md
@@ -1,0 +1,57 @@
+---
+slug: 0287-probe-whatsmeow-provision-pending-ativo-e-queda
+number: 287
+title: "probe whatsmeow trata PROVISION_PENDING em canal que estava healthy como queda (fim da 'queda invisível') + logout remoto não é ban"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-18"
+module: whatsapp
+tags: [whatsapp, whatsmeow, health-probe, channel-health, incident, caixa-unificada, atendimento]
+supersedes: []
+superseded_by: []
+related:
+  - 0286-channel-health-corroborado-por-mensagem-real
+  - 0206-state-machine-whatsmeow-reconciliacao
+  - 0096-modulo-whatsapp-meta-cloud-api-direto
+---
+
+# ADR 0287 — `PROVISION_PENDING` em canal ativo é queda (não provisionamento)
+
+## Contexto
+
+Durante a Fase B do "evoluir o WuzAPI" (assinar o evento `LoggedOut` nativo, sessão 2026-06-18 / [doc vivo](../sessions/2026-06-18-arte-whatsapp-naoficiais.md)), verificação ao vivo no daemon de produção (CT 100) achou um canal whatsmeow (`ch-a5d3…`, a Jana) com `connected=False, loggedIn=False` — **morto na sessão** — enquanto a Caixa Unificada exibia o canal como `ativo`. Ou seja: **uma queda real estava invisível** pro app.
+
+Causa raiz (duas camadas):
+
+1. **Máquina de estados** ([ADR 0206](0206-state-machine-whatsmeow-reconciliacao.md)): `WhatsmeowReconciler::reconcile()` retorna `PROVISION_PENDING` quando o daemon reporta `connected=False` (independente de o canal já ter sido pareado).
+2. **Decisão do probe** ([ADR 0286](0286-channel-health-corroborado-por-mensagem-real.md), US-WA-308): `WhatsmeowHealthProbeCommand::decideAction()` mapeava `PROVISION_PENDING` → `ACTION_NONE` ("estado transitório / pareando, não muta health"). Isso é correto pra um canal **nunca-pareado** (provisionando de fato), mas **errado** pra um canal que estava `healthy` e caiu — o teste `WhatsmeowHealthProbeDecisionTest` inclusive **codificava** esse comportamento como intencional.
+
+Achado correlato no mesmo fluxo: `WhatsmeowWebhookController::handleDisconnected` listava `'logged_out'` entre os `banKeywords` → um logout remoto seria classificado como **ban** (P0, "número banido pela Meta"). Um logout é **re-pareável** (gerar novo QR), não um ban.
+
+## Decisão
+
+**1. `PROVISION_PENDING` num canal cujo `channel_health` era `healthy` é tratado como queda** (`connected=False` num canal que estava no ar = sessão caiu), seguindo o mesmo ramo de `LOGGED_OUT`/`NOT_EXISTS`:
+   - sem inbound recente → marca `disconnected`;
+   - com inbound recente (janela [ADR 0286](0286-channel-health-corroborado-por-mensagem-real.md)) → **suprime** o falso disconnected / auto-cura.
+
+**2. `PROVISION_PENDING` num canal `never_checked`/`disconnected` segue transitório** (`ACTION_NONE`) — provisionamento legítimo de canal nunca-pareado não vira "fora do ar".
+
+**3. Logout remoto não é ban.** `'logged_out'` sai dos `banKeywords` do webhook → vira `disconnected` (re-pareável), consistente com o probe. (`banned`/`forbidden`/`multidevice_mismatch` permanecem ban.)
+
+**4. A decisão continua PURA e testada** em `decideAction(state, healthBefore, freshInbound)` — a catraca é o teste determinístico; `handle()` usa a mesma definição de "caído" pra computar o inbound.
+
+## Consequências
+
+- ✅ Uma queda real com `connected=False` (logout que não emitiu evento, restart do daemon, socket morto) **passa a ser detectada** e some o "ativo" falso.
+- ✅ Sem regressão da supressão de falso-positivo: inbound recente ainda prova "no ar".
+- ✅ Logout deixa de disparar alerta de ban indevido (P0) + UX errada ("use Meta Cloud").
+- ⚠️ Muda 1 caso que o teste antigo fixava (`PROVISION_PENDING + healthy → NONE`) — atualizado no mesmo PR (decisão append-only: este ADR é a fonte da nova regra).
+- 📝 Não fecha a observabilidade (uptime%/alerta) — isso é ADR próprio (SLO/SLI de canal, follow-up).
+
+## Anchor
+
+**Implementado em:** `Modules/Whatsapp/Console/Commands/WhatsmeowHealthProbeCommand.php` (`decideAction` + `handle`), `Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php` (`handleDisconnected` banKeywords), `Modules/Whatsapp/Tests/Feature/WhatsmeowHealthProbeDecisionTest.php`.

--- a/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
+++ b/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
@@ -1,0 +1,51 @@
+---
+slug: 0288-slo-sli-saude-canal-whatsapp
+number: 288
+title: "SLO/SLI de saúde de canal WhatsApp — uptime%, time-to-detect e alerta canal-down (observabilidade que não depende de olhar a tela)"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-18"
+module: whatsapp
+tags: [whatsapp, observability, slo, sli, channel-health, alerting]
+supersedes: []
+superseded_by: []
+related:
+  - 0286-channel-health-corroborado-por-mensagem-real
+  - 0058-reverb-substituido-por-centrifugo-frankenphp
+---
+
+# ADR 0288 — SLO/SLI de saúde de canal WhatsApp
+
+## Contexto
+
+O dossiê de profissionalização (2026-06-18, [channel-reliability](../sessions/2026-06-18-arte-whatsapp-channel-reliability.md)) marcou **observabilidade em 20%** — o pilar mais atrás. Hoje o app **detecta** queda (probe 3min + `LoggedOut` nativo + corroboração por inbound do [ADR 0286](0286-channel-health-corroborado-por-mensagem-real.md)) e agora **reflete na tela** (realtime, Centrifugo). MAS não **mede** nem **alerta**: não há uptime% por canal, time-to-detect, nem alerta de canal-down. Resultado: um canal pode ficar caído e ninguém é avisado fora de quem está olhando a Caixa.
+
+## Decisão
+
+Definir SLIs + SLOs de disponibilidade de canal e um alerta — todos **por canal, por business** (Tier 0, [ADR 0093](0093-multi-tenant-isolation-tier-0.md)).
+
+**SLIs:**
+1. **uptime%** = tempo em `channel_health=healthy` / tempo total (janela rolante 24h/7d/30d).
+2. **time-to-detect** = intervalo entre a queda real e o flip de `channel_health` (com `LoggedOut` nativo deve ser **segundos**; antes era até 3min+10min).
+3. **webhook delivery success rate** = entregas 2xx / total.
+
+**SLOs (alvo — [W] calibra):** uptime ≥ **99%**/30d · time-to-detect **p95 < 1 min** · webhook delivery ≥ **99,5%**.
+
+**Alerta:** canal `status=active` com `channel_health` caído (`disconnected`/`banned`/`logged_out`) por **> N min** (default **10**, via env) → **notifica** (canal de alerta do projeto: `mcp_alertas` / log `ALERT` / Centrifugo), não só banner.
+
+**Onde:** snapshot periódico (padrão `MetricsAggregateCommand` + `WhatsappObservabilityHealthCommand`) gravando série temporal de `channel_health` (tabela append-only) pra computar uptime%/time-to-detect; OTel span no ciclo de sessão (estende o OTel GenAI do Jana).
+
+## Consequências
+
+- ✅ Saber a confiabilidade real de cada canal **sem depender de alguém olhar a tela**.
+- ✅ Base pro dashboard de saúde de canal **e** pro gatilho de failover ([ADR 0289](0289-failover-saude-canal-cloud-api-tenants-criticos.md)).
+- ⚠️ Requer tabela de snapshot (append-only) + cron — **implementação após o aceite** (sequência: aceitar SLI/SLO aqui → codar a métrica).
+- 📝 `time-to-detect` só é honesto depois do `LoggedOut` nativo (#2994) + probe corrigido (#3003 / ADR 0287).
+
+## Anchor
+
+**Implementado em:** (pendente — segue o aceite desta proposta) `Modules/Whatsapp/Console/Commands/` (snapshot + alerta), tabela `channel_health_snapshots`, `Modules/Whatsapp/Console/Commands/WhatsappObservabilityHealthCommand.php`.

--- a/memory/decisions/0289-failover-saude-canal-cloud-api-tenants-criticos.md
+++ b/memory/decisions/0289-failover-saude-canal-cloud-api-tenants-criticos.md
@@ -1,0 +1,47 @@
+---
+slug: 0289-failover-saude-canal-cloud-api-tenants-criticos
+number: 289
+title: "failover automático por saúde de canal: tenant crítico cai pro Cloud API (oficial, ban-zero) quando o canal não-oficial cai — emenda 0096"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-18"
+module: whatsapp
+tags: [whatsapp, resilience, failover, meta-cloud-api, channel-health, tier-0]
+supersedes: []
+superseded_by: []
+related:
+  - 0096-modulo-whatsapp-meta-cloud-api-direto
+  - 0288-slo-sli-saude-canal-whatsapp
+---
+
+# ADR 0289 — failover automático saúde→Cloud API pra tenants críticos
+
+## Contexto
+
+A [ADR 0096](0096-modulo-whatsapp-meta-cloud-api-direto.md) põe a Meta Cloud API como default universal + não-oficial (whatsmeow) como opção por custo/flexibilidade; o `MetaCloudDriver` já existe (705 linhas). MAS **não há failover automático por saúde**: se um canal não-oficial cai (logout/ban), o envio do tenant **não** migra sozinho pro Cloud API. O dossiê (2026-06-18) marca hedge oficial em **60%** (driver existe, failover não automatiza). Pra um tenant **crítico**, isso é perda de mensageria numa queda.
+
+## Decisão
+
+Pra canais/tenants marcados **críticos**, quando `channel_health` estiver caído além do limiar (sinal do [ADR 0288](0288-slo-sli-saude-canal-whatsapp.md)), o **envio outbound** faz **failover automático** pro canal Cloud API (oficial, único ban-zero) do **mesmo business**, se configurado:
+
+- **Escopo:** outbound (envio). Inbound segue por-canal (não há o que rotear se a sessão caiu).
+- **Gatilho:** `channel_health` caído > limiar (0288) **E** flag `critical` no canal/tenant **E** existe canal Cloud API ativo no business.
+- **Reversível + idempotente:** quando o não-oficial recupera (`healthy`), o roteamento volta. **Histerese** (só volta após X min healthy) pra evitar flap.
+- **Transparência:** registra no `AuditLog` + sinaliza na UI qual canal está servindo (não-oficial vs failover oficial).
+- **Tier 0:** failover **nunca** cruza business ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) — só usa o Cloud API do mesmo tenant.
+
+## Consequências
+
+- ✅ Tenant crítico **não perde envio** quando o canal não-oficial cai/bane — o caminho ban-zero assume.
+- ✅ Materializa o modelo "não-oficial por custo + oficial por criticidade" (0096) de forma **automática**, não manual.
+- ⚠️ Custo: Cloud API cobra por conversa → failover só pra `critical` (não universal), pra não estourar custo.
+- ⚠️ Depende do sinal de saúde do [ADR 0288](0288-slo-sli-saude-canal-whatsapp.md) (sequência: 0288 → 0289).
+- 📝 Inbound durante o failover + reconciliação de histórico pós-recuperação ficam fora de escopo deste ADR.
+
+## Anchor
+
+**Implementado em:** (pendente — segue aceite + ADR 0288) seletor de driver de outbound por saúde (`Modules/Whatsapp/Services/`), flag `critical` em `channels`/`business`.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **291** arquivos · **276** números únicos · máx **0286**
-- **ADRs ATIVOS (lifecycle ativo): 251** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 228 · proposto 37 · superseded 23 · (vazio) 2 · rascunho 1
-- Por lifecycle: ativo 251 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **294** arquivos · **279** números únicos · máx **0289**
+- **ADRs ATIVOS (lifecycle ativo): 254** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 228 · proposto 40 · superseded 23 · (vazio) 2 · rascunho 1
+- Por lifecycle: ativo 254 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -32,7 +32,7 @@ _(íntegra)_
 ## Recusadas (0) — o NÃO consultável
 _(nenhuma — nenhum pedido recusado catalogado ainda)_
 
-## Todas as ADRs (291)
+## Todas as ADRs (294)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -326,3 +326,6 @@ _(nenhuma — nenhum pedido recusado catalogado ainda)_
 | 0284 | aceito | ativo | decision | Pipeline de incidente graduado por confiança — porta única, redação cross-tenant |
 | 0285 | aceito | ativo | decision | Publisher Cowork→repo — fechar o 1º hop do loop zero-paste reusando a cowork-inb |
 | 0286 | proposto | ativo | decision | channel_health de canal whatsmeow é corroborado por fluxo de mensagem real — inb |
+| 0287 | proposto | ativo | decision | probe whatsmeow trata PROVISION_PENDING em canal que estava healthy como queda ( |
+| 0288 | proposto | ativo | decision | SLO/SLI de saúde de canal WhatsApp — uptime%, time-to-detect e alerta canal-down |
+| 0289 | proposto | ativo | decision | failover automático por saúde de canal: tenant crítico cai pro Cloud API (oficia |


### PR DESCRIPTION
## Roadmap saúde de canal WhatsApp — probe (queda invisível) + ADRs (consolidado)

Consolidado num merge só pra manter o índice de ADR consistente (evita conflito entre PRs de ADR sequenciais).

### Código (fix)
- **Fim da "queda invisível"** (ADR 0287): `PROVISION_PENDING` num canal que estava `healthy` = **queda real**. Achado ao vivo: a Jana estava morta no daemon e a Caixa mostrava `ativo`. + `'logged_out'` sai dos `banKeywords` (logout é re-pareável, não ban). `decideAction` + `handle()` + webhook + teste (vermelho-primeiro).

### Decisões (proposals, `proposto`)
- **ADR 0287** — probe `PROVISION_PENDING`-ativo = queda.
- **ADR 0288** — SLO/SLI de canal (uptime% · time-to-detect · alerta canal-down) — pilar observabilidade.
- **ADR 0289** — failover automático saúde→Cloud API pra tenants críticos (emenda 0096).
- `_INDEX-GENERATED.md` regenerado (294 ADRs · `--check` ok).

> 0288/0289 vieram do #3004 (agora fechado) — consolidados aqui pra um índice consistente num único merge.

## Infra Contract
- **Schema/DB:** sem migration. Só muda quais *valores* de `channel_health` o probe grava (`PROVISION_PENDING`-ativo → `disconnected`).
- **Env/secrets:** nenhum novo.
- **Runtime:** app-only (Hostinger, deploy ADR 0269). **Não toca** o daemon WuzAPI (CT 100).
- **Migração/rollback:** sem migração; rollback = reverter o PR (decisão de probe é pura, sem estado novo).
- **Risco prod:** baixo — passa a marcar quedas reais antes invisíveis; sem efeito sobre envio/recebimento. ADRs 0288/0289 são `proposto` (sem efeito de runtime até implementação).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
