### PR TITLE
docs(adr): 0288 SLO/SLI de canal + 0289 failover saude->Cloud API (roadmap profissionalizacao)

### DIFF
--- a/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
+++ b/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
@@ -1,0 +1,51 @@
+---
+slug: 0288-slo-sli-saude-canal-whatsapp
+number: 288
+title: "SLO/SLI de saúde de canal WhatsApp — uptime%, time-to-detect e alerta canal-down (observabilidade que não depende de olhar a tela)"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-18"
+module: whatsapp
+tags: [whatsapp, observability, slo, sli, channel-health, alerting]
+supersedes: []
+superseded_by: []
+related:
+  - 0286-channel-health-corroborado-por-mensagem-real
+  - 0058-reverb-substituido-por-centrifugo-frankenphp
+---
+
+# ADR 0288 — SLO/SLI de saúde de canal WhatsApp
+
+## Contexto
+
+O dossiê de profissionalização (2026-06-18, [channel-reliability](../sessions/2026-06-18-arte-whatsapp-channel-reliability.md)) marcou **observabilidade em 20%** — o pilar mais atrás. Hoje o app **detecta** queda (probe 3min + `LoggedOut` nativo + corroboração por inbound do [ADR 0286](0286-channel-health-corroborado-por-mensagem-real.md)) e agora **reflete na tela** (realtime, Centrifugo). MAS não **mede** nem **alerta**: não há uptime% por canal, time-to-detect, nem alerta de canal-down. Resultado: um canal pode ficar caído e ninguém é avisado fora de quem está olhando a Caixa.
+
+## Decisão
+
+Definir SLIs + SLOs de disponibilidade de canal e um alerta — todos **por canal, por business** (Tier 0, [ADR 0093](0093-multi-tenant-isolation-tier-0.md)).
+
+**SLIs:**
+1. **uptime%** = tempo em `channel_health=healthy` / tempo total (janela rolante 24h/7d/30d).
+2. **time-to-detect** = intervalo entre a queda real e o flip de `channel_health` (com `LoggedOut` nativo deve ser **segundos**; antes era até 3min+10min).
+3. **webhook delivery success rate** = entregas 2xx / total.
+
+**SLOs (alvo — [W] calibra):** uptime ≥ **99%**/30d · time-to-detect **p95 < 1 min** · webhook delivery ≥ **99,5%**.
+
+**Alerta:** canal `status=active` com `channel_health` caído (`disconnected`/`banned`/`logged_out`) por **> N min** (default **10**, via env) → **notifica** (canal de alerta do projeto: `mcp_alertas` / log `ALERT` / Centrifugo), não só banner.
+
+**Onde:** snapshot periódico (padrão `MetricsAggregateCommand` + `WhatsappObservabilityHealthCommand`) gravando série temporal de `channel_health` (tabela append-only) pra computar uptime%/time-to-detect; OTel span no ciclo de sessão (estende o OTel GenAI do Jana).
+
+## Consequências
+
+- ✅ Saber a confiabilidade real de cada canal **sem depender de alguém olhar a tela**.
+- ✅ Base pro dashboard de saúde de canal **e** pro gatilho de failover ([ADR 0289](0289-failover-saude-canal-cloud-api-tenants-criticos.md)).
+- ⚠️ Requer tabela de snapshot (append-only) + cron — **implementação após o aceite** (sequência: aceitar SLI/SLO aqui → codar a métrica).
+- 📝 `time-to-detect` só é honesto depois do `LoggedOut` nativo (#2994) + probe corrigido (#3003 / ADR 0287).
+
+## Anchor
+
+**Implementado em:** (pendente — segue o aceite desta proposta) `Modules/Whatsapp/Console/Commands/` (snapshot + alerta), tabela `channel_health_snapshots`, `Modules/Whatsapp/Console/Commands/WhatsappObservabilityHealthCommand.php`.

--- a/memory/decisions/0289-failover-saude-canal-cloud-api-tenants-criticos.md
+++ b/memory/decisions/0289-failover-saude-canal-cloud-api-tenants-criticos.md
@@ -1,0 +1,47 @@
+---
+slug: 0289-failover-saude-canal-cloud-api-tenants-criticos
+number: 289
+title: "failover automático por saúde de canal: tenant crítico cai pro Cloud API (oficial, ban-zero) quando o canal não-oficial cai — emenda 0096"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-18"
+module: whatsapp
+tags: [whatsapp, resilience, failover, meta-cloud-api, channel-health, tier-0]
+supersedes: []
+superseded_by: []
+related:
+  - 0096-modulo-whatsapp-meta-cloud-api-direto
+  - 0288-slo-sli-saude-canal-whatsapp
+---
+
+# ADR 0289 — failover automático saúde→Cloud API pra tenants críticos
+
+## Contexto
+
+A [ADR 0096](0096-modulo-whatsapp-meta-cloud-api-direto.md) põe a Meta Cloud API como default universal + não-oficial (whatsmeow) como opção por custo/flexibilidade; o `MetaCloudDriver` já existe (705 linhas). MAS **não há failover automático por saúde**: se um canal não-oficial cai (logout/ban), o envio do tenant **não** migra sozinho pro Cloud API. O dossiê (2026-06-18) marca hedge oficial em **60%** (driver existe, failover não automatiza). Pra um tenant **crítico**, isso é perda de mensageria numa queda.
+
+## Decisão
+
+Pra canais/tenants marcados **críticos**, quando `channel_health` estiver caído além do limiar (sinal do [ADR 0288](0288-slo-sli-saude-canal-whatsapp.md)), o **envio outbound** faz **failover automático** pro canal Cloud API (oficial, único ban-zero) do **mesmo business**, se configurado:
+
+- **Escopo:** outbound (envio). Inbound segue por-canal (não há o que rotear se a sessão caiu).
+- **Gatilho:** `channel_health` caído > limiar (0288) **E** flag `critical` no canal/tenant **E** existe canal Cloud API ativo no business.
+- **Reversível + idempotente:** quando o não-oficial recupera (`healthy`), o roteamento volta. **Histerese** (só volta após X min healthy) pra evitar flap.
+- **Transparência:** registra no `AuditLog` + sinaliza na UI qual canal está servindo (não-oficial vs failover oficial).
+- **Tier 0:** failover **nunca** cruza business ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) — só usa o Cloud API do mesmo tenant.
+
+## Consequências
+
+- ✅ Tenant crítico **não perde envio** quando o canal não-oficial cai/bane — o caminho ban-zero assume.
+- ✅ Materializa o modelo "não-oficial por custo + oficial por criticidade" (0096) de forma **automática**, não manual.
+- ⚠️ Custo: Cloud API cobra por conversa → failover só pra `critical` (não universal), pra não estourar custo.
+- ⚠️ Depende do sinal de saúde do [ADR 0288](0288-slo-sli-saude-canal-whatsapp.md) (sequência: 0288 → 0289).
+- 📝 Inbound durante o failover + reconciliação de histórico pós-recuperação ficam fora de escopo deste ADR.
+
+## Anchor
+
+**Implementado em:** (pendente — segue aceite + ADR 0288) seletor de driver de outbound por saúde (`Modules/Whatsapp/Services/`), flag `critical` em `channels`/`business`.


### PR DESCRIPTION
Propoe os 2 ADRs do roadmap de profissionalizacao do canal WhatsApp (sessao 2026-06-18, aprovado): 0288 (SLO/SLI + alerta canal-down -- pilar observabilidade, hoje 20%) e 0289 (failover automatico saude->Cloud API pra tenants criticos, emenda 0096). Status proposto. Impl segue o aceite: 0288 primeiro (define os SLIs), 0289 depois (usa o sinal). Dossie: memory/sessions/2026-06-18-arte-whatsapp-channel-reliability.md