### PR TITLE
feat(whatsapp): observabilidade de canal — snapshot + alerta canal-down + uptime% (ADR 0288)

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -79,6 +79,9 @@ return [
         // "no ar" — suprime o falso "fora do ar" do loggedIn não-confiável do WuzAPI
         // e auto-cura pra healthy (incidente 2026-06-18; martelo [W] = 10min).
         'health_fresh_inbound_minutes' => (int) env('WHATSMEOW_HEALTH_FRESH_INBOUND_MINUTES', 10),
+        // Minutos que um canal `active` pode ficar caído antes do alerta canal-down
+        // (ADR 0288, observabilidade). Alerta dispara 1× por streak (no cruzamento).
+        'health_alert_after_minutes' => (int) env('WHATSMEOW_HEALTH_ALERT_AFTER_MINUTES', 10),
     ],
 
     /*

--- a/Modules/Whatsapp/Console/Commands/ChannelHealthSnapshotCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ChannelHealthSnapshotCommand.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+
+/**
+ * whatsapp:channel-health-snapshot — observabilidade de saúde de canal (ADR 0288).
+ *
+ * Grava um snapshot append-only de `channel_health` por canal (série temporal,
+ * `channel_health_snapshots`) e **ALERTA** quando um canal `active` fica caído
+ * (`disconnected`/`banned`/`degraded`) por mais de N min (config
+ * `whatsapp.whatsmeow.health_alert_after_minutes`, default 10). O alerta dispara
+ * **uma vez por streak** (no cruzamento do limiar) via Log `ALERT` — canal
+ * monitorado (jana:health-check). A série habilita uptime% e time-to-detect (SLIs).
+ *
+ * Fecha o pilar de observabilidade (dossiê 2026-06-18: 20% → o maior salto): a
+ * queda passa a avisar sem ninguém olhar a tela. Decisão de alerta **PURA** em
+ * `shouldAlert()` (catraca de teste determinístico).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): cron sem session → `withoutGlobalScope`; cada
+ * row carrega `business_id`; queries escopadas por `channel_id` (PK única por business).
+ *
+ * @see memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
+ */
+class ChannelHealthSnapshotCommand extends Command
+{
+    protected $signature = 'whatsapp:channel-health-snapshot
+                            {--dry-run : Não grava nem alerta (preview)}
+                            {--detail : Loga cada canal}';
+
+    protected $description = 'Snapshot append-only de channel_health + alerta canal-down > N min + uptime% (ADR 0288).';
+
+    /** Estados que contam como "caído" (alerta + uptime). */
+    public const DOWN_HEALTHS = ['disconnected', 'banned', 'degraded'];
+
+    public const DEFAULT_ALERT_AFTER_MINUTES = 10;
+
+    public function handle(): int
+    {
+        $threshold = (int) config('whatsapp.whatsmeow.health_alert_after_minutes', self::DEFAULT_ALERT_AFTER_MINUTES);
+        $dryRun = (bool) $this->option('dry-run');
+        $now = now();
+
+        // SUPERADMIN: cron sem session — Tier 0 garantido pelo business_id de cada row.
+        $channels = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->whereIn('type', [
+                Channel::TYPE_WHATSAPP_WHATSMEOW,
+                Channel::TYPE_WHATSAPP_BAILEYS,
+                Channel::TYPE_WHATSAPP_META,
+                Channel::TYPE_WHATSAPP_ZAPI,
+            ])
+            ->where('status', 'active')
+            ->orderBy('business_id')->orderBy('id')
+            ->get();
+
+        if ($channels->isEmpty()) {
+            $this->info('Nenhum canal WhatsApp ativo pra snapshot.');
+
+            return self::SUCCESS;
+        }
+
+        $recorded = 0;
+        $alerted = 0;
+        $rows = [];
+
+        foreach ($channels as $ch) {
+            $health = (string) $ch->channel_health;
+
+            if (! $dryRun) {
+                DB::table('channel_health_snapshots')->insert([
+                    'business_id' => $ch->business_id,
+                    'channel_id' => $ch->id,
+                    'channel_health' => $health,
+                    'recorded_at' => $now,
+                ]);
+                $recorded++;
+            }
+
+            [$downMinNow, $downMinPrev] = $this->downStreak($ch->id, $now);
+            $uptime = $this->uptimePercent24h($ch->id);
+
+            if (! $dryRun && self::shouldAlert($downMinNow, $downMinPrev, $threshold)) {
+                $alerted++;
+                Log::channel('single')->error('ALERT whatsapp.channel_health.down', [
+                    'event' => 'whatsapp.channel_health.alert_down',
+                    'business_id' => $ch->business_id,
+                    'channel_id' => $ch->id,
+                    'channel_health' => $health,
+                    'down_minutes' => $downMinNow,
+                    'threshold_minutes' => $threshold,
+                ]);
+            }
+
+            $rows[] = [
+                $ch->id, $ch->business_id, mb_strimwidth((string) $ch->label, 0, 20, '…'),
+                $health, $downMinNow === null ? '-' : (int) $downMinNow, $uptime === null ? '-' : $uptime.'%',
+            ];
+
+            if ($this->option('detail')) {
+                $this->line(sprintf(
+                    '  ch#%d biz=%d "%s" health=%s down=%s uptime24h=%s',
+                    $ch->id, $ch->business_id, $ch->label, $health,
+                    $downMinNow === null ? '-' : ((int) $downMinNow).'min',
+                    $uptime === null ? '-' : $uptime.'%',
+                ));
+            }
+        }
+
+        $this->table(['ch', 'biz', 'label', 'health', 'down(min)', 'uptime24h'], $rows);
+        $this->info("Snapshots: {$recorded} · alertas: {$alerted}".($dryRun ? ' (dry-run)' : ''));
+
+        Log::info('whatsapp.channel_health.snapshot_done', [
+            'event' => 'whatsapp.channel_health.snapshot_done',
+            'recorded' => $recorded,
+            'alerted' => $alerted,
+            'threshold_minutes' => $threshold,
+            'dry_run' => $dryRun,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Decisão PURA do alerta — dispara UMA vez por streak (no cruzamento do limiar).
+     *
+     * @param  float|null  $downMinutesNow   minutos em queda agora (null = não caído)
+     * @param  float|null  $downMinutesPrev  minutos em queda no snapshot anterior da streak (null = streak começou agora)
+     */
+    public static function shouldAlert(?float $downMinutesNow, ?float $downMinutesPrev, int $thresholdMin): bool
+    {
+        if ($downMinutesNow === null) {
+            return false; // não caído
+        }
+        if ($downMinutesNow < $thresholdMin) {
+            return false; // dentro do limiar
+        }
+        if ($downMinutesPrev !== null && $downMinutesPrev >= $thresholdMin) {
+            return false; // já alertou nesta streak
+        }
+
+        return true; // cruzou o limiar agora
+    }
+
+    /**
+     * Duração (min) da streak de queda atual, agora e no snapshot anterior da streak.
+     * Tier 0: escopado por channel_id. Retorna [null, null] se o canal não está caído.
+     *
+     * @return array{0: float|null, 1: float|null}
+     */
+    private function downStreak(int $channelId, Carbon $now): array
+    {
+        $snaps = DB::table('channel_health_snapshots')
+            ->where('channel_id', $channelId)
+            ->orderByDesc('recorded_at')->orderByDesc('id')
+            ->limit(500)
+            ->get(['channel_health', 'recorded_at']);
+
+        $run = []; // recorded_at dos snapshots caídos consecutivos, mais-recente primeiro
+        foreach ($snaps as $s) {
+            if (in_array($s->channel_health, self::DOWN_HEALTHS, true)) {
+                $run[] = Carbon::parse($s->recorded_at);
+            } else {
+                break; // streak quebrou
+            }
+        }
+
+        if (empty($run)) {
+            return [null, null];
+        }
+
+        $downSince = end($run); // o mais antigo consecutivo
+        $downMinNow = (float) $downSince->diffInMinutes($now);
+        $downMinPrev = count($run) >= 2 ? (float) $downSince->diffInMinutes($run[1]) : null;
+
+        return [$downMinNow, $downMinPrev];
+    }
+
+    /** uptime% (snapshots healthy / total) nas últimas 24h. null se sem amostras. */
+    private function uptimePercent24h(int $channelId): ?float
+    {
+        $since = now()->subDay();
+
+        $total = DB::table('channel_health_snapshots')
+            ->where('channel_id', $channelId)->where('recorded_at', '>=', $since)->count();
+        if ($total === 0) {
+            return null;
+        }
+
+        $healthy = DB::table('channel_health_snapshots')
+            ->where('channel_id', $channelId)->where('recorded_at', '>=', $since)
+            ->where('channel_health', 'healthy')->count();
+
+        return round($healthy / $total * 100, 1);
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_06_19_000001_create_channel_health_snapshots_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_06_19_000001_create_channel_health_snapshots_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * channel_health_snapshots — série temporal append-only de `channel_health` por
+ * canal (ADR 0288). Base pra SLIs (uptime%, time-to-detect) + alerta canal-down.
+ * Append-only (nunca UPDATE/DELETE no fluxo normal); retenção via job futuro.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('channel_health_snapshots')) {
+            return; // idempotente
+        }
+
+        Schema::create('channel_health_snapshots', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedInteger('business_id');           // Tier 0 (ADR 0093)
+            $table->unsignedBigInteger('channel_id');
+            $table->string('channel_health', 20);
+            $table->timestamp('recorded_at')->useCurrent();
+
+            $table->index(['channel_id', 'recorded_at'], 'chs_channel_recorded_idx'); // streak/uptime
+            $table->index(['business_id', 'recorded_at'], 'chs_biz_recorded_idx');     // agregação por tenant
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('channel_health_snapshots');
+    }
+};

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -17,6 +17,7 @@ use Modules\Whatsapp\Console\Commands\CustomerMemoryRefreshDailyCommand;
 use Modules\Whatsapp\Console\Commands\EmployeePerformanceBackfillCommand;
 use Modules\Whatsapp\Console\Commands\EmployeePerformanceRefreshDailyCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
+use Modules\Whatsapp\Console\Commands\ChannelHealthSnapshotCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
 use Modules\Whatsapp\Console\Commands\CleanupStaleJobsCommand;
 use Modules\Whatsapp\Console\Commands\CleanupWebhookNoncesCommand;
@@ -112,6 +113,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 ChannelsReconcilerCommand::class,       // 2026-05-13 — auto-fix drift channels↔daemon (cron 5min)
                 WhatsmeowHealthProbeCommand::class,      // US-WA-308 — detecta queda sessão whatsmeow (cron 3min, incidente 2026-06-18)
                 WhatsmeowResubscribeEventsCommand::class, // Fase B — re-assina LoggedOut em canais já provisionados (one-off, mecanismo D)
+                ChannelHealthSnapshotCommand::class,    // ADR 0288 — snapshot channel_health + alerta canal-down > N min (cron 5min, observabilidade)
                 ChannelResetCommand::class,             // 2026-05-13 — reset 1-comando channel travado
                 CleanupWebhookNoncesCommand::class,     // US-WA-082 — purga nonces >24h (replay protection cleanup)
                 CleanupStaleJobsCommand::class,         // US-WA-084 — purga jobs presos da fila whatsapp-history (>6h)

--- a/Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Console\Commands\ChannelHealthSnapshotCommand as Snap;
+use Modules\Whatsapp\Entities\Channel;
+
+uses(Tests\TestCase::class);
+
+/**
+ * ChannelHealthSnapshotCommandTest — observabilidade de canal (ADR 0288).
+ *
+ * Cobre a decisão PURA do alerta (catraca shouldAlert) + o snapshot append-only +
+ * o alerta no cruzamento do limiar. Schema sintético espelha HealthProbeChannelsCommandTest.
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('schema sintético manual incompatível com MySQL persistente.');
+    }
+
+    Schema::dropIfExists('channels');
+    Schema::dropIfExists('channel_health_snapshots');
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamp('last_health_check_at')->nullable();
+        $table->text('last_health_message')->nullable();
+        $table->timestamp('lgpd_acknowledged_at')->nullable();
+        $table->unsignedInteger('lgpd_acknowledged_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('channel_health_snapshots', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->string('channel_health', 20);
+        $table->timestamp('recorded_at')->nullable();
+    });
+
+    config(['whatsapp.whatsmeow.health_alert_after_minutes' => 10]);
+});
+
+function makeSnapChannel(int $bizId, string $health = 'healthy'): Channel
+{
+    return Channel::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id' => $bizId,
+        'channel_uuid' => sprintf('snap%04d-0000-0000-0000-%012d', $bizId, random_int(1, 999999)),
+        'label' => "Canal {$bizId}",
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+        'status' => 'active',
+        'channel_health' => $health,
+    ]);
+}
+
+// ── catraca PURA do alerta ──────────────────────────────────────────────
+it('shouldAlert: não caído / dentro do limiar → false', function () {
+    expect(Snap::shouldAlert(null, null, 10))->toBeFalse();      // não caído
+    expect(Snap::shouldAlert(5.0, null, 10))->toBeFalse();       // 5 < 10
+});
+
+it('shouldAlert: cruzou o limiar agora → true (dispara 1×)', function () {
+    expect(Snap::shouldAlert(12.0, null, 10))->toBeTrue();       // streak começou e já passou
+    expect(Snap::shouldAlert(11.0, 8.0, 10))->toBeTrue();        // prev < limiar, now >= limiar = cruzamento
+});
+
+it('shouldAlert: já alertou nesta streak → false (sem spam)', function () {
+    expect(Snap::shouldAlert(25.0, 15.0, 10))->toBeFalse();      // prev já >= limiar
+});
+
+// ── snapshot + alerta ───────────────────────────────────────────────────
+it('grava um snapshot append-only por canal ativo', function () {
+    makeSnapChannel(1, 'healthy');
+
+    \Artisan::call('whatsapp:channel-health-snapshot');
+
+    expect(DB::table('channel_health_snapshots')->count())->toBe(1);
+    $row = DB::table('channel_health_snapshots')->first();
+    expect($row->channel_health)->toBe('healthy');
+});
+
+it('alerta quando canal cruza o limiar de queda (down > N min)', function () {
+    $ch = makeSnapChannel(1, 'disconnected');
+    // snapshot anterior caído há 12 min → ao gravar o atual, streak = 12min (>= 10), prev=0 → cruzamento.
+    DB::table('channel_health_snapshots')->insert([
+        'business_id' => 1, 'channel_id' => $ch->id, 'channel_health' => 'disconnected',
+        'recorded_at' => now()->subMinutes(12),
+    ]);
+
+    \Artisan::call('whatsapp:channel-health-snapshot');
+    $out = \Artisan::output();
+
+    expect($out)->toContain('alertas: 1');
+});
+
+it('--dry-run não grava nem alerta', function () {
+    makeSnapChannel(1, 'disconnected');
+    DB::table('channel_health_snapshots')->insert([
+        'business_id' => 1, 'channel_id' => 1, 'channel_health' => 'disconnected',
+        'recorded_at' => now()->subMinutes(30),
+    ]);
+
+    \Artisan::call('whatsapp:channel-health-snapshot', ['--dry-run' => true]);
+
+    // só o snapshot seed (1), nenhum novo gravado
+    expect(DB::table('channel_health_snapshots')->count())->toBe(1);
+    expect(\Artisan::output())->toContain('(dry-run)');
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -765,6 +765,20 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // whatsapp:channel-health-snapshot (5 em 5 min) — série temporal append-only de
+        // channel_health (ADR 0288): habilita uptime%/time-to-detect (SLIs) e ALERTA
+        // canal-down > N min (1× por streak). Fecha o pilar de observabilidade (não
+        // depende de ninguém olhar a tela).
+        $schedule->command('whatsapp:channel-health-snapshot')
+            ->everyFiveMinutes()
+            ->withoutOverlapping(5)
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule whatsapp:channel-health-snapshot FALHOU — observabilidade de canal pode estar cega'
+                );
+            });
+
         // Worker da fila `whatsapp-history` (Wagner request 2026-05-14 02h):
         // "recebe tudo de maneira rapida... depois sincroniza com o banco,
         // sempre guarda para não perder". Cron everyMinute pra processar

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13016,7 +13016,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 55
+			count: 56
 			path: Modules/Whatsapp/Config/config.php
 
 		-


### PR DESCRIPTION
## Observabilidade de canal — ADR 0288 (fase 1)

Fecha o **pilar mais atrás** do dossiê (observabilidade, 20%): a queda de canal passa a **avisar sem ninguém olhar a tela**.

### O quê
- **Série temporal** append-only `channel_health_snapshots` (migration idempotente + `down()`, `business_id` Tier 0).
- **`whatsapp:channel-health-snapshot`** (cron 5min, `live`): grava o snapshot + **ALERTA** quando um canal `active` fica caído (`disconnected`/`banned`/`degraded`) por **> N min** (config `health_alert_after_minutes`, default 10) — **1× por streak** (no cruzamento), via Log `ALERT` (monitorado pelo `jana:health-check`). Computa **uptime% 24h**.
- Decisão de alerta **PURA** (`shouldAlert`) travada por teste (catraca).

### SLIs habilitados (ADR 0288)
uptime% por canal · time-to-detect (agora segundos, pós-`LoggedOut` nativo) · base pro dashboard + pro failover (ADR 0289).

## Infra Contract
- **Schema/DB:** **+1 tabela** `channel_health_snapshots` (aditiva, append-only). Migration **idempotente** (`hasTable` guard) + `down()` (`dropIfExists`). Sem alteração em tabela existente.
- **Env/secrets:** `WHATSMEOW_HEALTH_ALERT_AFTER_MINUTES` (opcional, default 10). Nenhum segredo.
- **Runtime:** app-only (Hostinger, deploy ADR 0269). **Não toca** o daemon WuzAPI (CT 100). Novo cron `everyFiveMinutes` (env `live`, `withoutOverlapping`).
- **Migração/rollback:** aditiva e reversível (`down()` derruba a tabela). Rollback = reverter o PR; sem perda de dado de negócio (telemetria).
- **Risco prod:** baixo — cron leve (1 INSERT + queries indexadas por canal); alerta é Log (sem efeito em envio/recebimento).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
