### PR TITLE
fix(jana): mensagem do decisions-search diz 'recusadas' (completa honestidade #2998)

### DIFF
--- a/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
@@ -38,7 +38,7 @@ class DecisionsSearchTool extends Tool
                 ->description('Quantos resultados retornar (default 5, max 20)'),
             'include_archived' => $schema->boolean()
                 ->default(false)
-                ->description('Se true, inclui ADRs superseded/deprecated/sunsetting na busca. Default false (só accepted + accepted-historical).'),
+                ->description('Se true, inclui ADRs superseded/deprecated/sunsetting na busca. Default false (ativas + recusadas: accepted/accepted-historical/recusado — o NÃO consultável).'),
         ];
     }
 
@@ -94,7 +94,7 @@ class DecisionsSearchTool extends Tool
 
         $scopeNote = $includeArchived
             ? '(incluindo superseded/deprecated)'
-            : '(só ativas — aceito/accepted/accepted-historical)';
+            : '(ativas + recusadas — aceito/accepted/accepted-historical/recusado)';
 
         $output = "Encontrados " . $rows->count() . " ADR(s) pra \"$query\" $scopeNote:\n\n";
         foreach ($rows as $doc) {


### PR DESCRIPTION
Fecha o resíduo de honestidade do [#2998](https://github.com/wagnerra23/oimpresso.com/pull/2998) que **achei rodando o `decisions-search` vivo** ("vai fundo"): o filtro e a `$description` foram corrigidos, mas 2 strings de **saída** ainda diziam "só ativas":

- `$scopeNote` → `(ativas + recusadas — aceito/accepted/accepted-historical/recusado)`;
- description do param `include_archived` → idem.

Cosmético, mas evita a tool dizer "só ativas" enquanto retorna recusadas. Efeito só quando o **CT 100 redeployar** o MCP com #2998/#3000 (o gap merged≠deployed que o teste de ouro expôs).

Refs: #2998, #3000, ADR 0290.