### PR TITLE
fix(session): related_adrs como slugs (corrige gate session-log de #3009)

### DIFF
--- a/memory/sessions/2026-06-19-ct100-spec-drift-rescue.md
+++ b/memory/sessions/2026-06-19-ct100-spec-drift-rescue.md
@@ -1,8 +1,11 @@
 ---
 topic: "Resgate de backlog não-commitado (US-WA-308..311) da drift do checkout do CT 100 + nota de deploy"
 date: "2026-06-19"
-autor: "Claude Code (sessão veredito-ledger / deploy MCP)"
-related_adrs: [0286, 0062, 0256, 0202]
+authors: ["Claude Code"]
+related_adrs:
+  - 0286-channel-health-corroborado-por-mensagem-real
+  - 0062-separacao-runtime-hostinger-ct100
+  - 0202-whatsapp-profissionalizacao-baileys-out
 ---
 
 # Resgate da drift do CT 100 — backlog US-WA-308..311 + lição de deploy


### PR DESCRIPTION
O [#3009](https://github.com/wagnerra23/oimpresso.com/pull/3009) mergeou pelo auto-merge **apesar do gate `Session log` vermelho** (advisory, não-required) — então o session log entrou em main com `related_adrs: [0286, 0062, 0256, 0202]` (números). O schema exige strings no formato `^[0-9]{4}-[a-z0-9-]+$`. Corrige pros slugs reais + `autor`→`authors`. (`0256` saiu do campo por slug incerto, segue citado no corpo.)

Nota de processo: um gate de schema **advisory** deixou memória inválida entrar em main — mesma classe do que a gente discutiu na sessão (advisory que não morde).