### PR TITLE
fix(session): authors=['C'] — fecha o gate session-log (fim da cadeia #3009/#3010)

### DIFF
--- a/memory/sessions/2026-06-19-ct100-spec-drift-rescue.md
+++ b/memory/sessions/2026-06-19-ct100-spec-drift-rescue.md
@@ -1,7 +1,7 @@
 ---
 topic: "Resgate de backlog não-commitado (US-WA-308..311) da drift do checkout do CT 100 + nota de deploy"
 date: "2026-06-19"
-authors: ["Claude Code"]
+authors: ["C"]
 related_adrs:
   - 0286-channel-health-corroborado-por-mensagem-real
   - 0062-separacao-runtime-hostinger-ct100


### PR DESCRIPTION
Último elo: o session log entrou em main via auto-merge advisory com 2 erros de schema em sequência (#3009 related_adrs-número, #3010 authors-'Claude Code'). `authors` exige enum `[W,F,M,L,E,C]` — **C=Claude**. Este corrige + **NÃO usa auto-merge** (mergeio manual com o gate verde, pra não repetir o merge-vermelho).