### PR TITLE
feat(governance): stream MEM no sdd-scorecard — une SDD + memória num só sistema (keystone peça 4)

### DIFF
--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -4,7 +4,8 @@
     "generator": "scripts/governance/sdd-scorecard.mjs",
     "plan": "memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md",
     "determinismo": "sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio",
-    "composta": "v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured",
+    "composta": "v1 (fontes parciais) ≠ v2 (12/12 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured",
+    "streams": "cada métrica tem `stream` — SA/FV/KL/GT + MEM (memória-unificada · read-path do ADR 0270). Um só scorecard governa SDD e memória (peça 4 da união; ledger memory/sessions/2026-06-19-adversario-uniao-sdd-memoria.md)",
     "anchor_coverage_regra": "delegado a scripts/governance/anchor-lint.mjs (ADR 0273 §2 — fonte única): (anchored_ok + pendente + parcial) / us_total. Antes era grep estrito próprio (divergia); unificado no PR do ledger §A.",
     "ratchet": {
       "baseline": "governance/sdd-scorecard-baseline.json — armed POR MÉTRICA (ADR 0275 §3: arma após 3 medições válidas consecutivas da fonte real; armar/desarmar/piorar = PR editando o baseline, diff visível)",
@@ -14,31 +15,32 @@
   "metrics": {
     "anchor_coverage": {
       "status": "measured",
-      "value": 5.4,
+      "value": 7.5,
       "unit": "%",
       "direction": "up",
       "target": 100,
       "source": "scripts/governance/anchor-lint.mjs --json .summary.anchor_coverage_pct (fonte única — ADR 0273 §2)",
       "detail": {
-        "coverage_pct": 5.4,
+        "coverage_pct": 7.5,
         "specs_total": 56,
         "us_total": 775,
-        "anchor_coverage_pct": 5.4,
+        "anchor_coverage_pct": 7.5,
         "by_state": {
-          "sem_campo": 696,
+          "sem_campo": 680,
           "placeholder": 22,
           "pendente": 23,
           "parcial": 0,
-          "anchored_ok": 19,
+          "anchored_ok": 35,
           "anchored_dead": 15
         },
-        "fields_total": 84,
+        "fields_total": 100,
         "fields_placeholder": 22,
-        "fields_grammar_ok": 28,
+        "fields_grammar_ok": 44,
         "orphan_fields": 5,
         "v1_files": 0,
         "v1_violations": "0"
-      }
+      },
+      "stream": "SA"
     },
     "full_suite_pass_rate": {
       "status": "not_yet_measured",
@@ -46,7 +48,8 @@
       "direction": "down",
       "target": 0,
       "source": "governance/nightly-floor.json ainda não publicado pelo write-side CT100 (ADR 0279 PR-2 — precisa de credencial de push no CT100). A nightly FV-F3 roda (15+ runs reais); falta o transporte.",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "FV"
     },
     "n_quarantine": {
       "status": "measured",
@@ -57,7 +60,8 @@
       "source": "convenção legacy-quarantine (@group | ->group() | skip) em tests/ + Modules/*/Tests (este script)",
       "detail": {
         "quarantined_files": 27
-      }
+      },
+      "stream": "FV"
     },
     "coverage_pct": {
       "status": "not_yet_measured",
@@ -65,7 +69,8 @@
       "direction": "up",
       "target": "só sobe (catraca C2)",
       "source": "pcov instrumentado em CI (P0-2) — hoje coverage: none",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "FV"
     },
     "ghost_count": {
       "status": "measured",
@@ -76,7 +81,8 @@
       "source": "scripts/governance/knowledge-drift.mjs --json (Modules/<X> citado e inexistente no disco; nomes: rodar a fonte direto)",
       "detail": {
         "citing_modules": 24
-      }
+      },
+      "stream": "KL"
     },
     "front_door_coverage": {
       "status": "measured",
@@ -88,7 +94,8 @@
       "detail": {
         "with_door": 70,
         "modules": 70
-      }
+      },
+      "stream": "MEM"
     },
     "recall_eval_violations": {
       "status": "not_yet_measured",
@@ -96,7 +103,8 @@
       "direction": "down",
       "target": 0,
       "source": "golden set recall (KL-C2) — depende do alias map das 13 colisões ADR",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "MEM"
     },
     "ragas_real_uptime": {
       "status": "not_yet_measured",
@@ -104,7 +112,26 @@
       "direction": "up",
       "target": "≥95%",
       "source": "RAGAS canário modo REAL diário (KL-D1/D4) — hoje compara mock com mock",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "MEM"
+    },
+    "distiller_freshness": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "target": "< 7d em 100% das portas",
+      "source": "ADR 0270 F3/D-5 — ProfileDistiller estendido p/ verdade-do-módulo; hoje só destila perfil comercial, NÃO escreve BRIEFING (instrumentação pendente — peça 2/3 do keystone)",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "MEM"
+    },
+    "read_path_hops": {
+      "status": "not_yet_measured",
+      "value": null,
+      "direction": "down",
+      "target": 1,
+      "source": "ADR 0270 D-5 — nº de docs abertos pra saber o estado atual de um módulo (meta 1; instrumentação pendente)",
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "MEM"
     },
     "drift_alarms": {
       "status": "not_yet_measured",
@@ -112,7 +139,8 @@
       "direction": "down",
       "target": "advisory perene",
       "source": "protection-drift + watchdog de staleness (GT-G4)",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "GT"
     },
     "backfill_error_rate": {
       "status": "not_yet_measured",
@@ -120,7 +148,8 @@
       "direction": "down",
       "target": "<2%",
       "source": "ledger do protocolo refutador G5 — só existe após 1º lote IA refutado",
-      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)"
+      "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
+      "stream": "GT"
     }
   }
 }

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -92,6 +92,20 @@ const notYet = (direction, target, source) => ({
   baseline_rule: '1ª medição real da fonte, nunca do plano (anti-stale)',
 });
 
+// ── stream de cada métrica (a "cola" que une SDD + memória num só scorecard) ──
+// SA=spec-anchor · FV=full-suite/verificação · KL=knowledge/ghost · GT=garantia ·
+// MEM=memória-unificada (read-path do ADR 0270) como stream de 1ª classe.
+// É a peça 4 do keystone da união (ledger 2026-06-19-adversario-uniao-sdd-memoria.md):
+// um SÓ scorecard governa SDD e memória — não dois sistemas paralelos.
+const STREAM = {
+  anchor_coverage: 'SA',
+  full_suite_pass_rate: 'FV', n_quarantine: 'FV', coverage_pct: 'FV',
+  ghost_count: 'KL',
+  front_door_coverage: 'MEM', recall_eval_violations: 'MEM', ragas_real_uptime: 'MEM',
+  distiller_freshness: 'MEM', read_path_hops: 'MEM',
+  drift_alarms: 'GT', backfill_error_rate: 'GT',
+};
+
 // ── fonte: floor do nightly CT100 (ADR 0279 — transporte Opção A · US-GOV-023) ─
 // Read-side do elo MEDIR→GOVERNAR. Lê governance/nightly-floor.json, que o write-side
 // (PR-2) escreve no CT100 via git-push [skip ci]. O artefato carrega floor_count =
@@ -128,13 +142,14 @@ function buildScorecard() {
   const kd = measureKnowledgeDrift();
   const an = measureAnchors();
   const q = measureQuarantine();
-  return {
+  const sc = {
     _meta: {
       scorecard: 'SDD — sistema spec-anchored + verificação agêntica (plano 2026-06-12 §2)',
       generator: 'scripts/governance/sdd-scorecard.mjs',
       plan: 'memory/sessions/2026-06-12-plano-reestruturacao-sdd-ondas-paralelas.md',
       determinismo: 'sem timestamps/sha no corpo — re-run sem mudança no repo = diff vazio',
-      composta: 'v1 (fontes parciais) ≠ v2 (10/10 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured',
+      composta: 'v1 (fontes parciais) ≠ v2 (12/12 vivas) — regimes não comparáveis; composta NÃO é calculada enquanto houver not_yet_measured',
+      streams: 'cada métrica tem `stream` — SA/FV/KL/GT + MEM (memória-unificada · read-path do ADR 0270). Um só scorecard governa SDD e memória (peça 4 da união; ledger memory/sessions/2026-06-19-adversario-uniao-sdd-memoria.md)',
       anchor_coverage_regra: 'delegado a scripts/governance/anchor-lint.mjs (ADR 0273 §2 — fonte única): (anchored_ok + pendente + parcial) / us_total. Antes era grep estrito próprio (divergia); unificado no PR do ledger §A.',
       ratchet: {
         baseline: 'governance/sdd-scorecard-baseline.json — armed POR MÉTRICA (ADR 0275 §3: arma após 3 medições válidas consecutivas da fonte real; armar/desarmar/piorar = PR editando o baseline, diff visível)',
@@ -173,12 +188,19 @@ function buildScorecard() {
         'golden set recall (KL-C2) — depende do alias map das 13 colisões ADR'),
       ragas_real_uptime: notYet('up', '≥95%',
         'RAGAS canário modo REAL diário (KL-D1/D4) — hoje compara mock com mock'),
+      distiller_freshness: notYet('down', '< 7d em 100% das portas',
+        'ADR 0270 F3/D-5 — ProfileDistiller estendido p/ verdade-do-módulo; hoje só destila perfil comercial, NÃO escreve BRIEFING (instrumentação pendente — peça 2/3 do keystone)'),
+      read_path_hops: notYet('down', 1,
+        'ADR 0270 D-5 — nº de docs abertos pra saber o estado atual de um módulo (meta 1; instrumentação pendente)'),
       drift_alarms: notYet('down', 'advisory perene',
         'protection-drift + watchdog de staleness (GT-G4)'),
       backfill_error_rate: notYet('down', '<2%',
         'ledger do protocolo refutador G5 — só existe após 1º lote IA refutado'),
     },
   };
+  // carimba o stream (SA/FV/KL/GT/MEM) em cada métrica — a "cola" da união num só scorecard
+  for (const [k, m] of Object.entries(sc.metrics)) m.stream = STREAM[k] ?? '?';
+  return sc;
 }
 
 // ── ratchet vs baseline VERSIONADO (GT-G3 meta-catraca) ─────────────────────


### PR DESCRIPTION
## Une SDD + memória num só scorecard (peça 4 do keystone da união)

Origem: o adversário (`memory/sessions/2026-06-19-adversario-uniao-sdd-memoria.md`) provou que NÃO há "um só sistema" — 4 scorecards paralelos. Esta peça começa a fechar isso pelo lado mais barato e seguro.

### O quê
- Carimba `stream` (SA/FV/KL/GT/**MEM**) em cada métrica do `sdd-scorecard.json`.
- **MEM = memória-unificada (read-path do ADR 0270) como cidadã de 1ª classe NO MESMO scorecard** — não num paralelo. `front_door_coverage`/`recall_eval`/`ragas` reetiquetados MEM.
- 2 métricas MEM novas, **notYet honestas** (anti-stale): `distiller_freshness` + `read_path_hops` — declaram que o distiller do 0270 (F3) ainda não escreve BRIEFING (peça 2/3 pendente).
- Read-side do **0279** (`full_suite` via `nightly-floor.json`) **já estava em main** — não dupliquei.

### Verificado local (node) — a régua nasce medida
- ✓ regenera · 12 `stream` · **determinístico** (2 runs, diff vazio)
- ✓ **2 lados do full_suite**: com `nightly-floor.json` → `measured` / sem → `not_yet_measured`
- ✓ **gate-selftest 8/8** — todas as catracas mordem (sdd-scorecard bad → exit 1)

### O que falta da união (não neste PR)
peça 1 (0279 read) ✅ em main · **peça 2** distiller-módulo-verdade (0270 F3, CT100) · **peça 3** `distiller_freshness` vivo · **peça 5** tirar `continue-on-error` quando armar. Additivo: não muda comportamento de gate (notYet não governa; stream é metadado).