### PR TITLE
feat(jana): ModuleTruthEventCollector — núcleo puro do distiller (PR-B)

### DIFF
--- a/Modules/Jana/Services/Memoria/ModuleTruthEventCollector.php
+++ b/Modules/Jana/Services/Memoria/ModuleTruthEventCollector.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Memoria;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * PR-B do keystone distiller-módulo-verdade ([ADR 0291] D-A · emenda 0270 F3).
+ *
+ * A DECISÃO de "o que distilar" — pura, determinística, testável SEM LLM/FS/DB.
+ * Dado o catálogo de eventos recentes de um módulo (sessions/handoffs/PRs/audits,
+ * cada um já com a lista de módulos que cita/toca) + a porta (`lastDistilledAt`)
+ * + a janela, devolve o subconjunto RELEVANTE e ORDENADO a alimentar a LLM.
+ *
+ * Espelha a separação ProfileDistiller × ContextSnapshotService: o cálculo
+ * (barato, testável) fica separado da chamada cara. O DistillerModuloVerdade
+ * (PR-C) lê o filesystem/git pra montar os eventos, chama este seletor, e só
+ * então invoca o AnonymousAgent.
+ *
+ * Regra da janela ([ADR 0291] D-A): "desde o último `distilled_at` OU 30 dias,
+ * o que for MAIOR". Janela maior = começa mais cedo = pega mais eventos — assim
+ * nunca se perde o que aconteceu desde a última destilação, e há sempre um piso
+ * de recência de 30d.
+ *
+ * Formato de evento (entrada — injetada, nunca lida aqui):
+ *   ['type' => 'session'|'handoff'|'pr'|'audit',
+ *    'ref'  => string,            // path do doc OU "#NNNN" do PR (proveniência)
+ *    'date' => ?string,           // 'YYYY-MM-DD' ou null (undated)
+ *    'modules' => string[],       // módulos citados/tocados pelo evento
+ *    'title'=> string]
+ */
+final class ModuleTruthEventCollector
+{
+    public const DEFAULT_WINDOW_DAYS = 30;
+
+    /** Sentinela de ordenação pra eventos sem data — sempre o "mais recente". */
+    private const UNDATED_SENTINEL = '9999-12-31';
+
+    /**
+     * Data-limite inferior (inclusiva) da janela de destilação.
+     *
+     * start = min(now - windowDays, lastDistilledAt) — a MAIOR janela vence.
+     */
+    public static function windowStart(?string $lastDistilledAt, int $windowDays, string $now): string
+    {
+        $base = CarbonImmutable::parse($now)->subDays(max(0, $windowDays))->toDateString();
+
+        return ($lastDistilledAt !== null && $lastDistilledAt !== '' && $lastDistilledAt < $base)
+            ? $lastDistilledAt
+            : $base;
+    }
+
+    /** Verdadeiro se o evento cita/toca o módulo (membership case-insensitive). */
+    public static function isRelevant(array $event, string $module): bool
+    {
+        $needle = mb_strtolower(trim($module));
+        if ($needle === '') {
+            return false;
+        }
+        foreach (($event['modules'] ?? []) as $m) {
+            if (mb_strtolower(trim((string) $m)) === $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Seleciona + ordena os eventos a destilar pra um módulo.
+     *
+     * Filtra por (relevante ao módulo) E (sem data OU dentro da janela). Ordena
+     * do mais recente pro mais antigo, com os undated no topo (relevantes mas
+     * sem data não são silenciosamente descartados). `maxEvents` (>0) limita aos
+     * N mais recentes — prioridade é parte da decisão.
+     *
+     * @param  array<int, array<string, mixed>>  $events
+     * @return array<int, array<string, mixed>>
+     */
+    public static function select(
+        array $events,
+        string $module,
+        ?string $lastDistilledAt,
+        int $windowDays = self::DEFAULT_WINDOW_DAYS,
+        ?string $now = null,
+        ?int $maxEvents = null,
+    ): array {
+        $now ??= CarbonImmutable::now()->toDateString();
+        $start = self::windowStart($lastDistilledAt, $windowDays, $now);
+
+        $selected = array_values(array_filter($events, static function (array $e) use ($module, $start): bool {
+            if (! self::isRelevant($e, $module)) {
+                return false;
+            }
+            $date = $e['date'] ?? null;
+
+            return $date === null || $date === '' || (string) $date >= $start;
+        }));
+
+        // Ordena desc por data (undated = sentinela = topo). usort do PHP 8+ é
+        // estável → empates preservam a ordem de inserção (determinístico).
+        usort($selected, static function (array $a, array $b): int {
+            $ka = ($a['date'] ?? null) ?: self::UNDATED_SENTINEL;
+            $kb = ($b['date'] ?? null) ?: self::UNDATED_SENTINEL;
+
+            return strcmp((string) $kb, (string) $ka);
+        });
+
+        if ($maxEvents !== null && $maxEvents > 0 && count($selected) > $maxEvents) {
+            $selected = array_slice($selected, 0, $maxEvents);
+        }
+
+        return $selected;
+    }
+}

--- a/Modules/Jana/Tests/Unit/ModuleTruthEventCollectorTest.php
+++ b/Modules/Jana/Tests/Unit/ModuleTruthEventCollectorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Memoria\ModuleTruthEventCollector;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-B do keystone distiller-módulo-verdade (ADR 0291 D-A).
+ *
+ * A decisão de "o que distilar" é PURA e testável: dada uma lista de eventos
+ * (sessions/handoffs/PRs/audits) + a porta (`lastDistilledAt`) + a janela,
+ * devolve o subconjunto relevante ao módulo, ordenado. SEM LLM, SEM filesystem,
+ * SEM DB — só a regra de seleção. Espelha a separação ProfileDistiller ×
+ * ContextSnapshotService (o cálculo separado da chamada cara).
+ *
+ * Regra da janela (ADR 0291 D-A): "desde o último distilled_at OU 30 dias, o
+ * que for MAIOR" — janela maior = começa mais cedo = pega mais eventos.
+ */
+
+$NOW = '2026-06-19';
+
+/** Helper compacto pra montar evento de teste. */
+function ev(string $type, string $ref, ?string $date, array $modules, string $title = ''): array
+{
+    return ['type' => $type, 'ref' => $ref, 'date' => $date, 'modules' => $modules, 'title' => $title];
+}
+
+// ---------------------------------------------------------------------------
+// windowStart — a regra "o que for maior"
+// ---------------------------------------------------------------------------
+
+test('windowStart usa 30d quando nunca destilou (lastDistilledAt null)', function () use ($NOW) {
+    expect(ModuleTruthEventCollector::windowStart(null, 30, $NOW))->toBe('2026-05-20');
+});
+
+test('windowStart estende pra trás até lastDistilledAt quando ele é mais velho que a janela', function () use ($NOW) {
+    // destilado há 60d → janela "desde destilado" (60d) é MAIOR que 30d → começa em 2026-04-20
+    expect(ModuleTruthEventCollector::windowStart('2026-04-20', 30, $NOW))->toBe('2026-04-20');
+});
+
+test('windowStart mantém o piso de 30d quando lastDistilledAt é recente', function () use ($NOW) {
+    // destilado há 5d → 30d é MAIOR → mantém o piso 2026-05-20 (não 2026-06-14)
+    expect(ModuleTruthEventCollector::windowStart('2026-06-14', 30, $NOW))->toBe('2026-05-20');
+});
+
+// ---------------------------------------------------------------------------
+// isRelevant — pertinência por módulo (case-insensitive)
+// ---------------------------------------------------------------------------
+
+test('isRelevant casa o módulo independente de caixa', function () {
+    $e = ev('session', 's1.md', '2026-06-10', ['Financeiro', 'Sells']);
+    expect(ModuleTruthEventCollector::isRelevant($e, 'financeiro'))->toBeTrue();
+    expect(ModuleTruthEventCollector::isRelevant($e, 'SELLS'))->toBeTrue();
+});
+
+test('isRelevant é falso quando o módulo não está citado ou a chave falta', function () {
+    expect(ModuleTruthEventCollector::isRelevant(ev('pr', '#1', '2026-06-10', ['Crm']), 'Financeiro'))->toBeFalse();
+    expect(ModuleTruthEventCollector::isRelevant(['type' => 'pr', 'ref' => '#1'], 'Financeiro'))->toBeFalse();
+});
+
+// ---------------------------------------------------------------------------
+// select — a seleção completa
+// ---------------------------------------------------------------------------
+
+test('select pega evento relevante dentro da janela', function () use ($NOW) {
+    $events = [ev('session', 's1.md', '2026-06-10', ['Financeiro'], 'fix baixa')];
+    $out = ModuleTruthEventCollector::select($events, 'Financeiro', null, 30, $NOW);
+    expect($out)->toHaveCount(1);
+    expect($out[0]['ref'])->toBe('s1.md');
+});
+
+test('select exclui evento que não cita o módulo', function () use ($NOW) {
+    $events = [ev('session', 's1.md', '2026-06-10', ['Crm'])];
+    expect(ModuleTruthEventCollector::select($events, 'Financeiro', null, 30, $NOW))->toBe([]);
+});
+
+test('select exclui evento relevante mais velho que a janela (sem lastDistilledAt)', function () use ($NOW) {
+    $events = [ev('handoff', 'h1.md', '2026-04-01', ['Financeiro'])]; // > 30d
+    expect(ModuleTruthEventCollector::select($events, 'Financeiro', null, 30, $NOW))->toBe([]);
+});
+
+test('select inclui evento entre lastDistilledAt antigo e o piso de 30d (janela estendida)', function () use ($NOW) {
+    $events = [ev('audit', 'a1.md', '2026-04-25', ['Financeiro'])]; // fora dos 30d, mas após destilado 04-20
+    $out = ModuleTruthEventCollector::select($events, 'Financeiro', '2026-04-20', 30, $NOW);
+    expect($out)->toHaveCount(1);
+    expect($out[0]['ref'])->toBe('a1.md');
+});
+
+test('select inclui evento relevante sem data (undated não é silenciosamente descartado)', function () use ($NOW) {
+    $events = [ev('pr', '#42', null, ['Financeiro'])];
+    $out = ModuleTruthEventCollector::select($events, 'Financeiro', null, 30, $NOW);
+    expect($out)->toHaveCount(1);
+});
+
+test('select ordena do mais recente pro mais antigo, com undated no topo', function () use ($NOW) {
+    $events = [
+        ev('session', 'velho.md', '2026-06-01', ['Financeiro']),
+        ev('session', 'novo.md', '2026-06-15', ['Financeiro']),
+        ev('pr', 'sem-data', null, ['Financeiro']),
+    ];
+    $out = ModuleTruthEventCollector::select($events, 'Financeiro', null, 30, $NOW);
+    expect(array_column($out, 'ref'))->toBe(['sem-data', 'novo.md', 'velho.md']);
+});
+
+test('select respeita o teto maxEvents mantendo os mais recentes', function () use ($NOW) {
+    $events = [
+        ev('session', 'd1', '2026-06-10', ['Financeiro']),
+        ev('session', 'd2', '2026-06-12', ['Financeiro']),
+        ev('session', 'd3', '2026-06-18', ['Financeiro']),
+    ];
+    $out = ModuleTruthEventCollector::select($events, 'Financeiro', null, 30, $NOW, 2);
+    expect(array_column($out, 'ref'))->toBe(['d3', 'd2']);
+});
+
+test('select devolve vazio quando não há evento do módulo', function () use ($NOW) {
+    expect(ModuleTruthEventCollector::select([], 'Financeiro', null, 30, $NOW))->toBe([]);
+});


### PR DESCRIPTION
## PR-B do keystone distiller-módulo-verdade — a decisão PURA de "o que distilar"

Implementa **[ADR 0291](memory/decisions/0291-distiller-modulo-verdade-contrato-emenda-0270-f3.md) D-A** (entregável "decisão de o que distilar pura/testável"). Contrato em PR **#3015**.

`Modules\Jana\Services\Memoria\ModuleTruthEventCollector` — dada uma lista de eventos (sessions/handoffs/PRs/audits, cada um com os módulos que cita/toca) + `lastDistilledAt` + janela, devolve o subconjunto **relevante ao módulo, ordenado**. **SEM LLM, SEM filesystem, SEM DB** — espelha a separação `ProfileDistiller` × `ContextSnapshotService` (cálculo barato separado da chamada cara). O `DistillerModuloVerdade` (PR-C) vai ler FS/git pra montar os eventos, chamar este seletor, e só então invocar o `AnonymousAgent`.

### Regras (testadas)
- **Janela "o que for maior"** (D-A): `windowStart` = `min(now − 30d, lastDistilledAt)` → nunca perde o que houve desde a última destilação, com piso de recência de 30d.
- **Relevância** case-insensitive (`isRelevant`).
- **Ordenação** mais-recente-primeiro; **undated no topo** (relevante sem data não é descartado em silêncio).
- **`maxEvents`** limita aos N mais recentes (prioridade faz parte da decisão).

### Testes
13 testes Pest unitários (`ModuleTruthEventCollectorTest`) cobrindo windowStart (3 casos da regra), isRelevant (2), select (8: relevância, janela estendida, exclusão por idade, undated, ordenação, cap, vazio). Puros — não tocam DB/rede (CI roda; sem PHP local neste worktree).

### Disciplina
- RED-first (teste antes da impl). 236 linhas. PII scan limpo. `feat(jana)` 1-intent.
- Independente de #3015 (referencia o ADR, não importa). Próximo: **PR-C** (service + comando + cron) — onde entra a LLM/escrita de BRIEFING (mais sensível ao contrato → aguardo sinal de revisão do #3015).

🤖 Generated with [Claude Code](https://claude.com/claude-code)