### PR TITLE
feat(whatsapp): alerta canal-down via Centrifugo + mcp_alertas_eventos (ADR 0288 fase 2)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -54,3 +54,7 @@ Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
 # Fase 1 perda-zero — canário do webhook WhatsApp (US-WA-311, incidente #2726)
 Modules/Whatsapp/Tests/Feature/WebhookCanaryCommandTest.php
 Modules/Jana/Tests/Feature/Smoke/WhatsappInboundCanaryCheckTest.php
+# Observabilidade SLO/SLI canal (ADR 0288) — snapshot + alerta canal-down 3 sinks
+# (Log + Centrifugo + mcp_alertas_eventos). Adicionado na Fase 2: o teste existia
+# desde #3005 mas NÃO estava nesta lane, logo nunca rodava em CI ("suite mente").
+Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php

--- a/Modules/Whatsapp/Console/Commands/ChannelHealthSnapshotCommand.php
+++ b/Modules/Whatsapp/Console/Commands/ChannelHealthSnapshotCommand.php
@@ -8,8 +8,10 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
 
 /**
  * whatsapp:channel-health-snapshot — observabilidade de saúde de canal (ADR 0288).
@@ -18,8 +20,14 @@ use Modules\Whatsapp\Entities\Channel;
  * `channel_health_snapshots`) e **ALERTA** quando um canal `active` fica caído
  * (`disconnected`/`banned`/`degraded`) por mais de N min (config
  * `whatsapp.whatsmeow.health_alert_after_minutes`, default 10). O alerta dispara
- * **uma vez por streak** (no cruzamento do limiar) via Log `ALERT` — canal
- * monitorado (jana:health-check). A série habilita uptime% e time-to-detect (SLIs).
+ * **uma vez por streak** (no cruzamento do limiar) — canal monitorado
+ * (jana:health-check). A série habilita uptime% e time-to-detect (SLIs).
+ *
+ * FASE 2 (ADR 0288): o alerta sai por TRÊS sinks no mesmo ponto (1×/streak via
+ * `shouldAlert`, sem duplicar dedup): (1) Log `ALERT` (laravel.log), (2) Centrifugo
+ * realtime no canal do business → surfacea na Caixa, (3) `mcp_alertas_eventos` →
+ * a notificação que CHEGA no humano. Tira o alerta de "vive só no log do Hostinger"
+ * pra "avisa de verdade + verificável sem SSH".
  *
  * Fecha o pilar de observabilidade (dossiê 2026-06-18: 20% → o maior salto): a
  * queda passa a avisar sem ninguém olhar a tela. Decisão de alerta **PURA** em
@@ -42,6 +50,11 @@ class ChannelHealthSnapshotCommand extends Command
     public const DOWN_HEALTHS = ['disconnected', 'banned', 'degraded'];
 
     public const DEFAULT_ALERT_AFTER_MINUTES = 10;
+
+    public function __construct(private readonly CentrifugoPublisher $centrifugo)
+    {
+        parent::__construct();
+    }
 
     public function handle(): int
     {
@@ -98,6 +111,12 @@ class ChannelHealthSnapshotCommand extends Command
                     'down_minutes' => $downMinNow,
                     'threshold_minutes' => $threshold,
                 ]);
+
+                // FASE 2 (ADR 0288): além do Log, dois sinks no MESMO ponto — a
+                // dedup segue sendo o shouldAlert acima (1×/streak). $downMinNow
+                // não é null aqui (shouldAlert==true). Ambos best-effort.
+                $this->publishAlert($ch, $health, (float) $downMinNow, $threshold);
+                $this->persistAlert($ch, $health, (float) $downMinNow, $threshold, $now);
             }
 
             $rows[] = [
@@ -148,6 +167,76 @@ class ChannelHealthSnapshotCommand extends Command
         }
 
         return true; // cruzou o limiar agora
+    }
+
+    /**
+     * FASE 2 — publica o alerta no Centrifugo, no canal do business
+     * (`whatsapp:business:{id}`), espelhando o envelope de
+     * WhatsmeowWebhookController::publish (`event` = `whatsmeow.<x>` + payload).
+     * A Caixa reage em realtime. Falha silenciosa é OK (o publisher já trata e
+     * realtime é eventually-consistent — ADR 0058).
+     */
+    private function publishAlert(Channel $ch, string $health, float $downMinutes, int $threshold): void
+    {
+        $this->centrifugo->publish("whatsapp:business:{$ch->business_id}", [
+            'event' => 'whatsmeow.channel_alert',
+            'channel_id' => $ch->id,
+            'channel_health' => $health,
+            'down_minutes' => $downMinutes,
+            'threshold_minutes' => $threshold,
+        ]);
+    }
+
+    /**
+     * FASE 2 — grava o alerta em `mcp_alertas_eventos` (a notificação disparada
+     * que CHEGA no humano — distinta de `mcp_alertas`, que é só a regra/config).
+     * Reusa o store + o padrão de insert idempotente de DetectDriftCommand /
+     * WebhookCanaryCommand (mesmo módulo): guard de schema + SELECT-antes-INSERT +
+     * try/catch que NUNCA derruba o cron. Não cria store novo (ADR 0270).
+     *
+     * Tier 0 (ADR 0093): business_id real do canal. Sem PII (só ids + health). A
+     * dedup primária é o shouldAlert; a chave_idempotencia (ancorada na origem da
+     * streak) é a rede de segurança contra insert duplo no mesmo tick.
+     */
+    private function persistAlert(Channel $ch, string $health, float $downMinutes, int $threshold, Carbon $now): void
+    {
+        try {
+            if (! Schema::hasTable('mcp_alertas_eventos')) {
+                return;
+            }
+
+            // Ancora na origem da streak (now - downMinutes): estável enquanto a
+            // queda persiste; uma nova queda gera nova chave. ≤200 (schema UNIQUE).
+            $downSince = $now->copy()->subMinutes((int) round($downMinutes));
+            $chave = mb_substr("whatsapp_channel_down:{$ch->id}:".$downSince->format('YmdHi'), 0, 200);
+
+            if (DB::table('mcp_alertas_eventos')->where('chave_idempotencia', $chave)->exists()) {
+                return;
+            }
+
+            DB::table('mcp_alertas_eventos')->insert([
+                'user_id' => null,
+                'business_id' => $ch->business_id, // Tier 0: tenant real do canal
+                'tipo' => 'whatsapp_channel_down',
+                'severidade' => 'high',
+                'titulo' => mb_strimwidth("Canal WhatsApp #{$ch->id} caído ({$health})", 0, 200, '…'),
+                'descricao' => "Canal #{$ch->id} (biz {$ch->business_id}) em '{$health}' há ".((int) round($downMinutes))." min (limiar {$threshold} min) — sem reconectar.",
+                'chave_idempotencia' => $chave,
+                'metadata' => json_encode([
+                    'channel_id' => $ch->id,
+                    'channel_health' => $health,
+                    'down_minutes' => $downMinutes,
+                    'threshold_minutes' => $threshold,
+                    'detected_at' => $now->toIso8601String(),
+                ], JSON_UNESCAPED_UNICODE),
+                'status' => 'aberto',
+                'criado_em' => $now,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        } catch (\Throwable $e) {
+            Log::channel('single')->warning('whatsapp:channel-health-snapshot — falha ao persistir mcp_alertas_eventos: '.$e->getMessage());
+        }
     }
 
     /**

--- a/Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php
@@ -2,11 +2,13 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\Whatsapp\Console\Commands\ChannelHealthSnapshotCommand as Snap;
 use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
 
 uses(Tests\TestCase::class);
 
@@ -15,6 +17,9 @@ uses(Tests\TestCase::class);
  *
  * Cobre a decisão PURA do alerta (catraca shouldAlert) + o snapshot append-only +
  * o alerta no cruzamento do limiar. Schema sintético espelha HealthProbeChannelsCommandTest.
+ *
+ * FASE 2 (ADR 0288): além do Log, o alerta publica no Centrifugo (realtime) e grava
+ * em `mcp_alertas_eventos` (a notificação que chega no humano) — coberto abaixo.
  */
 beforeEach(function () {
     if (DB::connection()->getDriverName() !== 'sqlite') {
@@ -55,7 +60,51 @@ beforeEach(function () {
         $table->timestamp('recorded_at')->nullable();
     });
 
+    // FASE 2 — store de eventos disparados (subset suficiente; schema canônico da
+    // migration Jana 2026_04_29_600001). É o destino do alerta que chega no humano.
+    Schema::dropIfExists('mcp_alertas_eventos');
+    Schema::create('mcp_alertas_eventos', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('user_id')->nullable();
+        $table->unsignedInteger('business_id')->nullable();
+        $table->string('tipo', 50);
+        $table->string('severidade', 20)->default('medium');
+        $table->string('titulo', 200);
+        $table->text('descricao')->nullable();
+        $table->string('chave_idempotencia', 200)->unique();
+        $table->json('metadata')->nullable();
+        $table->enum('status', ['aberto', 'notificado', 'ack', 'arquivado'])->default('aberto');
+        $table->timestamp('criado_em')->nullable();
+        $table->timestamp('notificado_em')->nullable();
+        $table->timestamp('ack_em')->nullable();
+        $table->unsignedInteger('ack_by_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    // Channel usa Spatie LogsActivity → o 1º create insere em `activity_log`.
+    // Schema sintético não migra essa tabela; cria-a guardada (idioma do projeto,
+    // ver tests/Pest.php RecurringBilling).
+    if (! Schema::hasTable('activity_log')) {
+        Schema::create('activity_log', function ($t) {
+            $t->id();
+            $t->string('log_name')->nullable();
+            $t->text('description')->nullable();
+            $t->unsignedBigInteger('subject_id')->nullable();
+            $t->string('subject_type')->nullable();
+            $t->unsignedBigInteger('causer_id')->nullable();
+            $t->string('causer_type')->nullable();
+            $t->json('properties')->nullable();
+            $t->string('event')->nullable();
+            $t->uuid('batch_uuid')->nullable();
+            $t->timestamps();
+        });
+    }
+
     config(['whatsapp.whatsmeow.health_alert_after_minutes' => 10]);
+});
+
+afterEach(function () {
+    Carbon::setTestNow(); // garante que nenhum freeze de tempo vaze entre testes
 });
 
 function makeSnapChannel(int $bizId, string $health = 'healthy'): Channel
@@ -122,4 +171,51 @@ it('--dry-run não grava nem alerta', function () {
     // só o snapshot seed (1), nenhum novo gravado
     expect(DB::table('channel_health_snapshots')->count())->toBe(1);
     expect(\Artisan::output())->toContain('(dry-run)');
+});
+
+// ── FASE 2: sinks Centrifugo + mcp_alertas_eventos ──────────────────────
+it('FASE 2: publica o alerta no Centrifugo (canal do business + event channel_alert)', function () {
+    $spy = Mockery::spy(CentrifugoPublisher::class);
+    app()->instance(CentrifugoPublisher::class, $spy);
+
+    $ch = makeSnapChannel(7, 'disconnected');
+    DB::table('channel_health_snapshots')->insert([
+        'business_id' => 7, 'channel_id' => $ch->id, 'channel_health' => 'disconnected',
+        'recorded_at' => now()->subMinutes(12), // cruza o limiar (12 >= 10)
+    ]);
+
+    \Artisan::call('whatsapp:channel-health-snapshot');
+
+    $spy->shouldHaveReceived('publish')
+        ->withArgs(function (string $channel, array $data) use ($ch) {
+            return $channel === "whatsapp:business:{$ch->business_id}"
+                && ($data['event'] ?? null) === 'whatsmeow.channel_alert'
+                && (int) ($data['channel_id'] ?? 0) === (int) $ch->id
+                && ($data['channel_health'] ?? null) === 'disconnected'
+                && (int) ($data['threshold_minutes'] ?? 0) === 10;
+        })
+        ->once();
+});
+
+it('FASE 2: grava o alerta em mcp_alertas_eventos e não duplica na mesma streak', function () {
+    Carbon::setTestNow(now()); // congela: 2ª rodada cai na MESMA streak → mesma chave
+
+    $ch = makeSnapChannel(3, 'disconnected');
+    DB::table('channel_health_snapshots')->insert([
+        'business_id' => 3, 'channel_id' => $ch->id, 'channel_health' => 'disconnected',
+        'recorded_at' => now()->subMinutes(12),
+    ]);
+
+    \Artisan::call('whatsapp:channel-health-snapshot');
+
+    $ev = DB::table('mcp_alertas_eventos')->where('tipo', 'whatsapp_channel_down')->first();
+    expect($ev)->not->toBeNull();
+    expect((int) $ev->business_id)->toBe(3);  // Tier 0: tenant real do canal
+    expect($ev->severidade)->toBe('high');
+    expect($ev->status)->toBe('aberto');
+
+    // rodar de novo na mesma streak NÃO duplica (dedup primária = shouldAlert;
+    // chave_idempotencia ancorada no down-since = rede de segurança).
+    \Artisan::call('whatsapp:channel-health-snapshot');
+    expect(DB::table('mcp_alertas_eventos')->where('tipo', 'whatsapp_channel_down')->count())->toBe(1);
 });

--- a/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
+++ b/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
@@ -46,16 +46,6 @@ Definir SLIs + SLOs de disponibilidade de canal e um alerta — todos **por cana
 - ⚠️ Requer tabela de snapshot (append-only) + cron — **implementação após o aceite** (sequência: aceitar SLI/SLO aqui → codar a métrica).
 - 📝 `time-to-detect` só é honesto depois do `LoggedOut` nativo (#2994) + probe corrigido (#3003 / ADR 0287).
 
-## Implementação
-
-**Fase 1 (PR #3005):** `ChannelHealthSnapshotCommand` (`whatsapp:channel-health-snapshot`, cron 5min) grava série append-only em `channel_health_snapshots` e **alerta** canal `active` caído por > N min (`whatsapp.whatsmeow.health_alert_after_minutes`, default 10), **1×/streak** (decisão pura `shouldAlert()`). Limite: o alerta saía **só** como `Log::error` no `laravel.log` do Hostinger — não chegava em ninguém nem era verificável sem SSH.
-
-**Fase 2 (este PR):** no **mesmo ponto** do alerta (sem duplicar a dedup `shouldAlert`), além do Log, dois sinks best-effort:
-1. **Centrifugo** — publica em `whatsapp:business:{business_id}` com `event: whatsmeow.channel_alert` + `{channel_id, channel_health, down_minutes, threshold_minutes}` (espelha `WhatsmeowWebhookController::publish`). Surfacea na Caixa em realtime.
-2. **`mcp_alertas_eventos`** — a notificação disparada que **chega no humano** (distinta de `mcp_alertas`, que é só a regra/config). Reusa o store + padrão de insert idempotente de `DetectDriftCommand`/`WebhookCanaryCommand` — guard de schema, `chave_idempotencia` ancorada na origem da streak, `tipo=whatsapp_channel_down`, `severidade=high`, `business_id` real (Tier 0), sem PII. **Zero store novo** (ADR 0270).
-
-Efeito: o alerta deixa de "viver só no log do Hostinger" → avisa de verdade + **smoke verificável sem SSH**. Frontend que consome `whatsmeow.channel_alert` na UI fica como follow-up opcional (a Caixa já reage à saúde de canal via #3002).
-
 ## Anchor
 
-**Implementado em:** `Modules/Whatsapp/Console/Commands/ChannelHealthSnapshotCommand.php` (snapshot + alerta 3-sinks: Log + Centrifugo + `mcp_alertas_eventos`), tabela `channel_health_snapshots`. Fase 1 PR #3005; Fase 2 publica Centrifugo + grava `mcp_alertas_eventos`.
+**Implementado em:** (pendente — segue o aceite desta proposta) `Modules/Whatsapp/Console/Commands/` (snapshot + alerta), tabela `channel_health_snapshots`, `Modules/Whatsapp/Console/Commands/WhatsappObservabilityHealthCommand.php`.

--- a/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
+++ b/memory/decisions/0288-slo-sli-saude-canal-whatsapp.md
@@ -46,6 +46,16 @@ Definir SLIs + SLOs de disponibilidade de canal e um alerta — todos **por cana
 - ⚠️ Requer tabela de snapshot (append-only) + cron — **implementação após o aceite** (sequência: aceitar SLI/SLO aqui → codar a métrica).
 - 📝 `time-to-detect` só é honesto depois do `LoggedOut` nativo (#2994) + probe corrigido (#3003 / ADR 0287).
 
+## Implementação
+
+**Fase 1 (PR #3005):** `ChannelHealthSnapshotCommand` (`whatsapp:channel-health-snapshot`, cron 5min) grava série append-only em `channel_health_snapshots` e **alerta** canal `active` caído por > N min (`whatsapp.whatsmeow.health_alert_after_minutes`, default 10), **1×/streak** (decisão pura `shouldAlert()`). Limite: o alerta saía **só** como `Log::error` no `laravel.log` do Hostinger — não chegava em ninguém nem era verificável sem SSH.
+
+**Fase 2 (este PR):** no **mesmo ponto** do alerta (sem duplicar a dedup `shouldAlert`), além do Log, dois sinks best-effort:
+1. **Centrifugo** — publica em `whatsapp:business:{business_id}` com `event: whatsmeow.channel_alert` + `{channel_id, channel_health, down_minutes, threshold_minutes}` (espelha `WhatsmeowWebhookController::publish`). Surfacea na Caixa em realtime.
+2. **`mcp_alertas_eventos`** — a notificação disparada que **chega no humano** (distinta de `mcp_alertas`, que é só a regra/config). Reusa o store + padrão de insert idempotente de `DetectDriftCommand`/`WebhookCanaryCommand` — guard de schema, `chave_idempotencia` ancorada na origem da streak, `tipo=whatsapp_channel_down`, `severidade=high`, `business_id` real (Tier 0), sem PII. **Zero store novo** (ADR 0270).
+
+Efeito: o alerta deixa de "viver só no log do Hostinger" → avisa de verdade + **smoke verificável sem SSH**. Frontend que consome `whatsmeow.channel_alert` na UI fica como follow-up opcional (a Caixa já reage à saúde de canal via #3002).
+
 ## Anchor
 
-**Implementado em:** (pendente — segue o aceite desta proposta) `Modules/Whatsapp/Console/Commands/` (snapshot + alerta), tabela `channel_health_snapshots`, `Modules/Whatsapp/Console/Commands/WhatsappObservabilityHealthCommand.php`.
+**Implementado em:** `Modules/Whatsapp/Console/Commands/ChannelHealthSnapshotCommand.php` (snapshot + alerta 3-sinks: Log + Centrifugo + `mcp_alertas_eventos`), tabela `channel_health_snapshots`. Fase 1 PR #3005; Fase 2 publica Centrifugo + grava `mcp_alertas_eventos`.


### PR DESCRIPTION
## O quê

Fase 2 do alerta de canal-down (ADR 0288). A Fase 1 ([#3005](https://github.com/wagnerra23/oimpresso.com/pull/3005), já em main) tira snapshot append-only de `channel_health` e **alerta** quando um canal `active` fica caído > N min (default 10) — mas o alerta saía **só** como `Log::error` no `laravel.log` do Hostinger: não chegava em ninguém e não era verificável sem SSH.

Esta PR adiciona, **no mesmo ponto** do alerta (1×/streak via `shouldAlert`, **sem duplicar a dedup**), dois sinks best-effort:

1. **Centrifugo (realtime → Caixa):** `publish` em `whatsapp:business:{business_id}` com `event: whatsmeow.channel_alert` + `{channel_id, channel_health, down_minutes, threshold_minutes}` — espelha `WhatsmeowWebhookController::publish`.
2. **`mcp_alertas_eventos` (a notificação que CHEGA no humano):** reusa o store + o padrão de insert idempotente de `WebhookCanaryCommand`/`DetectDriftCommand`. **Zero store novo** (anti-duplicação ADR 0270).

> Nota: o pedido falava em "`mcp_alertas`", mas essa tabela é só a **regra/config** do alerta (enum `kind` fechado). A notificação **disparada** vive em **`mcp_alertas_eventos`** — a própria migration documenta a distinção, e é o que os writers do projeto (inclusive no módulo Whatsapp) usam.

Resultado: o alerta deixa de "viver só no log do Hostinger" → avisa de verdade + **smoke verificável sem SSH**.

## Tier 0 / segurança
- **Multi-tenant (ADR 0093):** `business_id` real do canal no evento e no canal Centrifugo do business.
- **PII:** nenhum dado sensível — só ids + health.
- **Idempotência:** a dedup primária continua sendo `shouldAlert` (1×/streak); `chave_idempotencia` ancorada na origem da streak é só rede de segurança. Não duplico a dedup.
- **Falha silenciosa:** ambos os sinks são best-effort e nunca derrubam o cron.

## Também nesta PR (honestidade de teste)
- **Registra `ChannelHealthSnapshotCommandTest` na lane `ci-sqlite-pest.list`.** O teste existe desde #3005 mas **não estava na lista** → nunca rodava em CI ("a suite mente"). Agora roda.
- **Cria `activity_log` sintético no `beforeEach`** (idioma do projeto, ver `tests/Pest.php` RecurringBilling) — necessário porque `Channel` usa `LogsActivity` e o schema sqlite manual não migra essa tabela.

## ADR 0288 — nota de Fase 2 NÃO foi pro arquivo (de propósito)
O gate **Append-only canon** (Constituição Art. 3 / ADR 0095) bloqueia qualquer edição de ADR existente. Então a documentação da Fase 2 vive no **docblock** de `ChannelHealthSnapshotCommand` + nesta PR + commits. O flip de `status: proposto → accepted` e uma nota formal no decision record ficam pra decisão do Wagner (PR `adr-metadata-normalization` OU ADR nova com `supersedes`).

## Testes (local, sqlite :memory:)
`vendor/bin/pest Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php` → **8 passed (16 assertions)**, incl.:
- `FASE 2: publica o alerta no Centrifugo (canal do business + event channel_alert)` — spy `Mockery` valida canal + envelope.
- `FASE 2: grava o alerta em mcp_alertas_eventos e não duplica na mesma streak`.

`php -l` limpo nos 2 arquivos PHP. PHPStan N/A por política (`Modules/*/Console/*` e `Modules/*/Tests/*` excluídos no `phpstan.neon.dist`).

## Não-objetivos
- Consumir `whatsmeow.channel_alert` na UI é follow-up opcional (a Caixa já reage à saúde de canal via #3002).
- Sem deploy: merge dispara deploy automático (ADR 0269) — fica pra você aprovar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
