### PR TITLE
docs(proposal): Camada 6 — resiliência download de mídia + alarme daemon-inalcançável

### DIFF
--- a/memory/decisions/proposals/whatsapp-ingestao-perda-zero.md
+++ b/memory/decisions/proposals/whatsapp-ingestao-perda-zero.md
@@ -58,6 +58,11 @@ count/chat/oldest-id) → emite eventos `HistorySync`. Plano:
 **Bônus:** o mesmo mecanismo **recupera as mensagens dos 3 dias do #2726** — resolve o
 "backlog perdido" da US-WA-311 de graça.
 
+> ⚠️ **Não confundir dois backlogs distintos:** (1) **mensagens perdidas** (#2726, webhook
+> recusado) = esta Camada 2. (2) **mídia não-baixada** de mensagens que *chegaram* normalmente
+> (48.569 em `media_download_status='pending'`, incidente DNS 2026-06-19) = **Camada 6** abaixo.
+> A mensagem existe na Caixa; só a mídia não desceu. Mecanismos e causas-raiz diferentes.
+
 ### Camada 3 — Auto-cura
 Sessão caiu (`Disconnected`/stream error) → `WhatsmeowReconciler` reconecta sozinho
 (já resolve pending-pair; estender pra reconexão proativa). Falha transitória de
@@ -74,7 +79,47 @@ O canário (camada 1) PROVA continuamente que o caminho + o alerta funcionam. Se
 o monitor pode apodrecer mentindo "verde" (raiz do #2726). Opcional: um 2º canário
 no CT 100 testando o caminho daemon→app (rede), não só app→app.
 
+### Camada 6 — resiliência do download de mídia + alarme de daemon-inalcançável (era o "US-WA-311")
+
+**Incidente 2026-06-19 (root cause provado):** **48.569** mensagens em
+`media_download_status='pending'` (vs 659 `success`, 14 `failed_permanent`) acumuladas desde
+~12/jun. Diagnóstico read-only (handoff `2026-06-19-1103-midia-dns-rootcause`):
+
+- O A record **`whatsapp-whatsmeow.oimpresso.com` sumiu da zona DNS Hostinger** → **NXDOMAIN**
+  (DoH `dns.google` Status 3 + `getent` do próprio CT 100; SOA serial `2026061801`).
+- O daemon (CT 100, `177.74.67.30`) está **`Up 3 semanas (healthy)`**; Traefik **casa o `Host()` rule**
+  (loopback → `http_404`, não-000 = rota OK) e o daemon serve `/health` `http_200` direto.
+- `DownloadMediaJob::fetchViaWhatsmeowDownload` (roda no **Hostinger**) chama
+  `config('whatsapp.whatsmeow.daemon_url')` = o host que NXDOMAINa → **soft-fail silencioso** →
+  fica `pending` pra sempre. Webhooks inbound seguem OK (vão pro `oimpresso.com`, que resolve).
+
+→ **Não é bug de código.** O worker, o endpoint e o env estão corretos. Quebrou **1 entrada de DNS**.
+
+**Fix imediato (PROD/DNS — Wagner aprova/executa, publication-policy):** recriar o A record via
+Hostinger DNS API ([ADR 0045](../0045-hostinger-dns-api-endpoint-canonico.md)), `overwrite:false`:
+
+```bash
+curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+  "https://developers.hostinger.com/api/dns/v1/zones/oimpresso.com" \
+  -d '{"overwrite":false,"zone":[{"name":"whatsapp-whatsmeow","type":"A","ttl":300,"records":[{"content":"177.74.67.30"}]}]}'
+```
+
+**Drain (pós-DNS, idempotente):** `php artisan whatsapp:backfill-media-download --business=all --since=2026-06-01`
+em lotes (`--limit`); a Camada 4 (`RetryFailedMediaDownloadsJob`, hourly) também redreca sozinha.
+
+**O gap durável (o que o US-WA-311 pedia — observabilidade):** o daemon ficou inalcançável ~7 dias
+**sem nenhum alarme**. Proposta: **sentinela "daemon whatsmeow alcançável"** —
+1. checagem ativa (resolve DNS + `GET /health` via Traefik) no `jana:health-check`, OU
+2. detecção passiva: N soft-fails de download consecutivos **business-wide** na mesma janela →
+   `mcp_alertas` ALERT em <5min (não 1 por mensagem — agregado, anti-ruído).
+
+Isso transforma "48k mídias presas em silêncio por uma semana" em "alerta em minutos". Tier 0
+preservado (agregação por `business_id`). Pareia com a Camada 1 (canário) — mesma filosofia
+aplicada ao caminho **app→daemon** (download), que hoje não tem canário.
+
 ## Faseamento (cada fase = 1 PR testado, pode parar entre fases)
+0. **Mídia/DNS (Camada 6)** — hotfix DNS (imediato, destrava 48k) + drain; depois a sentinela de
+   alcançabilidade (baixo risco, só observa). Independente das demais.
 1. **Canário** (camada 1+5) — maior salto isolado: detecção <5min + perda-zero pra
    maioria das falhas. Baixo risco (só observa, não toca a via de recebimento).
 2. **Backfill/HistorySync** (camada 2) — perda-zero pra qualquer duração + recupera os 3 dias.


### PR DESCRIPTION
Dobra o achado do incidente **2026-06-19** (mídia WhatsApp travada) no proposal `whatsapp-ingestao-perda-zero.md` — **decisão de produto do Wagner** (registrar aqui em vez de US nova; o número 311 já é referenciado pelo proposal).

## O que entra (+45 linhas, 1 arquivo)

**Camada 6 — resiliência do download de mídia + alarme de daemon-inalcançável** (era o conteúdo do "US-WA-311"):

- **Root cause provado:** `whatsapp-whatsmeow.oimpresso.com` = **NXDOMAIN** (A record sumiu da zona Hostinger). Daemon CT100 (`177.74.67.30`) `Up 3 semanas healthy`, Traefik roteia OK → 48.569 mídias `pending`. **Não é bug de código** — quebrou 1 entrada de DNS.
- **Fix imediato** (prod/DNS → Wagner): recriar A record via Hostinger DNS API ([ADR 0045](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0045-hostinger-dns-api-endpoint-canonico.md)) + **drain** `whatsapp:backfill-media-download` idempotente.
- **Gap durável (observabilidade):** sentinela "daemon whatsmeow alcançável" → alerta **agregado business-wide** em <5min (não 1 por mensagem). Pareia com o canário da Camada 1, mas no caminho **app→daemon**.
- **Disambiguação:** 2 backlogs distintos — mensagens perdidas (#2726 = Camada 2) vs mídia não-baixada de mensagens que chegaram (Camada 6).

Documento é `status: proposal` (append-friendly); frontmatter intocado.

Refs: [#3018](https://github.com/wagnerra23/oimpresso.com/pull/3018)

🤖 Generated with [Claude Code](https://claude.com/claude-code)