### PR TITLE
feat(governance): distiller_freshness instrumentado (PR-D · peça 3)

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -65,7 +65,7 @@ class HealthCheckCommand extends Command
                             {--json : Output JSON em vez de tabela}
                             {--notify : Loga ALERT em jana-health channel se algo falhou}';
 
-    protected $description = 'Health check diário Jana + Constituição v2 (11 checks SQL + ledger de lições + charter/loop advisory)';
+    protected $description = 'Health check diário Jana + Constituição v2 (12 checks DUROS incl. distiller_freshness + ledger de lições + charter/loop advisory)';
 
     /**
      * Margem de segurança da invariante de valor (check 1b). Desconto só REDUZ;
@@ -103,6 +103,7 @@ class HealthCheckCommand extends Command
             $this->checkCustoBrainB(),
             $this->checkPiiLeak(),
             $this->checkProfileDrift(),
+            $this->checkDistillerFreshness(),
             $this->checkProcedureDrift(),
             $this->checkSpecIdDrift(),
             $this->checkWhatsappMediaPending1h(),
@@ -417,6 +418,87 @@ class HealthCheckCommand extends Command
                 'message' => 'ERRO: ' . $e->getMessage(),
             ];
         }
+    }
+
+    /**
+     * Check 5b — Distiller freshness (ADR 0291 D-D · peça 3 do keystone SDD×memória).
+     *
+     * Gêmeo DURO da métrica `distiller_freshness` do sdd-scorecard. Lá (commitado,
+     * determinístico) a staleness é medida contra a data-git do doc mais novo do
+     * módulo; AQUI (runtime, não-commitado) o alarme usa "hoje" — espelha
+     * checkProfileDrift (`gerado_em` < now()->subDays(7)). Conta portas
+     * memory/requisitos/<Mod>/BRIEFING.md cujo `distilled_at` ficou > 7d vs agora.
+     *
+     * Anti-stale: SKIP (ok) enquanto NENHUMA porta tiver `distilled_at` — o distiller
+     * (PR-C) só roda em prod sob gate Wagner/CT100; não acende vermelho antes do 1º
+     * carimbo. DURO (não-advisory): destilação que parou derruba o exit/cron (D-3).
+     *
+     * @see Modules/Jana/Services/Memoria/DistillerModuloVerdade.php (PR-C — escreve o carimbo)
+     */
+    protected function checkDistillerFreshness(): array
+    {
+        $name = 'distiller_freshness';
+        $reqDir = base_path('memory/requisitos');
+        if (! is_dir($reqDir)) {
+            return [
+                'name' => $name, 'ok' => true, 'value' => 'n/a', 'threshold' => '<= 7d',
+                'message' => 'Skipped (memory/requisitos/ ausente)',
+            ];
+        }
+
+        $contents = array_map(
+            static fn ($f) => (string) @file_get_contents($f),
+            glob($reqDir . '/*/BRIEFING.md') ?: [],
+        );
+        $r = self::distillerFreshnessStats($contents, now()->toDateString());
+
+        if ($r['stamped'] === 0) {
+            return [
+                'name' => $name, 'ok' => true, 'value' => 'n/a', 'threshold' => '<= 7d',
+                'message' => 'Skipped (nenhuma porta com distilled_at — distiller não rodou; gate Wagner/CT100 · ADR 0291 D-D)',
+            ];
+        }
+
+        return [
+            'name' => $name,
+            'ok' => $r['stale'] === 0,
+            'value' => $r['stale'],
+            'threshold' => 0,
+            'message' => $r['stale'] === 0
+                ? "Todas as {$r['stamped']} portas destiladas frescas (<= 7d)"
+                : "STALE: {$r['stale']}/{$r['stamped']} portas com distilled_at > 7d (mais velha: {$r['stalest_days']}d) — rodar jana:distill-module-truth",
+        ];
+    }
+
+    /**
+     * Estatística pura de frescor das portas (testável sem filesystem — espelha
+     * parseLessonLedger). Parseia `distilled_at:` do frontmatter de cada conteúdo
+     * de BRIEFING e conta carimbadas + as que ficaram > $staleDays vs $now.
+     *
+     * @param  array<int, string>  $briefingContents  conteúdo de cada BRIEFING.md
+     * @return array{total:int, stamped:int, stale:int, stalest_days:int}
+     */
+    public static function distillerFreshnessStats(array $briefingContents, string $now, int $staleDays = 7): array
+    {
+        $reference = \Carbon\Carbon::parse($now);
+        $cutoff = $reference->copy()->subDays($staleDays);
+        $stamped = 0;
+        $stale = 0;
+        $stalestDays = 0;
+
+        foreach ($briefingContents as $content) {
+            if (! preg_match('/^distilled_at:\s*["\']?(\d{4}-\d{2}-\d{2})/m', (string) $content, $m)) {
+                continue;
+            }
+            $stamped++;
+            $date = \Carbon\Carbon::parse($m[1]);
+            if ($date->lt($cutoff)) {
+                $stale++;
+                $stalestDays = max($stalestDays, (int) $date->diffInDays($reference));
+            }
+        }
+
+        return ['total' => count($briefingContents), 'stamped' => $stamped, 'stale' => $stale, 'stalest_days' => $stalestDays];
     }
 
     /**

--- a/Modules/Jana/Tests/Unit/DistillerFreshnessStatsTest.php
+++ b/Modules/Jana/Tests/Unit/DistillerFreshnessStatsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-D do keystone distiller-módulo-verdade (ADR 0291 D-D · peça 3).
+ *
+ * Testa o gêmeo DURO de freshness do jana:health-check pela sua parte PURA
+ * (HealthCheckCommand::distillerFreshnessStats) — sem tocar o filesystem, igual
+ * a parseLessonLedger. O check runtime usa "hoje"; aqui injetamos $now fixo.
+ *
+ * Limite: distilled_at exatamente 7d atrás = fresco (alarme só dispara > 7d).
+ */
+
+$NOW = '2026-06-19';
+
+/** Monta o conteúdo de uma BRIEFING.md com (ou sem) carimbo distilled_at. */
+function briefingContent(?string $distilledAt): string
+{
+    $fm = $distilledAt ? "distilled_at: \"{$distilledAt}\"\n" : '';
+
+    return "---\nslug: porta\n{$fm}---\n# Porta\nestado atual...\n";
+}
+
+test('sem distilled_at → zero carimbadas, zero stale', function () use ($NOW) {
+    $r = HealthCheckCommand::distillerFreshnessStats([briefingContent(null), briefingContent(null)], $NOW);
+    expect($r['total'])->toBe(2);
+    expect($r['stamped'])->toBe(0);
+    expect($r['stale'])->toBe(0);
+});
+
+test('porta fresca (1d) não é stale', function () use ($NOW) {
+    $r = HealthCheckCommand::distillerFreshnessStats([briefingContent('2026-06-18')], $NOW);
+    expect($r['stamped'])->toBe(1);
+    expect($r['stale'])->toBe(0);
+});
+
+test('limite exato de 7d ainda é fresco', function () use ($NOW) {
+    $r = HealthCheckCommand::distillerFreshnessStats([briefingContent('2026-06-12')], $NOW);
+    expect($r['stale'])->toBe(0);
+});
+
+test('porta > 7d é stale e reporta stalest_days', function () use ($NOW) {
+    $r = HealthCheckCommand::distillerFreshnessStats([briefingContent('2026-05-01')], $NOW);
+    expect($r['stamped'])->toBe(1);
+    expect($r['stale'])->toBe(1);
+    expect($r['stalest_days'])->toBe(49);
+});
+
+test('mistura conta só carimbadas e só stale, com a mais velha', function () use ($NOW) {
+    $r = HealthCheckCommand::distillerFreshnessStats([
+        briefingContent('2026-06-18'), // 1d  — fresca
+        briefingContent('2026-06-11'), // 8d  — stale
+        briefingContent('2026-05-01'), // 49d — stale
+        briefingContent(null),         // sem carimbo — cobertura pendente
+    ], $NOW);
+    expect($r['total'])->toBe(4);
+    expect($r['stamped'])->toBe(3);
+    expect($r['stale'])->toBe(2);
+    expect($r['stalest_days'])->toBe(49);
+});
+
+test('ignora conteúdo sem linha distilled_at no frontmatter', function () use ($NOW) {
+    $r = HealthCheckCommand::distillerFreshnessStats(['# só um título sem frontmatter'], $NOW);
+    expect($r['stamped'])->toBe(0);
+    expect($r['total'])->toBe(1);
+});

--- a/governance/sdd-scorecard.json
+++ b/governance/sdd-scorecard.json
@@ -119,8 +119,8 @@
       "status": "not_yet_measured",
       "value": null,
       "direction": "down",
-      "target": "< 7d em 100% das portas",
-      "source": "ADR 0270 F3/D-5 — ProfileDistiller estendido p/ verdade-do-módulo; hoje só destila perfil comercial, NÃO escreve BRIEFING (instrumentação pendente — peça 2/3 do keystone)",
+      "target": "< 7d atrás do doc mais novo em 100% das portas",
+      "source": "ADR 0291 D-D — nenhuma porta tem distilled_at ainda (distiller-módulo-verdade não rodou em prod; gate Wagner/CT100). Vira measured no 1º carimbo, como o floor do 0279.",
       "baseline_rule": "1ª medição real da fonte, nunca do plano (anti-stale)",
       "stream": "MEM"
     },

--- a/memory/decisions/0292-errata-0291-distiller-freshness-scorecard-deterministico.md
+++ b/memory/decisions/0292-errata-0291-distiller-freshness-scorecard-deterministico.md
@@ -1,0 +1,76 @@
+---
+slug: 0292-errata-0291-distiller-freshness-scorecard-deterministico
+number: 292
+title: "Errata 0291 D-D — distiller_freshness no scorecard mede staleness vs doc mais novo do módulo (determinístico, não vs 'hoje')"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: errata
+decided_by: [W]
+decided_at: "2026-06-19"
+module: jana
+tags: [memoria, distiller, freshness, scorecard, determinismo, sdd, errata, keystone]
+supersedes: []
+superseded_by: []
+related:
+  - 0291-distiller-modulo-verdade-contrato-emenda-0270-f3
+  - 0270-ciclo-de-vida-da-informacao-porta-unica-destilacao-decaimento
+  - 0275-scorecard-sdd-canonico-10-metricas-calendario-promocoes
+  - 0279-sdd-medir-governar-floor-nightly
+pii: false
+---
+
+> **Errata de [ADR 0291] D-D**, proposta por [CL] em 2026-06-19, **autorizada por [W]** no chat 2026-06-19
+> ("Sim — stale vs doc mais novo do módulo"). O corpo do 0291 é append-only (Constituição Art. 3); por isso
+> esta correção vem em ADR nova `kind: errata`, **não** em edição inline (gate `Append-only canon`). Ratificação = merge.
+
+# ADR 0292 — Errata 0291 D-D: `distiller_freshness` no scorecard é determinístico
+
+## O que o 0291 D-D dizia (e por que precisa de errata)
+
+O [ADR 0291] D-D, ao contratar a métrica `distiller_freshness`, descreveu o valor medido como
+*"nº de portas com `distilled_at` > 7d (stale)"* — um critério **relativo a "hoje"**. Ao implementar (PR
+do PR-D), isso colidiu com uma invariante dura do scorecard:
+
+- `governance/sdd-scorecard.json` é **determinístico por contrato** (`_meta.determinismo`: *"sem timestamps
+  no corpo — re-run sem mudança no repo = diff vazio"*; o `sdd-scorecard.yml` avisa quando o JSON commitado
+  "defasa"). Um valor relativo a "hoje" **mudaria todo dia** mesmo sem mudança no repo → quebraria a
+  invariante e faria o aviso de defasagem disparar perpetuamente.
+
+## Correção (o critério, por runtime)
+
+`distiller_freshness` continua lendo o `distilled_at:` das portas e continua **anti-stale** (`not_yet_measured`
+até o 1º carimbo, como o floor do [ADR 0279]). Muda só **como** a staleness é definida, e isso difere por runtime
+**de propósito**:
+
+- **Scorecard** (commitado, determinístico): uma porta é *stale* quando seu `distilled_at` ficou **>7d atrás
+  da data-git do doc mais novo do módulo** — um **fato imutável da história**, não o relógio. Mede *"o distiller
+  ficou pra trás dos eventos?"*, que é exatamente o D-3 do [ADR 0270] (*"destilação que para = porta envelhece"*).
+  Portas **sem** `distilled_at` entram só no `detail` (cobertura pendente), **não** contam como stale (rollout
+  não-punitivo, espelha `front_door` 62%→100%).
+- **Health-check** (`jana:health-check`, runtime, **não-commitado**): o alarme **DURO** pode usar **"hoje"** —
+  conta portas com `distilled_at` **>7d vs agora** (espelha `checkProfileDrift`, que compara `gerado_em` vs
+  `now()->subDays(7)`). >0 → derruba exit code + ALERT de cron.
+
+Ambos leem o **mesmo** `distilled_at` e disparam a **mesma** ação (rodar `jana:distill-module-truth` na porta
+atrasada). A diferença de âncora (história do git × relógio) é o que reconcilia *determinismo no placar* com
+*alarme vivo na operação*.
+
+## O que NÃO muda do 0291
+
+Tudo o mais do D-D e do contrato (D-A input, D-B output mutável + `distilled_at` + proveniência, D-C comando +
+cron, D-E guardas Tier 0 G5/PII/CT100) permanece como em [ADR 0291]. Esta errata é cirúrgica: só o critério de
+staleness do **scorecard**.
+
+## Implementado em
+
+PR-D do keystone — `scripts/governance/sdd-scorecard.mjs` (`measureDistillerFreshness()` + node test
+`sdd-distiller-freshness.test.mjs`) e `Modules/Jana/Console/Commands/HealthCheckCommand.php`
+(`checkDistillerFreshness()` + helper puro `distillerFreshnessStats()` + Pest).
+
+## Referências
+- [ADR 0291] contrato do distiller-módulo-verdade (alvo desta errata)
+- [ADR 0270] D-3/D-5 (ciclo de vida; "destilação que para = porta envelhece")
+- [ADR 0279] padrão anti-stale `notYet`→`measured` + determinismo do scorecard
+- [ADR 0275] scorecard SDD canônico (onde vive a métrica, stream MEM)

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **296** arquivos · **281** números únicos · máx **0291**
-- **ADRs ATIVOS (lifecycle ativo): 256** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 228 · proposto 41 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
-- Por lifecycle: ativo 256 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **297** arquivos · **282** números únicos · máx **0292**
+- **ADRs ATIVOS (lifecycle ativo): 257** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 228 · proposto 42 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
+- Por lifecycle: ativo 257 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -32,7 +32,7 @@ _(íntegra)_
 ## Recusadas (1) — o NÃO consultável
 - **0290** v0 'Fidelity Lock' (screenshot pareado em CI) — RECUSADO: fidelidade visual não  · recusada 2026-06-18 — Inviável + tautológico + backdoor de prosa (3 motivos na Decisão). REABRE só se surgir um check de fidelidade HERMÉTICO 
 
-## Todas as ADRs (296)
+## Todas as ADRs (297)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -331,3 +331,4 @@ _(íntegra)_
 | 0289 | proposto | ativo | decision | failover automático por saúde de canal: tenant crítico cai pro Cloud API (oficia |
 | 0290 | recusado | ativo | decision | v0 'Fidelity Lock' (screenshot pareado em CI) — RECUSADO: fidelidade visual não  |
 | 0291 | proposto | ativo | meta | Emenda 0270 F3/D-5 — contrato do distiller-módulo-verdade (diário→manual) + inst |
+| 0292 | proposto | ativo | errata | Errata 0291 D-D — distiller_freshness no scorecard mede staleness vs doc mais no |

--- a/scripts/governance/sdd-distiller-freshness.test.mjs
+++ b/scripts/governance/sdd-distiller-freshness.test.mjs
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+// Meta-teste do read-side de distiller_freshness (ADR 0291 D-D · peça 3 do keystone).
+// Importa measureDistillerFreshness de sdd-scorecard.mjs (guard isMain garante que o
+// import NÃO dispara o scorecard inteiro) e prova o padrão anti-stale + determinístico:
+//   A) zero portas carimbadas        → not_yet_measured (honesto; distiller não rodou)
+//   B) ≥1 carimbada + 1 atrasada      → measured, value = nº atrás do doc mais novo (>7d)
+//   C) carimbada e fresca             → não conta como stale
+//   D) porta SEM carimbo              → entra no detail (cobertura pendente), não stale
+//   E) reqDir ausente                 → not_yet_measured
+// `newestDocDate` é injetado (mapa) → sem git/FS real, determinístico.
+// Uso: node scripts/governance/sdd-distiller-freshness.test.mjs
+import { measureDistillerFreshness } from './sdd-scorecard.mjs';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, basename } from 'node:path';
+
+let fails = 0;
+const ok = (cond, msg) => { if (cond) console.log(`  ✓ ${msg}`); else { console.error(`  ✗ ${msg}`); fails++; } };
+
+/** Monta um memory/requisitos/ de teste. spec: { Mod: {distilledAt?, briefing?} } */
+function makeReq(spec) {
+  const dir = mkdtempSync(join(tmpdir(), 'distfresh-'));
+  for (const [mod, cfg] of Object.entries(spec)) {
+    const md = join(dir, mod);
+    mkdirSync(md, { recursive: true });
+    if (cfg.briefing !== false) {
+      const fm = cfg.distilledAt ? `distilled_at: "${cfg.distilledAt}"\n` : '';
+      writeFileSync(join(md, 'BRIEFING.md'), `---\nslug: ${mod}\n${fm}---\n# ${mod}\n`);
+    }
+  }
+  return dir;
+}
+/** newestDocDate injetado a partir de um mapa por nome de módulo. */
+const newestFrom = (map) => (modDir) => map[basename(modDir)] ?? null;
+
+// ── A: zero carimbadas → notYet ─────────────────────────────────────────────
+let dir = makeReq({ SemCarimbo: {}, Outra: {} });
+try {
+  const r = measureDistillerFreshness(dir, { newestDocDate: newestFrom({}) });
+  ok(r.status === 'not_yet_measured', 'zero portas carimbadas → not_yet_measured');
+  ok(r.value === null, 'sem carimbo → value null (não mente 0)');
+} finally { rmSync(dir, { recursive: true, force: true }); }
+
+// ── B/C/D: mistura fresca + atrasada + sem-carimbo + sem-porta ──────────────
+dir = makeReq({
+  Fresca: { distilledAt: '2026-06-15' },
+  Atrasada: { distilledAt: '2026-05-01' },
+  SemCarimbo: {},
+  SemPorta: { briefing: false },
+});
+try {
+  const r = measureDistillerFreshness(dir, {
+    newestDocDate: newestFrom({ Fresca: '2026-06-16', Atrasada: '2026-06-18' }),
+  });
+  ok(r.status === 'measured', '≥1 carimbada → measured');
+  ok(r.value === 1, 'value === 1 (só a Atrasada está >7d atrás do doc mais novo)');
+  ok(r.direction === 'down' && r.target === 0, 'distiller_freshness DESCE pra 0');
+  ok(r.detail.portas === 3, 'detail.portas = 3 (SemPorta sem BRIEFING é ignorada)');
+  ok(r.detail.carimbadas === 2, 'detail.carimbadas = 2');
+  ok(r.detail.sem_carimbo === 1, 'detail.sem_carimbo = 1 (cobertura pendente, não stale)');
+  ok(r.detail.stale === 1, 'detail.stale = 1');
+  ok(r.detail.oldest_distilled_at === '2026-05-01', 'detail.oldest_distilled_at = mais antigo');
+} finally { rmSync(dir, { recursive: true, force: true }); }
+
+// ── C isolado: fresca dentro de 7d não conta ────────────────────────────────
+dir = makeReq({ Fresca: { distilledAt: '2026-06-15' } });
+try {
+  const r = measureDistillerFreshness(dir, { newestDocDate: newestFrom({ Fresca: '2026-06-20' }) });
+  ok(r.status === 'measured' && r.value === 0, 'porta carimbada e fresca (5d) → value 0');
+} finally { rmSync(dir, { recursive: true, force: true }); }
+
+// ── E: reqDir ausente → notYet ──────────────────────────────────────────────
+ok(
+  measureDistillerFreshness(join(tmpdir(), `req-inexistente-${process.pid}`)).status === 'not_yet_measured',
+  'reqDir ausente → not_yet_measured',
+);
+
+console.log(fails === 0 ? '\n  distiller_freshness read-side (ADR 0291 D-D): OK\n' : `\n  distiller_freshness: ${fails} FALHA(S)\n`);
+process.exit(fails === 0 ? 0 : 1);

--- a/scripts/governance/sdd-scorecard.mjs
+++ b/scripts/governance/sdd-scorecard.mjs
@@ -138,6 +138,88 @@ export function measureFullSuiteFloor(floorPath = join(ROOT, 'governance', 'nigh
   };
 }
 
+// ── fonte: distilled_at das portas BRIEFING (ADR 0291 D-D — peça 3 do keystone) ─
+// Lê o carimbo `distilled_at:` do frontmatter de cada memory/requisitos/<Mod>/BRIEFING.md
+// (o distiller-módulo-verdade — PR-C — escreve esse carimbo ao reescrever a porta).
+// DETERMINÍSTICO por contrato (_meta.determinismo): a "frescura" é medida contra a
+// data-git do doc MAIS NOVO do módulo (fato imutável da história), NÃO contra "hoje"
+// (senão o JSON commitado mudaria todo dia). Mede "o distiller ficou pra trás dos
+// eventos?" = D-3 do 0270 ("destilação que para = porta envelhece"). O alarme DURO
+// >7d-vs-hoje vive no jana:health-check (runtime, não-commitado — ADR 0291 D-D).
+//
+// Anti-stale (espelha measureFullSuiteFloor): ZERO portas carimbadas → not_yet_measured
+// (honesto — distiller nunca rodou; gate Wagner/CT100). ≥1 carimbada → measured: value =
+// nº de portas carimbadas atrás do doc mais novo por > staleDays. Portas SEM carimbo
+// entram só no detail (cobertura pendente), NÃO como stale (rollout não-punitivo, espelha
+// front_door 62%→100%). `reqDir`/`newestDocDate` injetáveis pra teste sem git/FS real.
+const STALE_DAYS_DISTILLER = 7;
+const DISTILLED_AT_RE = /^distilled_at:\s*["']?(\d{4}-\d{2}-\d{2})/m;
+
+function gitDateOf(file) {
+  try {
+    return execSync(`git log -1 --format=%cs -- "${file}"`, { cwd: ROOT, stdio: ['ignore', 'pipe', 'ignore'] })
+      .toString().trim() || null;
+  } catch { return null; }
+}
+
+// Data-git (committer %cs) do doc .md mais novo do módulo, EXCETO a própria BRIEFING.
+// Só é chamada pras portas carimbadas → barato no rollout (poucas portas têm carimbo).
+function gitNewestModuleDocDate(modDir) {
+  let newest = null;
+  const briefing = join(modDir, 'BRIEFING.md');
+  const walk = (d) => {
+    for (const e of readdirSync(d, { withFileTypes: true })) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) { walk(p); continue; }
+      if (!e.name.endsWith('.md') || p === briefing) continue;
+      const dt = gitDateOf(p);
+      if (dt && (!newest || dt > newest)) newest = dt;
+    }
+  };
+  try { walk(modDir); } catch { /* módulo sem docs legíveis — ignora */ }
+  return newest;
+}
+
+// dias que `toDate` está À FRENTE de `fromDate` (ambas YYYY-MM-DD fixas → determinístico).
+function daysAhead(fromDate, toDate) {
+  return (Date.parse(toDate) - Date.parse(fromDate)) / 86400000;
+}
+
+export function measureDistillerFreshness(
+  reqDir = join(ROOT, 'memory', 'requisitos'),
+  { newestDocDate = gitNewestModuleDocDate, staleDays = STALE_DAYS_DISTILLER } = {},
+) {
+  const FRESH_TARGET = '< 7d atrás do doc mais novo em 100% das portas';
+  if (!existsSync(reqDir)) {
+    return notYet('down', FRESH_TARGET, 'ADR 0291 D-D — memory/requisitos/ ausente; nada a medir.');
+  }
+  let total = 0, stamped = 0, stale = 0, oldest = null;
+  for (const mod of readdirSync(reqDir, { withFileTypes: true })) {
+    if (!mod.isDirectory()) continue;
+    const modDir = join(reqDir, mod.name);
+    const briefing = join(modDir, 'BRIEFING.md');
+    if (!existsSync(briefing)) continue;
+    total++;
+    const m = readFileSync(briefing, 'utf8').match(DISTILLED_AT_RE);
+    if (!m) continue; // porta sem carimbo → cobertura pendente, não stale
+    stamped++;
+    const distilledAt = m[1];
+    if (!oldest || distilledAt < oldest) oldest = distilledAt;
+    const newest = newestDocDate(modDir);
+    if (newest && daysAhead(distilledAt, newest) > staleDays) stale++;
+  }
+  if (stamped === 0) {
+    return notYet('down', FRESH_TARGET,
+      'ADR 0291 D-D — nenhuma porta tem distilled_at ainda (distiller-módulo-verdade não rodou em prod; gate Wagner/CT100). Vira measured no 1º carimbo, como o floor do 0279.');
+  }
+  return {
+    status: 'measured', value: stale, unit: 'portas atrás dos eventos (>7d vs doc mais novo · ADR 0291 D-D)',
+    direction: 'down', target: 0,
+    source: 'memory/requisitos/*/BRIEFING.md frontmatter distilled_at vs data-git do doc mais novo do módulo (determinístico — ADR 0291 D-D)',
+    detail: { portas: total, carimbadas: stamped, sem_carimbo: total - stamped, stale, oldest_distilled_at: oldest },
+  };
+}
+
 function buildScorecard() {
   const kd = measureKnowledgeDrift();
   const an = measureAnchors();
@@ -188,8 +270,7 @@ function buildScorecard() {
         'golden set recall (KL-C2) — depende do alias map das 13 colisões ADR'),
       ragas_real_uptime: notYet('up', '≥95%',
         'RAGAS canário modo REAL diário (KL-D1/D4) — hoje compara mock com mock'),
-      distiller_freshness: notYet('down', '< 7d em 100% das portas',
-        'ADR 0270 F3/D-5 — ProfileDistiller estendido p/ verdade-do-módulo; hoje só destila perfil comercial, NÃO escreve BRIEFING (instrumentação pendente — peça 2/3 do keystone)'),
+      distiller_freshness: measureDistillerFreshness(),
       read_path_hops: notYet('down', 1,
         'ADR 0270 D-5 — nº de docs abertos pra saber o estado atual de um módulo (meta 1; instrumentação pendente)'),
       drift_alarms: notYet('down', 'advisory perene',


### PR DESCRIPTION
## PR-D do keystone distiller-módulo-verdade — peça 3 (`distiller_freshness` vivo)

Instrumenta a métrica `distiller_freshness` (stream MEM) que a peça 4 deixou como `not_yet_measured`. Implementa **[ADR 0291](memory/decisions/0291-distiller-modulo-verdade-contrato-emenda-0270-f3.md) D-D**. Contrato em #3015 (merged); núcleo puro em #3016 (merged).

### 2 commits
1. **`feat(governance)`** — a instrumentação (código + testes).
2. **`docs(adr)` errata 0292** — registra o refinamento de determinismo que Wagner aprovou (chat 2026-06-19). Como o corpo do 0291 é **append-only** (o gate `Append-only canon` pega edição de ADR mergeada — a 1ª versão deste PR tentou editar inline e o gate reprovou, corretamente), a correção vem em **ADR nova `kind: errata`**, não inline.

### O design (dois runtimes, de propósito — ADR 0292)
- **Scorecard** (`scripts/governance/sdd-scorecard.mjs` → `measureDistillerFreshness()`): lê `distilled_at` das portas. **Anti-stale** (`not_yet_measured` até o 1º carimbo — igual ao floor do 0279) **+ determinístico** (staleness = `distilled_at` >7d atrás da **data-git do doc mais novo do módulo**, NÃO "hoje" — senão o JSON commitado driftaria e quebraria `_meta.determinismo`). Mede "o distiller ficou pra trás dos eventos?" = D-3.
- **Health-check** (`HealthCheckCommand::checkDistillerFreshness()`): gêmeo **DURO** e **runtime** (>7d **vs hoje**, espelha `checkProfileDrift`). Skip (ok) enquanto 0 carimbos. Lógica pura em `distillerFreshnessStats()` (testável, espelha `parseLessonLedger`).

### Hoje → measured sozinha
Zero portas têm `distilled_at` em main → a métrica fica `not_yet_measured` (honesto: o distiller roda em prod só sob **gate Wagner/CT100** — PR-C). **Vira `measured` no 1º carimbo**, automaticamente.

### Testes (rodados localmente com node v24 ✓)
- `sdd-distiller-freshness.test.mjs` — 12 asserts (notYet, measured, stale vs fresco, unstamped, reqDir ausente). **OK.**
- `DistillerFreshnessStatsTest.php` — 6 testes Pest do helper puro (limite exato 7d, mistura, stalest_days). _CI roda (sem PHP local)._
- Regressão `sdd-floor-read.test.mjs` **OK**; `--ratchet` sem regressão; `sdd-scorecard.json` regenerado e válido (só o bloco `distiller_freshness` mudou).

### Notas
- **Não** tira `continue-on-error` (promoção a required = peça 5, calendário do 0275 — decisão Wagner). **Não** roda destilação em prod. Falta só **PR-C** (service + comando + cron) — segurado aguardando seu sinal (escreve memória canônica + roda LLM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)