### PR TITLE
docs: correção dos números da mídia WhatsApp (#3018/#3019 auto-mergearam antes da verificação)

### DIFF
--- a/memory/decisions/proposals/whatsapp-ingestao-perda-zero.md
+++ b/memory/decisions/proposals/whatsapp-ingestao-perda-zero.md
@@ -60,7 +60,7 @@ count/chat/oldest-id) → emite eventos `HistorySync`. Plano:
 
 > ⚠️ **Não confundir dois backlogs distintos:** (1) **mensagens perdidas** (#2726, webhook
 > recusado) = esta Camada 2. (2) **mídia não-baixada** de mensagens que *chegaram* normalmente
-> (48.569 em `media_download_status='pending'`, incidente DNS 2026-06-19) = **Camada 6** abaixo.
+> (backlog real = **10.134**, todo do driver Baileys descomissionado) = **Camada 6** abaixo.
 > A mensagem existe na Caixa; só a mídia não desceu. Mecanismos e causas-raiz diferentes.
 
 ### Camada 3 — Auto-cura
@@ -81,45 +81,41 @@ no CT 100 testando o caminho daemon→app (rede), não só app→app.
 
 ### Camada 6 — resiliência do download de mídia + alarme de daemon-inalcançável (era o "US-WA-311")
 
-**Incidente 2026-06-19 (root cause provado):** **48.569** mensagens em
-`media_download_status='pending'` (vs 659 `success`, 14 `failed_permanent`) acumuladas desde
-~12/jun. Diagnóstico read-only (handoff `2026-06-19-1103-midia-dns-rootcause`):
+**Incidente 2026-06-19 — dois achados separados** (diagnóstico read-only + verificação na app prod; handoff `2026-06-19-1103-midia-dns-rootcause`):
 
-- O A record **`whatsapp-whatsmeow.oimpresso.com` sumiu da zona DNS Hostinger** → **NXDOMAIN**
-  (DoH `dns.google` Status 3 + `getent` do próprio CT 100; SOA serial `2026061801`).
-- O daemon (CT 100, `177.74.67.30`) está **`Up 3 semanas (healthy)`**; Traefik **casa o `Host()` rule**
-  (loopback → `http_404`, não-000 = rota OK) e o daemon serve `/health` `http_200` direto.
-- `DownloadMediaJob::fetchViaWhatsmeowDownload` (roda no **Hostinger**) chama
-  `config('whatsapp.whatsmeow.daemon_url')` = o host que NXDOMAINa → **soft-fail silencioso** →
-  fica `pending` pra sempre. Webhooks inbound seguem OK (vão pro `oimpresso.com`, que resolve).
+**Achado A — A record do daemon sumiu (corrigido).** `whatsapp-whatsmeow.oimpresso.com` estava
+**NXDOMAIN** (removido da zona Hostinger; DoH `dns.google` Status 3 + `getent` do CT 100; SOA
+`2026061801`). O daemon (CT 100, `177.74.67.30`) está **`Up 3 semanas (healthy)`** e o Traefik
+**casa o `Host()` rule** (loopback → `http_404`; daemon direto → `http_200`). Como o
+`DownloadMediaJob` roda no **Hostinger** e chama `config('whatsapp.whatsmeow.daemon_url')`, o
+caminho app→daemon ficou morto. **Recriei o A record** (→ `177.74.67.30`, [ADR 0045](../0045-hostinger-dns-api-endpoint-canonico.md),
+`overwrite:false`; `dig`+DoH confirmam). Hygiene de infra **necessária** (health-probe ADR 0286,
+admin do daemon, mídia whatsmeow futura) — **mas não era a causa de um backlog**: ver Achado B.
 
-→ **Não é bug de código.** O worker, o endpoint e o env estão corretos. Quebrou **1 entrada de DNS**.
+**Achado B — o "48k mídia travada" era um número inflado.** `media_download_status` tem
+**default `'pending'` pra TODA mensagem** (texto incluso). Filtrando só tipos de mídia, o backlog
+**real é 10.134** — e **100% são `whatsapp_baileys`** (driver descomissionado [ADR 0202](../0202-whatsapp-profissionalizacao-baileys-out.md),
+27/mai: daemon de decrypt morto + URLs `.enc` expiradas = **undownloadable**). **Mídia whatsmeow
+pending = 0** (teste síncrono na app: pipeline em dia). Ou seja: o DNS estava quebrado, mas não
+havia backlog de mídia whatsmeow esperando por ele.
 
-**Fix imediato (PROD/DNS — Wagner aprova/executa, publication-policy):** recriar o A record via
-Hostinger DNS API ([ADR 0045](../0045-hostinger-dns-api-endpoint-canonico.md)), `overwrite:false`:
+→ **Não é bug de código.** Worker/endpoint/env corretos. (1) A record: corrigido. (2) os 10.134
+Baileys: **dead-letter** — recomendado marcar `failed_permanent` (decisão de dados do Wagner; mutação
+de 10k linhas não foi aplicada sozinha).
 
-```bash
-curl -s -X PUT -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
-  "https://developers.hostinger.com/api/dns/v1/zones/oimpresso.com" \
-  -d '{"overwrite":false,"zone":[{"name":"whatsapp-whatsmeow","type":"A","ttl":300,"records":[{"content":"177.74.67.30"}]}]}'
-```
-
-**Drain (pós-DNS, idempotente):** `php artisan whatsapp:backfill-media-download --business=all --since=2026-06-01`
-em lotes (`--limit`); a Camada 4 (`RetryFailedMediaDownloadsJob`, hourly) também redreca sozinha.
-
-**O gap durável (o que o US-WA-311 pedia — observabilidade):** o daemon ficou inalcançável ~7 dias
-**sem nenhum alarme**. Proposta: **sentinela "daemon whatsmeow alcançável"** —
+**O gap durável (o que o US-WA-311 pedia — observabilidade):** um A record sumir em silêncio e
+ninguém ver é a classe de falha que precisa de alarme (mesmo que desta vez não tenha gerado
+backlog). Proposta: **sentinela "daemon whatsmeow alcançável"** —
 1. checagem ativa (resolve DNS + `GET /health` via Traefik) no `jana:health-check`, OU
 2. detecção passiva: N soft-fails de download consecutivos **business-wide** na mesma janela →
    `mcp_alertas` ALERT em <5min (não 1 por mensagem — agregado, anti-ruído).
 
-Isso transforma "48k mídias presas em silêncio por uma semana" em "alerta em minutos". Tier 0
-preservado (agregação por `business_id`). Pareia com a Camada 1 (canário) — mesma filosofia
+Tier 0 preservado (agregação por `business_id`). Pareia com a Camada 1 (canário) — mesma filosofia
 aplicada ao caminho **app→daemon** (download), que hoje não tem canário.
 
 ## Faseamento (cada fase = 1 PR testado, pode parar entre fases)
-0. **Mídia/DNS (Camada 6)** — hotfix DNS (imediato, destrava 48k) + drain; depois a sentinela de
-   alcançabilidade (baixo risco, só observa). Independente das demais.
+0. **Mídia/DNS (Camada 6)** — A record já recriado; resta dead-letter dos 10.134 Baileys + a
+   sentinela de alcançabilidade do daemon (baixo risco, só observa). Independente das demais.
 1. **Canário** (camada 1+5) — maior salto isolado: detecção <5min + perda-zero pra
    maioria das falhas. Baixo risco (só observa, não toca a via de recebimento).
 2. **Backfill/HistorySync** (camada 2) — perda-zero pra qualquer duração + recupera os 3 dias.

--- a/memory/handoffs/2026-06-19-1124-midia-correcao-numeros.md
+++ b/memory/handoffs/2026-06-19-1124-midia-correcao-numeros.md
@@ -1,0 +1,78 @@
+---
+date: 2026-06-19
+time: "1124 BRT"
+slug: "midia-correcao-numeros"
+tldr: "Corrige o handoff 1103 (#3018, mergeado): o '48k mídia whatsmeow travada' não procede. pending é default de TODA msg (texto incluso). Mídia REAL = 10.134, 100% whatsapp_baileys (driver morto ADR 0202 = dead-letter); whatsmeow media pending = 0. O A record whatsapp-whatsmeow estava NXDOMAIN e foi RECRIADO (177.74.67.30, W autorizou) — hygiene, NÃO causa de backlog. Recomendo dead-letter dos 10.134 Baileys. US-WA-309 já feito; mergear #2964."
+decided_by: [W]
+cycle: null
+prs: [3018, 3019, 2964]
+us: ["US-WA-309"]
+next_steps:
+  - "DECISÃO W (dados): marcar os 10.134 mídia pending (100% whatsapp_baileys, undownloadable) como failed_permanent — dead-letter pra limpar a métrica. SQL no corpo; NÃO rodei (mutação 10k linhas escala)."
+  - "FEITO: A record whatsapp-whatsmeow.oimpresso.com -> 177.74.67.30 recriado (Hostinger DNS API, overwrite:false, dig+DoH ok)."
+  - "US-WA-309: mergear #2964 (banner business-wide + probe provision_pending)."
+related_adrs:
+  - 0202-whatsapp-profissionalizacao-baileys-out
+  - 0204-whatsmeow-driver-substituto-baileys
+  - 0286-channel-health-corroborado-por-mensagem-real
+  - 0045-hostinger-dns-api-endpoint-canonico
+---
+
+# Handoff 2026-06-19 11:24 BRT — CORREÇÃO dos números do 1103 (mídia WhatsApp)
+
+> **Supera o handoff [1103](2026-06-19-1103-midia-dns-rootcause.md) (#3018), que foi mergeado por auto-merge ANTES desta verificação.** O 1103 está certo sobre o DNS, mas o número "48k mídia whatsmeow travada" não procede. Append-only (ADR 0130): este doc corrige; o 1103 fica como está.
+
+## TL;DR
+
+Dois fatos separados, não um:
+
+1. **O A record sumiu (real, corrigido).** `whatsapp-whatsmeow.oimpresso.com` estava **NXDOMAIN** na zona Hostinger. **Recriei** (→ `177.74.67.30`, ADR 0045, `overwrite:false`; `dig @1.1.1.1` + DoH `Status:0` confirmam). Hygiene necessária (health-probe ADR 0286, admin do daemon, mídia whatsmeow futura). Daemon estava `Up 3 semanas (healthy)`; Traefik roteia — só o DNS estava morto.
+
+2. **O "48k mídia travada" era número inflado.** Verificado na app de prod (SSH Hostinger, query builder na connection do app):
+
+| métrica | valor |
+|---|---|
+| `media_download_status='pending'` (todos os tipos) | 48.574 — **mas é o DEFAULT de toda msg, texto incluso** |
+| mídia REAL pending (`type` ∈ image/audio/video/document) | **10.134** |
+| └ por provider | **100% `whatsapp_baileys`** (0 whatsmeow, 0 outros) |
+| mídia **whatsmeow** pending | **0** (teste síncrono: nada pra baixar) |
+
+**Conclusão:** os 10.134 são mídia do **driver Baileys descomissionado** ([ADR 0202](../decisions/0202-whatsapp-profissionalizacao-baileys-out.md), 27/mai) — daemon de decrypt morto + URLs `.enc` expiradas = **undownloadable / dead-letter**, problema mais antigo (desde ~15/mai) e **independente do DNS**. Não havia backlog de mídia whatsmeow esperando o DNS.
+
+## Como verifiquei (anti-erro-do-1103)
+
+O 1103 leu `pending = 48.569` da connection e assumiu "48k mídia whatsmeow travada". Errei ao não filtrar por tipo de mídia nem por provider. Aqui:
+- `Message::withoutGlobalScopes()->where('media_download_status','pending')->whereIn('type', [media])->...->groupBy('provider')` → 10.134, todo `whatsapp_baileys`.
+- Teste síncrono de 1 mídia whatsmeow pendente → **0 candidatas** (`whatsmeow_media_pending=0`).
+- `backfill-media-download --dry-run` → **0 candidatas** (filtra `media_mime NOT NULL`; e não há mídia whatsmeow pendente).
+
+## O que o W decide
+
+- [ ] **(dados)** dead-letter dos 10.134 Baileys — limpa a métrica `pending`. SQL (NÃO rodei):
+  ```php
+  Modules\Whatsapp\Entities\Message::withoutGlobalScopes()
+    ->where('media_download_status','pending')->where('provider','whatsapp_baileys')
+    ->whereIn('type',['image','audio','video','document'])
+    ->update(['media_download_status'=>'failed_permanent',
+              'media_download_failed_reason'=>'Baileys descomissionado (ADR 0202) — mídia .enc expirada']);
+  ```
+- [ ] **(merge)** #2964 (banner business-wide US-WA-309).
+- [ ] **(produto)** sentinela "daemon whatsmeow alcançável" (Camada 6 do proposal `ingestao-perda-zero`, corrigida no #3019/este PR) — promover a trabalho ativo quando o time tocar.
+
+## Estado MCP no momento do fechamento
+
+> MCP oimpresso passou a aparecer tarde na sessão (worktree órfão). Não rodei `brief-fetch` neste passo de correção; fonte de verdade = git/gh + DoH + CT100/Hostinger (read-only + 1 write DNS autorizado).
+
+### Estado via git/gh + DB prod (substituto)
+```
+origin/main: handoff 1103 (#3018) e proposal Camada6 (#3019) MERGED por auto-merge (squash) ANTES da correção.
+DB prod mídia real pending = 10.134 (100% whatsapp_baileys); whatsmeow media pending = 0.
+DNS: whatsapp-whatsmeow.oimpresso.com A=177.74.67.30 (recriado; DoH Status:0).
+US-WA-309: #2956/#2963/#3002 merged; #2964 aberto.
+```
+
+## Referências
+
+- Handoff corrigido: [2026-06-19-1103-midia-dns-rootcause.md](2026-06-19-1103-midia-dns-rootcause.md) (#3018)
+- Proposal (Camada 6 corrigida): [whatsapp-ingestao-perda-zero.md](../decisions/proposals/whatsapp-ingestao-perda-zero.md) (#3019 + este PR)
+- ADR 0202: [Baileys OUT](../decisions/0202-whatsapp-profissionalizacao-baileys-out.md) · ADR 0045: [Hostinger DNS API](../decisions/0045-hostinger-dns-api-endpoint-canonico.md)


### PR DESCRIPTION
**Por que:** os PRs [#3018](https://github.com/wagnerra23/oimpresso.com/pull/3018) (handoff 1103) e [#3019](https://github.com/wagnerra23/oimpresso.com/pull/3019) (Camada 6) **auto-mergearam (squash) antes** de eu verificar os números na app de prod. Eles afirmam "48k mídia whatsmeow travada / DNS é a causa" — **incorreto**. Este PR corrige o main.

## O que muda

1. **NOVO handoff de correção** `2026-06-19-1124-midia-correcao-numeros.md` (append-only ADR 0130 — não edita o 1103 mergeado; cria sucessor que o supera).
2. **Cherry-pick da correção do proposal** `whatsapp-ingestao-perda-zero.md` Camada 6 (números reais).

## Achados verificados na app de prod (SSH Hostinger, query builder)

| métrica | valor |
|---|---|
| `media_download_status='pending'` (todos tipos) | 48.574 — **default de toda msg, texto incluso** |
| mídia REAL pending (`type` ∈ image/audio/video/document) | **10.134** |
| por provider | **100% `whatsapp_baileys`** |
| mídia **whatsmeow** pending | **0** |

- Os 10.134 são do **driver Baileys descomissionado** ([ADR 0202](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0202-whatsapp-profissionalizacao-baileys-out.md)) — daemon morto + `.enc` expirado = **dead-letter**. Independente do DNS.
- O A record `whatsapp-whatsmeow.oimpresso.com` estava **NXDOMAIN** e foi **recriado** (→ `177.74.67.30`, você autorizou; `dig`+DoH confirmam) — hygiene necessária, **mas não era causa de backlog** (whatsmeow pending = 0).

## Decisão pendente (W)
- Dead-letter dos 10.134 Baileys (SQL no handoff) · mergear #2964 · promover a sentinela de alcançabilidade do daemon.

Frontmatter validado à mão (tldr 443≤500, date/time strings, related_adrs slugs).

Refs: #3018 #3019

🤖 Generated with [Claude Code](https://claude.com/claude-code)