### PR TITLE
fix(whatsapp): remover --stop-when-empty do queue:work — corta latência de msg entrante (~30s→~1-3s)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -784,13 +784,15 @@ class Kernel extends ConsoleKernel
         // sempre guarda para não perder". Cron everyMinute pra processar
         // PersistHistorySyncBatchJob da tabela `jobs` (queue=database).
         //
-        // --max-time=55 sai antes do próximo tick. --stop-when-empty para
-        // quando fila vazia (não fica 55s ocioso). Pior caso: 1min latência
-        // pra primeira msg histórica aparecer no Inbox após pareamento.
+        // --max-time=55 sai antes do próximo tick. SEM --stop-when-empty
+        // (2026-06-19): o worker fica vivo os 55s pegando os batches em ~1-3s em
+        // vez de morrer assim que a fila esvazia (antes: até 1min de latência pra
+        // 1ª msg histórica aparecer pós-pareamento). withoutOverlapping(1) mantém
+        // 1 processo/fila (respeita o limite de LSPHP do shared hosting).
         //
         // Hostinger shared hosting sem supervisor — cron é o workaround
         // padrão pra rodar queue worker.
-        $schedule->command('queue:work database --queue=whatsapp-history --max-time=55 --stop-when-empty --tries=3')
+        $schedule->command('queue:work database --queue=whatsapp-history --max-time=55 --tries=3')
             ->everyMinute()
             ->withoutOverlapping(1)
             ->environments(['live'])
@@ -808,11 +810,15 @@ class Kernel extends ConsoleKernel
         // healthy e fix de código aplicado (PR #1825). Webhook chegava, job
         // enfileirado, ninguém executava. Worker manual processou 54 jobs em 2s.
         //
-        // Mesmo padrão Hostinger shared hosting cron-based: --max-time=55 +
-        // --stop-when-empty + everyMinute + runInBackground evita CPU ocioso
-        // e respeita limite de processos LSPHP. Tries=3 cobre retry transient
-        // (DB lock, OTel sidecar momentâneo).
-        $schedule->command('queue:work database --queue=whatsapp --max-time=55 --stop-when-empty --tries=3')
+        // Hostinger shared hosting cron-based (sem supervisor). SEM --stop-when-empty
+        // (2026-06-19): antes o worker morria assim que a fila esvaziava, deixando a
+        // maior parte do minuto SEM worker → a msg entrante esperava o próximo tick
+        // (0-60s, ~30s médio; reclamação real "~20s pra um oi" chegar na Caixa).
+        // Agora fica vivo os 55s do --max-time e pega o webhook em ~1-3s. Custo:
+        // poll leve do DB durante os 55s — limitado por --max-time=55 +
+        // withoutOverlapping(1) (1 processo/fila → respeita LSPHP). Tries=3 cobre
+        // retry transient (DB lock, OTel sidecar momentâneo).
+        $schedule->command('queue:work database --queue=whatsapp --max-time=55 --tries=3')
             ->everyMinute()
             ->withoutOverlapping(1)
             ->environments(['live'])


### PR DESCRIPTION
## Sintoma
Mensagem **recebida do cliente** demora ~20s pra aparecer na Caixa; mídia "uma eternidade".

## Causa-raiz (confirmada em prod, read-only)
Inbound: `cliente → daemon → webhook → enfileira ProcessIncomingWebhookJob (fila database `whatsapp`) → cron drena → grava + Centrifugo → Caixa`.

O drain é um cron **everyMinute** (Hostinger shared hosting, sem supervisor):
```
* * * * * php artisan queue:work database --queue=whatsapp --max-time=55 --stop-when-empty --tries=3
```
O **`--stop-when-empty`** fazia o worker **morrer no instante em que a fila esvaziava** → a maior parte de cada minuto ficava **sem worker** → a mensagem entrante esperava o próximo tick do scheduler: **0–60s, ~30s médio** = os "~20s pra um oi". Mídia = mesma fila, pior por ser job maior.

Confirmado por SSH (read-only): `QUEUE_CONNECTION=database`, e `schedule:list` mostrava os dois `queue:work ... --stop-when-empty` everyMinute.

## Fix
Remove `--stop-when-empty` das filas `whatsapp` e `whatsapp-history`. O worker passa a ficar vivo os **55s** do `--max-time` e pega o webhook em **~1-3s**. Latência inbound cai de **~30s → ~1-3s**.

**Trade-off (único):** durante os 55s o worker faz poll leve do DB em vez de sair quando vazio (era o motivo original do flag, "evita CPU ocioso"). É limitado por `--max-time=55` + `withoutOverlapping(1)` (no máx. 1 processo por fila → respeita o limite de LSPHP do shared hosting). Reversível em 1 linha se o Hostinger reclamar de CPU/processos.

## Verificação
- `php -l` limpo.
- `schedule:list` (sqlite override, sem tocar DB prod) confirma os 2 comandos registrados everyMinute **sem** a flag.
- Mudança não-testável por Pest (string de agendamento) — CI valida o boot.

## Nota lateral
Os 16 `failed_jobs` em prod são todos `ProcessIncomingWebhookJob` de **um incidente único em 2026-05-27** (~3 semanas atrás) — débito antigo, não relacionado a esta latência nem a mídia recente. Pode ser limpo à parte (`queue:flush`).

## Deploy
Sem deploy manual: merge dispara deploy automático (ADR 0269). O cron passa a usar o novo comando no próximo tick após o deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
