### PR TITLE
feat(jana): DistillerModuloVerdade — motor diário→manual (PR-C1)

### DIFF
--- a/Modules/Jana/Services/Memoria/DistillerModuloVerdade.php
+++ b/Modules/Jana/Services/Memoria/DistillerModuloVerdade.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Memoria;
+
+use App\Util\OtelHelper;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AnonymousAgent;
+use Modules\Jana\Services\Privacy\PiiRedactor;
+
+/**
+ * PR-C do keystone distiller-módulo-verdade ([ADR 0291] · emenda 0270 F3 · peça 2).
+ *
+ * O motor "diário → manual": lê os eventos recentes de um módulo (sessions,
+ * handoffs, PRs, audits — já coletados pelo COMANDO) e REESCREVE a porta
+ * `memory/requisitos/<Mod>/BRIEFING.md` como verdade mastigada ≤1 página, MUTÁVEL
+ * (sobrescreve, NÃO append — D-1/D-2), carimbando `distilled_at:` + proveniência
+ * no rodapé. Reusa a chamada LLM do ProfileDistiller (AnonymousAgent) — não reinventa.
+ *
+ * Tier 0 ([ADR 0291] D-E): o output passa pelo PiiRedactor ANTES de escrever e a
+ * destilação é RECUSADA se houver PII estruturada (CPF/CNPJ/email/telefone/CEP) —
+ * repo público; não envenena a canon. A SELEÇÃO de "o que distilar" é pura/testável
+ * (ModuleTruthEventCollector, PR-B). A EXECUÇÃO em prod é gate Wagner/CT100 (não aqui).
+ *
+ * Recebe os eventos já coletados (impuro = FS/git fica no comando) → testável com
+ * Ai::fakeAgent + path de BRIEFING temporário, sem git nem prod.
+ */
+final class DistillerModuloVerdade
+{
+    /** Teto de eventos alimentados à LLM (recência prioriza — ADR 0291 D-A). */
+    public const MAX_EVENTS = 40;
+
+    public function __construct(private PiiRedactor $pii) {}
+
+    /**
+     * Destila a verdade-do-módulo e (re)escreve a porta.
+     *
+     * @param  array<int, array<string, mixed>>  $candidateEvents  eventos crus do módulo
+     * @return array{status:string, written:bool, selected?:int, content?:string, pii?:array<string,int>, path?:string}
+     *         status ∈ {written, dry, refused_pii, no_events}
+     */
+    public function destilar(
+        string $module,
+        array $candidateEvents,
+        string $briefingPath,
+        ?string $lastDistilledAt = null,
+        bool $dryRun = false,
+        ?string $now = null,
+    ): array {
+        $now ??= CarbonImmutable::now()->toDateString();
+
+        return OtelHelper::span('jana.distiller.modulo_verdade', [
+            'module' => $module,
+            'dry_run' => $dryRun,
+        ], fn () => $this->destilarInternal($module, $candidateEvents, $briefingPath, $lastDistilledAt, $dryRun, $now));
+    }
+
+    /** @param array<int, array<string, mixed>> $candidateEvents */
+    private function destilarInternal(
+        string $module,
+        array $candidateEvents,
+        string $briefingPath,
+        ?string $lastDistilledAt,
+        bool $dryRun,
+        string $now,
+    ): array {
+        $selected = ModuleTruthEventCollector::select(
+            $candidateEvents, $module, $lastDistilledAt, ModuleTruthEventCollector::DEFAULT_WINDOW_DAYS, $now, self::MAX_EVENTS,
+        );
+
+        if ($selected === []) {
+            return ['status' => 'no_events', 'written' => false, 'selected' => 0];
+        }
+
+        $existing = is_file($briefingPath) ? (string) file_get_contents($briefingPath) : null;
+
+        // LLM destila a verdade atual (reusa AnonymousAgent — idem ProfileDistiller).
+        $agent = new AnonymousAgent(
+            instructions: $this->systemPrompt($module),
+            messages: [],
+            tools: [],
+        );
+        $body = trim((string) $agent->prompt($this->userPrompt($module, $selected, $existing)));
+
+        // Tier 0 D-E: recusa se a LLM emitiu PII estruturada — NÃO sobrescreve a porta
+        // (preserva o que estava lá; um humano destila de novo). Não silencia redactando.
+        $detected = $this->pii->detect($body);
+        if ($detected !== []) {
+            Log::channel('copiloto-ai')->warning('DistillerModuloVerdade: recusado por PII', [
+                'module' => $module,
+                'pii_types' => array_keys($detected),
+            ]);
+
+            return ['status' => 'refused_pii', 'written' => false, 'selected' => count($selected), 'pii' => $detected];
+        }
+
+        $content = $this->montarBriefing($module, $body, $selected, $now);
+
+        if ($dryRun) {
+            return ['status' => 'dry', 'written' => false, 'selected' => count($selected), 'content' => $content];
+        }
+
+        file_put_contents($briefingPath, $content);
+        Log::channel('copiloto-ai')->info('DistillerModuloVerdade: porta reescrita', [
+            'module' => $module,
+            'path' => $briefingPath,
+            'eventos' => count($selected),
+        ]);
+
+        return ['status' => 'written', 'written' => true, 'selected' => count($selected), 'content' => $content, 'path' => $briefingPath];
+    }
+
+    /**
+     * Monta a porta final: frontmatter (carimbo) + corpo destilado + proveniência
+     * no RODAPÉ (não inline — D-2). Sobrescreve por completo (mutável).
+     *
+     * @param  array<int, array<string, mixed>>  $selected
+     */
+    private function montarBriefing(string $module, string $body, array $selected, string $now): string
+    {
+        $fm = "---\ndistilled_at: \"{$now}\"\ndistilled_by: jana:distill-module-truth\nmodule: {$module}\n---\n";
+
+        $prov = "\n\n## Proveniência (destilado de)\n\n";
+        foreach ($selected as $e) {
+            $type = (string) ($e['type'] ?? 'evento');
+            $ref = (string) ($e['ref'] ?? '?');
+            $date = $e['date'] ?? null;
+            $title = trim((string) ($e['title'] ?? ''));
+            $prov .= "- {$type} `{$ref}`" . ($date ? " ({$date})" : '') . ($title !== '' ? " — {$title}" : '') . "\n";
+        }
+
+        return $fm . "\n# BRIEFING — {$module} (verdade destilada)\n\n" . $body . $prov;
+    }
+
+    private function systemPrompt(string $module): string
+    {
+        return <<<PROMPT
+        Você destila a VERDADE ATUAL de um módulo de software num BRIEFING de ≤1 página.
+
+        OBJETIVO: ler os eventos recentes (sessions/handoffs/PRs/audits) + a porta atual
+        (se houver) e produzir a verdade mastigada de HOJE do módulo "{$module}".
+
+        ESTRUTURA obrigatória (markdown, seções `##`, nesta ordem):
+          ## Estado atual    — 2-4 frases: o que o módulo faz e em que pé está
+          ## Capacidades     — bullets curtos do que já funciona
+          ## Gaps            — bullets do que falta (próxima onda)
+          ## Última mudança  — 1-2 frases do que mudou nos eventos recentes
+
+        REGRAS DURAS:
+        - Português brasileiro. Conciso. No MÁXIMO ~1 página.
+        - É VERDADE DESTILADA, não índice de links: NÃO cole links/paths no corpo
+          (a proveniência é anexada automaticamente fora do seu texto).
+        - NUNCA inclua PII: nada de CPF, CNPJ, e-mail, telefone, CEP. Repo é PÚBLICO.
+        - Não invente: se um fato não está nos eventos nem na porta atual, omita.
+        - Sobrescreve a verdade anterior — escreva o estado de AGORA, não um diário.
+        PROMPT;
+    }
+
+    /**
+     * Prompt do usuário: porta atual (contexto) + eventos selecionados.
+     *
+     * @param  array<int, array<string, mixed>>  $selected
+     */
+    private function userPrompt(string $module, array $selected, ?string $existing): string
+    {
+        $linhas = [];
+        foreach ($selected as $e) {
+            $type = (string) ($e['type'] ?? 'evento');
+            $date = $e['date'] ?? 's/data';
+            $title = trim((string) ($e['title'] ?? ($e['ref'] ?? '')));
+            $linhas[] = "- [{$type} · {$date}] {$title}";
+        }
+        $eventos = implode("\n", $linhas);
+
+        $atual = $existing !== null
+            ? "PORTA ATUAL (refine/atualize, não copie cega):\n\n" . mb_substr($existing, 0, 4000) . "\n\n"
+            : "PORTA ATUAL: (nenhuma — primeira destilação)\n\n";
+
+        return "Módulo: {$module}\n\n{$atual}EVENTOS RECENTES a destilar:\n{$eventos}";
+    }
+}

--- a/Modules/Jana/Tests/Feature/Memoria/DistillerModuloVerdadeTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/DistillerModuloVerdadeTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Laravel\Ai\Ai;
+use Laravel\Ai\AnonymousAgent;
+use Modules\Jana\Services\Memoria\DistillerModuloVerdade;
+use Modules\Jana\Services\Privacy\PiiRedactor;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-C do keystone distiller-módulo-verdade (ADR 0291 D-B/D-E · peça 2).
+ *
+ * Testa o motor "diário → manual" SEM git e SEM prod: eventos injetados +
+ * Ai::fakeAgent (LLM determinístico, sem custo) + BRIEFING em dir temporário.
+ * Cobre: escreve com carimbo+proveniência · dry-run não escreve · PII recusa ·
+ * sem-eventos não chama LLM · sobrescreve (não append) · proveniência no rodapé.
+ */
+
+$NOW = '2026-06-19';
+
+function distillerSvc(): DistillerModuloVerdade
+{
+    return new DistillerModuloVerdade(new PiiRedactor());
+}
+
+function evento(string $type, string $ref, ?string $date, array $modules, string $title = ''): array
+{
+    return compact('type', 'ref', 'date', 'modules', 'title');
+}
+
+beforeEach(function () {
+    $dir = sys_get_temp_dir() . '/distiller_verdade_' . uniqid();
+    File::makeDirectory($dir, 0o755, recursive: true);
+    test()->dir = $dir;
+    test()->path = $dir . '/BRIEFING.md';
+});
+
+afterEach(function () {
+    if (isset(test()->dir) && File::isDirectory(test()->dir)) {
+        File::deleteDirectory(test()->dir);
+    }
+});
+
+test('destila e escreve BRIEFING com carimbo + corpo + proveniência no rodapé', function () use ($NOW) {
+    Ai::fakeAgent(AnonymousAgent::class, [
+        "## Estado atual\nFinanceiro fechando a bridge Sells→fin_titulos.\n\n## Gaps\nBackfill retroativo.",
+    ]);
+    $events = [evento('session', 'memory/sessions/2026-06-15-bridge.md', '2026-06-15', ['Financeiro'], 'fix bridge')];
+
+    $r = distillerSvc()->destilar('Financeiro', $events, test()->path, null, false, $NOW);
+
+    expect($r['status'])->toBe('written');
+    expect($r['written'])->toBeTrue();
+    expect(File::exists(test()->path))->toBeTrue();
+
+    $c = File::get(test()->path);
+    expect($c)->toContain('distilled_at: "2026-06-19"')
+        ->toContain('distilled_by: jana:distill-module-truth')
+        ->toContain('Financeiro fechando a bridge')
+        ->toContain('## Proveniência (destilado de)')
+        ->toContain('2026-06-15-bridge.md');
+
+    // proveniência fica no RODAPÉ (depois do corpo), não inline
+    expect(strpos($c, 'Financeiro fechando a bridge'))->toBeLessThan(strpos($c, '## Proveniência'));
+});
+
+test('dry-run calcula mas NÃO escreve', function () use ($NOW) {
+    Ai::fakeAgent(AnonymousAgent::class, ["## Estado atual\nok"]);
+    $events = [evento('session', 's.md', '2026-06-15', ['Financeiro'])];
+
+    $r = distillerSvc()->destilar('Financeiro', $events, test()->path, null, true, $NOW);
+
+    expect($r['status'])->toBe('dry');
+    expect($r['written'])->toBeFalse();
+    expect(File::exists(test()->path))->toBeFalse();
+    expect($r['content'])->toContain('distilled_at');
+});
+
+test('PII no output da LLM → recusa e preserva a porta original', function () use ($NOW) {
+    // LLM "vazou" um CPF sintético — o distiller tem que RECUSAR e não sobrescrever.
+    Ai::fakeAgent(AnonymousAgent::class, [
+        "## Estado atual\nCliente CPF 123.456.789-09 em aberto.", // pii-allowlist (PII sintética pra testar a recusa)
+    ]);
+    File::put(test()->path, "PORTA ORIGINAL PRESERVADA");
+    $events = [evento('session', 's.md', '2026-06-15', ['Financeiro'])];
+
+    $r = distillerSvc()->destilar('Financeiro', $events, test()->path, null, false, $NOW);
+
+    expect($r['status'])->toBe('refused_pii');
+    expect($r['written'])->toBeFalse();
+    expect($r['pii'])->toHaveKey('CPF');
+    expect(File::get(test()->path))->toBe('PORTA ORIGINAL PRESERVADA');
+});
+
+test('sem eventos relevantes → no_events, não escreve', function () use ($NOW) {
+    Ai::fakeAgent(AnonymousAgent::class, ['NUNCA DEVERIA SER CHAMADO']);
+    $events = [evento('session', 's.md', '2026-06-15', ['Crm'])]; // outro módulo
+
+    $r = distillerSvc()->destilar('Financeiro', $events, test()->path, null, false, $NOW);
+
+    expect($r['status'])->toBe('no_events');
+    expect(File::exists(test()->path))->toBeFalse();
+});
+
+test('sobrescreve a porta (mutável, não append)', function () use ($NOW) {
+    File::put(test()->path, "VELHO CONTEUDO QUE DEVE SUMIR");
+    Ai::fakeAgent(AnonymousAgent::class, ["## Estado atual\nnovo conteudo destilado"]);
+    $events = [evento('session', 's.md', '2026-06-15', ['Financeiro'])];
+
+    distillerSvc()->destilar('Financeiro', $events, test()->path, null, false, $NOW);
+
+    $c = File::get(test()->path);
+    expect($c)->toContain('novo conteudo destilado')
+        ->not->toContain('VELHO CONTEUDO QUE DEVE SUMIR');
+});


### PR DESCRIPTION
## PR-C1 do keystone — o motor da destilação (service)

Implementa **[ADR 0291](memory/decisions/0291-distiller-modulo-verdade-contrato-emenda-0270-f3.md) D-A/D-B/D-E**. É a metade que o 0270 deixou como roadmap F3: o "diário → manual". Contrato + métrica já em main (#3015, #3016, #3020).

`Modules\Jana\Services\Memoria\DistillerModuloVerdade::destilar()` recebe os **eventos recentes do módulo** (sessions/handoffs/PRs/audits — já coletados; o gathering FS/git vem no PR-C2) e:
1. **Seleciona** o que distilar — `ModuleTruthEventCollector` (PR-B, puro/testável).
2. **Destila** via LLM — `AnonymousAgent` (mesmo padrão do `ProfileDistiller`/`ConversationSummarizer`, não reinventa).
3. **Gate PII** — passa o output por `PiiRedactor` e **RECUSA escrever** se houver PII estruturada (CPF/CNPJ/email/telefone/CEP). Repo é público (D-E); não envenena a canon nem silencia redactando — falha e preserva a porta.
4. **Reescreve** `BRIEFING.md` — ≤1 página, **mutável (sobrescreve, NÃO append — D-1/D-2)**, com `distilled_at:` + `distilled_by:` no frontmatter e **proveniência no rodapé** (não inline — D-2).

`--dry-run` calcula e não escreve.

### Testes (Pest — LLM mockado via `Ai::fakeAgent`, BRIEFING em temp dir, sem git/DB/prod)
- escreve com carimbo + corpo + proveniência **no rodapé** (asserção de ordem)
- `dry-run` não escreve
- **PII no output → `refused_pii`**, porta original **preservada**
- sem eventos relevantes → `no_events`, LLM não é chamado
- **sobrescreve ≠ append**

### Disciplina / escopo
- RED-first; 301 linhas; PII scan limpo (CPF sintético do teste allowlistado). Padrões espelham `ConversationSummarizer` (AnonymousAgent + OtelHelper + PiiRedactor) e `HandoffDraftToolTest` (Ai::fakeAgent).
- **Não** roda em prod (execução = gate Wagner/CT100 — ADR 0291 D-E). Falta só **PR-C2**: comando `jana:distill-module-truth {--module=}{--all}{--dry-run}` (coleta FS/git) + cron diário em `app/Console/Kernel.php`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)