### PR TITLE
feat(jana): jana:distill-module-truth + cron gated (PR-C2)

### DIFF
--- a/Modules/Jana/Console/Commands/DistillModuleTruthCommand.php
+++ b/Modules/Jana/Console/Commands/DistillModuleTruthCommand.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+use Modules\Jana\Services\Memoria\DistillerModuloVerdade;
+use Modules\Jana\Services\Memoria\ModuleTruthEventCollector;
+
+/**
+ * PR-C2 do keystone distiller-módulo-verdade ([ADR 0291] D-C · emenda 0270 F3).
+ *
+ * Driver do motor: COLETA os eventos recentes de um módulo (sessions/handoffs/PRs/
+ * audits — parte impura, FS + git) e chama o DistillerModuloVerdade (PR-C1) que
+ * reescreve a porta BRIEFING.md. Cron diário torna o brief-update obrigatório/
+ * auditável (D-3). EXECUÇÃO em prod é gate Wagner/CT100 (ADR 0291 D-E) — este comando
+ * existe pra rodar quando o Wagner mandar (smoke skim 10min/lote), não automaticamente
+ * sem supervisão até o gate liberar.
+ *
+ * Dirs configuráveis (testabilidade — espelha jana.handoffs_dir):
+ *   jana.requisitos_dir · jana.sessions_dir · jana.handoffs_dir
+ */
+class DistillModuleTruthCommand extends Command
+{
+    protected $signature = 'jana:distill-module-truth
+                            {--module= : Módulo específico (ex: Financeiro)}
+                            {--all : Destila todos os módulos que já têm porta BRIEFING.md}
+                            {--dry-run : Calcula e mostra o resultado, NÃO escreve}';
+
+    protected $description = 'Destila a verdade-do-módulo: eventos recentes → reescreve BRIEFING.md (ADR 0291 · porta única mutável)';
+
+    public function handle(DistillerModuloVerdade $distiller): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+        $modules = $this->resolveModules();
+
+        if ($modules === []) {
+            $this->error('Nenhum módulo a destilar. Use --module=<Nome> ou --all.');
+
+            return self::FAILURE;
+        }
+
+        $now = now()->toDateString();
+        $failures = 0;
+
+        foreach ($modules as $module) {
+            $briefingPath = $this->reqDir() . "/{$module}/BRIEFING.md";
+            $events = $this->gatherEvents($module, $now);
+            $lastDistilledAt = $this->lastDistilledAt($briefingPath);
+
+            $r = $distiller->destilar($module, $events, $briefingPath, $lastDistilledAt, $dryRun, $now);
+
+            $this->reportar($module, $r, count($events));
+            if (($r['status'] ?? '') === 'refused_pii') {
+                $failures++;
+            }
+        }
+
+        return $failures === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    /** @return array<int, string> */
+    private function resolveModules(): array
+    {
+        if ($m = $this->option('module')) {
+            return [(string) $m];
+        }
+        if (! $this->option('all')) {
+            return [];
+        }
+        // --all: módulos que JÁ têm porta (rollout: só refresca o que existe).
+        $out = [];
+        foreach (glob($this->reqDir() . '/*/BRIEFING.md') ?: [] as $briefing) {
+            $out[] = basename(dirname($briefing));
+        }
+        sort($out);
+
+        return $out;
+    }
+
+    /**
+     * Coleta candidatos (impuro — FS + git). A SELEÇÃO/janela é do collector (puro).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function gatherEvents(string $module, string $now): array
+    {
+        return [
+            ...$this->scanDocs($this->sessionsDir(), 'session', $module),
+            ...$this->scanDocs($this->handoffsDir(), 'handoff', $module),
+            ...$this->scanAudits($module),
+            ...$this->scanPrs($module, $now),
+        ];
+    }
+
+    /**
+     * Sessions/handoffs que citam o módulo (filename ou `Modules/<Mod>` no corpo).
+     * Data = prefixo YYYY-MM-DD do nome do arquivo (convenção); senão null.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function scanDocs(string $dir, string $type, string $module): array
+    {
+        if (! is_dir($dir)) {
+            return [];
+        }
+        $needle = mb_strtolower($module);
+        $events = [];
+        foreach (glob($dir . '/*.md') ?: [] as $path) {
+            $name = basename($path);
+            $body = (string) @file_get_contents($path);
+            $cita = str_contains($body, "Modules/{$module}")
+                || str_contains(mb_strtolower($name), $needle)
+                || str_contains(mb_strtolower($body), mb_strtolower("resources/js/Pages/{$module}"));
+            if (! $cita) {
+                continue;
+            }
+            $date = preg_match('/^(\d{4}-\d{2}-\d{2})/', $name, $m) ? $m[1] : null;
+            $events[] = ['type' => $type, 'ref' => "{$type}s/{$name}", 'date' => $date, 'modules' => [$module], 'title' => $name];
+        }
+
+        return $events;
+    }
+
+    /**
+     * AUDIT/AUDITORIA/CAPTERRA do próprio módulo (proveniência local).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function scanAudits(string $module): array
+    {
+        $dir = $this->reqDir() . "/{$module}";
+        if (! is_dir($dir)) {
+            return [];
+        }
+        $events = [];
+        foreach (glob($dir . '/{AUDIT,AUDITORIA,CAPTERRA}*.md', GLOB_BRACE) ?: [] as $path) {
+            $name = basename($path);
+            $events[] = ['type' => 'audit', 'ref' => "requisitos/{$module}/{$name}", 'date' => null, 'modules' => [$module], 'title' => $name];
+        }
+
+        return $events;
+    }
+
+    /**
+     * PRs/commits mergeados tocando Modules/<Mod> ou Pages/<Mod> (best-effort via git).
+     * Process::fake() nos testes → sem git real. Falha de git não derruba a destilação.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function scanPrs(string $module, string $now): array
+    {
+        $since = ModuleTruthEventCollector::windowStart(null, ModuleTruthEventCollector::DEFAULT_WINDOW_DAYS, $now);
+        try {
+            $result = Process::path(base_path())->run(
+                'git log --since=' . escapeshellarg($since) . ' --format=%cs|%s -n 40 -- '
+                . escapeshellarg("Modules/{$module}") . ' ' . escapeshellarg("resources/js/Pages/{$module}")
+            );
+            if (! $result->successful()) {
+                return [];
+            }
+            $events = [];
+            foreach (preg_split('/\r?\n/', trim($result->output())) ?: [] as $line) {
+                if ($line === '' || ! str_contains($line, '|')) {
+                    continue;
+                }
+                [$date, $subject] = explode('|', $line, 2);
+                $events[] = ['type' => 'pr', 'ref' => $subject, 'date' => $date, 'modules' => [$module], 'title' => $subject];
+            }
+
+            return $events;
+        } catch (\Throwable) {
+            return []; // git ausente/erro — best-effort, não bloqueia
+        }
+    }
+
+    private function lastDistilledAt(string $briefingPath): ?string
+    {
+        if (! is_file($briefingPath)) {
+            return null;
+        }
+        $content = (string) file_get_contents($briefingPath);
+
+        return preg_match('/^distilled_at:\s*["\']?(\d{4}-\d{2}-\d{2})/m', $content, $m) ? $m[1] : null;
+    }
+
+    /** @param array<string, mixed> $r */
+    private function reportar(string $module, array $r, int $candidatos): void
+    {
+        $status = (string) ($r['status'] ?? '?');
+        $sel = $r['selected'] ?? 0;
+        match ($status) {
+            'written' => $this->info("✓ {$module}: porta reescrita ({$sel} eventos de {$candidatos} candidatos)."),
+            'dry' => $this->line("• {$module}: dry-run ({$sel} eventos) — não escrito. Use sem --dry-run pra aplicar."),
+            'refused_pii' => $this->error("✗ {$module}: RECUSADO — LLM emitiu PII (" . implode(',', array_keys($r['pii'] ?? [])) . "). Porta preservada."),
+            'no_events' => $this->line("· {$module}: sem eventos recentes — porta inalterada."),
+            default => $this->warn("? {$module}: status inesperado '{$status}'."),
+        };
+    }
+
+    private function reqDir(): string
+    {
+        return (string) config('jana.requisitos_dir', base_path('memory/requisitos'));
+    }
+
+    private function sessionsDir(): string
+    {
+        return (string) config('jana.sessions_dir', base_path('memory/sessions'));
+    }
+
+    private function handoffsDir(): string
+    {
+        return (string) config('jana.handoffs_dir', base_path('memory/handoffs'));
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -75,6 +75,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\ReconcileCommand::class, // ADR 0237 — jana:reconcile loop único (orquestra Reconcilers index/settings/content/deploy/eval)
                 \Modules\Jana\Console\Commands\UiJudgeTrendCommand::class, // parecer PR #2270 — medição do PR UI Judge (trend score/verdict/custo)
                 \Modules\Jana\Console\Commands\JanaRecallEvalCommand::class, // KL-C2 SDD F1 — eval determinístico de recall (golden set expected/violations, ADR 0270 D-4/D-5 + 0274 + 0275)
+                \Modules\Jana\Console\Commands\DistillModuleTruthCommand::class, // ADR 0291 — distiller-módulo-verdade (diário→manual; reescreve BRIEFING.md)
             ]);
         }
     }

--- a/Modules/Jana/Tests/Feature/Memoria/DistillModuleTruthCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/DistillModuleTruthCommandTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+use Laravel\Ai\Ai;
+use Laravel\Ai\AnonymousAgent;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-C2 do keystone distiller-módulo-verdade (ADR 0291 D-C · peça 2).
+ *
+ * Testa o comando jana:distill-module-truth SEM git e SEM prod: dirs via config
+ * (jana.requisitos_dir/sessions_dir/handoffs_dir), Process::fake (PRs vazios),
+ * Ai::fakeAgent (LLM determinístico), tempo congelado (janela de 30d determinística).
+ */
+
+beforeEach(function () {
+    Carbon::setTestNow('2026-06-19 12:00:00');
+
+    $base = sys_get_temp_dir() . '/distill_cmd_' . uniqid();
+    test()->base = $base;
+    File::makeDirectory($base . '/requisitos/Financeiro', 0o755, recursive: true);
+    File::makeDirectory($base . '/sessions', 0o755, recursive: true);
+    File::makeDirectory($base . '/handoffs', 0o755, recursive: true);
+    config([
+        'jana.requisitos_dir' => $base . '/requisitos',
+        'jana.sessions_dir' => $base . '/sessions',
+        'jana.handoffs_dir' => $base . '/handoffs',
+    ]);
+
+    Process::fake(); // git log → fake vazio (PRs não entram; FS é a fonte testada)
+});
+
+afterEach(function () {
+    Carbon::setTestNow();
+    if (isset(test()->base) && File::isDirectory(test()->base)) {
+        File::deleteDirectory(test()->base);
+    }
+});
+
+function seedSession(string $name, string $body): void
+{
+    File::put(test()->base . '/sessions/' . $name, $body);
+}
+
+function briefingPath(): string
+{
+    return test()->base . '/requisitos/Financeiro/BRIEFING.md';
+}
+
+test('--module escreve a porta a partir de session que cita o módulo', function () {
+    seedSession('2026-06-15-bridge.md', "# Sessão\nMexi em Modules/Financeiro hoje.");
+    Ai::fakeAgent(AnonymousAgent::class, ["## Estado atual\nBridge Sells→fin_titulos fechando."]);
+
+    $this->artisan('jana:distill-module-truth', ['--module' => 'Financeiro'])->assertExitCode(0);
+
+    expect(File::exists(briefingPath()))->toBeTrue();
+    expect(File::get(briefingPath()))
+        ->toContain('distilled_at:')
+        ->toContain('Bridge Sells→fin_titulos fechando')
+        ->toContain('2026-06-15-bridge.md');
+});
+
+test('--dry-run calcula mas não escreve', function () {
+    seedSession('2026-06-15-bridge.md', 'Modules/Financeiro');
+    Ai::fakeAgent(AnonymousAgent::class, ["## Estado atual\nok"]);
+
+    $this->artisan('jana:distill-module-truth', ['--module' => 'Financeiro', '--dry-run' => true])
+        ->assertExitCode(0);
+
+    expect(File::exists(briefingPath()))->toBeFalse();
+});
+
+test('módulo sem eventos recentes → não escreve (não chama LLM)', function () {
+    seedSession('2026-06-15-outro.md', 'Modules/Crm apenas');
+    Ai::fakeAgent(AnonymousAgent::class, ['NUNCA DEVERIA SER CHAMADO']);
+
+    $this->artisan('jana:distill-module-truth', ['--module' => 'Financeiro'])->assertExitCode(0);
+
+    expect(File::exists(briefingPath()))->toBeFalse();
+});
+
+test('sem --module nem --all → falha com instrução', function () {
+    $this->artisan('jana:distill-module-truth')->assertExitCode(1);
+});
+
+test('--all resolve módulos que já têm porta e a refresca (sobrescreve)', function () {
+    File::put(briefingPath(), "---\ndistilled_at: \"2026-05-01\"\n---\nCONTEUDO VELHO");
+    seedSession('2026-06-15-bridge.md', 'update em Modules/Financeiro');
+    Ai::fakeAgent(AnonymousAgent::class, ["## Estado atual\nconteudo refrescado"]);
+
+    $this->artisan('jana:distill-module-truth', ['--all' => true])->assertExitCode(0);
+
+    expect(File::get(briefingPath()))
+        ->toContain('conteudo refrescado')
+        ->not->toContain('CONTEUDO VELHO');
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -182,6 +182,22 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Distiller-módulo-verdade ([ADR 0291] · keystone SDD×memória, peça 2).
+        // Reescreve as portas BRIEFING.md a partir dos eventos recentes (diário→manual).
+        // COMENTADO DE PROPÓSITO: D-E exige gate Wagner/CT100 (smoke skim 10min/lote) —
+        // a destilação chama LLM e MUTA memória canônica PÚBLICA; não pode auto-rodar sem
+        // supervisão. O comando existe e roda manual (`php artisan jana:distill-module-truth
+        // --all [--dry-run]`); o Wagner DESCOMENTA aqui quando o processo de skim estiver de pé.
+        // $schedule->command('jana:distill-module-truth --all')
+        //     ->dailyAt('05:30')
+        //     ->withoutOverlapping()
+        //     ->environments(['live'])
+        //     ->onFailure(function () {
+        //         \Illuminate\Support\Facades\Log::channel('single')->error(
+        //             'Schedule jana:distill-module-truth FALHOU — portas BRIEFING podem envelhecer (ADR 0291 D-5)'
+        //         );
+        //     });
+
         // Sentinela de FLUXO de inbound WhatsApp — cadência HORÁRIA em horário
         // comercial BRT (incidente 2026-06-16 #2726: recebimento morto 3 dias sem
         // ninguém ver; o cron diário 06:00 só detectaria ~22h depois). Reusa o


### PR DESCRIPTION
## PR-C2 do keystone — o comando que dirige a destilação

> **Empilhado em #3023 (PR-C1, o service).** Base = `feat/distiller-modulo-verdade-service` pra mostrar só o diff do comando. Quando #3023 mergear, retargeto pra `main`.

Implementa **[ADR 0291](memory/decisions/0291-distiller-modulo-verdade-contrato-emenda-0270-f3.md) D-C**. Completa o keystone (peça 2): A (contrato) + B (collector) + D (freshness) em main; C1 (service) em #3023; este é o **driver**.

`jana:distill-module-truth {--module=}{--all}{--dry-run}`:
- **Coleta** eventos recentes (impuro, FS + git): sessions/handoffs que citam `Modules/<Mod>` + AUDIT/CAPTERRA locais + PRs via `git log` (best-effort com `Process`).
- Lê `lastDistilledAt` da porta atual, chama `DistillerModuloVerdade::destilar()` (PR-C1), reporta por módulo.
- Dirs **configuráveis** (`jana.requisitos_dir`/`sessions_dir`/`handoffs_dir`) — testável sem tocar `memory/` real.

### Cron — COMENTADO de propósito (D-E)
`app/Console/Kernel.php` traz a wiring do cron diário **comentada**: a destilação chama LLM + **muta memória canônica pública** → exige **gate Wagner/CT100** (smoke skim). O comando roda manual; o Wagner **descomenta** quando o processo de skim estiver de pé. Espelha o precedente `memcofre:sync-memories`.

### Testes (Pest — tempo congelado, `Process::fake`, `Ai::fakeAgent`, dirs temp) ✅ verde
5 casos: escreve de session · `--dry-run` não escreve · sem-eventos não chama LLM · sem flags → erro · `--all` sobrescreve.

## Infra Contract

**Mudança de runtime:** registra o comando CLI `jana:distill-module-truth` no `JanaServiceProvider` (**sem rota/middleware/HTTP novo**) + wiring de cron **comentado** em `Kernel.php` (não ativa nada). **Nenhuma superfície HTTP** nova → não há `curl`/HTTP status pra colar.

**Validação prod (GATED — ADR 0291 D-E):** a destilação chama LLM + muta memória canônica pública → **NÃO** roda em prod sem gate Wagner/CT100. Plano quando liberar:
- `php artisan jana:distill-module-truth --module=<X> --dry-run` no CT100 → inspeciona diff da porta + custo LLM + 0 PII.
- Smoke skim 10min/lote antes de **descomentar** o cron.
- `--all` só após skim aprovado.

**Rollback:** comando idempotente (sobrescreve a porta) → reverter = `git checkout` da BRIEFING. Cron comentado = zero impacto até descomentar.

<!-- evidence-override: PR sem superfície HTTP (CLI command + cron COMENTADO); validação prod é gated Wagner/CT100 per ADR 0291 D-E. Sem curl porque não há endpoint. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)