### PR TITLE
fix(whatsapp): banner canal-caiu business-wide (qualquer conta vê) — rebase de #2964

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -181,7 +181,7 @@ class CaixaUnificadaController extends Controller
             // eager (query trivial na tabela channels) pro banner "canal caiu —
             // religar" aparecer no first-paint sem esperar o defer de
             // availableAccounts. Tier 0 ADR 0093 + ACL canal=fila (US-WA-069).
-            'unhealthyChannels' => $this->buildUnhealthyChannelsPayload($businessId, $userId),
+            'unhealthyChannels' => $this->buildUnhealthyChannelsPayload($businessId),
 
             // US-WA-301 (ADR 0267) — filas agora vêm do DB (seed lazy do config
             // na 1ª visita; fallback config se DB vazio). Shape QueueConfig compat.
@@ -641,23 +641,22 @@ class CaixaUnificadaController extends Controller
      * "canal desconectado — religar" no topo da Caixa Unificada.
      *
      * Eager (custo trivial: tabela `channels`, poucas rows) pra o aviso aparecer no
-     * first-paint — diferente de `availableAccounts` (deferred). Tier 0 ADR 0093 +
-     * ACL canal=fila (US-WA-069): só canais que o user pode ver. `degraded` entra
-     * junto de `disconnected`/`banned` porque já significa "não confiável agora".
+     * first-paint — diferente de `availableAccounts` (deferred). Tier 0 ADR 0093
+     * (escopado por `business_id`). **Business-wide** (Wagner 2026-06-18): um alerta
+     * "seu WhatsApp caiu" aparece pra QUALQUER pessoa com acesso ao atendimento (a
+     * página já gateia por `whatsapp.access`), não só admin view-all — ainda mais
+     * porque o business pode não ter grants de canal. `degraded` entra junto.
      *
      * @return array<int, array{id: int, label: string, type: string, channel_health: string, last_health_message: ?string, last_health_check_at: ?string}>
      */
-    protected function buildUnhealthyChannelsPayload(int $businessId, int $userId): array
+    protected function buildUnhealthyChannelsPayload(int $businessId): array
     {
-        $query = Channel::query()
+        // SEM filtro ACL-de-canal de propósito (business-wide). Tier 0 preservado
+        // pelo `business_id`. A página já exige permissão `whatsapp.access`.
+        return Channel::query()
             ->where('business_id', $businessId)
             ->where('status', 'active')
-            ->whereIn('channel_health', ['disconnected', 'banned', 'degraded']);
-        if (! $this->canSeeAllChannels()) {
-            $query->whereIn('id', $this->allowedChannelIdsSubquery($businessId, $userId));
-        }
-
-        return $query
+            ->whereIn('channel_health', ['disconnected', 'banned', 'degraded'])
             ->orderBy('label')
             ->get(['id', 'label', 'type', 'channel_health', 'last_health_message', 'last_health_check_at'])
             ->map(fn (Channel $ch) => [

--- a/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CaixaUnificadaControllerTest.php
@@ -430,36 +430,39 @@ it('R-WA-CAIXA-UNIF-013 — canal whatsmeow ativo vira chip ativo com count real
 });
 
 /**
- * R-WA-CAIXA-UNIF-014 — US-WA-308 (incidente 2026-06-18): canal ATIVO com saúde
- * caída entra no payload eager `unhealthyChannels` (banner "religar" no topo da
- * Caixa); canal saudável NÃO entra; e o Tier 0 (ADR 0093) impede vazar canal caído
- * de OUTRO business.
+ * R-WA-CAIXA-UNIF-015 — US-WA-308/309 (incidente 2026-06-18): canal ATIVO com saúde
+ * caída entra no payload eager `unhealthyChannels` (banner "religar"), **business-wide**
+ * — aparece MESMO sem grant ACL no canal (Wagner 2026-06-18: alerta de queda é pra
+ * todos do business). Canal saudável NÃO entra; Tier 0 (ADR 0093) impede vazar canal
+ * caído de OUTRO business.
  *
- * red-first: sem o payload `unhealthyChannels` (ou filtrando health errado) o
- * pluck/firstWhere não acha o canal → falha; é o discriminador, não tautológico.
+ * red-first: o user NÃO tem grant em canal nenhum e `can()`=false (fake user) → com o
+ * filtro ACL antigo o canal caído sumiria (0 rows); business-wide mantém ele. É o
+ * discriminador da mudança, não tautológico.
  */
-it('R-WA-CAIXA-UNIF-014 — canal ativo deslogado entra em unhealthyChannels + Tier 0', function () {
-    // biz=1 canal caído (logout) — DEVE aparecer
-    $down = cuctMakeChannel(1, 'caixa-unif-014-down');
-    $down->forceFill(['channel_health' => 'disconnected', 'last_health_message' => 'whatsmeow disconnected: logged_out'])->save();
+it('R-WA-CAIXA-UNIF-015 — canal caído entra business-wide (sem grant) + saudável fora + Tier 0', function () {
+    // biz=1 caído, SEM grant pro user — DEVE aparecer (business-wide)
+    $down = cuctMakeChannel(1, 'caixa-unif-015-down');
+    $down->forceFill(['channel_health' => 'disconnected', 'last_health_message' => 'whatsmeow disconnected: provision_pending'])->save();
 
-    // biz=1 canal saudável — NÃO deve aparecer
-    $ok = cuctMakeChannel(1, 'caixa-unif-014-ok');
+    // biz=1 saudável — NÃO aparece
+    $ok = cuctMakeChannel(1, 'caixa-unif-015-ok');
     $ok->forceFill(['channel_health' => 'healthy'])->save();
 
-    // biz=99 canal caído — Tier 0 impede vazar pra biz=1
-    $cross = cuctMakeChannel(99, 'caixa-unif-014-cross');
+    // biz=99 caído — Tier 0 impede vazar pra biz=1
+    $cross = cuctMakeChannel(99, 'caixa-unif-015-cross');
     $cross->forceFill(['channel_health' => 'disconnected'])->save();
 
-    cuctSetUserAndGrant(1, 10, [$down->id, $ok->id]);
+    // user do biz=1 SEM grant em canal nenhum (fake user retorna can()=false)
+    cuctSetUserAndGrant(1, 10, []);
 
     $props = cuctIndexProps(new CaixaUnificadaController(), cuctBuildRequest());
     $unhealthy = cuctResolveDefer($props['unhealthyChannels']); // eager — array direto
 
     $ids = collect($unhealthy)->pluck('id')->all();
-    expect($ids)->toContain($down->id)
-        ->and($ids)->not->toContain($ok->id)
-        ->and($ids)->not->toContain($cross->id);
+    expect($ids)->toContain($down->id)         // aparece mesmo sem grant (business-wide)
+        ->and($ids)->not->toContain($ok->id)    // saudável fora
+        ->and($ids)->not->toContain($cross->id); // Tier 0
 
     $row = collect($unhealthy)->firstWhere('id', $down->id);
     expect($row['channel_health'])->toBe('disconnected')

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -19,7 +19,7 @@ related_adrs:
   - 0135-omnichannel-inbox-arquitetura
 related_charters: [resources/js/Pages/Atendimento/Inbox/Index.charter.md]
 tier: A
-charter_version: 18
+charter_version: 19
 permissao: whatsapp.access
 ---
 
@@ -308,7 +308,7 @@ Substituirá `/atendimento/inbox` após canary aprovado. Durante coexistência,
 | ✅ | `R-WA-CAIXA-UNIF-010 — startConversation: cria, reabre (não duplica) + guards canal/phone` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-011 — broadcast pre-flight: opt-in LGPD + janela 24h + draft auditável` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-012 — inbox AI: dry_run devolve fixture sem LLM + ACL canal fail-loud` | mesmo arquivo |
-| ✅ | `R-WA-CAIXA-UNIF-014 — canal ativo deslogado entra em unhealthyChannels + Tier 0` | mesmo arquivo |
+| ✅ | `R-WA-CAIXA-UNIF-015 — canal caído entra business-wide (sem grant) + saudável fora + Tier 0` | mesmo arquivo |
 | ✅ | `R-WA-CAIXA-UNIF-013 — canal whatsmeow ativo vira chip ativo com count real (PARTE 4)` | mesmo arquivo |
 
 ---
@@ -354,6 +354,7 @@ Após Wagner aprovar canary 7d:
 
 | Data | Autor | Mudança |
 |---|---|---|
+| 2026-06-19 | Claude Code [CL] (rebase de #2964 · direção [W] "qualquer conta pode ver") | **Banner de saúde business-wide.** `buildUnhealthyChannelsPayload` perde o filtro ACL-de-canal (assinatura cai pra `(int $businessId)`): o alerta "seu WhatsApp caiu" aparece pra QUALQUER conta com `whatsapp.access`, não só admin `view-all-phones` — o business pode não ter grants de canal e ninguém via o banner. Tier 0 preservado por `business_id`. Pest renomeado `R-WA-CAIXA-UNIF-014 (health) → 015` (business-wide; resolve a colisão com o `014 media_inbound_24h` pré-existente no main). A parte "probe detecta provision_pending" do #2964 original foi **descartada**: o main já cobre via ADR 0287 (`decideAction` com guard `healthBefore==healthy` + supressão por inbound recente) — superior. Charter v19. |
 | 2026-06-18 | Claude Code [CL] (follow-up de #2963 · direção [W]) | **Banner de saúde movido pro topo da LISTA + layout via primitivos.** Após [W] apontar o screenshot do protótipo ("esse seria o lugar correto? mantenha íntegro"), o `ChannelHealthBanner` saiu do `Index.tsx` (full-width no topo da tela) e foi pro topo da **coluna de conversas** (renderizado por `ConversationListV4`, logo após a busca — fiel ao protótipo). Prop eager `unhealthyChannels` desce `Index → ConversationListV4 → banner`. **Também conserta o `main`:** o #2963 mergeou só o 1º commit (versão com `<div className="flex/grid">` cru) e o **layout-primitives ratchet (ADR 0253)** ficou vermelho no `main` — refeito 100% com `<Stack>`/`<Inline>` (centragem de ícone via idioma permitido `grid place-items-center`); `node scripts/layout-primitives-guard.mjs` verde. `R-WA-CAIXA-UNIF-014` (payload) intacto. Charter v18. |
 | 2026-06-18 | Claude Code [CL] (handoff Cowork [CC]→[CL] · escolha [W]) | **Redesign visual do `ChannelHealthBanner` (Cowork).** O handoff `PROMPT_PARA_CODE_CHANNEL-HEALTH-BANNER` chegou com premissa stale ("a tela não avisa") — validei vs `main` (§10.4) e o banner US-WA-308 já estava live no topo (`Index.tsx:422`), e o agregado backend (`unhealthyChannels` + `last_health_check_at`) já existia (a "Onda 4" do prompt). [W] escolheu **trocar o visual** pelo design Cowork mantendo a arquitetura: tom graduado warn/err, dispensável, resumo multi-canal e CTA Reconectar. Adaptado aos estados REAIS do `whatsmeow:health-probe` — `disconnected`/`banned` (err) + `degraded` (warn); o prompt assumia um estado `down` que o backend **nunca emite** (seria dead-code). Único arquivo de produção: `_components/ChannelHealthBanner.tsx` (mesmo prop `channels: UnhealthyChannel[]` → `Index.tsx` intocado). Cor 100% semântica (tokens `warning`/`destructive`, R1 + ADR 0281). `R-WA-CAIXA-UNIF-014` (payload) intacto. Charter v17. |
 | 2026-06-18 | Claude (incidente WhatsApp atendimento) | **US-WA-308/309 banner "canal caiu — religar".** Origem: canal 11 (biz=1) deslogou "logged out from another device" às 07:50 sem webhook `LoggedOut` (WuzAPI não assina) → `channel_health` ficou `healthy`, a Caixa não avisou, linha caída ~3h sem ninguém ver. Fix: (1) prop eager `unhealthyChannels` no `CaixaUnificadaController` (ACL + Tier 0) + `ChannelHealthBanner` no topo da Caixa (clique → `/atendimento/canais/{id}` re-parear, QR já existente); (2) comando `whatsmeow:health-probe` (cron 3min, Kernel) que sonda `/session/status` real e converge disconnected/banned/healthy — fecha a lacuna do reconciler Baileys-only. Charter v16. Pest R-WA-CAIXA-UNIF-014. Sem dev server no worktree → build/typecheck/visual-regression no CI + screenshot [W] na prod (Wagner re-pareia e valida o fluxo real). |


### PR DESCRIPTION
Rebase limpo de [#2964](https://github.com/wagnerra23/oimpresso.com/pull/2964) sobre o main atual (estava `CONFLICTING`). Direção [W]: **"qualquer conta pode ver"** o alerta de canal caído.

## O que entra (3 arquivos)
- **`CaixaUnificadaController.php`** — `buildUnhealthyChannelsPayload` **perde o filtro ACL-de-canal** (assinatura cai pra `(int $businessId)`). O banner "seu WhatsApp caiu" aparece pra **qualquer conta com `whatsapp.access`**, não só admin `view-all-phones` (o business pode não ter grants de canal → ninguém via). **Tier 0 preservado** por `business_id`.
- **Pest** `CaixaUnificadaControllerTest` — health `R-WA-CAIXA-UNIF-014 → 015` (business-wide: canal caído entra sem grant + saudável fora + Tier 0). Resolve de quebra a **colisão pré-existente no main** (havia dois `014`: health + `media_inbound_24h`).
- **Charter** v19 — entrada + R-table.

## Conflitos resolvidos
- **`WhatsmeowHealthProbeCommand.php` → fica = main.** A parte "probe detecta `provision_pending`" do #2964 original foi **descartada**: o main já cobre via **ADR 0287** (`decideAction` com guard `healthBefore==healthy` + supressão por inbound recente), que é superior e mais conservador. #2964 marcava `provision_pending` incondicionalmente; main só quando o canal estava `healthy`.

Substitui #2964 (que vou fechar). CI roda o Pest 015 + build + PHPStan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)