### PR TITLE
ci(whatsapp): activity_log beforeEach desbloqueia 21 testes LogsActivity na lane sqlite

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -58,3 +58,31 @@ Modules/Jana/Tests/Feature/Smoke/WhatsappInboundCanaryCheckTest.php
 # (Log + Centrifugo + mcp_alertas_eventos). Adicionado na Fase 2: o teste existia
 # desde #3005 mas NÃO estava nesta lane, logo nunca rodava em CI ("suite mente").
 Modules/Whatsapp/Tests/Feature/ChannelHealthSnapshotCommandTest.php
+# ── Whatsapp LogsActivity sqlite-safe (auditoria cobertura-CI 2026-06-19) ─────
+# Estes 21 falhavam só por "no such table: activity_log" (models com Spatie
+# LogsActivity, 341 falhas na audit). O beforeEach scoped ao dir Whatsapp em
+# tests/Pest.php agora provisiona a tabela (idioma do bloco RecurringBilling).
+# Verde determinístico em 4 seeds rodados juntos (152 passed) + 3 seeds no
+# combinado dos 57 Whatsapp da lane (431 passed, 0 fail). FORA: DispatchToJanaBot
+# e PhoneResolutionWebhook (flaky order-dependente em grupo, fix à parte).
+Modules/Whatsapp/Tests/Feature/AuditChannelAccessCommandTest.php
+Modules/Whatsapp/Tests/Feature/ChannelBaileysInstanceIdHelperTest.php
+Modules/Whatsapp/Tests/Feature/ChannelBaileysWebhookIdempotencyTest.php
+Modules/Whatsapp/Tests/Feature/ChannelRequestUniqueIdentifierTest.php
+Modules/Whatsapp/Tests/Feature/ChannelUserAccessTest.php
+Modules/Whatsapp/Tests/Feature/CsatFlowTest.php
+Modules/Whatsapp/Tests/Feature/GuardiaoMidiaTest.php
+Modules/Whatsapp/Tests/Feature/HistorySyncQueueArchitectureTest.php
+Modules/Whatsapp/Tests/Feature/InboxQueueDerivationTest.php
+Modules/Whatsapp/Tests/Feature/InternalNoteTest.php
+Modules/Whatsapp/Tests/Feature/LastMessageDenormalizeTest.php
+Modules/Whatsapp/Tests/Feature/MacroVariantPickerTest.php
+Modules/Whatsapp/Tests/Feature/MediaMessageTest.php
+Modules/Whatsapp/Tests/Feature/MetricsAggregateCommandTest.php
+Modules/Whatsapp/Tests/Feature/PersistContactsFromHistorySyncJobTest.php
+Modules/Whatsapp/Tests/Feature/ReparseMediaFromPayloadCommandTest.php
+Modules/Whatsapp/Tests/Feature/SlaScanCommandTest.php
+Modules/Whatsapp/Tests/Feature/SlashConfigTest.php
+Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php
+Modules/Whatsapp/Tests/Feature/WhatsmeowCicloE2ETest.php
+Modules/Whatsapp/Tests/Feature/WhatsmeowResubscribeEventsCommandTest.php

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -59,3 +59,43 @@ if ($rbFeatureDir !== false) {
         }
     })->in($rbFeatureDir);
 }
+
+// Whatsapp — mesma dor do RB: muitos models têm Spatie LogsActivity, mas os testes
+// montam schema sintético sem `activity_log` e quebram no 1º create logável
+// ("no such table: activity_log" — 341 das falhas na auditoria de cobertura-CI
+// 2026-06-19). Garante a tabela (idempotente) num beforeEach scoped ao dir.
+//
+// O dir Whatsapp é MISTO: tem testes de reflexão pura que NÃO bootam app completo
+// (ex MessageHasArquivosTraitTest, sem `uses(TestCase)`). Neles `DB::connection()`
+// estoura ("facade root not set" / config não carregado). Por isso envolvemos em
+// try/catch: provisionar a tabela é best-effort — se não há DB booted, no-op. Não
+// mascara nada: se um teste REAL precisar de activity_log e a criação falhar, ele
+// quebra sozinho no 1º create logável. Só toca sqlite (no MySQL real a migration
+// canônica já cria a tabela, então `hasTable` curto-circuita).
+$waFeatureDir = realpath(__DIR__ . '/../Modules/Whatsapp/Tests/Feature');
+if ($waFeatureDir !== false) {
+    uses()->beforeEach(function () {
+        try {
+            if (\Illuminate\Support\Facades\DB::connection()->getDriverName() !== 'sqlite') {
+                return;
+            }
+            if (! \Illuminate\Support\Facades\Schema::hasTable('activity_log')) {
+                \Illuminate\Support\Facades\Schema::create('activity_log', function ($t) {
+                    $t->id();
+                    $t->string('log_name')->nullable();
+                    $t->text('description')->nullable();
+                    $t->unsignedBigInteger('subject_id')->nullable();
+                    $t->string('subject_type')->nullable();
+                    $t->unsignedBigInteger('causer_id')->nullable();
+                    $t->string('causer_type')->nullable();
+                    $t->json('properties')->nullable();
+                    $t->string('event')->nullable();
+                    $t->uuid('batch_uuid')->nullable();
+                    $t->timestamps();
+                });
+            }
+        } catch (\Throwable $e) {
+            // teste sem app/DB booted (reflexão pura) — nada a provisionar
+        }
+    })->in($waFeatureDir);
+}


### PR DESCRIPTION
## Contexto — continuação da auditoria de cobertura-CI Whatsapp (2026-06-19)

`Modules/Whatsapp/Tests/Feature/` tem 120 testes, mas a maioria nunca rodava em CI (ver PR #3027 pra o mapeamento completo de qual lane roda o quê). Triando as falhas dos ~118 fora da lane, **a causa #1 disparada é uma só: `no such table: activity_log` (341 falhas)** — vários models Whatsapp usam Spatie `LogsActivity` e os testes montam schema sintético sem essa tabela.

## O que este PR faz

Aplica o **mesmo idioma já presente no bloco RecurringBilling de `tests/Pest.php`**: um `beforeEach` scoped ao dir `Modules/Whatsapp/Tests/Feature` que provisiona `activity_log` (idempotente, `if (! hasTable)`).

O dir Whatsapp é **misto** (nem todo teste boota app completo), então o bloco precisa de 2 guards a mais que o do RB:
- `try/catch` — testes de reflexão pura sem `uses(TestCase)` (ex `MessageHasArquivosTraitTest`) fazem `DB::connection()` estourar; ali o provisionamento vira no-op. **Sem mascaramento**: se um teste real precisar da tabela e a criação falhar, ele quebra sozinho no 1º create logável.
- só toca **sqlite** (no MySQL real a migration canônica já cria `activity_log`).

Resultado: **21 testes** ficam verdes e entram na lane sqlite.

## Verificação local (worktree limpo off `origin/main`, sqlite `:memory:`)

- 21 rodados juntos: **4 seeds → 152 passed, 0 fail**.
- Combinado dos **57** Whatsapp que ficam na lane pós-merge (este PR + #3027 + os 3 já wired upstream): **3 seeds → 431 passed, 0 fail, 0 regressão** nos já-verdes.

## Fora desta leva

- **`DispatchToJanaBotTest`, `PhoneResolutionWebhookTest`** — verdes isolados mas **flaky order-dependente** em grupo (3/6 e 1/6 das rodadas) → fix à parte, não entram na lane.
- **~58 restantes** — precisam do schema MySQL real (`business`, `conversations`, `channel_user_access`, `contacts.deleted_at`, `whatsapp_*`...) ou de mais schema sintético. Decisão de lane MySQL fica pra outro momento.

## Relação com #3027

Independente e complementar. Ambos só adicionam à allowlist (`merge=union` via `.gitattributes` + `sort -u`) → sem conflito. Este PR também edita `tests/Pest.php` (bloco novo, não toca o do RB).

Refs: auditoria-cobertura-ci-whatsapp 2026-06-19

🤖 Generated with [Claude Code](https://claude.com/claude-code)