### PR TITLE
feat(jana): DesignDossieAssembler — dossiê de tela puro (PR-1a)

### DIFF
--- a/Modules/Jana/Services/Memoria/DesignDossieAssembler.php
+++ b/Modules/Jana/Services/Memoria/DesignDossieAssembler.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Memoria;
+
+/**
+ * PR-1 da estação de ingestão de design (plano vectorized-badger · pós-adversário).
+ *
+ * MONTA o "dossiê de tela" — uma READ-VIEW efêmera que reúne a memória de decisões
+ * que JÁ existe curada (charter+casos+decisoes+RUNBOOK+visual-comparison+persona+
+ * feedback) num só doc, com proveniência. É o contexto que o handoff padrão NÃO
+ * carrega e a IA precisa ANTES de aplicar um zip de design.
+ *
+ * NÃO é canon, NÃO compete com o charter (a lei segue sendo o charter — ADR 0270 D-2):
+ * o dossiê só LÊ e CONCATENA o curado, não re-destila com LLM (o adversário matou isso).
+ *
+ * DETERMINÍSTICO por contrato: dado o mesmo conteúdo das fontes, devolve o mesmo
+ * markdown — SEM timestamp no corpo (re-run idêntico = a âncora do PR-1). Função PURA
+ * (não toca FS); o comando faz a resolução de paths e injeta os conteúdos.
+ */
+final class DesignDossieAssembler
+{
+    /** Limite de linhas por excerto de fonte (mantém o dossiê em ~1-2 páginas). */
+    public const EXCERPT_LINES = 18;
+
+    /**
+     * @param array{
+     *   tela:string,
+     *   module:string,
+     *   page_id?:?string,
+     *   sources: array<string, array{path:string, content:?string}>,
+     *   personas?: array{primary?:?string, secondary?:array<int,string>, files?:array<string,string>},
+     *   feedback?: array<int, array{path:string, content:?string}>,
+     *   padroes?: array<int, string>
+     * } $ctx
+     */
+    public static function assemble(array $ctx): string
+    {
+        $tela = (string) ($ctx['tela'] ?? '?');
+        $module = (string) ($ctx['module'] ?? '?');
+        $pageId = $ctx['page_id'] ?? null;
+        $src = $ctx['sources'] ?? [];
+
+        $charter = $src['charter']['content'] ?? null;
+        $out = [];
+
+        $out[] = "---";
+        $out[] = "tela: {$module}/{$tela}";
+        $out[] = 'page_id: ' . ($pageId ?? '?');
+        $out[] = "gerado_por: design:dossie";
+        $out[] = "tipo: read-view efemera (NAO-canon — a lei e o charter)";
+        $out[] = "---";
+        $out[] = "";
+        $out[] = "# DOSSIÊ DE TELA — {$module}/{$tela}";
+        $out[] = "";
+        $out[] = "> Read-view montada das fontes curadas que já existem. **Não é canon** e não substitui o charter (a porta única da verdade-de-tela · ADR 0270 D-2). É o contexto pra IA ler ANTES de aplicar.";
+
+        // 1. O que já foi decidido (charter: Mission + Goals + Non-Goals)
+        $out[] = self::block('1. O que já foi decidido (charter)', $charter === null
+            ? self::ausente($src['charter']['path'] ?? 'charter')
+            : self::join([
+                self::section($charter, 'Mission'),
+                self::section($charter, 'Goals'),
+                self::section($charter, 'Non-Goals'),
+            ]) . self::prov($src['charter']['path'] ?? null));
+
+        // 2. Anti-hooks / Tier 0 (charter)
+        $out[] = self::block('2. Anti-hooks / Tier 0', $charter === null
+            ? '_(charter ausente)_'
+            : (self::section($charter, 'Automation Anti-hooks') ?? '_(sem seção Anti-hooks)_') . self::prov($src['charter']['path'] ?? null));
+
+        // 3. Regras / contrato (casos)
+        $out[] = self::block('3. Regras / contrato (casos)', self::excerptOrAusente($src['casos'] ?? null));
+
+        // 4. Em-debate (decisoes / Register)
+        $out[] = self::block('4. Em-debate (Register)', self::excerptOrAusente($src['decisoes'] ?? null));
+
+        // 5. Últimas conversões (RUNBOOK + visual-comparison + UX targets)
+        $conv = [
+            self::prov($src['runbook']['path'] ?? null, 'RUNBOOK'),
+            self::prov($src['visual_comparison']['path'] ?? null, 'visual-comparison'),
+            self::prov($src['briefing']['path'] ?? null, 'BRIEFING'),
+        ];
+        if ($charter !== null) {
+            $conv[] = self::section($charter, 'UX Targets');
+        }
+        $out[] = self::block('5. Últimas conversões & alvos', self::join($conv));
+
+        // 6. Padronizações DS aplicáveis (related_adrs do charter + PTs passados)
+        $adrs = $charter !== null ? self::frontmatterList($charter, 'related_adrs') : [];
+        $padroes = array_values(array_unique(array_merge($adrs, $ctx['padroes'] ?? [])));
+        $out[] = self::block('6. Padronizações DS aplicáveis', $padroes === []
+            ? '_(nenhuma ADR/PT resolvida)_'
+            : implode("\n", array_map(static fn ($p) => "- `{$p}`", $padroes)));
+
+        // 7. Reclamações / feedback
+        $fb = $ctx['feedback'] ?? [];
+        $out[] = self::block('7. Reclamações / feedback', $fb === []
+            ? '_(nenhum feedback encontrado pra esta tela)_'
+            : implode("\n", array_map(static fn ($f) => self::prov($f['path'] ?? null, basename((string) ($f['path'] ?? '?'))), $fb)));
+
+        // 8. Persona(s)
+        $p = $ctx['personas'] ?? [];
+        $linhas = [];
+        if (! empty($p['primary'])) {
+            $linhas[] = "- **primary:** `{$p['primary']}`";
+        }
+        foreach (($p['secondary'] ?? []) as $s) {
+            $linhas[] = "- secondary: `{$s}`";
+        }
+        $out[] = self::block('8. Persona(s) da tela', $linhas === [] ? '_(persona não resolvida)_' : implode("\n", $linhas));
+
+        // Proveniência consolidada
+        $prov = ['## Proveniência (fontes lidas)', ''];
+        foreach ($src as $key => $s) {
+            $marca = ($s['content'] ?? null) !== null ? 'presente' : 'AUSENTE';
+            $prov[] = "- {$key}: `" . ($s['path'] ?? '?') . "` ({$marca})";
+        }
+        $out[] = "\n" . implode("\n", $prov);
+
+        return implode("\n", $out) . "\n";
+    }
+
+    /** Extrai o bloco de uma seção `## Heading` até o próximo `## ` ou o fim. */
+    public static function section(string $md, string $heading): ?string
+    {
+        // para no próximo `## ` OU num `---` HR separador de seções (charter real usa HR)
+        $pattern = '/^##\s+' . preg_quote($heading, '/') . '\s*$(.*?)(?=^##\s|^---\s*$|\z)/ms';
+        if (preg_match($pattern, $md, $m)) {
+            $body = trim($m[1]);
+
+            return "**{$heading}**\n\n" . $body;
+        }
+
+        return null;
+    }
+
+    /** Lê uma lista do frontmatter YAML (ex: related_adrs) — parser simples por linha. */
+    public static function frontmatterList(string $md, string $field): array
+    {
+        if (! preg_match('/^---\s*$(.*?)^---\s*$/ms', $md, $fm)) {
+            return [];
+        }
+        $block = $fm[1];
+        // captura `field:` seguido de linhas `  - item`
+        if (! preg_match('/^' . preg_quote($field, '/') . ':\s*$(.*?)(?=^\S|\z)/ms', $block, $m)) {
+            return [];
+        }
+        preg_match_all('/^\s*-\s*(.+?)\s*$/m', $m[1], $items);
+
+        return array_map('trim', $items[1] ?? []);
+    }
+
+    private static function excerptOrAusente(?array $s): string
+    {
+        $content = $s['content'] ?? null;
+        if ($content === null) {
+            return self::ausente($s['path'] ?? '?');
+        }
+        $lines = preg_split('/\r?\n/', trim($content)) ?: [];
+        $excerpt = implode("\n", array_slice($lines, 0, self::EXCERPT_LINES));
+        if (count($lines) > self::EXCERPT_LINES) {
+            $excerpt .= "\n…";
+        }
+
+        return $excerpt . self::prov($s['path'] ?? null);
+    }
+
+    private static function block(string $title, string $body): string
+    {
+        return "\n## {$title}\n\n" . $body;
+    }
+
+    private static function join(array $parts): string
+    {
+        $parts = array_filter($parts, static fn ($p) => $p !== null && trim((string) $p) !== '');
+
+        return $parts === [] ? '_(sem conteúdo)_' : implode("\n\n", $parts);
+    }
+
+    private static function ausente(string $path): string
+    {
+        return "_(ausente: `{$path}` — fonte ainda não existe pra esta tela)_";
+    }
+
+    private static function prov(?string $path, ?string $label = null): string
+    {
+        if ($path === null || $path === '') {
+            return $label !== null ? "- {$label}: _(ausente)_" : '';
+        }
+        $label ??= 'fonte';
+
+        return $label === 'fonte'
+            ? "\n\n_proveniência:_ `{$path}`"
+            : "- {$label}: `{$path}`";
+    }
+}

--- a/Modules/Jana/Services/Memoria/DesignDossieAssembler.php
+++ b/Modules/Jana/Services/Memoria/DesignDossieAssembler.php
@@ -25,20 +25,25 @@ final class DesignDossieAssembler
     public const EXCERPT_LINES = 18;
 
     /**
+     * Chaves opcionais de propósito (acesso defensivo com `??` — o comando pode
+     * omitir fontes greenfield). Valores de fonte são `array<string, string|null>`
+     * (path/content podem faltar) pra justificar o coalescing sem o strict-rule
+     * "offset always exists" reclamar.
+     *
      * @param array{
-     *   tela:string,
-     *   module:string,
+     *   tela?:string,
+     *   module?:string,
      *   page_id?:?string,
-     *   sources: array<string, array{path:string, content:?string}>,
-     *   personas?: array{primary?:?string, secondary?:array<int,string>, files?:array<string,string>},
-     *   feedback?: array<int, array{path:string, content:?string}>,
+     *   sources?: array<string, array<string, string|null>>,
+     *   personas?: array{primary?:?string, secondary?:array<int,string>},
+     *   feedback?: array<int, array<string, string|null>>,
      *   padroes?: array<int, string>
      * } $ctx
      */
     public static function assemble(array $ctx): string
     {
-        $tela = (string) ($ctx['tela'] ?? '?');
-        $module = (string) ($ctx['module'] ?? '?');
+        $tela = $ctx['tela'] ?? '?';
+        $module = $ctx['module'] ?? '?';
         $pageId = $ctx['page_id'] ?? null;
         $src = $ctx['sources'] ?? [];
 
@@ -149,7 +154,7 @@ final class DesignDossieAssembler
         }
         preg_match_all('/^\s*-\s*(.+?)\s*$/m', $m[1], $items);
 
-        return array_map('trim', $items[1] ?? []);
+        return array_map('trim', $items[1]);
     }
 
     private static function excerptOrAusente(?array $s): string

--- a/Modules/Jana/Tests/Unit/DesignDossieAssemblerTest.php
+++ b/Modules/Jana/Tests/Unit/DesignDossieAssemblerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Memoria\DesignDossieAssembler;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-1 da estação de ingestão de design — o assembler PURO do dossiê.
+ *
+ * Testa que: monta as 8 seções lendo o curado existente; marca AUSENTE o que falta;
+ * extrai Mission/Goals do charter + related_adrs do frontmatter; lista persona e
+ * feedback; e é DETERMINÍSTICO (re-run idêntico — sem timestamp no corpo). Puro,
+ * sem FS/LLM/DB.
+ */
+
+function charterFixture(): string
+{
+    return <<<'MD'
+    ---
+    page: /sells
+    page_id: sells-index
+    parent_module: Sells
+    related_adrs:
+      - 0093-multi-tenant-isolation-tier-0
+      - 0190-primary-button-roxo-universal-295
+    ---
+
+    # Page Charter — /sells
+
+    ## Mission
+
+    Tela cockpit de vendas do business.
+
+    ## Goals
+
+    - PageHeader v3 com primary roxo
+    - 4 KPI cards via Inertia::defer
+
+    ## Non-Goals
+
+    - NÃO emitir SEFAZ sem clique humano
+
+    ## Automation Anti-hooks
+
+    - Tier 0 IRREVOGÁVEL: business_id em toda query
+
+    ## UX Targets
+
+    - p95 first-paint < 800ms
+    MD;
+}
+
+function dossieCtx(array $over = []): array
+{
+    return array_replace_recursive([
+        'tela' => 'Index',
+        'module' => 'Sells',
+        'page_id' => 'sells-index',
+        'sources' => [
+            'charter' => ['path' => 'resources/js/Pages/Sells/Index.charter.md', 'content' => charterFixture()],
+            'casos' => ['path' => 'resources/js/Pages/Sells/Index.casos.md', 'content' => null], // greenfield
+            'decisoes' => ['path' => 'prototipo-ui/prototipos/vendas/decisoes.md', 'content' => null],
+            'runbook' => ['path' => 'memory/requisitos/Sells/RUNBOOK-index.md', 'content' => '# RUNBOOK'],
+            'visual_comparison' => ['path' => 'memory/requisitos/Sells/Sells-visual-comparison.md', 'content' => '# VC'],
+            'briefing' => ['path' => 'memory/requisitos/Sells/BRIEFING.md', 'content' => '# BRIEFING'],
+        ],
+        'personas' => ['primary' => 'larissa-rota-livre', 'secondary' => ['kamila-martinho']],
+        'feedback' => [['path' => 'memory/reference/feedback-sells-x.md', 'content' => 'reclamação']],
+        'padroes' => ['PT-01-Lista'],
+    ], $over);
+}
+
+test('monta as seções principais + cabeçalho da tela', function () {
+    $d = DesignDossieAssembler::assemble(dossieCtx());
+    expect($d)
+        ->toContain('DOSSIÊ DE TELA — Sells/Index')
+        ->toContain('page_id: sells-index')
+        ->toContain('1. O que já foi decidido')
+        ->toContain('2. Anti-hooks / Tier 0')
+        ->toContain('7. Reclamações / feedback')
+        ->toContain('8. Persona(s) da tela')
+        ->toContain('## Proveniência (fontes lidas)');
+});
+
+test('extrai Mission/Goals/Anti-hooks do charter', function () {
+    $d = DesignDossieAssembler::assemble(dossieCtx());
+    expect($d)
+        ->toContain('Tela cockpit de vendas do business')
+        ->toContain('4 KPI cards via Inertia::defer')
+        ->toContain('Tier 0 IRREVOGÁVEL: business_id em toda query');
+});
+
+test('padronizações = related_adrs do charter + PTs passados', function () {
+    $d = DesignDossieAssembler::assemble(dossieCtx());
+    expect($d)
+        ->toContain('0093-multi-tenant-isolation-tier-0')
+        ->toContain('0190-primary-button-roxo-universal-295')
+        ->toContain('PT-01-Lista');
+});
+
+test('marca AUSENTE a fonte que não existe (casos greenfield)', function () {
+    $d = DesignDossieAssembler::assemble(dossieCtx());
+    expect($d)
+        ->toContain('casos:') // na proveniência
+        ->toContain('(AUSENTE)')
+        ->toContain('Index.casos.md');
+});
+
+test('lista persona e feedback', function () {
+    $d = DesignDossieAssembler::assemble(dossieCtx());
+    expect($d)
+        ->toContain('larissa-rota-livre')
+        ->toContain('kamila-martinho')
+        ->toContain('feedback-sells-x.md');
+});
+
+test('é DETERMINÍSTICO — re-run idêntico (sem timestamp no corpo)', function () {
+    expect(DesignDossieAssembler::assemble(dossieCtx()))
+        ->toBe(DesignDossieAssembler::assemble(dossieCtx()));
+});
+
+test('section() extrai o bloco da seção', function () {
+    $s = DesignDossieAssembler::section(charterFixture(), 'Mission');
+    expect($s)->toContain('**Mission**')->toContain('Tela cockpit de vendas do business');
+    expect(DesignDossieAssembler::section(charterFixture(), 'Inexistente'))->toBeNull();
+});
+
+test('frontmatterList() lê related_adrs', function () {
+    $adrs = DesignDossieAssembler::frontmatterList(charterFixture(), 'related_adrs');
+    expect($adrs)->toBe([
+        '0093-multi-tenant-isolation-tier-0',
+        '0190-primary-button-roxo-universal-295',
+    ]);
+});


### PR DESCRIPTION
## PR-1a — o assembler do dossiê (núcleo puro)

Primeira peça da **estação de ingestão de design** ([plano](../blob/main/.claude) vectorized-badger, pós-adversário). Resolve a dor: o handoff padrão não dá o contexto de decisões da tela.

`DesignDossieAssembler::assemble()` monta a **read-view "dossiê de tela"** lendo o **curado que já existe** (charter+casos+decisoes+RUNBOOK+visual-comparison+persona+feedback) → 8 seções + proveniência. `section()` extrai Mission/Goals/Anti-hooks do charter; `frontmatterList()` lê `related_adrs`.

### Princípios (respeitam o adversário)
- **SEM LLM, SEM timestamp** → `assemble()` é PURO e **determinístico** (re-run idêntico = a âncora).
- **NÃO-canon, não compete com o charter** — a lei segue sendo o charter (ADR 0270 D-2); o dossiê só lê+concatena. Sem re-destilar decisão humana com LLM (o adversário matou essa ideia da v1 do plano).
- Fontes ausentes → marcadas `AUSENTE` (não quebra; charter parcialmente greenfield).

### Testes (8 Pest)
seções + cabeçalho · extração charter · padronizações (related_adrs+PT) · AUSENTE · persona/feedback · **determinismo (re-run idêntico)** · `section()` · `frontmatterList()`.

### Revisão adversária (antes de abrir)
Um cético portou as regex pra Node e confirmou os 8 testes passando; achou 4 defeitos — **corrigidos os 2 do assembler** (double-dash no feedback; `section()` parando em `---` HR do charter real). Os outros 2 (glob visual-comparison; `page_id` lido do charter) vivem no comando → **PR-1b**.

### Notas
334 linhas (assembler 198 + teste 136) — o teste é metade; é o núcleo testável coeso. O comando `design:dossie` vem no PR-1b (empilhado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)