### PR TITLE
feat(jana): comando design:dossie (PR-1b)

### DIFF
--- a/Modules/Jana/Console/Commands/DesignDossieCommand.php
+++ b/Modules/Jana/Console/Commands/DesignDossieCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Jana\Services\Memoria\DesignDossieAssembler;
+
+/**
+ * PR-1 da estação de ingestão de design ([plano] vectorized-badger · ADR 0270 D-2).
+ *
+ * `design:dossie --module=Sells --tela=Index` → MONTA o dossiê da tela lendo as fontes
+ * curadas que JÁ existem (charter+casos+decisoes+RUNBOOK+visual-comparison+briefing+
+ * persona+feedback) e imprime/escreve a READ-VIEW. É o contexto que o handoff padrão
+ * não carrega e a IA deve ler ANTES de aplicar um zip de design.
+ *
+ * Read-only sobre a memória: NÃO escreve canon, NÃO chama LLM, NÃO aplica nada.
+ * Determinístico (o corpo do dossiê não carrega timestamp). Raiz configurável
+ * (`jana.dossie_root`) pra testar com fixtures sem tocar o repo real.
+ */
+class DesignDossieCommand extends Command
+{
+    protected $signature = 'design:dossie
+                            {--module= : Módulo (ex: Sells)}
+                            {--tela= : Tela/arquivo (ex: Index)}
+                            {--out= : Caminho de saída (default: stdout)}';
+
+    protected $description = 'Monta o dossiê de decisões de uma tela (read-view do curado existente) — contexto pra IA antes de aplicar design';
+
+    public function handle(): int
+    {
+        $module = (string) $this->option('module');
+        $tela = (string) $this->option('tela');
+        if ($module === '' || $tela === '') {
+            $this->error('Use --module=<Mod> --tela=<Tela>.');
+
+            return self::FAILURE;
+        }
+
+        $sources = $this->resolveSources($module, $tela);
+        $dossie = DesignDossieAssembler::assemble([
+            'tela' => $tela,
+            'module' => $module,
+            // page_id vem do charter (verdade); fallback ao slug derivado se ausente
+            'page_id' => $this->pageIdFromCharter($sources['charter']['content'] ?? null)
+                ?? mb_strtolower("{$module}-{$tela}"),
+            'sources' => $sources,
+            'personas' => $this->resolvePersonas($module),
+            'feedback' => $this->resolveFeedback($module),
+            'padroes' => [],
+        ]);
+
+        $out = (string) $this->option('out');
+        if ($out !== '' && $out !== '-') {
+            @mkdir(dirname($out), 0o775, true);
+            file_put_contents($out, $dossie);
+            $this->info("Dossiê escrito em {$out} (read-view efêmera, não-canon).");
+        } else {
+            $this->line($dossie);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function root(): string
+    {
+        return rtrim((string) config('jana.dossie_root', base_path()), '/\\');
+    }
+
+    /** @return array<string, array{path:string, content:?string}> */
+    private function resolveSources(string $module, string $tela): array
+    {
+        $telaLower = mb_strtolower($tela);
+        $rel = [
+            'charter' => "resources/js/Pages/{$module}/{$tela}.charter.md",
+            'casos' => "resources/js/Pages/{$module}/{$tela}.casos.md",
+            'runbook' => "memory/requisitos/{$module}/RUNBOOK-{$telaLower}.md",
+            'briefing' => "memory/requisitos/{$module}/BRIEFING.md",
+        ];
+        $sources = [];
+        foreach ($rel as $key => $path) {
+            $sources[$key] = ['path' => $path, 'content' => $this->read($path)];
+        }
+        // best-effort por glob (nomes variam): decisoes do protótipo + visual-comparison
+        $sources['decisoes'] = $this->firstGlob([
+            "prototipo-ui/prototipos/{$telaLower}/decisoes.md",
+            "prototipo-ui/prototipos/" . mb_strtolower($module) . "/decisoes.md",
+        ]);
+        $sources['visual_comparison'] = $this->firstGlob([
+            "memory/requisitos/{$module}/*{$telaLower}*visual-comparison.md", // prioriza a tela
+            "memory/requisitos/{$module}/*visual-comparison.md",
+        ]);
+
+        return $sources;
+    }
+
+    /** @return array{primary:?string, secondary:array<int,string>} */
+    private function resolvePersonas(string $module): array
+    {
+        $path = $this->root() . '/memory/requisitos/_DesignSystem/personas-por-modulo.yml';
+        if (! is_file($path)) {
+            return ['primary' => null, 'secondary' => []];
+        }
+        try {
+            $parsed = \Symfony\Component\Yaml\Yaml::parseFile($path);
+        } catch (\Throwable) {
+            return ['primary' => null, 'secondary' => []];
+        }
+        $node = $parsed[mb_strtolower($module)] ?? null;
+        if (! is_array($node)) {
+            return ['primary' => null, 'secondary' => []];
+        }
+
+        return [
+            'primary' => is_string($node['primary'] ?? null) ? $node['primary'] : null,
+            'secondary' => array_values(array_filter((array) ($node['secondary'] ?? []), 'is_string')),
+        ];
+    }
+
+    /** @return array<int, array{path:string, content:?string}> */
+    private function resolveFeedback(string $module, int $max = 5): array
+    {
+        $needle = mb_strtolower($module);
+        $found = [];
+        foreach (glob($this->root() . '/memory/reference/feedback-*.md') ?: [] as $abs) {
+            $name = basename($abs);
+            $content = (string) @file_get_contents($abs);
+            if (str_contains(mb_strtolower($name), $needle) || str_contains(mb_strtolower($content), "modules/{$needle}")) {
+                $found[] = ['path' => 'memory/reference/' . $name, 'content' => mb_substr($content, 0, 600)];
+            }
+            if (count($found) >= $max) {
+                break;
+            }
+        }
+
+        return $found;
+    }
+
+    /** Lê o `page_id:` real do frontmatter do charter (não fabrica). */
+    private function pageIdFromCharter(?string $charter): ?string
+    {
+        if ($charter === null) {
+            return null;
+        }
+
+        return preg_match('/^page_id:\s*(.+?)\s*$/m', $charter, $m) ? trim($m[1]) : null;
+    }
+
+    private function read(string $rel): ?string
+    {
+        $abs = $this->root() . '/' . $rel;
+
+        return is_file($abs) ? (string) file_get_contents($abs) : null;
+    }
+
+    /** @param array<int,string> $rels @return array{path:string, content:?string} */
+    private function firstGlob(array $rels): array
+    {
+        foreach ($rels as $rel) {
+            foreach (glob($this->root() . '/' . $rel) ?: [] as $abs) {
+                return ['path' => ltrim(str_replace($this->root(), '', $abs), '/\\'), 'content' => (string) file_get_contents($abs)];
+            }
+        }
+
+        return ['path' => $rels[0] ?? '?', 'content' => null];
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -76,6 +76,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\UiJudgeTrendCommand::class, // parecer PR #2270 — medição do PR UI Judge (trend score/verdict/custo)
                 \Modules\Jana\Console\Commands\JanaRecallEvalCommand::class, // KL-C2 SDD F1 — eval determinístico de recall (golden set expected/violations, ADR 0270 D-4/D-5 + 0274 + 0275)
                 \Modules\Jana\Console\Commands\DistillModuleTruthCommand::class, // ADR 0291 — distiller-módulo-verdade (diário→manual; reescreve BRIEFING.md)
+                \Modules\Jana\Console\Commands\DesignDossieCommand::class, // plano vectorized-badger PR-1 — dossiê de tela (read-view do curado, pré-aplicação)
             ]);
         }
     }


### PR DESCRIPTION
## PR-1b — o comando que monta o dossiê

> Empilhado em #3032 (PR-1a, o assembler). Base = `feat/design-dossie`; retargeto pra `main` quando #3032 mergear.

`design:dossie --module=Sells --tela=Index [--out=]` — resolve as fontes curadas no disco e chama o `DesignDossieAssembler` (PR-1a): charter/casos/RUNBOOK/briefing + glob decisoes/visual-comparison + personas (`personas-por-modulo.yml`) + feedback. Imprime a read-view (ou `--out` arquivo). **Read-only, SEM LLM, prepare-only.** Raiz configurável (`jana.dossie_root`).

Corrige os 2 defeitos do resolver que o adversário achou: visual-comparison glob prioriza a tela; `page_id` LIDO do frontmatter do charter (não fabricado).

## Infra Contract

**Mudança de runtime:** registra **1 comando CLI** (`design:dossie`) no `JanaServiceProvider` (`$this->commands([...])`, dentro de `runningInConsole()`). **Nenhuma rota/middleware/HTTP/migration novos** — só artisan. **Nenhuma superfície HTTP** → não há `curl`/HTTP status pra colar.

**Validação:** `php artisan design:dossie --module=Sells --tela=Index` imprime o dossiê (read-view, não escreve canon). Read-only sobre a memória; não toca prod, não chama LLM, não aplica nada. Determinístico (assembler sem timestamp).

**Rollback:** remover a linha do array de comandos no provider. Zero efeito em dados/rotas.

<!-- evidence-override: PR só registra um comando artisan (sem HTTP/rota/middleware/migration); read-only, sem LLM, sem superfície de rede. Sem curl porque não há endpoint. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)