### PR TITLE
feat(jana): design:ingest-zip + cowork-map (PR-2b)

### DIFF
--- a/.github/scripts/pii-scan.sh
+++ b/.github/scripts/pii-scan.sh
@@ -70,7 +70,7 @@ CNPJ_REGEX='[0-9]{2}\.[0-9]{3}\.[0-9]{3}/[0-9]{4}-[0-9]{2}'
 # pra design visual — não código operacional, não vai pra prod). Inclusão aqui evita
 # floods de falso-positivo em PRs que tocam outros arquivos. Catalogado 2026-05-17:
 # data-os.jsx + vendas-extras.jsx + vendas-output.jsx têm 16+ CNPJs fake placeholder.
-SKIP_DIR_REGEX='^(vendor|node_modules|public|storage|bootstrap/cache|\.git|prototipo-ui/prototipos)/'
+SKIP_DIR_REGEX='^(vendor|node_modules|public|storage|bootstrap/cache|\.git|prototipo-ui/prototipos|prototipo-ui/_incoming)/'
 SKIP_EXT_REGEX='\.(lock|min\.js|min\.css|map|svg|png|jpg|jpeg|gif|webp|pdf|zip|woff2?|ttf|eot)$'
 
 violations=0

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 /node_modules
 /public/hot
 /public/storage
+
+# Estação de ingestão de design (plano vectorized-badger PR-2): staging volátil
+# do unzip + artefatos preparados (PLANO-MUDANCAS, SESSION). Read-view efêmera,
+# nunca canon — o que vira verdade entra via prototipos/<tela>/ sob gate Wagner.
+/prototipo-ui/_incoming/
 /storage/*.key
 /storage/
 /vendor

--- a/Modules/Jana/Console/Commands/DesignIngestZipCommand.php
+++ b/Modules/Jana/Console/Commands/DesignIngestZipCommand.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Process;
+use Modules\Jana\Services\Memoria\DesignIngestPlanner;
+
+/**
+ * PR-2b da estação de ingestão de design ([plano] vectorized-badger · ADR 0270).
+ *
+ * `design:ingest-zip --zip=<x.zip> --tela=vendas` (prepare-only): descompacta SEMPRE
+ * no mesmo lugar (`prototipo-ui/_incoming/<tela>/`, gitignored) → roteia contra o
+ * `cowork-map.json` (DesignIngestPlanner) → `git diff --no-index` vs a tela commitada
+ * → escreve os entregáveis em `_prepared/`: PLANO-MUDANCAS-<tela>.md + a memória de
+ * sessão da ingestão. NADA é aplicado: a aplicação real (`prototipos/<tela>/`) é gate
+ * Wagner/CT100 (ADR 0291 D-E). Raiz configurável (`jana.dossie_root`) p/ fixtures.
+ */
+class DesignIngestZipCommand extends Command
+{
+    protected $signature = 'design:ingest-zip
+                            {--zip= : Caminho do zip de design do Cowork}
+                            {--tela= : Tela alvo (chave no cowork-map.json, ex: vendas)}
+                            {--dry-run : (DEFAULT) prepara e NÃO aplica}';
+
+    protected $description = 'Ingere um zip de design (pré-aplicação): unzip + map-roteamento + diff + PLANO-MUDANCAS + memória de sessão. Prepare-only.';
+
+    public function handle(): int
+    {
+        $zip = (string) $this->option('zip');
+        $tela = (string) $this->option('tela');
+        if ($zip === '' || $tela === '') {
+            $this->error('Use --zip=<arquivo.zip> --tela=<tela>.');
+
+            return self::FAILURE;
+        }
+        if (! is_file($zip)) {
+            $this->error("Zip não encontrado: {$zip}");
+
+            return self::FAILURE;
+        }
+
+        $root = rtrim((string) config('jana.dossie_root', base_path()), '/\\');
+        $incomingDir = "{$root}/prototipo-ui/_incoming/{$tela}";
+        $committedDir = "{$root}/prototipo-ui/prototipos/{$tela}";
+        $preparedDir = "{$incomingDir}/_prepared";
+
+        $files = $this->extractZip($zip, $incomingDir);
+        if ($files === []) {
+            $this->warn('Zip vazio — nada a ingerir.');
+
+            return self::SUCCESS;
+        }
+
+        $map = $this->loadMap($root);
+        $routing = DesignIngestPlanner::route($map, $files, $tela);
+        $diff = DesignIngestPlanner::parseDiff($this->diffNameStatus($root, $committedDir, $incomingDir, $files));
+
+        $plano = DesignIngestPlanner::renderPlano($tela, $routing, $diff);
+        $session = DesignIngestPlanner::renderSession($tela, $routing, $diff, now()->toDateString());
+
+        @mkdir($preparedDir, 0o775, true);
+        file_put_contents("{$preparedDir}/PLANO-MUDANCAS-{$tela}.md", $plano);
+        file_put_contents("{$preparedDir}/SESSION-design-ingest-{$tela}.md", $session);
+
+        $this->info("✓ Ingestão preparada (NADA aplicado) em {$preparedDir}:");
+        $this->line("  • PLANO-MUDANCAS-{$tela}.md — " . count($routing['routed']) . " roteados, " . count($routing['extras']) . " extra(s)");
+        $this->line("  • SESSION-design-ingest-{$tela}.md — memória da ingestão");
+        if ($routing['extras'] !== []) {
+            $this->warn('  ⚠ ' . count($routing['extras']) . ' arquivo(s) fora do cowork-map — avaliar antes de aplicar.');
+        }
+        $this->line('  Aplicar é decisão do Wagner (gate CT100) — esta estação só prepara.');
+
+        return self::SUCCESS;
+    }
+
+    /** @return list<string> nomes relativos extraídos (ordenados, determinístico) */
+    private function extractZip(string $zipPath, string $destDir): array
+    {
+        $zip = new \ZipArchive();
+        if ($zip->open($zipPath) !== true) {
+            $this->error("Falha ao abrir o zip: {$zipPath}");
+
+            return [];
+        }
+        if (! is_dir($destDir)) {
+            @mkdir($destDir, 0o775, true);
+        }
+        $zip->extractTo($destDir);
+        $zip->close();
+
+        $out = [];
+        if (is_dir($destDir)) {
+            $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($destDir, \FilesystemIterator::SKIP_DOTS));
+            foreach ($it as $f) {
+                if ($f instanceof \SplFileInfo && $f->isFile()) {
+                    $rel = ltrim(str_replace($destDir, '', $f->getPathname()), '/\\');
+                    if (! str_starts_with($rel, '_prepared')) {
+                        $out[] = str_replace('\\', '/', $rel);
+                    }
+                }
+            }
+        }
+        sort($out);
+
+        return $out;
+    }
+
+    /** @return array<string, mixed> */
+    private function loadMap(string $root): array
+    {
+        $path = "{$root}/prototipo-ui/cowork-map.json";
+        if (! is_file($path)) {
+            return [];
+        }
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * `git diff --no-index --name-status` da tela commitada vs a extraída. Se a tela
+     * ainda não existe commitada, tudo é "added" (deriva dos arquivos extraídos).
+     *
+     * @param  list<string>  $files
+     */
+    private function diffNameStatus(string $root, string $committedDir, string $incomingDir, array $files): string
+    {
+        if (! is_dir($committedDir)) {
+            return implode("\n", array_map(static fn ($f) => "A\t{$f}", $files));
+        }
+        try {
+            $result = Process::path($root)->run([
+                'git', 'diff', '--no-index', '--name-status', '--', $committedDir, $incomingDir,
+            ]);
+
+            return $result->output(); // exit 1 quando há diff — output válido mesmo assim
+        } catch (\Throwable) {
+            return implode("\n", array_map(static fn ($f) => "A\t{$f}", $files));
+        }
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -76,6 +76,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\UiJudgeTrendCommand::class, // parecer PR #2270 — medição do PR UI Judge (trend score/verdict/custo)
                 \Modules\Jana\Console\Commands\JanaRecallEvalCommand::class, // KL-C2 SDD F1 — eval determinístico de recall (golden set expected/violations, ADR 0270 D-4/D-5 + 0274 + 0275)
                 \Modules\Jana\Console\Commands\DistillModuleTruthCommand::class, // ADR 0291 — distiller-módulo-verdade (diário→manual; reescreve BRIEFING.md)
+                \Modules\Jana\Console\Commands\DesignIngestZipCommand::class, // plano vectorized-badger PR-2 — ingestão de design-zip (prepare-only)
             ]);
         }
     }

--- a/prototipo-ui/cowork-map.json
+++ b/prototipo-ui/cowork-map.json
@@ -1,0 +1,16 @@
+{
+  "version": "1",
+  "_doc": "Map de roteamento da ingestão de design-zip (plano vectorized-badger PR-2). Para cada tela, routes[].glob casa o NOME do arquivo extraído do zip → .to (destino no repo; se .to termina em '/', preserva o nome do arquivo). Arquivo sem rota = EXTRA (reportado no PLANO-MUDANCAS pra avaliar antes de aplicar). 1 projeto Cowork hoje (não há contas múltiplas). Destinos seguem PROTOCOL-F3-COWORK-CODE.md §4 (prototipos/<tela>/).",
+  "screens": {
+    "vendas": {
+      "module": "Sells",
+      "page_id": "sells-index",
+      "routes": [
+        { "glob": "*-page.jsx", "to": "prototipo-ui/prototipos/vendas/" },
+        { "glob": "*-data.jsx", "to": "prototipo-ui/prototipos/vendas/" },
+        { "glob": "*.css", "to": "prototipo-ui/prototipos/vendas/" },
+        { "glob": "*.html", "to": "prototipo-ui/prototipos/vendas/" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## PR-2b — o comando da ingestão + o map

> Empilhado em #3034 (PR-2a, o planner puro). Base = `feat/design-ingest`; retargeto pra `main` quando #3034 mergear.

`design:ingest-zip --zip=<x.zip> --tela=vendas` (**prepare-only**):
1. descompacta SEMPRE em `prototipo-ui/_incoming/<tela>/` (gitignored) via `ZipArchive` (saída ordenada → determinístico).
2. roteia contra `prototipo-ui/cowork-map.json` (`DesignIngestPlanner::route`) → routed + **extras** (fora do map, reportados).
3. `git diff --no-index` (via `Process`) vs a tela commitada → add/mod/del (tela nova = tudo added).
4. escreve em `_prepared/`: **`PLANO-MUDANCAS-<tela>.md`** (o que muda por arquivo, `STATUS: PROPOSTA`) + `SESSION-design-ingest-<tela>.md` (memória da ingestão).
5. **NADA aplicado** — `prototipos/<tela>/` só muda sob gate Wagner/CT100 (ADR 0291 D-E).

### Cobre o pedido (textual)
"descompactar sempre no mesmo lugar" ✓ · "saber onde fica os arquivos (map)" ✓ · "comparar o que mudou" ✓ · "avaliar arquivos extras não autorizado no map" ✓ (reportados) · "preparar o que muda em cada arquivo antes de aplicar" ✓ (PLANO-MUDANCAS) · "memória de sessão da ingestão" ✓.

### Infra Contract

**Mudança de runtime:** registra **1 comando CLI** (`design:ingest-zip`) no `JanaServiceProvider`; ajusta `pii-scan.sh` (SKIP `_incoming`) e `.gitignore` (ignora staging). **Nenhuma rota/middleware/HTTP/migration.** **Nenhuma superfície HTTP** → não há `curl`/HTTP status pra colar.

**Validação:** `php artisan design:ingest-zip --zip=<fixture.zip> --tela=vendas` → gera `_prepared/{PLANO-MUDANCAS,SESSION}` em `_incoming/`, **nada aplicado**. Read/write só em `_incoming/` (gitignored) — não toca canon nem prod. Lógica determinística testada no PR-2a.

**Rollback:** remover a linha do provider + reverter os 2-line edits de pii-scan/.gitignore. Zero efeito em dados/rotas.

<!-- evidence-override: PR só registra um comando artisan + edits de gitignore/pii-scan (sem HTTP/rota/middleware/migration); escreve só em _incoming gitignored, sem LLM, sem rede. Sem curl porque não há endpoint. -->

### Nota
144 linhas (comando). O núcleo lógico (route/diff/render) é testado no PR-2a (8 Pest). Conflito de merge esperado no provider com #3033 (PR-1b) — resolvo rebaseando após o merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)