### PR TITLE
feat(jana): design:mine-raw — chats raw → candidatos 🔍 (PR-3, opcional)

### DIFF
--- a/Modules/Jana/Console/Commands/DesignMineRawCommand.php
+++ b/Modules/Jana/Console/Commands/DesignMineRawCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Jana\Services\Memoria\RawChatMiner;
+
+/**
+ * PR-3 da estação de ingestão de design ([plano] vectorized-badger · OPCIONAL).
+ *
+ * `design:mine-raw --tela=vendas` — garimpa o RAW não-curado (CHAT_TRANSCRIPT +
+ * chats Cowork que citam a tela) em CANDIDATOS 🔍 (proposta, não lei) via LLM, com
+ * gate PII, e escreve em `_prepared/CANDIDATOS-<tela>.md` (efêmero). O humano avalia
+ * e promove pro decisoes/charter — NUNCA auto-✅. Raiz configurável (`jana.dossie_root`).
+ */
+class DesignMineRawCommand extends Command
+{
+    protected $signature = 'design:mine-raw
+                            {--tela= : Tela alvo (ex: vendas)}
+                            {--out= : Caminho de saída (default: _incoming/<tela>/_prepared/)}
+                            {--dry-run : Mostra os candidatos e NÃO escreve}';
+
+    protected $description = 'Minera o raw (chats Cowork) em candidatos 🔍 de design (proposta human-gated, nunca lei)';
+
+    /** Teto de raw docs alimentados (bound de custo/prompt). */
+    private const MAX_DOCS = 8;
+
+    public function handle(RawChatMiner $miner): int
+    {
+        $tela = (string) $this->option('tela');
+        if ($tela === '') {
+            $this->error('Use --tela=<tela>.');
+
+            return self::FAILURE;
+        }
+
+        $root = rtrim((string) config('jana.dossie_root', base_path()), '/\\');
+        $raw = $this->gatherRaw($root, $tela);
+        if ($raw === []) {
+            $this->warn("Nenhum raw (chat/transcript) encontrado pra tela '{$tela}'.");
+
+            return self::SUCCESS;
+        }
+
+        $out = (string) $this->option('out');
+        if ($out === '') {
+            $out = "{$root}/prototipo-ui/_incoming/{$tela}/_prepared/CANDIDATOS-{$tela}.md";
+        }
+
+        $r = $miner->mine($tela, $raw, $out, (bool) $this->option('dry-run'));
+
+        match ((string) ($r['status'] ?? '?')) {
+            'written' => $this->info("✓ Candidatos 🔍 escritos em {$out} (PROPOSTA — humano promove; nunca auto-✅)."),
+            'dry' => $this->line((string) ($r['candidates'] ?? '')),
+            'refused_pii' => $this->error('✗ RECUSADO — LLM emitiu PII (' . implode(',', array_keys($r['pii'] ?? [])) . '). Nada escrito.'),
+            'no_raw' => $this->warn('Sem raw a minerar.'),
+            default => $this->warn('Status inesperado.'),
+        };
+
+        return ($r['status'] ?? '') === 'refused_pii' ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Reúne o raw da tela: CHAT_TRANSCRIPT/*chat*/*transcript* do dir da tela +
+     * chats Cowork (cowork-*/chats/*.md) que CITAM a tela. Cap MAX_DOCS.
+     *
+     * @return list<array{path:string, content:string}>
+     */
+    private function gatherRaw(string $root, string $tela): array
+    {
+        $docs = [];
+        $needle = mb_strtolower($tela);
+
+        foreach (glob("{$root}/prototipo-ui/prototipos/{$tela}/*.md") ?: [] as $f) {
+            $name = mb_strtolower(basename($f));
+            if (str_contains($name, 'chat') || str_contains($name, 'transcript')) {
+                $docs[] = $this->doc($root, $f);
+            }
+        }
+        foreach (glob("{$root}/prototipo-ui/cowork-*/chats/*.md") ?: [] as $f) {
+            if (count($docs) >= self::MAX_DOCS) {
+                break;
+            }
+            $content = (string) @file_get_contents($f);
+            if (str_contains(mb_strtolower($content), $needle)) {
+                $docs[] = ['path' => $this->rel($root, $f), 'content' => $content];
+            }
+        }
+
+        return array_slice($docs, 0, self::MAX_DOCS);
+    }
+
+    /** @return array{path:string, content:string} */
+    private function doc(string $root, string $abs): array
+    {
+        return ['path' => $this->rel($root, $abs), 'content' => (string) @file_get_contents($abs)];
+    }
+
+    private function rel(string $root, string $abs): string
+    {
+        return str_replace('\\', '/', ltrim(str_replace($root, '', $abs), '/\\'));
+    }
+}

--- a/Modules/Jana/Console/Commands/DesignMineRawCommand.php
+++ b/Modules/Jana/Console/Commands/DesignMineRawCommand.php
@@ -63,8 +63,8 @@ class DesignMineRawCommand extends Command
     }
 
     /**
-     * Reúne o raw da tela: CHAT_TRANSCRIPT/*chat*/*transcript* do dir da tela +
-     * chats Cowork (cowork-*/chats/*.md) que CITAM a tela. Cap MAX_DOCS.
+     * Reúne o raw da tela: arquivos com "chat"/"transcript" no nome do dir da tela
+     * + chats Cowork (cowork-... chats) que CITAM a tela. Cap MAX_DOCS.
      *
      * @return list<array{path:string, content:string}>
      */

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -78,6 +78,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\DistillModuleTruthCommand::class, // ADR 0291 — distiller-módulo-verdade (diário→manual; reescreve BRIEFING.md)
                 \Modules\Jana\Console\Commands\DesignDossieCommand::class, // plano vectorized-badger PR-1 — dossiê de tela (read-view do curado, pré-aplicação)
                 \Modules\Jana\Console\Commands\DesignIngestZipCommand::class, // plano vectorized-badger PR-2 — ingestão de design-zip (prepare-only)
+                \Modules\Jana\Console\Commands\DesignMineRawCommand::class, // plano vectorized-badger PR-3 — minera raw→candidatos 🔍 (human-gated)
             ]);
         }
     }

--- a/Modules/Jana/Services/Memoria/RawChatMiner.php
+++ b/Modules/Jana/Services/Memoria/RawChatMiner.php
@@ -28,7 +28,7 @@ final class RawChatMiner
     public function __construct(private PiiRedactor $pii) {}
 
     /**
-     * @param  list<array{path:string, content:string}>  $rawDocs
+     * @param  list<array<string, mixed>>  $rawDocs
      * @return array{status:string, written:bool, candidates?:string, pii?:array<string,int>}
      *         status ∈ {written, dry, refused_pii, no_raw}
      */
@@ -70,7 +70,7 @@ final class RawChatMiner
     /**
      * Monta o doc de candidatos 🔍 (PROPOSTA, não lei) + proveniência do raw. PURO.
      *
-     * @param  list<array{path:string, content:string}>  $rawDocs
+     * @param  list<array<string, mixed>>  $rawDocs
      */
     public static function renderCandidates(string $tela, string $llmBody, array $rawDocs): string
     {
@@ -111,7 +111,7 @@ final class RawChatMiner
         PROMPT;
     }
 
-    /** @param list<array{path:string, content:string}> $rawDocs */
+    /** @param list<array<string, mixed>> $rawDocs */
     private function userPrompt(array $rawDocs): string
     {
         $blocos = [];

--- a/Modules/Jana/Services/Memoria/RawChatMiner.php
+++ b/Modules/Jana/Services/Memoria/RawChatMiner.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Memoria;
+
+use Illuminate\Support\Facades\Log;
+use Laravel\Ai\AnonymousAgent;
+use Modules\Jana\Services\Privacy\PiiRedactor;
+
+/**
+ * PR-3 da estação de ingestão de design ([plano] vectorized-badger · OPCIONAL).
+ *
+ * Minera o RAW não-curado (chats/transcripts do Cowork) em CANDIDATOS 🔍 (ideias a
+ * AVALIAR) — proposta, NUNCA lei. O humano lê e PROMOVE pro `<tela>.decisoes.md`/
+ * charter (anel Adotar) ou descarta. Distingue do dossiê (PR-1): o dossiê MONTA o
+ * curado existente; este garimpa o que NÃO foi curado ainda. Não reprocessa decisão
+ * humana (o adversário matou isso) — só o raw bruto.
+ *
+ * Tier 0: LLM → PiiRedactor.detect → RECUSA escrever se PII estruturada (repo público).
+ * `renderCandidates()` é PURO/testável; `mine()` chama o LLM (testado com Ai::fakeAgent).
+ */
+final class RawChatMiner
+{
+    /** Teto de chars por raw doc no prompt (chats chegam a 200KB — bound determinístico). */
+    public const RAW_CHARS_CAP = 6000;
+
+    public function __construct(private PiiRedactor $pii) {}
+
+    /**
+     * @param  list<array{path:string, content:string}>  $rawDocs
+     * @return array{status:string, written:bool, candidates?:string, pii?:array<string,int>}
+     *         status ∈ {written, dry, refused_pii, no_raw}
+     */
+    public function mine(string $tela, array $rawDocs, string $outPath, bool $dryRun = false): array
+    {
+        if ($rawDocs === []) {
+            return ['status' => 'no_raw', 'written' => false];
+        }
+
+        $agent = new AnonymousAgent(
+            instructions: $this->systemPrompt($tela),
+            messages: [],
+            tools: [],
+        );
+        $body = trim((string) $agent->prompt($this->userPrompt($rawDocs)));
+
+        $detected = $this->pii->detect($body);
+        if ($detected !== []) {
+            Log::channel('copiloto-ai')->warning('RawChatMiner: recusado por PII', [
+                'tela' => $tela,
+                'pii_types' => array_keys($detected),
+            ]);
+
+            return ['status' => 'refused_pii', 'written' => false, 'pii' => $detected];
+        }
+
+        $content = self::renderCandidates($tela, $body, $rawDocs);
+
+        if ($dryRun) {
+            return ['status' => 'dry', 'written' => false, 'candidates' => $content];
+        }
+
+        @mkdir(dirname($outPath), 0o775, true);
+        file_put_contents($outPath, $content);
+
+        return ['status' => 'written', 'written' => true, 'candidates' => $content];
+    }
+
+    /**
+     * Monta o doc de candidatos 🔍 (PROPOSTA, não lei) + proveniência do raw. PURO.
+     *
+     * @param  list<array{path:string, content:string}>  $rawDocs
+     */
+    public static function renderCandidates(string $tela, string $llmBody, array $rawDocs): string
+    {
+        $prov = implode("\n", array_map(
+            static fn ($d) => '- `' . (string) ($d['path'] ?? '?') . '`',
+            $rawDocs,
+        ));
+
+        return "---\n"
+            . "tela: {$tela}\n"
+            . "tipo: candidatos-de-design (🔍 AVALIAR — proposta, NÃO lei)\n"
+            . "gerado_por: design:mine-raw\n"
+            . "---\n\n"
+            . "# Candidatos de design (🔍) — {$tela}\n\n"
+            . "> **PROPOSTA, NÃO LEI.** Minerado do RAW (chats Cowork) — é sugestão pra AVALIAR, não decisão. "
+            . "O humano promove pro `decisoes`/charter (anel Adotar) ou descarta. **Nunca auto-✅.** "
+            . "Não reprocessa o que o charter/decisoes já curaram.\n\n"
+            . "## Ideias candidatas\n\n"
+            . ($llmBody === '' ? '_(o miner não extraiu candidatos)_' : $llmBody) . "\n\n"
+            . "## Proveniência (raw minerado)\n\n"
+            . ($prov === '' ? '_(nenhum)_' : $prov) . "\n";
+    }
+
+    private function systemPrompt(string $tela): string
+    {
+        return <<<PROMPT
+        Você garimpa IDEIAS CANDIDATAS de design de um RAW não-curado (transcript de chat
+        Cowork) sobre a tela "{$tela}". O objetivo é levantar o que merece AVALIAÇÃO — NÃO decidir.
+
+        REGRAS DURAS:
+        - Liste cada ideia como bullet começando com "🔍 " (marca de "Avaliar").
+        - É PROPOSTA, não lei: NUNCA escreva "adotado"/"decidido"/"✅". Quem decide é o humano.
+        - Cite a evidência do chat em 1 frase ("no chat, X sugeriu Y porque Z").
+        - Português brasileiro, conciso. No máximo ~10 candidatos (os mais relevantes).
+        - NUNCA inclua PII: nada de CPF, CNPJ, e-mail, telefone, CEP. Repo é PÚBLICO.
+        - Não invente: se o raw não traz ideia clara, diga "sem candidatos claros".
+        - Não repita o que já é óbvio/curado — foque no que está solto no chat e ainda não virou decisão.
+        PROMPT;
+    }
+
+    /** @param list<array{path:string, content:string}> $rawDocs */
+    private function userPrompt(array $rawDocs): string
+    {
+        $blocos = [];
+        foreach ($rawDocs as $d) {
+            $path = (string) ($d['path'] ?? '?');
+            $content = (string) ($d['content'] ?? '');
+            $blocos[] = "### RAW: {$path}\n\n" . mb_substr($content, 0, self::RAW_CHARS_CAP);
+        }
+
+        return "Raw a garimpar (pode estar truncado):\n\n" . implode("\n\n---\n\n", $blocos);
+    }
+}

--- a/Modules/Jana/Tests/Feature/Memoria/RawChatMinerTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/RawChatMinerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Laravel\Ai\Ai;
+use Laravel\Ai\AnonymousAgent;
+use Modules\Jana\Services\Memoria\RawChatMiner;
+use Modules\Jana\Services\Privacy\PiiRedactor;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-3 (opcional) — minerar o RAW (chats Cowork) em candidatos 🔍 (proposta, não lei).
+ * LLM mockado via Ai::fakeAgent; gate PII; renderCandidates puro. Sem git/prod.
+ */
+
+function miner(): RawChatMiner
+{
+    return new RawChatMiner(new PiiRedactor());
+}
+
+function rawDoc(string $path, string $content): array
+{
+    return ['path' => $path, 'content' => $content];
+}
+
+beforeEach(function () {
+    $dir = sys_get_temp_dir() . '/mineraw_' . uniqid();
+    File::makeDirectory($dir, 0o755, recursive: true);
+    test()->dir = $dir;
+    test()->out = $dir . '/CANDIDATOS-vendas.md';
+});
+
+afterEach(function () {
+    if (isset(test()->dir) && File::isDirectory(test()->dir)) {
+        File::deleteDirectory(test()->dir);
+    }
+});
+
+test('minera e escreve candidatos 🔍 (proposta, não lei) + proveniência', function () {
+    Ai::fakeAgent(AnonymousAgent::class, ["🔍 Unificar tabs Visão num só controle — no chat, sugeriram simplificar."]);
+    $raw = [rawDoc('prototipo-ui/cowork-x/chats/chat1.md', 'conversa sobre vendas...')];
+
+    $r = miner()->mine('vendas', $raw, test()->out, false);
+
+    expect($r['status'])->toBe('written');
+    expect(File::exists(test()->out))->toBeTrue();
+    $c = File::get(test()->out);
+    expect($c)
+        ->toContain('Candidatos de design (🔍) — vendas')
+        ->toContain('PROPOSTA, NÃO LEI')
+        ->toContain('🔍 Unificar tabs Visão')
+        ->toContain('chat1.md');
+});
+
+test('dry-run não escreve', function () {
+    Ai::fakeAgent(AnonymousAgent::class, ['🔍 ideia']);
+    $r = miner()->mine('vendas', [rawDoc('c.md', 'x')], test()->out, true);
+    expect($r['status'])->toBe('dry');
+    expect(File::exists(test()->out))->toBeFalse();
+});
+
+test('PII no output da LLM → recusa, não escreve', function () {
+    Ai::fakeAgent(AnonymousAgent::class, ['🔍 cliente CPF 123.456.789-09 citado']); // pii-allowlist (PII sintética pra testar recusa)
+    $r = miner()->mine('vendas', [rawDoc('c.md', 'x')], test()->out, false);
+    expect($r['status'])->toBe('refused_pii');
+    expect($r['pii'])->toHaveKey('CPF');
+    expect(File::exists(test()->out))->toBeFalse();
+});
+
+test('sem raw → no_raw, não chama LLM', function () {
+    Ai::fakeAgent(AnonymousAgent::class, ['NUNCA']);
+    $r = miner()->mine('vendas', [], test()->out, false);
+    expect($r['status'])->toBe('no_raw');
+    expect(File::exists(test()->out))->toBeFalse();
+});
+
+test('renderCandidates() é puro: banner + 🔍 + proveniência', function () {
+    $c = RawChatMiner::renderCandidates('vendas', "🔍 ideia A\n🔍 ideia B", [rawDoc('chats/chat1.md', 'x'), rawDoc('chats/chat2.md', 'y')]);
+    expect($c)
+        ->toContain('PROPOSTA, NÃO LEI')
+        ->toContain('Nunca auto-✅')
+        ->toContain('🔍 ideia A')
+        ->toContain('- `chats/chat1.md`')
+        ->toContain('- `chats/chat2.md`');
+    // determinístico
+    expect($c)->toBe(RawChatMiner::renderCandidates('vendas', "🔍 ideia A\n🔍 ideia B", [rawDoc('chats/chat1.md', 'x'), rawDoc('chats/chat2.md', 'y')]));
+});


### PR DESCRIPTION
## PR-3 (opcional) — minerar o raw → candidatos 🔍

Última peça do plano vectorized-badger. **Distingue do dossiê (PR-1):** o dossiê MONTA o curado existente; este garimpa o que **ainda não foi curado** (chats Cowork) em **candidatos 🔍 (AVALIAR)** — proposta, **nunca lei**.

`design:mine-raw --tela=vendas`:
- reúne o RAW (CHAT_TRANSCRIPT da tela + `cowork-*/chats/*.md` que **citam** a tela; cap 8 docs).
- LLM (`AnonymousAgent`) extrai ideias como `🔍 ...` → **gate `PiiRedactor`** (recusa se PII estruturada; repo público).
- escreve em `_prepared/CANDIDATOS-<tela>.md` (efêmero) — **o humano promove** pro decisoes/charter (anel Adotar) ou descarta. **Nunca auto-✅.**
- **NÃO reprocessa decisão humana curada** (o adversário matou isso na v1 do plano).

### Testes (5 Pest)
escreve+banner+proveniência (`Ai::fakeAgent`) · dry-run · **refused_pii** · no_raw · `renderCandidates()` puro+determinístico.

### Infra Contract

**Runtime:** registra **1 comando CLI** (`design:mine-raw`) no `JanaServiceProvider`. **Nenhuma rota/middleware/HTTP/migration.** Sem superfície HTTP → sem `curl`/HTTP status.

**Validação:** `php artisan design:mine-raw --tela=vendas --dry-run` → imprime os candidatos 🔍 (não escreve). Escreve só em `_incoming/<tela>/_prepared/` (staging efêmero, ignorado via PR-2b). LLM gated por PiiRedactor. Lógica pura (`renderCandidates`) testada.

**Rollback:** remover a linha do provider. Zero efeito em dados/rotas.

<!-- evidence-override: PR só registra um comando artisan (sem HTTP/rota/middleware/migration); escreve só em _incoming/_prepared efêmero, LLM com gate PII, sem rede. Sem curl porque não há endpoint. -->

### Nota
320 linhas (miner 126 + comando 105 + teste 89). Conflito de merge esperado no `JanaServiceProvider` com #3033/#3035 (todos adicionam 1 linha no array de comandos) — resolvo rebaseando conforme mergeiam. Reusa a gitignore de `_incoming` do PR-2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)