### PR TITLE
fix(jana): estação de design — diff por conteúdo (sem git) + resolver de paths robusto

### DIFF
--- a/Modules/Jana/Console/Commands/DesignDossieCommand.php
+++ b/Modules/Jana/Console/Commands/DesignDossieCommand.php
@@ -42,9 +42,7 @@ class DesignDossieCommand extends Command
         $dossie = DesignDossieAssembler::assemble([
             'tela' => $tela,
             'module' => $module,
-            // page_id vem do charter (verdade); fallback ao slug derivado se ausente
-            'page_id' => $this->pageIdFromCharter($sources['charter']['content'] ?? null)
-                ?? mb_strtolower("{$module}-{$tela}"),
+            'page_id' => $this->resolvePageId($module, $tela, $sources['charter']['content'] ?? null),
             'sources' => $sources,
             'personas' => $this->resolvePersonas($module),
             'feedback' => $this->resolveFeedback($module),
@@ -71,24 +69,31 @@ class DesignDossieCommand extends Command
     /** @return array<string, array{path:string, content:?string}> */
     private function resolveSources(string $module, string $tela): array
     {
-        $telaLower = mb_strtolower($tela);
+        // tela aninhada (ex: "CaixaUnificada/Index") → slug sem `/` pra não virar
+        // subpasta em RUNBOOK-/decisoes/visual-comparison. charter+casos usam o path real.
+        $telaSlug = str_replace('/', '-', mb_strtolower($tela));
         $rel = [
             'charter' => "resources/js/Pages/{$module}/{$tela}.charter.md",
             'casos' => "resources/js/Pages/{$module}/{$tela}.casos.md",
-            'runbook' => "memory/requisitos/{$module}/RUNBOOK-{$telaLower}.md",
+            'runbook' => "memory/requisitos/{$module}/RUNBOOK-{$telaSlug}.md",
             'briefing' => "memory/requisitos/{$module}/BRIEFING.md",
         ];
         $sources = [];
         foreach ($rel as $key => $path) {
             $sources[$key] = ['path' => $path, 'content' => $this->read($path)];
         }
-        // best-effort por glob (nomes variam): decisoes do protótipo + visual-comparison
-        $sources['decisoes'] = $this->firstGlob([
-            "prototipo-ui/prototipos/{$telaLower}/decisoes.md",
-            "prototipo-ui/prototipos/" . mb_strtolower($module) . "/decisoes.md",
-        ]);
+        // decisoes do protótipo: a pasta vem do cowork-map (Sells → vendas), não do nome
+        // da tela (Index ≠ vendas). Fallback ao slug + ao módulo se o map não casar.
+        $decisoes = [];
+        foreach ($this->prototypeDirsForModule($module) as $dir) {
+            $decisoes[] = "prototipo-ui/prototipos/{$dir}/decisoes.md";
+        }
+        $decisoes[] = "prototipo-ui/prototipos/{$telaSlug}/decisoes.md";
+        $decisoes[] = 'prototipo-ui/prototipos/' . mb_strtolower($module) . '/decisoes.md';
+        $sources['decisoes'] = $this->firstGlob($decisoes);
+
         $sources['visual_comparison'] = $this->firstGlob([
-            "memory/requisitos/{$module}/*{$telaLower}*visual-comparison.md", // prioriza a tela
+            "memory/requisitos/{$module}/*{$telaSlug}*visual-comparison.md", // prioriza a tela
             "memory/requisitos/{$module}/*visual-comparison.md",
         ]);
 
@@ -137,6 +142,18 @@ class DesignDossieCommand extends Command
         return $found;
     }
 
+    /**
+     * page_id na ordem de verdade: `page_id:` do charter → `page:` do charter (slug) →
+     * page_id do cowork-map (entrada do módulo) → slug normalizado SEM `/` (último caso).
+     */
+    private function resolvePageId(string $module, string $tela, ?string $charter): string
+    {
+        return $this->pageIdFromCharter($charter)
+            ?? $this->pageFromCharter($charter)
+            ?? $this->pageIdFromMap($module)
+            ?? str_replace('/', '-', mb_strtolower("{$module}-{$tela}"));
+    }
+
     /** Lê o `page_id:` real do frontmatter do charter (não fabrica). */
     private function pageIdFromCharter(?string $charter): ?string
     {
@@ -145,6 +162,61 @@ class DesignDossieCommand extends Command
         }
 
         return preg_match('/^page_id:\s*(.+?)\s*$/m', $charter, $m) ? trim($m[1]) : null;
+    }
+
+    /** Deriva page_id do `page:` do charter (ex: `/atendimento/caixa-unificada` → `atendimento-caixa-unificada`). */
+    private function pageFromCharter(?string $charter): ?string
+    {
+        if ($charter === null || ! preg_match('/^page:\s*(.+?)\s*$/m', $charter, $m)) {
+            return null;
+        }
+        $slug = trim(str_replace('/', '-', mb_strtolower(trim($m[1]))), '-');
+
+        return $slug !== '' ? $slug : null;
+    }
+
+    /** page_id da 1ª entrada do cowork-map cujo `module` casa (best-effort quando 1 tela/módulo). */
+    private function pageIdFromMap(string $module): ?string
+    {
+        foreach ($this->coworkScreens() as $screen) {
+            if (mb_strtolower((string) ($screen['module'] ?? '')) === mb_strtolower($module)) {
+                $pid = trim((string) ($screen['page_id'] ?? ''));
+                if ($pid !== '') {
+                    return $pid;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Chaves do cowork-map cujo `module` casa = pasta(s) de protótipo do módulo (Sells → vendas).
+     *
+     * @return list<string>
+     */
+    private function prototypeDirsForModule(string $module): array
+    {
+        $dirs = [];
+        foreach ($this->coworkScreens() as $key => $screen) {
+            if (mb_strtolower((string) ($screen['module'] ?? '')) === mb_strtolower($module)) {
+                $dirs[] = (string) $key;
+            }
+        }
+
+        return $dirs;
+    }
+
+    /** @return array<string, array<string, mixed>> screens do cowork-map (keyed por tela). */
+    private function coworkScreens(): array
+    {
+        $path = $this->root() . '/prototipo-ui/cowork-map.json';
+        if (! is_file($path)) {
+            return [];
+        }
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? (array) ($decoded['screens'] ?? []) : [];
     }
 
     private function read(string $rel): ?string

--- a/Modules/Jana/Console/Commands/DesignIngestZipCommand.php
+++ b/Modules/Jana/Console/Commands/DesignIngestZipCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Modules\Jana\Console\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Support\Facades\Process;
 use Modules\Jana\Services\Memoria\DesignIngestPlanner;
 
 /**
@@ -13,7 +12,7 @@ use Modules\Jana\Services\Memoria\DesignIngestPlanner;
  *
  * `design:ingest-zip --zip=<x.zip> --tela=vendas` (prepare-only): descompacta SEMPRE
  * no mesmo lugar (`prototipo-ui/_incoming/<tela>/`, gitignored) → roteia contra o
- * `cowork-map.json` (DesignIngestPlanner) → `git diff --no-index` vs a tela commitada
+ * `cowork-map.json` (DesignIngestPlanner) → diff por conteúdo (sha) vs a tela commitada
  * → escreve os entregáveis em `_prepared/`: PLANO-MUDANCAS-<tela>.md + a memória de
  * sessão da ingestão. NADA é aplicado: a aplicação real (`prototipos/<tela>/`) é gate
  * Wagner/CT100 (ADR 0291 D-E). Raiz configurável (`jana.dossie_root`) p/ fixtures.
@@ -56,7 +55,10 @@ class DesignIngestZipCommand extends Command
 
         $map = $this->loadMap($root);
         $routing = DesignIngestPlanner::route($map, $files, $tela);
-        $diff = DesignIngestPlanner::parseDiff($this->diffNameStatus($root, $committedDir, $incomingDir, $files));
+        $diff = DesignIngestPlanner::diffByContent(
+            $this->hashDir($committedDir),
+            $this->hashDir($incomingDir),
+        );
 
         $plano = DesignIngestPlanner::renderPlano($tela, $routing, $diff);
         $session = DesignIngestPlanner::renderSession($tela, $routing, $diff, now()->toDateString());
@@ -121,24 +123,29 @@ class DesignIngestZipCommand extends Command
     }
 
     /**
-     * `git diff --no-index --name-status` da tela commitada vs a extraída. Se a tela
-     * ainda não existe commitada, tudo é "added" (deriva dos arquivos extraídos).
+     * Mapa relpath => sha1 dos arquivos de um diretório (pula `_prepared/`). Sem git —
+     * o diff é por conteúdo (DesignIngestPlanner::diffByContent). Dir inexistente → [].
      *
-     * @param  list<string>  $files
+     * @return array<string, string>
      */
-    private function diffNameStatus(string $root, string $committedDir, string $incomingDir, array $files): string
+    private function hashDir(string $dir): array
     {
-        if (! is_dir($committedDir)) {
-            return implode("\n", array_map(static fn ($f) => "A\t{$f}", $files));
+        if (! is_dir($dir)) {
+            return [];
         }
-        try {
-            $result = Process::path($root)->run([
-                'git', 'diff', '--no-index', '--name-status', '--', $committedDir, $incomingDir,
-            ]);
+        $out = [];
+        $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS));
+        foreach ($it as $f) {
+            if (! $f instanceof \SplFileInfo || ! $f->isFile()) {
+                continue;
+            }
+            $rel = str_replace('\\', '/', ltrim(str_replace($dir, '', $f->getPathname()), '/\\'));
+            if (str_starts_with($rel, '_prepared')) {
+                continue;
+            }
+            $out[$rel] = sha1_file($f->getPathname()) ?: '';
+        }
 
-            return $result->output(); // exit 1 quando há diff — output válido mesmo assim
-        } catch (\Throwable) {
-            return implode("\n", array_map(static fn ($f) => "A\t{$f}", $files));
-        }
+        return $out;
     }
 }

--- a/Modules/Jana/Services/Memoria/DesignIngestPlanner.php
+++ b/Modules/Jana/Services/Memoria/DesignIngestPlanner.php
@@ -13,8 +13,12 @@ namespace Modules\Jana\Services\Memoria;
  * de aplicar) e a memória de sessão da ingestão.
  *
  * Tudo PURO/determinístico (sem FS/git/zip/LLM/timestamp gerado): o comando (PR-2b)
- * faz unzip via ZipArchive + `git diff --no-index` via Process e injeta as strings aqui.
- * `now` é injetado (determinismo no teste).
+ * faz unzip via ZipArchive + lê os arquivos commitados/extraídos e injeta os hashes
+ * aqui (`diffByContent`). `now` é injetado (determinismo no teste).
+ *
+ * Diff por CONTEÚDO (sha), NÃO via `git diff`: o runtime alvo (container CT100) não
+ * tem `git` (git fica no host) — depender dele fazia o diff sair vazio e o PLANO
+ * reportar "sem mudanças" mesmo havendo arquivos novos. Calcular aqui é robusto.
  */
 final class DesignIngestPlanner
 {
@@ -82,6 +86,37 @@ final class DesignIngestPlanner
                 $removed[] = $path;
             }
         }
+
+        return ['added' => $added, 'modified' => $modified, 'removed' => $removed];
+    }
+
+    /**
+     * Diff por CONTEÚDO (sha) — tela commitada vs extraída. PURO, sem git: o container
+     * CT100 não tem git, então o comando lê os arquivos e injeta os mapas aqui.
+     * Determinístico (listas ordenadas).
+     *
+     * @param  array<string, string>  $committed  relpath => hash (da pasta commitada)
+     * @param  array<string, string>  $incoming   relpath => hash (do zip extraído)
+     * @return array{added: list<string>, modified: list<string>, removed: list<string>}
+     */
+    public static function diffByContent(array $committed, array $incoming): array
+    {
+        $added = $modified = $removed = [];
+        foreach ($incoming as $path => $hash) {
+            if (! array_key_exists($path, $committed)) {
+                $added[] = $path;
+            } elseif ($committed[$path] !== $hash) {
+                $modified[] = $path;
+            }
+        }
+        foreach ($committed as $path => $hash) {
+            if (! array_key_exists($path, $incoming)) {
+                $removed[] = $path;
+            }
+        }
+        sort($added);
+        sort($modified);
+        sort($removed);
 
         return ['added' => $added, 'modified' => $modified, 'removed' => $removed];
     }

--- a/Modules/Jana/Tests/Feature/Memoria/DesignDossieCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/DesignDossieCommandTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-fix — fiação do comando design:dossie (resolução de paths/page_id), que os testes
+ * unit do Assembler não cobrem. Codifica os 3 furos achados no smoke CT100:
+ *   - tela aninhada (`Sub/Index`) não pode virar subpasta em RUNBOOK-/decisoes;
+ *   - page_id deriva do `page:` do charter (e do cowork-map) quando falta `page_id:`;
+ *   - a pasta do protótipo vem do cowork-map (Sells→vendas), não do nome da tela.
+ * Tudo via fixture em tempdir (`jana.dossie_root`) — não toca o repo real, sem git/LLM.
+ */
+
+beforeEach(function () {
+    $dir = sys_get_temp_dir() . '/dossie_cmd_' . uniqid();
+    File::makeDirectory($dir, 0o755, recursive: true);
+    test()->root = $dir;
+    test()->out = $dir . '/_out.md';
+    config(['jana.dossie_root' => $dir]);
+});
+
+afterEach(function () {
+    if (isset(test()->root) && File::isDirectory(test()->root)) {
+        File::deleteDirectory(test()->root);
+    }
+});
+
+function dossieSeed(string $rel, string $content): void
+{
+    $abs = test()->root . '/' . $rel;
+    File::ensureDirectoryExists(dirname($abs));
+    File::put($abs, $content);
+}
+
+function dossieRun(string $module, string $tela): string
+{
+    $code = Artisan::call('design:dossie', ['--module' => $module, '--tela' => $tela, '--out' => test()->out]);
+    expect($code)->toBe(0);
+
+    return File::get(test()->out);
+}
+
+$charterCaixa = <<<'MD'
+---
+page: /atendimento/caixa-unificada
+component: resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+---
+
+## Mission
+
+Inbox unificada de atendimento omnichannel.
+
+## Goals
+
+- Centralizar canais num só lugar
+
+## Non-Goals
+
+- ❌ Não vazar dados entre tenants
+MD;
+
+test('tela aninhada: slug normaliza `/` → `-` (RUNBOOK achado, sem path quebrado)', function () use ($charterCaixa) {
+    dossieSeed('resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md', $charterCaixa);
+    dossieSeed('memory/requisitos/Atendimento/RUNBOOK-caixaunificada-index.md', "# RUNBOOK caixa\nreceita.");
+
+    $out = dossieRun('Atendimento', 'CaixaUnificada/Index');
+
+    expect($out)
+        ->toContain('RUNBOOK-caixaunificada-index.md') // slug normalizado achou o arquivo
+        ->not->toContain('caixaunificada/index'); // nunca o path quebrado com `/`
+});
+
+test('page_id deriva do `page:` quando o charter não tem `page_id:`', function () use ($charterCaixa) {
+    dossieSeed('resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md', $charterCaixa);
+
+    $out = dossieRun('Atendimento', 'CaixaUnificada/Index');
+
+    // antes do fix saía `atendimento-caixaunificada/index` (slug feio com `/`)
+    expect($out)->toContain('page_id: atendimento-caixa-unificada');
+});
+
+test('page_id vem do cowork-map quando charter não tem page_id nem page:', function () {
+    dossieSeed('resources/js/Pages/Macros/Index.charter.md', "---\nowner: wagner\n---\n\n## Mission\n\nMacros.\n");
+    dossieSeed('prototipo-ui/cowork-map.json', json_encode([
+        'screens' => ['macros' => ['module' => 'Macros', 'page_id' => 'atendimento-macros', 'routes' => []]],
+    ]));
+
+    $out = dossieRun('Macros', 'Index');
+
+    expect($out)->toContain('page_id: atendimento-macros');
+});
+
+test('pasta do protótipo vem do cowork-map (decisoes achado por chave, não nome da tela)', function () {
+    dossieSeed('resources/js/Pages/Sells/Index.charter.md', "---\npage_id: sells-index\n---\n\n## Mission\n\nVendas.\n");
+    dossieSeed('prototipo-ui/cowork-map.json', json_encode([
+        'screens' => ['vendas' => ['module' => 'Sells', 'page_id' => 'sells-index', 'routes' => []]],
+    ]));
+    dossieSeed('prototipo-ui/prototipos/vendas/decisoes.md', "# decisoes vendas\n- adotado X");
+
+    $out = dossieRun('Sells', 'Index');
+
+    // tela=Index, mas o protótipo é prototipos/vendas/ — resolvido via cowork-map
+    expect($out)->toContain('prototipo-ui/prototipos/vendas/decisoes.md');
+});

--- a/Modules/Jana/Tests/Feature/Memoria/DesignIngestZipCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/DesignIngestZipCommandTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR-fix — fiação do comando design:ingest-zip, que os testes unit do Planner não cobrem.
+ * Codifica o furo mais grave do smoke CT100: o diff via `git diff --no-index` saía VAZIO
+ * no container (sem git) → PLANO dizia "sem mudanças" mesmo com arquivo novo. Agora o diff
+ * é por CONTEÚDO (sha) — sem git. Fixture em tempdir (`jana.dossie_root`); zip real via
+ * ZipArchive. Continua prepare-only: nada é aplicado no protótipo commitado.
+ */
+
+beforeEach(function () {
+    $dir = sys_get_temp_dir() . '/ingest_cmd_' . uniqid();
+    File::makeDirectory($dir, 0o755, recursive: true);
+    test()->root = $dir;
+    config(['jana.dossie_root' => $dir]);
+});
+
+afterEach(function () {
+    if (isset(test()->root) && File::isDirectory(test()->root)) {
+        File::deleteDirectory(test()->root);
+    }
+});
+
+function ingestSeed(string $rel, string $content): void
+{
+    $abs = test()->root . '/' . $rel;
+    File::ensureDirectoryExists(dirname($abs));
+    File::put($abs, $content);
+}
+
+/** @param array<string,string> $files name => content */
+function ingestZipFile(string $path, array $files): void
+{
+    $z = new ZipArchive();
+    $z->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    foreach ($files as $name => $content) {
+        $z->addFromString($name, $content);
+    }
+    $z->close();
+}
+
+function ingestSeedMap(): void
+{
+    ingestSeed('prototipo-ui/cowork-map.json', json_encode([
+        'screens' => ['vendas' => ['module' => 'Sells', 'page_id' => 'sells-index', 'routes' => [
+            ['glob' => '*-page.jsx', 'to' => 'prototipo-ui/prototipos/vendas/'],
+            ['glob' => '*.css', 'to' => 'prototipo-ui/prototipos/vendas/'],
+        ]]],
+    ]));
+}
+
+test('diff por CONTEÚDO (sem git): add/mod/del + extra no PLANO', function () {
+    ingestSeedMap();
+    // tela commitada: 1 arquivo que será modificado + 1 que será removido
+    ingestSeed('prototipo-ui/prototipos/vendas/vendas-page.jsx', 'v1');
+    ingestSeed('prototipo-ui/prototipos/vendas/old.css', 'x');
+    // zip do Cowork: page modificado + css novo + extra fora do map
+    $zip = test()->root . '/export.zip';
+    ingestZipFile($zip, [
+        'vendas-page.jsx' => 'v2',          // modified
+        'nova.css' => 'z',                  // added (roteado)
+        'NOTES-cowork.md' => 'ideia solta', // added + extra (fora do map)
+    ]);
+
+    $code = Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'vendas']);
+    expect($code)->toBe(0);
+
+    $plano = File::get(test()->root . '/prototipo-ui/_incoming/vendas/_prepared/PLANO-MUDANCAS-vendas.md');
+    expect($plano)
+        ->toContain('| `vendas-page.jsx` | mod |')   // <- antes saía vazio (sem git)
+        ->toContain('| `nova.css` | add |')
+        ->toContain('| `NOTES-cowork.md` | add |')
+        ->toContain('| `old.css` | del |')
+        ->toContain('⚠️ `NOTES-cowork.md` — **fora do cowork-map**')
+        ->not->toContain('sem mudanças vs a tela commitada');
+});
+
+test('prepare-only: NÃO aplica no protótipo commitado', function () {
+    ingestSeedMap();
+    ingestSeed('prototipo-ui/prototipos/vendas/vendas-page.jsx', 'v1');
+    $zip = test()->root . '/export.zip';
+    ingestZipFile($zip, ['vendas-page.jsx' => 'v2-NOVO']);
+
+    Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'vendas']);
+
+    // o commitado segue intocado (a aplicação é gate Wagner/CT100)
+    expect(File::get(test()->root . '/prototipo-ui/prototipos/vendas/vendas-page.jsx'))->toBe('v1');
+    expect(File::exists(test()->root . '/prototipo-ui/prototipos/vendas/_prepared'))->toBeFalse();
+    // mas o PLANO + a memória de sessão foram preparados
+    expect(File::exists(test()->root . '/prototipo-ui/_incoming/vendas/_prepared/PLANO-MUDANCAS-vendas.md'))->toBeTrue();
+    expect(File::exists(test()->root . '/prototipo-ui/_incoming/vendas/_prepared/SESSION-design-ingest-vendas.md'))->toBeTrue();
+});


### PR DESCRIPTION
## Contexto

Smoke **real no CT 100** (`oimpresso-staging`) da estação de ingestão de design (PRs #3032–#3037), usando a tela `Atendimento/CaixaUnificada` como cobaia. Os comandos rodaram, mas o smoke revelou **4 furos na fiação dos comandos** que os testes unit não pegavam (eles cobriam só os _services_ puros).

## Os 4 furos (achados em dados reais)

| # | Furo | Conserto |
|---|---|---|
| 1 ⚠️ | `ingest-zip`: `git diff --no-index` saía **vazio** no container (sem `git` no runtime — git fica no host) → `PLANO-MUDANCAS` dizia *"sem mudanças"* mesmo com arquivo novo | Diff por **conteúdo (sha)** via `DesignIngestPlanner::diffByContent` — sem dependência de git, determinístico |
| 2 | `dossie`: telas aninhadas (`CaixaUnificada/Index`) viravam **subpasta** nos paths (`RUNBOOK-caixaunificada/index.md`) | Slug normalizado (`/` → `-`) |
| 3 | `dossie`: a pasta do protótipo vinha do **nome da tela** (`Index` ≠ `vendas`) → `decisoes` sempre AUSENTE | Resolve a pasta pelo **cowork-map** (`Sells` → `vendas`) |
| 4 | `dossie`: `page_id` caía num slug feio (`atendimento-caixaunificada/index`) | Cadeia: charter `page_id:` → `page:` → cowork-map → slug normalizado |

## Testes

- 6 **feature tests** novos cobrindo a fiação dos 2 comandos (a camada que faltava), um por furo.
- Rodados no **CT 100** (`oimpresso-staging`, MySQL real): **54 passed / 159 assertions** ✅ (os 6 novos + os existentes, sem regressão).

## Escopo

- `DesignIngestPlanner.php` — `+ diffByContent` (puro); `parseDiff` mantido.
- `DesignIngestZipCommand.php` — usa hash de conteúdo, remove `Process`/git.
- `DesignDossieCommand.php` — resolução de paths/page_id robusta + leitura do cowork-map.
- 2 arquivos de teste novos. (~120 linhas de produção + ~210 de teste.)

Nada de canon/aplicação muda — a estação segue **prepare-only** (gate Wagner/CT 100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)