### PR TITLE
feat(prototipo-ui): registra caixa-unificada no cowork-map (destrava ingest da Inbox)

### DIFF
--- a/prototipo-ui/cowork-map.json
+++ b/prototipo-ui/cowork-map.json
@@ -11,6 +11,15 @@
         { "glob": "*.css", "to": "prototipo-ui/prototipos/vendas/" },
         { "glob": "*.html", "to": "prototipo-ui/prototipos/vendas/" }
       ]
+    },
+    "caixa-unificada": {
+      "module": "Atendimento",
+      "page_id": "atendimento-caixa-unificada",
+      "routes": [
+        { "glob": "*.jsx", "to": "prototipo-ui/prototipos/caixa-unificada/" },
+        { "glob": "*.css", "to": "prototipo-ui/prototipos/caixa-unificada/" },
+        { "glob": "*.html", "to": "prototipo-ui/prototipos/caixa-unificada/" }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Por quê

A Inbox de Atendimento (`prototipos/caixa-unificada/`, 6 arquivos) **já é fonte única**, mas não estava no `cowork-map.json` → a estação de ingestão não roteava a tela (tudo virava "extra"). Este PR registra a entrada pra **destravar o teste real de ingest da caixa** (zip novo → diff; zip modificado → pega o que mudou).

## O que muda

Adiciona ao `cowork-map.json`:
```json
"caixa-unificada": {
  "module": "Atendimento",
  "page_id": "atendimento-caixa-unificada",
  "routes": [ { "glob": "*.jsx" }, { "glob": "*.css" }, { "glob": "*.html" } → "prototipo-ui/prototipos/caixa-unificada/" ]
}
```

## Validação

- JSON válido (telas: `vendas`, `caixa-unificada`).
- `integrity-check.mjs` §15: **todos os IT duros passaram**.

Primeiro passo do caminho "uma única fonte da verdade" (a consolidação do legado vem nos PRs faseados seguintes). Pareado com #3039 (fix do diff por conteúdo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)