### PR TITLE
feat(jana): estação ingere handoff completo — diff sobre roteados + extras inteligentes

### DIFF
--- a/Modules/Jana/Console/Commands/DesignIngestZipCommand.php
+++ b/Modules/Jana/Console/Commands/DesignIngestZipCommand.php
@@ -55,25 +55,32 @@ class DesignIngestZipCommand extends Command
 
         $map = $this->loadMap($root);
         $routing = DesignIngestPlanner::route($map, $files, $tela);
-        $diff = DesignIngestPlanner::diffByContent(
-            $this->hashDir($committedDir),
-            $this->hashDir($incomingDir),
-        );
+        // diff dos arquivos ROTEADOS (pelo nome final do destino) vs a baseline commitada —
+        // NÃO o dump bruto do zip: o handoff vem aninhado (project/inbox-page.jsx) e a baseline
+        // é flat (inbox-page.jsx); casar pelo basename do destino faz add/mod/del baterem.
+        $incomingMap = [];
+        foreach ($routing['routed'] as $r) {
+            $incomingMap[basename($r['to'])] = sha1_file("{$incomingDir}/{$r['from']}") ?: '';
+        }
+        $diff = DesignIngestPlanner::diffByContent($this->hashDir($committedDir), $incomingMap);
+        // extras: separa "de outra tela conhecida do handoff" (ruído, agrega) de "desconhecido" (avaliar)
+        $extras = DesignIngestPlanner::classifyExtras($map, $routing['extras'], $tela);
 
-        $plano = DesignIngestPlanner::renderPlano($tela, $routing, $diff);
-        $session = DesignIngestPlanner::renderSession($tela, $routing, $diff, now()->toDateString());
+        $plano = DesignIngestPlanner::renderPlano($tela, $routing, $diff, $extras);
+        $session = DesignIngestPlanner::renderSession($tela, $routing, $diff, now()->toDateString(), $extras);
 
         @mkdir($preparedDir, 0o775, true);
         file_put_contents("{$preparedDir}/PLANO-MUDANCAS-{$tela}.md", $plano);
         file_put_contents("{$preparedDir}/SESSION-design-ingest-{$tela}.md", $session);
 
         $this->info("✓ Ingestão preparada (NADA aplicado) em {$preparedDir}:");
-        $this->line("  • PLANO-MUDANCAS-{$tela}.md — " . count($routing['routed']) . " roteados, " . count($routing['extras']) . " extra(s)");
+        $this->line('  • PLANO-MUDANCAS-' . $tela . '.md — ' . count($routing['routed']) . ' roteados, '
+            . count($extras['desconhecidos']) . ' a avaliar, ' . count($extras['outras_telas']) . ' de outras telas');
         $this->line("  • SESSION-design-ingest-{$tela}.md — memória da ingestão");
-        if ($routing['extras'] !== []) {
-            $this->warn('  ⚠ ' . count($routing['extras']) . ' arquivo(s) fora do cowork-map — avaliar antes de aplicar.');
+        if ($extras['desconhecidos'] !== []) {
+            $this->warn('  ⚠ ' . count($extras['desconhecidos']) . ' arquivo(s) desconhecido(s) fora do cowork-map — avaliar antes de aplicar.');
         }
-        $this->line('  Aplicar é decisão do Wagner (gate CT100) — esta estação só prepara.');
+        $this->line('  Aplicar = mover os roteados pra prototipos/' . $tela . '/ via PR (gate Wagner/CT100) — esta estação só prepara.');
 
         return self::SUCCESS;
     }

--- a/Modules/Jana/Services/Memoria/DesignIngestPlanner.php
+++ b/Modules/Jana/Services/Memoria/DesignIngestPlanner.php
@@ -61,6 +61,45 @@ final class DesignIngestPlanner
     }
 
     /**
+     * Classifica os extras (não roteados pra ESTA tela): "de outra tela conhecida do map"
+     * (o basename casa o glob de outra screen → ruído natural de um handoff completo, agrega)
+     * vs "desconhecido" (não casa nenhuma tela → avaliar antes de aplicar). PURO.
+     *
+     * @param  array<string, mixed>  $map  cowork-map.json decodificado
+     * @param  list<string>  $extras  arquivos sem rota pra $telaAtual (de route())
+     * @return array{outras_telas: list<string>, desconhecidos: list<string>}
+     */
+    public static function classifyExtras(array $map, array $extras, string $telaAtual): array
+    {
+        $screens = (array) ($map['screens'] ?? []);
+        $outras = [];
+        $desconhecidos = [];
+        foreach ($extras as $f) {
+            $base = basename($f);
+            $casaOutra = false;
+            foreach ($screens as $key => $screen) {
+                if ((string) $key === $telaAtual) {
+                    continue;
+                }
+                foreach ((array) (((array) $screen)['routes'] ?? []) as $r) {
+                    $glob = (string) (((array) $r)['glob'] ?? '');
+                    if ($glob !== '' && fnmatch($glob, $base)) {
+                        $casaOutra = true;
+                        break 2;
+                    }
+                }
+            }
+            if ($casaOutra) {
+                $outras[] = $f;
+            } else {
+                $desconhecidos[] = $f;
+            }
+        }
+
+        return ['outras_telas' => $outras, 'desconhecidos' => $desconhecidos];
+    }
+
+    /**
      * Parseia a saída de `git diff --no-index --name-status`. Puro.
      *
      * @return array{added: list<string>, modified: list<string>, removed: list<string>}
@@ -126,8 +165,10 @@ final class DesignIngestPlanner
      *
      * @param  array{routed: list<array{from:string, to:string}>, extras: list<string>}  $routing
      * @param  array{added: list<string>, modified: list<string>, removed: list<string>}  $diff
+     * @param  array{outras_telas: list<string>, desconhecidos: list<string>}|null  $extras
+     *         classificação de classifyExtras(); null = trata todos os extras como "a avaliar" (compat)
      */
-    public static function renderPlano(string $tela, array $routing, array $diff): string
+    public static function renderPlano(string $tela, array $routing, array $diff, ?array $extras = null): string
     {
         $rows = [];
         foreach (['added' => 'add', 'modified' => 'mod', 'removed' => 'del'] as $key => $label) {
@@ -139,14 +180,20 @@ final class DesignIngestPlanner
             ? '_(sem mudanças vs a tela commitada)_'
             : "| arquivo | status |\n|---|---|\n" . implode("\n", $rows);
 
-        $extras = $routing['extras'] === []
+        // desconhecidos = avaliar (listados); outras_telas = ruído de handoff (agregado)
+        $desconhecidos = $extras['desconhecidos'] ?? $routing['extras'];
+        $nOutras = count($extras['outras_telas'] ?? []);
+        $extrasBloco = $desconhecidos === []
             ? '_(nenhum)_'
-            : implode("\n", array_map(static fn ($e) => "- ⚠️ `{$e}` — **fora do cowork-map** (avaliar antes de aplicar)", $routing['extras']));
+            : implode("\n", array_map(static fn ($e) => "- ⚠️ `{$e}` — **fora do cowork-map** (avaliar antes de aplicar)", $desconhecidos));
+        if ($nOutras > 0) {
+            $extrasBloco .= "\n\n_+{$nOutras} arquivo(s) de outras telas do handoff (fora desta tela — ignorados)._";
+        }
 
         return "# PLANO-MUDANCAS — {$tela}\n\n"
-            . "> **STATUS: PROPOSTA — nada aplicado.** Aplicar só via `design:ingest-zip --apply` (gate Wagner/CT100).\n\n"
+            . "> **STATUS: PROPOSTA — nada aplicado.** Aplicar = mover os arquivos roteados pra `prototipo-ui/prototipos/{$tela}/` via PR (gate Wagner/CT100).\n\n"
             . "## Mudanças por arquivo (vs tela commitada)\n\n{$tabela}\n\n"
-            . "## Arquivos extras (não-autorizados no map)\n\n{$extras}\n\n"
+            . "## Arquivos extras (não-autorizados no map)\n\n{$extrasBloco}\n\n"
             . "## Roteamento (map → destino)\n\n"
             . ($routing['routed'] === []
                 ? '_(nenhum arquivo roteado)_'
@@ -159,18 +206,20 @@ final class DesignIngestPlanner
      *
      * @param  array{routed: list<array{from:string, to:string}>, extras: list<string>}  $routing
      * @param  array{added: list<string>, modified: list<string>, removed: list<string>}  $diff
+     * @param  array{outras_telas: list<string>, desconhecidos: list<string>}|null  $extras  de classifyExtras() (null = compat)
      */
-    public static function renderSession(string $tela, array $routing, array $diff, string $now): string
+    public static function renderSession(string $tela, array $routing, array $diff, string $now, ?array $extras = null): string
     {
         $nAdd = count($diff['added']);
         $nMod = count($diff['modified']);
         $nDel = count($diff['removed']);
-        $nExtra = count($routing['extras']);
+        $nDesconhecidos = count($extras['desconhecidos'] ?? $routing['extras']);
+        $nOutras = count($extras['outras_telas'] ?? []);
         $nRoute = count($routing['routed']);
 
         return "---\n"
             . "date: \"{$now}\"\n"
-            . "topic: \"Ingestão de design-zip da tela {$tela}: {$nRoute} arquivos roteados, diff {$nAdd}+/{$nMod}~/{$nDel}- vs commitado, {$nExtra} extra(s). Prepare-only (nada aplicado).\"\n"
+            . "topic: \"Ingestão de design-zip da tela {$tela}: {$nRoute} arquivos roteados, diff {$nAdd}+/{$nMod}~/{$nDel}- vs commitado, {$nDesconhecidos} a avaliar (+{$nOutras} de outras telas). Prepare-only (nada aplicado).\"\n"
             . "authors: [C]\n"
             . "related_adrs:\n  - 0270-ciclo-de-vida-da-informacao-porta-unica-destilacao-decaimento\n"
             . "prs: []\n"
@@ -178,7 +227,7 @@ final class DesignIngestPlanner
             . "# Ingestão de design — {$tela}\n\n"
             . "> Estação prepare-only (plano vectorized-badger PR-2). Unzip → map-roteamento → diff vs commitado → PLANO-MUDANCAS. **Nada aplicado** — a aplicação é gate Wagner/CT100.\n\n"
             . "## Resumo\n\n"
-            . "- Roteados: **{$nRoute}** · Extras (fora do map): **{$nExtra}**\n"
+            . "- Roteados: **{$nRoute}** · A avaliar (desconhecidos): **{$nDesconhecidos}** · De outras telas: **{$nOutras}**\n"
             . "- Diff vs tela commitada: **{$nAdd}** add · **{$nMod}** mod · **{$nDel}** del\n\n"
             . "## Próximo passo\n\n"
             . "Ler o `PLANO-MUDANCAS-{$tela}.md` + o `DOSSIE-{$tela}.md` (design:dossie) ANTES de aplicar. Resolver extras. Só então `--apply` sob gate.\n";

--- a/Modules/Jana/Tests/Feature/Memoria/DesignIngestZipCommandTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/DesignIngestZipCommandTest.php
@@ -8,11 +8,13 @@ use Illuminate\Support\Facades\File;
 uses(Tests\TestCase::class);
 
 /**
- * PR-fix — fiação do comando design:ingest-zip, que os testes unit do Planner não cobrem.
- * Codifica o furo mais grave do smoke CT100: o diff via `git diff --no-index` saía VAZIO
- * no container (sem git) → PLANO dizia "sem mudanças" mesmo com arquivo novo. Agora o diff
- * é por CONTEÚDO (sha) — sem git. Fixture em tempdir (`jana.dossie_root`); zip real via
- * ZipArchive. Continua prepare-only: nada é aplicado no protótipo commitado.
+ * Fiação do comando design:ingest-zip (os testes unit do Planner não cobrem).
+ *
+ * Cobre os 2 descompassos achados ao ingerir o HANDOFF completo do Cowork (não um zip
+ * de 1 tela): (A) o diff é sobre os arquivos ROTEADOS (pelo nome final do destino), não
+ * o dump bruto — então um handoff aninhado (project/inbox-page.jsx) casa a baseline flat
+ * (inbox-page.jsx); (B) extras de OUTRA tela conhecida do map são agregados (ruído), só
+ * os DESCONHECIDOS são listados. Fixture em tempdir (jana.dossie_root); zip real; sem git.
  */
 
 beforeEach(function () {
@@ -35,7 +37,7 @@ function ingestSeed(string $rel, string $content): void
     File::put($abs, $content);
 }
 
-/** @param array<string,string> $files name => content */
+/** @param array<string,string> $files name(=path no zip) => content */
 function ingestZipFile(string $path, array $files): void
 {
     $z = new ZipArchive();
@@ -46,54 +48,88 @@ function ingestZipFile(string $path, array $files): void
     $z->close();
 }
 
+/** map com 2 telas + globs ESPECÍFICOS por prefixo (caixa=inbox-*, vendas=vendas-*). */
 function ingestSeedMap(): void
 {
     ingestSeed('prototipo-ui/cowork-map.json', json_encode([
-        'screens' => ['vendas' => ['module' => 'Sells', 'page_id' => 'sells-index', 'routes' => [
-            ['glob' => '*-page.jsx', 'to' => 'prototipo-ui/prototipos/vendas/'],
-            ['glob' => '*.css', 'to' => 'prototipo-ui/prototipos/vendas/'],
-        ]]],
+        'screens' => [
+            'caixa-unificada' => ['module' => 'Atendimento', 'page_id' => 'atendimento-caixa-unificada', 'routes' => [
+                ['glob' => 'inbox-*.jsx', 'to' => 'prototipo-ui/prototipos/caixa-unificada/'],
+                ['glob' => 'inbox-*.css', 'to' => 'prototipo-ui/prototipos/caixa-unificada/'],
+            ]],
+            'vendas' => ['module' => 'Sells', 'page_id' => 'sells-index', 'routes' => [
+                ['glob' => 'vendas-*.jsx', 'to' => 'prototipo-ui/prototipos/vendas/'],
+            ]],
+        ],
     ]));
 }
 
-test('diff por CONTEÚDO (sem git): add/mod/del + extra no PLANO', function () {
+function ingestPlano(string $tela): string
+{
+    return File::get(test()->root . "/prototipo-ui/_incoming/{$tela}/_prepared/PLANO-MUDANCAS-{$tela}.md");
+}
+
+test('diff é sobre os ROTEADOS: add/mod/del corretos; extra desconhecido listado', function () {
     ingestSeedMap();
-    // tela commitada: 1 arquivo que será modificado + 1 que será removido
-    ingestSeed('prototipo-ui/prototipos/vendas/vendas-page.jsx', 'v1');
-    ingestSeed('prototipo-ui/prototipos/vendas/old.css', 'x');
-    // zip do Cowork: page modificado + css novo + extra fora do map
+    ingestSeed('prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx', 'v1'); // será modificado
+    ingestSeed('prototipo-ui/prototipos/caixa-unificada/inbox-old.css', 'x');   // será removido
     $zip = test()->root . '/export.zip';
     ingestZipFile($zip, [
-        'vendas-page.jsx' => 'v2',          // modified
-        'nova.css' => 'z',                  // added (roteado)
-        'NOTES-cowork.md' => 'ideia solta', // added + extra (fora do map)
+        'inbox-page.jsx' => 'v2',   // roteado → mod
+        'inbox-novo.css' => 'z',    // roteado → add
+        'lixo.txt' => 'nada',       // não casa NENHUMA tela → desconhecido
     ]);
 
-    $code = Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'vendas']);
-    expect($code)->toBe(0);
+    expect(Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'caixa-unificada']))->toBe(0);
 
-    $plano = File::get(test()->root . '/prototipo-ui/_incoming/vendas/_prepared/PLANO-MUDANCAS-vendas.md');
-    expect($plano)
-        ->toContain('| `vendas-page.jsx` | mod |')   // <- antes saía vazio (sem git)
-        ->toContain('| `nova.css` | add |')
-        ->toContain('| `NOTES-cowork.md` | add |')
-        ->toContain('| `old.css` | del |')
-        ->toContain('⚠️ `NOTES-cowork.md` — **fora do cowork-map**')
+    expect(ingestPlano('caixa-unificada'))
+        ->toContain('| `inbox-page.jsx` | mod |')
+        ->toContain('| `inbox-novo.css` | add |')
+        ->toContain('| `inbox-old.css` | del |')
+        ->toContain('⚠️ `lixo.txt` — **fora do cowork-map**')
         ->not->toContain('sem mudanças vs a tela commitada');
+});
+
+test('handoff ANINHADO idêntico → "sem mudanças"; arquivo de outra tela é agregado', function () {
+    ingestSeedMap();
+    ingestSeed('prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx', 'CONTEUDO_A');
+    // zip no formato handoff: tudo sob oimpresso-x/project/, todas as telas juntas
+    $zip = test()->root . '/handoff.zip';
+    ingestZipFile($zip, [
+        'oimpresso-x/project/inbox-page.jsx' => 'CONTEUDO_A',   // IDÊNTICO à baseline
+        'oimpresso-x/project/vendas-page.jsx' => 'qualquer',    // de OUTRA tela (vendas)
+    ]);
+
+    expect(Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'caixa-unificada']))->toBe(0);
+
+    $plano = ingestPlano('caixa-unificada');
+    expect($plano)
+        ->toContain('sem mudanças vs a tela commitada')         // aninhado casou a baseline flat
+        ->toContain('de outras telas do handoff')               // vendas-page.jsx agregado
+        ->not->toContain('⚠️ `oimpresso-x/project/vendas-page.jsx`'); // NÃO listado como desconhecido
+});
+
+test('handoff ANINHADO modificado → o diff PEGA o arquivo modificado', function () {
+    ingestSeedMap();
+    ingestSeed('prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx', 'CONTEUDO_A');
+    $zip = test()->root . '/handoff.zip';
+    ingestZipFile($zip, ['oimpresso-x/project/inbox-page.jsx' => 'CONTEUDO_B_MUDOU']);
+
+    expect(Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'caixa-unificada']))->toBe(0);
+
+    expect(ingestPlano('caixa-unificada'))->toContain('| `inbox-page.jsx` | mod |');
 });
 
 test('prepare-only: NÃO aplica no protótipo commitado', function () {
     ingestSeedMap();
-    ingestSeed('prototipo-ui/prototipos/vendas/vendas-page.jsx', 'v1');
-    $zip = test()->root . '/export.zip';
-    ingestZipFile($zip, ['vendas-page.jsx' => 'v2-NOVO']);
+    ingestSeed('prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx', 'v1');
+    $zip = test()->root . '/handoff.zip';
+    ingestZipFile($zip, ['oimpresso-x/project/inbox-page.jsx' => 'v2-NOVO']);
 
-    Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'vendas']);
+    Artisan::call('design:ingest-zip', ['--zip' => $zip, '--tela' => 'caixa-unificada']);
 
-    // o commitado segue intocado (a aplicação é gate Wagner/CT100)
-    expect(File::get(test()->root . '/prototipo-ui/prototipos/vendas/vendas-page.jsx'))->toBe('v1');
-    expect(File::exists(test()->root . '/prototipo-ui/prototipos/vendas/_prepared'))->toBeFalse();
-    // mas o PLANO + a memória de sessão foram preparados
-    expect(File::exists(test()->root . '/prototipo-ui/_incoming/vendas/_prepared/PLANO-MUDANCAS-vendas.md'))->toBeTrue();
-    expect(File::exists(test()->root . '/prototipo-ui/_incoming/vendas/_prepared/SESSION-design-ingest-vendas.md'))->toBeTrue();
+    // commitado intocado (aplicação é gate Wagner/CT100)
+    expect(File::get(test()->root . '/prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx'))->toBe('v1');
+    expect(File::exists(test()->root . '/prototipo-ui/_incoming/caixa-unificada/_prepared/PLANO-MUDANCAS-caixa-unificada.md'))->toBeTrue();
+    expect(File::exists(test()->root . '/prototipo-ui/_incoming/caixa-unificada/_prepared/SESSION-design-ingest-caixa-unificada.md'))->toBeTrue();
 });

--- a/Modules/Jana/Tests/Unit/DesignIngestPlannerTest.php
+++ b/Modules/Jana/Tests/Unit/DesignIngestPlannerTest.php
@@ -80,8 +80,30 @@ test('renderSession() tem frontmatter de sessão + contagens', function () {
         ->toContain('date: "2026-06-19"')
         ->toContain('authors: [C]')
         ->toContain('Roteados: **2**')
-        ->toContain('Extras (fora do map): **1**')
+        ->toContain('A avaliar (desconhecidos): **1**')
         ->toContain('**1** add · **1** mod · **0** del');
+});
+
+test('classifyExtras() separa "de outra tela conhecida" de "desconhecido"', function () {
+    $map = ['screens' => [
+        'caixa-unificada' => ['routes' => [['glob' => 'inbox-*.jsx', 'to' => 'prototipo-ui/prototipos/caixa-unificada/']]],
+        'vendas' => ['routes' => [['glob' => 'vendas-*.jsx', 'to' => 'prototipo-ui/prototipos/vendas/']]],
+    ]];
+    // extras de --tela=caixa-unificada: vendas-page.jsx casa OUTRA tela (vendas); lixo.txt não casa nada
+    $r = DesignIngestPlanner::classifyExtras($map, ['oimpresso-x/project/vendas-page.jsx', 'lixo.txt'], 'caixa-unificada');
+    expect($r['outras_telas'])->toBe(['oimpresso-x/project/vendas-page.jsx']);
+    expect($r['desconhecidos'])->toBe(['lixo.txt']);
+});
+
+test('renderPlano() com extras classificados: agrega outras telas, lista só desconhecidos', function () {
+    $routing = ['routed' => [], 'extras' => ['vendas-page.jsx', 'lixo.txt']];
+    $diff = ['added' => [], 'modified' => [], 'removed' => []];
+    $extras = ['outras_telas' => ['vendas-page.jsx'], 'desconhecidos' => ['lixo.txt']];
+    $plano = DesignIngestPlanner::renderPlano('caixa-unificada', $routing, $diff, $extras);
+    expect($plano)
+        ->toContain('⚠️ `lixo.txt` — **fora do cowork-map**')
+        ->toContain('+1 arquivo(s) de outras telas do handoff')
+        ->not->toContain('⚠️ `vendas-page.jsx`'); // agregado, não listado individualmente
 });
 
 test('é DETERMINÍSTICO — route/parseDiff/render idênticos em re-run', function () {


### PR DESCRIPTION
## Por quê

Smoke real no CT 100 com o **handoff completo do Cowork** (projeto inteiro: 1129 arquivos aninhados em `oimpresso-…/project/`, todas as telas juntas) provou 2 descompassos vs o design original "zip de 1 tela": `241 roteados / 888 extras` e diff `add=1129, del=6`.

## O que muda

**A) Diff sobre os arquivos ROTEADOS, não o dump bruto** (`DesignIngestZipCommand`). O handoff guarda `project/inbox-page.jsx` e a baseline é `inbox-page.jsx` (flat) → o relpath não casava e o mesmo arquivo virava `add` **e** `del`. Agora o diff compara pelo **nome final do destino** (basename) → `add/mod/del` corretos (aninhado casa a baseline flat).

**B) Extras inteligentes** (`DesignIngestPlanner::classifyExtras`). Um handoff traz todas as telas; antes os ~1123 arquivos de **outras telas** viravam "extras a avaliar" (ruído). Agora separa **"casa o glob de outra tela conhecida do map"** (agregado, 1 linha) de **"desconhecido"** (listado pra avaliar).

\+ Banner do PLANO ajustado (aplicação = mover roteados via PR; não promete o `--apply` que não existe).

## Testes (CT 100)

Feature tests com **fixture de handoff aninhado** (`oimpresso-x/project/inbox-page.jsx`): (a) aninhado idêntico → "sem mudanças"; (b) aninhado modificado → `mod`; (c) extra de outra tela agregado, desconhecido listado; (d) prepare-only intocado. + unit de `classifyExtras`. **58 passed / 168 assertions** ✅.

> Sozinho, este PR conserta a *fiação*. O handoff só roteia limpo (6 da caixa, não 241) **com o PR-2** (cowork-map v2 com globs específicos `inbox-*`). Os dois juntos fecham o ciclo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)