### PR TITLE
docs(adr): 0293 — governança da decisão de design (responsável + registro + retorno)

### DIFF
--- a/governance/design-requests/2026-06-19-caixa-unificada-dark.md
+++ b/governance/design-requests/2026-06-19-caixa-unificada-dark.md
@@ -1,0 +1,25 @@
+---
+tela: caixa-unificada
+tema: dark
+veredito: rejeitado
+responsavel: gate-automatico
+status: pendente
+---
+# Caixa Unificada — dark mode com paleta bespoke `--omd-*`
+
+- **detecção:** ao aplicar o handoff "n" em `prototipo-ui/prototipos/caixa-unificada/`, o `ds-guard`
+  barrou `inbox-page.css` por **paleta inventada `--omd-*` (13 tokens)**. A baseline em `origin/main`
+  tinha **0** ocorrências — regressão **nova** trazida pelo handoff, não dívida pré-existente.
+- **motivo:** viola **L-02** (cor só por `.<tela>-scope{--accent}`, nunca paleta `--x-*` paralela ao DS)
+  e contraria **[ADR 0281]** (dark ativa por `[data-theme="dark"]` flipando tokens canônicos —
+  **sem cunhar token novo, sem paleta por-tela**).
+- **padrão (o que o redesign deve seguir):**
+  - **neutros** (`--omd-canvas/panel/raise/line`) → tokens canônicos que já flipam no dark:
+    `var(--bg)`, `var(--surface)`, `var(--color-card)`, `var(--color-border)`.
+  - **âmbar** (`--omd-amb*`) → `var(--color-warning)` / `--color-warning-soft` / `-fg`.
+  - **verde da marca** (`--omd-sel*/me*/grn`, identidade da inbox/WhatsApp) → **accent scoped**:
+    `.caixa-unificada-scope { --accent: <verde> }` + `var(--accent)` (única forma de cor por-tela
+    permitida pelo L-02). NÃO usar o primary roxo 295 ([ADR 0190]) à força.
+- **ação Cowork:** refazer o dark da Caixa no **data-theme bridge** ([ADR 0281]); zero `--omd-*`.
+- **decisão Tier-0 pendente [W]:** harmonizar via Code (mesmo mapeamento acima, sob gate visual)
+  **ou** devolver pro Cowork refazer na fonte. Registrado como `D-01` da Caixa quando a decisão sair.

--- a/governance/design-requests/README.md
+++ b/governance/design-requests/README.md
@@ -1,0 +1,37 @@
+# `governance/design-requests/` — ledger de vereditos de design (retorno pro Cowork)
+
+> Canal estruturado de **retorno do que não foi aprovado** pro design (Cowork) refazer.
+> Etapa 6 do ciclo de vida ([ADR 0270]), governança em [ADR 0293]. **Append-only.**
+
+## O que é
+
+Quando um protótipo de design **não passa** — um gate barrou (`ds-guard`/`integrity-check`) ou
+[W] rejeitou no gate visual ([ADR 0107]) — o veredito é registrado aqui, com **motivo + o padrão
+canônico a seguir**. O **próximo handoff do Cowork lê esta pasta** antes de refazer a tela, em vez
+de o feedback virar "lição solta" ou o Code maquiar a regressão.
+
+## Formato (um arquivo por veredito, `AAAA-MM-DD-<tela>-<tema>.md`)
+
+```
+---
+tela: <chave-cowork-map>
+tema: <ex: dark, densidade, copy>
+veredito: rejeitado | aprovado-com-ressalva
+responsavel: [W] | [CC] | gate-automatico
+status: pendente | resolvido
+---
+# <título>
+- detecção: <o que disparou>
+- motivo:   <por que não passou>
+- padrão:   <ADR/regra que o redesign deve seguir>
+- ação Cowork: <o que refazer, concretamente>
+```
+
+## Relação com o Decision Register
+
+O **Decision Register por tela** (`<tela>.decisoes.md`, [ADR 0293] D-B) é o debate interno da tela.
+Este ledger é o **recorte que volta pro Cowork** — só os vereditos que exigem redesign na fonte.
+
+[ADR 0270]: ../../memory/decisions/0270-ciclo-de-vida-da-informacao-porta-unica-destilacao-decaimento.md
+[ADR 0293]: ../../memory/decisions/0293-governanca-decisao-design-responsavel-registro-veredito.md
+[ADR 0107]: ../../memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md

--- a/memory/decisions/0293-governanca-decisao-design-responsavel-registro-veredito.md
+++ b/memory/decisions/0293-governanca-decisao-design-responsavel-registro-veredito.md
@@ -1,0 +1,120 @@
+---
+slug: 0293-governanca-decisao-design-responsavel-registro-veredito
+number: 293
+title: "Governança da decisão de design: responsável por etapa do ciclo + Decision Register por tela + ledger de vereditos pro Cowork"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-19"
+module: design-system
+tags: [design, governanca, ciclo-de-vida, cowork, decision-register, veredito, responsabilidade, tier-0, ds-guard]
+supersedes: []
+superseded_by: []
+related:
+  - 0270-ciclo-de-vida-da-informacao-porta-unica-destilacao-decaimento
+  - 0291-distiller-modulo-verdade-contrato-emenda-0270-f3
+  - 0114-prototipo-ui-cowork-loop-formalizado
+  - 0107-emendation-0104-visual-comparison-gate-f3
+  - 0281-dark-mode-bridge-data-theme-tokens
+  - 0094-constituicao-v2-7-camadas-8-principios
+pii: false
+---
+
+> **Proposta por [CC] em 2026-06-19.** Ratificação formal = merge por [W] (convenção [ADR 0270]).
+> Direção dada por Wagner no chat 2026-06-19: *"vai ser o responsável por cada parte. e a decisão
+> deve ficar guardada e como foi feita ou decidida?"* — durante o piloto de ingestão do handoff Cowork.
+
+# ADR 0293 — Governança da decisão de design (responsável + registro + retorno)
+
+## Contexto (verificado em `origin/main`)
+
+A esteira de ingestão de design ficou pronta e provada: `design:ingest-zip` (diff por conteúdo
+sobre os roteados — [#3041]) + `cowork-map` v2 (rota por prefixo de tela — [#3042]) levam um
+**handoff completo do Cowork → `prototipo-ui/prototipos/<tela>/`** com gates (`ds-guard`,
+`integrity-check`). Isso cobre **design → fonte**.
+
+O que **faltava** era a governança do resto do ciclo (etapas 4–6 do [ADR 0270]): para **cada
+decisão de design**, (a) **quem é o responsável** e (b) **onde fica registrado o que foi
+decidido, como e por quê** — incluindo o **retorno do que foi rejeitado** pro design refazer.
+
+O gatilho concreto: o handoff "n" da Caixa Unificada trouxe um **dark bespoke** (`--omd-*`,
+13 tokens; a baseline tinha 0). O `ds-guard` barrou (L-02) e o [ADR 0281] (dark por
+`[data-theme="dark"]`, token canônico, **sem paleta por-tela**) dá o padrão correto — mas **não
+havia onde registrar a decisão nem canal pra devolver ao Cowork**. Esta ADR crava essa governança.
+
+## Decisão
+
+### D-A — Responsável por etapa do ciclo (quem decide o quê)
+
+| Etapa | Responsável | Natureza |
+|---|---|---|
+| Ingestão (handoff → `prototipos/`) | **[CC]** | mecânico (rota + diff) |
+| `cowork-map` (rota das telas) | [CC] propõe → **[W] ratifica** (merge) | canônico |
+| Gates `ds-guard` / `integrity-check` | **automático** | passa/barra (gera veredito) |
+| Aplicar na fonte (`prototipos/<tela>/`) | [CC] executa sob gate | mecânico |
+| **Cor / identidade / dark / tokens / DS** | **[W]** (Tier-0) ou devolve a **[Design/Cowork]** | Tier-0 |
+| Aplicar na vida real (tela Inertia) | [CC] migra (MWART) → **[W] aprova screenshot** | gate visual ([ADR 0107]) |
+| Refazer o rejeitado | **[Design/Cowork]** | design |
+
+Regra-mestre: **decisão Tier-0 (cor/identidade/token/DS/constituição) é sempre [W]** ([ADR 0094]
+princípio 7 + invariante #10 do método). [CC] propõe e executa o mecânico; nunca decide Tier-0 sozinho.
+
+### D-B — Registro por tela: Decision Register (`<tela>.decisoes.md`)
+
+Cada decisão de design de uma tela é registrada no **Decision Register irmão** do charter
+(padrão `D-NN` já em uso — ex. `prototipo-ui/prototipos/producao-oficina/OficinaProducao.decisoes.md`;
+o `integrity-check` IT2 exige o par charter↔decisoes). Schema mínimo por entrada:
+
+```
+D-NN · <título curto>
+  responsável: [W] | [CC] | [Design]
+  detecção:    <o que disparou — gate, review, sinal>
+  padrão:      <ADR/regra canônica que se aplica>
+  opções:      <as alternativas consideradas>
+  status:      PENDENTE [W] | DECIDIDO (<como/por quê>) | APLICADO (<PR>) | DEVOLVIDO ([Design])
+```
+
+O **anel** (Avaliar→Testar→Adotar→Descartar) do método continua valendo; o Register é onde o
+debate vive até gradar pro charter como `✅`.
+
+### D-C — Ledger de vereditos: `governance/design-requests/` (retorno pro Cowork)
+
+O que **não** foi aprovado (gate barrou ou [W] rejeitou) vira um **veredito append-only** em
+`governance/design-requests/` — com **motivo + padrão a seguir** — que o **próximo handoff do
+Cowork lê** antes de refazer. É a **etapa 6** (retorno) do [ADR 0270], materializada. Fecha o loop
+Cowork↔Code ([ADR 0114]) com um canal estruturado em vez de "vira lição solta".
+
+### D-D — Gate = decisor automático com veredito explícito
+
+Quando `ds-guard`/`integrity-check` barram, **não é erro silencioso**: gera um veredito (D-C) com
+o motivo (ex. "paleta `--omd-*` viola L-02 / [ADR 0281]"). "Defesa que dispara > regra que se lê"
+(método NÚCLEO #5). A aplicação só prossegue quando a decisão Tier-0 correspondente for tomada por [W].
+
+## Consequências
+
+**Positivas**
+- Toda decisão de design passa a ter **dono** e **rastro** (o quê, quem, como, por quê) — responde
+  "como foi decidido aplicar cada protótipo" e "o que volta pro design".
+- O retorno ao Cowork deixa de ser informal; vira ledger que o próximo handoff consome.
+- Reusa o que já existe (Decision Register + gates), **sem cunhar 5º placar** ([ADR 0270] D-6).
+
+**Riscos / pegadinhas**
+- Disciplina: exige registrar a decisão **na hora** (senão o rastro fura). Mitigado porque o gate
+  já força o veredito quando barra.
+- `governance/design-requests/` é novo — manter **append-only** e fora do escopo de tela (não rotear).
+
+## Roadmap de PRs (cada ≤300 linhas · 1 intent)
+
+- **PR-A (este):** ADR 0293 + `governance/design-requests/` (README + 1º veredito: dark da Caixa). `docs`.
+- **PR-B+:** ao aplicar cada tela, registrar as decisões no Decision Register e os rejeitados no ledger.
+
+## Referências
+
+- [ADR 0270] ciclo de vida da informação (etapas 4–6 que esta ADR governa)
+- [ADR 0291] distiller (registro datado/proveniência — padrão herdado) · [ADR 0114] loop Cowork↔Code
+- [ADR 0107] gate visual F3 · [ADR 0281] dark por `[data-theme="dark"]` (padrão do caso-gatilho)
+- [ADR 0094] Constituição v2 (princípio 7 transparência · soberania [W]) · método NÚCLEO #5/#10
+- Estação: [#3041] (diff sobre roteados) · [#3042] (cowork-map v2)

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **297** arquivos · **282** números únicos · máx **0292**
-- **ADRs ATIVOS (lifecycle ativo): 257** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 228 · proposto 42 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
-- Por lifecycle: ativo 257 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **298** arquivos · **283** números únicos · máx **0293**
+- **ADRs ATIVOS (lifecycle ativo): 258** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 228 · proposto 43 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
+- Por lifecycle: ativo 258 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -32,7 +32,7 @@ _(íntegra)_
 ## Recusadas (1) — o NÃO consultável
 - **0290** v0 'Fidelity Lock' (screenshot pareado em CI) — RECUSADO: fidelidade visual não  · recusada 2026-06-18 — Inviável + tautológico + backdoor de prosa (3 motivos na Decisão). REABRE só se surgir um check de fidelidade HERMÉTICO 
 
-## Todas as ADRs (297)
+## Todas as ADRs (298)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | !!binary gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZ |
@@ -332,3 +332,4 @@ _(íntegra)_
 | 0290 | recusado | ativo | decision | v0 'Fidelity Lock' (screenshot pareado em CI) — RECUSADO: fidelidade visual não  |
 | 0291 | proposto | ativo | meta | Emenda 0270 F3/D-5 — contrato do distiller-módulo-verdade (diário→manual) + inst |
 | 0292 | proposto | ativo | errata | Errata 0291 D-D — distiller_freshness no scorecard mede staleness vs doc mais no |
+| 0293 | proposto | ativo | decision | Governança da decisão de design: responsável por etapa do ciclo + Decision Regis |


### PR DESCRIPTION
## Por quê

Você pediu: *"vai ser o responsável por cada parte. e a decisão deve ficar guardada e como foi feita ou decidida?"*. A esteira de ingestão ([#3041]/[#3042]) cobre **design → fonte**; faltava a governança das etapas 4–6 do ciclo ([ADR 0270]): **quem decide cada parte** + **onde fica o registro** (com o porquê) + **retorno do rejeitado** pro Cowork.

## O que entra

- **ADR 0293** — formaliza:
  - **D-A** Matriz de responsabilidade por etapa (Tier-0 cor/identidade/DS = sempre **[W]**; mecânico = [CC]; gate = automático).
  - **D-B** Registro por tela no **Decision Register** (`<tela>.decisoes.md`, padrão `D-NN` já em uso).
  - **D-C** **Ledger de vereditos** `governance/design-requests/` (retorno pro Cowork — append-only).
  - **D-D** Gate barra → gera veredito explícito (não erro silencioso).
- **`governance/design-requests/`** — README do canal + **1º veredito real**: `2026-06-19-caixa-unificada-dark.md` (o dark `--omd-*` que o ds-guard barrou, **PENDENTE [W]**).

## Validação

- `jana:validate-memory --schema=adr`: **0 erros no 0293** (as 186 violações do validator são dívida legada de outros ADRs, fora do diff deste PR).
- Reusa o que já existe (Decision Register + gates), sem cunhar 5º placar ([ADR 0270] D-6).

Não muda código nem aplica nada — é o contrato de governança. O dark da Caixa segue **decisão sua** (Tier-0), agora registrada e rastreável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)