### PR TITLE
fix(atendimento): dark flipa sem F5 (toggle sincroniza data-theme) + thread usa token

### DIFF
--- a/resources/js/Hooks/useTheme.ts
+++ b/resources/js/Hooks/useTheme.ts
@@ -95,4 +95,11 @@ function applyClass(theme: 'light' | 'dark') {
   const el = document.documentElement;
   if (theme === 'dark') el.classList.add('dark');
   else el.classList.remove('dark');
+  // ADR 0281: o dark ativa por `.dark` OU `[data-theme="dark"]` (OR). O `data-theme`
+  // mora em DOIS lugares — `<html>` (anti-flash, inertia.blade) e `.cockpit`
+  // (AppShellV2, prop server-side que só muda no F5). Sem sincronizar AMBOS aqui, o
+  // `data-theme=dark` residual mantém a tela no tema antigo (o "precisa F5" da Caixa).
+  // Verificado em prod: setar data-theme nos dois + a classe → flip sem reload.
+  el.setAttribute('data-theme', theme);
+  document.querySelector('.cockpit')?.setAttribute('data-theme', theme);
 }

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -118,10 +118,11 @@ export default function ConversationThreadV4({
     // referência → conteúdo empurrava layout 375px além viewport → `.cockpit` ancestor
     // tem overflow:hidden → cortado sem scrollbar. Fix: <div> semântico + h-full.
     <div
-      // Fundo da thread: tom verde-WA suave do protótipo (.om-thread-c L421
-      // oklch(0.97 0.013 145)) no claro; neutro dark-aware no escuro (flipa via
-      // .dark/[data-theme=dark] — ADR 0281). Antes era bg-muted/15 cinza neutro.
-      className="flex flex-col bg-[oklch(0.97_0.013_145)] dark:bg-muted/15 min-h-0 min-w-0 h-full"
+      // Fundo da thread: token neutro `bg-muted` (flipa nativo light/dark pelos tokens
+      // canônicos — ADR 0281). Antes usava `bg-[oklch(0.97 0.013 145)]` (cor crua
+      // arbitrária — viola "cor = token") + `dark:bg-muted/15`, par que não flipava no
+      // toggle sem F5. Token único resolve a regra e o flip de uma vez.
+      className="flex flex-col bg-muted/30 min-h-0 min-w-0 h-full"
       aria-label="Thread da conversa"
       role="region"
     >


### PR DESCRIPTION
## Bug (reportado por [W], na Caixa Unificada)
Ao trocar o tema (Aparência → Claro/Escuro), o fundo da tela/thread **não muda até dar F5**.

## Causa (verificada no DOM, em produção — não inferida)
- O toggle (`useTheme.applyClass`) só mexia na classe `.dark` do `<html>`.
- Mas o `data-theme` mora em **dois** lugares: `<html>` (anti-flash) e `.cockpit` (`AppShellV2:471`, prop server-side que só muda no F5).
- O `dark:` do Tailwind ativa por `.dark` **OU** `[data-theme=dark]` (OR, ADR 0281). Então o `data-theme=dark` **residual** mantinha tudo escuro.
- **Prova ao vivo:** cliquei "Claro" sem F5 → `html.dark=false` (saiu) mas `data-theme=dark` (ficou) → fundo continuou escuro. Setando `data-theme=light` nos **dois** + removendo `.dark` → thread ficou clara (`rgb(240,248,240)`).

## Fix
1. **`useTheme.ts`** — `applyClass` agora sincroniza `data-theme` no `<html>` **e** no `.cockpit`, junto com a classe → flip imediato, sem reload. (foundation: vale pra todas as telas)
2. **`ConversationThreadV4.tsx`** — fundo era `bg-[oklch(0.97 0.013 145)]` (cor crua arbitrária, viola "cor = token") + `dark:bg-muted/15` (não flipava). Trocado por **`bg-muted/30`** (token único que flipa nativo). Responde a 2ª pergunta: ali a regra de CSS não estava sendo respeitada.

## Validação
- Lógica **provada no DOM de produção** (simulação acima).
- Build TS/Vite: pela CI.
- Toggle real pós-build: validar no staging antes de mergear (é foundation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)