### PR TITLE
feat(caixa-unificada): composer em 2 linhas (input no topo) — C1 handoff Cowork

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -25,7 +25,7 @@ import { useState, useRef, useEffect, useMemo } from 'react';
 import { useForm, router, usePage } from '@inertiajs/react';
 import { Braces, LayoutList, Loader2, Send, FileText, Paperclip, Slash, Sparkles, X } from 'lucide-react';
 import { cn } from '@/Lib/utils';
-import { Inline } from '@/Components/layout';
+import { Inline, Stack } from '@/Components/layout';
 import {
   Popover,
   PopoverContent,
@@ -582,9 +582,10 @@ export default function ComposerV4({
           ))}
         </div>
       )}
-    <div
+    <Stack
+      gap={2}
       className={cn(
-        'flex flex-col gap-2 border-t px-3.5 py-2.5 transition-colors',
+        'border-t px-3.5 py-2.5 transition-colors',
         !internalMode && 'bg-card',
       )}
       style={
@@ -601,7 +602,7 @@ export default function ComposerV4({
       {/* C1 (handoff 2026-06-19) — composer em 2 linhas (.om-composer coluna do
           protótipo Cowork): ferramentas na 2ª linha (order-2); input + Enviar
           sobem pro topo (order-1). Sem mudança de lógica — só layout. */}
-      <div className="flex items-center flex-wrap gap-1.5 order-2">
+      <Inline wrap className="gap-1.5 order-2">
       {/* PR-9 — ✦ Sugerir resposta (IA preenche o input; humano revisa e envia) */}
       {!internalMode && (
         <button
@@ -792,10 +793,10 @@ export default function ComposerV4({
           <LayoutList size={12} aria-hidden />
         </button>
       )}
-      </div>
+      </Inline>
 
       {/* C1 — 1ª linha: input + Enviar (.om-input-main), sobe via order-1 */}
-      <div className="flex items-center gap-2 order-1">
+      <Inline gap={2} className="order-1">
       {/* Input */}
       <input
         ref={inputRef}
@@ -862,8 +863,8 @@ export default function ComposerV4({
           </>
         )}
       </button>
-      </div>
-    </div>
+      </Inline>
+    </Stack>
 
     {/* Wave 4-B F1 — Interactive message dialog (List/Button Meta) */}
     {supportsInteractive && (

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ComposerV4.tsx
@@ -584,7 +584,7 @@ export default function ComposerV4({
       )}
     <div
       className={cn(
-        'flex items-center gap-1.5 border-t px-3.5 py-2.5 transition-colors',
+        'flex flex-col gap-2 border-t px-3.5 py-2.5 transition-colors',
         !internalMode && 'bg-card',
       )}
       style={
@@ -598,6 +598,10 @@ export default function ComposerV4({
       }
       data-testid="caixa-unif-composer"
     >
+      {/* C1 (handoff 2026-06-19) — composer em 2 linhas (.om-composer coluna do
+          protótipo Cowork): ferramentas na 2ª linha (order-2); input + Enviar
+          sobem pro topo (order-1). Sem mudança de lógica — só layout. */}
+      <div className="flex items-center flex-wrap gap-1.5 order-2">
       {/* PR-9 — ✦ Sugerir resposta (IA preenche o input; humano revisa e envia) */}
       {!internalMode && (
         <button
@@ -788,7 +792,10 @@ export default function ComposerV4({
           <LayoutList size={12} aria-hidden />
         </button>
       )}
+      </div>
 
+      {/* C1 — 1ª linha: input + Enviar (.om-input-main), sobe via order-1 */}
+      <div className="flex items-center gap-2 order-1">
       {/* Input */}
       <input
         ref={inputRef}
@@ -855,6 +862,7 @@ export default function ComposerV4({
           </>
         )}
       </button>
+      </div>
     </div>
 
     {/* Wave 4-B F1 — Interactive message dialog (List/Button Meta) */}


### PR DESCRIPTION
## C1 — composer 2 linhas ("onde digita")

Handoff Cowork 2026-06-19, item C1. O composer da Caixa vira **coluna**: input + Enviar na **1ª linha**; ferramentas (Sugerir/Resp/Templates/Macros/Variáveis/Anexar/Mic/Interactive) na **2ª linha**. Antes era 1 linha só com o input espremido entre os ícones — divergência que o [W] apontou.

**Diff mínimo:** `container flex items-center` → `flex flex-col` + 2 wrappers com `order-1` (input) / `order-2` (ferramentas). **Zero** mudança de lógica/estado/backend — só layout. Tokens intactos (LEI "não repintar": nenhuma cor muda).

**Gate visual:** screenshot claro+escuro vai no smoke pós-deploy (a tela só renderiza no app; sigo o fluxo do time `tela-smoke-pos-merge`). Reversível (1 arquivo, 9 linhas).

**Follow-up conhecido:** ordem de foco do teclado segue o DOM (ferramentas antes do input); se incomodar, troco `order` por mover o bloco no DOM. C2/C3/C4 (estilo dos botões, toggle como ícone, divisor) ficam pra PRs separados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)