### PR TITLE
test(teammcp): preserva 4 testes Feature do Forja (não estavam no main)

### DIFF
--- a/Modules/TeamMcp/Tests/Feature/ForjaBacklogServiceTest.php
+++ b/Modules/TeamMcp/Tests/Feature/ForjaBacklogServiceTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Database\Seeders\ForjaDemoTicketsSeeder;
+use Modules\TeamMcp\Services\Forja\ForjaBacklogService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Forja · aba Backlog — ForjaBacklogService::build().
+ *
+ * Cobertura (Onda Forja — código novo sem teste):
+ *   1. build($projectId) com FORJA semeado → lista de issues; cada item carrega
+ *      display_id/title/tipo/fase/papel/onda/modulo/prioridade/status.
+ *   2. build(null) → [] (sem dado fantasma; o front mostra empty-state).
+ *
+ * Padrão era-sqlite (espelha AcceptanceRefTest): schema sintético + activitylog OFF.
+ * Assertions ROBUSTAS (chaves/tipos/contagem), nunca valores frágeis.
+ *
+ * @see Modules\TeamMcp\Services\Forja\ForjaBacklogService
+ * @see memory/decisions/0070-jira-style-task-management.md
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético incompatível com MySQL persistente (floor SDD).');
+    }
+
+    config(['activitylog.enabled' => false]);
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_jira_projects');
+
+    Schema::create('mcp_jira_projects', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('key', 20)->unique();
+        $t->string('name', 120)->nullable();
+        $t->text('description')->nullable();
+        $t->string('status', 20)->default('active');
+        $t->string('icon', 40)->nullable();
+        $t->unsignedInteger('next_task_number')->default(1);
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 40)->nullable();
+        $t->unsignedBigInteger('project_id')->nullable();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->text('description')->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('type', 20)->nullable();
+        $t->string('owner', 60)->nullable();
+        $t->string('priority', 10)->nullable();
+        $t->json('custom_fields')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_jira_projects');
+});
+
+// -------------------------------------------------------------------------
+// 1. build() com FORJA semeado — SHAPE da lista
+// -------------------------------------------------------------------------
+
+it('build() devolve lista de issues com o shape canônico do backlog', function () {
+    (new ForjaDemoTicketsSeeder())->run();
+    $projectId = (int) DB::table('mcp_jira_projects')->where('key', 'FORJA')->value('id');
+
+    $rows = app(ForjaBacklogService::class)->build($projectId);
+
+    expect($rows)->toBeArray()->not->toBeEmpty();
+
+    // O seeder cria 14 tickets (3 triagem + 11 triadas), todos project=FORJA.
+    expect(count($rows))->toBe(14);
+
+    foreach ($rows as $row) {
+        expect($row)->toHaveKeys([
+            'display_id', 'title', 'tipo', 'fase', 'papel',
+            'onda', 'modulo', 'prioridade', 'status',
+        ]);
+        // Tipos: campos sempre-string vs projeções nullable.
+        expect($row['display_id'])->toBeString()->not->toBe('');
+        expect($row['title'])->toBeString();
+        expect($row['prioridade'])->toBeString(); // fallback p2, nunca null
+        expect($row['status'])->toBeString();
+    }
+});
+
+it('build() projeta custom_fields (tipo/fase/papel/onda) de issue triada', function () {
+    (new ForjaDemoTicketsSeeder())->run();
+    $projectId = (int) DB::table('mcp_jira_projects')->where('key', 'FORJA')->value('id');
+
+    $rows = app(ForjaBacklogService::class)->build($projectId);
+
+    // FORJA-142 é uma issue triada com fase=F1, onda=V1.1, papel=CC, tipo=Tela.
+    $f142 = collect($rows)->firstWhere('display_id', 'FORJA-142');
+    expect($f142)->not->toBeNull('FORJA-142 deveria aparecer no backlog');
+    expect($f142['fase'])->toBe('F1');
+    expect($f142['onda'])->toBe('V1.1');
+    expect($f142['papel'])->toBe('CC');
+    expect($f142['tipo'])->toBe('Tela');
+    expect($f142['prioridade'])->toBe('p0');
+});
+
+it('build() aplica fallback p2 quando a issue não tem prioridade (badge não quebra)', function () {
+    (new ForjaDemoTicketsSeeder())->run();
+    $projectId = (int) DB::table('mcp_jira_projects')->where('key', 'FORJA')->value('id');
+
+    $rows = app(ForjaBacklogService::class)->build($projectId);
+
+    // FORJA-150 é proposta em triagem (priority null no seeder).
+    $f150 = collect($rows)->firstWhere('display_id', 'FORJA-150');
+    expect($f150)->not->toBeNull();
+    expect($f150['prioridade'])->toBe('p2', 'prioridade null deve cair no fallback p2');
+});
+
+// -------------------------------------------------------------------------
+// 2. build(null) — sem project FORJA → lista vazia
+// -------------------------------------------------------------------------
+
+it('build(null) → [] (sem dado fantasma)', function () {
+    expect(app(ForjaBacklogService::class)->build(null))->toBe([]);
+});
+
+it('build(0) → [] (projectId falsy tratado como ausente)', function () {
+    expect(app(ForjaBacklogService::class)->build(0))->toBe([]);
+});

--- a/Modules/TeamMcp/Tests/Feature/ForjaChangelogServiceTest.php
+++ b/Modules/TeamMcp/Tests/Feature/ForjaChangelogServiceTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpCcSession;
+use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+use Modules\TeamMcp\Services\Forja\ForjaChangelogService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Forja · aba Changelog — ForjaChangelogService::build().
+ *
+ * Projeta "o que shippou" SÓ de fonte real: ADRs/SPECs (mcp_memory_documents) +
+ * sessões Claude Code (mcp_cc_sessions), mescladas por data desc. PR/Onda omitidos
+ * de propósito (sem dado fantasma — disciplina da Triagem).
+ *
+ * Cobertura (Onda Forja — código novo sem teste):
+ *   1. build() com docs + sessões → lista de entries kind/id/title/actor/date,
+ *      ordenada por data desc.
+ *   2. build() com tabelas-fonte ausentes → [] (guard Schema::hasTable, sem fantasma).
+ *
+ * Padrão era-sqlite (espelha AcceptanceRefTest): schema sintético sqlite-friendly.
+ * Scout NullEngine (SCOUT_DRIVER=null no phpunit.xml) torna o Searchable do
+ * McpMemoryDocument no-op; activitylog não se aplica a essas entidades.
+ *
+ * @see Modules\TeamMcp\Services\Forja\ForjaChangelogService
+ * @see memory/decisions/0053-mcp-server-governanca-como-produto.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético incompatível com MySQL persistente (floor SDD).');
+    }
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_memory_documents');
+    Schema::dropIfExists('mcp_cc_sessions');
+});
+
+/** Monta as 2 tabelas-fonte (sqlite-friendly, só as colunas que o Service lê). */
+function forjaChangelogBuildSchema(): void
+{
+    Schema::dropIfExists('mcp_memory_documents');
+    Schema::dropIfExists('mcp_cc_sessions');
+
+    Schema::create('mcp_memory_documents', function ($t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->nullable();
+        $t->string('slug', 191)->nullable();
+        $t->string('type', 40)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->date('decided_at')->nullable();
+        $t->json('decided_by')->nullable();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('mcp_cc_sessions', function ($t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->nullable();
+        $t->string('session_uuid', 64)->nullable();
+        $t->string('summary_auto', 500)->nullable();
+        $t->string('git_branch', 191)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamp('started_at')->nullable();
+        $t->softDeletes();
+        $t->timestamps();
+    });
+}
+
+// -------------------------------------------------------------------------
+// 1. build() com fontes reais — SHAPE + ordenação
+// -------------------------------------------------------------------------
+
+it('build() devolve entries kind/id/title/actor/date a partir de ADRs + sessões', function () {
+    forjaChangelogBuildSchema();
+
+    McpMemoryDocument::create([
+        'slug'       => '0114-prototipo-ui-cowork-loop',
+        'type'       => 'adr',
+        'title'      => 'Loop Cowork formalizado',
+        'decided_at' => '2026-05-30',
+        'decided_by' => ['Wagner'],
+    ]);
+    McpCcSession::create([
+        'business_id'  => 1,
+        'session_uuid' => 'abcdef1234567890',
+        'summary_auto' => 'Cockpit Forja — abas restantes',
+        'git_branch'   => 'feat/forja-abas-restantes',
+        'metadata'     => ['actor' => 'CC'],
+        'started_at'   => '2026-06-15 10:00:00',
+    ]);
+
+    $rows = app(ForjaChangelogService::class)->build();
+
+    expect($rows)->toBeArray()->not->toBeEmpty();
+
+    foreach ($rows as $row) {
+        expect($row)->toHaveKeys(['kind', 'id', 'title', 'actor', 'date']);
+        expect($row['kind'])->toBeIn(['adr', 'session']);
+        expect($row['id'])->toBeString();
+        expect($row['title'])->toBeString()->not->toBe('');
+        expect($row['actor'])->toBeString();
+        expect($row['date'])->toBeString();
+    }
+
+    // Ambas as fontes representadas.
+    $kinds = array_column($rows, 'kind');
+    expect($kinds)->toContain('adr')->toContain('session');
+});
+
+it('build() ordena por data desc (mais recente primeiro)', function () {
+    forjaChangelogBuildSchema();
+
+    McpMemoryDocument::create([
+        'slug' => '0001-antigo', 'type' => 'adr', 'title' => 'ADR antigo',
+        'decided_at' => '2026-01-01', 'decided_by' => ['Wagner'],
+    ]);
+    McpCcSession::create([
+        'business_id' => 1, 'session_uuid' => 'sessrecente0001',
+        'summary_auto' => 'Sessão recente', 'started_at' => '2026-06-15 09:00:00',
+        'metadata' => ['actor' => 'CC'],
+    ]);
+
+    $rows = app(ForjaChangelogService::class)->build();
+    $datas = array_column($rows, 'date');
+    $ordenado = $datas;
+    rsort($ordenado);
+    expect($datas)->toBe($ordenado, 'changelog deve sair ordenado por data desc');
+});
+
+it('build() usa metadata.actor da sessão, senão fallback CL', function () {
+    forjaChangelogBuildSchema();
+
+    McpCcSession::create([
+        'business_id' => 1, 'session_uuid' => 'comactor00000001',
+        'summary_auto' => 'Com actor', 'started_at' => '2026-06-14 12:00:00',
+        'metadata' => ['actor' => 'CD'],
+    ]);
+    McpCcSession::create([
+        'business_id' => 1, 'session_uuid' => 'semactor00000002',
+        'summary_auto' => 'Sem actor', 'started_at' => '2026-06-13 12:00:00',
+        'metadata' => [],
+    ]);
+
+    $rows = collect(app(ForjaChangelogService::class)->build());
+
+    $comActor = $rows->firstWhere('id', 'comactor');
+    $semActor = $rows->firstWhere('id', 'semactor');
+    expect($comActor['actor'])->toBe('CD');
+    expect($semActor['actor'])->toBe('CL', 'sessão sem metadata.actor cai no fallback CL');
+});
+
+// -------------------------------------------------------------------------
+// 2. build() com fontes ausentes — guard Schema::hasTable → []
+// -------------------------------------------------------------------------
+
+it('build() devolve [] quando as tabelas-fonte não existem (sem dado fantasma)', function () {
+    // Garante ausência das duas tabelas.
+    Schema::dropIfExists('mcp_memory_documents');
+    Schema::dropIfExists('mcp_cc_sessions');
+
+    expect(app(ForjaChangelogService::class)->build())->toBe([]);
+});

--- a/Modules/TeamMcp/Tests/Feature/ForjaQuadroServiceTest.php
+++ b/Modules/TeamMcp/Tests/Feature/ForjaQuadroServiceTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\TeamMcp\Database\Seeders\ForjaDemoTicketsSeeder;
+use Modules\TeamMcp\Services\Forja\ForjaQuadroService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Forja · aba Quadro (board F0→F3.5) — ForjaQuadroService::build().
+ *
+ * Cobertura (Onda Forja — código novo sem teste):
+ *   1. build($projectId) com FORJA semeado → fases: 6 colunas key/label/cards,
+ *      cards com display_id/title/tipo/onda.
+ *   2. build(null) → 6 colunas com cards vazios (esqueleto do board, sem fantasma).
+ *
+ * Padrão era-sqlite (espelha AcceptanceRefTest): schema sintético + activitylog OFF.
+ *
+ * @see Modules\TeamMcp\Services\Forja\ForjaQuadroService
+ * @see memory/decisions/0070-jira-style-task-management.md
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético incompatível com MySQL persistente (floor SDD).');
+    }
+
+    config(['activitylog.enabled' => false]);
+
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_jira_projects');
+
+    Schema::create('mcp_jira_projects', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('key', 20)->unique();
+        $t->string('name', 120)->nullable();
+        $t->text('description')->nullable();
+        $t->string('status', 20)->default('active');
+        $t->string('icon', 40)->nullable();
+        $t->unsignedInteger('next_task_number')->default(1);
+        $t->softDeletes();
+        $t->timestamps();
+    });
+
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 40)->nullable();
+        $t->unsignedBigInteger('project_id')->nullable();
+        $t->string('module', 60)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->text('description')->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('type', 20)->nullable();
+        $t->string('owner', 60)->nullable();
+        $t->string('priority', 10)->nullable();
+        $t->json('custom_fields')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_tasks');
+    Schema::dropIfExists('mcp_jira_projects');
+});
+
+/** Fases canônicas do board, na ordem do pipeline (espelha o Service). */
+function forjaFasesEsperadas(): array
+{
+    return ['F0', 'F1', 'F1.5', 'F2', 'F3', 'F3.5'];
+}
+
+// -------------------------------------------------------------------------
+// 1. build() com FORJA semeado — board com 6 colunas + cards
+// -------------------------------------------------------------------------
+
+it('build() devolve fases: 6 colunas na ordem canônica com key/label/cards', function () {
+    (new ForjaDemoTicketsSeeder())->run();
+    $projectId = (int) DB::table('mcp_jira_projects')->where('key', 'FORJA')->value('id');
+
+    $out = app(ForjaQuadroService::class)->build($projectId);
+
+    expect($out)->toBeArray()->toHaveKey('fases');
+    expect($out['fases'])->toBeArray()->toHaveCount(6);
+
+    // Ordem + presença das fases.
+    expect(array_column($out['fases'], 'key'))->toBe(forjaFasesEsperadas());
+
+    foreach ($out['fases'] as $col) {
+        expect($col)->toHaveKeys(['key', 'label', 'cards']);
+        expect($col['label'])->toBeString()->not->toBe('');
+        expect($col['cards'])->toBeArray();
+
+        foreach ($col['cards'] as $card) {
+            expect($card)->toHaveKeys(['display_id', 'title', 'tipo', 'onda']);
+            expect($card['display_id'])->toBeString()->not->toBe('');
+            expect($card['title'])->toBeString();
+        }
+    }
+});
+
+it('build() distribui os cards do seeder pelas colunas (board não fica vazio)', function () {
+    (new ForjaDemoTicketsSeeder())->run();
+    $projectId = (int) DB::table('mcp_jira_projects')->where('key', 'FORJA')->value('id');
+
+    $out = app(ForjaQuadroService::class)->build($projectId);
+
+    // active() inclui backlog/todo/doing/review/blocked (exclui done/cancelled).
+    // O seeder não tem done/cancelled → todos os 14 tickets viram cards.
+    $totalCards = array_sum(array_map(fn ($c) => count($c['cards']), $out['fases']));
+    expect($totalCards)->toBe(14);
+
+    // FORJA-137 tem forja_fase=F0 → deve cair na coluna F0.
+    $colF0 = collect($out['fases'])->firstWhere('key', 'F0');
+    $idsF0 = array_column($colF0['cards'], 'display_id');
+    expect($idsF0)->toContain('FORJA-137');
+});
+
+it('build() joga proposta sem fase (forja_fase null) no fallback F0', function () {
+    (new ForjaDemoTicketsSeeder())->run();
+    $projectId = (int) DB::table('mcp_jira_projects')->where('key', 'FORJA')->value('id');
+
+    $out = app(ForjaQuadroService::class)->build($projectId);
+
+    // FORJA-152 é proposta em triagem (fase=null no seeder) → fallback F0.
+    $colF0 = collect($out['fases'])->firstWhere('key', 'F0');
+    $idsF0 = array_column($colF0['cards'], 'display_id');
+    expect($idsF0)->toContain('FORJA-152');
+});
+
+// -------------------------------------------------------------------------
+// 2. build(null) — board esqueleto (6 colunas, cards vazios)
+// -------------------------------------------------------------------------
+
+it('build(null) → 6 colunas com cards vazios (sem dado fantasma)', function () {
+    $out = app(ForjaQuadroService::class)->build(null);
+
+    expect($out)->toHaveKey('fases');
+    expect($out['fases'])->toHaveCount(6);
+    expect(array_column($out['fases'], 'key'))->toBe(forjaFasesEsperadas());
+
+    foreach ($out['fases'] as $col) {
+        expect($col)->toHaveKeys(['key', 'label', 'cards']);
+        expect($col['cards'])->toBe([], "coluna {$col['key']} deveria vir vazia sem project FORJA");
+    }
+});

--- a/Modules/TeamMcp/Tests/Feature/ForjaRoutesSmokeTest.php
+++ b/Modules/TeamMcp/Tests/Feature/ForjaRoutesSmokeTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Inertia\Testing\AssertableInertia;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Forja · smoke das 6 rotas GET do cockpit (/forja, /backlog, /quadro,
+ * /changelog, /mcp, /saude).
+ *
+ * Cobertura (Onda Forja — código novo sem teste):
+ *   - cada rota autenticada (permission copiloto.mcp.usage.all) responde 200
+ *     e renderiza o componente Inertia `team-mcp/Forja/Cockpit` com a prop `tab`
+ *     correta (e tabLabel/subtitle/meta sempre presentes).
+ *   - acesso anônimo → bloqueado pelo middleware auth (302/401/403).
+ *
+ * Stack UltimatePOS (Modules/TeamMcp/Http/routes.php): ['web','SetSessionData',
+ * 'auth','language','timezone','AdminSidebarMenu','CheckUserLogin'] + can:.
+ * Esses middlewares exigem schema MySQL (business/users/permissions) → skip
+ * gracioso em sqlite :memory: (mesma estratégia de SmokeRoutesTest/TokensList).
+ * NUNCA biz=4 (ROTA LIVRE prod) — ADR 0101 usa biz=1 canônico.
+ *
+ * @see Modules\TeamMcp\Http\Controllers\ForjaController
+ * @see memory/decisions/0070-jira-style-task-management.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+/** As 6 abas: route name → prop `tab` esperada no componente Cockpit. */
+function forjaRotasAbas(): array
+{
+    return [
+        'forja.triagem'   => 'triagem',
+        'forja.backlog'   => 'backlog',
+        'forja.quadro'    => 'quadro',
+        'forja.changelog' => 'changelog',
+        'forja.mcp'       => 'mcp',
+        'forja.saude'     => 'saude',
+    ];
+}
+
+/** Bootstrap: tenant canônico + user com copiloto.mcp.usage.all + sessão UltimatePOS. */
+function forjaSmokeBootstrap(): User
+{
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        test()->markTestSkipped(
+            'SQLite-incompatível: middlewares UltimatePOS (SetSessionData/AdminSidebarMenu/'.
+            'CheckUserLogin) exigem schema MySQL com business/users/permissions (ADR 0101).'
+        );
+    }
+    if (! Schema::hasTable('users') || ! Schema::hasTable('permissions')) {
+        test()->markTestSkipped('Schema UltimatePOS ausente — rode com DB_CONNECTION=mysql.');
+    }
+
+    try {
+        $business = test()->seededTenant(); // biz=1 canônico (ADR 0101)
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tenant canônico ausente: '.$e->getMessage());
+    }
+
+    $user = User::where('business_id', $business->id)
+        ->where('user_type', '!=', 'user_customer')
+        ->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user não-customer no business pra autenticar.');
+    }
+
+    // Garante a permission canon (Wagner/superadmin) pra passar o can: middleware.
+    Permission::firstOrCreate(['name' => 'copiloto.mcp.usage.all', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('copiloto.mcp.usage.all')) {
+        $user->givePermissionTo('copiloto.mcp.usage.all');
+    }
+
+    session([
+        'user.id'          => $user->id,
+        'user.business_id' => $business->id,
+        'business.id'      => $business->id,
+    ]);
+
+    return $user;
+}
+
+// -------------------------------------------------------------------------
+// 1. Cada rota autenticada → 200 + componente Cockpit + prop tab
+// -------------------------------------------------------------------------
+
+it('cada rota Forja renderiza team-mcp/Forja/Cockpit com a prop tab certa', function (string $routeName, string $tab) {
+    $user = forjaSmokeBootstrap();
+
+    $response = $this->actingAs($user)->get(route($routeName));
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('team-mcp/Forja/Cockpit')
+        ->where('tab', $tab)
+        ->has('tabLabel')
+        ->has('subtitle')
+        ->has('meta')
+    );
+})->with(forjaRotasAbas());
+
+// -------------------------------------------------------------------------
+// 2. Acesso anônimo bloqueado pelo middleware auth
+// -------------------------------------------------------------------------
+
+it('rota Forja bloqueia acesso anônimo via middleware auth (302/401/403)', function (string $routeName) {
+    // Mesmo guard de schema/sqlite do happy-path, mas SEM autenticar nem semear sessão.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        test()->markTestSkipped('SQLite-incompatível: middlewares UltimatePOS exigem MySQL (ADR 0101).');
+    }
+
+    $response = $this->get(route($routeName));
+    $status = $response->getStatusCode();
+
+    expect(in_array($status, [302, 401, 403], true))->toBeTrue(
+        "Esperado 302/401/403 (auth) em {$routeName} — recebeu {$status}. ".
+        'Cockpit Forja sem auth = exposição de governança cross-business (Tier 0).'
+    );
+})->with(array_keys(forjaRotasAbas()));


### PR DESCRIPTION
Resgate: 4 testes Pest Feature do Forja (Backlog/Changelog/Quadro/RoutesSmoke, 577 linhas) estavam **untracked** na worktree `forja-pr1`, **fora do main** — iam ser perdidos na limpeza de worktrees. Preservados aqui pra revisão.

Draft: podem ser WIP / precisar ajuste pós-#2848/#2915. [W] decide se completa+mergeia ou descarta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)