### PR TITLE
feat(caixa-unificada): T1 — Resumir/Perguntar do header → Contexto (seção Inteligência)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -18,7 +18,7 @@
 
 import { useState } from 'react';
 import { router } from '@inertiajs/react';
-import { Ban, Check, Link as LinkIcon, Plus, UserMinus, UserPlus } from 'lucide-react';
+import { Ban, Check, Link as LinkIcon, Plus, Sparkles, UserMinus, UserPlus } from 'lucide-react';
 import {
   Popover,
   PopoverContent,
@@ -36,6 +36,7 @@ import type {
   CustomerContext,
 } from './helpers';
 import { avatarHue, formatBRL, initials, relativeTimeBR } from './helpers';
+import InboxAiDialog, { type InboxAiMode } from './InboxAiDialog';
 
 interface Props {
   thread: CaixaUnifThread;
@@ -82,6 +83,8 @@ export default function ContextSidebarV4({ thread, customerContext, channels, qu
 
   // US-WA-302 — atribuir/remover operador (PATCH /atendimento/inbox/{id}/assign)
   const [assignPopOpen, setAssignPopOpen] = useState(false);
+  // T1 (handoff 2026-06-19) — IA movida do header da thread pra cá (seção Inteligência)
+  const [aiMode, setAiMode] = useState<InboxAiMode | null>(null);
   function assignTo(assigneeId: number | null) {
     router.patch(
       route('atendimento.inbox.assign', thread.id),
@@ -200,6 +203,29 @@ export default function ContextSidebarV4({ thread, customerContext, channels, qu
             external_sources Firebird OfficeImpresso, flags VIP/frágil, LGPD. */}
         {thread.customer_external_id && (
           <CustomerMemoryBlock customerExternalId={thread.customer_external_id} />
+        )}
+
+        {/* T1 — Inteligência (Resumir/Perguntar movidos do header da thread · protótipo .om-ctx-ai) */}
+        {!thread.preview_only && (
+          <Stack gap={1} className="pb-2.5 border-b border-border/50">
+            <span className="text-[10px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">Inteligência</span>
+            <button
+              type="button"
+              onClick={() => setAiMode('summarize')}
+              className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-transparent hover:bg-muted text-[12px] text-foreground transition-colors text-left"
+              data-testid="caixa-unif-thread-ai-summarize"
+            >
+              <Sparkles size={13} className="text-primary" aria-hidden /> Resumir conversa
+            </button>
+            <button
+              type="button"
+              onClick={() => setAiMode('ask')}
+              className="inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-transparent hover:bg-muted text-[12px] text-foreground transition-colors text-left"
+              data-testid="caixa-unif-thread-ai-ask"
+            >
+              <Sparkles size={13} className="text-primary" aria-hidden /> Perguntar ao histórico
+            </button>
+          </Stack>
         )}
 
         {/* 1. Fila — US-WA-305: select de override manual (vence heurística tag→fila) */}
@@ -621,6 +647,16 @@ export default function ContextSidebarV4({ thread, customerContext, channels, qu
         onSelect={linkContact}
         customerPhone={thread.customer_external_id}
       />
+
+      {/* T1 — IA Resumir/Perguntar (movido do header da thread) */}
+      {aiMode !== null && (
+        <InboxAiDialog
+          open={aiMode !== null}
+          onOpenChange={(o) => { if (!o) setAiMode(null); }}
+          mode={aiMode}
+          conversationId={thread.id}
+        />
+      )}
     </aside>
   );
 }

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -11,7 +11,7 @@
 // Empty state quando thread=null (mantém UX Cockpit V2 do legacy Inbox).
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, CheckCheck, ClipboardCheck, Sparkles, Star } from 'lucide-react';
+import { Check, CheckCheck, ClipboardCheck, Star } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 import { Stack } from '@/Components/layout';
 import {
@@ -27,7 +27,6 @@ import {
   SLA_META,
 } from './helpers';
 import ComposerV4 from './ComposerV4';
-import InboxAiDialog, { type InboxAiMode } from './InboxAiDialog';
 import { useInboxFavs } from './useInboxFavs';
 import CaptureFeedbackSheet, { type CaptureFeedbackInput } from '@/Pages/Whatsapp/_components/CaptureFeedbackSheet';
 import MediaFullscreenModal from '@/Pages/Whatsapp/_components/MediaFullscreenModal';
@@ -83,8 +82,7 @@ export default function ConversationThreadV4({
   // T2 (handoff 2026-06-19) — favoritos da thread (localStorage, port inbox-cur)
   const { isFav, toggleFav } = useInboxFavs();
 
-  // PR-9 — IA na thread (Resumir / Perguntar)
-  const [aiMode, setAiMode] = useState<InboxAiMode | null>(null);
+  // T1 — IA (Resumir/Perguntar) movida pro ContextSidebarV4 (seção Inteligência)
 
   // Polish V2 §1 — SLA no header (direção da última msg não-nota vem das messages)
   const lastRealMsg = useMemo(
@@ -193,33 +191,15 @@ export default function ConversationThreadV4({
             </span>
           );
         })()}
-        {/* PR-9 — IA: Resumir / Perguntar (laravel/ai server-side, PII redigida) */}
-        <button
-          type="button"
-          onClick={() => setAiMode('summarize')}
-          className={cn(
-            'inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0',
-            headerSla === null && 'ml-auto',
-          )}
-          title="Resumir conversa com IA"
-          data-testid="caixa-unif-thread-ai-summarize"
-        >
-          <Sparkles size={12} aria-hidden /> Resumir
-        </button>
-        <button
-          type="button"
-          onClick={() => setAiMode('ask')}
-          className="inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0"
-          title="Perguntar sobre a conversa (IA responde só com o transcript)"
-          data-testid="caixa-unif-thread-ai-ask"
-        >
-          Perguntar
-        </button>
+        {/* T1 — Resumir/Perguntar movidos pro Contexto (seção Inteligência) */}
         {/* T2 — Favoritar (estrela no header · port inbox-cur · protótipo .om-fav-btn-h) */}
         <button
           type="button"
           onClick={() => toggleFav(thread.id)}
-          className="inline-flex items-center px-2 py-1 rounded transition-colors flex-shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted"
+          className={cn(
+            'inline-flex items-center px-2 py-1 rounded transition-colors flex-shrink-0 text-muted-foreground hover:text-foreground hover:bg-muted',
+            headerSla === null && 'ml-auto',
+          )}
           style={isFav(thread.id) ? { color: 'oklch(0.78 0.15 80)' } : undefined}
           title={isFav(thread.id) ? 'Remover dos favoritos' : 'Favoritar conversa'}
           aria-label={isFav(thread.id) ? 'Remover dos favoritos' : 'Favoritar conversa'}
@@ -463,16 +443,6 @@ export default function ConversationThreadV4({
           filenames={imageMessages.map(m => m.media_filename ?? null)}
           currentIndex={Math.max(0, lightboxIndex)}
           onClose={() => setLightboxIndex(null)}
-        />
-      )}
-
-      {/* PR-9 — IA Resumir/Perguntar */}
-      {aiMode !== null && (
-        <InboxAiDialog
-          open={aiMode !== null}
-          onOpenChange={(o) => { if (!o) setAiMode(null); }}
-          mode={aiMode}
-          conversationId={thread.id}
         />
       )}
 


### PR DESCRIPTION
Item **T1** (último do handoff). Header da thread fica enxuto (protótipo `.om-thread-h-r` = SLA · ★ · Resolver); Resumir/Perguntar vão pra seção **Inteligência** no topo do Contexto (`.om-ctx-ai`).

- ConversationThreadV4: remove os 2 botões + state/dialog/import órfãos; `ml-auto` migra pro favorito.
- ContextSidebarV4: seção Inteligência (Resumir conversa / Perguntar ao histórico) + InboxAiDialog, gated !preview_only. data-testid mantidos.

Mesma IA, só de lugar. Sem backend. Stacked sobre #3052 (já mergeado) → diff = só T1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)