### PR TITLE
feat(caixa-unificada): Contexto vira drawer lateral (handoff [W] 2026-06-19)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -133,16 +133,9 @@ export default function CaixaUnificadaIndex({
   const [guiaOpen, setGuiaOpen] = useState(false);
   // Polish V2 §5 — mobile tabs (<lg mostra 1 coluna por vez; desktop intacto)
   const [mobileView, setMobileView] = useState<MobileView>('list');
-  // Contexto recolhível (canon Cowork `.om-ctx`) — auto-recolhe < 1440px, lembra a escolha
-  const [ctxOpen, setCtxOpen] = useState(() => {
-    if (typeof window === 'undefined') return true;
-    const saved = localStorage.getItem('oimpresso.caixa-unif.ctx-open');
-    if (saved !== null) return saved === '1';
-    return window.innerWidth >= 1440;
-  });
-  useEffect(() => {
-    try { localStorage.setItem('oimpresso.caixa-unif.ctx-open', ctxOpen ? '1' : '0'); } catch { /* ignore */ }
-  }, [ctxOpen]);
+  // Contexto-drawer ([W] 2026-06-19): some a coluna fixa de Contexto; abre como drawer
+  // lateral (overlay) por um botão na thread. Supersede o recolhível #2858.
+  const [ctxDrawerOpen, setCtxDrawerOpen] = useState(false);
 
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -451,15 +444,13 @@ export default function CaixaUnificadaIndex({
       {/* Polish V2 §5 — tabs mobile (abaixo de lg; desktop 3-col intacto) */}
       <InboxMobileTabs
         view={mobileView}
-        onChange={setMobileView}
+        onChange={(v) => { if (v === 'context') { setCtxDrawerOpen(true); } else { setMobileView(v); } }}
         hasThread={thread !== null}
         unread={stats?.unread ?? 0}
       />
 
-      {/* Shell 3-col */}
-      <div className={`flex-1 grid grid-cols-1 gap-0 min-h-0 overflow-hidden border rounded-md ${
-        thread ? (ctxOpen ? 'lg:grid-cols-[320px_1fr_300px]' : 'lg:grid-cols-[320px_1fr_44px]') : 'lg:grid-cols-[320px_1fr]'
-      }`}>
+      {/* Shell 2-col ([W] 2026-06-19) — Contexto saiu da grade fixa e virou drawer */}
+      <div className="flex-1 grid grid-cols-1 lg:grid-cols-[320px_1fr] gap-0 min-h-0 overflow-hidden border rounded-md">
         {/* Lista esquerda — no mobile só aparece na tab Conversas */}
         <div className={mobileView === 'list' ? 'min-h-0 h-full' : 'min-h-0 h-full hidden lg:block'}>
         <Deferred
@@ -521,6 +512,7 @@ export default function CaixaUnificadaIndex({
               messages={messages}
               channels={availableChannels ?? []}
               onResolve={resolveThread}
+              onOpenContext={() => setCtxDrawerOpen(true)}
               templates={availableTemplates ?? []}
             />
           ) : (
@@ -573,23 +565,39 @@ export default function CaixaUnificadaIndex({
           templates={availableTemplates ?? []}
         />
 
-        {thread && (
-          <div className={mobileView === 'context' ? 'min-h-0 h-full' : 'min-h-0 h-full hidden lg:block'}>
-          <Deferred data="availableChannels" fallback={null}>
-            <ContextSidebarV4
-              thread={thread}
-              customerContext={customerContext}
-              channels={availableChannels ?? []}
-              queues={queues}
-              availableTags={availableTags ?? []}
-              availableAssignees={availableAssignees ?? []}
-              open={ctxOpen}
-              onToggle={() => setCtxOpen((v) => !v)}
-            />
-          </Deferred>
-          </div>
-        )}
       </div>
+
+      {/* Contexto-drawer ([W] 2026-06-19): some a coluna fixa; abre como overlay lateral
+          (botão "Contexto" na thread / tab mobile). ContextSidebarV4 renderiza dentro,
+          com open=true (cheio) e o ✕/recolher fechando o drawer. */}
+      {thread && ctxDrawerOpen && (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-black/40"
+            onClick={() => setCtxDrawerOpen(false)}
+            aria-hidden
+          />
+          <div
+            className="fixed top-0 right-0 bottom-0 z-50 w-[400px] max-w-[92vw] flex flex-col min-h-0 bg-card border-l shadow-xl"
+            role="dialog"
+            aria-label="Contexto da conversa"
+            data-testid="caixa-unif-ctx-drawer"
+          >
+            <Deferred data="availableChannels" fallback={null}>
+              <ContextSidebarV4
+                thread={thread}
+                customerContext={customerContext}
+                channels={availableChannels ?? []}
+                queues={queues}
+                availableTags={availableTags ?? []}
+                availableAssignees={availableAssignees ?? []}
+                open={true}
+                onToggle={() => setCtxDrawerOpen(false)}
+              />
+            </Deferred>
+          </div>
+        </>
+      )}
 
       {/* Polish V2 §3 — cheat-sheet de atalhos ("?") */}
       <InboxCheatSheet open={cheatOpen} onOpenChange={setCheatOpen} />

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -11,7 +11,7 @@
 // Empty state quando thread=null (mantém UX Cockpit V2 do legacy Inbox).
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, CheckCheck, ClipboardCheck, Star } from 'lucide-react';
+import { Check, CheckCheck, ClipboardCheck, PanelRight, Star } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 import { Stack } from '@/Components/layout';
 import {
@@ -39,12 +39,14 @@ interface Props {
   messages: CaixaUnifMessage[];
   channels: ChannelCatalogItem[];
   onResolve?: () => void;
+  /** Contexto-drawer ([W] 2026-06-19) — abre o painel de Contexto como drawer lateral. */
+  onOpenContext?: () => void;
   /** US-WA-303 — templates ready do business (picker do composer). */
   templates?: ReadyTemplate[];
 }
 
 export default function ConversationThreadV4({
-  thread, messages, channels, onResolve, templates = [],
+  thread, messages, channels, onResolve, onOpenContext, templates = [],
 }: Props) {
   const threadRef = useRef<HTMLDivElement>(null);
 
@@ -208,6 +210,18 @@ export default function ConversationThreadV4({
         >
           <Star size={13} fill={isFav(thread.id) ? 'currentColor' : 'none'} aria-hidden />
         </button>
+        {/* Contexto-drawer — abre o painel de Contexto (some a coluna fixa · [W] 2026-06-19) */}
+        {onOpenContext && (
+          <button
+            type="button"
+            onClick={onOpenContext}
+            className="inline-flex items-center gap-1 px-2 py-1 text-[11.5px] font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded transition-colors flex-shrink-0"
+            title="Ver contexto da conversa"
+            data-testid="caixa-unif-ctx-open"
+          >
+            <PanelRight size={12} aria-hidden /> Contexto
+          </button>
+        )}
         {!isPreview && !isBlocked && onResolve && (
           <button
             type="button"


### PR DESCRIPTION
Mod nova legítima do handoff de teste: **Contexto sai da coluna fixa e vira drawer lateral**, aberto por botão na thread. Supersede o recolhível #2858.

- **Index.tsx**: shell 3-col → **2-col**; ContextSidebarV4 → overlay drawer (400px/max 92vw + backdrop); tab mobile "Contexto" abre o drawer.
- **ConversationThreadV4**: botão "Contexto" (PanelRight) no header (`onOpenContext`).
- ContextSidebarV4 **intacto** (reusado dentro do drawer). Sem backend/token.

⚠️ **Mudança grande de layout no gold screen, sem preview local** — segurando merge pra **[W] aprovar o screenshot** (gate visual). CI build = checagem de compilação.

Follow-up separado (não neste PR): a11y de ordem de foco do composer (exige reordenar bloco grande de JSX; faço sozinho num PR de 2 linhas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)