### PR TITLE
ci(governance): roda hooks Claude Code em CI (smoke PS 5.1 + node tests)

### DIFF
--- a/.github/workflows/gate-selftest.yml
+++ b/.github/workflows/gate-selftest.yml
@@ -49,6 +49,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
+      - name: Parse-check de TODO hook .ps1 (PS 5.1, deterministico, sem depender de payload)
+        shell: powershell
+        run: |
+          $fail = Get-ChildItem .claude/hooks -Filter *.ps1 |
+            Where-Object { $_.Name -notmatch '\.test\.ps1$' -and $_.Name -notmatch '^test-' } |
+            Where-Object {
+              $e = $null
+              [void][System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$e)
+              if ($e -and $e.Count -gt 0) { Write-Host ("PARSE FAIL: " + $_.Name); $e | ForEach-Object { Write-Host ("  " + $_.Message) }; $true } else { Write-Host ("ok " + $_.Name); $false }
+            }
+          if (@($fail).Count -gt 0) { Write-Error ([string]@($fail).Count + " hook(s) .ps1 com erro de parse PS 5.1"); exit 1 }
+          Write-Host "OK: todos os .ps1 parseiam limpo (PS 5.1; cobre TODOS os hooks, nao so os 12 com payload no smoke)."
       - name: PowerShell hooks smoke (compat PS 5.1 — encoding/reserved-var)
         shell: powershell
         run: .\.claude\hooks\test-all-hooks-smoke.ps1

--- a/.github/workflows/gate-selftest.yml
+++ b/.github/workflows/gate-selftest.yml
@@ -35,3 +35,22 @@ jobs:
           node-version: '20'
       - name: Selftest — 4 catracas × 2 fixtures (+ tabela no job summary)
         run: node scripts/governance/gate-selftest.mjs
+
+  # GT-G6 (cont.) — os ~50 hooks Claude Code (camada que bloqueia o agente em
+  # tempo real) só rodavam LOCAL (test-all-hooks-smoke.ps1). Em mai/2026 isso
+  # deixou 4 hooks quebrarem em prod sem CI pegar. Roda em windows-latest porque
+  # o smoke valida compat PS 5.1 (encoding/BOM/$input reservada) — Windows-coupled.
+  hooks-selftest:
+    name: hooks selftest (advisory · PS 5.1 smoke + node hook tests)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: PowerShell hooks smoke (compat PS 5.1 — encoding/reserved-var)
+        shell: powershell
+        run: .\.claude\hooks\test-all-hooks-smoke.ps1
+      - name: Node hook tests (*.test.mjs)
+        run: node --test .claude/hooks/


### PR DESCRIPTION
## Contexto
Auditoria do IA OS de engenharia agêntica — **gap #2** (Onda 1).

Os ~50 hooks Claude Code (a camada que bloqueia o agente em tempo real) só rodavam **local** (`test-all-hooks-smoke.ps1`). Em mai/2026, 4 hooks quebraram em prod sem nenhum CI pegar.

## O que faz
- Novo job `hooks-selftest` no `gate-selftest.yml`, em `windows-latest` (o smoke valida compat **PS 5.1**: encoding/BOM/`$input` reservada — Windows-coupled).
- Roda o smoke PS + `node --test .claude/hooks/` (os `*.test.mjs`). `timeout-minutes: 10`.

## Ressalva (honesta)
- **Advisory** de nascença (não entra em branch protection — ADR 0271/0275).
- Não validei o verde localmente: precisa de **1 run de CI** (`workflow_dispatch`) pra confirmar — em especial porque `brief-fetch-curl` faz rede pra `mcp.oimpresso.com`. Se travar, gating do hook de rede em CI é o follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)