### PR TITLE
fix(governance): registra hook R10 (block-pr-without-approval) em settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -134,6 +134,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-serving-branch-switch.ps1"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/block-pr-without-approval.mjs"
           }
         ]
       },
@@ -206,6 +210,10 @@
           {
             "type": "command",
             "command": "node .claude/hooks/design-handoff-reprocess.mjs"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/block-pr-without-approval.mjs"
           }
         ]
       }


### PR DESCRIPTION
## Contexto
Auditoria do IA OS de engenharia agêntica — **gap #3** (Onda 1).

O hook `block-pr-without-approval.mjs` (mecaniza R10 do PROTOCOLO-WAGNER: aprovação humana antes de publicar) **existia mas não estava registrado** em `.claude/settings.json` — então R10 dependia do modelo "lembrar".

## O que faz
Registra o hook nos 2 eventos da sua mecânica:
- **UserPromptSubmit** — grava flag de aprovação quando Wagner sinaliza ("pode fazer", "manda", "merge").
- **PreToolUse / Bash** — bloqueia `git push` / `gh pr create|merge` sem flag válida (TTL 15min).

## Escopo / follow-up
- Cobre a tool **Bash** (design do hook). Push via tool PowerShell fica como follow-up (exige o hook checar `tool_name`).
- Escape: `OIMPRESSO_PR_APPROVAL_OVERRIDE=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)