### PR TITLE
test(governance): cobre correções Onda 1 (decoder !!binary + registro R10) + CI

### DIFF
--- a/.github/workflows/governance-script-tests.yml
+++ b/.github/workflows/governance-script-tests.yml
@@ -1,0 +1,35 @@
+name: Governance script tests (advisory)
+
+# Roda os testes de regressao dos scripts de governanca (scripts/governance/*.test.mjs).
+# Fecha o gap "test local-only" (auditoria IA OS Onda 1, gap #2) para os scripts de
+# governanca: ate aqui esses .test.mjs so rodavam na maquina do dev.
+#   - adr-index-generate.test.mjs       decoder de titulo !!binary (Onda 1, gap #1, PR #3056)
+#   - settings-r10-registration.test.mjs R10 registrado em settings.json (gap #3, PR #3058)
+# Node puro, sem deps/DB/rede -- segundos. Advisory de nascenca (gates novos nunca
+# nascem required -- ADR 0271/0275); nao entra em branch protection.
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: governance-script-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    name: governance script tests (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Decoder de titulo !!binary (adr-index-generate)
+        run: node scripts/governance/adr-index-generate.test.mjs
+      - name: Registro R10 em settings.json
+        run: node scripts/governance/settings-r10-registration.test.mjs

--- a/scripts/governance/adr-index-generate.test.mjs
+++ b/scripts/governance/adr-index-generate.test.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+// Teste de regressao do decoder de titulos YAML !!binary do adr-index-generate
+// (Onda 1, gap #1, PR #3056). Caracterizacao do comportamento ja shipado
+// (decodeBinaryScalar) -- protege contra regressao no gerador de indice; o RED
+// aqui foi o proprio bug dos 56 titulos base64 ilegiveis na fonte unica queryable.
+//
+// Hermetico: monta um memory/decisions/ temporario com ADRs fixos e roda o gerador
+// como subprocesso (cwd=tmp), depois inspeciona o _INDEX-GENERATED.md gerado.
+//
+// Rodar: node scripts/governance/adr-index-generate.test.mjs   (exit 0 = passa)
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SCRIPT = join(__dirname, 'adr-index-generate.mjs');
+const b64 = (s) => Buffer.from(s, 'utf8').toString('base64');
+
+let fails = 0;
+function check(name, cond) {
+  console.log((cond ? '[OK] ' : '[FAIL] ') + name);
+  if (!cond) fails++;
+}
+
+// --- fixtures: memory/decisions/ temporario ---
+const tmp = mkdtempSync(join(tmpdir(), 'adr-idx-test-'));
+const dir = join(tmp, 'memory', 'decisions');
+mkdirSync(dir, { recursive: true });
+
+function writeAdr(file, title, binary) {
+  const tline = binary ? `title: !!binary ${b64(title)}` : `title: ${title}`;
+  writeFileSync(join(dir, file), `---\n${tline}\ntype: adr\nstatus: aceito\n---\n\n# ${file}\n`, 'utf8');
+}
+
+// 1. titulo binario arbitrario -> roundtrip identico (base64 ida e volta)
+const ROUNDTRIP = 'Maquina de estados canonica FSM e RBAC';
+writeAdr('0001-roundtrip.md', ROUNDTRIP, true);
+
+// 2. caso REAL legado: bytes de lixo (0x80 0x94) antes do texto + corpo UTF-8 multibyte
+//    (este base64 e de um ADR real; "proprio" tem o e' acentuado -> testa multibyte).
+const REAL_LEGACY_B64 = 'gJQgRXN0ZW5kZXIgVWx0aW1hdGVQT1MgZW0gdmV6IGRlIGJ1aWxkIHByw7NwcmlvIG91IGZvcms=';
+writeFileSync(
+  join(dir, '0002-legado.md'),
+  `---\ntitle: !!binary ${REAL_LEGACY_B64}\ntype: adr\nstatus: aceito\n---\n\n# 0002\n`,
+  'utf8',
+);
+
+// 3. titulo normal (nao-binario) -> passthrough intacto
+writeAdr('0003-normal.md', 'Titulo Normal Sem Binario', false);
+
+// 4. dash INTERNO nao pode ser comido (a poda so vale pro prefixo lixo)
+writeAdr('0004-dash.md', 'Pre-venda e pos-venda no fluxo', true);
+
+// --- roda o gerador como subprocesso ---
+const r = spawnSync('node', [SCRIPT, '--write'], { cwd: tmp, encoding: 'utf8' });
+const idx = readFileSync(join(dir, '_INDEX-GENERATED.md'), 'utf8');
+
+check('gerador roda sem erro (exit 0)', r.status === 0);
+check('nenhum !!binary sobra no indice', !idx.includes('!!binary'));
+check('titulo binario faz roundtrip identico', idx.includes(ROUNDTRIP));
+check('lixo de prefixo legado podado + corpo decodificado (0002 real)', idx.includes('Estender UltimatePOS em vez de build'));
+check('titulo normal passa intacto', idx.includes('Titulo Normal Sem Binario'));
+check('dash interno preservado (nao comido pela poda)', idx.includes('Pre-venda e pos-venda no fluxo'));
+
+// cleanup
+rmSync(tmp, { recursive: true, force: true });
+
+console.log('');
+if (fails === 0) {
+  console.log('[PASS] decoder !!binary integro (6/6).');
+  process.exit(0);
+} else {
+  console.log(`[FAIL] ${fails} caso(s) -- decoder de titulo regrediu.`);
+  process.exit(1);
+}

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -158,6 +158,10 @@
       "nome": "Governance Gate (pre-merge)",
       "classe": "gate"
     },
+    "governance-script-tests.yml": {
+      "nome": "Governance script tests (advisory · scripts/governance/*.test.mjs — Onda 1)",
+      "classe": "gate"
+    },
     "infra-contract-required.yml": {
       "nome": "Infra Contract Required",
       "classe": "gate"

--- a/scripts/governance/settings-r10-registration.test.mjs
+++ b/scripts/governance/settings-r10-registration.test.mjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+// Teste de regressao: o enforcement R10 (block-pr-without-approval.mjs) continua
+// REGISTRADO em .claude/settings.json (Onda 1, gap #3, PR #3058). Complementa
+// .claude/hooks/block-pr-without-approval.test.mjs (que testa a LOGICA do hook)
+// garantindo que a ATIVACAO nao seja removida -- registrar o arquivo e' o que liga
+// a regra (criar o hook sem registrar nao enforca nada -- foi exatamente o gap #3).
+//
+// Rodar: node scripts/governance/settings-r10-registration.test.mjs   (exit 0 = passa)
+
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SETTINGS = join(__dirname, '..', '..', '.claude', 'settings.json');
+const HOOK_CMD = 'node .claude/hooks/block-pr-without-approval.mjs';
+
+let fails = 0;
+function check(name, cond) {
+  console.log((cond ? '[OK] ' : '[FAIL] ') + name);
+  if (!cond) fails++;
+}
+
+let cfg = null;
+try {
+  cfg = JSON.parse(readFileSync(SETTINGS, 'utf8'));
+} catch (e) {
+  console.log('[FAIL] settings.json ilegivel/JSON invalido: ' + e.message);
+  process.exit(1);
+}
+const hooks = cfg.hooks || {};
+
+function commandsFor(event, matcherIncludes) {
+  const cmds = [];
+  for (const g of hooks[event] || []) {
+    if (matcherIncludes && !String(g.matcher || '').includes(matcherIncludes)) continue;
+    for (const h of g.hooks || []) if (h.command) cmds.push(h.command);
+  }
+  return cmds;
+}
+
+check('settings.json e JSON valido', !!cfg && typeof cfg === 'object');
+check('R10 registrado em UserPromptSubmit (grava flag de aprovacao)', commandsFor('UserPromptSubmit', '').includes(HOOK_CMD));
+check('R10 registrado em PreToolUse/Bash (bloqueia push/PR sem aprovacao)', commandsFor('PreToolUse', 'Bash').includes(HOOK_CMD));
+
+console.log('');
+if (fails === 0) {
+  console.log('[PASS] R10 ativado nos 2 eventos (registro persistido).');
+  process.exit(0);
+}
+console.log(`[FAIL] ${fails} caso(s) -- R10 NAO esta registrado; a regra ficou orfa.`);
+process.exit(1);


### PR DESCRIPTION
## Contexto
Aplica **testes de regressão** sobre as correções da Onda 1 da auditoria do IA OS (PRs #3056/#3058, já mergeados) e as faz **rodar em CI** — fechando o "test local-only" (gap #2) para os scripts de governança.

## O que entra
- **`scripts/governance/adr-index-generate.test.mjs`** — 6 casos herméticos do decoder `!!binary` (gap #1): monta um `memory/decisions/` temporário e roda o gerador como subprocesso, checando: roundtrip base64 idêntico, **lixo de prefixo legado real** (base64 de um ADR real com bytes `0x80 0x94`), passthrough de título normal, e **dash interno preservado** (não comido pela poda).
- **`scripts/governance/settings-r10-registration.test.mjs`** — garante que o hook R10 (`block-pr-without-approval.mjs`) continua **registrado** em `settings.json` nos 2 eventos (UserPromptSubmit + PreToolUse/Bash). Complementa o teste de *lógica* do hook (gap #3).
- **`.github/workflows/governance-script-tests.yml`** (advisory) — roda os dois em CI. Padrão de `foundation-ratchet.yml`.

## Verificação local
Ambos verdes: decoder **6/6**, registro R10 **3/3**. Node puro, sem deps/DB/rede.

## Nota
Advisory de nascença (ADR 0271/0275). O teste do decoder **caracteriza** o comportamento shipado; se a reconferência adversarial em curso apontar que a poda de prefixo come algum traço legítimo, ajusto decoder + fixture juntos antes de mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)