### PR TITLE
fix(hook): endurece R10 — falso-positivo merge, ancora publish, cobre PowerShell

### DIFF
--- a/.claude/hooks/block-pr-without-approval.mjs
+++ b/.claude/hooks/block-pr-without-approval.mjs
@@ -37,11 +37,13 @@ const TTL_MIN = 15;
 
 // Sinais FORTES de aprovação de publicação (não qualquer "sim" solto).
 const approvePatterns = [
-  /\bpode\s+(fazer|commitar|comitar|pushar|push|subir|mergear|merge|criar|abrir)\b/i,
+  /\bpode\s+(fazer|commitar|comitar|pushar|push|subir|mergear|merge|criar|abrir|publicar|mandar)\b/i,
   /\b(faça|faz|abre|abra|cria|crie)\s+o\s+pr\b/i,
-  /\b(merge|mergeia|mergear|mergeie)\b/i,
-  /\b(aprovado|autorizado|pode\s+mandar|manda\s+ver)\b/i,
-  /\b(suba|sobe|publica|publique|pode\s+publicar)\b/i,
+  // 'merge' SO com verbo de ordem — nao casa 'merge' incidental ("estrategia de merge", "merge conflict")
+  /\b(pode\s+mergear|faz(?:\s+o)?\s+merge|mergeia\s+(?:o|os|esse|essa|a|isso|agora)|manda\s+(?:o\s+)?merge|aprovo\s+o\s+merge)\b/i,
+  /\b(aprovado|autorizado|manda\s+ver)\b/i,
+  // publicar/subir SO com objeto/ordem — nao 'publica/suba' solto incidental
+  /\b(suba|sobe|publica|publique)\s+(?:o|os|essa|esse|isso|pra|agora|tudo)\b/i,
   /\bvai\s+em\s+frente\b/i,
   /^\s*(pode|sim,?\s*pode|ok,?\s*pode)\b/i,
 ];
@@ -58,7 +60,10 @@ function isApproval(text) {
   return approvePatterns.some((r) => r.test(text));
 }
 
-const publishPatterns = [/gh\s+pr\s+create/i, /gh\s+pr\s+merge/i, /git\s+push/i];
+// Ancorados no inicio efetivo do comando (apos ; & |) com limite de palavra —
+// evita falso-bloqueio quando a frase aparece dentro de string/comentario/arg de busca
+// (ex: rg 'git push', history | grep 'git push').
+const publishPatterns = [/(^|[;&|]\s*)gh\s+pr\s+(create|merge)(\s|$)/i, /(^|[;&|]\s*)git\s+push(\s|$)/i];
 function isPublish(cmd) {
   return !!cmd && publishPatterns.some((r) => r.test(cmd));
 }
@@ -101,8 +106,9 @@ async function readStdin() {
     process.exit(0);
   }
 
-  // 2. PreToolUse Bash → exige aprovação válida pra publicar
-  if (event === 'PreToolUse' && p.tool_name === 'Bash') {
+  // 2. PreToolUse Bash/PowerShell → exige aprovação válida pra publicar
+  //    (PowerShell e o shell primario deste ambiente — sem isto o R10 era contornavel)
+  if (event === 'PreToolUse' && (p.tool_name === 'Bash' || p.tool_name === 'PowerShell')) {
     const cmd = p.tool_input?.command || '';
     if (!isPublish(cmd)) process.exit(0);
 

--- a/.claude/hooks/block-pr-without-approval.test.mjs
+++ b/.claude/hooks/block-pr-without-approval.test.mjs
@@ -86,13 +86,31 @@ check('override env → ALLOW', runHook(PUSH, { OIMPRESSO_PR_APPROVAL_OVERRIDE: 
 
 // 9. "merge" do Wagner aprova → gh pr merge passa.
 clearFlag();
-runHook(prompt('merge'));
+runHook(prompt('pode mergear'));
 check('"merge" aprova → gh pr merge ALLOW', runHook({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: 'gh pr merge 1908 --admin' } }).code === 0);
+
+// 10. FALSO-POSITIVO corrigido: 'merge' incidental em conversa NAO aprova publicacao.
+clearFlag();
+runHook(prompt('qual a estrategia de merge antes?'));
+check('"estrategia de merge" NAO aprova (falso-positivo) -> BLOCK', !existsSync(FLAG) && runHook(PUSH).code === 2);
+
+// 11. Gap PowerShell fechado: push via tool PowerShell sem aprovacao -> BLOCK.
+clearFlag();
+check('PowerShell push sem aprovacao -> BLOCK', runHook({ hook_event_name: 'PreToolUse', tool_name: 'PowerShell', tool_input: { command: 'git push' } }).code === 2);
+
+// 12. PowerShell push COM aprovacao -> ALLOW.
+clearFlag();
+runHook(prompt('pode pushar'));
+check('PowerShell push com aprovacao -> ALLOW', runHook({ hook_event_name: 'PreToolUse', tool_name: 'PowerShell', tool_input: { command: 'git push -u origin HEAD' } }).code === 0);
+
+// 13. publishPatterns ancorado: 'git push' embebido em comando de busca NAO bloqueia.
+clearFlag();
+check('busca com "git push" embebido (rg) -> ALLOW (nao e publicacao)', runHook({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: "rg 'git push' .claude/hooks" } }).code === 0);
 
 clearFlag();
 console.log('');
 if (fails === 0) {
-  console.log('[PASS] R10 enforçada pela MÁQUINA — sobrevive sem a skill. (9/9)');
+  console.log('[PASS] R10 enforçada pela MÁQUINA — sobrevive sem a skill. (13/13)');
   process.exit(0);
 } else {
   console.log(`[FAIL] ${fails} caso(s) — R10 NÃO está garantida pela máquina. NÃO rebaixar a skill.`);

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -142,6 +142,15 @@
         ]
       },
       {
+        "matcher": "PowerShell",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/block-pr-without-approval.mjs"
+          }
+        ]
+      },
+      {
         "matcher": "mcp__computer-use__screenshot|mcp__Claude_in_Chrome__.*",
         "hooks": [
           {


### PR DESCRIPTION
## Contexto
Follow-up **prioritário** da reconferência adversarial — **T3 (ressalva)**. O R10 mergeado (#3058) bloqueia, mas o adversário achou 3 furos que entregam menos segurança do que aparenta.

## 3 furos fechados
1. **MÉDIO — falso-positivo de aprovação:** `approvePattern /\b(merge|…)\b/` casava `merge` **incidental** ("qual a estratégia de **merge**?", "**merge** conflict") → gravava a flag de aprovação (TTL 15min) **sem você ter aprovado publicação nenhuma**. Agora exige verbo de ordem (`pode mergear`, `faz o merge`, `manda o merge`…).
2. **BAIXO — falso-bloqueio:** `publishPatterns` casava substring em qualquer lugar do comando → bloqueava `rg 'git push'`, `cat arquivo-com-git-push`. Agora **ancorado** no início efetivo do comando (após `; & |`) com limite de palavra.
3. **BAIXO mas grave — gap PowerShell:** o gate só agia em tool `Bash` → **contornável no shell primário deste ambiente**. Agora registra grupo `matcher: "PowerShell"` em `settings.json` + guarda estendida `(Bash || PowerShell)`.

## Teste
`block-pr-without-approval.test.mjs` estendido **9 → 13 casos** — cada fix tem um caso que valida (falso-positivo→BLOCK, PowerShell BLOCK/ALLOW, `rg` embebido→ALLOW). **13/13 verde** local.

> ⚠️ Isto muda como o R10 reconhece **suas** frases de aprovação de publicação. Dá uma olhada nos patterns se quiser — auto-merge armado, mas é só cancelar se discordar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)