### PR TITLE
chore(skills): grava tier: nas 18 skills sem tier (Parte A)

### DIFF
--- a/.claude/skills/cliente-discovery/SKILL.md
+++ b/.claude/skills/cliente-discovery/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: cliente-discovery
 description: ATIVAR quando Wagner pedir /cliente-discovery, "entrevistar cliente X", "fazer discovery do cliente Y", "criar persona pra <pessoa>", "vou visitar cliente <nome> amanhã", "ligar pra cliente <nome>", OU antes de qualquer sessão presencial/call com cliente real do oimpresso. Skill que apresenta script canônico de entrevista combinando The Mom Test (Rob Fitzpatrick) + Job-to-be-done (Christensen) + Day-in-the-life observation (IDEO). 12 perguntas estruturadas + checklist de captura raw + template de saída em memory/clientes/<cliente>/discovery-YYYY-MM-DD.md + draft de persona YAML pronto pra refinar. Refs ADR UI-0016, ADR 0105 (cliente-como-sinal). NÃO substitui visita real — orquestra o que perguntar e como capturar.
+tier: B
 ---
 
 # cliente-discovery — Entrevista canônica de cliente real

--- a/.claude/skills/cowork-prototype-replication/SKILL.md
+++ b/.claude/skills/cowork-prototype-replication/SKILL.md
@@ -2,6 +2,7 @@
 name: cowork-prototype-replication
 description: ATIVAR quando user pedir "fazer layout estado-da-arte", "replicar protótipo Cowork", "espelhar visual-source.html", "transformar prototipo-ui/* em Inertia React", "usar layout do cockpit pra módulo X", OU em Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx` quando existe `prototipo-ui/prototipos/<tela>/visual-source.html` ou `F1.html` correspondente. Carrega processo canônico de 7 fases (F0 sync + F1 mapping vocabulário vertical + F2 mapping CSS Cowork→Tailwind + F3 component hierarchy + F4 useMemo/useCallback + F5 Pest + F6 deploy + F7 smoke INTERATIVO) — RUNBOOK detalhado em [memory/requisitos/_DesignSystem/RUNBOOK-replicar-prototipo-cowork.md](../../memory/requisitos/_DesignSystem/RUNBOOK-replicar-prototipo-cowork.md). Caso real validado: Kanban Producao Oficina Caçambas 2026-05-13 (PRs #735→#740 madrugada pré-Martinho 10h).
 trigger_intensity: B
+tier: B
 ---
 
 # Skill `cowork-prototype-replication` — replicar protótipo Cowork pra Inertia React (Tier B)

--- a/.claude/skills/curador/SKILL.md
+++ b/.claude/skills/curador/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: curador
 description: ATIVAR quando user pedir "ingerir conhecimento", "triar D:\\Conhecimento", "organizar arquivos do computador", "ler tudo e classificar", "/curador <subcomando>", OU mencionar ingestão de batch de docs/manuais/PDFs pra alimentar Jana/oimpresso. Pipeline 5-fase (DISCOVER→CLASSIFY→REPORT→REVIEW→APPLY) com heurística-first (70-80% determinístico) e Claude-second (só itens ambíguos). Estado persistente em `scripts/curador/db/files.jsonl` (sobrevive /clear, /compact, reboot). NUNCA aplica sem aprovação humana batch-a-batch. Sensitive (.env, .pfx, .rdp, .key, XML cliente) BLOQUEIA commit. Multi-usuário consent-first (LGPD). ADR 0124.
+tier: B
 ---
 
 # Curador — pipeline canônico de ingestão

--- a/.claude/skills/design-deep-analysis/SKILL.md
+++ b/.claude/skills/design-deep-analysis/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: design-deep-analysis
 description: ATIVAR quando Wagner pedir /design-deep <persona-slug>, "analisar visualmente tela X pra persona Y", "design profundo da tela <Z>", OU em refator visual de tela que afeta cliente paga + reportou fricção. Skill canônica de análise contextualizada por persona — carrega persona YAML de memory/clientes/<cliente>/personas/, invoca design:* skills Anthropic em paralelo (critique + system + ux-copy + accessibility-review + research-synthesis), score 15 dimensões com ponderação por persona, entrega 3 alternativas A/B/C com diff de código preparado + métrica antes/depois. Refs ADR UI-0016, framework-15-dimensoes.md, RUNBOOK-design-deep.md.
+tier: B
 ---
 
 # design-deep-analysis — Análise contextualizada de tela por persona

--- a/.claude/skills/design-memoria-reprocess/SKILL.md
+++ b/.claude/skills/design-memoria-reprocess/SKILL.md
@@ -10,6 +10,7 @@ description: >
   Mantém o INDEX-DESIGN-MEMORIAS.md vivo SEM quebrar a estrutura — append-only +
   ratchet + freshness + idempotente. Tier B auto-trigger. Refs ADR proposto
   governanca-evolucao-doc-design, ADR 0230/0231/0233, INDEX-DESIGN-MEMORIAS.md.
+tier: B
 ---
 
 # design-memoria-reprocess — reprocessar a doc de design sem quebrar a estrutura

--- a/.claude/skills/feedback-capture/SKILL.md
+++ b/.claude/skills/feedback-capture/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: feedback-capture
 description: ATIVAR quando Wagner colar feedback de cliente real OU disser "Daniela reclamou X", "Larissa pediu Y", "Kamila falou que Z", "Jair quer W", "via WhatsApp <pessoa> reportou", "/feedback ..." OU mencionar reclamação/pedido alteração/sugestão de cliente real do oimpresso. Estrutura captura em 7 campos canônicos (canal, persona, literal, JTBD, workaround, severity NN/g 0-4, frequência) + grava append-only em memory/clientes/<cliente>/feedback/YYYY-MM-DD-<slug>.md + atualiza persona.fricoes + atualiza charter.fricoes_conhecidas + cria MCP task quando severity ≥ 3. Skill Tier B auto-trigger. Refs ADR UI-0016, ADR 0105.
+tier: B
 ---
 
 # feedback-capture — Captura estruturada de feedback de cliente

--- a/.claude/skills/feedback-dashboard/SKILL.md
+++ b/.claude/skills/feedback-dashboard/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: feedback-dashboard
 description: ATIVAR quando Wagner pedir "/feedback-dashboard", "mostra feedback", "como está o feedback", "que feedback tem aberto", "feedback do <cliente>", "feedback da <persona>", "feedback do mês", OU quando Wagner abrir sessão pra review de backlog feedback. Gera relatório agregado do estado atual: pendentes por persona/cliente/severity/módulo + RICE ranking top 10 + patterns emergentes (3+ clientes reportaram similar) + métricas SLA + comparação período. Lê memory/clientes/*/feedback/*.md append-only e calcula. Skill Tier B. Refs ADR UI-0016.
+tier: B
 ---
 
 # feedback-dashboard — Estado atual do feedback canon

--- a/.claude/skills/hostinger-dns-autonomy/SKILL.md
+++ b/.claude/skills/hostinger-dns-autonomy/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: hostinger-dns-autonomy
 description: BLOQUEADOR Tier A — ATIVAR antes de pedir Wagner pra criar/editar DNS record, qualquer ação Hostinger painel/UI, OU sempre que agente cogitar "pode você fazer isso no hPanel". Skill canon que IMPEDE escalar pro Wagner ações que tem API/CLI automatizadas. Carrega receita ADR 0045 (DNS API canônica) + lista de 6 paths onde token Hostinger pode estar + receita Vaultwarden API + fallback "se realmente impossível, registra como Tier 0 gap, NÃO pede Wagner". Inclui anti-padrão formal "pedir Wagner ação automatizável = erro de protocolo Tier A". Aprende falha 2026-05-28 17:55 quando agente pediu Wagner criar A record minio.oimpresso.com no hPanel em vez de via API. Ref PROTOCOLO-WAGNER-SEMPRE regra 1, ADR 0045, skill publication-policy.
+tier: A
 ---
 
 # Autonomia Hostinger DNS — Tier A bloqueante

--- a/.claude/skills/incident-done-checklist/SKILL.md
+++ b/.claude/skills/incident-done-checklist/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: incident-done-checklist
 description: BLOQUEADOR — ATIVAR antes de declarar "incident fechado" / "está pronto" / "feature funcionando" / encerrar sessão de fix em prod. Skill carrega a Definition of Done canônica (DoD-v1) que EXIGE smoke real prod end-to-end pra cada fix antes de marcar pronto. Funciona como gate procedural — sem TODOS os checks ✅, status fica `awaiting-smoke` no commit/PR/handoff, NÃO `done`. Aprende incident 2026-05-28 onde declarei "10 PRs fechados" com 3 fixes (M1/M2/M3 mídia) NUNCA validados por smoke real → 10.144 mídias ainda órfãs prod descoberto pelo Wagner depois. Operacional Tier A — DEVE ativar SEMPRE que agente escreve "está pronto", "fechado", "completou", "deployed", "validado" em mensagem ao Wagner. Bloco D (Reflexion runtime): quando o incidente foi erro de OPERAÇÃO da Jana (≠ saída do LLM), registrar a lição em Modules/Jana/LICOES-OPERACAO.md + graduar (MEC→check jana:health-check / JULG→regra). Refs PATTERN-INCIDENT-RESPONSE-VELOCITY.md passo 4, ADR 0093, skill commit-discipline.
+tier: A
 ---
 
 # Incident Done Checklist — Definition of Done bloqueante (DoD-v1)

--- a/.claude/skills/memory-first-secret-search/SKILL.md
+++ b/.claude/skills/memory-first-secret-search/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: memory-first-secret-search
 description: BLOQUEADOR Tier A — ATIVAR ANTES de qualquer busca por token / API key / password / SSH key / credential / secret. Skill canon que IMPEDE busca disgrega em paths aleatórios (.env, containers, etc) sem consultar PRIMEIRO o índice canônico `memory/_INDEX-SECRETS.md`. Origem falha 2026-05-28 18:30: agente declarou Tier 0 gap "token Hostinger inacessível" sem ter pesquisado memory canon (o token estava catalogado, o agente é que não consultou o índice). Wagner cobrou "tem api da hostinger na memoria". Skill força ordem fixa: (1) Read memory/_INDEX-SECRETS.md (2) follow ponteiro (3) se expired/missing registra rotação. NÃO escala Wagner se ponteiro existe.
+tier: A
 ---
 
 # Memory-First Secret Search — Tier A bloqueante

--- a/.claude/skills/module-grades-gate/SKILL.md
+++ b/.claude/skills/module-grades-gate/SKILL.md
@@ -20,6 +20,7 @@ triggers_on:
   - "renomear módulo baseline"
   - "diagnosticar falha CI module grades"
   - "/module-grades-gate"
+tier: C
 ---
 
 # Module Grades Gate — anti-regressão da rubrica v3

--- a/.claude/skills/officeimpresso-financial-snapshot/SKILL.md
+++ b/.claude/skills/officeimpresso-financial-snapshot/SKILL.md
@@ -4,6 +4,7 @@ description: ATIVAR quando user pedir "analisar receita do cliente X", "snapshot
 type: tier-b-auto-trigger
 status: draft
 date: 2026-05-09
+tier: B
 ---
 
 # officeimpresso-financial-snapshot — Skill

--- a/.claude/skills/officeimpresso-source-analysis/SKILL.md
+++ b/.claude/skills/officeimpresso-source-analysis/SKILL.md
@@ -4,6 +4,7 @@ description: ATIVAR quando precisar entender comportamento real de uma tela/feat
 type: tier-b-auto-trigger
 status: draft
 date: 2026-05-11
+tier: B
 ---
 
 # officeimpresso-source-analysis — análise via código-fonte Delphi

--- a/.claude/skills/pageheader-canon/SKILL.md
+++ b/.claude/skills/pageheader-canon/SKILL.md
@@ -2,6 +2,7 @@
 name: pageheader-canon
 description: ATIVAR quando agente vai aplicar o PageHeader canon (ADR 0180/0182/0189/0190) em módulo novo — user pede "aplicar pageheader canon no módulo X", "padronizar header do <Modulo>", "/pageheader-canon <Modulo>", "header v3 nas telas Y", OU em Edit/Write em `resources/js/Pages/<Mod>/<Tela>/Index.tsx` que tenha sub-navegação (sub-views no DataController). **2 modos** — (A) **Index/Show modo NAV** com SubNav + primary roxo universal (3 zonas) e (B) **Edit/Create modo FOCO** sem SubNav (página de form sem distração lateral, pattern Notion/Linear, Fase 4-bis). Skill carrega — (1) **algoritmo de descoberta** do módulo (cruzar DataController.php + Pages/<Mod>/**/*.tsx pra mapear sub-views + primary contextual + ações features), (2) **tabela de decisão** dos botões (duplicado-com-ghost REMOVE / features → extraOverflowItems / primary "Nova X" → Zona R / per-linha INTACTO), (3) **naming convention** de labels (≤2 palavras, sem repetir nome do módulo), (4) **PRIMARY UNIVERSAL ROXO 295** — `oklch(0.55 0.15 295)` bg + `oklch(0.45 0.15 295)` border (ADR 0190 2026-05-25 supersede hue-per-grupo do primary), (5) **validação POST-implementação OBRIGATÓRIA** via browser MCP (script JS valida labels curtos + auto-promove + primary roxo 295 NÃO outro hue + bg NÃO magenta 330) e (6) **gate ✓/⚠️** que FALHA o PR se alguma tela não passar. Tier B auto-trigger por description.
 supersedes_partially_via_adr: [0180, 0190]
+tier: B
 ---
 
 > ⚠️ **RECONCILIADO 2026-05-25 — ADR 0190 supersede parcial:** Esta skill anteriormente

--- a/.claude/skills/personas-resolve/SKILL.md
+++ b/.claude/skills/personas-resolve/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: personas-resolve
 description: BLOQUEADOR Tier A — ATIVAR ANTES de qualquer Edit/Write/MultiEdit em arquivos de `resources/js/Pages/**/*.tsx` ou criação de tela nova. Resolve a(s) persona(s) alvo da tela em 3 níveis de fallback (1) charter da tela `<Tela>.charter.md` campo `personas_alvo`; (2) mapping módulo em `memory/requisitos/_DesignSystem/personas-por-modulo.yml`; (3) pergunta interativa ao Wagner. Carrega persona YAML completa de `memory/clientes/<cliente>/personas/<slug>.yml` no contexto antes de codar. Sem persona resolvida = NÃO procede com edit visual. Reforça ADR UI-0016 (design contextualizado por persona). NUNCA usar persona hipotética sem cliente real (ADR 0105).
+tier: B
 ---
 
 # personas-resolve — Auto-load persona alvo da tela (Tier A bloqueador)

--- a/.claude/skills/sdd-avaliar/SKILL.md
+++ b/.claude/skills/sdd-avaliar/SKILL.md
@@ -11,6 +11,7 @@ description: >
   stream, lista modos de falha, e escreve um session log `YYYY-MM-DD-sdd-avaliacao-*.md`.
   É o sistema imunológico do SDD: caça "a suite mente" (gate que não morde, baseline
   nunca armado, métrica de forma não de correção, feito-que-depende-de-algo-que-nunca-rodou).
+tier: C
 ---
 
 # sdd-avaliar — avaliador adversarial do processo SDD

--- a/.claude/skills/ticket-triage/SKILL.md
+++ b/.claude/skills/ticket-triage/SKILL.md
@@ -33,6 +33,7 @@ does_not_trigger_on:
   - "marcar resolvido" (action ≠ análise)
   - "enviar mensagem" (composer ≠ triagem)
   - perguntas conversacionais sem ID/cliente alvo
+tier: B
 ---
 
 # ticket-triage — Skill de triagem de atendimento

--- a/.claude/skills/wagner-request-refiner/SKILL.md
+++ b/.claude/skills/wagner-request-refiner/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: wagner-request-refiner
 description: ATIVAR quando Wagner manda múltiplos pedidos curtos não-estruturados num mesmo turno (ex: lista com 3+ items, "todo: a) b) c)", bullets numerados, screenshots com várias anotações simultâneas, ou texto corrido com várias intenções misturadas). Decompõe em tasks atômicas, infere owner/priority/module/estimate cruzando com SPEC.md + MCP, propõe estrutura ANTES de criar via MCP ou editar código. Anti-pattern: pegar tudo de uma vez e implementar sem cruzar dependências. Wagner valoriza economia de crédito + escopo confirmado antes de execução massiva.
+tier: B
 ---
 
 # wagner-request-refiner — refina pedidos vagos em US estruturadas


### PR DESCRIPTION
## Contexto
Auditoria do IA OS — **T7-A**. A convenção de tier (ADR 0095) estava driftando de si mesma: **51/70** skills declaravam `tier:` → agora **70/70**.

## Decisão de tier (executa ADR 0225/0229, não cria decisão nova)
Fonte de verdade = roster `tier-a-banner.ps1`:
- **Tier A (3):** `incident-done-checklist`, `memory-first-secret-search`, `hostinger-dns-autonomy`
- **Tier B (13):** pageheader-canon, feedback-capture, feedback-dashboard, design-memoria-reprocess, cliente-discovery, design-deep-analysis, cowork-prototype-replication, ticket-triage, wagner-request-refiner, officeimpresso-financial-snapshot, officeimpresso-source-analysis, **personas-resolve**, **curador**
- **Tier C (2):** module-grades-gate, **sdd-avaliar**

### Borderline (Wagner delegou — "faça o melhor")
- **personas-resolve → B**: auto-rotula "BLOQUEADOR Tier A" na desc, mas **não está no roster A** (ADR 0229 anti-drift); o enforcement real é via hook `charter-validate`, não o tier. Frontmatter passa a refletir o roster.
- **curador → B**, **sdd-avaliar → C** (on-demand `/sdd-avaliar`).

## Segurança
- **Não** promove nada a Tier A novo, **não** edita ADR 0095/0225/0229 (append-only) — só grava no frontmatter a decisão que já existe.
- Campo `tier:` é convenção **interna** (Claude Code core ignora) → puramente documental/auditável, runtime real = hook + description. Baixíssimo risco.
- Inserção via awk preservando LF (0 CRLF). Gate: `grep -L '^tier:'` nas skills ativas = **0**.

Parte B (command `skills:tier-review` de telemetria trimestral) fica pra depois — precisa Pest no CT 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)