### PR TITLE
feat(jana): bi-temporal event-time na memória — slice 1 (ADR 0295, T4)

### DIFF
--- a/.github/workflows/jana-bitemporal-pest.yml
+++ b/.github/workflows/jana-bitemporal-pest.yml
@@ -1,0 +1,87 @@
+name: Jana bi-temporal Pest (T4)
+
+# ADR 0295 — verifica a LOGICA pura do predicado event-time (BiTemporalResolver) no CI.
+# Escopo ESTREITO: roda SO o BiTemporalResolverTest (pura-logica, sem DB), NAO o
+# modulo Jana inteiro nem o dir Unit todo — Jana so tem allowlist MySQL (jana-pest.yml)
+# e jogar tudo exporia debito alheio a este PR. A traducao pra SQL (buscarHistorico)
+# e exercitada no CT 100 nos slices seguintes. Extensoes casam com modules-pest.yml
+# (composer.lock exige opentelemetry/gd/pdo_mysql).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Modules/Jana/Services/Memoria/BiTemporalResolver.php'
+      - 'Modules/Jana/Tests/Unit/BiTemporalResolverTest.php'
+      - 'Modules/Jana/Database/Migrations/*_add_event_time_to_jana_memoria_facts.php'
+      - '.github/workflows/jana-bitemporal-pest.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: jana-bitemporal-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pest:
+    name: Pest BiTemporalResolver (logica pura)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: bcmath, ctype, dom, fileinfo, intl, json, mbstring, openssl, pdo, pdo_sqlite, pdo_mysql, tokenizer, xml, zip, gd, opentelemetry
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Prepare dirs
+        run: mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+
+      - name: Install PHP deps
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+      - name: Create .env
+        run: |
+          printf '%s\n' \
+            'APP_NAME=oimpresso-ci' \
+            'APP_ENV=testing' \
+            'APP_DEBUG=true' \
+            'APP_URL=http://localhost' \
+            'LOG_CHANNEL=stderr' \
+            'DB_CONNECTION=sqlite' \
+            'DB_DATABASE=:memory:' \
+            'CACHE_DRIVER=array' \
+            'QUEUE_CONNECTION=sync' \
+            'SESSION_DRIVER=array' \
+            'MAIL_MAILER=array' \
+            'BCRYPT_ROUNDS=4' \
+            'TELESCOPE_ENABLED=false' \
+            'SCOUT_DRIVER=null' \
+            'MCP_TOOLS_EXPOSED=false' > .env
+          php artisan key:generate
+          php artisan package:discover --ansi
+
+      - name: Run Pest (BiTemporalResolver)
+        env:
+          APP_ENV: testing
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ":memory:"
+          CACHE_DRIVER: array
+          SESSION_DRIVER: array
+          QUEUE_CONNECTION: sync
+        run: |
+          vendor/bin/pest Modules/Jana/Tests/Unit/BiTemporalResolverTest.php \
+            --no-coverage \
+            --colors=always

--- a/Modules/Jana/Database/Migrations/2026_06_20_000002_add_event_time_to_jana_memoria_facts.php
+++ b/Modules/Jana/Database/Migrations/2026_06_20_000002_add_event_time_to_jana_memoria_facts.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0295 (slice 1) — bi-temporal event-time na memoria Jana.
+ *
+ * SO ADITIVA: event_valid_from/until (event-time, quando o fato valeu NO MUNDO,
+ * distinto do system-time valid_from/until) + supersedes_id (link explicito pro
+ * fato que este substitui). Tudo nullable — fatos legados ficam "sempre event-
+ * validos" (sem backfill retroativo, nao-decisao de 0074). Nenhuma mudanca de
+ * comportamento neste slice; popular as colunas e slice 2/3.
+ *
+ * Tabela jana_memoria_facts (rename ADR 0092, VIEW legacy) — Schema::hasTable
+ * guard pra nao tentar ALTER na VIEW / em ambiente sem a tabela (CI SQLite).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('jana_memoria_facts')) {
+            return;
+        }
+
+        Schema::table('jana_memoria_facts', function (Blueprint $table) {
+            if (! Schema::hasColumn('jana_memoria_facts', 'event_valid_from')) {
+                $table->dateTime('event_valid_from')->nullable()->after('valid_until')
+                    ->comment('Event-time: quando o fato passou a valer no mundo (ADR 0295). Null = desde sempre');
+            }
+            if (! Schema::hasColumn('jana_memoria_facts', 'event_valid_until')) {
+                $table->dateTime('event_valid_until')->nullable()->after('event_valid_from')
+                    ->comment('Event-time: quando o fato deixou de valer no mundo (ADR 0295). Null = ainda vale');
+            }
+            if (! Schema::hasColumn('jana_memoria_facts', 'supersedes_id')) {
+                $table->unsignedBigInteger('supersedes_id')->nullable()->after('event_valid_until')
+                    ->comment('Link explicito pro fato que este substitui (ADR 0295). FK logica — app enforce');
+            }
+
+            $table->index(['event_valid_from', 'event_valid_until'], 'jmf_event_validity_idx');
+            $table->index('supersedes_id', 'jmf_supersedes_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('jana_memoria_facts')) {
+            return;
+        }
+
+        Schema::table('jana_memoria_facts', function (Blueprint $table) {
+            $table->dropIndex('jmf_event_validity_idx');
+            $table->dropIndex('jmf_supersedes_idx');
+            $table->dropColumn(['supersedes_id', 'event_valid_until', 'event_valid_from']);
+        });
+    }
+};

--- a/Modules/Jana/Entities/MemoriaFato.php
+++ b/Modules/Jana/Entities/MemoriaFato.php
@@ -55,12 +55,18 @@ class MemoriaFato extends Model
         'metadata',
         'valid_from',
         'valid_until',
+        'event_valid_from',  // event-time bi-temporal (ADR 0295)
+        'event_valid_until',
+        'supersedes_id',
     ];
 
     protected $casts = [
         'metadata' => 'array',
         'valid_from' => 'datetime',
         'valid_until' => 'datetime',
+        'event_valid_from' => 'datetime',  // ADR 0295
+        'event_valid_until' => 'datetime',
+        'supersedes_id' => 'integer',
     ];
 
     public function searchableAs(): string

--- a/Modules/Jana/Services/Memoria/BiTemporalResolver.php
+++ b/Modules/Jana/Services/Memoria/BiTemporalResolver.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\Jana\Services\Memoria;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * BiTemporalResolver — predicado de EVENT-TIME da memoria Jana (ADR 0295, T4 slice 1).
+ *
+ * Bi-temporal (Zep/Graphiti): alem do system-time (valid_from/valid_until — quando
+ * o SISTEMA soube), o event-time (event_valid_from/until — quando o fato valeu NO
+ * MUNDO). Time-travel "as_of T" = quais fatos eram EVENT-validos no instante T.
+ *
+ * Logica PURA (testavel no CI sem DB). A traducao pra SQL (buscarHistorico) e a
+ * tool MCP memoria-historica ficam pro slice 2. FAILSAFE: parse tolerante (nunca lanca).
+ */
+class BiTemporalResolver
+{
+    /**
+     * Fato era event-valido em $asOf?
+     * Inicio inclusivo, fim exclusivo. Null-from = "desde sempre"; null-until = "ainda vale".
+     *
+     * @param  mixed  $from   event_valid_from (Carbon|DateTimeInterface|string|null)
+     * @param  mixed  $until  event_valid_until
+     * @param  mixed  $asOf   instante-mundo de referencia
+     */
+    public static function vigenteEm($from, $until, $asOf): bool
+    {
+        $asOf = self::ts($asOf);
+        if ($asOf === null) {
+            return false; // sem instante de referencia, nada a afirmar
+        }
+
+        $from = self::ts($from);
+        $until = self::ts($until);
+
+        $depoisDoInicio = $from === null || $from <= $asOf;   // inclusivo no inicio
+        $antesDoFim     = $until === null || $until > $asOf;   // exclusivo no fim
+
+        return $depoisDoInicio && $antesDoFim;
+    }
+
+    /** Normaliza pra timestamp (segundos) ou null. FAILSAFE — nao lanca. */
+    private static function ts($v): ?int
+    {
+        if ($v === null || $v === '') {
+            return null;
+        }
+        if ($v instanceof \DateTimeInterface) {
+            return $v->getTimestamp();
+        }
+        try {
+            return Carbon::parse((string) $v)->getTimestamp();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+}

--- a/Modules/Jana/Tests/Unit/BiTemporalResolverTest.php
+++ b/Modules/Jana/Tests/Unit/BiTemporalResolverTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Modules\Jana\Services\Memoria\BiTemporalResolver;
+
+/**
+ * Teste de LOGICA PURA (sem DB, sem app boot) do predicado event-time (ADR 0295, T4 slice 1).
+ * Roda no CI porque so chama o metodo estatico com strings/null. A traducao pra SQL
+ * (buscarHistorico) e exercitada no CT 100 nos slices seguintes.
+ */
+$T = '2026-04-15 10:00:00';   // instante-mundo de referencia
+
+it('dentro da janela -> vigente', function () use ($T) {
+    expect(BiTemporalResolver::vigenteEm('2026-04-10 00:00:00', '2026-04-20 00:00:00', $T))->toBeTrue();
+});
+
+it('antes do inicio -> NAO vigente', function () use ($T) {
+    expect(BiTemporalResolver::vigenteEm('2026-04-16 00:00:00', null, $T))->toBeFalse();
+});
+
+it('no/depois do fim -> NAO vigente (fim exclusivo)', function () {
+    $until = '2026-04-15 10:00:00';
+    expect(BiTemporalResolver::vigenteEm('2026-04-01 00:00:00', $until, $until))->toBeFalse()
+        ->and(BiTemporalResolver::vigenteEm('2026-04-01 00:00:00', $until, '2026-04-16 00:00:00'))->toBeFalse();
+});
+
+it('no inicio exato -> vigente (inicio inclusivo)', function () {
+    $from = '2026-04-15 10:00:00';
+    expect(BiTemporalResolver::vigenteEm($from, null, $from))->toBeTrue();
+});
+
+it('from null = desde sempre', function () use ($T) {
+    expect(BiTemporalResolver::vigenteEm(null, '2026-04-20 00:00:00', $T))->toBeTrue();
+});
+
+it('until null = ainda vale', function () use ($T) {
+    expect(BiTemporalResolver::vigenteEm('2026-01-01 00:00:00', null, $T))->toBeTrue();
+});
+
+it('ambos null = sempre vigente (fato legado sem event-time)', function () use ($T) {
+    expect(BiTemporalResolver::vigenteEm(null, null, $T))->toBeTrue();
+});
+
+it('asOf null -> NAO afirma nada (false)', function () {
+    expect(BiTemporalResolver::vigenteEm('2026-01-01 00:00:00', null, null))->toBeFalse();
+});
+
+it('data nao-parseavel -> tratada como null (FAILSAFE, nao lanca)', function () use ($T) {
+    // from lixo -> tratado como null (desde sempre) -> vigente se antes do until
+    expect(BiTemporalResolver::vigenteEm('xxx-nao-data', null, $T))->toBeTrue();
+});

--- a/memory/decisions/0295-bitemporal-event-time-memoria-jana.md
+++ b/memory/decisions/0295-bitemporal-event-time-memoria-jana.md
@@ -1,0 +1,57 @@
+---
+slug: 0295-bitemporal-event-time-memoria-jana
+number: 295
+title: "aceitar e implementar bi-temporal event-time na memoria Jana (ratifica desenho 0074) — slice 1: schema + predicado puro"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+kind: decision
+decided_by: [W]
+decided_at: "2026-06-20"
+module: jana
+tags: [jana, memoria, bi-temporal, time-travel, event-time, tier-0]
+supersedes: []
+superseded_by: []
+related:
+  - 0074-temporal-validity-bi-temporal-time-travel
+  - 0092-tabela-rename-copiloto-para-jana
+  - 0093-multi-tenant-isolation-tier-0
+  - 0036-replanejamento-meilisearch-first
+---
+
+# ADR 0295 — bi-temporal event-time na memoria Jana (aceita 0074; slice 1)
+
+> Origem: auditoria do IA OS 2026-06-20 (gap T4). Wagner delegou ("faca o melhor") e ratificou ("vai"). Esta ADR **aceita o desenho da ADR 0074** (proposto) e registra a implementacao FATIADA. Como 0074 e append-only e tem historia desconexa, nao a edito in-place — esta ADR e a aceitacao + plano.
+
+## Contexto
+
+Hoje a memoria Jana e **uni-temporal**: `valid_from`/`valid_until` em `jana_memoria_facts` modelam SO o system-time (quando o sistema soube do fato). Falta o **event-time** (quando o fato valeu NO MUNDO). A vitoria de manchete de Zep/Graphiti (+18.5% acc em "knowledge updates", onde LLMs caem ~30%) vem justamente do **bi-temporal**: responder "X estava ativo em 15/04?" exige separar os dois eixos.
+
+## Decisao
+
+1. **Aceitar o desenho da ADR 0074** e shipar bi-temporal em **3 slices** (PRs <=300 linhas, todos pra review — Tier-0-adjacente):
+   - **Slice 1 (este PR):** schema aditivo (`event_valid_from`, `event_valid_until`, `supersedes_id`) + fillable/casts + **predicado PURO** `BiTemporalResolver::vigenteEm()` (testavel no CI sem DB). **Sem mudanca de comportamento** — colunas nullable, nada as popula ainda.
+   - **Slice 2:** tool MCP `memoria-historica` (time-travel `as_of`) + `buscarHistorico()` via **Eloquent/SQL direto** (NUNCA Scout — `shouldBeSearchable()` so indexa `valid_until=NULL`, entao fato superseded fica fora do index). Filtra `business_id`+`user_id` (ADR 0093); tool replica a checagem cross-tenant superadmin de `MemoriaSearchTool`.
+   - **Slice 3:** deteccao automatica de update temporal (agent Haiku) **atras de flag OFF default** (`config('jana.memoria.supersede_detection.enabled', false)`) — flag OFF = job byte-identico ao legado; liga so em homolog. `atualizar()` grava `supersedes_id` (link explicito) sem deixar de ser append-only.
+
+2. **Semantica do predicado event-time:** fato e event-valido em `asOf` se `(event_valid_from is null OU <= asOf)` E `(event_valid_until is null OU > asOf)` — inicio inclusivo, fim exclusivo; null-from = "desde sempre", null-until = "ainda vale". Fatos legados (sem event-time) ficam **sempre event-validos** — sem backfill retroativo (nao-decisao deliberada de 0074).
+
+## Consequencias
+
+- **+** Base pronta pra time-travel; predicado isolado e testado no CI (logica pura).
+- **+** Append-only preservado: migration so adiciona colunas; `atualizar()` (slice 3) continua marcando `valid_until` + criando novo, so adicionando o link `supersedes_id`.
+- **−** 3 PRs + custo LLM novo no slice 3 (mitigado por flag OFF default).
+- **Pegadinhas registradas (Tier-0):** tabela e `jana_memoria_facts` (rename 0092, VIEW legacy — `Schema::hasTable` guard); Scout nao indexa superseded (buscarHistorico = Eloquent); indices nomeados <=64 char.
+
+## Alternativas
+
+- **So uni-temporal (status quo):** rejeitada — nao responde knowledge-updates, o gap de maior valor da auditoria de memoria.
+- **Backfill de event-time nas linhas legadas:** rejeitada (0074) — sem fonte de verdade do event-time passado; legado = "sempre valido".
+- **Grafo (Neo4j/Graphiti nativo):** fora de escopo; frontmatter-grafo-leve deliberado (ADR 0072). Bi-temporal tabular cobre o gap.
+
+## Implementacao (slice 1)
+
+- Migration `2026_06_20_000002_add_event_time_to_jana_memoria_facts` (aditiva, idempotente, `Schema::hasTable` guard).
+- `MemoriaFato`: 3 colunas no fillable + casts.
+- `BiTemporalResolver` (predicado puro) + teste de logica pura + job CI focado.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **299** arquivos · **284** números únicos · máx **0294**
-- **ADRs ATIVOS (lifecycle ativo): 259** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 229 · proposto 43 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
-- Por lifecycle: ativo 259 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **300** arquivos · **285** números únicos · máx **0295**
+- **ADRs ATIVOS (lifecycle ativo): 260** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 229 · proposto 44 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
+- Por lifecycle: ativo 260 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (13) — auto-detectadas
@@ -32,7 +32,7 @@ _(íntegra)_
 ## Recusadas (1) — o NÃO consultável
 - **0290** v0 'Fidelity Lock' (screenshot pareado em CI) — RECUSADO: fidelidade visual não  · recusada 2026-06-18 — Inviável + tautológico + backdoor de prosa (3 motivos na Decisão). REABRE só se surgir um check de fidelidade HERMÉTICO 
 
-## Todas as ADRs (299)
+## Todas as ADRs (300)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | Estender UltimatePOS em vez de build próprio ou fork |
@@ -334,3 +334,4 @@ _(íntegra)_
 | 0292 | proposto | ativo | errata | Errata 0291 D-D — distiller_freshness no scorecard mede staleness vs doc mais no |
 | 0293 | proposto | ativo | decision | Governança da decisão de design: responsável por etapa do ciclo + Decision Regis |
 | 0294 | aceito | ativo | decision | Método de planejamento: dual-track + Shape Up travado por catraca (incubadora →  |
+| 0295 | proposto | ativo | decision | aceitar e implementar bi-temporal event-time na memoria Jana (ratifica desenho 0 |

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -162,6 +162,10 @@
       "nome": "Infra Contract Required",
       "classe": "gate"
     },
+    "jana-bitemporal-pest.yml": {
+      "nome": "Jana bi-temporal Pest (T4 · predicado event-time BiTemporalResolver · ADR 0295)",
+      "classe": "gate"
+    },
     "jana-pest.yml": {
       "nome": "Jana · Pest (MySQL)",
       "classe": "gate"


### PR DESCRIPTION
## Contexto
Auditoria do IA OS — **T4** (bi-temporal Jana). Wagner delegou ("faça o melhor") e ratificou ("vai"). **ADR 0295** aceita o desenho da 0074 e shipa **fatiado**. Este é o **slice 1** (fundação). **Não auto-merge — Tier-0-adjacente, você revisa.**

## O que entra (slice 1 — sem mudança de comportamento)
- **ADR 0295** (aceita 0074 + plano de 3 slices) + índice regenerado.
- **Migration aditiva** (`event_valid_from`, `event_valid_until`, `supersedes_id` nullable em `jana_memoria_facts`) — idempotente, `Schema::hasTable` guard (tabela é rename 0092 com VIEW legacy). Índices nomeados ≤64 char.
- **`MemoriaFato`** — 3 colunas no fillable + casts.
- **`BiTemporalResolver::vigenteEm()`** — predicado event-time **PURO**: início inclusivo / fim exclusivo; `from null` = desde sempre; `until null` = ainda vale; legado (ambos null) = sempre vigente; FAILSAFE (parse tolerante).
- **Teste pura-lógica** (9 casos) + **job CI focado** registrado no censo de gates.

## O que NÃO entra (próximos slices, pra review separado)
- **Slice 2:** tool MCP `memoria-historica` (`as_of`) + `buscarHistorico()` via **Eloquent** (nunca Scout — não indexa superseded) + scope `business_id`+`user_id`.
- **Slice 3:** detecção automática de update temporal (Haiku) **atrás de flag OFF default** + `atualizar()` grava `supersedes_id`.

## Verificação
- Lógica pura, sem DB → roda no CI deste PR (não tenho php local; **o CI é a verificação**). Já apliquei a lição do T5 (extensões `opentelemetry/gd/pdo_mysql` + registro no `gates-registry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)