### PR TITLE
feat(whatsapp): US-WA-311 triagem no inbox (promove E2 do plano)

### DIFF
--- a/memory/requisitos/Whatsapp/PLANO-ATENDIMENTO-AUTOMATICO.md
+++ b/memory/requisitos/Whatsapp/PLANO-ATENDIMENTO-AUTOMATICO.md
@@ -13,7 +13,7 @@
 - **status:** ativo  <!-- proposto→ativo: [W] aprovou ordem ROI 2026-06-20 (merge #3064 + aceite ADR 0294). em-execução só quando houver task MCP parent_plan -->
 - **owner:** W
 - **criado:** 2026-06-20 · **reviewed_at:** 2026-06-20 · **próxima-revisão:** 2026-07-20
-- **cycle:** CYCLE-08 · **execução:** `parent_plan=plano-atendimento-automatico` (tasks a criar — MCP não conectado nesta sessão)
+- **cycle:** off-CYCLE-08 (cycle ativo = receita/carteira legacy) · **execução:** `parent_plan=plano-atendimento-automatico` — US-WA-311 criada (backlog); E1/E3 (JANA Pro) + E4/E5 a criar
 - **gate-de-saída (DoD):** E1+E3 com ≥5 clientes pagando JANA Pro (espelha gates da ADR 0140)
 - **kill-condition:** mês 2 com < 2 conversões trial→pago → congela (review_triggers ADR 0140)
 - **verdade-viva:** este doc
@@ -21,7 +21,7 @@
 | Etapa | Task MCP (`parent_plan=plano-atendimento-automatico`) | Status | % |
 |---|---|---|---|
 | E1 JANA Pro MVP (brief operador) | US-COPI-201..205 | a criar | 0 |
-| E2 Triagem no inbox | US-WA-TRIAGE-001 | a criar | 0 |
+| E2 Triagem no inbox | US-WA-311 | todo | 0 |
 | E3 Cobrança Asaas + 5 beta | US-COPI-211..215 | a criar | 0 |
 | E4 Bot responde cliente | US-WA-BOT-001 | adiada (§6) | 0 |
 | E5 Entidade ticket | — | não agora (decisão §7) | 0 |

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -1772,3 +1772,21 @@ Botão "+ Nova conversa" no topnav direita hoje é placeholder. Implementação:
 
 **Anti-padrões:** **NÃO** inventar `StartConversationService` antes de checar `InboxController::send` flow — reusar pattern de envio + criar Conversation row.
 
+### US-WA-311 · Triagem automática no inbox — score + prioridade P1-P4 pro operador (L1)
+
+> owner: wagner · sprint: TBD · priority: p2 · estimate: 12h IA-pair · status: backlog · type: story
+
+parent_plan=plano-atendimento-automatico (etapa E2, maior ROI — [ADR 0294](../../decisions/0294-metodo-dual-track-shapeup-catraca.md)). Triagem **L1** ao chegar conversa: `TriageService` (Modules/Jana, porta runtime do skill `ticket-triage`) gera score 0-100 + prioridade P1-P4 + sugestão de ação; listener `TriageOnInbound` (Modules/Whatsapp) na 1ª inbound; persiste como tag P1-P4 (`whatsapp_tags`) + badge na Caixa Unificada (ordenar fila). L1 = analisa, **NÃO** responde/atribui/resolve.
+
+**AC:**
+- Conversa nova recebe prioridade + score + sugestão em < 5s do inbound.
+- L1: triagem só anota; não atribui, não responde, não resolve.
+- PII redigida antes da chamada LLM e em qualquer log (vetor `inbound_preview`).
+- Tier 0: `TriageService` + listener filtram `business_id`; teste cross-tenant não vaza.
+- Re-triagem idempotente; falha do LLM → fila sem prioridade (degradado), nunca trava o inbound.
+- Flag `copiloto.triage.inbox_enabled` (default off) → canary biz=4 (ROTA LIVRE).
+- Testes Pest R-WA-TRIAGE-001..007 + cross-tenant; eval advisory `triage-gold-set.json`.
+
+**Refs:** AC completos em [PLANO-ATENDIMENTO-AUTOMATICO.md](./PLANO-ATENDIMENTO-AUTOMATICO.md) §5. **NOTA:** off-CYCLE-08 (cycle ativo = receita/carteira legacy) — backlog até atendimento virar prioridade de cycle.
+
+**Anti-padrões:** cérebro de IA mora em Modules/Jana; inbox (listener/badge) em Modules/Whatsapp. **NÃO** reusar o ADS PolicyEngine como guardrail conversacional (é firewall de ações de código, não de respostas).


### PR DESCRIPTION
**Promover** a etapa E2 do `plano-atendimento-automatico` (membrana → tem task) — fecha o ciclo merge/aceito/promover.

- **+** `US-WA-311 · Triagem automática no inbox` na SPEC canônica (`Modules/Whatsapp/SPEC.md`): TriageService (Jana) + listener TriageOnInbound + badge P1-P4. L1 (analisa, não responde), PII/Tier 0, flag+canary biz=4, Pest R-WA-TRIAGE-001..007. `parent_plan=plano-atendimento-automatico`.
- **~** Status vivo do plano: linha E2 `a criar` → `US-WA-311 / todo`; cycle corrigido pra **off-CYCLE-08** (cycle ativo = receita/carteira legacy — triagem é backlog até virar prioridade de cycle).

**Numeração:** 311 = após o max canônico 310 (301-307 são blocos definidos; 308/310 são só menções em prosa). O MCP gerou "308" porque seu SPEC está stale (vê max 307) — corrigido aqui manualmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
