### PR TITLE
feat(brief): skills:tier-review — loop telemetria→tier (Parte B T7, ADR 0095)

### DIFF
--- a/Modules/Brief/Console/Commands/SkillTierReviewCommand.php
+++ b/Modules/Brief/Console/Commands/SkillTierReviewCommand.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Brief\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/**
+ * skills:tier-review — loop telemetria → promoção/rebaixamento de tier (Parte B T7).
+ *
+ * Fecha o ciclo da Parte A (PR #3067, que gravou `tier:` nas ~70 .claude/skills/):
+ * parseia o tier de cada SKILL.md, lê uso em `mcp_skill_telemetry` e aplica as 4
+ * regras da ADR 0095 — B→A uso ≥80% 30d (exige ADR, nunca auto), B→C uso <10% 60d
+ * (trivial, auto), C→arquivar sem uso >90d (exige ADR HISTORICAL), A→B só Wagner.
+ * Default READ-ONLY; --apply-suggestions aplica SÓ B→C.
+ *
+ * Relatório APPEND-ONLY em memory/governance/skill-tier-review-AAAA-QN.md — SÓ
+ * agregados; `context_payload` NUNCA é gravado (pode ter PII — LGPD/ADR 0093).
+ *
+ * Tier 0: `mcp_skill_telemetry` é GOVERNANÇA cross-tenant — sem business_id (exceção
+ * superadmin, ADR 0093); queries rodam sem global scope. Hostinger ≠ CT 100 (ADR
+ * 0062): só artisan + schedule. "Sessão" = par distinto (agent_id, dia) — proxy
+ * honesto, a tabela não tem session_id.
+ *
+ * @see memory/decisions/0095-skills-tiers-convencao-interna.md
+ * @see Modules\Brief\Mcp\Tools\BriefFetchTool::logSkillTelemetry (produtor)
+ */
+class SkillTierReviewCommand extends Command
+{
+    protected $signature = 'skills:tier-review
+                            {--since=90 : Janela de telemetria em dias (default cobre as 3 regras)}
+                            {--apply-suggestions : Aplica SÓ rebaixamentos triviais B→C (nunca promove/arquiva)}';
+
+    protected $description = 'Loop telemetria→tier (ADR 0095): relatório de promoção/rebaixamento de skills. Read-only por default.';
+
+    /** Mínimo de sessões-proxy na janela pra uma % ser confiável (anti-ruído "0 sessões → 0%"). */
+    public const MIN_SESSIONS = 10;
+
+    /** Colunas lidas de mcp_skill_telemetry. `context_payload` NUNCA entra (LGPD). */
+    public static function telemetrySelectColumns(): array
+    {
+        return ['skill_name', 'agent_id', 'triggered_at', 'success', 'tokens_saved_estimate'];
+    }
+
+    public function handle(): int
+    {
+        $since = max(1, (int) $this->option('since'));
+        $apply = (bool) $this->option('apply-suggestions');
+
+        $skills = $this->loadSkills(base_path('.claude/skills'));
+        $semTier = array_keys(array_filter($skills, static fn ($s) => $s['tier'] === null));
+
+        // CATRACA (Parte A): 0 skills sem tier. Se a Parte A regredir, falha aqui.
+        if ($semTier !== []) {
+            $this->error('CATRACA FALHOU — '.count($semTier).' skill(s) sem tier: '.implode(', ', $semTier));
+
+            return self::FAILURE;
+        }
+
+        $metrics = $this->loadTelemetryMetrics($since);
+        $suggestions = self::evaluateRules($this->mergeMetrics($skills, $metrics), self::MIN_SESSIONS);
+        $applied = $apply ? $this->applyTrivialDemotions($suggestions, $skills) : [];
+
+        $tierCounts = array_count_values(array_map(static fn ($s) => $s['tier'], $skills));
+        $reportPath = base_path('memory/governance/skill-tier-review-'.self::quarterLabel(now()).'.md');
+        $this->appendReport($reportPath, self::renderReportSection([
+            'now_str' => now()->format('Y-m-d H:i'), 'quarter' => self::quarterLabel(now()),
+            'since' => $since, 'apply' => $apply, 'total_skills' => count($skills), 'tier_counts' => $tierCounts,
+            'total_sessions_30d' => $metrics['total_sessions_30d'], 'total_sessions_60d' => $metrics['total_sessions_60d'],
+            'events' => $metrics['events'], 'skills_with_use' => count($metrics['per_skill']),
+            'suggestions' => $suggestions, 'applied' => $applied,
+        ]));
+
+        $this->renderConsole($tierCounts, $suggestions, $applied, $reportPath, $apply);
+
+        return self::SUCCESS;
+    }
+
+    /** Carrega skills ativas (glob `*\/SKILL.md` exclui `_archive/`). */
+    private function loadSkills(string $dir): array
+    {
+        $out = [];
+        foreach (glob($dir.'/*/SKILL.md') ?: [] as $path) {
+            $name = basename(dirname($path));
+            $out[$name] = ['name' => $name, 'path' => $path, 'tier' => self::parseTier((string) file_get_contents($path))];
+        }
+        ksort($out);
+
+        return $out;
+    }
+
+    /** Extrai `tier: A|B|C` do frontmatter. null = sem tier (a catraca pega). PURO. */
+    public static function parseTier(string $content): ?string
+    {
+        $front = preg_match('/\A---\s*\n(.*?)\n---/s', $content, $m) ? $m[1] : $content;
+
+        return preg_match('/^tier:[ \t]*([ABC])\b/mi', $front, $t) ? strtoupper($t[1]) : null;
+    }
+
+    private function loadTelemetryMetrics(int $since): array
+    {
+        try {
+            $rows = DB::table('mcp_skill_telemetry')
+                ->where('triggered_at', '>=', now()->subDays($since))
+                ->select(self::telemetrySelectColumns()) // NUNCA context_payload (LGPD)
+                ->orderBy('triggered_at')->get();
+        } catch (Throwable $e) {
+            $this->warn('Telemetria indisponível ('.$e->getMessage().') — relatório sem métricas.');
+            $rows = collect();
+        }
+
+        return self::aggregate($rows, now()->timestamp, min($since, 30), min($since, 60), min($since, 90))
+            + ['events' => $rows->count()];
+    }
+
+    /**
+     * Agrega telemetria crua em métricas por skill. PURO — testável sem DB.
+     * "Sessão" = par distinto (agent_id, dia). `context_payload` nunca é passado aqui.
+     *
+     * @param  iterable<object>  $rows  cada um com skill_name, agent_id, triggered_at
+     * @return array{total_sessions_30d:int, total_sessions_60d:int, per_skill:array<string, array{sessions_30d:int, sessions_60d:int, triggers_90d:int}>}
+     */
+    public static function aggregate(iterable $rows, int $nowTs, int $w30 = 30, int $w60 = 60, int $w90 = 90): array
+    {
+        [$cut30, $cut60, $cut90] = [$nowTs - $w30 * 86400, $nowTs - $w60 * 86400, $nowTs - $w90 * 86400];
+        $tot30 = $tot60 = $per = [];
+
+        foreach ($rows as $r) {
+            $name = (string) $r->skill_name;
+            $ts = is_int($r->triggered_at) ? $r->triggered_at : (int) strtotime((string) $r->triggered_at);
+            if ($ts <= 0) {
+                continue;
+            }
+            $day = is_int($r->triggered_at) ? gmdate('Y-m-d', $ts) : substr((string) $r->triggered_at, 0, 10);
+            $sess = ((string) $r->agent_id).'|'.$day;
+            $per[$name] ??= ['s30' => [], 's60' => [], 't90' => 0];
+            if ($ts >= $cut90) {
+                $per[$name]['t90']++;
+            }
+            if ($ts >= $cut60) {
+                $per[$name]['s60'][$sess] = $tot60[$sess] = true;
+            }
+            if ($ts >= $cut30) {
+                $per[$name]['s30'][$sess] = $tot30[$sess] = true;
+            }
+        }
+
+        $perOut = [];
+        foreach ($per as $n => $v) {
+            $perOut[$n] = ['sessions_30d' => count($v['s30']), 'sessions_60d' => count($v['s60']), 'triggers_90d' => $v['t90']];
+        }
+
+        return ['total_sessions_30d' => count($tot30), 'total_sessions_60d' => count($tot60), 'per_skill' => $perOut];
+    }
+
+    /** Junta tier (do SKILL.md) + métricas (telemetria) → input da régua de regras. */
+    private function mergeMetrics(array $skills, array $agg): array
+    {
+        [$t30, $t60] = [$agg['total_sessions_30d'], $agg['total_sessions_60d']];
+        $out = [];
+        foreach ($skills as $name => $s) {
+            $m = $agg['per_skill'][$name] ?? ['sessions_30d' => 0, 'sessions_60d' => 0, 'triggers_90d' => 0];
+            $out[] = [
+                'name' => $name, 'tier' => $s['tier'],
+                'sessions_30d' => $m['sessions_30d'], 'sessions_60d' => $m['sessions_60d'], 'triggers_90d' => $m['triggers_90d'],
+                'total_sessions_30d' => $t30, 'total_sessions_60d' => $t60,
+                'usage_30d_pct' => $t30 > 0 ? round($m['sessions_30d'] / $t30 * 100, 1) : 0.0,
+                'usage_60d_pct' => $t60 > 0 ? round($m['sessions_60d'] / $t60 * 100, 1) : 0.0,
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Aplica as 4 regras da ADR 0095. PURO — testável sem DB nem filesystem.
+     *
+     * @param  array<int, array<string, mixed>>  $skills  rows de mergeMetrics()
+     * @return array<int, array<string, mixed>>  sugestões
+     */
+    public static function evaluateRules(array $skills, int $minSessions = self::MIN_SESSIONS): array
+    {
+        $out = [];
+        foreach ($skills as $s) {
+            if ($s['tier'] === 'B' && $s['total_sessions_30d'] >= $minSessions && $s['usage_30d_pct'] >= 80.0) {
+                $out[] = self::suggestion($s['name'], 'B', 'A', 'B→A uso ≥80% 30d',
+                    sprintf('uso %s%% em 30d (%d/%d sessões)', self::pct($s['usage_30d_pct']), $s['sessions_30d'], $s['total_sessions_30d']),
+                    auto: false, needsAdr: true, needsHistorical: false);
+            } elseif ($s['tier'] === 'B' && $s['total_sessions_60d'] >= $minSessions && $s['usage_60d_pct'] < 10.0) {
+                $out[] = self::suggestion($s['name'], 'B', 'C', 'B→C uso <10% 60d',
+                    sprintf('uso %s%% em 60d (%d/%d sessões)', self::pct($s['usage_60d_pct']), $s['sessions_60d'], $s['total_sessions_60d']),
+                    auto: true, needsAdr: false, needsHistorical: false);
+            } elseif ($s['tier'] === 'C' && $s['triggers_90d'] === 0) {
+                $out[] = self::suggestion($s['name'], 'C', 'arquivar', 'C→arquivar sem uso >90d',
+                    '0 eventos em 90d (verificar que nenhum charter de mission referencia)',
+                    auto: false, needsAdr: false, needsHistorical: true);
+            }
+            // tier A: A→B só por regressão consciente do Wagner (manual — nunca auto).
+        }
+
+        return $out;
+    }
+
+    private static function suggestion(string $skill, string $from, string $to, string $rule, string $reason, bool $auto, bool $needsAdr, bool $needsHistorical): array
+    {
+        return compact('skill', 'from', 'to', 'rule', 'reason', 'auto', 'needsAdr', 'needsHistorical');
+    }
+
+    private static function pct(float $v): string
+    {
+        return rtrim(rtrim(number_format($v, 1, '.', ''), '0'), '.');
+    }
+
+    /** Aplica SÓ B→C (auto). Promoção/arquivamento NUNCA são auto-aplicados. */
+    private function applyTrivialDemotions(array $suggestions, array $skills): array
+    {
+        $applied = [];
+        foreach ($suggestions as $sg) {
+            $path = ($sg['auto'] ?? false) ? ($skills[$sg['skill']]['path'] ?? null) : null;
+            if ($path === null || ! is_file($path)) {
+                continue;
+            }
+            $content = (string) file_get_contents($path);
+            $new = self::applyDemotion($content, $sg['from'], $sg['to']);
+            if ($new !== $content) {
+                file_put_contents($path, $new);
+                $applied[] = $sg['skill'];
+            }
+        }
+
+        return $applied;
+    }
+
+    /** Reescreve só a linha `tier: <from>` → `tier: <to>` no frontmatter. PURO + idempotente. */
+    public static function applyDemotion(string $content, string $from, string $to): string
+    {
+        return preg_replace('/^(tier:[ \t]*)'.preg_quote($from, '/').'[ \t]*$/m', '${1}'.$to, $content, 1) ?? $content;
+    }
+
+    /** Rótulo de trimestre AAAA-QN a partir de uma data. PURO. */
+    public static function quarterLabel(\DateTimeInterface $d): string
+    {
+        return $d->format('Y').'-Q'.(int) ceil(((int) $d->format('n')) / 3);
+    }
+
+    /**
+     * Renderiza a seção markdown da run. PURO. SÓ agregados — `context_payload`
+     * NUNCA é recebido nem emitido (LGPD · hook pii-redactor).
+     */
+    public static function renderReportSection(array $ctx): string
+    {
+        $tc = $ctx['tier_counts'];
+        $withTier = ($tc['A'] ?? 0) + ($tc['B'] ?? 0) + ($tc['C'] ?? 0);
+        $semTier = $ctx['total_skills'] - $withTier;
+
+        $l = [];
+        $l[] = sprintf('## Run %s (%s) — --since=%d · apply=%s', $ctx['now_str'], $ctx['quarter'], $ctx['since'], $ctx['apply'] ? 'sim' : 'não');
+        $l[] = '';
+        $l[] = sprintf('- Skills analisadas: **%d** (com tier: %d · sem tier: %d %s catraca)', $ctx['total_skills'], $withTier, $semTier, $semTier === 0 ? '✅' : '❌');
+        $l[] = sprintf('- Distribuição de tier: A=%d · B=%d · C=%d', $tc['A'] ?? 0, $tc['B'] ?? 0, $tc['C'] ?? 0);
+        $l[] = sprintf('- Telemetria: %d eventos · %d skills com uso · sessões-proxy 30d=%d · 60d=%d', $ctx['events'], $ctx['skills_with_use'], $ctx['total_sessions_30d'], $ctx['total_sessions_60d']);
+        $l[] = '';
+        $l[] = sprintf('### Sugestões (%d)', count($ctx['suggestions']));
+        if ($ctx['suggestions'] === []) {
+            $l[] = '_Nenhuma — distribuição de tier saudável pra esta janela._';
+        } else {
+            $l[] = '| Skill | De | Para | Regra | Motivo | Ação |';
+            $l[] = '|---|---|---|---|---|---|';
+            foreach ($ctx['suggestions'] as $s) {
+                $acao = $s['needsAdr'] ? '⚠️ EXIGE ADR (nunca auto)' : ($s['needsHistorical'] ? 'requer ADR HISTORICAL + Wagner' : ($s['auto'] ? 'auto-aplicável (B→C)' : 'manual'));
+                $l[] = sprintf('| %s | %s | %s | %s | %s | %s |', $s['skill'], $s['from'], $s['to'], $s['rule'], $s['reason'], $acao);
+            }
+        }
+        $l[] = '';
+        $l[] = '### Aplicado nesta run';
+        $l[] = $ctx['applied'] === [] ? '- (nenhum rebaixamento aplicado)' : '- B→C aplicado: '.implode(', ', $ctx['applied']);
+        $l[] = '';
+        $l[] = '> ⚠️ Apenas agregados. `context_payload` NUNCA é gravado aqui (LGPD · ADR 0093 + hook pii-redactor).';
+
+        return implode("\n", $l)."\n";
+    }
+
+    private function appendReport(string $path, string $section): void
+    {
+        if (! is_dir($dir = dirname($path))) {
+            mkdir($dir, 0775, true);
+        }
+        $header = is_file($path) ? '' : (
+            "# Skill Tier Review — loop telemetria→tier (ADR 0095)\n\n"
+            ."> Append-only. Cada run de `php artisan skills:tier-review` adiciona uma seção.\n"
+            ."> SÓ agregados; `context_payload` NUNCA é gravado (pode conter PII). Parte B do T7.\n\n"
+        );
+        file_put_contents($path, $header.$section, FILE_APPEND);
+    }
+
+    private function renderConsole(array $tierCounts, array $suggestions, array $applied, string $reportPath, bool $apply): void
+    {
+        $this->newLine();
+        $this->info(sprintf('Skill Tier Review — A=%d B=%d C=%d', $tierCounts['A'] ?? 0, $tierCounts['B'] ?? 0, $tierCounts['C'] ?? 0));
+        if ($suggestions === []) {
+            $this->line('Nenhuma sugestão pra esta janela.');
+        } else {
+            $this->table(['Skill', 'De', 'Para', 'Motivo', 'Ação'], array_map(static fn ($s) => [
+                $s['skill'], $s['from'], $s['to'], $s['reason'],
+                $s['needsAdr'] ? 'EXIGE ADR' : ($s['needsHistorical'] ? 'ADR HISTORICAL' : ($s['auto'] ? 'auto B→C' : 'manual')),
+            ], $suggestions));
+        }
+        $this->line($apply
+            ? ($applied === [] ? 'Nada aplicado.' : 'Aplicado (B→C): '.implode(', ', $applied))
+            : 'Read-only. Use --apply-suggestions pra aplicar SÓ rebaixamentos triviais (B→C).');
+        $this->line('Relatório: '.$reportPath);
+        $this->newLine();
+    }
+}

--- a/Modules/Brief/Providers/BriefServiceProvider.php
+++ b/Modules/Brief/Providers/BriefServiceProvider.php
@@ -4,6 +4,7 @@ namespace Modules\Brief\Providers;
 
 use Illuminate\Support\ServiceProvider;
 use Modules\Brief\Console\Commands\GenerateBriefCommand;
+use Modules\Brief\Console\Commands\SkillTierReviewCommand;
 
 /**
  * ServiceProvider do módulo Brief.
@@ -35,6 +36,7 @@ class BriefServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 GenerateBriefCommand::class,
+                SkillTierReviewCommand::class,
             ]);
         }
     }

--- a/Modules/Brief/Tests/Feature/SkillTierReviewCommandTest.php
+++ b/Modules/Brief/Tests/Feature/SkillTierReviewCommandTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Brief\Console\Commands\SkillTierReviewCommand as Cmd;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Parte B do T7 — loop telemetria→tier (ADR 0095). Testa a régua de regras, o
+ * parser-catraca ("0 skills sem tier"), idempotência e PII-guard via os métodos
+ * PUROS do command — sem DB nem filesystem (hermético = roda no CT 100 sem prod).
+ *
+ * @see Modules/Brief/Console/Commands/SkillTierReviewCommand.php
+ * @see memory/decisions/0095-skills-tiers-convencao-interna.md
+ */
+function tierRow(array $over = []): array
+{
+    return array_merge([
+        'name' => 'skill-x', 'tier' => 'B', 'sessions_30d' => 0, 'sessions_60d' => 0, 'triggers_90d' => 0,
+        'total_sessions_30d' => 100, 'total_sessions_60d' => 100, 'usage_30d_pct' => 0.0, 'usage_60d_pct' => 0.0,
+    ], $over);
+}
+
+it('cenário 1: B→A com uso ≥80% em 30d é SUGESTÃO que exige ADR (nunca auto)', function () {
+    $s = Cmd::evaluateRules([tierRow(['usage_30d_pct' => 85.0, 'sessions_30d' => 42, 'total_sessions_30d' => 50])]);
+    expect($s)->toHaveCount(1);
+    expect([$s[0]['to'], $s[0]['auto'], $s[0]['needsAdr']])->toBe(['A', false, true]);
+});
+
+it('cenário 2: B→C com uso <10% em 60d é rebaixamento trivial auto-aplicável', function () {
+    $s = Cmd::evaluateRules([tierRow(['usage_30d_pct' => 4.0, 'usage_60d_pct' => 5.0, 'sessions_60d' => 2, 'total_sessions_60d' => 40])]);
+    expect($s)->toHaveCount(1);
+    expect([$s[0]['to'], $s[0]['auto']])->toBe(['C', true]);
+});
+
+it('cenário 3: C→arquivar sem uso >90d é SUGESTÃO que exige ADR HISTORICAL', function () {
+    $s = Cmd::evaluateRules([tierRow(['tier' => 'C', 'triggers_90d' => 0])]);
+    expect($s)->toHaveCount(1);
+    expect([$s[0]['to'], $s[0]['auto'], $s[0]['needsHistorical']])->toBe(['arquivar', false, true]);
+});
+
+it('cenário 4: tier A nunca gera sugestão automática (A→B só por decisão do Wagner)', function () {
+    expect(Cmd::evaluateRules([
+        tierRow(['tier' => 'A', 'usage_30d_pct' => 2.0, 'usage_60d_pct' => 1.0, 'total_sessions_60d' => 80]),
+        tierRow(['tier' => 'A', 'usage_30d_pct' => 99.0]),
+    ]))->toBe([]);
+});
+
+it('cenário 5: tier B saudável (uso 10%–80%) não gera sugestão', function () {
+    expect(Cmd::evaluateRules([tierRow(['usage_30d_pct' => 40.0, 'usage_60d_pct' => 35.0, 'total_sessions_60d' => 90])]))->toBe([]);
+});
+
+it('guard anti-ruído: poucas sessões (< MIN_SESSIONS) não rebaixa mesmo com 0% de uso', function () {
+    expect(Cmd::evaluateRules([tierRow(['usage_60d_pct' => 0.0, 'total_sessions_30d' => 3, 'total_sessions_60d' => 3])]))->toBe([]);
+});
+
+it('idempotência: evaluateRules é determinística e applyDemotion B→C é no-op na 2ª passada', function () {
+    $rows = [tierRow(['usage_30d_pct' => 90.0, 'sessions_30d' => 45, 'total_sessions_30d' => 50]), tierRow(['tier' => 'C', 'triggers_90d' => 0])];
+    expect(Cmd::evaluateRules($rows))->toBe(Cmd::evaluateRules($rows));
+
+    $once = Cmd::applyDemotion("---\nname: foo\ntier: B\n---\nbody", 'B', 'C');
+    expect($once)->toContain('tier: C')->not->toContain('tier: B');
+    expect(Cmd::applyDemotion($once, 'B', 'C'))->toBe($once);
+});
+
+it('PII-guard: telemetria nunca seleciona context_payload e o relatório só tem agregados', function () {
+    expect(Cmd::telemetrySelectColumns())->not->toContain('context_payload');
+
+    $report = Cmd::renderReportSection([
+        'now_str' => '2026-06-20 06:40', 'quarter' => '2026-Q2', 'since' => 90, 'apply' => false,
+        'total_skills' => 70, 'tier_counts' => ['A' => 8, 'B' => 51, 'C' => 11],
+        'total_sessions_30d' => 40, 'total_sessions_60d' => 75, 'events' => 900, 'skills_with_use' => 33,
+        'suggestions' => [['skill' => 'foo', 'from' => 'B', 'to' => 'C', 'rule' => 'B→C uso <10% 60d', 'reason' => 'uso 5% em 60d', 'auto' => true, 'needsAdr' => false, 'needsHistorical' => false]],
+        'applied' => [],
+    ]);
+    expect($report)->toContain('LGPD');
+    expect(substr_count($report, 'context_payload'))->toBe(1); // só na frase-guard, nunca como dado
+});
+
+it('catraca parser: tier ausente vira null e quarterLabel resolve o trimestre da run', function () {
+    expect(Cmd::parseTier("---\nname: foo\ntier: A\n---\nx"))->toBe('A');
+    expect(Cmd::parseTier("---\ntier:B\n---"))->toBe('B');
+    expect(Cmd::parseTier("---\ntier: c\n---"))->toBe('C');           // case-insensitive
+    expect(Cmd::parseTier("---\nname: foo\nowner: wagner\n---\nx"))->toBeNull();
+    expect(Cmd::quarterLabel(new DateTimeImmutable('2026-06-20')))->toBe('2026-Q2');
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -182,6 +182,24 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Parte B do T7 (auditoria IA OS) — loop telemetria→tier de skills (ADR 0095).
+        // Trimestral: emite relatório APPEND-ONLY em memory/governance/skill-tier-review-AAAA-QN.md
+        // com sugestões de promoção/rebaixamento. NÃO auto-aplica (sem --apply-suggestions):
+        // B→A exige ADR, C→arquivar exige ADR HISTORICAL. quarterlyOn(1, '06:40') = 1º dia de
+        // cada trimestre, ancorado no eixo 06:00-06:50 BRT (após jana:health-check 06:00).
+        // Cross-tenant intencional (mcp_skill_telemetry é governança, sem business_id — ADR 0093).
+        // Hostinger ≠ CT 100 (ADR 0062): só artisan + schedule, sem daemon.
+        $schedule->command('skills:tier-review')
+            ->quarterlyOn(1, '06:40')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule skills:tier-review FALHOU — investigar storage/logs/laravel.log'
+                );
+            });
+
         // Distiller-módulo-verdade ([ADR 0291] · keystone SDD×memória, peça 2).
         // Reescreve as portas BRIEFING.md a partir dos eventos recentes (diário→manual).
         // COMENTADO DE PROPÓSITO: D-E exige gate Wagner/CT100 (smoke skim 10min/lote) —


### PR DESCRIPTION
## Parte B do T7 (auditoria IA OS) — loop telemetria → tier

A Parte A (#3067) gravou `tier:` no frontmatter das ~70 skills (catraca 70/70). Esta é a **Parte B**: o loop que fecha o ciclo — telemetria → sugestão de promoção/rebaixamento, ancorado na **ADR 0095**.

### O que entra
- **`Modules/Brief/Console/Commands/SkillTierReviewCommand.php`** — `php artisan skills:tier-review {--since=90} {--apply-suggestions}`
  - parseia o `tier:` das `.claude/skills/*/SKILL.md` (catraca **"0 skills sem tier"** → falha se a Parte A regredir);
  - lê uso real em `mcp_skill_telemetry` (produtor: `BriefFetchTool::logSkillTelemetry`);
  - aplica as **4 regras da ADR 0095**:

  | Regra | Critério | Ação |
  |---|---|---|
  | B→A | uso ≥80% em 30d | **SUGESTÃO** — exige ADR nova, **nunca** auto |
  | B→C | uso <10% em 60d | rebaixamento **trivial** — auto via `--apply-suggestions` |
  | C→arquivar | sem uso >90d | **SUGESTÃO** — exige ADR HISTORICAL + Wagner |
  | A→B | regressão consciente do Wagner | manual — nunca calculado aqui |

- **Default READ-ONLY** (só relatório). `--apply-suggestions` aplica **SÓ** B→C (nunca promove a A nem arquiva).
- **Relatório append-only** em `memory/governance/skill-tier-review-AAAA-QN.md` — **só agregados** (counts/%); `context_payload` **NUNCA** é gravado (pode conter PII — LGPD · ADR 0093 + hook pii-redactor).
- **Schedule quarterly** em `app/Console/Kernel.php` (`quarterlyOn(1, '06:40')` BRT, ancorado no `jana:health-check` 06:00) — emite o relatório, **não** auto-aplica.
- **Teste Pest hermético** (`SkillTierReviewCommandTest`): 5 cenários de regra + guard anti-ruído + idempotência + PII-guard + parser-catraca. Sem DB/filesystem → roda no CT 100 sem prod.

### Tier 0 / decisões respeitadas
- `mcp_skill_telemetry` é tabela de **governança cross-tenant** — sem `business_id` e **não deve ter** (exceção superadmin, ADR 0093). As queries rodam sem global scope, sem `businessId`.
- **Hostinger ≠ CT 100** (ADR 0062): só comando artisan + schedule, sem daemon.
- "Sessão" é aproximada pelo par distinto `(agent_id, dia)` — `mcp_skill_telemetry` não tem `session_id`. Proxy honesto e documentado no código + no cabeçalho do relatório.

### Validação local
- `php -l` limpo nos 4 arquivos.
- Smoke da lógica pura (parser, 4 regras, agregação por sessão-proxy, idempotência, PII-guard, quarterLabel) — **29/29 checks OK** (Pest não roda local — CT 100 only).

### Nota de tamanho
424 linhas: comando (317) + teste (87) + registro/schedule (20). Acima do alvo de 300, mas é **1 intent coeso** (comando + teste hermético); dividir significaria mergear código sem teste. Posso quebrar se preferir.

---

## Infra Contract

**Sem rota HTTP testável** — esta mudança é **comando artisan + schedule**, não runtime HTTP. O gate disparou porque o PR toca `Modules/Brief/Providers/BriefServiceProvider.php`, mas a edição ali é **registro de comando CLI** dentro de `if ($this->app->runningInConsole())` — **zero impacto em request/middleware/routing**. O `Kernel.php` tocado é `app/Console/Kernel.php` (scheduler), **não** `app/Http/Kernel.php`.

### 1. Happy path — comando + output esperado (read-only, default)

```bash
$ php artisan skills:tier-review

Skill Tier Review — A=8 B=51 C=11
Nenhuma sugestão pra esta janela.        # (ou tabela De/Para/Motivo/Ação se houver)
Read-only. Use --apply-suggestions pra aplicar SÓ rebaixamentos triviais (B→C).
Relatório: .../memory/governance/skill-tier-review-2026-Q2.md
```

- Exit code **0** em caso normal; **1** (FAILURE) só se a catraca "0 skills sem tier" quebrar.
- READ-ONLY por default: NÃO toca SKILL.md, NÃO promove a A, NÃO arquiva. Só lê telemetria + escreve o relatório append-only.

### 2. Regression adjacent — o que NÃO muda

- Nenhuma rota HTTP, middleware ou provider de request alterado. `GenerateBriefCommand` segue registrado e intacto (só foi **adicionado** `SkillTierReviewCommand` ao array `commands()`).
- `php artisan list | grep -E 'skills:tier-review|brief:generate'` deve listar ambos.

### 3. Environment delta — Pest local NÃO prova prod

- Pest **não roda local** (CT 100 only). A lógica de regras/parser/agregação é coberta por teste **hermético** (sem DB) + smoke de lógica pura (29/29 OK).
- A leitura real de `mcp_skill_telemetry` só acontece em prod (Hostinger), onde a tabela é alimentada pelo `BriefFetchTool`. Validação prod = rodar `php artisan skills:tier-review` no servidor e conferir o relatório gerado.

### 4. Smoke prod pós-deploy (preencher após merge + git pull Hostinger)

```bash
# (timestamp + colar saída real de `php artisan skills:tier-review` aqui pós-deploy)
```

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `skills:tier-review` (read-only) | exit 0 + relatório AAAA-QN.md gerado | _(pós-deploy)_ | ⬜ |
| catraca íntegra | "sem tier: 0 ✅" no relatório | _(pós-deploy)_ | ⬜ |

> Review do Wagner antes do merge. Promoções a Tier A e arquivamentos **nunca** são automáticos — sempre passam por ADR.
