### PR TITLE
feat(jana): bi-temporal time-travel — slice 2 (memoria-historica + buscarHistorico, ADR 0295 T4)

### DIFF
--- a/.github/workflows/jana-bitemporal-slice2-pest.yml
+++ b/.github/workflows/jana-bitemporal-slice2-pest.yml
@@ -1,0 +1,92 @@
+name: Jana bi-temporal Pest (T4 slice 2)
+
+# ADR 0295 (slice 2) — verifica a LOGICA pura das helpers do time-travel
+# (HistoricoMemoriaService::normalizarAsOf + violacaoCrossTenant) no CI.
+# Escopo ESTREITO: roda SO o HistoricoMemoriaServiceTest (pura-logica, sem DB),
+# nao o modulo Jana inteiro. A parte que toca DB (buscarHistorico) e exercitada
+# na lane MySQL (jana-pest.yml allowlist) e no CT 100. Extensoes casam com
+# modules-pest.yml (composer.lock exige opentelemetry/gd/pdo_mysql).
+#
+# SEM filtro `branches: [main]` de proposito: este PR e EMPILHADO sobre o slice 1
+# (base = feat/bitemporal-jana-t4-slice1 enquanto #3073 nao mergeia). Restringir
+# a main faria o gate nao disparar no PR empilhado. Roda em qualquer base que
+# toque os paths abaixo; quando o slice 1 mergear e o PR retargetar main, segue
+# rodando.
+
+on:
+  pull_request:
+    paths:
+      - 'Modules/Jana/Services/Memoria/HistoricoMemoriaService.php'
+      - 'Modules/Jana/Tests/Unit/HistoricoMemoriaServiceTest.php'
+      - 'Modules/Jana/Mcp/Tools/MemoriaHistoricaTool.php'
+      - '.github/workflows/jana-bitemporal-slice2-pest.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: jana-bitemporal-slice2-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pest:
+    name: Pest HistoricoMemoriaService (logica pura)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: bcmath, ctype, dom, fileinfo, intl, json, mbstring, openssl, pdo, pdo_sqlite, pdo_mysql, tokenizer, xml, zip, gd, opentelemetry
+          tools: composer:v2
+          coverage: none
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-
+
+      - name: Prepare dirs
+        run: mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+
+      - name: Install PHP deps
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+      - name: Create .env
+        run: |
+          printf '%s\n' \
+            'APP_NAME=oimpresso-ci' \
+            'APP_ENV=testing' \
+            'APP_DEBUG=true' \
+            'APP_URL=http://localhost' \
+            'LOG_CHANNEL=stderr' \
+            'DB_CONNECTION=sqlite' \
+            'DB_DATABASE=:memory:' \
+            'CACHE_DRIVER=array' \
+            'QUEUE_CONNECTION=sync' \
+            'SESSION_DRIVER=array' \
+            'MAIL_MAILER=array' \
+            'BCRYPT_ROUNDS=4' \
+            'TELESCOPE_ENABLED=false' \
+            'SCOUT_DRIVER=null' \
+            'MCP_TOOLS_EXPOSED=false' > .env
+          php artisan key:generate
+          php artisan package:discover --ansi
+
+      - name: Run Pest (HistoricoMemoriaService)
+        env:
+          APP_ENV: testing
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ":memory:"
+          CACHE_DRIVER: array
+          SESSION_DRIVER: array
+          QUEUE_CONNECTION: sync
+        run: |
+          vendor/bin/pest Modules/Jana/Tests/Unit/HistoricoMemoriaServiceTest.php \
+            --no-coverage \
+            --colors=always

--- a/.github/workflows/jana-pest.yml
+++ b/.github/workflows/jana-pest.yml
@@ -115,7 +115,8 @@ jobs:
           mkdir -p test-results
           vendor/bin/pest --no-coverage --colors=always \
             --log-junit test-results/pest-jana-junit.xml \
-            Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php
+            Modules/Jana/Tests/Feature/Mcp/ImmutabilityTriggersTest.php \
+            Modules/Jana/Tests/Feature/Memoria/BuscarHistoricoTest.php
 
       - name: Upload JUnit (Jana · MySQL)
         if: ${{ !cancelled() && steps.changes.outputs.jana == 'true' }}

--- a/Modules/Jana/Entities/MemoriaFato.php
+++ b/Modules/Jana/Entities/MemoriaFato.php
@@ -20,6 +20,13 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * Indexa em Meilisearch via Scout. toSearchableArray controla o que vai pro index.
  *
  * Ver ADRs 0031/0033/0036/0090.
+ *
+ * Colunas bi-temporais (ADR 0295) ainda fora do schema-dump que o Larastan lê;
+ * anotadas aqui pra resolução de tipo (event-time + link de supersede).
+ *
+ * @property \Illuminate\Support\Carbon|null $event_valid_from  event-time: quando passou a valer no mundo
+ * @property \Illuminate\Support\Carbon|null $event_valid_until event-time: quando deixou de valer no mundo
+ * @property int|null                        $supersedes_id     link explícito pro fato que este substitui
  */
 class MemoriaFato extends Model
 {

--- a/Modules/Jana/Mcp/OimpressoMcpServer.php
+++ b/Modules/Jana/Mcp/OimpressoMcpServer.php
@@ -86,6 +86,10 @@ class OimpressoMcpServer extends Server
         // ─── PAGE 2 (cliente precisa paginar pra carregar) ───
         Tools\ClaudeCodeUsageSelfTool::class,
         Tools\MemoriaSearchTool::class,
+        // ADR 0295 (T4 slice 2) — time-travel bi-temporal: "o que valia em as_of?".
+        // Espelha memoria-search mas via Eloquent direto (HistoricoMemoriaService),
+        // pra alcançar fatos superseded que ficam fora do index Meilisearch.
+        Tools\MemoriaHistoricaTool::class,
         Tools\CcSearchTool::class,
         // ADR 0119 Tier 1 — coordenação entre sessões Claude (alerta passivo,
         // não lock). Agregação derivada de mcp_cc_sessions + mcp_cc_messages.

--- a/Modules/Jana/Mcp/Tools/MemoriaHistoricaTool.php
+++ b/Modules/Jana/Mcp/Tools/MemoriaHistoricaTool.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Mcp\Tools;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Services\Memoria\HistoricoMemoriaService;
+
+/**
+ * memoria-historica (ADR 0295, T4 slice 2) — TIME-TRAVEL na memoria Jana.
+ *
+ * Espelha MemoriaSearchTool, mas em vez de buscar fatos ATUAIS, responde "quais
+ * fatos eram EVENT-validos em as_of?" (bi-temporal event-time). Usa Eloquent
+ * DIRETO (HistoricoMemoriaService) — NUNCA Scout: o fato superseded que o
+ * time-travel precisa ver fica fora do index Meilisearch.
+ *
+ * Cross-tenant safety (ADR 0093): user so acessa o proprio business (superadmin
+ * qualquer) — MESMA checagem do MemoriaSearchTool. Scope business_id + user_id.
+ */
+class MemoriaHistoricaTool extends Tool
+{
+    protected string $name = 'memoria-historica';
+
+    protected string $title = 'Time-travel na memória do Copiloto';
+
+    protected string $description = 'Time-travel na memória do Copiloto (jana_memoria_facts): retorna os fatos que eram EVENT-válidos num instante (as_of), INCLUSIVE fatos já superseded — que não aparecem no memoria-search. Use pra "o que valia em DD/MM?" (bi-temporal event-time, ADR 0295).';
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'as_of' => $schema->string()
+                ->description('Instante-mundo de referência (ex: "2026-04-15" ou "2026-04-15 10:00:00"). Omitido = agora (estado atual).'),
+            'business_id' => $schema->integer()
+                ->min(1)
+                ->description('Business ID alvo. Se omitido, usa o business do user autenticado.'),
+            'user_id' => $schema->integer()
+                ->min(1)
+                ->description('User ID alvo dentro do business. Se omitido, usa o próprio user autenticado.'),
+            'limit' => $schema->integer()
+                ->min(1)
+                ->max(20)
+                ->default(5)
+                ->description('Quantos fatos retornar (default 5, max 20)'),
+        ];
+    }
+
+    public function handle(Request $request): Response
+    {
+        $asOfRaw = $request->get('as_of');
+        $bizParaBusca = (int) ($request->get('business_id') ?? 0);
+        $userParaBusca = (int) ($request->get('user_id') ?? 0);
+        $limit = max(1, min(20, (int) $request->get('limit', 5)));
+
+        $user = $request->user();
+        if ($user === null) {
+            return Response::error('Autenticação requerida.');
+        }
+
+        // Resolve business_id: parâmetro OR user.business_id
+        if ($bizParaBusca === 0) {
+            $bizParaBusca = (int) ($user->business_id ?? 0);
+        }
+
+        // Cross-tenant safety (espelha MemoriaSearchTool): user só acessa o
+        // próprio business — exceto superadmin (ADR 0093).
+        $isSuperadmin = method_exists($user, 'hasRole') && $user->hasRole('superadmin');
+        if (HistoricoMemoriaService::violacaoCrossTenant((int) ($user->business_id ?? 0), $bizParaBusca, $isSuperadmin)) {
+            return Response::error(sprintf(
+                'Cross-tenant violation: user biz=%d tentou acessar biz=%d',
+                (int) ($user->business_id ?? 0),
+                $bizParaBusca,
+            ));
+        }
+
+        if ($bizParaBusca === 0) {
+            return Response::error('business_id não pôde ser resolvido.');
+        }
+
+        // user_id default = próprio user autenticado (memória pessoal — scope ADR 0093)
+        if ($userParaBusca === 0) {
+            $userParaBusca = (int) ($user->id ?? 0);
+        }
+        if ($userParaBusca === 0) {
+            return Response::error('user_id não pôde ser resolvido.');
+        }
+
+        $asOf = HistoricoMemoriaService::normalizarAsOf($asOfRaw);
+        $fatos = app(HistoricoMemoriaService::class)
+            ->buscarHistorico($bizParaBusca, $userParaBusca, $asOf, $limit);
+
+        if ($fatos->isEmpty()) {
+            return Response::text(sprintf(
+                "Nenhum fato event-válido em %s (biz=%d, user=%d).",
+                $asOf->toDateTimeString(),
+                $bizParaBusca,
+                $userParaBusca,
+            ));
+        }
+
+        $output = sprintf(
+            "%d fato(s) event-válido(s) em %s (time-travel):\n\n",
+            $fatos->count(),
+            $asOf->toDateTimeString(),
+        );
+        foreach ($fatos as $f) {
+            $meta = $f->metadata ?? [];
+            $cat = (string) ($meta['categoria'] ?? '');
+
+            $output .= "## Fato #{$f->id}";
+            if ($cat !== '') {
+                $output .= " [{$cat}]";
+            }
+            $output .= $f->valid_until !== null ? ' · (superseded no sistema)' : ' · (ativo)';
+            $output .= "\n".$f->fato."\n";
+            $ev = $f->event_valid_from?->toDateTimeString() ?? 'desde sempre';
+            $ate = $f->event_valid_until?->toDateTimeString() ?? 'ainda vale';
+            $output .= "_Event-time: {$ev} → {$ate}_\n\n";
+        }
+
+        return Response::text($output);
+    }
+}

--- a/Modules/Jana/Services/Memoria/HistoricoMemoriaService.php
+++ b/Modules/Jana/Services/Memoria/HistoricoMemoriaService.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Memoria;
+
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Modules\Jana\Entities\MemoriaFato;
+use Modules\Jana\Scopes\ScopeByBusiness;
+
+/**
+ * HistoricoMemoriaService — TIME-TRAVEL na memoria Jana (ADR 0295, T4 slice 2).
+ *
+ * Responde "quais fatos eram EVENT-validos no instante T?" usando o event-time
+ * (event_valid_from/until) adicionado no slice 1. O predicado puro vive em
+ * BiTemporalResolver::vigenteEm() (testado no slice 1); aqui ele vira SQL.
+ *
+ * Por que Eloquent/SQL DIRETO e NUNCA Scout: MemoriaFato::shouldBeSearchable()
+ * so indexa fatos ativos (valid_until = NULL). Time-travel busca justamente os
+ * fatos SUPERSEDED (valid_until preenchido), que ficam FORA do index Meilisearch
+ * — buscar via Scout voltaria vazio.
+ */
+class HistoricoMemoriaService
+{
+    /**
+     * Fatos EVENT-validos em $asOf, scoped por business + user.
+     *
+     * Predicado event-time (espelha BiTemporalResolver::vigenteEm em SQL):
+     *   (event_valid_from IS NULL OR event_valid_from <= asOf)   -- inicio inclusivo
+     *   AND (event_valid_until IS NULL OR event_valid_until > asOf) -- fim exclusivo
+     * null-from = "desde sempre"; null-until = "ainda vale"; legado (ambos null)
+     * = sempre event-valido.
+     *
+     * Multi-tenant Tier 0 (ADR 0093): escapamos o ScopeByBusiness (MCP/CLI nao tem
+     * session de business) e filtramos business_id + user_id EXPLICITOS. SoftDeletes
+     * permanece (fatos esquecidos via LGPD ficam fora).
+     *
+     * @return Collection<int, MemoriaFato>
+     */
+    public function buscarHistorico(int $businessId, int $userId, mixed $asOf, int $limit = 5): Collection
+    {
+        $ts = self::normalizarAsOf($asOf);
+        $limit = max(1, min(50, $limit));
+
+        // SUPERADMIN/MCP: sem session de business, escape consciente do scope +
+        // filtro manual business_id+user_id (ADR 0093). Ver HasBusinessScope.
+        return MemoriaFato::withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('user_id', $userId)
+            ->where(function ($q) use ($ts) {
+                $q->whereNull('event_valid_from')
+                    ->orWhere('event_valid_from', '<=', $ts);
+            })
+            ->where(function ($q) use ($ts) {
+                $q->whereNull('event_valid_until')
+                    ->orWhere('event_valid_until', '>', $ts);
+            })
+            ->orderByDesc('event_valid_from')
+            ->orderByDesc('id')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
+     * Normaliza o as_of pra Carbon. FAILSAFE — nunca lanca; null/''/lixo => agora
+     * (time-travel sem instante de referencia = estado atual). Espelha o parse
+     * tolerante do BiTemporalResolver.
+     */
+    public static function normalizarAsOf(mixed $asOf): Carbon
+    {
+        if ($asOf instanceof \DateTimeInterface) {
+            return Carbon::instance($asOf);
+        }
+        if ($asOf === null || $asOf === '') {
+            return Carbon::now();
+        }
+        try {
+            return Carbon::parse((string) $asOf);
+        } catch (\Throwable $e) {
+            return Carbon::now();
+        }
+    }
+
+    /**
+     * Cross-tenant guard (espelha MemoriaSearchTool): true = VIOLACAO.
+     * User comum so acessa o proprio business; superadmin acessa qualquer (ADR 0093).
+     */
+    public static function violacaoCrossTenant(?int $userBusinessId, int $alvoBusinessId, bool $isSuperadmin): bool
+    {
+        if ($isSuperadmin) {
+            return false;
+        }
+
+        return $alvoBusinessId !== (int) $userBusinessId;
+    }
+}

--- a/Modules/Jana/Tests/Feature/Memoria/BuscarHistoricoTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/BuscarHistoricoTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Modules\Jana\Entities\MemoriaFato;
+use Modules\Jana\Services\Memoria\HistoricoMemoriaService;
+
+/**
+ * Teste DB (MySQL-only) do time-travel buscarHistorico (ADR 0295, T4 slice 2).
+ *
+ * Roda na lane MySQL (allowlist jana-pest.yml) — exige as colunas event_valid_*
+ * adicionadas pela migration do slice 1. Usa DatabaseTransactions (NAO
+ * RefreshDatabase: a lane preserva schema + seed biz=1/biz=2; migrate:fresh
+ * dropa FK e envenena os demais testes da catraca).
+ *
+ * Valida: (1) filtro event-time inicio-inclusivo/fim-exclusivo, (2) fato
+ * superseded (valid_until != NULL, fora do Scout) reaparece no time-travel,
+ * (3) isolamento multi-tenant business_id + user_id (Tier 0, ADR 0093).
+ */
+uses(Tests\TestCase::class, DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Lane MySQL (jana-pest.yml): o schema baseline + migration do slice 1 garantem
+    // as colunas event_valid_*. Skip defensivo se rodar fora de MySQL/MariaDB.
+    if (! in_array(DB::connection()->getDriverName(), ['mysql', 'mariadb'], true)) {
+        $this->markTestSkipped('buscarHistorico exercitado na lane MySQL (jana-pest.yml).');
+    }
+
+    $this->service = new HistoricoMemoriaService();
+});
+
+function fatoTeste(array $attrs): MemoriaFato
+{
+    return MemoriaFato::create(array_merge([
+        'business_id' => 1,
+        'user_id' => 777001,
+        'fato' => 'fato de teste',
+    ], $attrs));
+}
+
+it('inclui fato event-valido no as_of e exclui o ja expirado (fim exclusivo)', function () {
+    $vigente = fatoTeste([
+        'fato' => 'meta trimestral 100k',
+        'event_valid_from' => '2026-01-01 00:00:00',
+        'event_valid_until' => null,
+    ]);
+    $expirado = fatoTeste([
+        'fato' => 'meta antiga 50k',
+        'event_valid_from' => '2025-01-01 00:00:00',
+        'event_valid_until' => '2026-01-01 00:00:00', // fim exclusivo: nao vale em/depois de 2026-01-01
+        'valid_until' => now(),                        // superseded no sistema => fora do Scout
+    ]);
+
+    $ids = $this->service->buscarHistorico(1, 777001, '2026-06-01 00:00:00')->pluck('id')->all();
+
+    expect($ids)->toContain($vigente->id)
+        ->and($ids)->not->toContain($expirado->id);
+});
+
+it('time-travel ao passado reencontra fato superseded (fora do index Meilisearch)', function () {
+    $expirado = fatoTeste([
+        'fato' => 'meta antiga 50k',
+        'event_valid_from' => '2025-01-01 00:00:00',
+        'event_valid_until' => '2026-01-01 00:00:00',
+        'valid_until' => now(),
+    ]);
+
+    $ids = $this->service->buscarHistorico(1, 777001, '2025-06-01 00:00:00')->pluck('id')->all();
+
+    expect($ids)->toContain($expirado->id);
+});
+
+it('isola por business_id e user_id (multi-tenant Tier 0)', function () {
+    $meu = fatoTeste(['user_id' => 777001]);
+    $outroUser = fatoTeste(['user_id' => 777002]);
+    $outroBiz = fatoTeste(['business_id' => 2, 'user_id' => 777001]);
+
+    $ids = $this->service->buscarHistorico(1, 777001, '2026-06-01 00:00:00')->pluck('id')->all();
+
+    expect($ids)->toContain($meu->id)
+        ->and($ids)->not->toContain($outroUser->id)
+        ->and($ids)->not->toContain($outroBiz->id);
+});

--- a/Modules/Jana/Tests/Unit/HistoricoMemoriaServiceTest.php
+++ b/Modules/Jana/Tests/Unit/HistoricoMemoriaServiceTest.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Support\Carbon;
+use Modules\Jana\Services\Memoria\HistoricoMemoriaService;
+
+/**
+ * Teste de LOGICA PURA (sem DB, sem app boot) das helpers do slice 2 (ADR 0295, T4).
+ * O predicado event-time ja e coberto pelo BiTemporalResolverTest (slice 1); aqui
+ * cobrimos normalizarAsOf (FAILSAFE) + violacaoCrossTenant (multi-tenant Tier 0).
+ * A parte que toca DB (buscarHistorico) roda na lane MySQL (jana-pest.yml).
+ */
+it('normalizarAsOf: string valida -> Carbon correspondente', function () {
+    expect(HistoricoMemoriaService::normalizarAsOf('2026-04-15 10:00:00')->toDateTimeString())
+        ->toBe('2026-04-15 10:00:00');
+});
+
+it('normalizarAsOf: null/vazio -> agora (estado atual)', function () {
+    expect(HistoricoMemoriaService::normalizarAsOf(null))->toBeInstanceOf(Carbon::class)
+        ->and(HistoricoMemoriaService::normalizarAsOf(null)->diffInMinutes(Carbon::now()))->toBeLessThan(1)
+        ->and(HistoricoMemoriaService::normalizarAsOf(''))->toBeInstanceOf(Carbon::class);
+});
+
+it('normalizarAsOf: lixo nao-parseavel -> agora (FAILSAFE, nao lanca)', function () {
+    expect(HistoricoMemoriaService::normalizarAsOf('xxx-nao-data'))->toBeInstanceOf(Carbon::class);
+});
+
+it('normalizarAsOf: DateTimeInterface -> Carbon equivalente', function () {
+    $dt = new DateTimeImmutable('2026-01-02 03:04:05');
+    expect(HistoricoMemoriaService::normalizarAsOf($dt)->toDateTimeString())->toBe('2026-01-02 03:04:05');
+});
+
+it('violacaoCrossTenant: mesmo business -> sem violacao', function () {
+    expect(HistoricoMemoriaService::violacaoCrossTenant(4, 4, false))->toBeFalse();
+});
+
+it('violacaoCrossTenant: business diferente -> VIOLACAO', function () {
+    expect(HistoricoMemoriaService::violacaoCrossTenant(4, 1, false))->toBeTrue();
+});
+
+it('violacaoCrossTenant: superadmin acessa qualquer business', function () {
+    expect(HistoricoMemoriaService::violacaoCrossTenant(4, 1, true))->toBeFalse();
+});
+
+it('violacaoCrossTenant: user sem business (null) acessando biz real -> VIOLACAO', function () {
+    expect(HistoricoMemoriaService::violacaoCrossTenant(null, 1, false))->toBeTrue();
+});

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -170,6 +170,10 @@
       "nome": "Jana bi-temporal Pest (T4 · predicado event-time BiTemporalResolver · ADR 0295)",
       "classe": "gate"
     },
+    "jana-bitemporal-slice2-pest.yml": {
+      "nome": "Jana bi-temporal Pest (T4 slice 2 · HistoricoMemoriaService normalizarAsOf/violacaoCrossTenant · ADR 0295)",
+      "classe": "gate"
+    },
     "jana-pest.yml": {
       "nome": "Jana · Pest (MySQL)",
       "classe": "gate"


### PR DESCRIPTION
Slice 2 do bi-temporal da memória Jana (ADR 0295, T4). Constrói sobre o **slice 1 (já mergeado, #3073)**: usa o schema event-time + o predicado puro `BiTemporalResolver` pra entregar **time-travel** (`as_of`): "quais fatos eram event-válidos no instante T?".

> **Sem auto-merge** — Tier-0-adjacente (memória multi-tenant). Aguarda revisão do Wagner.

## Escopo

- **`HistoricoMemoriaService::buscarHistorico($businessId, $userId, $asOf)`** — Eloquent/SQL **DIRETO, nunca Scout** (o `shouldBeSearchable()` só indexa `valid_until=NULL`, então fato superseded fica fora do índice Meilisearch — e o time-travel precisa justamente dele). Predicado event-time `(event_valid_from IS NULL OR <= asOf) AND (event_valid_until IS NULL OR > asOf)` — início inclusivo, fim exclusivo (espelha `BiTemporalResolver::vigenteEm`). Escape consciente do `ScopeByBusiness` + filtro **`business_id` + `user_id`** explícito (ADR 0093).
- **Tool MCP `memoria-historica`** — espelha `MemoriaSearchTool`, **inclusive a checagem cross-tenant superadmin** (`Response::error` em violação). Registrada no `OimpressoMcpServer` (page 2, cluster de conhecimento).
- **Testes** — lógica pura (`normalizarAsOf` FAILSAFE + `violacaoCrossTenant`) no novo job CI focado `jana-bitemporal-slice2-pest.yml` (registrado no `gates-registry.json` — senão memory-health Check G falha); a parte DB-only (`buscarHistorico`: filtro event-time, superseded reaparece, isolamento multi-tenant) na **allowlist da lane MySQL** `jana-pest.yml` (`DatabaseTransactions`, **sem** `RefreshDatabase`, skip defensivo fora de MySQL).

## Notas de revisão

- **Não rodei Pest local** (CT 100 only — hook `block-test-fora-ct100`). A lógica pura roda no novo gate; a parte DB roda na lane MySQL.
- A migration do slice 1 é aditiva (`event_valid_*` + `supersedes_id`, guards `hasTable`/`hasColumn`); o teste DB desta lane é a 1ª execução dela contra MySQL real.
- **Tamanho:** 454 linhas (> guideline 300 da `commit-discipline`). Composição: produto ~227 (tool 126 + service 97 + registros) · testes ~129 · CI/governança ~98. O excedente é scaffolding de teste + workflow CI mandados pelo escopo (job focado novo + allowlist MySQL). Posso dobrar o workflow no `jana-bitemporal-pest.yml` (−~96 linhas) se preferir.

Próximo: **slice 3** (detecção automática de update temporal via agent Haiku, atrás de flag OFF default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
