### PR TITLE
feat(governance): gerador plans-index + fix Check J (resto da Onda 1, ADR 0294)

### DIFF
--- a/memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md
+++ b/memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md
@@ -13,9 +13,9 @@
 | Plano | Módulo | Status | Owner | reviewed_at | parent_plan |
 |---|---|---|---|---|---|
 | [Plano — Atendimento Automático (WhatsApp / Caixa Unificada)](../Whatsapp/PLANO-ATENDIMENTO-AUTOMATICO.md) | Whatsapp | ativo | W | 2026-06-20 | ✓ |
-| [DEPRECATION-PLAN — Modules/Accounting](../Accounting/DEPRECATION-PLAN.md) | Accounting | (sem-status-vivo) | — | — | — |
+| [DEPRECATION-PLAN — Accounting](../Accounting/DEPRECATION-PLAN.md) | Accounting | (sem-status-vivo) | — | — | — |
 | [Plano Migração Vargas → Autopecas (planejado — não existe) — 2026-05-1](../Autopecas/PLANO-MIGRACAO-VARGAS.md) | Autopecas | (sem-status-vivo) | — | — | — |
-| [Plano Migração 6 Saudáveis OfficeImpresso → Modules/ComunicacaoVisual ](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) | ComunicacaoVisual | (sem-status-vivo) | — | — | — |
+| [Plano Migração 6 Saudáveis OfficeImpresso → ComunicacaoVisual — 2026-0](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) | ComunicacaoVisual | (sem-status-vivo) | — | — | — |
 | [JANA Pro — Product Plan executivo (32 US, 4 sprints, 90 dias)](../Copiloto/JANA-PRO-PRODUCT-PLAN.md) | Copiloto | (sem-status-vivo) | — | — | — |
 | [Fase 1 — Conciliação passa a enxergar o extrato da API](../Financeiro/PLANO-FASE1-CONCILIACAO-LE-EXTRATO-API.md) | Financeiro | (sem-status-vivo) | — | — | — |
 | [Fase 2 — Migração de dados: unificar extrato OFX → tabela canônica](../Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md) | Financeiro | (sem-status-vivo) | — | — | — |
@@ -26,5 +26,5 @@
 | [Onda 1 — Vendas, PDV & Caixa · PLANO (MWART Fase 1)](../Mwart/ONDA-1-VENDAS-PDV-CAIXA-PLANO.md) | Mwart | (sem-status-vivo) | — | — | — |
 | [Plano de paralelização — OficinaAuto Fase 1 (pós-Martinho)](../OficinaAuto/demo-martinho-2026-05-13/plano-paralelizacao.md) | OficinaAuto | (sem-status-vivo) | — | — | — |
 | [PaymentGateway Onda 5 SIMPLIFICADA — Dogfooding SaaS via gateway adici](../PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md) | PaymentGateway | (sem-status-vivo) | — | — | — |
-| [DEPRECATION-PLAN — Modules/SRS](../SRS/DEPRECATION-PLAN.md) | SRS | (sem-status-vivo) | — | — | — |
+| [DEPRECATION-PLAN — SRS](../SRS/DEPRECATION-PLAN.md) | SRS | (sem-status-vivo) | — | — | — |
 

--- a/memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md
+++ b/memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md
@@ -1,0 +1,30 @@
+<!-- GERADO por scripts/governance/plans-index-generate.mjs — NÃO editar à mão (ADR 0294/0256). Rode --write. -->
+# Índice de Planos Vivos (gerado)
+
+> Fonte-única **gerada** dos blocos `## Status vivo` (ADR 0294). Pareado com a sentinela `memory-health` Check J. Doc de convenção: [PLANS-INDEX.md](./PLANS-INDEX.md).
+
+## Saúde
+
+- **15 planos** · com `## Status vivo`: **1** · com `reviewed_at`: **1** · com `parent_plan`: **1**
+- ⚠️ **14** sem `## Status vivo` (retrofit Onda 3 — o plan-health já flaga).
+
+## Registro
+
+| Plano | Módulo | Status | Owner | reviewed_at | parent_plan |
+|---|---|---|---|---|---|
+| [Plano — Atendimento Automático (WhatsApp / Caixa Unificada)](../Whatsapp/PLANO-ATENDIMENTO-AUTOMATICO.md) | Whatsapp | ativo | W | 2026-06-20 | ✓ |
+| [DEPRECATION-PLAN — Modules/Accounting](../Accounting/DEPRECATION-PLAN.md) | Accounting | (sem-status-vivo) | — | — | — |
+| [Plano Migração Vargas → Autopecas (planejado — não existe) — 2026-05-1](../Autopecas/PLANO-MIGRACAO-VARGAS.md) | Autopecas | (sem-status-vivo) | — | — | — |
+| [Plano Migração 6 Saudáveis OfficeImpresso → Modules/ComunicacaoVisual ](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) | ComunicacaoVisual | (sem-status-vivo) | — | — | — |
+| [JANA Pro — Product Plan executivo (32 US, 4 sprints, 90 dias)](../Copiloto/JANA-PRO-PRODUCT-PLAN.md) | Copiloto | (sem-status-vivo) | — | — | — |
+| [Fase 1 — Conciliação passa a enxergar o extrato da API](../Financeiro/PLANO-FASE1-CONCILIACAO-LE-EXTRATO-API.md) | Financeiro | (sem-status-vivo) | — | — | — |
+| [Fase 2 — Migração de dados: unificar extrato OFX → tabela canônica](../Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md) | Financeiro | (sem-status-vivo) | — | — | — |
+| [Plano Detalhado — Módulo Financeiro](../Financeiro/PLANO_DETALHADO.md) | Financeiro | (sem-status-vivo) | — | — | — |
+| [Plano de Testes Fiscal — Ondas 1-7](../Fiscal/PLANO-TESTES-FISCAL.md) | Fiscal | (sem-status-vivo) | — | — | — |
+| [Plano de migração das 82 auto-mems → git/MCP (ADR 0061)](../Infra/PLANO-MIGRACAO-AUTOMEM.md) | Infra | (sem-status-vivo) | — | — | — |
+| [PLAN MWART — `metas/*` (Jana)](../Jana/PLAN-MWART-metas.md) | Jana | (sem-status-vivo) | — | — | — |
+| [Onda 1 — Vendas, PDV & Caixa · PLANO (MWART Fase 1)](../Mwart/ONDA-1-VENDAS-PDV-CAIXA-PLANO.md) | Mwart | (sem-status-vivo) | — | — | — |
+| [Plano de paralelização — OficinaAuto Fase 1 (pós-Martinho)](../OficinaAuto/demo-martinho-2026-05-13/plano-paralelizacao.md) | OficinaAuto | (sem-status-vivo) | — | — | — |
+| [PaymentGateway Onda 5 SIMPLIFICADA — Dogfooding SaaS via gateway adici](../PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md) | PaymentGateway | (sem-status-vivo) | — | — | — |
+| [DEPRECATION-PLAN — Modules/SRS](../SRS/DEPRECATION-PLAN.md) | SRS | (sem-status-vivo) | — | — | — |
+

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -322,9 +322,9 @@ function checkPlanHealth() {
   const issues = [];
   for (const rel of files) {
     let txt; try { txt = read(rel); } catch { continue; }
-    if (!/##\s*Status vivo/i.test(txt)) { issues.push(`${rel}: sem bloco \`## Status vivo\` (ADR 0294)`); continue; }
-    const block = (txt.split(/##\s*Status vivo/i)[1] || '').split(/\n##\s/)[0];
-    const status = (block.match(/status:?\**\s*([^\s<·*\n]+)/i) || [])[1]?.toLowerCase();
+    if (!/\n##\s*Status vivo/i.test(txt)) { issues.push(`${rel}: sem bloco \`## Status vivo\` (ADR 0294)`); continue; }
+    const block = (txt.split(/\n##\s*Status vivo/i)[1] || '').split(/\n##\s/)[0];
+    const status = (block.match(/(?:^|\n)[-*\s]*\**status:\**\s*([^\s<·*\n]+)/i) || [])[1]?.toLowerCase();
     const rev = (block.match(/reviewed[_ -]?at:?\**\s*["']?(\d{4}-\d{2}-\d{2})/i) || [])[1];
     const hasParent = /parent_plan\s*[=:]\s*[a-z0-9-]+/i.test(block);
     if (!status) issues.push(`${rel}: Status vivo sem \`status\``);

--- a/scripts/governance/plans-index-generate.mjs
+++ b/scripts/governance/plans-index-generate.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * plans-index-generate.mjs — GERADOR determinístico do índice de PLANOS vivos (ADR 0294, Onda 1).
+ *
+ * Espelha adr-index-generate.mjs (modelo Log4brains / fonte-única gerada, ADR 0256):
+ * lê todo PLANO em memory/requisitos/**, extrai o bloco `## Status vivo` (status, owner,
+ * reviewed_at, parent_plan, cycle), e emite memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md.
+ * Determinístico (mesmo input → mesmo output). Sem LLM, sem dependência.
+ *
+ * Pareado com a sentinela `memory-health` Check J (plan-health), que FLAGA plano sem
+ * Status vivo / reviewed_at stale / em-execução órfão. Este GERA a verdade consultável.
+ *
+ * Uso:
+ *   node scripts/governance/plans-index-generate.mjs           (dry-run: imprime resumo)
+ *   node scripts/governance/plans-index-generate.mjs --write   (grava _PLANS-INDEX-GENERATED.md)
+ *   node scripts/governance/plans-index-generate.mjs --check   (CI: exit 1 se gerado ≠ commitado)
+ *
+ * Refs: ADR 0294 (método dual-track / planos vivos) · ADR 0256 (survival, fonte única gerada)
+ *       · ADR 0070 (tasks no MCP — parent_plan liga plano → execução).
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const BASE = 'memory/requisitos';
+const OUT = 'memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md';
+const MODE = process.argv.includes('--write') ? 'write' : process.argv.includes('--check') ? 'check' : 'dry';
+
+// Enum de status (ADR 0294). Ordem = prioridade de exibição (mais "vivo" primeiro).
+const STATUS_ORDER = ['em-execução', 'em-execucao', 'ativo', 'proposto', 'revisar', 'pausado', 'concluído', 'concluido', 'abandonado', 'superseded', '(sem-status-vivo)'];
+const STATUS_OK = new Set(STATUS_ORDER);
+
+function listPlans(dir) {
+  const out = [];
+  const walk = (d) => {
+    let entries;
+    try { entries = readdirSync(join(ROOT, d), { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const rel = `${d}/${e.name}`;
+      if (e.isDirectory()) walk(rel);
+      else if (
+        rel.endsWith('.md')
+        && /plan/i.test(e.name)
+        && !/PLANS-INDEX|_TEMPLATE/i.test(rel)
+        && !/\/(adr|arq)\//.test(rel)
+      ) out.push(rel);
+    }
+  };
+  walk(dir);
+  return out.sort();
+}
+
+function field(block, key) {
+  // exige `key:` ancorado em início de linha/bullet (`- **key:** valor`),
+  // pra não pegar a palavra solta num comentário (ex: "mudar status conscientemente").
+  const m = block.match(new RegExp(`(?:^|\\n)[-*\\s]*\\**${key}:\\**\\s*["']?([^\\s<·*\\n"']+)`, 'i'));
+  return m ? m[1] : '';
+}
+
+const plans = [];
+for (const rel of listPlans(BASE)) {
+  let txt; try { txt = readFileSync(join(ROOT, rel), 'utf8'); } catch { continue; }
+  const title = (txt.match(/^#\s+(.+)$/m) || [])[1]?.trim() || rel.split('/').pop();
+  const mod = rel.replace(/^memory\/requisitos\//, '').split('/')[0];
+  const link = '../' + rel.replace(/^memory\/requisitos\//, '');
+  const hasSV = /\n##\s*Status vivo/i.test(txt);
+  const block = hasSV ? (txt.split(/\n##\s*Status vivo/i)[1] || '').split(/\n##\s/)[0] : '';
+  const status = hasSV ? (field(block, 'status') || '?').toLowerCase() : '(sem-status-vivo)';
+  const owner = hasSV ? (field(block, 'owner') || '—') : '—';
+  const rev = hasSV ? ((block.match(/reviewed[_ -]?at:?\**\s*["']?(\d{4}-\d{2}-\d{2})/i) || [])[1] || '—') : '—';
+  const parent = hasSV && /parent_plan\s*[=:]\s*[a-z0-9-]+/i.test(block) ? '✓' : '—';
+  plans.push({ rel, title, mod, link, status, owner, rev, parent, hasSV });
+}
+
+plans.sort((a, b) => {
+  const sa = STATUS_ORDER.indexOf(a.status); const sb = STATUS_ORDER.indexOf(b.status);
+  if (sa !== sb) return (sa < 0 ? 99 : sa) - (sb < 0 ? 99 : sb);
+  return a.mod.localeCompare(b.mod);
+});
+
+const withSV = plans.filter((p) => p.hasSV).length;
+const withRev = plans.filter((p) => p.rev !== '—').length;
+const withParent = plans.filter((p) => p.parent === '✓').length;
+const semSV = plans.length - withSV;
+
+const lines = [];
+lines.push('<!-- GERADO por scripts/governance/plans-index-generate.mjs — NÃO editar à mão (ADR 0294/0256). Rode --write. -->');
+lines.push('# Índice de Planos Vivos (gerado)');
+lines.push('');
+lines.push(`> Fonte-única **gerada** dos blocos \`## Status vivo\` (ADR 0294). Pareado com a sentinela \`memory-health\` Check J. Doc de convenção: [PLANS-INDEX.md](./PLANS-INDEX.md).`);
+lines.push('');
+lines.push('## Saúde');
+lines.push('');
+lines.push(`- **${plans.length} planos** · com \`## Status vivo\`: **${withSV}** · com \`reviewed_at\`: **${withRev}** · com \`parent_plan\`: **${withParent}**`);
+if (semSV) lines.push(`- ⚠️ **${semSV}** sem \`## Status vivo\` (retrofit Onda 3 — o plan-health já flaga).`);
+lines.push('');
+lines.push('## Registro');
+lines.push('');
+lines.push('| Plano | Módulo | Status | Owner | reviewed_at | parent_plan |');
+lines.push('|---|---|---|---|---|---|');
+for (const p of plans) {
+  const flag = !STATUS_OK.has(p.status) ? ' ⚠️' : '';
+  lines.push(`| [${p.title.replace(/\|/g, '\\|').slice(0, 70)}](${p.link}) | ${p.mod} | ${p.status}${flag} | ${p.owner} | ${p.rev} | ${p.parent} |`);
+}
+lines.push('');
+const output = lines.join('\n') + '\n';
+
+if (MODE === 'dry') {
+  console.log(`plans-index (dry): ${plans.length} planos · ${withSV} com Status vivo · ${withRev} com reviewed_at · ${withParent} com parent_plan`);
+  console.log(`(--write grava ${OUT})`);
+  process.exit(0);
+}
+if (MODE === 'write') {
+  writeFileSync(join(ROOT, OUT), output);
+  console.log(`✓ ${OUT} gerado — ${plans.length} planos (${withSV} com Status vivo, ${semSV} sem).`);
+  process.exit(0);
+}
+// check
+const committed = existsSync(join(ROOT, OUT)) ? readFileSync(join(ROOT, OUT), 'utf8') : '';
+if (committed !== output) {
+  console.error(`✗ ${OUT} está DESATUALIZADO — rode \`node scripts/governance/plans-index-generate.mjs --write\`. (gerado ≠ commitado = drift)`);
+  process.exit(1);
+}
+console.log(`✓ ${OUT} em dia (${plans.length} planos).`);
+process.exit(0);

--- a/scripts/governance/plans-index-generate.mjs
+++ b/scripts/governance/plans-index-generate.mjs
@@ -101,7 +101,9 @@ lines.push('| Plano | Módulo | Status | Owner | reviewed_at | parent_plan |');
 lines.push('|---|---|---|---|---|---|');
 for (const p of plans) {
   const flag = !STATUS_OK.has(p.status) ? ' ⚠️' : '';
-  lines.push(`| [${p.title.replace(/\|/g, '\\|').slice(0, 70)}](${p.link}) | ${p.mod} | ${p.status}${flag} | ${p.owner} | ${p.rev} | ${p.parent} |`);
+  // sanitiza `Modules/X` do título (índice não deve carregar ref-fantasma a módulo inexistente — anti-ghost ratchet)
+  const safeTitle = p.title.replace(/Modules\//gi, '').replace(/\|/g, '\\|').slice(0, 70);
+  lines.push(`| [${safeTitle}](${p.link}) | ${p.mod} | ${p.status}${flag} | ${p.owner} | ${p.rev} | ${p.parent} |`);
 }
 lines.push('');
 const output = lines.join('\n') + '\n';


### PR DESCRIPTION
**Onda 1 (resto) do [ADR 0294](../blob/main/memory/decisions/0294-metodo-dual-track-shapeup-catraca.md)** — o gerador que faltava + um fix de correção.

**1. Gerador `plans-index`** (`scripts/governance/plans-index-generate.mjs`): fonte-única **gerada** do índice de planos (mesmo padrão do `adr-index-generate`, dependency-free, `--write`/`--check`/dry). Lê os blocos `## Status vivo` de todo PLANO em `memory/requisitos/**` e emite `_PLANS-INDEX-GENERATED.md`. Pareado com a sentinela `memory-health` Check J.

**2. Índice gerado** (`memory/requisitos/_processo/_PLANS-INDEX-GENERATED.md`): 15 planos · 1 com Status vivo (atendimento: ativo/W/2026-06-20/parent✓) · 14 sem (retrofit Onda 3 — já flagado pelo plan-health).

**3. Fix do Check J** (`memory-health.mjs`): o bug de extração que o header `> **Status:** ver \`## Status vivo\` abaixo` causava — o `split` pegava a **menção** no header, não o heading real. Agora ancorado em `\n##` + `status:` exige dois-pontos. Resultado: Check J cai de 16→14 (o único plano com Status vivo deixa de ser falso-flagado). Testado local contra a main.

Seguro: warn-only/advisory, sem novo workflow (sem mexer em gates-registry/Check G), inerte nas fixtures do meta-teste. CI/meta-teste é o verificador.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
