### PR TITLE
feat(governance): adr-index double-supersede — conflito de herança vira gate

### DIFF
--- a/scripts/governance/adr-index-generate.mjs
+++ b/scripts/governance/adr-index-generate.mjs
@@ -116,6 +116,14 @@ for (const a of adrs) {
   if ((a.statusN === 'superseded' || a.lifecycleN === 'substituido') && a.superseded_by.length === 0)
     supWarn.push(`${a.num} é superseded mas sem superseded_by (órfã)`);
 }
+// double-supersede (adversário 2026-06-20): >1 ADR herdando o MESMO número = conflito
+// de herança — duas decisões reivindicam suceder a mesma, ramo de herança ambíguo. Como
+// supWarn é GATE DURO no --check (ADR 0258), bloqueia até consolidar numa sucessora só.
+const supersededBy = {};
+for (const a of adrs) for (const t of a.supersedes) (supersededBy[t] ??= new Set()).add(a.num);
+for (const [t, srcs] of Object.entries(supersededBy)) {
+  if (srcs.size > 1) supWarn.push(`ADR ${t} é supersedida por ${srcs.size} ADRs (${[...srcs].sort().join(', ')}) → conflito de herança (double-supersede); só 1 deve suceder — consolide.`);
+}
 
 // ── render ──────────────────────────────────────────────────────────────────
 const fmtTally = (o) => Object.entries(o).sort((x, y) => y[1] - x[1]).map(([k, v]) => `${k} ${v}`).join(' · ');

--- a/tests/governanceAdrScripts.spec.ts
+++ b/tests/governanceAdrScripts.spec.ts
@@ -126,3 +126,27 @@ describe('GAP 2 — memory-health ENFORCE + baseline ratchet (Check C, ADR 0258)
     expect(out).toMatch(/0 .*fail|saudável|🩺/i);
   });
 });
+
+describe('double-supersede — >1 ADR herdando a mesma (adversário 2026-06-20, físico)', () => {
+  it('SENSIBILIDADE: 2 ADRs supersedem o MESMO número → --check FALHA citando conflito de herança', () => {
+    adr(tmp, '0930-target.md', 'slug: 0930-target\nnumber: 930\ntitle: "T"\ntype: adr\nstatus: superseded\nauthority: canonical\nlifecycle: substituido\ndecided_by: [W]\ndecided_at: "2026-06-07"\nsuperseded_by: [\'0931-a\']');
+    adr(tmp, '0931-a.md', 'slug: 0931-a\nnumber: 931\ntitle: "A"\ntype: adr\nstatus: aceito\nauthority: canonical\nlifecycle: ativo\ndecided_by: [W]\ndecided_at: "2026-06-07"\nsupersedes: [\'0930-target\']');
+    adr(tmp, '0932-b.md', 'slug: 0932-b\nnumber: 932\ntitle: "B"\ntype: adr\nstatus: aceito\nauthority: canonical\nlifecycle: ativo\ndecided_by: [W]\ndecided_at: "2026-06-07"\nsupersedes: [\'0930-target\']');
+    run(`node "${GEN}" --write`);
+    let threw = false; let msg = '';
+    try { run(`node "${GEN}" --check`); }
+    catch (e: any) { threw = true; msg = (e.stdout || '') + (e.stderr || ''); }
+    expect(threw).toBe(true);                          // double-supersede entra em supWarn → gate bloqueia
+    expect(msg).toMatch(/double-supersede|conflito de herança/i);
+    expect(msg).toMatch(/0930/);
+  });
+
+  it('ESPECIFICIDADE: supersede 1→1 (sucessora única) → sem conflito, --check passa', () => {
+    adr(tmp, '0940-old.md', 'slug: 0940-old\nnumber: 940\ntitle: "Old"\ntype: adr\nstatus: superseded\nauthority: canonical\nlifecycle: substituido\ndecided_by: [W]\ndecided_at: "2026-06-07"\nsuperseded_by: [\'0941-new\']');
+    adr(tmp, '0941-new.md', 'slug: 0941-new\nnumber: 941\ntitle: "New"\ntype: adr\nstatus: aceito\nauthority: canonical\nlifecycle: ativo\ndecided_by: [W]\ndecided_at: "2026-06-07"\nsupersedes: [\'0940-old\']');
+    run(`node "${GEN}" --write`);
+    const out = run(`node "${GEN}" --check`); // exit 0 (não lança)
+    expect(out).not.toMatch(/double-supersede|conflito de herança/i);
+    expect(out).toMatch(/em dia|íntegra/i);
+  });
+});


### PR DESCRIPTION
## O quê

`scripts/governance/adr-index-generate.mjs`: detecta **double-supersede** — quando `>1` ADR aponta `supersedes` pro **mesmo** número. Entra em `supWarn`.

## Por quê

O adversário da convergência (`2026-06-20-adversario-convergencia-sistema.md`) listou `double-supersede-sem-gate` como um dos **4 modos que quebram a convergência hoje**. Se duas decisões reivindicam suceder a mesma ADR, o ramo de herança fica ambíguo e ninguém percebe.

## Garantias (rule c — não armar gate às cegas)

- `supWarn` é **gate duro** no `--check` (GAP 1, ADR 0258) — que é required no umbrella.
- **Verifiquei: 0 double-supersedes hoje** (301 ADRs, `--check` verde, "supersede íntegra"). → arma a violação **futura** **sem** travar o CI atual.
- **Render do índice inalterado** (com 0 conflitos, `supWarn` continua vazio → `_(íntegra)_`) → o `--check` que compara o `_INDEX-GENERATED.md` commitado segue passando.

## Meta-teste (ADR 0258)

`tests/governanceAdrScripts.spec.ts`: sensibilidade (2 ADRs supersedem 0930 → `--check` falha citando conflito de herança) + especificidade (1→1 → passa). Validado em fixtures reais: **5/5 pass**.

## Alinhamento

Base: `origin/main` atual (pós #3083). Sem overlap. Item 6 do backlog de armamento.

Refs: ADR 0256 (índice gerado fonte única) · ADR 0258 (supersede-integrity gate duro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
