### PR TITLE
feat(governance): gerador do Índice de Planos Vivos + teste canário (ADR 0294)

### DIFF
--- a/.github/workflows/governance-gate-umbrella.yml
+++ b/.github/workflows/governance-gate-umbrella.yml
@@ -41,6 +41,11 @@ jobs:
         run: npm run test:adr-governance
       - name: Meta-teste dos checks G/H/I do memory-health (Onda Q5 — controle-negativo)
         run: npm run test:memory-health
+      - name: Teste canário do gerador de planos (controle-negativo · ADR 0294)
+        run: node scripts/governance/plans-index.test.mjs
+      - name: Índice de Planos em dia (advisory · ADR 0294 · nasce advisory ADR 0271)
+        continue-on-error: true
+        run: node scripts/governance/plans-index.mjs --check
       # ADVISORY (GT-G5 · ledger §D): refutação adversarial de lote-IA de BRIEFINGs/SPECs
       # (PROTOCOLO-REFUTADOR-BACKFILL). Sem --enforce → exit 0 sempre nesta fase; promover a
       # required = adicionar --enforce após o protocolo assentar. Só em PR (precisa nº + base_ref).

--- a/memory/requisitos/_processo/PLANS-INDEX-GENERATED.md
+++ b/memory/requisitos/_processo/PLANS-INDEX-GENERATED.md
@@ -1,0 +1,36 @@
+# Índice de Planos Vivos — GERADO (não editar à mão)
+
+> ⚙️ **Auto-gerado** por `scripts/governance/plans-index.mjs` a partir do bloco `## Status vivo` de cada plano (ADR 0294). Regenerar: `node scripts/governance/plans-index.mjs --write`.
+> Fonte única: o plano é a verdade, este índice é derivado ([ADR 0256](../../decisions/0256-knowledge-survival-meia-vida-catraca-sentinela.md)). Execução mora no MCP via `parent_plan` ([ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md)). Frescor/órfão = sentinela `plan-health` (memory-health Check J).
+
+## Saúde (derivada)
+- **1** planos registrados (com `## Status vivo`) · **16** pendentes de backfill (arquivo *plan* sem bloco)
+- reviewed_at preenchido: **1/1** · vinculados a MCP (`parent_plan`): **1/1**
+- Por status: ativo 1
+- Inconsistências de schema: 0
+
+## Registrados (1)
+| Plano | Módulo | Status | Owner | reviewed_at | parent_plan | gate-de-saída |
+|---|---|---|---|---|---|---|
+| [Plano — Atendimento Automático (WhatsApp / Caixa Unificada)](../Whatsapp/PLANO-ATENDIMENTO-AUTOMATICO.md) | Whatsapp | ativo | W | 2026-06-20 | `plano-atendimento-automatico` | E1+E3 com ≥5 clientes pagando JANA Pro (espelha gates da ADR |
+
+## Pendentes de `## Status vivo` (16) — backfill dirigido pela sentinela
+| Plano | Módulo |
+|---|---|
+| [DEPRECATION-PLAN — Modules/Accounting](../Accounting/DEPRECATION-PLAN.md) | Accounting |
+| [Plano Migração Vargas → Autopecas (planejado — não existe) — 2026-05-1](../Autopecas/PLANO-MIGRACAO-VARGAS.md) | Autopecas |
+| [Plano Migração 6 Saudáveis OfficeImpresso → Modules/ComunicacaoVisual ](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) | ComunicacaoVisual |
+| [JANA Pro — Product Plan executivo (32 US, 4 sprints, 90 dias)](../Copiloto/JANA-PRO-PRODUCT-PLAN.md) | Copiloto |
+| [Fase 1 — Conciliação passa a enxergar o extrato da API](../Financeiro/PLANO-FASE1-CONCILIACAO-LE-EXTRATO-API.md) | Financeiro |
+| [Fase 2 — Migração de dados: unificar extrato OFX → tabela canônica](../Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md) | Financeiro |
+| [Plano Detalhado — Módulo Financeiro](../Financeiro/PLANO_DETALHADO.md) | Financeiro |
+| [Plano de Testes Fiscal — Ondas 1-7](../Fiscal/PLANO-TESTES-FISCAL.md) | Fiscal |
+| [Plano de migração das 82 auto-mems → git/MCP (ADR 0061)](../Infra/PLANO-MIGRACAO-AUTOMEM.md) | Infra |
+| [PLAN MWART — `metas/*` (Jana)](../Jana/PLAN-MWART-metas.md) | Jana |
+| [Onda 1 — Vendas, PDV & Caixa · PLANO (MWART Fase 1)](../Mwart/ONDA-1-VENDAS-PDV-CAIXA-PLANO.md) | Mwart |
+| [Plano de paralelização — OficinaAuto Fase 1 (pós-Martinho)](../OficinaAuto/demo-martinho-2026-05-13/plano-paralelizacao.md) | OficinaAuto |
+| [PaymentGateway Onda 5 SIMPLIFICADA — Dogfooding SaaS via gateway adici](../PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md) | PaymentGateway |
+| [DEPRECATION-PLAN — Modules/SRS](../SRS/DEPRECATION-PLAN.md) | SRS |
+| [ADR ARQ-0001 (TaskRegistry) · Sistema de tasks MCP-native, não Plane s](../TaskRegistry/adr/arq/0001-mcp-native-vs-plane.md) | TaskRegistry |
+| [Índice de Planos Vivos (gerado)](_PLANS-INDEX-GENERATED.md) | _processo |
+

--- a/scripts/governance/plans-index.mjs
+++ b/scripts/governance/plans-index.mjs
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * plans-index.mjs — GERADOR determinístico do Índice de Planos Vivos (ADR 0294 + 0256).
+ *
+ * Espelha adr-index-generate.mjs (modelo Log4brains, fonte-única gerada). O índice de
+ * planos deve ser GERADO dos próprios planos, nunca mantido à mão — senão drifta (era
+ * `generated: false` v1 à mão). Lê o bloco `## Status vivo` (convenção ADR 0294) de cada
+ * plano e emite memory/requisitos/_processo/PLANS-INDEX-GENERATED.md.
+ *
+ * Descoberta (2 categorias):
+ *   - REGISTRADOS  → arquivo com bloco `## Status vivo` (em memory/requisitos/** ou
+ *                    memory/sessions/**). Dados completos parseados do bloco.
+ *   - PENDENTES    → arquivo cujo basename casa /plan/i em memory/requisitos/** SEM o
+ *                    bloco. Listado com ⚠️ pra dirigir o backfill (a sentinela plan-health
+ *                    cobra; aqui só expõe).
+ *
+ * Determinístico: NÃO computa "stale" (depende de now → quebraria --check). Frescor/órfão
+ * é trabalho da sentinela plan-health (runtime, advisory) — aqui só ecoa reviewed_at.
+ *
+ * Uso:
+ *   node scripts/governance/plans-index.mjs           (dry-run: resumo)
+ *   node scripts/governance/plans-index.mjs --write    (grava PLANS-INDEX-GENERATED.md)
+ *   node scripts/governance/plans-index.mjs --check     (CI: exit 1 se gerado ≠ commitado)
+ *   node scripts/governance/plans-index.mjs --json      (saída JSON pro brief/sentinela)
+ *
+ * Refs: ADR 0294 (dual-track + Status vivo) · ADR 0256 (survival, fonte única gerada)
+ *       · ADR 0070 (execução no MCP via parent_plan) · ADR 0274 (slug).
+ */
+import { readdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { join, basename, relative } from 'node:path';
+
+const ROOT = process.cwd();
+const OUT = 'memory/requisitos/_processo/PLANS-INDEX-GENERATED.md';
+const SCAN_DIRS = ['memory/requisitos', 'memory/sessions'];
+// os próprios índices NÃO são planos (e o hand-index tem o template `## Status vivo` num code-fence)
+const SELF = new Set([OUT, 'memory/requisitos/_processo/PLANS-INDEX.md']);
+// remove code-fences antes de detectar/parsear (exemplos de template não contam)
+const stripFences = (t) => t.replace(/```[\s\S]*?```/g, '').replace(/^~~~[\s\S]*?^~~~/gm, '');
+const MODE = process.argv.includes('--write') ? 'write'
+  : process.argv.includes('--check') ? 'check'
+  : process.argv.includes('--json') ? 'json' : 'dry';
+
+const STATUS_OK = new Set(['proposto', 'ativo', 'em-execução', 'pausado', 'concluído', 'abandonado', 'superseded', 'revisar']);
+
+// ── walk recursivo (espelha memory-health.listFiles) ────────────────────────
+function listFiles(dir, filterFn) {
+  const out = [];
+  const walk = (d) => {
+    let entries;
+    try { entries = readdirSync(join(ROOT, d), { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const rel = `${d}/${e.name}`;
+      if (e.isDirectory()) walk(rel);
+      else if (filterFn(rel)) out.push(rel);
+    }
+  };
+  walk(dir);
+  return out.sort();
+}
+
+// ── parse do bloco `## Status vivo` ──────────────────────────────────────────
+function parseStatusVivo(txt) {
+  const m = txt.match(/^##\s+Status vivo\s*$([\s\S]*?)(?=^##\s|^---\s*$)/m);
+  if (!m) return null;
+  const blk = m[1];
+  const grab = (re) => { const x = blk.match(re); return x ? x[1].trim().replace(/\s*<!--.*$/, '').trim() : ''; };
+  return {
+    status: (grab(/\*\*status:\*\*\s*([^\s<·]+)/i) || '').toLowerCase(),
+    owner: grab(/\*\*owner:\*\*\s*([A-Z](?:\/[A-Z])*)/),
+    criado: grab(/\*\*criado:\*\*\s*(\d{4}-\d{2}-\d{2})/),
+    reviewed_at: grab(/\*\*reviewed_at:\*\*\s*(\d{4}-\d{2}-\d{2})/),
+    proxima_revisao: grab(/\*\*pr[óo]xima-revis[ãa]o:\*\*\s*(\d{4}-\d{2}-\d{2})/),
+    cycle: grab(/\*\*cycle:\*\*\s*([^·\n]+)/),
+    parent_plan: grab(/parent_plan=([a-z0-9-]+)/),
+    gate_saida: grab(/\*\*gate-de-sa[íi]da[^:]*:\*\*\s*([^\n<]+)/),
+    kill: grab(/\*\*kill-condition:\*\*\s*([^\n<]+)/),
+  };
+}
+
+function moduleOf(rel) {
+  // memory/requisitos/<Mod>/... → <Mod> ; memory/sessions/... → (sessão)
+  const mr = rel.match(/^memory\/requisitos\/([^/]+)\//);
+  if (mr) return mr[1] === '_processo' ? '_processo' : mr[1];
+  if (rel.startsWith('memory/sessions/')) return '(sessão)';
+  return '?';
+}
+function title(rel, txt) {
+  const h1 = (txt.match(/^#\s+(.+)$/m) || [])[1];
+  return (h1 || basename(rel, '.md')).replace(/\|/g, '/').slice(0, 70);
+}
+
+// ── descoberta ───────────────────────────────────────────────────────────────
+const registered = [];
+const withVivo = new Set();
+for (const dir of SCAN_DIRS) {
+  for (const rel of listFiles(dir, (p) => p.endsWith('.md'))) {
+    if (SELF.has(rel)) continue;
+    let txt; try { txt = readFileSync(join(ROOT, rel), 'utf8'); } catch { continue; }
+    const body = stripFences(txt);
+    if (!/^##\s+Status vivo\s*$/m.test(body)) continue;
+    const sv = parseStatusVivo(body);
+    if (!sv) continue;
+    withVivo.add(rel);
+    registered.push({ rel, mod: moduleOf(rel), title: title(rel, txt), ...sv });
+  }
+}
+registered.sort((a, b) => (a.mod + a.rel).localeCompare(b.mod + b.rel));
+
+// pendentes: arquivo *plan* em requisitos SEM bloco Status vivo
+const pending = listFiles('memory/requisitos', (p) => p.endsWith('.md') && /plan/i.test(basename(p)))
+  .filter((rel) => !withVivo.has(rel) && !SELF.has(rel))
+  .map((rel) => { let txt = ''; try { txt = readFileSync(join(ROOT, rel), 'utf8'); } catch {} return { rel, mod: moduleOf(rel), title: title(rel, txt) }; });
+
+// ── validação leve (não-bloqueante; reportada) ──────────────────────────────
+const issues = [];
+for (const p of registered) {
+  if (!STATUS_OK.has(p.status)) issues.push(`${p.rel}: status inválido "${p.status || '(vazio)'}" (enum ADR 0294)`);
+  if (!p.reviewed_at) issues.push(`${p.rel}: sem reviewed_at`);
+}
+
+// ── render ────────────────────────────────────────────────────────────────────
+const dash = (s) => (s && s.length ? s : '—');
+const withReviewed = registered.filter((p) => p.reviewed_at).length;
+const withParent = registered.filter((p) => p.parent_plan).length;
+const byStatus = registered.reduce((o, p) => ((o[p.status || '(vazio)'] = (o[p.status || '(vazio)'] || 0) + 1), o), {});
+const fmtTally = (o) => Object.entries(o).sort((x, y) => y[1] - x[1]).map(([k, v]) => `${k} ${v}`).join(' · ') || '—';
+
+let md = `# Índice de Planos Vivos — GERADO (não editar à mão)
+
+> ⚙️ **Auto-gerado** por \`scripts/governance/plans-index.mjs\` a partir do bloco \`## Status vivo\` de cada plano (ADR 0294). Regenerar: \`node scripts/governance/plans-index.mjs --write\`.
+> Fonte única: o plano é a verdade, este índice é derivado ([ADR 0256](../../decisions/0256-knowledge-survival-meia-vida-catraca-sentinela.md)). Execução mora no MCP via \`parent_plan\` ([ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md)). Frescor/órfão = sentinela \`plan-health\` (memory-health Check J).
+
+## Saúde (derivada)
+- **${registered.length}** planos registrados (com \`## Status vivo\`) · **${pending.length}** pendentes de backfill (arquivo *plan* sem bloco)
+- reviewed_at preenchido: **${withReviewed}/${registered.length}** · vinculados a MCP (\`parent_plan\`): **${withParent}/${registered.length}**
+- Por status: ${fmtTally(byStatus)}
+- Inconsistências de schema: ${issues.length}${issues.length ? ' — ver final' : ''}
+
+## Registrados (${registered.length})
+| Plano | Módulo | Status | Owner | reviewed_at | parent_plan | gate-de-saída |
+|---|---|---|---|---|---|---|
+${registered.map((p) => `| [${p.title}](${relative('memory/requisitos/_processo', p.rel).replace(/\\/g, '/')}) | ${p.mod} | ${dash(p.status)} | ${dash(p.owner)} | ${dash(p.reviewed_at)} | ${p.parent_plan ? '`' + p.parent_plan + '`' : '—'} | ${dash(p.gate_saida).slice(0, 60)} |`).join('\n') || '_(nenhum)_'}
+
+## Pendentes de \`## Status vivo\` (${pending.length}) — backfill dirigido pela sentinela
+${pending.length ? '| Plano | Módulo |\n|---|---|\n' + pending.map((p) => `| [${p.title}](${relative('memory/requisitos/_processo', p.rel).replace(/\\/g, '/')}) | ${p.mod} |`).join('\n') : '_(nenhum — todos os planos registrados)_'}
+
+${issues.length ? `## Inconsistências de schema (${issues.length})\n${issues.map((i) => `- ⚠️ ${i}`).join('\n')}\n` : ''}`;
+
+// ── saída ─────────────────────────────────────────────────────────────────────
+if (MODE === 'json') {
+  console.log(JSON.stringify({ registered, pending, issues, counts: { registered: registered.length, pending: pending.length, withReviewed, withParent } }, null, 2));
+  process.exit(0);
+}
+if (MODE === 'check') {
+  const cur = existsSync(join(ROOT, OUT)) ? readFileSync(join(ROOT, OUT), 'utf8') : '';
+  if (cur.trim() !== md.trim()) {
+    console.error(`✗ ${OUT} DESATUALIZADO — rode --write. (índice gerado ≠ commitado = drift)`);
+    process.exit(1);
+  }
+  console.log(`✓ ${OUT} em dia (${registered.length} registrados, ${pending.length} pendentes).`);
+  process.exit(0);
+}
+if (MODE === 'write') {
+  writeFileSync(join(ROOT, OUT), md);
+  console.log(`✓ ${OUT} gerado — ${registered.length} registrados, ${pending.length} pendentes, ${issues.length} inconsistências.`);
+} else {
+  console.log(md.split('\n').slice(0, 28).join('\n'));
+  console.log(`\n[dry-run] ${registered.length} registrados · ${pending.length} pendentes · ${issues.length} inconsistências. Rode --write.`);
+}

--- a/scripts/governance/plans-index.test.mjs
+++ b/scripts/governance/plans-index.test.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * plans-index.test.mjs — TESTE CANÁRIO do gerador de planos (prova que "ficou automático").
+ *
+ * Caixa-preta (espelha gate-selftest): monta fixtures num cwd temporário, roda
+ * plans-index.mjs lá, e prova:
+ *   1. plano com `## Status vivo` → REGISTRADO + campos parseados (o canário cai sozinho)
+ *   2. arquivo *plan* SEM bloco → PENDENTE (não some, vira backfill dirigido)
+ *   3. `## Status vivo` dentro de code-fence (template) → NÃO registra (anti-falso-positivo)
+ *   4. --check: gerado==commitado → exit 0 ; depois de mexer → exit 1 (a catraca MORDE)
+ *
+ * Uso: node scripts/governance/plans-index.test.mjs   (exit 1 se qualquer caso falhar)
+ */
+import { mkdirSync, writeFileSync, rmSync, readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join, dirname } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const GEN = fileURLToPath(new URL('./plans-index.mjs', import.meta.url));
+const TMP = join(tmpdir(), 'plans-index-selftest');
+const fails = [];
+const ok = (cond, msg) => { if (cond) console.log(`  ✓ ${msg}`); else { fails.push(msg); console.error(`  ✗ ${msg}`); } };
+
+function write(rel, content) { const p = join(TMP, rel); mkdirSync(dirname(p), { recursive: true }); writeFileSync(p, content); }
+function run(args) {
+  try { return { out: execSync(`node "${GEN}" ${args}`, { cwd: TMP, encoding: 'utf8' }), code: 0 }; }
+  catch (e) { return { out: (e.stdout || '') + (e.stderr || ''), code: e.status || 1 }; }
+}
+
+// ── setup fixtures ───────────────────────────────────────────────────────────
+rmSync(TMP, { recursive: true, force: true });
+mkdirSync(join(TMP, 'memory/requisitos/_processo'), { recursive: true });
+
+// caso 1: plano registrado (canário)
+write('memory/requisitos/Canary/PLANO-CANARY.md', `# Plano Canário de Teste
+
+## Status vivo
+<!-- catraca ADR 0294 -->
+- **status:** em-execução
+- **owner:** W
+- **criado:** 2026-06-20 · **reviewed_at:** 2026-06-20 · **próxima-revisão:** 2026-07-20
+- **cycle:** CYCLE-08 · **execução:** \`parent_plan=plano-canary\`
+- **gate-de-saída (DoD):** quando o gerador provar que cai sozinho
+- **kill-condition:** nunca
+- **verdade-viva:** este doc
+
+## Corpo
+texto.
+`);
+
+// caso 2: arquivo *plan* SEM bloco → pendente
+write('memory/requisitos/Canary/PLANO-SEM-BLOCO.md', `# Plano sem Status vivo\n\nsó corpo, sem bloco.\n`);
+
+// caso 3: armadilha — \`## Status vivo\` dentro de code-fence (template), NÃO deve registrar
+write('memory/requisitos/Canary/PLANO-TEMPLATE-FENCE.md', `# Doc com template em code-fence\n\nExemplo:\n\n\`\`\`\n## Status vivo\n- **status:** ativo\n\`\`\`\n\nfim.\n`);
+
+// ── caso 1/2/3 via --json ─────────────────────────────────────────────────────
+console.log('— descoberta (registrado / pendente / anti-fence) —');
+const j = JSON.parse(run('--json').out);
+const reg = j.registered.find((p) => p.rel.endsWith('PLANO-CANARY.md'));
+ok(!!reg, 'plano com ## Status vivo é REGISTRADO (cai sozinho)');
+ok(reg && reg.status === 'em-execução', 'status parseado = em-execução');
+ok(reg && reg.reviewed_at === '2026-06-20', 'reviewed_at parseado');
+ok(reg && reg.parent_plan === 'plano-canary', 'parent_plan parseado do execução=');
+ok(j.pending.some((p) => p.rel.endsWith('PLANO-SEM-BLOCO.md')), 'arquivo *plan* sem bloco → PENDENTE');
+ok(!j.registered.some((p) => p.rel.endsWith('PLANO-TEMPLATE-FENCE.md')), 'template em code-fence NÃO registra (anti-falso-positivo)');
+
+// ── caso 4: --check morde drift ───────────────────────────────────────────────
+console.log('— catraca --check (drift) —');
+run('--write');
+ok(existsSync(join(TMP, 'memory/requisitos/_processo/PLANS-INDEX-GENERATED.md')), '--write gera o índice');
+ok(run('--check').code === 0, '--check passa quando gerado==commitado');
+// muta um plano → o gerado fica defasado → --check deve exit 1
+const cpath = join(TMP, 'memory/requisitos/Canary/PLANO-CANARY.md');
+writeFileSync(cpath, readFileSync(cpath, 'utf8').replace('status:** em-execução', 'status:** pausado'));
+ok(run('--check').code === 1, '--check MORDE (exit 1) quando um plano muda e o índice não foi regenerado');
+
+// ── teardown ──────────────────────────────────────────────────────────────────
+rmSync(TMP, { recursive: true, force: true });
+console.log(`\nplans-index.test: ${fails.length ? fails.length + ' FALHA(S)' : 'TODOS OS CASOS PASSARAM ✓'}`);
+process.exit(fails.length ? 1 : 0);


### PR DESCRIPTION
## A máquina do Índice de Planos Vivos (ADR 0294)

Resolve a pergunta "se eu criar um plano, cai certinho no índice sozinho?" — a resposta era **não** (o índice era `generated: false`, à mão; só a sentinela `plan-health` existia). Este PR constrói **o gerador que faltava** + um **teste canário** que prova que ficou automático.

### O que entra
| Arquivo | Papel |
|---|---|
| `scripts/governance/plans-index.mjs` | **Gerador** determinístico (`dry`/`--write`/`--check`/`--json`). Lê o bloco `## Status vivo` de cada plano → emite `PLANS-INDEX-GENERATED.md`. Espelha `adr-index-generate.mjs` (fonte única gerada). Ignora code-fences e os próprios índices (anti-falso-positivo). |
| `scripts/governance/plans-index.test.mjs` | **Teste canário** (caixa-preta, fixtures). Prova: ① plano com `## Status vivo` → cai sozinho; ② arquivo `*plan*` sem bloco → pendente; ③ template em code-fence **não** registra; ④ `--check` **morde** drift. |
| `governance-gate-umbrella.yml` | Canário (hard) + `plans-index --check` (**advisory**, nasce advisory · ADR 0271). Sem workflow novo → `gates-registry` Check G intacto. |
| `PLANS-INDEX-GENERATED.md` | Saída: **1 registrado** (PLANO-ATENDIMENTO-AUTOMATICO) + **16 pendentes** de backfill. |

### Não-duplicação
A sentinela `plan-health` **já existe** em `memory-health.mjs` (Check J, warn-only) — não tocada. O gerador a complementa: gera dos registrados, a sentinela cobra os pendentes. Mesma convenção (ADR 0294).

### Provado rodando (não no "confia")
```
plans-index --check  → exit 0 (índice em dia)
plans-index.test     → TODOS OS CASOS PASSARAM ✓
memory-health        → 0 🔴 (não quebra) · Check J: 14 pendentes (advisory)
```

### Estado honesto
Só **1 plano** dogfoodou o `## Status vivo` até agora. A máquina o encontra + lista os 16 pendentes; o backfill é dirigido pela sentinela ao longo do tempo. Quando todos tiverem o bloco, o `PLANS-INDEX.md` à mão pode ser aposentado (como os 4 índices de ADR foram).

Refs: ADR 0294 (dual-track + `## Status vivo`) · ADR 0256 (survival/fonte única gerada) · ADR 0070 (execução no MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)