### PR TITLE
feat(governance): memory-health Check K — detector dos planos perdidos (advisory)

### DIFF
--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -339,6 +339,62 @@ function checkPlanHealth() {
   }
 }
 
+// ── Check K: decisão em session log sem âncora (detector dos "155 perdidos") ─
+// Adversário 2026-06-20 (memory/sessions/2026-06-20-adversario-convergencia-sistema.md):
+// decisão/rollout escrito num session log que NUNCA virou ADR aceito nem entrou num
+// BRIEFING "se perde" — converge só pela atenção manual. Este check flagga session log
+// >30d com marcador de decisão (`## Decisão`, `US-`, `rollout`, `### Passo`) que NÃO
+// referencia nenhum ADR ACEITO nem um BRIEFING. Warn-only (advisory): é fila de triagem,
+// não bloqueio — promover a ADR/BRIEFING OU registrar resolução. Complementa Check J
+// (que cuida de PLANOs vivos, ADR 0294); aqui o alvo é o session log histórico.
+const SESSION_DECISION_STALE_DAYS = 30;
+function acceptedAdrNums() {
+  const dir = 'memory/decisions';
+  const set = new Set();
+  if (!exists(dir)) return set;
+  for (const f of readdirSync(join(ROOT, dir))) {
+    const m = f.match(/^(\d{4})-.+\.md$/);
+    if (!m) continue;
+    let txt; try { txt = read(`${dir}/${f}`); } catch { continue; }
+    const st = (txt.match(/^status:\s*["']?([^\s"'#]+)/mi) || [])[1]?.toLowerCase();
+    if (st && /^(aceito|accepted|aceita)/.test(st)) set.add(m[1]);
+  }
+  return set;
+}
+function checkSessionDecisionAnchor() {
+  const dir = 'memory/sessions';
+  if (!exists(dir)) return;
+  const accepted = acceptedAdrNums();
+  const today = new Date(gitLastDate('.') || '2026-06-20'); // determinismo CI (sem Date.now)
+  const cutoff = new Date(today); cutoff.setDate(cutoff.getDate() - SESSION_DECISION_STALE_DAYS);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const files = listFiles(dir, (rel) => rel.endsWith('.md') && !/_TEMPLATE|README/i.test(rel));
+  const lost = [];
+  for (const rel of files) {
+    let txt; try { txt = read(rel); } catch { continue; }
+    // marcador de decisão/rollout (lista do adversário 2026-06-20)
+    const hasDecision = /^##\s*Decis[aã]o\b/im.test(txt)
+      || /^###\s*Passo\b/im.test(txt)
+      || /\bUS-[A-Z0-9]{2,}/.test(txt)
+      || /\brollout\b/i.test(txt);
+    if (!hasDecision) continue;
+    // idade: `date:` do frontmatter (quando a sessão ocorreu) → fallback git
+    const when = (txt.match(/^date:\s*["']?(\d{4}-\d{2}-\d{2})/mi) || [])[1] || gitLastDate(rel);
+    if (!when || when >= cutoffStr) continue; // só >30d
+    // âncora: referencia algum ADR ACEITO (nº existente + status aceito) OU um BRIEFING
+    const refs = new Set();
+    for (const m of txt.matchAll(/\bADR[\s-]*(\d{3,4})\b/gi)) refs.add(m[1].padStart(4, '0'));
+    for (const m of txt.matchAll(/\b(\d{4})-[a-z]{2,}/g)) refs.add(m[1]); // slug related_adrs / link decisions/NNNN
+    const anchoredByAdr = [...refs].some((n) => accepted.has(n));
+    const anchoredByBriefing = /BRIEFING/i.test(txt);
+    if (!anchoredByAdr && !anchoredByBriefing) lost.push(`${rel} (${when})`);
+  }
+  if (lost.length) {
+    warns.push({ check: 'K', kind: 'session-decisao-sem-ancora', count: lost.length, sample: lost.slice(0, 12),
+      msg: `${lost.length} session log(s) >${SESSION_DECISION_STALE_DAYS}d com marcador de decisão (\`## Decisão\`/\`US-\`/\`rollout\`/\`### Passo\`) SEM link pra ADR aceito nem BRIEFING — os "planos perdidos" (adversário 2026-06-20). Triagem: promover a ADR/BRIEFING ou registrar resolução.` });
+  }
+}
+
 // ── run ─────────────────────────────────────────────────────────────────────
 checkAdrCollisions();
 checkScorecardFantasma();
@@ -350,6 +406,7 @@ checkGatesRegistry();
 checkLidoFreshness();
 checkLicaoSemAssercao();
 try { checkPlanHealth(); } catch (e) { warns.push({ check: 'J', kind: 'plan-health-error', msg: 'plan-health falhou (não bloqueia): ' + e.message }); }
+try { checkSessionDecisionAnchor(); } catch (e) { warns.push({ check: 'K', kind: 'session-anchor-error', msg: 'session-anchor falhou (não bloqueia): ' + e.message }); }
 
 if (UPDATE_BASELINE) {
   writeFileSync(join(ROOT, BASELINE_FILE), JSON.stringify({ checkC: checkCByFile }, null, 2) + '\n');

--- a/tests/memoryHealth.spec.ts
+++ b/tests/memoryHealth.spec.ts
@@ -113,3 +113,26 @@ describe('memory-health — Check I: lição sem asserção (Onda Q5, físico)',
     expect(out).not.toMatch(/licao-sem-assercao/);
   });
 });
+
+describe('memory-health — Check K: decisão em session log sem âncora (Onda armar-gates, físico)', () => {
+  it('SENSIBILIDADE: session log >30d com `## Decisão` sem ADR aceito/BRIEFING → 🟡 K, não bloqueia', () => {
+    write('memory/sessions/2026-01-01-perdido.md', '---\ndate: "2026-01-01"\n---\n\n# Sessão\n\n## Decisão\n\nFazer X. US-FOO-001 em rollout por ondas.\n');
+    const out = run();
+    expect(out).toMatch(/session-decisao-sem-ancora/);
+    expect(out).toMatch(/2026-01-01-perdido\.md/);
+    expect(out).toMatch(/"ok": true/); // warn não bloqueia
+  });
+
+  it('ESPECIFICIDADE: referencia ADR ACEITO existente → sem warn K', () => {
+    write('memory/decisions/0294-metodo.md', '---\nstatus: aceito\nlifecycle: ativo\n---\n\n# ADR 0294\n');
+    write('memory/sessions/2026-01-02-ancorado.md', '---\ndate: "2026-01-02"\n---\n\n# Sessão\n\n## Decisão\n\nDecisão landou na ADR 0294. rollout ok.\n');
+    const out = run();
+    expect(out).not.toMatch(/session-decisao-sem-ancora/);
+  });
+
+  it('ESPECIFICIDADE: session log RECENTE (<30d) com decisão → sem warn K (filtro de idade)', () => {
+    write('memory/sessions/2026-06-19-fresco.md', '---\ndate: "2026-06-19"\n---\n\n# Sessão\n\n## Decisão\n\nDecidiu Y. rollout amanhã.\n');
+    const out = run();
+    expect(out).not.toMatch(/session-decisao-sem-ancora/);
+  });
+});


### PR DESCRIPTION
## O quê
Cherry-pick **cirúrgico** do Check K do `memory-health.mjs` — o detector dos "planos perdidos" (adversário convergência 2026-06-20, run wf_5925027a). O código estava pronto e testado, mas **preso** na branch `feat/memory-health-session-anchor-check`, que mistura ~420k deleções de CSS de protótipo (design-memory protegida) e não é mergeável como bloco. Este PR traz **só** o Check K: 2 arquivos, +80 linhas, **zero deleção**.

## Por quê
A avaliação adversarial apontou: `front_door_coverage=100%` mede *existência* de BRIEFING, não destilação — por isso os 155 planos perdidos passaram batido. O Check K fecha esse buraco: session log >30d com marcador de decisão (`## Decisão`/`US-`/`rollout`/`### Passo`) sem link pra ADR aceito nem BRIEFING → WARN (fila de triagem). Complementa o Check J (planos vivos, ADR 0294); aqui o alvo é o session log histórico.

## Comportamento
- **Advisory (warn-only), exit 0** — nunca bloqueia o gate.
- Smoke no repo real: **4 logs flagueados**, exit 0:
  - `2026-05-04-auditoria-regras-concorrentes-adr0069`
  - `2026-05-06-fase-3-7-pr1-drift-controllers`
  - `2026-05-06-governance-ui-completa-bugfix-marathon`
  - `2026-05-07-noite-audit-claude-desktop-nfe`
- Meta-teste físico (sensibilidade + especificidade) em `tests/memoryHealth.spec.ts` conforme ADR 0258 (todo check visto FALHAR e PASSAR num fixture).

Refs: ADR 0256 (knowledge survival) · ADR 0258 (controle-negativo) · ADR 0294 (planos vivos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)