### PR TITLE
fix(governance): índice de planos gerado não propaga Modules/<X> (anti-ghost)

### DIFF
--- a/memory/requisitos/_processo/PLANS-INDEX-GENERATED.md
+++ b/memory/requisitos/_processo/PLANS-INDEX-GENERATED.md
@@ -17,9 +17,9 @@
 ## Pendentes de `## Status vivo` (16) — backfill dirigido pela sentinela
 | Plano | Módulo |
 |---|---|
-| [DEPRECATION-PLAN — Modules/Accounting](../Accounting/DEPRECATION-PLAN.md) | Accounting |
+| [DEPRECATION-PLAN — Accounting](../Accounting/DEPRECATION-PLAN.md) | Accounting |
 | [Plano Migração Vargas → Autopecas (planejado — não existe) — 2026-05-1](../Autopecas/PLANO-MIGRACAO-VARGAS.md) | Autopecas |
-| [Plano Migração 6 Saudáveis OfficeImpresso → Modules/ComunicacaoVisual ](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) | ComunicacaoVisual |
+| [Plano Migração 6 Saudáveis OfficeImpresso → ComunicacaoVisual ](../ComunicacaoVisual/PLANO-MIGRACAO-6-SAUDAVEIS.md) | ComunicacaoVisual |
 | [JANA Pro — Product Plan executivo (32 US, 4 sprints, 90 dias)](../Copiloto/JANA-PRO-PRODUCT-PLAN.md) | Copiloto |
 | [Fase 1 — Conciliação passa a enxergar o extrato da API](../Financeiro/PLANO-FASE1-CONCILIACAO-LE-EXTRATO-API.md) | Financeiro |
 | [Fase 2 — Migração de dados: unificar extrato OFX → tabela canônica](../Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md) | Financeiro |
@@ -30,7 +30,7 @@
 | [Onda 1 — Vendas, PDV & Caixa · PLANO (MWART Fase 1)](../Mwart/ONDA-1-VENDAS-PDV-CAIXA-PLANO.md) | Mwart |
 | [Plano de paralelização — OficinaAuto Fase 1 (pós-Martinho)](../OficinaAuto/demo-martinho-2026-05-13/plano-paralelizacao.md) | OficinaAuto |
 | [PaymentGateway Onda 5 SIMPLIFICADA — Dogfooding SaaS via gateway adici](../PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md) | PaymentGateway |
-| [DEPRECATION-PLAN — Modules/SRS](../SRS/DEPRECATION-PLAN.md) | SRS |
+| [DEPRECATION-PLAN — SRS](../SRS/DEPRECATION-PLAN.md) | SRS |
 | [ADR ARQ-0001 (TaskRegistry) · Sistema de tasks MCP-native, não Plane s](../TaskRegistry/adr/arq/0001-mcp-native-vs-plane.md) | TaskRegistry |
 | [Índice de Planos Vivos (gerado)](_PLANS-INDEX-GENERATED.md) | _processo |
 

--- a/scripts/governance/plans-index.mjs
+++ b/scripts/governance/plans-index.mjs
@@ -147,6 +147,11 @@ ${pending.length ? '| Plano | Módulo |\n|---|---|\n' + pending.map((p) => `| [$
 
 ${issues.length ? `## Inconsistências de schema (${issues.length})\n${issues.map((i) => `- ⚠️ ${i}`).join('\n')}\n` : ''}`;
 
+// deghost: índice DERIVADO não propaga citação `Modules/<X>` (vinda de título/gate de um
+// plano) — senão o knowledge-drift atribui o ghost ao próprio _processo. Mantém o nome do
+// módulo sem o path. (ADR 0274 — catraca anti-ghost por módulo.)
+md = md.replace(/Modules\/([A-Za-z0-9]+)/g, '$1');
+
 // ── saída ─────────────────────────────────────────────────────────────────────
 if (MODE === 'json') {
   console.log(JSON.stringify({ registered, pending, issues, counts: { registered: registered.length, pending: pending.length, withReviewed, withParent } }, null, 2));


### PR DESCRIPTION
Resolve o **anti-ghost advisory vermelho** que o #3086 introduziu: o índice gerado (`_processo/PLANS-INDEX-GENERATED.md`) copiava `Modules/Accounting` do título do plano de deprecação → `knowledge-drift` atribuía o ghost ao `_processo` (1 NOVO).

**Fix** (contido no gerador): deghost da saída — `Modules/<X>` → `<X>`. Índice derivado não propaga citação de path de módulo.

**Verificado local:** `knowledge-drift --check` = **0 NOVOS (OK)** · canário verde · `plans-index --check` em dia · 0 ocorrências de `Modules/` no gerado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)