### PR TITLE
fix(governance): endurece Check K após review adversarial (idade + âncora estrutural)

### DIFF
--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -378,20 +378,28 @@ function checkSessionDecisionAnchor() {
       || /\bUS-[A-Z0-9]{2,}/.test(txt)
       || /\brollout\b/i.test(txt);
     if (!hasDecision) continue;
-    // idade: `date:` do frontmatter (quando a sessão ocorreu) → fallback git
-    const when = (txt.match(/^date:\s*["']?(\d{4}-\d{2}-\d{2})/mi) || [])[1] || gitLastDate(rel);
+    // idade: nome do arquivo `YYYY-MM-DD-…` é a fonte PRIMÁRIA — ~50% dos logs não têm
+    // `date:` no frontmatter, e `gitLastDate` "rejuvenesce" o doc no touch em massa
+    // (mascarava ~46 logs antigos como recentes). Ordem: slug → frontmatter `date:` → git.
+    const when = (rel.match(/(?:^|\/)(\d{4}-\d{2}-\d{2})-/) || [])[1]
+      || (txt.match(/^date:\s*["']?(\d{4}-\d{2}-\d{2})/mi) || [])[1]
+      || gitLastDate(rel);
     if (!when || when >= cutoffStr) continue; // só >30d
-    // âncora: referencia algum ADR ACEITO (nº existente + status aceito) OU um BRIEFING
+    // âncora ESTRUTURAL (não menção solta em prosa, que premiava name-dropping):
+    //   ADR aceito referenciado no FRONTMATTER (related_adrs/supersedes/superseded_by)
+    //   OU link `decisions/NNNN-…` no corpo  ·  BRIEFING pelo arquivo real (BRIEFING.md).
+    const fmEnd = txt.startsWith('---') ? txt.indexOf('\n---', 3) : -1;
+    const fm = fmEnd === -1 ? '' : txt.slice(0, fmEnd);
     const refs = new Set();
-    for (const m of txt.matchAll(/\bADR[\s-]*(\d{3,4})\b/gi)) refs.add(m[1].padStart(4, '0'));
-    for (const m of txt.matchAll(/\b(\d{4})-[a-z]{2,}/g)) refs.add(m[1]); // slug related_adrs / link decisions/NNNN
+    for (const m of fm.matchAll(/\b(\d{4})-[a-z]{2,}/g)) refs.add(m[1]);         // slug em related_adrs/supersedes
+    for (const m of txt.matchAll(/decisions\/(\d{4})-[a-z]/gi)) refs.add(m[1]);  // link pro arquivo do ADR
     const anchoredByAdr = [...refs].some((n) => accepted.has(n));
-    const anchoredByBriefing = /BRIEFING/i.test(txt);
+    const anchoredByBriefing = /BRIEFING\.md/i.test(txt);
     if (!anchoredByAdr && !anchoredByBriefing) lost.push(`${rel} (${when})`);
   }
   if (lost.length) {
     warns.push({ check: 'K', kind: 'session-decisao-sem-ancora', count: lost.length, sample: lost.slice(0, 12),
-      msg: `${lost.length} session log(s) >${SESSION_DECISION_STALE_DAYS}d com marcador de decisão (\`## Decisão\`/\`US-\`/\`rollout\`/\`### Passo\`) SEM link pra ADR aceito nem BRIEFING — os "planos perdidos" (adversário 2026-06-20). Triagem: promover a ADR/BRIEFING ou registrar resolução.` });
+      msg: `${lost.length} session log(s) >${SESSION_DECISION_STALE_DAYS}d com marcador de decisão (\`## Decisão\`/\`US-\`/\`rollout\`/\`### Passo\`) SEM âncora ESTRUTURAL (related_adrs/link decisions pra ADR aceito, ou BRIEFING.md) — os "planos perdidos" (adversário 2026-06-20). Triagem: promover a ADR/BRIEFING ou registrar resolução.` });
   }
 }
 

--- a/tests/memoryHealth.spec.ts
+++ b/tests/memoryHealth.spec.ts
@@ -115,7 +115,7 @@ describe('memory-health — Check I: lição sem asserção (Onda Q5, físico)',
 });
 
 describe('memory-health — Check K: decisão em session log sem âncora (Onda armar-gates, físico)', () => {
-  it('SENSIBILIDADE: session log >30d com `## Decisão` sem ADR aceito/BRIEFING → 🟡 K, não bloqueia', () => {
+  it('SENSIBILIDADE: session log >30d com `## Decisão` sem âncora → 🟡 K, não bloqueia', () => {
     write('memory/sessions/2026-01-01-perdido.md', '---\ndate: "2026-01-01"\n---\n\n# Sessão\n\n## Decisão\n\nFazer X. US-FOO-001 em rollout por ondas.\n');
     const out = run();
     expect(out).toMatch(/session-decisao-sem-ancora/);
@@ -123,9 +123,24 @@ describe('memory-health — Check K: decisão em session log sem âncora (Onda a
     expect(out).toMatch(/"ok": true/); // warn não bloqueia
   });
 
-  it('ESPECIFICIDADE: referencia ADR ACEITO existente → sem warn K', () => {
+  it('SENSIBILIDADE: idade vem do NOME do arquivo quando falta `date:` (fix do mascaramento gitLastDate)', () => {
+    write('memory/sessions/2026-01-03-sem-data-fm.md', '# Sessão\n\n## Decisão\n\nFez Z. rollout.\n'); // sem frontmatter
+    const out = run();
+    expect(out).toMatch(/session-decisao-sem-ancora/);
+    expect(out).toMatch(/2026-01-03-sem-data-fm\.md/);
+  });
+
+  it('SENSIBILIDADE: menção solta a ADR aceito em PROSA não ancora (anti name-dropping) → 🟡 K', () => {
     write('memory/decisions/0294-metodo.md', '---\nstatus: aceito\nlifecycle: ativo\n---\n\n# ADR 0294\n');
-    write('memory/sessions/2026-01-02-ancorado.md', '---\ndate: "2026-01-02"\n---\n\n# Sessão\n\n## Decisão\n\nDecisão landou na ADR 0294. rollout ok.\n');
+    write('memory/sessions/2026-01-04-prosa.md', '---\ndate: "2026-01-04"\n---\n\n# Sessão\n\n## Decisão\n\nDiferente da ADR 0294, decidimos Y. rollout.\n');
+    const out = run();
+    expect(out).toMatch(/session-decisao-sem-ancora/);
+    expect(out).toMatch(/2026-01-04-prosa\.md/);
+  });
+
+  it('ESPECIFICIDADE: âncora ESTRUTURAL (related_adrs → ADR aceito) → sem warn K', () => {
+    write('memory/decisions/0294-metodo.md', '---\nstatus: aceito\nlifecycle: ativo\n---\n\n# ADR 0294\n');
+    write('memory/sessions/2026-01-02-ancorado.md', '---\ndate: "2026-01-02"\nrelated_adrs: ["0294-metodo"]\n---\n\n# Sessão\n\n## Decisão\n\nDecisão registrada. rollout ok.\n');
     const out = run();
     expect(out).not.toMatch(/session-decisao-sem-ancora/);
   });


### PR DESCRIPTION
Follow-up de [#3084](https://github.com/wagnerra23/oimpresso.com/pull/3084) (mergeado com a versão fraca enquanto o adversário rodava).

Um cético adversarial achou **2 defeitos reais** no Check K como mergeado:

1. **Correção de bug (idade):** `gitLastDate(rel)` mascarava ~46 logs antigos — ~50% dos session logs não têm `date:` no frontmatter, e o touch em massa 'rejuvenesce' o git mtime → logs antigos pulados como 'recentes'. **Fix:** idade vem do **nome do arquivo** (`YYYY-MM-DD-…`) como fonte primária → frontmatter → git.
2. **Falso-negativo / gaming (âncora):** aceitava menção solta a ADR em **prosa** (premiava name-dropping) e a palavra 'BRIEFING' em qualquer lugar (silenciamento trivial). **Fix:** âncora **estrutural** — ADR aceito só via frontmatter `related_adrs`/`supersedes` ou link `decisions/NNNN`; BRIEFING só via arquivo real `BRIEFING.md`.

**Efeito:** detector sai de **4** (subnotificado pelo bug) → **32** logs reais. Segue WARN (`exit 0`). +2 casos de meta-teste (idade-do-nome, anti-prosa); harness local 5/5.

Refs: ADR 0256 · ADR 0258 (controle-negativo) · adversário 2026-06-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)