### PR TITLE
fix(governance): endurece hook R10 — comentário stale + 3 bypasses (review adversarial)

### DIFF
--- a/.claude/hooks/block-pr-without-approval.mjs
+++ b/.claude/hooks/block-pr-without-approval.mjs
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 // block-pr-without-approval.mjs — R10 enforcement POR MÁQUINA (cross-platform).
 //
-// PROPOSTA (2026-05-28) — ainda NÃO registrada em settings.json. Criar o arquivo
-// não ativa nada; só o registro ativa. Demo do padrão "regra → enforcement por
-// máquina" pedido por Wagner.
+// REGISTRADO em .claude/settings.json (PR #3058; endurecido #3065 + review adversarial
+// 2026-06-20) — em UserPromptSubmit + PreToolUse(Bash|PowerShell). Criar o arquivo não
+// ativa nada; o REGISTRO é o que ativa — scripts/governance/settings-r10-registration.test.mjs
+// guarda contra des-registro. Padrão "regra → enforcement por máquina" pedido por Wagner.
 //
 // Problema: R10 do PROTOCOLO-WAGNER-SEMPRE ("aprovação humana antes de
 // commit/push/merge/PR") era só ORIENTAÇÃO (skill wagner-protocol-enforce).
@@ -15,14 +16,20 @@
 //   1. UserPromptSubmit: se a mensagem do Wagner contém sinal de aprovação de
 //      PUBLICAÇÃO (pode fazer/pode pushar/merge/manda/aprovado...), grava flag
 //      com timestamp em tmpdir. TTL 15min.
-//   2. PreToolUse Bash: se o Claude tenta `gh pr create|merge` / `git push`,
-//      exige flag válida. Sem flag (ou expirada) → BLOQUEIA (exit 2).
-//      Com flag → permite e CONSOME (1 aprovação = 1 publicação).
+//   2. PreToolUse Bash/PowerShell: se o Claude tenta PUBLICAR — `gh pr create|merge`,
+//      `gh api` escrevendo em /pulls (criar PR) ou /pulls/N/merge, ou `git push`
+//      (inclusive `ENV=val git push` e `git -c k=v push`) — exige flag válida.
+//      Sem flag (ou expirada) → BLOQUEIA (exit 2). Com flag → permite e CONSOME.
 //
 // HONESTIDADE (limitações conhecidas):
 //   - Detecção por palavra-chave é uma REDE, não prova de escopo. Garante "houve
 //     sinal de aprovação recente", não "Wagner aprovou ESTE push específico".
-//   - Conservador: na dúvida, NÃO aprova (falso-negativo < falso-positivo).
+//   - Cobre gh pr create|merge, gh api escrevendo /pulls|/pulls/N/merge, e git push
+//     (+ env-prefix e flags `git -c`). NÃO cobre evasão deliberada exótica (alias
+//     custom, script intermediário). A defesa real de publicação é branch protection
+//     + enforce_admins (já ativos) — este hook é o PRIMEIRO filtro, não o último.
+//   - Conservador: na dúvida, NÃO aprova (falso-negativo < falso-positivo). Lê (GET)
+//     e comentários (/pulls/N/comments, /issues/N/comments) NÃO bloqueiam.
 //   - Escape valve: OIMPRESSO_PR_APPROVAL_OVERRIDE=1 (justificar no chat).
 //
 // Exit: 0 = continua | 2 = bloqueia (stderr vira razão pro Claude)
@@ -60,10 +67,21 @@ function isApproval(text) {
   return approvePatterns.some((r) => r.test(text));
 }
 
-// Ancorados no inicio efetivo do comando (apos ; & |) com limite de palavra —
-// evita falso-bloqueio quando a frase aparece dentro de string/comentario/arg de busca
-// (ex: rg 'git push', history | grep 'git push').
-const publishPatterns = [/(^|[;&|]\s*)gh\s+pr\s+(create|merge)(\s|$)/i, /(^|[;&|]\s*)git\s+push(\s|$)/i];
+// Ancorados no inicio efetivo do comando (apos ; & |) com limite de palavra — evita
+// falso-bloqueio quando a frase aparece dentro de string/comentario/arg de busca (ex:
+// rg 'git push', history | grep 'git push'). Cobre os bypasses do review adversarial
+// 2026-06-20: env-prefix, `git -c k=v push`, e `gh api` escrevendo em /pulls|/merge.
+const publishPatterns = [
+  /(^|[;&|]\s*)gh\s+pr\s+(create|merge)(\s|$)/i,
+  // git push — tolera prefixo de env (FOO=bar / FOO="a b") e flags do git antes de 'push'
+  /(^|[;&|]\s*)([A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)*git(\s+-\S+(\s+\S+)?)*\s+push(\s|$)/i,
+  // gh api — fazer MERGE de PR (endpoint .../pulls/N/merge)
+  /(^|[;&|]\s*)gh\s+api\b[^;&|]*\/pulls\/\d+\/merge\b/i,
+  // gh api — CRIAR PR: escrita (POST/-f/-F/--field/--input) no coletivo /pulls.
+  // Lookaheads exigem /pulls "folha" (nao /pulls/N/comments) + marcador de escrita →
+  // NAO casa reads (GET) nem comentarios de PR.
+  /(^|[;&|]\s*)gh\s+api\b(?=[^;&|]*\/pulls(?=[\s?'"]|$))(?=[^;&|]*(?:-X\s+POST|--method\s+POST|-f\b|-F\b|--field\b|--raw-field\b|--input\b))/i,
+];
 function isPublish(cmd) {
   return !!cmd && publishPatterns.some((r) => r.test(cmd));
 }

--- a/.claude/hooks/block-pr-without-approval.test.mjs
+++ b/.claude/hooks/block-pr-without-approval.test.mjs
@@ -107,10 +107,45 @@ check('PowerShell push com aprovacao -> ALLOW', runHook({ hook_event_name: 'PreT
 clearFlag();
 check('busca com "git push" embebido (rg) -> ALLOW (nao e publicacao)', runHook({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command: "rg 'git push' .claude/hooks" } }).code === 0);
 
+// --- Bypasses fechados no review adversarial 2026-06-20 (sem aprovacao -> BLOCK) ---
+const bash = (command) => ({ hook_event_name: 'PreToolUse', tool_name: 'Bash', tool_input: { command } });
+
+// 14. gh api -X POST .../pulls (cria PR via API) -> BLOCK.
+clearFlag();
+check('gh api -X POST /pulls -> BLOCK', runHook(bash('gh api -X POST repos/o/r/pulls -f title=x -f head=b -f base=main')).code === 2);
+
+// 15. gh api --method PUT .../pulls/N/merge (merge via API) -> BLOCK.
+clearFlag();
+check('gh api PUT /pulls/N/merge -> BLOCK', runHook(bash('gh api --method PUT repos/o/r/pulls/5/merge')).code === 2);
+
+// 16. gh api .../pulls -f (POST implicito por campo) -> BLOCK.
+clearFlag();
+check('gh api /pulls -f (POST implicito) -> BLOCK', runHook(bash('gh api repos/o/r/pulls -f title=x')).code === 2);
+
+// 17. git -c k=v push (flag entre git e push) -> BLOCK.
+clearFlag();
+check('git -c k=v push -> BLOCK', runHook(bash('git -c http.sslVerify=false push origin HEAD')).code === 2);
+
+// 18. ENV="a b" git push (prefixo de env com aspas) -> BLOCK.
+clearFlag();
+check('ENV="a b" git push -> BLOCK', runHook(bash('GIT_SSH_COMMAND="ssh -i k" git push')).code === 2);
+
+// 19. FALSO-POSITIVO: gh api GET em /pulls (listar PRs, read) -> ALLOW.
+clearFlag();
+check('gh api /pulls (GET read) -> ALLOW', runHook(bash('gh api repos/o/r/pulls')).code === 0);
+
+// 20. FALSO-POSITIVO: gh api comentario em PR (/pulls/N/comments) -> ALLOW.
+clearFlag();
+check('gh api /pulls/N/comments (comentario) -> ALLOW', runHook(bash('gh api repos/o/r/pulls/5/comments -f body=oi')).code === 0);
+
+// 21. FALSO-POSITIVO: git -c k=v log (nao e push) -> ALLOW.
+clearFlag();
+check('git -c k=v log (nao-push) -> ALLOW', runHook(bash('git -c core.pager=cat log --oneline')).code === 0);
+
 clearFlag();
 console.log('');
 if (fails === 0) {
-  console.log('[PASS] R10 enforçada pela MÁQUINA — sobrevive sem a skill. (13/13)');
+  console.log('[PASS] R10 enforçada pela MÁQUINA — sobrevive sem a skill. (21/21)');
   process.exit(0);
 } else {
   console.log(`[FAIL] ${fails} caso(s) — R10 NÃO está garantida pela máquina. NÃO rebaixar a skill.`);


### PR DESCRIPTION
Seguimento do review adversarial de 2026-06-20. O cético confirmou que o hook R10 (`block-pr-without-approval.mjs`) **está armado** (registrado em #3058, endurecido #3065) — mas **'armado-com-furos'**:

### 1. Comentário-cabeçalho mentiroso
Dizia *"ainda NÃO registrada em settings.json"* — foi **exatamente o que enganou o adversário original** a diagnosticar R10 como teatro. Corrigido para refletir o estado real (registrado + guardado por `settings-r10-registration.test.mjs`).

### 2. Três bypasses reais de publicação
Passavam direto pelo `publishPatterns` (que só pegava `gh pr create|merge` e `git push` ancorado):
| Bypass | Antes | Agora |
|---|---|---|
| `gh api -X POST/-f .../pulls` (cria PR pela API) | ✅ passava | 🛑 BLOCK |
| `gh api --method PUT .../pulls/N/merge` | ✅ passava | 🛑 BLOCK |
| `git -c k=v push` / `ENV=val git push` | ✅ passava | 🛑 BLOCK |

Lookaheads garantem que **reads (GET)** e **comentários** (`/pulls/N/comments`, `/issues/N/comments`) **não** bloqueiam — o fluxo do ci-monitor (que comenta via `gh api`) segue livre.

### Meta-teste
`block-pr-without-approval.test.mjs` sobe de **13 → 21** casos (5 bypasses BLOCK + 3 falso-positivos ALLOW). **21/21 verde** local; roda no `hooks selftest` do CI.

Continua sendo uma **rede, não prova** (evasão deliberada exótica fica fora) — a defesa real de publicação é branch protection + `enforce_admins`, já ativos; este hook é o **primeiro filtro**.

Refs: ADR 0258 (controle-negativo) · PROTOCOLO-WAGNER-SEMPRE R10 · adversário 2026-06-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)