### PR TITLE
fix(memory): quota frontmatter date/version em SPECs pro schema gate

### DIFF
--- a/memory/requisitos/Fiscal/SPEC.md
+++ b/memory/requisitos/Fiscal/SPEC.md
@@ -1,7 +1,7 @@
 ---
 module: Fiscal
 status: ativo
-version: 1.9.0
+version: "1.9.0"
 last_updated: "2026-05-25"
 piloto: oimpresso biz=1 (Wagner empresa) — depende de NfeBrasil já produção
 last_review: "2026-05-25"

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -1,6 +1,6 @@
 ---
 module: OficinaAuto
-version: 0.2.0
+version: "0.2.0"
 last_updated: "2026-06-09"
 status: ativo
 lifecycle: ativo

--- a/memory/requisitos/Ponto/SPEC.md
+++ b/memory/requisitos/Ponto/SPEC.md
@@ -1,7 +1,7 @@
 ---
 module: Ponto
 status: ativo
-version: 1.1.0
+version: "1.1.0"
 last_updated: "2026-05-25"
 owners: [W, E]
 parent_adr: 0094-constituicao-v2-7-camadas-8-principios

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -5,8 +5,8 @@ type: spec
 module: Sells
 status: ativo
 owner: wagner
-version: 1.0.0
-last_updated: 2026-05-31
+version: "1.0.0"
+last_updated: "2026-05-31"
 ---
 
 # Especificação funcional — Sells (migração MWART de /sells/create)


### PR DESCRIPTION
## Problema

O gate CI **SPEC (memory/requisitos/*/SPEC.md)** (Memory schema gate, advisory/não-required) falhava de forma recorrente porque campos de frontmatter sem aspas eram parseados pelo `gray-matter` (js-yaml) como `Date`/número, violando `type: string` do `scripts/memory-schemas/spec.schema.json`.

Annotation original (PR #3090, job 82526214694):
`memory/requisitos/Sells/SPEC.md: /last_updated must be string`

## Correção

Só frontmatter YAML do topo — **nenhum conteúdo de US / corpo tocado**:

| Arquivo | Mudança |
|---|---|
| `Sells/SPEC.md` | `version` + `last_updated` → quoted |
| `Fiscal/SPEC.md` | `version` → quoted (`last_updated` já estava) |
| `Ponto/SPEC.md` | `version` → quoted (`last_updated` já estava) |
| `OficinaAuto/SPEC.md` | `version` → quoted (`last_updated` já estava) |

## Verificação local

Validado com a **mesma stack do CI** (`gray-matter@4` + `ajv/dist/2020@8` + `ajv-formats@3`, `strict:false`, `allErrors:true`) contra `spec.schema.json`:

```
OK    Sells/SPEC.md
OK    Fiscal/SPEC.md
OK    Ponto/SPEC.md
OK    OficinaAuto/SPEC.md
```

## Fora de escopo (follow-up) — Dashboard

`Dashboard/SPEC.md` tem o mesmo `last_updated` cru, **mas também** viola o schema em dois pontos pré-existentes e independentes:
- `status: live` — fora do enum (`rascunho|ativo|arquivado|historical`)
- `related_adrs: [0093, 0094, 0101, 0104]` — inteiros, não slugs `^[0-9]{4}-[a-z0-9-]+$`

Esses erros hoje ficam latentes (o gate só valida arquivos no diff do PR). Incluir Dashboard aqui só pra quotar a data **acenderia** o gate em vermelho. Além disso, o fix correto exige decisão semântica (`live`→`ativo`?) e desambiguar o ADR `0101` (que tem dois slugs candidatos) — então fica para um PR separado.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)