### PR TITLE
fix(memory): zera violações do SPEC schema gate no Dashboard

### DIFF
--- a/memory/requisitos/Dashboard/SPEC.md
+++ b/memory/requisitos/Dashboard/SPEC.md
@@ -1,13 +1,17 @@
 ---
 module: Dashboard
-status: live
+status: ativo
 phase: F6 Soft wrapper (entrega 2026-05-21)
 parent_route: /home
-version: 1.0.0
+version: "1.0.0"
 owner: wagner
-last_updated: 2026-05-21
-last_validated: 2026-05-21
-related_adrs: [0093, 0094, 0101, 0104]
+last_updated: "2026-05-21"
+last_validated: "2026-05-21"
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0101-tests-business-id-1-nunca-cliente
+  - 0104-processo-mwart-canonico-unico-caminho
 ---
 
 # SPEC — Dashboard (tela inicial pós-login `/home`)


### PR DESCRIPTION
Follow-up do #3095. Esse PR zera as violações **latentes** do `spec.schema.json` no `Dashboard/SPEC.md` — hoje invisíveis (o gate só valida arquivos no diff do PR), mas que falhariam (6 erros) assim que alguém tocasse o arquivo.

## Mudanças (só frontmatter — nenhum conteúdo/US tocado)

| Antes | Depois | Motivo |
|---|---|---|
| `status: live` | `status: ativo` | `live` fora do enum (`rascunho\|ativo\|arquivado\|historical`) |
| `last_updated: 2026-05-21` | `last_updated: "2026-05-21"` | data crua vira `Date`, viola `type: string` |
| `last_validated` / `version` | quoted | consistência (não eram gate-blocking, mas crus) |
| `related_adrs: [0093, 0094, 0101, 0104]` | lista de slugs | inteiros não batem `^[0-9]{4}-[a-z0-9-]+$` |

ADRs resolvidos contra `memory/decisions/` (sem inventar):
- `0093-multi-tenant-isolation-tier-0`
- `0094-constituicao-v2-7-camadas-8-principios`
- `0101-tests-business-id-1-nunca-cliente` ← **0101 tem dois slugs**; escolhido o de tests (Wagner-confirmado; mesmo cluster 0093/0094/0104 do Ponto)
- `0104-processo-mwart-canonico-unico-caminho`

## Verificação local

Validado com a mesma stack do CI (`gray-matter@4` + `ajv/dist/2020@8` + `ajv-formats@3`): **1 OK, 0 FAIL**.

> **Nota:** `Inventory/SPEC.md` tem violações piores (faltam `module`/`version`/`last_updated` obrigatórios), mas vive na branch `feat/governance-ds-rollout-ledger` (não está em `main` — veio do #2761), então o fix dela vai naquela branch, não aqui.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)