### PR TITLE
feat(governance): bateria de sentinelas honesta + bite-tests + agregador

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -120,7 +120,7 @@ class HealthCheckCommand extends Command
 
         // Advisory checks (charter) reportam mas não derrubam o exit code:
         // contam como "ok" pro gate enquanto não viram ratchet.
-        $allOk = collect($checks)->every(fn ($c) => $c['ok'] || ($c['advisory'] ?? false));
+        $allOk = self::allChecksOk($checks);
 
         if ($this->option('json')) {
             $this->line(json_encode([
@@ -153,6 +153,18 @@ class HealthCheckCommand extends Command
         }
 
         return $allOk ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * Veredito do gate: OK a menos que algum check NÃO-advisory tenha ok=false.
+     * Extraído pra ser testável SEM DB (bite-test SentinelBiteTest) — prova que o
+     * exit code RESPONDE ao estado dos checks, não é constante (auditoria de
+     * sentinelas 2026-06-20). A regra advisory é a parte sutil: advisory false NÃO
+     * derruba o gate; check duro false derruba.
+     */
+    public static function allChecksOk(array $checks): bool
+    {
+        return collect($checks)->every(fn ($c) => ($c['ok'] ?? false) || ($c['advisory'] ?? false));
     }
 
     /**

--- a/Modules/Jana/Console/Commands/JanaDriftSentinelCommand.php
+++ b/Modules/Jana/Console/Commands/JanaDriftSentinelCommand.php
@@ -16,7 +16,10 @@ use Modules\Jana\Services\Ragas\RagasJudgeService;
  * Compara respostas atuais vs baseline checked-in (baseline-responses.json).
  * Alerta se >10% das perguntas divergirem ≥ DRIFT_THRESHOLD do baseline.
  *
- * Schedule: weekly Sun 06:00 BRT (app/Console/Kernel.php).
+ * Schedule: weekly Sun 06:00 BRT (app/Console/Kernel.php) — RELIGADO 2026-06-20.
+ * Requer OPENAI_API_KEY no servidor pra rodar real; sem a chave o run falha e o
+ * onFailure registra (sinal honesto). --mock é só pra CI/teste (mock NÃO detecta
+ * drift real — faithfulness fixa em 0.85).
  *
  * Uso:
  *   php artisan jana:drift-sentinel                    # roda real (precisa OPENAI_API_KEY)

--- a/Modules/Jana/Console/Commands/JanaValidateMemoryCommand.php
+++ b/Modules/Jana/Console/Commands/JanaValidateMemoryCommand.php
@@ -16,8 +16,10 @@ use JsonSchema\Validator;
  * contra os JSON Schemas em scripts/memory-schemas/*.schema.json.
  *
  * Complementa o workflow CI (.github/workflows/memory-schema-gate.yml — gate A AJV).
- * Aqui é gate LOCAL pré-push + integra cron daily (~06:30 BRT) pra capturar
- * drift criado fora do PR (manual edit, ferramentas externas, etc).
+ * Aqui é gate LOCAL pré-push. NÃO está agendado no Kernel (auditoria de sentinelas
+ * 2026-06-20: o claim anterior "integra cron daily ~06:30 BRT" era FALSO — grep no
+ * Kernel.php não retorna este comando). Drift fora-do-PR (edit manual, SSH) depende
+ * de rodar local/CI; agendar com --strict é decisão pendente [W].
  *
  * Grace period 14d:
  *   - JANA_VALIDATE_MEMORY_STRICT=false (default) → warning + exit 0

--- a/Modules/Jana/Console/Commands/SystemAuditCommand.php
+++ b/Modules/Jana/Console/Commands/SystemAuditCommand.php
@@ -58,7 +58,7 @@ class SystemAuditCommand extends Command
             $this->checkTestCoverageGate(),
         ];
 
-        $allOk = collect($checks)->every(fn ($c) => $c['ok']);
+        $allOk = self::allChecksOk($checks);
 
         if ($this->option('json')) {
             $this->line(json_encode([
@@ -87,6 +87,17 @@ class SystemAuditCommand extends Command
         }
 
         return $allOk ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * Veredito do gate: OK só se TODOS os checks têm ok=true (system-audit não tem
+     * advisory — todos os 5 são duros). Extraído pra ser testável SEM DB (bite-test
+     * SentinelBiteTest) — prova que o exit code RESPONDE ao estado, não é constante.
+     * Auditoria de sentinelas 2026-06-20 (o comando tinha ZERO testes).
+     */
+    public static function allChecksOk(array $checks): bool
+    {
+        return collect($checks)->every(fn ($c) => (bool) ($c['ok'] ?? false));
     }
 
     /**

--- a/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+use Modules\Jana\Console\Commands\SystemAuditCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Bite-tests dos sentinelas de governança (auditoria de sentinelas 2026-06-20).
+ *
+ * Problema "a suite mente": jana:health-check e jana:system-audit MORDEM no código
+ * (return FAILURE quando um check duro falha), mas nenhum teste PROVAVA a mordida —
+ * o smoke (JanaHealthCheckTest) só assere exit ∈ {0,1} e o system-audit tinha ZERO
+ * testes. Um refactor poderia silenciar o exit code sem nenhum teste ficar vermelho.
+ *
+ * Estratégia DB-agnóstica (o schema completo só roda em MySQL no CI, não SQLite):
+ *   1. UNIT do veredito (allChecksOk) — prova a REGRA check→ok, incluindo a sutileza
+ *      advisory, sem tocar DB.
+ *   2. INTEGRAÇÃO — roda o comando REAL e exige exit == veredito(checks do JSON).
+ *      Pega "sempre retorna 0" (ou "sempre 1") em qualquer estado de DB.
+ */
+
+// ── 1. UNIT do veredito (determinístico, sem DB) ─────────────────────────────
+
+test('health-check veredito: check duro ok=false DERRUBA o gate', function () {
+    expect(HealthCheckCommand::allChecksOk([
+        ['name' => 'a', 'ok' => true],
+        ['name' => 'b', 'ok' => false], // duro falho
+    ]))->toBeFalse();
+});
+
+test('health-check veredito: tudo ok = passa', function () {
+    expect(HealthCheckCommand::allChecksOk([
+        ['name' => 'a', 'ok' => true],
+        ['name' => 'b', 'ok' => true],
+    ]))->toBeTrue();
+});
+
+test('health-check veredito: advisory ok=false NÃO derruba o gate', function () {
+    expect(HealthCheckCommand::allChecksOk([
+        ['name' => 'a', 'ok' => true],
+        ['name' => 'charter_missing', 'ok' => false, 'advisory' => true],
+    ]))->toBeTrue();
+});
+
+test('system-audit veredito: qualquer check ok=false derruba (sem advisory)', function () {
+    expect(SystemAuditCommand::allChecksOk([
+        ['name' => 'a', 'ok' => true],
+        ['name' => 'b', 'ok' => false],
+    ]))->toBeFalse();
+
+    expect(SystemAuditCommand::allChecksOk([
+        ['name' => 'a', 'ok' => true],
+    ]))->toBeTrue();
+});
+
+// ── 2. INTEGRAÇÃO: exit code == veredito (prova que NÃO é constante) ──────────
+
+/** Extrai o bloco JSON do output do comando (pode haver linhas de debug antes). */
+function biteJson(string $output): array
+{
+    $start = strpos($output, '{');
+    expect($start)->not->toBeFalse('Output não contém JSON');
+
+    return json_decode(substr($output, (int) $start), true);
+}
+
+test('jana:health-check: exit code BATE com o veredito dos checks', function () {
+    $exit = Artisan::call('jana:health-check', ['--json' => true]);
+    $json = biteJson(Artisan::output());
+
+    $esperaFalha = collect($json['checks'])
+        ->contains(fn ($c) => ! ($c['ok'] ?? false) && ! ($c['advisory'] ?? false));
+
+    expect($exit)->toBe($esperaFalha ? 1 : 0);
+});
+
+test('jana:system-audit: exit code BATE com o veredito dos checks', function () {
+    // Evita HTTP real no check de observability (rápido + sem flakiness de rede).
+    putenv('LANGFUSE_HOST');
+    unset($_ENV['LANGFUSE_HOST'], $_SERVER['LANGFUSE_HOST']);
+
+    $exit = Artisan::call('jana:system-audit', ['--json' => true]);
+    $json = biteJson(Artisan::output());
+
+    $esperaFalha = collect($json['checks'])->contains(fn ($c) => ! ($c['ok'] ?? false));
+
+    expect($exit)->toBe($esperaFalha ? 1 : 0);
+});
+
+test('jana:system-audit registrado no artisan list', function () {
+    Artisan::call('list');
+    expect(Artisan::output())->toContain('jana:system-audit');
+});

--- a/app/Console/Commands/MemAuditCommand.php
+++ b/app/Console/Commands/MemAuditCommand.php
@@ -42,9 +42,12 @@ class MemAuditCommand extends Command
         $automemDir = str_replace('\\', '/', $automemDir);
 
         if (! is_dir($automemDir)) {
-            $this->warn("Diretório auto-mem não encontrado: $automemDir");
+            // ADR 0061 descontinuou auto-mem privada — diretório AUSENTE é o estado
+            // DESEJADO, não falha. Antes retornava 1 (semântica invertida: "nada pra
+            // auditar" virava erro). Corrigido 2026-06-20 (auditoria de sentinelas).
+            $this->info("Sem diretório auto-mem ($automemDir) — estado esperado pós-ADR 0061.");
             $this->line('Use --automem-dir=PATH se ele estiver em outro local.');
-            return 1;
+            return 0;
         }
 
         $automems = glob("$automemDir/*.md") ?: [];
@@ -56,6 +59,7 @@ class MemAuditCommand extends Command
         }
 
         $rows = [];
+        $criticos = 0; // ❌ = auto-mem densa SEM ADR equivalente (forte candidato a promover)
         $candidatesOnly = (bool) $this->option('candidates-only');
 
         foreach ($automems as $autoPath) {
@@ -70,6 +74,10 @@ class MemAuditCommand extends Command
                 $match && $match['cobertura'] >= 0.3 => '⚠️',
                 default                              => '❌',
             };
+
+            if ($emoji === '❌') {
+                $criticos++;
+            }
 
             if ($candidatesOnly && $emoji === '✅') continue;
 
@@ -88,6 +96,15 @@ class MemAuditCommand extends Command
         }
 
         $this->table(['', 'auto-mem', 'ADR equivalente', 'cobertura', 'tamanho'], $rows);
+
+        // MORDE: ❌ = auto-mem densa sem ADR equivalente = conhecimento canônico que
+        // ficou de fora do git. Antes retornava SEMPRE 0 (teatro). Corrigido
+        // 2026-06-20 (auditoria de sentinelas) — exit 1 sinaliza pendência real.
+        if ($criticos > 0) {
+            $this->warn("$criticos auto-mem(s) ❌ sem ADR equivalente — promover pro git canônico (ADR 0061).");
+            return 1;
+        }
+
         return 0;
     }
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -384,6 +384,26 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Wave 23 — jana:drift-sentinel canary SEMANAL da Jana (dom 06:00 BRT).
+        // Compara faithfulness atual vs baseline canon; ALERT se >10% das perguntas
+        // divergirem. RELIGADO 2026-06-20 (auditoria de sentinelas): o docblock do
+        // comando afirmava "Schedule weekly Sun 06:00" mas NÃO existia entry aqui —
+        // ghost canary (existe + tem teste de mordida, nunca rodava). Requer
+        // OPENAI_API_KEY no servidor; sem a chave o run falha e o onFailure registra
+        // (sinal honesto de "canary cego", não silêncio). Domingo cedo pra não
+        // disputar DB com os health-checks diários (06:00-06:30).
+        $schedule->command('jana:drift-sentinel')
+            ->weeklyOn(0, '06:00')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule jana:drift-sentinel FALHOU — drift Jana acima do threshold ' .
+                    'OU canary não rodou (checar OPENAI_API_KEY). Ver storage/logs.'
+                );
+            });
+
         // Bug #4 BUGS-MCP-SYNC-2026-05-13 — mcp:tasks:health-check daily 06:20 BRT.
         // Flagga tasks dormentes em mcp_tasks (stale_todo >21d, stale_blocked >30d,
         // stale_doing >7d sem commit, stale_review >5d). Roda SEM --auto-comment

--- a/scripts/governance/governance-audit.mjs
+++ b/scripts/governance/governance-audit.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// governance-audit.mjs — AGREGADOR da bateria de sentinelas (auditoria de sentinelas
+// 2026-06-20). Resolve o buraco "não tem um botão": antes a verdade da governança
+// vivia espalhada em ~8 comandos soltos. Aqui é UM comando → UM scorecard.
+//
+// Roda a bateria inteira e devolve {ok, results[]}. Cobre os sentinelas Node
+// (determinísticos, sem infra) + os health-checks PHP (best-effort: skip gracioso
+// se php/app não bootar — eles têm enforcement próprio via cron prod + bite-tests).
+//
+// EXIT CODE só morde nos sentinelas `required` DETERMINÍSTICOS (node core), pra ser
+// confiável em qualquer ambiente (CI, dev, prod). Os PHP entram como advisory aqui
+// porque dependem de DB/Langfuse de prod — a mordida real deles é o cron + Pest.
+//
+// USO (na raiz do repo):
+//   node scripts/governance/governance-audit.mjs            # tabela
+//   node scripts/governance/governance-audit.mjs --json     # scorecard JSON (Daily Brief)
+//   node scripts/governance/governance-audit.mjs --node-only # pula os PHP
+//
+// Node puro (spawnSync). Sem deps.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const JSON_OUT = process.argv.includes('--json');
+const NODE_ONLY = process.argv.includes('--node-only');
+const stripAnsi = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+
+// runtime: node = process.execPath <script>; php = php artisan <cmd>
+// kind: required (entra no exit) | advisory (só reporta)
+const BATTERY = [
+  { id: 'memory-health',       runtime: 'node', kind: 'required', cmd: ['scripts/governance/memory-health.mjs', '--json'] },
+  { id: 'gate-selftest',       runtime: 'node', kind: 'required', cmd: ['scripts/governance/gate-selftest.mjs', '--json'] },
+  { id: 'integrity-check',     runtime: 'node', kind: 'advisory', cmd: ['prototipo-ui/integrity-check.mjs'] },
+  { id: 'knowledge-drift',     runtime: 'node', kind: 'advisory', cmd: ['scripts/governance/knowledge-drift.mjs', '--check'] },
+  { id: 'ds-guard',            runtime: 'node', kind: 'advisory', cmd: ['prototipo-ui/ds-guard.mjs', '--all'] },
+  // PHP health-checks: advisory aqui (dependem de infra prod) — enforcement = cron + Pest bite-tests.
+  { id: 'jana:health-check',   runtime: 'php',  kind: 'advisory', cmd: ['jana:health-check', '--json'] },
+  { id: 'jana:system-audit',   runtime: 'php',  kind: 'advisory', cmd: ['jana:system-audit', '--json'] },
+  { id: 'jana:validate-memory',runtime: 'php',  kind: 'advisory', cmd: ['jana:validate-memory', '--json'] },
+  { id: 'mem:audit',           runtime: 'php',  kind: 'advisory', cmd: ['mem:audit', '--candidates-only'] },
+];
+
+function run(entry) {
+  if (entry.runtime === 'node') {
+    const scriptPath = join(ROOT, entry.cmd[0]);
+    if (!existsSync(scriptPath)) return { status: 'skip', summary: `script ausente: ${entry.cmd[0]}` };
+    const r = spawnSync(process.execPath, [scriptPath, ...entry.cmd.slice(1)], {
+      cwd: ROOT, encoding: 'utf8', env: { ...process.env, GITHUB_STEP_SUMMARY: '' },
+    });
+    return interpret(entry, r);
+  }
+  // php
+  if (NODE_ONLY) return { status: 'skip', summary: '--node-only' };
+  // shell no Windows pra resolver php.bat (Herd); Linux/CI tem php binário no PATH.
+  const r = spawnSync('php', ['artisan', ...entry.cmd], {
+    cwd: ROOT, encoding: 'utf8', shell: process.platform === 'win32',
+  });
+  if (r.error) return { status: 'skip', summary: `php indisponível (${r.error.code || r.error.message})` };
+  return interpret(entry, r);
+}
+
+function interpret(entry, r) {
+  const out = stripAnsi((r.stdout || '') + (r.stderr || ''));
+  // Prefere o campo ok do JSON quando o sentinela o emite; senão usa exit code.
+  let ok = r.status === 0;
+  let summary = '';
+  const jStart = out.indexOf('{');
+  if (jStart !== -1) {
+    try {
+      const j = JSON.parse(out.slice(jStart));
+      if (typeof j.ok === 'boolean') ok = j.ok;
+      if (Array.isArray(j.fails) || Array.isArray(j.warns)) {
+        summary = `${(j.fails || []).length} fail · ${(j.warns || []).length} warn`;
+      } else if (Array.isArray(j.cases)) {
+        const bad = j.cases.filter((c) => !c.ok).length;
+        summary = `${j.cases.length} casos · ${bad} falhos`;
+      } else if (Array.isArray(j.checks)) {
+        const bad = j.checks.filter((c) => !c.ok && !(c.advisory)).length;
+        summary = `${j.checks.length} checks · ${bad} duros falhos`;
+      }
+    } catch { /* não era JSON — cai no fallback */ }
+  }
+  if (!summary) {
+    const lines = out.split('\n').map((l) => l.trim()).filter(Boolean);
+    summary = (lines[lines.length - 1] || '').slice(0, 90);
+  }
+  return { status: ok ? 'pass' : 'fail', summary, exit: r.status };
+}
+
+const results = BATTERY.map((e) => ({ id: e.id, kind: e.kind, runtime: e.runtime, ...run(e) }));
+
+// Exit morde só nos required determinísticos que falharam (não skip).
+const blocking = results.filter((r) => r.kind === 'required' && r.status === 'fail');
+const ok = blocking.length === 0;
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({ ok, ran_at: new Date().toISOString(), results }, null, 2));
+  process.exit(ok ? 0 : 1);
+}
+
+const icon = { pass: '✅', fail: '❌', skip: '⊘' };
+console.log(`\n  GOVERNANCE-AUDIT — bateria de sentinelas (${results.length} sentinelas)\n`);
+for (const r of results) {
+  const tag = r.kind === 'required' ? 'REQ' : 'adv';
+  console.log(`  ${icon[r.status]} ${r.id.padEnd(22)} [${tag}] ${r.summary}`);
+}
+console.log('');
+if (!ok) {
+  console.error(`  ✗ ${blocking.length} sentinela(s) REQUIRED falharam: ${blocking.map((r) => r.id).join(', ')}\n`);
+  process.exit(1);
+}
+console.log(`  ✓ core determinístico verde. (sentinelas PHP são best-effort — verdade de prod via cron + Pest.)\n`);
+process.exit(0);


### PR DESCRIPTION
## Por quê

Auditoria de sentinelas (2026-06-20, 3 agentes cruzando CI + cron + scripts vs `required-checks-baseline.json`) achou que a bateria de governança tinha verdade **espalhada e parcialmente apodrecida**: sentinelas que mentem no docblock que rodam, "teatro" que retorna verde, mordidas sem teste que as prove, e nenhum botão único.

Este PR fecha 3 dos buracos (streams 1–3). O stream 4 (catraca de planos órfãos) está sendo tratado em paralelo (`backlog-34`).

## O que muda

### 1. Tornar honestas (`fix`) — sentinelas fantasma/teatro
- **`jana:drift-sentinel`**: o docblock afirmava `weekly Sun 06:00 (Kernel.php)` mas **não havia entry no Kernel** — ghost canary (existe + tem teste de mordida, nunca rodava). **Religado de verdade** (`0 6 * * 0`, `environments(['live'])`, `onFailure`). Confirmado no `schedule:list`.
- **`mem:audit`**: semântica **invertida** — exit 0 ao ACHAR candidato `❌` e exit 1 por diretório ausente (o caso normal pós-ADR 0061). Corrigido: dir ausente = SUCCESS (estado desejado); `≥1 ❌` sem ADR equivalente = FAILURE (morde).
- **`jana:validate-memory`**: docblock afirmava um cron diário inexistente. Alinhado à realidade (gate local pré-push + CI).

### 2. Bite-tests (`test`) — provar que os health-checks MORDEM
`jana:health-check` e `jana:system-audit` mordem no código mas **nada provava** (o primeiro só asseria exit ∈ {0,1}; o segundo tinha **zero testes**). Risco "a suite mente".
- Extrai o veredito (`allChecksOk`) pra método estático testável nos 2 comandos (health-check preserva a regra *advisory*; system-audit é all-hard).
- `SentinelBiteTest`: unit do veredito (incl. sutileza advisory) **sem DB** + integração `exit == veredito(checks)` **DB-agnóstico** (o schema completo só roda em MySQL no CI — uma migration `ALTER…MODIFY ENUM` quebra em SQLite). Pega "sempre retorna 0/1".
- **7 testes / 10 asserções verde local** (php 8.4.21).

### 3. Agregador (`feat`) — `governance-audit.mjs`, o "botão único"
Roda a bateria inteira → UM scorecard `{ok, results[]}`. Core determinístico node (`memory-health`, `gate-selftest`) é REQUIRED no exit (confiável em qualquer ambiente); `integrity-check`/`knowledge-drift`/`ds-guard` advisory; health-checks PHP best-effort (skip gracioso se app não bootar — enforcement real = cron prod + bite-tests). `--json` alimenta o Daily Brief. Verificado de checkout limpo: core verde, exit 0.

## Fora de escopo / follow-ups
- **Catraca de planos órfãos** (stream 4) — em andamento no `backlog-34` (22 US já criadas).
- **`gate-selftest` cobrir `memory-health`** com fixtures good/bad (hoje cobre 4 catracas; `memory-health` é o único `.mjs` que morde no merge e não está no self-test).
- **`jana:drift-sentinel`** precisa de `OPENAI_API_KEY` no servidor pra rodar real; sem a chave, o `onFailure` semanal sinaliza "canary cego".
- **Promover ao branch protection** os gates `vermelho-mas-mergeável` (module-grades, scope-guard, etc.) — decisão + calendário ADR 0275.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
