### PR TITLE
feat(governance): plan-health no Daily Brief + gate CI advisory (ADR 0294 Onda 1)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -43,6 +43,8 @@ Modules/Jana/Tests/Feature/Mcp/AuthorizesMcpMutationTest.php
 # Source-ratchet (sem DB) → sqlite-safe.
 Modules/Jana/Tests/Feature/Mcp/McpAuthUserResolverTest.php
 Modules/Brief/Tests/Feature/LeaseBriefSectionServiceTest.php
+# Linha de saúde dos planos no brief (ADR 0294 Onda 1) — Process::fake, sem DB.
+Modules/Governance/Tests/Feature/PlanHealthBriefLineServiceTest.php
 tests/Feature/Modules/Copiloto/Mcp/WhatsActiveToolTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/ClaimlessMutationWarningTest.php
 Modules/Jana/Tests/Feature/TaskRegistry/TasksScopeSplitTest.php

--- a/.github/workflows/plan-health-gate.yml
+++ b/.github/workflows/plan-health-gate.yml
@@ -1,0 +1,50 @@
+name: Plan Health Gate (advisory)
+
+# ADR 0294 Onda 1 — catraca da membrana dual-track. Sentinela de PLANOS órfãos/
+# podres (scripts/governance/plan-health.mjs) plugada no CI: quando um PR toca um
+# *PLAN*.md (ou o próprio Índice de Planos Vivos), valida o índice + o bloco
+# `## Status vivo` de cada plano (status no enum, frescor reviewed_at ≤30d, órfão
+# em-execução sem parent_plan, superseded sem ponteiro, índice dangling).
+#
+# ── ADVISORY DE NASCENÇA (ADR 0271 / 0275: gate novo NUNCA nasce required) ─────
+# `continue-on-error: true` no job inteiro: roda `--check` (exit 1 quando há
+# achado → status 🟡 visível na PR), mas NÃO bloqueia merge. Padrão ratchet do
+# repo — espelha tier0-guards-advisory.yml + anchor-drift.yml. Promoção a required
+# só pelo CALENDÁRIO DE PROMOÇÕES (ADR 0275): remover o `continue-on-error` e
+# adicionar ao branch protection — nunca editando este arquivo direto.
+#
+# Sentinela é Node puro, sem deps, sem rede → setup mínimo (checkout + setup-node).
+# No-op gracioso: PLANS-INDEX ausente → exit 0 (a própria sentinela trata).
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'memory/requisitos/**/*PLAN*.md'
+      - 'memory/requisitos/**/*plano*.md'
+      - 'memory/requisitos/_processo/PLANS-INDEX.md'
+      - 'scripts/governance/plan-health.mjs'
+      - '.github/workflows/plan-health-gate.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: plan-health-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  plan-health:
+    name: plan-health ADR 0294 (advisory)
+    runs-on: ubuntu-latest
+    # ADVISORY: job inteiro não bloqueia merge. Remover quando virar required
+    # (calendário de promoções ADR 0275).
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: plan-health --check (morde, mas advisory via continue-on-error)
+        run: node scripts/governance/plan-health.mjs --check

--- a/.github/workflows/plan-health-gate.yml
+++ b/.github/workflows/plan-health-gate.yml
@@ -47,4 +47,9 @@ jobs:
         with:
           node-version: '20'
       - name: plan-health --check (morde, mas advisory via continue-on-error)
+        # `continue-on-error` no step também: o `--check` sai 1 quando há achado,
+        # mas o check fica VERDE-advisory (achados visíveis no log) em vez de 🔴
+        # bloqueante — mesmo padrão de tier0-guards-advisory.yml. Promoção a
+        # required = remover ambos continue-on-error (calendário ADR 0275).
+        continue-on-error: true
         run: node scripts/governance/plan-health.mjs --check

--- a/Modules/Brief/Console/Commands/GenerateBriefCommand.php
+++ b/Modules/Brief/Console/Commands/GenerateBriefCommand.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\DB;
 use Modules\Brief\Services\BriefGeneratorService;
 use Modules\Brief\Services\BriefValidator;
 use Modules\Brief\Services\LeaseBriefSectionService;
+use Modules\Governance\Services\PlanHealthBriefLineService;
 use Modules\Governance\Services\SddBriefLineService;
 use Throwable;
 
@@ -50,6 +51,13 @@ final class GenerateBriefCommand extends Command
         // mcp_sdd_scorecard_history OU há alerta (armada regrediu/fonte
         // vermelha). inject() é best-effort — brief nunca falha por causa dela.
         $content = app(SddBriefLineService::class)->inject($content);
+
+        // ADR 0294 Onda 1 — linha de SAÚDE DOS PLANOS (pós-LLM, determinística) na
+        // seção FLAGS: shell-out de scripts/governance/plan-health.mjs --json e
+        // injeta "Planos: N vivos · X órfãos · Y a revisar". Best-effort: `node`
+        // ausente / índice não-deployado → brief intacto. Catraca-irmã do gate CI
+        // plan-health-gate.yml (PLANS-INDEX §"Como manter vivo" item 2).
+        $content = app(PlanHealthBriefLineService::class)->inject($content);
 
         // C2+C3 (SDD Leva 2, ADR 0278) — bloco de leases ATIVOS + nudge "claim
         // antes de pegar", injetado sob `## EM VOO AGORA`. Best-effort (pós-LLM):

--- a/Modules/Governance/Config/config.php
+++ b/Modules/Governance/Config/config.php
@@ -126,4 +126,14 @@ return [
      * @see Modules\Governance\Services\SddBriefLineService
      */
     'sdd_brief_line' => env('GOVERNANCE_SDD_BRIEF_LINE', true),
+
+    /*
+     * Kill-switch ADR 0294 Onda 1 (default ON) — linha de saúde dos PLANOS no
+     * Daily Brief (shell-out de scripts/governance/plan-health.mjs --json).
+     * `GOVERNANCE_PLAN_HEALTH_BRIEF_LINE=false` no .env desliga o inject() sem
+     * deploy: PlanHealthBriefLineService devolve o brief intacto (zero linha,
+     * zero shell-out). Útil em host sem Node ou pra silenciar a linha.
+     * @see Modules\Governance\Services\PlanHealthBriefLineService
+     */
+    'plan_health_brief_line' => env('GOVERNANCE_PLAN_HEALTH_BRIEF_LINE', true),
 ];

--- a/Modules/Governance/Services/PlanHealthBriefLineService.php
+++ b/Modules/Governance/Services/PlanHealthBriefLineService.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+use Throwable;
+
+/**
+ * ADR 0294 Onda 1 — linha de SAÚDE DOS PLANOS no Daily Brief (catraca da membrana
+ * dual-track). Fecha o "meus planos se perdem": uma linha persistente no brief com
+ * a contagem de planos vivos + os que estão órfãos/a-revisar, lida 6x/dia sem
+ * esforço (PLANS-INDEX.md §"Como manter vivo" item 2).
+ *
+ * Transporte (o brief é PHP, a sentinela é Node): shell-out de
+ * `scripts/governance/plan-health.mjs --json` via Process (mesmo idioma de
+ * NpmAuditChecker/ComposerAuditChecker) + json_decode. Fonte-única: NÃO reimplementa
+ * o parser do `## Status vivo` em PHP — quem conta é a sentinela, aqui só se formata.
+ *
+ * Determinística (pós-LLM): `inject()` é chamado por GenerateBriefCommand DEPOIS do
+ * Brain B gerar o markdown — o modelo nunca inventa esse número. Espelha o pattern
+ * de SddBriefLineService (GT-G8): injeta um bullet na seção `## FLAGS`.
+ *
+ * Degrada graciosamente (brief NUNCA quebra por causa dela):
+ *  - `node` ausente / script não-deployado / timeout → null (sem linha)
+ *  - JSON inválido → null
+ *  - sentinela em no-op (`skipped`: PLANS-INDEX ausente) → null
+ *  - índice vazio (0 planos) → null
+ * Kill-switch: `governance.plan_health_brief_line` false → no-op (default ON).
+ *
+ * @see scripts/governance/plan-health.mjs (sentinela · shape {ok,planos,fail,warn,findings})
+ * @see Modules\Governance\Services\SddBriefLineService (pattern irmão GT-G8)
+ * @see Modules/Brief/Console/Commands/GenerateBriefCommand.php (plug-point inject)
+ * @see memory/requisitos/_processo/PLANS-INDEX.md §"Como manter vivo" item 2
+ */
+final class PlanHealthBriefLineService
+{
+    /** Teto de tempo do shell-out Node (s) — sentinela é local, sem rede; 20s folga. */
+    private const TIMEOUT_SECONDS = 20;
+
+    /**
+     * Injeta a linha de planos como 1º bullet da seção `## FLAGS`. Best-effort:
+     * qualquer falha (ou linha null) devolve o conteúdo intacto.
+     * Kill-switch: `governance.plan_health_brief_line` false → no-op (default ON).
+     */
+    public function inject(string $content): string
+    {
+        if (! (bool) config('governance.plan_health_brief_line', true)) {
+            return $content;
+        }
+
+        try {
+            $line = $this->line();
+        } catch (Throwable) {
+            return $content;
+        }
+
+        if ($line === null) {
+            return $content;
+        }
+
+        $injected = preg_replace('/^## FLAGS$/m', "## FLAGS\n- {$line}", $content, 1, $count);
+
+        return ($count === 1 && is_string($injected)) ? $injected : $content;
+    }
+
+    /**
+     * Linha de saúde dos planos, ou null quando não há nada confiável a reportar
+     * (sentinela indisponível / no-op / índice vazio — ver docblock da classe).
+     *
+     * Formato: `<emoji> Planos: N vivos · X órfãos · Y a revisar`, onde
+     *  - N        = planos no Índice de Planos Vivos (`planos`)
+     *  - X órfãos = planos DISTINTOS com achado 🔴 (índice dangling / órfão em-execução)
+     *  - Y revisar = planos DISTINTOS com achado 🟡 (sem Status vivo / frescor / etc)
+     *  - emoji    = 🔴 (há órfão) / 🟡 (só a-revisar) / 🟢 (todos saudáveis), convenção FLAGS.
+     */
+    public function line(): ?string
+    {
+        $data = $this->fetchHealth();
+
+        if ($data === null || ($data['skipped'] ?? false) === true) {
+            return null;
+        }
+
+        $planos = (int) ($data['planos'] ?? 0);
+        if ($planos === 0) {
+            return null;
+        }
+
+        $findings = array_values((array) ($data['findings'] ?? []));
+        $orfaos = $this->distinctPlans($findings, 'fail');
+        $revisar = $this->distinctPlans($findings, 'warn');
+
+        $emoji = $orfaos > 0 ? '🔴' : ($revisar > 0 ? '🟡' : '🟢');
+
+        return sprintf(
+            '%s Planos: %d vivos · %d órfãos · %d a revisar',
+            $emoji,
+            $planos,
+            $orfaos,
+            $revisar,
+        );
+    }
+
+    /**
+     * Roda a sentinela Node e devolve o JSON decodificado, ou null se o shell-out
+     * falhar/não produzir JSON. `--json` sai 1 quando há 🔴, mas ainda imprime o
+     * JSON no stdout — por isso parseamos o output independente do exit code (só
+     * o binário ausente/quebrado, que não produz JSON, vira null).
+     *
+     * @return array<string, mixed>|null
+     */
+    private function fetchHealth(): ?array
+    {
+        try {
+            $result = Process::path(base_path())
+                ->timeout(self::TIMEOUT_SECONDS)
+                ->run(['node', 'scripts/governance/plan-health.mjs', '--json']);
+        } catch (Throwable $e) {
+            // `node` ausente no host (ex.: shared hosting sem Node) → sem linha.
+            Log::debug('[plan-health brief line] shell-out falhou: '.$e->getMessage());
+
+            return null;
+        }
+
+        $decoded = json_decode($result->output(), true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    /**
+     * Conta planos DISTINTOS com pelo menos um achado do nível dado (um plano pode
+     * ter vários achados do mesmo nível — aqui interessa "quantos planos", não
+     * "quantos achados").
+     *
+     * @param  array<int, mixed>  $findings
+     */
+    private function distinctPlans(array $findings, string $level): int
+    {
+        $plans = [];
+        foreach ($findings as $f) {
+            if (is_array($f) && ($f['level'] ?? null) === $level && isset($f['plan'])) {
+                $plans[(string) $f['plan']] = true;
+            }
+        }
+
+        return count($plans);
+    }
+}

--- a/Modules/Governance/Tests/Feature/PlanHealthBriefLineServiceTest.php
+++ b/Modules/Governance/Tests/Feature/PlanHealthBriefLineServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Process;
+use Modules\Governance\Services\PlanHealthBriefLineService;
+
+/**
+ * Tests da linha de saúde dos PLANOS no Daily Brief (ADR 0294 Onda 1).
+ * A sentinela é Node (scripts/governance/plan-health.mjs --json); aqui o
+ * shell-out é fakeado (Process::fake) — testamos formatação + degradação, não
+ * o parser da sentinela (esse tem seu próprio meta-teste em governança).
+ *
+ * @see Modules/Governance/Services/PlanHealthBriefLineService.php
+ * @see Modules/Brief/Console/Commands/GenerateBriefCommand.php (plug-point inject)
+ */
+
+/**
+ * Stub do shell-out Node: devolve o JSON dado no stdout (exit 1 quando há 🔴,
+ * espelhando o `process.exit(ok?0:1)` da sentinela em modo --json). Catch-all
+ * `*`: o serviço faz exatamente uma chamada de processo (o `node ...`).
+ */
+function fakePlanHealth(array $json): void
+{
+    $exit = ((int) ($json['fail'] ?? 0)) > 0 ? 1 : 0;
+
+    Process::fake([
+        '*' => Process::result(
+            output: json_encode($json, JSON_UNESCAPED_UNICODE),
+            exitCode: $exit,
+        ),
+    ]);
+}
+
+/** Brief mínimo válido (7 seções + ---END---) pra exercitar o inject(). */
+function planHealthBrief(): string
+{
+    return "## ESTADO MACRO\n- x\n\n## EM VOO AGORA\n- x\n\n## DECISÕES RECENTES (24h)\n- x\n\n"
+        ."## SKILLS USO 7d\n- x\n\n## CHARTERS APODRECENDO\n—\n\n## FLAGS\n- 🟢 Migration aging: ok\n\n"
+        ."## METADATA\n- Gerado: hoje\n---END---";
+}
+
+it('só warns → 🟡 com contagem de planos DISTINTOS (não de achados)', function () {
+    fakePlanHealth([
+        'ok' => true, 'planos' => 16, 'fail' => 0, 'warn' => 3, 'findings' => [
+            ['plan' => 'A', 'issue' => 'sem bloco Status vivo', 'level' => 'warn'],
+            ['plan' => 'A', 'issue' => 'reviewed_at ausente', 'level' => 'warn'], // mesmo plano → conta 1
+            ['plan' => 'B', 'issue' => 'reviewed_at stale: 40d', 'level' => 'warn'],
+        ],
+    ]);
+
+    expect((new PlanHealthBriefLineService())->line())
+        ->toBe('🟡 Planos: 16 vivos · 0 órfãos · 2 a revisar');
+});
+
+it('com órfão (fail) → 🔴', function () {
+    fakePlanHealth([
+        'ok' => false, 'planos' => 16, 'fail' => 1, 'warn' => 1, 'findings' => [
+            ['plan' => 'X', 'issue' => 'órfão: em-execução SEM parent_plan', 'level' => 'fail'],
+            ['plan' => 'Y', 'issue' => 'reviewed_at ausente', 'level' => 'warn'],
+        ],
+    ]);
+
+    expect((new PlanHealthBriefLineService())->line())
+        ->toBe('🔴 Planos: 16 vivos · 1 órfãos · 1 a revisar');
+});
+
+it('todos saudáveis → 🟢', function () {
+    fakePlanHealth(['ok' => true, 'planos' => 8, 'fail' => 0, 'warn' => 0, 'findings' => []]);
+
+    expect((new PlanHealthBriefLineService())->line())
+        ->toBe('🟢 Planos: 8 vivos · 0 órfãos · 0 a revisar');
+});
+
+it('sentinela em no-op (skipped: PLANS-INDEX ausente) → null', function () {
+    fakePlanHealth(['ok' => true, 'skipped' => true, 'reason' => 'PLANS-INDEX ausente', 'findings' => []]);
+
+    expect((new PlanHealthBriefLineService())->line())->toBeNull();
+});
+
+it('índice vazio (0 planos) → null', function () {
+    fakePlanHealth(['ok' => true, 'planos' => 0, 'fail' => 0, 'warn' => 0, 'findings' => []]);
+
+    expect((new PlanHealthBriefLineService())->line())->toBeNull();
+});
+
+it('JSON inválido (node quebrado/ausente) → null', function () {
+    Process::fake(['*plan-health.mjs*' => Process::result(output: 'node: not found', exitCode: 127)]);
+
+    expect((new PlanHealthBriefLineService())->line())->toBeNull();
+});
+
+it('kill-switch OFF → inject vira no-op mesmo com órfão', function () {
+    config(['governance.plan_health_brief_line' => false]);
+    fakePlanHealth([
+        'ok' => false, 'planos' => 16, 'fail' => 1, 'warn' => 0, 'findings' => [
+            ['plan' => 'X', 'issue' => 'órfão', 'level' => 'fail'],
+        ],
+    ]);
+
+    expect((new PlanHealthBriefLineService())->inject(planHealthBrief()))->toBe(planHealthBrief());
+});
+
+it('inject coloca a linha como bullet no FLAGS sem quebrar o markdown', function () {
+    fakePlanHealth([
+        'ok' => true, 'planos' => 16, 'fail' => 0, 'warn' => 1, 'findings' => [
+            ['plan' => 'B', 'issue' => 'reviewed_at stale', 'level' => 'warn'],
+        ],
+    ]);
+
+    $out = (new PlanHealthBriefLineService())->inject(planHealthBrief());
+
+    expect($out)->toContain("## FLAGS\n- 🟡 Planos: 16 vivos · 0 órfãos · 1 a revisar")
+        ->and($out)->toContain('- 🟢 Migration aging: ok') // bullet original preservado
+        ->and(trim($out))->toEndWith('---END---');
+});

--- a/Modules/Governance/Tests/Feature/PlanHealthBriefLineServiceTest.php
+++ b/Modules/Governance/Tests/Feature/PlanHealthBriefLineServiceTest.php
@@ -5,6 +5,13 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\Process;
 use Modules\Governance\Services\PlanHealthBriefLineService;
 
+// EXPLÍCITO (não confiar só no Pest.php do módulo): quando ci.yml roda este
+// arquivo direto via .github/ci-sqlite-pest.list, o `uses(...)->in()` do
+// Modules/Governance/Tests/Pest.php pode não casar → sem TestCase, sem refresh
+// de app por teste → facades (Process/Config) vazam estado entre testes do
+// suite gigante (random order). Espelha LeaseBriefSectionServiceTest.
+uses(Tests\TestCase::class);
+
 /**
  * Tests da linha de saúde dos PLANOS no Daily Brief (ADR 0294 Onda 1).
  * A sentinela é Node (scripts/governance/plan-health.mjs --json); aqui o
@@ -85,7 +92,9 @@ it('índice vazio (0 planos) → null', function () {
 });
 
 it('JSON inválido (node quebrado/ausente) → null', function () {
-    Process::fake(['*plan-health.mjs*' => Process::result(output: 'node: not found', exitCode: 127)]);
+    // Catch-all '*' (mesma chave de fakePlanHealth): chaves consistentes entre
+    // testes evitam handlers acumulados/ambíguos no Process::fake.
+    Process::fake(['*' => Process::result(output: 'node: not found', exitCode: 127)]);
 
     expect((new PlanHealthBriefLineService())->line())->toBeNull();
 });

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6220,7 +6220,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 6
+			count: 7
 			path: Modules/Governance/Config/config.php
 
 		-

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -26,6 +26,10 @@
       "nome": "Anchor Drift — lint spec↔código ADR 0273 (diff-aware no PR + cron semanal full-tree · ADVISORY F1 — SA-A2/A3)",
       "classe": "gate"
     },
+    "plan-health-gate.yml": {
+      "nome": "Plan Health Gate (advisory · planos órfãos/podres · sentinela plan-health.mjs --check · ADR 0294 Onda 1)",
+      "classe": "gate"
+    },
     "adr-index-gate.yml": {
       "nome": "ADR Index Gate — ADR 0258",
       "classe": "gate"


### PR DESCRIPTION
## O quê

Fecha os **2 buracos prescritos pela [ADR 0294](memory/decisions/0294-metodo-dual-track-shapeup-catraca.md) + [PLANS-INDEX.md](memory/requisitos/_processo/PLANS-INDEX.md) §"Como manter vivo" item 2**, complementando a sentinela `plan-health.mjs` que mergeou em [#3100](https://github.com/wagnerra23/oimpresso.com/pull/3100).

### (a) Daily Brief — linha de saúde dos planos
- **`Modules/Governance/Services/PlanHealthBriefLineService.php`** — injeta `Planos: N vivos · X órfãos · Y a revisar` na seção `## FLAGS` do Daily Brief, **pós-LLM e determinística** (o Brain B nunca inventa o número).
- **Transporte** (o brief é PHP, a sentinela é Node): shell-out de `node scripts/governance/plan-health.mjs --json` via `Process::path(base_path())` (mesmo idioma de `NpmAuditChecker`/`ComposerAuditChecker`) + `json_decode`. **Fonte-única**: não reimplementa o parser do `## Status vivo` em PHP — quem conta é a sentinela.
- **Plug-point**: `Modules/Brief/Console/Commands/GenerateBriefCommand.php` (path que persiste em `mcp_briefs`, lido pelo `brief-fetch`), logo após a linha SDD (`SddBriefLineService`, GT-G8) — pattern irmão que este PR espelha.
- **Best-effort** (o brief NUNCA quebra): `node` ausente / índice não-deployado / JSON inválido / sentinela em no-op (`skipped`) / índice vazio → brief intacto, sem linha.
- **Kill-switch**: `governance.plan_health_brief_line` (`GOVERNANCE_PLAN_HEALTH_BRIEF_LINE=false`), default ON.

### (b) CI — gate advisory
- **`.github/workflows/plan-health-gate.yml`** — roda `plan-health.mjs --check` quando um PR toca `*PLAN*.md` / `PLANS-INDEX.md` / a própria sentinela.
- **ADVISORY de nascença** (`continue-on-error: true` no job inteiro): `--check` morde (exit 1 → status 🟡 visível na PR) mas **NÃO bloqueia merge**. Por [ADR 0271/0275](memory/decisions/0294-metodo-dual-track-shapeup-catraca.md): gate novo nunca nasce required. Promoção só pelo calendário de promoções (ADR 0275). Espelha `tier0-guards-advisory.yml` + `anchor-drift.yml`.

## Verificação local
- **Linha com dados reais**: replicando a lógica de contagem do serviço sobre a saída real da sentinela → `🟡 Planos: 16 vivos · 0 órfãos · 15 a revisar` (16 no índice, 15 ainda sem bloco `## Status vivo`, 1 saudável).
- **YAML válido**: parseado com `js-yaml` — 1 job `plan-health`, `continue-on-error: true`, triggers `pull_request`+`workflow_dispatch`, step roda `node scripts/governance/plan-health.mjs --check`.
- **`--check` sai 1** com os 15 warns atuais → tolerado pelo `continue-on-error` (advisory).
- **8 testes Pest** (`Process::fake`) cobrem formatação (contagem de planos **distintos**, não de achados), os 3 emojis, degradação (skipped / índice vazio / JSON inválido) e kill-switch. _Não rodados localmente_ (sem PHP/Pest no host — regra CT 100); rodam no CI.

## Notas
- A linha do brief é um **sinal soft** que ativa quando o host do gerador (cron `brief:generate`) tem `node` + `memory/` deployados; o gate CI (b) é a enforcement hard (runner GitHub sempre tem node). Ambos degradam graciosamente se faltar o índice.
- Diff: 335 linhas (≈166 são teste + YAML; restante são docblocks no estilo da casa). Intent único = fechar as 2 lacunas da ADR 0294 Onda 1.

Refs: ADR 0294 (dual-track + catraca) · PLANS-INDEX.md §Como manter vivo · #3100

🤖 Generated with [Claude Code](https://claude.com/claude-code)