### PR TITLE
fix(jana): tasks-create não reusa task_id de row órfã no DB (incidente US-RB-052)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -129,3 +129,10 @@ Modules/Whatsapp/Tests/Feature/SlashConfigTest.php
 Modules/Whatsapp/Tests/Feature/WhatsappMessageObserverTest.php
 Modules/Whatsapp/Tests/Feature/WhatsmeowCicloE2ETest.php
 Modules/Whatsapp/Tests/Feature/WhatsmeowResubscribeEventsCommandTest.php
+# tasks-create não reusa task_id de row órfã no DB (incidente US-RB-052 · 2026-06-20).
+# Ambos bootstram um mcp_tasks mínimo (sem RefreshDatabase → sem migration ENUM
+# MySQL-only) → sqlite-safe. Provam max(DB,SPEC)+guarda de colisão e o detector
+# mcp:tasks:orphans. Antes a lógica usava SUBSTRING (MySQL-only) e Tests/Feature/
+# TaskRegistry não rodava em lane nenhuma.
+Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
+Modules/Jana/Tests/Feature/TaskRegistry/McpTasksOrphansCommandTest.php

--- a/Modules/Jana/Console/Commands/McpTasksOrphansCommand.php
+++ b/Modules/Jana/Console/Commands/McpTasksOrphansCommand.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Entities\Mcp\McpTask;
+
+/**
+ * Detector de task_ids US-* órfãs — presentes no DB (mcp_tasks) mas AUSENTES de
+ * qualquer SPEC.md canônico (memory/requisitos/<Mod>/SPEC.md).
+ *
+ * Por que importa (incidente US-RB-052, 2026-06-20): uma US-* que vive só no DB
+ * (criada ad-hoc / direto no DB, ou resíduo de sync antigo) é invisível a quem lê
+ * o SPEC, mas o `tasks-create` PRECISA contá-la pra não reusar o ID. Se o ID for
+ * reusado, o webhook sync casa por task_id e UPDATE-a a órfã (ADR 0144),
+ * sobrescrevendo title/description em silêncio.
+ *
+ * `TaskCrudService::gerarProximoIdCanonical` já defende a ALOCAÇÃO (max(DB,SPEC) +
+ * guarda de colisão); este comando é a TRIAGEM das órfãs que já existem — pra
+ * decidir renomear / adotar como US do SPEC / cancelar.
+ *
+ * Tasks fechadas (done/cancelled) cujo bullet saiu do SPEC após o merge são
+ * esperadas e NÃO colidem (o max(nDb) ainda as conta) — ficam ocultas por padrão;
+ * use --include-closed pra vê-las.
+ *
+ * Saída: tabela no stdout (ou --json) + log estruturado. Exit 1 se houver órfã
+ * visível (permite usar como gate/cron).
+ *
+ * Multi-tenant: `mcp_tasks` é project-wide (ADR 0070), sem business_id.
+ */
+class McpTasksOrphansCommand extends Command
+{
+    protected $signature = 'mcp:tasks:orphans
+                            {--module= : Limita a um módulo (cruza só aquele SPEC.md + rows com module=<X>)}
+                            {--include-closed : Inclui done/cancelled (default: oculta — protegidas pelo max(nDb))}
+                            {--json : Output JSON em vez de tabela}';
+
+    protected $description = 'Detecta task_ids US-* no DB ausentes do SPEC.md (órfãs) — risco de colisão/sobrescrita silenciosa no sync (ADR 0144 / incidente US-RB-052).';
+
+    public function handle(): int
+    {
+        $apenasModulo = $this->option('module') ?: null;
+        $incluirFechadas = (bool) $this->option('include-closed');
+
+        $orfas = $this->detectarOrfas($apenasModulo, $incluirFechadas);
+
+        if ($this->option('json')) {
+            $this->line(json_encode([
+                'checked_at' => now()->toIso8601String(),
+                'module' => $apenasModulo,
+                'include_closed' => $incluirFechadas,
+                'total' => count($orfas),
+                'orphans' => $orfas,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        } else {
+            $this->renderTable($orfas);
+        }
+
+        Log::channel('single')->info('mcp:tasks:orphans', [
+            'module' => $apenasModulo,
+            'include_closed' => $incluirFechadas,
+            'total' => count($orfas),
+            'task_ids' => array_map(static fn ($o) => $o['task_id'], $orfas),
+        ]);
+
+        return $orfas === [] ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * Devolve as órfãs: US-* no DB ausentes de qualquer SPEC.md.
+     *
+     * Público pra ser testável sem console parsing (espelha o padrão de
+     * McpTasksHealthCheckCommand::scanStaleness).
+     *
+     * @return list<array{task_id:string, module:string, status:string, owner:?string, source_path:?string, title:string, created_at:?string}>
+     */
+    public function detectarOrfas(?string $apenasModulo = null, bool $incluirFechadas = false): array
+    {
+        $idsNoSpec = $this->idsDeclaradosNosSpecs($apenasModulo);
+
+        $query = McpTask::query()
+            ->where('task_id', 'LIKE', 'US-%')
+            ->when($apenasModulo !== null, fn ($q) => $q->where('module', $apenasModulo))
+            ->when(! $incluirFechadas, fn ($q) => $q->whereNotIn('status', ['done', 'cancelled']));
+
+        $orfas = [];
+        foreach ($query->get() as $task) {
+            $id = strtoupper((string) $task->task_id);
+
+            // Só US-XX-NNN canônicas — ad-hoc Linear-style (COPI-123) vive só no DB
+            // por design (ADR 0070) e não compete por ID no SPEC.
+            if (! preg_match('/^US-[A-Z0-9]+-\d+$/', $id)) {
+                continue;
+            }
+            if (isset($idsNoSpec[$id])) {
+                continue; // declarada no SPEC → não é órfã
+            }
+
+            $orfas[] = [
+                'task_id' => (string) $task->task_id,
+                'module' => (string) $task->module,
+                'status' => (string) $task->status,
+                'owner' => $task->owner,
+                'source_path' => $task->source_path,
+                'title' => (string) $task->title,
+                'created_at' => optional($task->created_at)->toDateString(),
+            ];
+        }
+
+        usort($orfas, static fn ($a, $b) => strcmp($a['task_id'], $b['task_id']));
+
+        return $orfas;
+    }
+
+    /**
+     * Set (TASK_ID => true) de todas as US-* declaradas nos SPEC.md — headers OU
+     * bullets, os mesmos 2 formatos do alocador (ADR 0134).
+     *
+     * @return array<string, true>
+     */
+    protected function idsDeclaradosNosSpecs(?string $apenasModulo): array
+    {
+        $base = base_path('memory/requisitos');
+        $ids = [];
+        if (! is_dir($base)) {
+            return $ids;
+        }
+
+        foreach (new \DirectoryIterator($base) as $dir) {
+            if ($dir->isDot() || ! $dir->isDir()) {
+                continue;
+            }
+            if ($apenasModulo !== null && $dir->getFilename() !== $apenasModulo) {
+                continue;
+            }
+            $spec = $dir->getPathname() . '/SPEC.md';
+            if (! is_file($spec)) {
+                continue;
+            }
+            $content = (string) @file_get_contents($spec);
+            if (preg_match_all('/(?:^###|^-)\s+(?:\S+\s+)?(US-[A-Z0-9]+-\d+)/m', $content, $m)) {
+                foreach ($m[1] as $id) {
+                    $ids[strtoupper($id)] = true;
+                }
+            }
+        }
+
+        return $ids;
+    }
+
+    /** @param list<array<string,mixed>> $orfas */
+    protected function renderTable(array $orfas): void
+    {
+        if ($orfas === []) {
+            $this->info('✨ Nenhuma task_id US-* órfã (toda US-* no DB consta em algum SPEC.md).');
+            return;
+        }
+
+        $this->warn(count($orfas) . ' task_id(s) US-* órfã(s) — no DB mas ausentes do SPEC.md:');
+        $this->table(
+            ['task_id', 'módulo', 'status', 'owner', 'criada', 'source_path'],
+            array_map(static fn ($o) => [
+                $o['task_id'],
+                $o['module'],
+                $o['status'],
+                $o['owner'] ?? '—',
+                $o['created_at'] ?? '—',
+                mb_strimwidth((string) ($o['source_path'] ?? '—'), 0, 42, '…'),
+            ], $orfas),
+        );
+        $this->newLine();
+        $this->line('Triagem: renomeie pro próximo ID livre (tasks-create já evita reuso), '
+            . 'adote a órfã como a US do SPEC, ou cancele (tasks-update <id> status:cancelled).');
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -61,6 +61,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\HealthCheckCommand::class,      // sentinela operacional 5 checks
                 \Modules\Jana\Console\Commands\SystemAuditCommand::class,      // ADR 0133 — 5 audits Constituição v2 (observ/evals/ADR-stale/cost/coverage)
                 \Modules\Jana\Console\Commands\McpTasksHealthCheckCommand::class, // Bug #4 BUGS-MCP-SYNC-2026-05-13 — staleness detection
+                \Modules\Jana\Console\Commands\McpTasksOrphansCommand::class,  // incidente US-RB-052 2026-06-20 — triagem de US-* no DB ausentes do SPEC (órfãs)
                 \Modules\Jana\Console\Commands\JanaBacklinksSweepCommand::class, // Gap G5 P1 auditoria 2026-05-13 — backlinks ADR↔SPEC sweep
                 \Modules\Jana\Console\Commands\JanaRagasEvalCommand::class,    // ADR 0037 §GAP-2 — RAGAS gate (faithfulness/relevancy/precision/recall)
                 \Modules\Jana\Console\Commands\JanaRagasCiCommand::class,      // W28-2 — RAGAS CI gate BLOQUEANTE (golden set + JSON gh pr comment)

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -543,29 +543,63 @@ class TaskCrudService
         $prefix = $this->detectarPrefixoSpec($module);
         $prefixo = "US-{$prefix}-";
 
-        $ultimoDb = McpTask::where('task_id', 'LIKE', $prefixo . '%')
-            ->orderByRaw('CAST(SUBSTRING(task_id, ' . (strlen($prefixo) + 1) . ') AS UNSIGNED) DESC')
-            ->value('task_id');
-        $nDb = $ultimoDb ? (int) substr($ultimoDb, strlen($prefixo)) : 0;
+        // max(DB, SPEC) cobre os 2 sentidos de drift:
+        //   - DB ATRÁS do SPEC: webhook ainda não rodou pro último push, OU o
+        //     operador escreveu US-XX-NNN à mão no SPEC.
+        //   - DB À FRENTE do SPEC: row órfã criada direto no DB / ad-hoc que nunca
+        //     entrou no SPEC. Incidente US-RB-052 (2026-06-20): wagner criou a row
+        //     em 2026-05-16 fora do SPEC; reusar o 052 fez o webhook sync casar por
+        //     task_id e UPDATE-ar a órfã (ADR 0144), sobrescrevendo title/description
+        //     em silêncio. Triagem das órfãs já existentes: `mcp:tasks:orphans`.
+        $n = max($this->maiorSequencialNoDb($prefixo), $this->maiorSequencialNoSpec($module, $prefixo)) + 1;
 
-        // Cobre o caso DB out-of-sync: webhook ainda não rodou pro último push
-        // OU o operador escreveu US-RB-NNN à mão no SPEC. Pegamos max(DB, SPEC).
-        // Captura 2 formatos (ADR 0134):
-        //   1. "### US-XX-NNN ·" (story detalhada — section header)
-        //   2. "- US-XX-NNN —" (placeholder em out-of-scope ou backlog futuro)
-        // Antes só pegava headers → 2026-05-11 deu drift em US-WA-053 (placeholder
-        // bullet no SPEC.md Whatsapp linha 572 colidiu com tasks-create).
-        $nSpec = 0;
+        // Guarda final de colisão: garante por CONSTRUÇÃO que o ID gerado não existe
+        // no DB. A aritmética acima pode ser furada por buraco de numeração ou
+        // mismatch de prefixo, e confirmar é barato. Avança até achar um slot livre —
+        // IDs nunca são reciclados (nem de tasks cancelled/done).
+        do {
+            $taskId = $prefixo . str_pad((string) $n, 3, '0', STR_PAD_LEFT);
+            $n++;
+        } while (McpTask::where('task_id', $taskId)->exists());
+
+        return $taskId;
+    }
+
+    /**
+     * Maior NNN já presente no DB pro prefixo — inclui rows órfãs criadas direto
+     * no DB / ad-hoc que nunca entraram no SPEC, e tasks cancelled/done (IDs não
+     * são reciclados). Calcula o max em PHP (não em SQL) pra ser portável entre
+     * MySQL e SQLite: o `CAST(SUBSTRING(...) AS UNSIGNED)` anterior era MySQL-only,
+     * o que deixava esta lógica sem cobertura de teste no CI sqlite.
+     */
+    protected function maiorSequencialNoDb(string $prefixo): int
+    {
+        $len = strlen($prefixo);
+
+        return (int) McpTask::where('task_id', 'LIKE', $prefixo . '%')
+            ->pluck('task_id')
+            ->map(fn (string $id): int => (int) substr($id, $len))
+            ->max();
+    }
+
+    /**
+     * Maior NNN declarado no SPEC.md pro prefixo. Captura 2 formatos (ADR 0134):
+     *   1. "### US-XX-NNN ·" (story detalhada — section header)
+     *   2. "- US-XX-NNN —"   (placeholder em out-of-scope ou backlog futuro)
+     * Antes só pegava headers → 2026-05-11 deu drift em US-WA-053 (placeholder
+     * bullet no SPEC.md Whatsapp colidiu com tasks-create).
+     */
+    protected function maiorSequencialNoSpec(string $module, string $prefixo): int
+    {
         $specPath = base_path("memory/requisitos/{$module}/SPEC.md");
-        if (is_file($specPath)) {
-            $content = (string) @file_get_contents($specPath);
-            if (preg_match_all('/(?:^###|^-)\s+(?:\S+\s+)?' . preg_quote($prefixo, '/') . '(\d+)/m', $content, $matches)) {
-                $nSpec = max(array_map('intval', $matches[1]));
-            }
+        if (! is_file($specPath)) {
+            return 0;
         }
-
-        $n = max($nDb, $nSpec) + 1;
-        return $prefixo . str_pad((string) $n, 3, '0', STR_PAD_LEFT);
+        $content = (string) @file_get_contents($specPath);
+        if (preg_match_all('/(?:^###|^-)\s+(?:\S+\s+)?' . preg_quote($prefixo, '/') . '(\d+)/m', $content, $matches)) {
+            return max(array_map('intval', $matches[1]));
+        }
+        return 0;
     }
 
     protected function stringValue(mixed $v): string

--- a/Modules/Jana/Tests/Feature/TaskRegistry/McpTasksOrphansCommandTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/McpTasksOrphansCommandTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Console\Commands\McpTasksOrphansCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Bonus do fix do incidente US-RB-052 (2026-06-20): detector de US-* no DB que
+ * não constam em nenhum SPEC.md (órfãs) — a classe de row que o reuso de ID
+ * sobrescreve em silêncio via webhook sync (ADR 0144).
+ */
+
+function orphanEnsureMcpTasksTable(): void
+{
+    if (Schema::hasTable('mcp_tasks')) {
+        return;
+    }
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 40)->nullable();
+        $t->string('module', 80)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->text('description')->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->string('source_path', 500)->nullable();
+        $t->timestamp('parsed_at')->nullable();
+        $t->timestamps();
+    });
+}
+
+function orphanWriteSpec(string $module, string $body): string
+{
+    $dir = base_path("memory/requisitos/{$module}");
+    if (! is_dir($dir)) {
+        File::makeDirectory($dir, 0755, true);
+    }
+    $path = $dir . '/SPEC.md';
+    file_put_contents($path, $body);
+    return $path;
+}
+
+function orphanSeed(string $taskId, string $status = 'todo'): void
+{
+    DB::table('mcp_tasks')->insert([
+        'task_id' => $taskId,
+        'module' => '__TestOrphanCmd',
+        'title' => $taskId,
+        'status' => $status,
+        'source_path' => 'ad-hoc',
+        'parsed_at' => now(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+beforeEach(function () {
+    orphanEnsureMcpTasksTable();
+    DB::table('mcp_tasks')->where('task_id', 'LIKE', 'US-ZZORPHCMD-%')->delete();
+});
+
+afterEach(function () {
+    DB::table('mcp_tasks')->where('task_id', 'LIKE', 'US-ZZORPHCMD-%')->delete();
+    $dir = base_path('memory/requisitos/__TestOrphanCmd');
+    if (is_dir($dir)) {
+        File::deleteDirectory($dir);
+    }
+});
+
+it('flagga US-* no DB ausente do SPEC e ignora as declaradas', function () {
+    orphanWriteSpec('__TestOrphanCmd', "# SPEC\n\n### US-ZZORPHCMD-001 · No SPEC\n");
+
+    orphanSeed('US-ZZORPHCMD-001');             // declarada no SPEC → não órfã
+    orphanSeed('US-ZZORPHCMD-099');             // órfã (nunca no SPEC)
+    orphanSeed('US-ZZORPHCMD-050', 'cancelled'); // fechada → oculta por default
+
+    $orfas = (new McpTasksOrphansCommand())->detectarOrfas('__TestOrphanCmd', false);
+    $ids = array_map(fn ($o) => $o['task_id'], $orfas);
+
+    expect($ids)->toContain('US-ZZORPHCMD-099')
+        ->and($ids)->not->toContain('US-ZZORPHCMD-001')
+        ->and($ids)->not->toContain('US-ZZORPHCMD-050');
+});
+
+it('--include-closed revela órfãs done/cancelled', function () {
+    orphanWriteSpec('__TestOrphanCmd', "# SPEC\n\n### US-ZZORPHCMD-001 · No SPEC\n");
+    orphanSeed('US-ZZORPHCMD-050', 'cancelled');
+
+    $orfas = (new McpTasksOrphansCommand())->detectarOrfas('__TestOrphanCmd', true);
+
+    expect(array_map(fn ($o) => $o['task_id'], $orfas))->toContain('US-ZZORPHCMD-050');
+});
+
+it('não flagga identifier ad-hoc Linear-style (COPI-123)', function () {
+    orphanWriteSpec('__TestOrphanCmd', "# SPEC sem stories ainda\n");
+
+    orphanSeed('US-ZZORPHCMD-077');  // US-* órfã → flagga
+
+    // Linear-style: task_id não casa US-XX-NNN → DB-only por design, não é órfã.
+    DB::table('mcp_tasks')->insert([
+        'task_id' => 'COPI-123',
+        'module' => '__TestOrphanCmd',
+        'title' => 'ad-hoc Linear-style',
+        'status' => 'todo',
+        'source_path' => 'ad-hoc',
+        'parsed_at' => now(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $ids = array_map(
+        fn ($o) => $o['task_id'],
+        (new McpTasksOrphansCommand())->detectarOrfas('__TestOrphanCmd', false),
+    );
+
+    expect($ids)->toContain('US-ZZORPHCMD-077')
+        ->and($ids)->not->toContain('COPI-123');
+
+    DB::table('mcp_tasks')->where('task_id', 'COPI-123')->delete();
+});
+
+it('exit SUCCESS quando não há órfã, FAILURE quando há', function () {
+    orphanWriteSpec('__TestOrphanCmd', "# SPEC\n\n### US-ZZORPHCMD-001 · No SPEC\n");
+    orphanSeed('US-ZZORPHCMD-001'); // só a declarada → zero órfã
+
+    $this->artisan('mcp:tasks:orphans', ['--module' => '__TestOrphanCmd'])
+        ->assertExitCode(0);
+
+    orphanSeed('US-ZZORPHCMD-088'); // agora há uma órfã
+
+    $this->artisan('mcp:tasks:orphans', ['--module' => '__TestOrphanCmd'])
+        ->assertExitCode(1);
+});

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Services\TaskRegistry\TaskCrudService;
 
 uses(Tests\TestCase::class);
@@ -33,7 +35,43 @@ function tcWriteSpec(string $module, string $body): string
     return $path;
 }
 
+/**
+ * Bootstrap mínimo de `mcp_tasks` pros testes que precisam de rows reais no DB.
+ * Só cria se ausente — em MySQL real a tabela já existe (guard). Em sqlite :memory:
+ * (CI/local) cria o suficiente pro alocador rodar. Padrão idêntico ao shim de
+ * activity_log/contacts em tests/Pest.php. Usa string (não enum) pra evitar
+ * CHECK constraints do sqlite. Seeds via DB::table — sem disparar LogsActivity.
+ */
+function tcEnsureMcpTasksTable(): void
+{
+    if (Schema::hasTable('mcp_tasks')) {
+        return;
+    }
+    Schema::create('mcp_tasks', function ($t) {
+        $t->bigIncrements('id');
+        $t->string('task_id', 40)->unique();
+        $t->string('identifier', 40)->nullable();
+        $t->string('module', 80)->nullable();
+        $t->string('title', 255)->nullable();
+        $t->text('description')->nullable();
+        $t->string('status', 20)->default('todo');
+        $t->string('owner', 60)->nullable();
+        $t->string('sprint', 40)->nullable();
+        $t->string('priority', 8)->nullable();
+        $t->string('source_path', 500)->nullable();
+        $t->timestamp('parsed_at')->nullable();
+        $t->timestamps();
+    });
+}
+
+beforeEach(function () {
+    tcEnsureMcpTasksTable();
+    // Prefixo fabricado ZZORPH não existe em dado real — isolamento entre runs.
+    DB::table('mcp_tasks')->where('task_id', 'LIKE', 'US-ZZORPH-%')->delete();
+});
+
 afterEach(function () {
+    DB::table('mcp_tasks')->where('task_id', 'LIKE', 'US-ZZORPH-%')->delete();
     foreach (['__TestCanonicalA', '__TestCanonicalB'] as $m) {
         $dir = base_path("memory/requisitos/{$m}");
         if (is_dir($dir)) {
@@ -121,4 +159,66 @@ it('regex bullet ignora menções inline em prose (não confunde com declaraçõ
     $reflect->setAccessible(true);
 
     expect($reflect->invoke($svc, '__TestCanonicalA'))->toBe('US-RB-006');
+});
+
+// ─── Rows órfãs no DB (incidente US-RB-052 · 2026-06-20) ───────────────────
+//
+// O risco real: uma US-* existe SÓ no DB (criada ad-hoc / direto no DB / resíduo
+// de sync antigo) e nunca no SPEC. Se o alocador olhar só o SPEC, reusa o ID; o
+// webhook sync então casa por task_id e UPDATE-a a órfã (ADR 0144), sobrescrevendo
+// title/description em silêncio. A defesa é max(DB, SPEC) + guarda de colisão.
+
+it('pula row órfã no DB ausente do SPEC (regressão incidente US-RB-052 · 2026-06-20)', function () {
+    // SPEC vai só até NNN-051 (prefixo fabricado ZZORPH pra não colidir com dado real).
+    tcWriteSpec('__TestCanonicalA', "# SPEC\n\n### US-ZZORPH-001 · X\n\n### US-ZZORPH-051 · Y\n");
+
+    // Órfã criada DIRETO no DB, acima do max do SPEC, nunca declarada no SPEC.
+    DB::table('mcp_tasks')->insert([
+        'task_id' => 'US-ZZORPH-052',
+        'module' => '__TestCanonicalA',
+        'title' => 'Órfã do wagner (nunca no SPEC)',
+        'status' => 'todo',
+        'source_path' => 'ad-hoc',
+        'parsed_at' => now(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $svc = new TaskCrudService();
+    $reflect = (new ReflectionClass(TaskCrudService::class))
+        ->getMethod('gerarProximoIdCanonical');
+    $reflect->setAccessible(true);
+
+    // Sem a defesa: max(nSpec=051)+1 = 052 → colide com a órfã.
+    // Com a defesa: max(nDb=052, nSpec=051)+1 = 053.
+    expect($reflect->invoke($svc, '__TestCanonicalA'))->toBe('US-ZZORPH-053');
+});
+
+it('nunca devolve um task_id que já existe no DB (guarda de colisão)', function () {
+    tcWriteSpec('__TestCanonicalA', "# SPEC\n\n### US-ZZORPH-010 · X\n");
+
+    // Bloco órfão no DB acima do SPEC, com buraco em 013. Mesmo cancelled conta —
+    // ID não recicla.
+    foreach (['US-ZZORPH-011', 'US-ZZORPH-012', 'US-ZZORPH-014'] as $id) {
+        DB::table('mcp_tasks')->insert([
+            'task_id' => $id,
+            'module' => '__TestCanonicalA',
+            'title' => 'órfã',
+            'status' => 'cancelled',
+            'source_path' => 'ad-hoc',
+            'parsed_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    $svc = new TaskCrudService();
+    $reflect = (new ReflectionClass(TaskCrudService::class))
+        ->getMethod('gerarProximoIdCanonical');
+    $reflect->setAccessible(true);
+
+    // max(nDb=014, nSpec=010)+1 = 015, e 015 está livre.
+    $next = $reflect->invoke($svc, '__TestCanonicalA');
+    expect($next)->toBe('US-ZZORPH-015')
+        ->and(DB::table('mcp_tasks')->where('task_id', $next)->exists())->toBeFalse();
 });


### PR DESCRIPTION
<!-- evidence-override: PR não toca runtime/infra-crítico (.htaccess/middleware/Kernel/routes/bootstrap). Muda método de service (TaskCrudService::gerarProximoIdCanonical), console command (mcp:tasks:orphans), testes e a allowlist .github/ci-sqlite-pest.list. Sem superfície HTTP/rota nova pra cur) -->

## Problema (incidente US-RB-052 · 2026-06-20)

`tasks-create` podia assinar um `US-{MOD}-{NNN}` que já existia como row no DB mas estava **ausente do SPEC.md** (task ad-hoc/nativa criada direto no DB, ou resíduo de sync antigo). O `TaskParserService::syncAll()` do webhook casa por `task_id` e faz UPDATE (ADR 0144) → **sobrescreve title/description da órfã em silêncio**.

Caso real: `US-RB-052` foi criada por wagner em 2026-05-16 (nunca no SPEC; SPEC ia só até `US-RB-051`); a criação de `recurring-billing-gateway-ativacao` reusou 052 e o sync do #3090 sobrescreveu o conteúdo original.

## O que muda

- **`TaskCrudService::gerarProximoIdCanonical`**: o `max(nDb, nSpec)` agora é calculado **em PHP** (helpers `maiorSequencialNoDb`/`maiorSequencialNoSpec`) em vez do `CAST(SUBSTRING(...) AS UNSIGNED)` **MySQL-only** que deixava a lógica sem teste em CI sqlite. + **guarda final de colisão**: avança até um `task_id` inexistente no DB (collision-proof por construção).
- **Teste de regressão DB-real** que seeda uma órfã acima do max do SPEC e prova o skip (antes só havia teste do *texto* do SPEC; o path do DB era descoberto). Reativa 6 testes canônicos antes dormentes (MySQL-only).
- **Bonus `mcp:tasks:orphans`**: triagem das órfãs já existentes (US-* no DB ausentes do SPEC). `--module`, `--include-closed`, `--json`; exit 1 se houver.
- Ambos os testes entram na lane sqlite via `.github/ci-sqlite-pest.list` (mecanismo union-merge do main).

## Contexto de release

`main` já tinha `fd96258ae` (o `max()` restaurado), mas o **MCP server CT 100 deployado estava atrás** — por isso o incidente em 2026-06-20. Este PR endurece a lógica e fecha a lacuna de teste; vai pra `main` pra (a) entrar no deploy Hostinger e (b) ser puxado pelo `deploy.sh main` do CT 100 (onde o `tasks-create` roda).

Supersede o [#3096](https://github.com/wagnerra23/oimpresso.com/pull/3096) (que mirava o branch `feat`). A grandfather de drift de casos do #3096 era específica do `feat` e **não se aplica** ao `main`.

## Test plan

`php -l` limpo. Os 2 testes passam em sqlite `:memory:` (verificados: 78 passed / 228 assertions no set curado). A lane sqlite do CI roda ambos neste PR.

Refs: ADR 0144 · ADR 0134 · ADR 0070 · incidente US-RB-052 2026-06-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
