### PR TITLE
fix(governance): drift-sentinel skip-guard honesto — dormant sem OPENAI_API_KEY

### DIFF
--- a/Modules/Jana/Console/Commands/JanaDriftSentinelCommand.php
+++ b/Modules/Jana/Console/Commands/JanaDriftSentinelCommand.php
@@ -17,18 +17,23 @@ use Modules\Jana\Services\Ragas\RagasJudgeService;
  * Alerta se >10% das perguntas divergirem ≥ DRIFT_THRESHOLD do baseline.
  *
  * Schedule: weekly Sun 06:00 BRT (app/Console/Kernel.php) — RELIGADO 2026-06-20.
- * Requer OPENAI_API_KEY no servidor pra rodar real; sem a chave o run falha e o
- * onFailure registra (sinal honesto). --mock é só pra CI/teste (mock NÃO detecta
- * drift real — faithfulness fixa em 0.85).
+ * Requer OPENAI_API_KEY no servidor pra rodar real. SEM a chave (e sem --mock) o
+ * canary entra em estado DORMANT honesto: exit 0 (não estoura o onFailure do cron
+ * toda semana) + status=dormant no JSON, que o agregador governance-audit.mjs
+ * mostra como ⊘ dormant (≠ silêncio, ≠ falso "DRIFT 100%"). Skip-guard adicionado
+ * 2026-06-20 (auditoria de sentinelas). --mock é só pra CI/teste (faithfulness
+ * fixa em 0.85 — NÃO detecta drift real).
  *
  * Uso:
  *   php artisan jana:drift-sentinel                    # roda real (precisa OPENAI_API_KEY)
  *   php artisan jana:drift-sentinel --mock              # mock-mode (CI safe)
+ *   php artisan jana:drift-sentinel --json              # só envelope JSON (agregador/Brief)
+ *   php artisan jana:drift-sentinel --status --json     # probe armed/dormant (sem custo/rede)
  *   php artisan jana:drift-sentinel --update-baseline   # regrava baseline (Wagner aprova)
  *   php artisan jana:drift-sentinel --detail            # log detalhado por pergunta
  *
  * Exit code:
- *   0 = drift dentro do aceitável (<10% perguntas divergiram)
+ *   0 = drift aceitável (<10%) OU dormant (sem OPENAI_API_KEY — não rodou)
  *   1 = drift acima do threshold — gera ALERT entry + retorna falha
  *
  * Custo aprox por run real (50 ex):
@@ -48,6 +53,8 @@ class JanaDriftSentinelCommand extends Command
                             {--mock : Usa RagasJudgeService em mock mode (CI safe)}
                             {--update-baseline : Regrava baseline-responses.json a partir do gold-set (Wagner aprova)}
                             {--detail : Log detalhado por pergunta}
+                            {--json : Emite só o envelope JSON (machine-readable; agregador/Brief)}
+                            {--status : Probe leve (sem custo/rede): só reporta armed vs dormant}
                             {--max-drift=10 : % perguntas divergentes acima disso → exit 1}
                             {--drift-threshold=0.25 : Δ faithfulness pra contar como divergência}';
 
@@ -62,6 +69,17 @@ class JanaDriftSentinelCommand extends Command
 
     private function doHandle(): int
     {
+        // Chave resolvida via config() — cache-safe (ver PEGADINHA no skip-guard abaixo).
+        $apiKey = config('openai.api_key') ?: config('services.openai.api_key');
+        $apiKey = is_string($apiKey) ? $apiKey : null;
+
+        // --status: probe leve consumido pelo agregador governance-audit.mjs. Responde
+        // "esse sentinela está vivo?" (armed=chave presente) SEM disparar o run pago
+        // real (que é o cron semanal). Sem custo, sem rede, sem DB.
+        if ($this->option('status')) {
+            return $this->reportStatus($apiKey);
+        }
+
         $goldPath = base_path('Modules/Jana/Tests/Feature/Ai/fixtures/jana-gold-set.json');
         $baselinePath = base_path('Modules/Jana/Tests/Feature/Ai/fixtures/baseline-responses.json');
 
@@ -84,6 +102,22 @@ class JanaDriftSentinelCommand extends Command
             // Mock mode: simula faithfulness alto (0.85±0.05) — CI safe.
             // Só ativa se NÃO estava em mock (preserva mocks customizados injetados via testing).
             $judge->enableMock(['faithfulness' => 0.85]);
+        }
+
+        // Skip-guard HONESTO (auditoria de sentinelas 2026-06-20): o run real precisa
+        // de OPENAI_API_KEY (RagasJudgeService chama a OpenAI). Sem mock e sem chave
+        // NÃO existe medição possível — em vez de pontuar 0.0 em tudo e gritar
+        // "DRIFT 100%" toda semana (falso-positivo) OU estourar o onFailure do cron
+        // (ruído), o canary entra em estado DORMANT explícito: exit 0 (não morde o
+        // cron) + status=dormant no JSON (agregador mostra ⊘, não silêncio).
+        //
+        // PEGADINHA: $apiKey acima é lido via config() (config/openai.php +
+        // config/services.php, ambos baked de OPENAI_API_KEY no config:cache) — NUNCA
+        // env() direto, que devolve null com config:cache ligado em prod e faria o
+        // guard pular SEMPRE (vira fantasma de novo). Mesma fonte que
+        // RagasJudgeService::callJudge().
+        if (self::isDormant($judge->isMockMode(), $apiKey)) {
+            return $this->reportDormant();
         }
 
         // Modo --update-baseline: regrava baseline atual (Wagner aprova caso a caso).
@@ -151,8 +185,12 @@ class JanaDriftSentinelCommand extends Command
 
         $driftPct = $total > 0 ? ($diverged / $total) * 100.0 : 0.0;
 
+        $isAlert = $driftPct > $maxDriftPct;
+
         $report = [
             'ran_at' => now()->toIso8601String(),
+            'status' => $isAlert ? 'drift' : 'ok',
+            'ok' => ! $isAlert,
             'total_questions' => $total,
             'diverged' => $diverged,
             'drift_pct' => round($driftPct, 2),
@@ -161,21 +199,101 @@ class JanaDriftSentinelCommand extends Command
             'mock_mode' => (bool) ($this->option('mock') || env('RAGAS_FORCE_MOCK', false)),
         ];
 
-        if ($this->option('detail')) {
+        if ($this->option('detail') && ! $this->option('json')) {
             $this->table(['#', 'Question', 'Baseline', 'Current', 'Δ', 'Drift'], $details);
         }
 
         $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
 
-        if ($driftPct > $maxDriftPct) {
+        if ($isAlert) {
             Log::channel('copiloto-ai')->warning('[Jana drift-sentinel] ALERT drift acima do threshold', $report);
-            $this->error("DRIFT ALERT: {$diverged}/{$total} divergiram ({$driftPct}%) > {$maxDriftPct}%");
+            if (! $this->option('json')) {
+                $this->error("DRIFT ALERT: {$diverged}/{$total} divergiram ({$driftPct}%) > {$maxDriftPct}%");
+            }
 
             return self::FAILURE;
         }
 
         Log::channel('copiloto-ai')->info('[Jana drift-sentinel] OK', $report);
-        $this->info("OK: drift {$driftPct}% ≤ {$maxDriftPct}%");
+        if (! $this->option('json')) {
+            $this->info("OK: drift {$driftPct}% ≤ {$maxDriftPct}%");
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Veredito de dormência (testável sem DB): o canary só roda real com
+     * OPENAI_API_KEY. Sem mock E sem chave NÃO há medição possível — estado
+     * "dormant" honesto (≠ drift, ≠ ok). Espelha o padrão allChecksOk() das
+     * sentinelas health-check/system-audit (PR #3098).
+     *
+     * @param  bool         $mockMode  judge em mock (--mock / RAGAS_FORCE_MOCK / injetado em teste)
+     * @param  string|null  $apiKey    chave já resolvida via config() (cache-safe)
+     */
+    public static function isDormant(bool $mockMode, ?string $apiKey): bool
+    {
+        return ! $mockMode && ($apiKey === null || $apiKey === '');
+    }
+
+    /**
+     * --status: probe armed/dormant pro agregador (sem rodar scoring, sem custo/rede).
+     * `armed` = OPENAI_API_KEY presente (o cron semanal roda real); `dormant` = ausente.
+     */
+    private function reportStatus(?string $apiKey): int
+    {
+        $armed = ! ($apiKey === null || $apiKey === '');
+
+        $report = [
+            'ran_at' => now()->toIso8601String(),
+            'status' => $armed ? 'armed' : 'dormant',
+            'ok' => true,
+            'armed' => $armed,
+            'probe' => true,
+            'reason' => $armed
+                ? 'OPENAI_API_KEY presente — canary semanal roda real'
+                : 'OPENAI_API_KEY ausente — canary dormant (não roda até a chave existir)',
+        ];
+
+        $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        if (! $this->option('json')) {
+            if ($armed) {
+                $this->info('ARMED: OPENAI_API_KEY presente — canary semanal ativo.');
+            } else {
+                $this->warn('DORMANT: OPENAI_API_KEY ausente — canary não roda até a chave existir.');
+            }
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Emite o estado DORMANT: exit 0 (não morde o cron) + status=dormant no JSON
+     * (agregador/Brief mostram ⊘). Loga INFO (não warning/error) — dormência é
+     * estado conhecido e benigno, não falha.
+     */
+    private function reportDormant(): int
+    {
+        $report = [
+            'ran_at' => now()->toIso8601String(),
+            'status' => 'dormant',
+            'ok' => true,
+            'reason' => 'OPENAI_API_KEY ausente — canary cego, não rodou',
+            'mock_mode' => false,
+        ];
+
+        Log::channel('copiloto-ai')->info(
+            '[Jana drift-sentinel] DORMANT — sem OPENAI_API_KEY (canary não rodou; sem ruído semanal)',
+            $report
+        );
+
+        $this->line(json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        if (! $this->option('json')) {
+            $this->warn(
+                'DORMANT: OPENAI_API_KEY ausente — canary não rodou. Defina a chave no '.
+                'ambiente live pra ativar o drift real (ou use --mock pra CI).'
+            );
+        }
 
         return self::SUCCESS;
     }

--- a/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Artisan;
 use Modules\Jana\Console\Commands\HealthCheckCommand;
+use Modules\Jana\Console\Commands\JanaDriftSentinelCommand;
 use Modules\Jana\Console\Commands\SystemAuditCommand;
 
 uses(Tests\TestCase::class);
@@ -94,4 +95,60 @@ test('jana:system-audit: exit code BATE com o veredito dos checks', function () 
 test('jana:system-audit registrado no artisan list', function () {
     Artisan::call('list');
     expect(Artisan::output())->toContain('jana:system-audit');
+});
+
+// ── 3. drift-sentinel: skip-guard HONESTO (sem OPENAI_API_KEY = dormant, não ruído) ──
+//
+// O canary semanal precisa de OPENAI_API_KEY pra rodar real. SEM a chave ele NÃO pode
+// medir — antes do skip-guard (2026-06-20) isso virava falso "DRIFT 100%" + onFailure
+// do cron toda semana. Agora sai DORMANT (exit 0, status=dormant) → ⊘ no agregador.
+// Estes testes provam que (a) a regra do veredito é a esperada e (b) o exit NÃO morde
+// o cron sem chave — pegando "o guard sumiu" OU "o guard pula sempre" num refactor.
+
+test('drift-sentinel veredito: sem mock E sem chave = DORMANT', function () {
+    expect(JanaDriftSentinelCommand::isDormant(false, null))->toBeTrue();
+    expect(JanaDriftSentinelCommand::isDormant(false, ''))->toBeTrue();
+});
+
+test('drift-sentinel veredito: mock OU chave presente = NÃO dormant', function () {
+    expect(JanaDriftSentinelCommand::isDormant(true, null))->toBeFalse();    // mock dispensa chave
+    expect(JanaDriftSentinelCommand::isDormant(false, 'sk-xxx'))->toBeFalse(); // chave presente
+});
+
+test('drift-sentinel: SEM OPENAI_API_KEY sai DORMANT (exit 0 — não morde o cron)', function () {
+    // config() vence env() e config:cache — fonte cache-safe que o guard usa.
+    config(['openai.api_key' => null, 'services.openai.api_key' => null]);
+
+    $exit = Artisan::call('jana:drift-sentinel', ['--json' => true]);
+    $json = biteJson(Artisan::output());
+
+    expect($exit)->toBe(0);                  // não estoura o onFailure do schedule
+    expect($json['status'])->toBe('dormant');
+    expect($json['ok'])->toBeTrue();
+});
+
+test('drift-sentinel --status: armed quando a chave existe, dormant quando não', function () {
+    config(['openai.api_key' => 'sk-test-armed', 'services.openai.api_key' => null]);
+    $exitArmed = Artisan::call('jana:drift-sentinel', ['--status' => true, '--json' => true]);
+    $armed = biteJson(Artisan::output());
+    expect($exitArmed)->toBe(0);
+    expect($armed['status'])->toBe('armed');
+    expect($armed['armed'])->toBeTrue();
+
+    config(['openai.api_key' => null, 'services.openai.api_key' => null]);
+    $exitDormant = Artisan::call('jana:drift-sentinel', ['--status' => true, '--json' => true]);
+    $dormant = biteJson(Artisan::output());
+    expect($exitDormant)->toBe(0);
+    expect($dormant['status'])->toBe('dormant');
+    expect($dormant['armed'])->toBeFalse();
+});
+
+test('drift-sentinel: ARMADO roda o veredito (mock 0.85 vs baseline 0.85 = ok)', function () {
+    // Prova que o guard NÃO pula quando dá pra rodar (mock dispensa rede/chave).
+    $exit = Artisan::call('jana:drift-sentinel', ['--mock' => true, '--json' => true]);
+    $json = biteJson(Artisan::output());
+
+    expect($exit)->toBe(0);
+    expect($json['status'])->toBe('ok');
+    expect($json['ok'])->toBeTrue();
 });

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -388,10 +388,13 @@ class Kernel extends ConsoleKernel
         // Compara faithfulness atual vs baseline canon; ALERT se >10% das perguntas
         // divergirem. RELIGADO 2026-06-20 (auditoria de sentinelas): o docblock do
         // comando afirmava "Schedule weekly Sun 06:00" mas NÃO existia entry aqui —
-        // ghost canary (existe + tem teste de mordida, nunca rodava). Requer
-        // OPENAI_API_KEY no servidor; sem a chave o run falha e o onFailure registra
-        // (sinal honesto de "canary cego", não silêncio). Domingo cedo pra não
-        // disputar DB com os health-checks diários (06:00-06:30).
+        // ghost canary (existe + tem teste de mordida, nunca rodava).
+        //
+        // Skip-guard honesto (2026-06-20): SEM OPENAI_API_KEY o canary NÃO falha o
+        // cron toda semana (era ruído / falso "DRIFT 100%") — sai DORMANT (exit 0,
+        // status=dormant), visível como ⊘ no agregador governance-audit.mjs. O
+        // onFailure abaixo só dispara em drift REAL acima do threshold. Domingo cedo
+        // pra não disputar DB com os health-checks diários (06:00-06:30).
         $schedule->command('jana:drift-sentinel')
             ->weeklyOn(0, '06:00')
             ->timezone('America/Sao_Paulo')
@@ -399,8 +402,8 @@ class Kernel extends ConsoleKernel
             ->environments(['live'])
             ->onFailure(function () {
                 \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
-                    'Schedule jana:drift-sentinel FALHOU — drift Jana acima do threshold ' .
-                    'OU canary não rodou (checar OPENAI_API_KEY). Ver storage/logs.'
+                    'Schedule jana:drift-sentinel FALHOU — drift Jana acima do threshold. ' .
+                    'Ver storage/logs (canary sem OPENAI_API_KEY sai DORMANT, não falha).'
                 );
             });
 

--- a/scripts/governance/governance-audit.mjs
+++ b/scripts/governance/governance-audit.mjs
@@ -41,6 +41,9 @@ const BATTERY = [
   { id: 'jana:system-audit',   runtime: 'php',  kind: 'advisory', cmd: ['jana:system-audit', '--json'] },
   { id: 'jana:validate-memory',runtime: 'php',  kind: 'advisory', cmd: ['jana:validate-memory', '--json'] },
   { id: 'mem:audit',           runtime: 'php',  kind: 'advisory', cmd: ['mem:audit', '--candidates-only'] },
+  // drift-sentinel: probe --status (armed vs dormant) — NÃO roda o canary pago real
+  // (esse é o cron semanal). Sem chave OPENAI sai dormant → ⊘ aqui (honesto, não silêncio).
+  { id: 'jana:drift-sentinel', runtime: 'php',  kind: 'advisory', cmd: ['jana:drift-sentinel', '--status', '--json'] },
 ];
 
 function run(entry) {
@@ -67,12 +70,19 @@ function interpret(entry, r) {
   // Prefere o campo ok do JSON quando o sentinela o emite; senão usa exit code.
   let ok = r.status === 0;
   let summary = '';
+  let dormant = false;
   const jStart = out.indexOf('{');
   if (jStart !== -1) {
     try {
       const j = JSON.parse(out.slice(jStart));
       if (typeof j.ok === 'boolean') ok = j.ok;
-      if (Array.isArray(j.fails) || Array.isArray(j.warns)) {
+      // Estado DORMANT (ex: drift-sentinel sem OPENAI_API_KEY) → ⊘, nem pass nem fail.
+      if (j.status === 'dormant') {
+        dormant = true;
+        summary = `dormant: ${j.reason || 'sem chave'}`;
+      } else if (j.status === 'armed') {
+        summary = 'armado (OPENAI_API_KEY presente)';
+      } else if (Array.isArray(j.fails) || Array.isArray(j.warns)) {
         summary = `${(j.fails || []).length} fail · ${(j.warns || []).length} warn`;
       } else if (Array.isArray(j.cases)) {
         const bad = j.cases.filter((c) => !c.ok).length;
@@ -85,6 +95,7 @@ function interpret(entry, r) {
       }
     } catch { /* não era JSON — cai no fallback */ }
   }
+  if (dormant) return { status: 'skip', summary: summary.slice(0, 90), exit: r.status };
   if (!summary) {
     const lines = out.split('\n').map((l) => l.trim()).filter(Boolean);
     summary = (lines[lines.length - 1] || '').slice(0, 90);


### PR DESCRIPTION
## Problema

`jana:drift-sentinel` foi religada no cron via [#3098](https://github.com/wagnerra23/oimpresso.com/pull/3098) (`weeklyOn(0,'06:00')`, `environments(['live'])`, `onFailure` → `copiloto-ai`). O run real precisa de `OPENAI_API_KEY` (RagasJudgeService → OpenAI).

Sem a chave no ambiente live, `RagasJudgeService::callJudge()` **não estoura** — ele retorna `0.0` e loga warning. Resultado: o canary pontua `0.0` em todas as 50 perguntas vs baseline `0.85` → **100% "drift"** → exit 1 → o `onFailure` do cron dispara um **falso "DRIFT ALERT" toda semana**. Pior que silêncio: é um sinal *mentiroso*. E se a chave some, o canary vira fantasma.

## Solução — skip-guard honesto (Opção B)

Sem `--mock` **e** sem chave, o canary entra em estado **DORMANT explícito**:

- **exit 0** → não morde o `onFailure` do cron (some o ruído semanal e o falso DRIFT).
- **`status: "dormant"` no JSON** → o agregador `governance-audit.mjs` mostra **⊘ dormant** (nem ✅ nem ❌) — visível, não silencioso.
- Veredito extraído pra estático testável `JanaDriftSentinelCommand::isDormant()` — espelha o padrão `allChecksOk()` do #3098.

### Pegadinha do `config:cache` (resolvida)

A chave é lida via `config('openai.api_key')` / `config('services.openai.api_key')` (ambos baked de `OPENAI_API_KEY` no `config:cache`), **nunca `env()` direto** — `env()` devolve `null` com `config:cache` ligado em prod, o que faria o guard pular **sempre** (vira fantasma de novo). É a mesma fonte que `RagasJudgeService::callJudge()`, então guard e run real nunca discordam.

### `--status` (probe) no agregador, não o run pago

O agregador roda `jana:drift-sentinel --status --json` — um probe leve **sem custo/rede** que só responde *armed* (chave presente) vs *dormant*. O run pago de verdade continua sendo só o cron semanal; o agregador não dispara OpenAI a cada execução.

## Arquivos

- `Modules/Jana/Console/Commands/JanaDriftSentinelCommand.php` — `isDormant()`, skip-guard, `--status`, `--json`, `status`/`ok` no report.
- `app/Console/Kernel.php` — comentário + `onFailure` alinhados (não afirmam mais "sem chave o run falha").
- `scripts/governance/governance-audit.mjs` — entry `jana:drift-sentinel` (advisory) + mapeamento `status:dormant` → ⊘.
- `Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php` — +5 bite-tests.

## Verificação local (php 8.4.21)

- **Pest:** `SentinelBiteTest` (12) + `JanaDriftSentinelTest` (5) = **17/17 verde** (43 asserts). 5 novos cobrem: unit `isDormant`, integração dormant (exit 0 + `status=dormant`), `--status` armed/dormant, e armado-roda-veredito (mock).
- **Agregador, com chave:** `✅ jana:drift-sentinel [adv] armado (OPENAI_API_KEY presente)`.
- **Agregador, sem chave:** `⊘ jana:drift-sentinel [adv] dormant: OPENAI_API_KEY ausente — canary dormant (não roda até a chave existir)`.

> Nota operacional (Opção A): se/quando `OPENAI_API_KEY` estiver setada no `.env` do ambiente live (Hostinger), o canary passa de ⊘ dormant pra ✅ armado automaticamente — sem novo deploy. O probe `--status` é o jeito honesto de auditar isso a qualquer momento.

Refs: auditoria de sentinelas 2026-06-20, [#3098](https://github.com/wagnerra23/oimpresso.com/pull/3098)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
