### PR TITLE
fix(jana): parent_plan dos 22 US plano-perdido em meta-line > (custom_fields)

### DIFF
--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskParserServiceTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskParserServiceTest.php
@@ -105,6 +105,41 @@ it('aceita blocked_by com múltiplas tasks', function () {
     expect($cand->first()['blocked_by'])->toBe(['US-NFSE-001', 'US-NFSE-002']);
 });
 
+it('roteia parent_plan da meta-line > pra custom_fields (contrato plano-perdido · ADR 0294 Onda 2)', function () {
+    // Espelha o formato pós-edição dos 22 US plano-perdido: parent_plan numa
+    // meta-line `>` (chave não-canônica → custom_fields), labels seguem no corpo.
+    // Fecha a "ponte transitória" do regex-na-description (PlanDriftCommand::resolveParentPlan).
+    $spec = escreverSpec($this->tmp, <<<MD
+    ### US-PG-009 · Smoke humano-limitado Onda 5
+
+    > owner: — · priority: p1 · estimate: 3h · status: todo · type: story
+    > blocked_by: —
+    > parent_plan: paymentgateway-onda-5-dogfooding
+
+    **Iniciativa-plano perdida** recuperada pro backlog.
+    labels: `plano-perdido`, `backlog-2026-06-20`
+    MD);
+
+    $cand = $this->svc->parseSpec($spec, 'PaymentGateway');
+    expect($cand)->toHaveCount(1)
+        ->and($cand->first()['custom_fields'])->toBe(['parent_plan' => 'paymentgateway-onda-5-dogfooding'])
+        // labels no corpo (não em meta-line `>`) NÃO viram custom field nem campo labels
+        ->and($cand->first()['labels'])->toBeNull();
+});
+
+it('aceita parent_plan com `=` e junto na meta-line de owner', function () {
+    $spec = escreverSpec($this->tmp, <<<MD
+    ### US-X-009 · Variações de sintaxe
+
+    > owner: wagner · parent_plan = sells-v2-paridade-blade-biz4
+
+    desc
+    MD);
+
+    $cand = $this->svc->parseSpec($spec, 'X');
+    expect($cand->first()['custom_fields'])->toBe(['parent_plan' => 'sells-v2-paridade-blade-biz4']);
+});
+
 it('ignora valores —/- como vazios', function () {
     $spec = escreverSpec($this->tmp, <<<MD
     ### US-X-001 · Teste

--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -1653,9 +1653,10 @@ Sessão Eliana 2026-06-08 ~6h. Fecha o loop da migração WR Comercial→oimpres
 
 > owner: — · priority: p1 · estimate: 8h · status: todo · type: story
 > blocked_by: —
+> parent_plan: migracao-firebird-boletos-contratos
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: migracao-firebird-boletos-contratos` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** handoff 2026-06-08 — 59 boletos órfãos + 3.372 `fin_titulos` com `origem_id` incorreto (resíduo da migração Firebird).
 **Dedup:** distinto de US-FIN-039 (vincular-baixas-sem-conta), US-FIN-040 (health-check) e US-FIN-042 (backfill cliente_descricao).

--- a/memory/requisitos/Governance/SPEC.md
+++ b/memory/requisitos/Governance/SPEC.md
@@ -414,9 +414,10 @@ Ref: floor `20260613-100035` (1870) / `20260613-115507` (1928) · doc `memory/se
 
 > owner: — · priority: p2 · estimate: 2h · status: todo · type: story
 > blocked_by: —
+> parent_plan: governance-sprint-2-cleanup
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: governance-sprint-2-cleanup` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** pre-commit com 3 blocos legados pendentes de limpeza.
 
@@ -430,9 +431,10 @@ Ref: floor `20260613-100035` (1870) / `20260613-115507` (1928) · doc `memory/se
 
 > owner: — · priority: p2 · estimate: 2h · status: todo · type: story
 > blocked_by: —
+> parent_plan: ia-os-onda2-endurecer
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: ia-os-onda2-endurecer` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** anchor-gate ainda advisory; endurecer pra required (onda 2 IA-OS).
 
@@ -446,9 +448,10 @@ Ref: floor `20260613-100035` (1870) / `20260613-115507` (1928) · doc `memory/se
 
 > owner: — · priority: p2 · estimate: 3h · status: todo · type: story
 > blocked_by: —
+> parent_plan: screen-qa-dim16-sentinela
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: screen-qa-dim16-sentinela` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** o workflow sentinela da dimensão 16 do screen-grade está ausente no CI (catraca sem sentinela = pode regredir).
 

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -720,9 +720,10 @@ Cada passo é individualmente seguro — sem janela de deadlock "Expected — wa
 
 > owner: — · priority: p2 · estimate: 4h · status: todo · type: story
 > blocked_by: —
+> parent_plan: css-hex-drift-fase2
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: css-hex-drift-fase2` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** 61 valores hex crus restantes (fase 2 do drift de cor do DS).
 **Dedup:** distinto de US-INFRA-035 (fusão dos 4 gates de cor) e US-SELL-043 (CSS Cowork → tokens no Sells).
@@ -737,9 +738,10 @@ Cada passo é individualmente seguro — sem janela de deadlock "Expected — wa
 
 > owner: — · priority: p2 · estimate: 6h · status: todo · type: story
 > blocked_by: —
+> parent_plan: manual-css-js-roadmap
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: manual-css-js-roadmap` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** CSS manual ~28k linhas, meta ~20k (redução via tokens/DS).
 
@@ -753,9 +755,10 @@ Cada passo é individualmente seguro — sem janela de deadlock "Expected — wa
 
 > owner: — · priority: p2 · estimate: 3h · status: todo · type: story
 > blocked_by: —
+> parent_plan: sdd-gate-required
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: sdd-gate-required` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** 3 steps do gate SDD estão em `continue-on-error` (não mordem — "a suite mente").
 
@@ -769,9 +772,10 @@ Cada passo é individualmente seguro — sem janela de deadlock "Expected — wa
 
 > owner: — · priority: p2 · estimate: 4h · status: todo · type: story
 > blocked_by: —
+> parent_plan: sdd-kl-e2-e3
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: sdd-kl-e2-e3` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** stream KL do SDD — 27 renames classe A pendentes (E2/E3).
 
@@ -785,9 +789,10 @@ Cada passo é individualmente seguro — sem janela de deadlock "Expected — wa
 
 > owner: — · priority: p2 · estimate: 8h · status: todo · type: story
 > blocked_by: —
+> parent_plan: sdd-sqlite-corruptors
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: sdd-sqlite-corruptors` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · métrica em drift):** 237 testes "corruptores" de SQLite a eliminar (burn-down do SDD).
 **Relacionado:** US-INFRA-031 (colisões const/function em tests/Feature que bloqueiam a suíte Pest).

--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -1234,9 +1234,10 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 
 > owner: — · priority: p0 · estimate: 4h · status: todo · type: story
 > blocked_by: —
+> parent_plan: adr0270-cockpit-mock-kill
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: adr0270-cockpit-mock-kill` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · P0 prod):** o Cockpit (`resources/js/Pages/Jana/Cockpit.tsx:705-780`) usa `startMockStream` numa rota **live** `/ia/dashboard` — responde dados mock em produção. Gap P0 do handoff 2026-06-11.
 
@@ -1251,9 +1252,10 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 
 > owner: — · priority: p0 · estimate: 4h · status: todo · type: story
 > blocked_by: —
+> parent_plan: content-reconciler-safe-heal
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: content-reconciler-safe-heal` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · P0 Tier-0):** `ContentReconciler` está `healable=false` porque o delete é **global, sem `business_id`** (comment no código: "delete global sem business_id — Tier-0-inseguro (ADR 0093)"). Risco de corrupção cross-tenant se reativado sem guard.
 
@@ -1268,9 +1270,10 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 
 > owner: — · priority: p0 · estimate: 8h · status: todo · type: story
 > blocked_by: —
+> parent_plan: kb-acl-aware-rag
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: kb-acl-aware-rag` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · P0 LGPD):** sem `kb_node_visibility` + ACL row-level no pre-retrieval, o RAG não pode ser liberado pro time MCP (risco de vazamento entre escopos). Bloqueante levantado pelo Agent D 2026-05-15.
 
@@ -1285,9 +1288,10 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 
 > owner: — · priority: p0 · estimate: 6h · status: todo · type: story
 > blocked_by: —
+> parent_plan: knowledge-drift-rename-propagation
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: knowledge-drift-rename-propagation` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** drift de nomenclatura — `git grep` acha ~112 PHP em `Modules/` citando `Copiloto` + 27 citando `MemCofre` (renames Copiloto→Jana / MemCofre→SRS não propagados).
 
@@ -1304,9 +1308,10 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 
 > owner: — · priority: p0 · estimate: 4h · status: todo · type: story
 > blocked_by: —
+> parent_plan: hitl-audit-card-ui-copiloto
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: hitl-audit-card-ui-copiloto` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · LGPD Art.20):** direito de revisão de decisão automatizada — a UI admin do HITL existe, mas falta a view do **cliente-final** em `/copiloto/decisoes/{id}/revisao`.
 

--- a/memory/requisitos/PaymentGateway/SPEC.md
+++ b/memory/requisitos/PaymentGateway/SPEC.md
@@ -182,9 +182,10 @@ if ($timestamp && abs(now()->timestamp - Carbon::parse($timestamp)->timestamp) >
 
 > owner: — · priority: p1 · estimate: 3h · status: todo · type: story
 > blocked_by: —
+> parent_plan: paymentgateway-onda-5-dogfooding
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: paymentgateway-onda-5-dogfooding` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** código da Onda 5 já feito (PR #1148); restam pendências **humano-limitadas** (relógio do mundo real, ADR 0106): smoke biz=1 + canary Larissa biz=4.
 **Dedup:** distinto de US-PG-002/003 (SEC webhooks) e US-PG-005/006/007 (webhook Inter).

--- a/memory/requisitos/RecurringBilling/SPEC.md
+++ b/memory/requisitos/RecurringBilling/SPEC.md
@@ -991,9 +991,10 @@ Refina/separa o `InterPixCobDriver` mencionado em US-RB-047 num `InterPixCobranc
 
 > owner: — · priority: p1 · estimate: 8h · status: todo · type: story
 > blocked_by: —
+> parent_plan: recurring-billing-gateway-ativacao
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: recurring-billing-gateway-ativacao` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** receita parada — 109 assinaturas ativas com `gateway=NULL` não geram cobrança (36 C6 + 51 Inter + 22 Cora). Maior ROI do batch.
 
@@ -1009,9 +1010,10 @@ Refina/separa o `InterPixCobDriver` mencionado em US-RB-047 num `InterPixCobranc
 
 > owner: — · priority: p1 · estimate: 3h · status: todo · type: story
 > blocked_by: —
+> parent_plan: pricing-3-ajustes-urgentes
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: pricing-3-ajustes-urgentes` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** Martinho com compra ativa (cliente pagante) — recalibração de pricing em 3 eixos: setup, trial, anual.
 

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -1030,9 +1030,10 @@ Ref: triage `memory/sessions/2026-06-13-sdd-f2b-triage-q2.md` · revisão advers
 
 > owner: — · priority: p0 · estimate: 4h · status: todo · type: story
 > blocked_by: —
+> parent_plan: timezone-format-date-migracao
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: timezone-format-date-migracao` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** bug histórico preservado em ADR 0066 — migration de timezone/format de `transaction_date` nunca rodou; afeta cliente real ROTA LIVRE (biz=4).
 
@@ -1047,9 +1048,10 @@ Ref: triage `memory/sessions/2026-06-13-sdd-f2b-triage-q2.md` · revisão advers
 
 > owner: — · priority: p1 · estimate: 8h · status: todo · type: story
 > blocked_by: —
+> parent_plan: sells-v2-paridade-blade-biz4
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: sells-v2-paridade-blade-biz4` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** Larissa biz=4; guard biz=4 já removido. Restam 3 features do Blade ausentes em V2: configure-search, quick-add, preço-diferenciado.
 **⚠️ Dedup parcial:** possível overlap com o epic MWART US-SELL-001..006 (migração /sells/create) — checar antes de abrir trabalho redundante.

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -1795,9 +1795,10 @@ parent_plan=plano-atendimento-automatico (etapa E2, maior ROI — [ADR 0294](../
 
 > owner: — · priority: p0 · estimate: 8h · status: todo · type: story
 > blocked_by: —
+> parent_plan: whatsapp-channel-reliability-roadmap
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: whatsapp-channel-reliability-roadmap` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105 · P0 confiabilidade):** 7/10 gaps do channel-reliability fechados (probe #3055 nesta sessão). Restam #6 nonce/dedup-key, #9 failover, #10 circuit-breaker. Relacionado ADR 0288.
 **Dedup:** distinto de US-WA-058/059 (inbox omnichannel) e US-WA-078/079 (banDetector/SIGTERM).
@@ -1814,9 +1815,10 @@ parent_plan=plano-atendimento-automatico (etapa E2, maior ROI — [ADR 0294](../
 
 > owner: — · priority: p1 · estimate: 12h · status: todo · type: story
 > blocked_by: —
+> parent_plan: voz-cliente-5-ondas
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: voz-cliente-5-ondas` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** `customer_memory` shipou (onda 1). Ondas 2-5 abertas: Customer 360 sidebar + inferência IA.
 **⚠️ Dedup parcial:** `customer-360-sidebar` aparece como *done* na triagem — confirmar o que de fato resta antes de escopar.
@@ -1832,9 +1834,10 @@ parent_plan=plano-atendimento-automatico (etapa E2, maior ROI — [ADR 0294](../
 
 > owner: — · priority: p1 · estimate: 10h · status: todo · type: story
 > blocked_by: —
+> parent_plan: voc-omnichannel-gaps
 
 **Iniciativa-plano perdida** recuperada pro backlog (triagem 2026-06-20 · run wf_1bfbefba).
-`parent_plan: voc-omnichannel-gaps` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
 
 **Sinal (ADR 0105):** `whatsapp_consent` + `customer_memory` shipparam. Restam Gap#3 (ContactProfile acumulativo) + Gap#4 (auto-tag IA + dashboard VoC).
 **Relacionado:** US-WA-316 (voz-cliente ondas 2-5) — coordenar pra não duplicar.


### PR DESCRIPTION
## O quê

Move `parent_plan: <slug>` da **linha de corpo** (backtick) pra uma **meta-line `>`** em cada um dos **22 US "plano-perdido"** materializados em [#3090](https://github.com/wagnerra23/oimpresso.com/pull/3090), nos SPECs de Financeiro, Governance (3), Infra (5), Jana (5), PaymentGateway, RecurringBilling (2), Sells (2) e Whatsapp (3).

```diff
 > owner: — · priority: p1 · estimate: 3h · status: todo · type: story
 > blocked_by: —
+> parent_plan: paymentgateway-onda-5-dogfooding

 **Iniciativa-plano perdida** recuperada pro backlog (...).
-`parent_plan: paymentgateway-onda-5-dogfooding` · labels: `plano-perdido`, `backlog-2026-06-20`
+labels: `plano-perdido`, `backlog-2026-06-20`
```

## Por quê

`TaskParserService::parseFrontmatterInline` só lê meta-lines que começam com `>`. Na linha de corpo, `parent_plan` **não chegava** em `McpTask.custom_fields['parent_plan']` no sync — ficava só na `description`. Isso obrigava a sentinela `jana:plan-drift` (ADR 0294 Onda 2) a resolver o vínculo pelo **fallback frágil de regex na description**.

Mover pra `>` faz `PlanDriftCommand::resolveParentPlan` resolver pela **precedência 1** (`custom_fields`) em vez da **precedência 3** (regex na description) — fechando a "ponte transitória" que o próprio docblock do comando documenta (linhas 43-46).

## Como (zero mudança de parser)

Chave não-canônica já cai em `custom_fields` no `default` do `switch`, e o parser aceita `:` e `=`. **Nenhuma mudança de código no parser** — só reposicionamento do campo no markdown.

- Slugs kebab-case **preservados** exatamente.
- `labels` **mantidos** na linha de corpo (inalterados, conforme contrato).
- Linhas de prose não-batch (ex. `parent_plan=plano-atendimento-automatico` da US-WA-311) **não tocadas**.

## Verificação

- ✅ **22** novas meta-lines `> parent_plan:` · **0** linhas-corpo no formato antigo restantes (grep estrutural).
- ✅ **Golden test** novo em `TaskParserServiceTest.php` trava o contrato `parent_plan` (meta-line `>`) → `custom_fields['parent_plan']`, incl. sintaxe `=` e junção na linha de `owner`. (CI roda o Pest; `php` não está disponível no host local.)
- ⏳ **Sync + `jana:plan-drift --json`**: o sync roda server-side via webhook GitHub→MCP **após o merge**; `jana:plan-drift` em si ainda está em [#3105](https://github.com/wagnerra23/oimpresso.com/pull/3105) (aberto). Pós-merge dos dois, o re-sync popula `custom_fields['parent_plan']` nas 22 tasks já existentes (descritivo, atualizável por ADR 0144) e o drift passa a resolver por `custom_fields`.

## Refs

- ADR 0294 Onda 2 (método dual-track / `jana:plan-drift`)
- Contrato: `memory/requisitos/_processo/PLANS-INDEX.md` §"Como manter vivo"
- Precede: [#3105](https://github.com/wagnerra23/oimpresso.com/pull/3105) (sentinela `jana:plan-drift`)
- Depende de (merged): [#3090](https://github.com/wagnerra23/oimpresso.com/pull/3090) (batch 22 US plano-perdido)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
