### PR TITLE
fix(jana): regex de SPEC casa #### (4 hashes) — corrige 70 falsos-positivos do mcp:tasks:orphans

### DIFF
--- a/Modules/Jana/Console/Commands/McpTasksOrphansCommand.php
+++ b/Modules/Jana/Console/Commands/McpTasksOrphansCommand.php
@@ -141,7 +141,10 @@ class McpTasksOrphansCommand extends Command
                 continue;
             }
             $content = (string) @file_get_contents($spec);
-            if (preg_match_all('/(?:^###|^-)\s+(?:\S+\s+)?(US-[A-Z0-9]+-\d+)/m', $content, $m)) {
+            // #{2,4} cobre ### E #### (ex: Cms/SPEC.md usa ####) — idem ao
+            // US_HEADING_REGEX do parser. Sem isso, US declaradas em heading ####
+            // viram falso-positivo de "órfã" (70 falsos no 1º run, 2026-06-21).
+            if (preg_match_all('/(?:^#{2,4}|^-)\s+(?:\S+\s+)?(US-[A-Z0-9]+-\d+)/m', $content, $m)) {
                 foreach ($m[1] as $id) {
                     $ids[strtoupper($id)] = true;
                 }

--- a/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskCrudService.php
@@ -531,7 +531,9 @@ class TaskCrudService
         $specPath = base_path("memory/requisitos/{$module}/SPEC.md");
         if (is_file($specPath)) {
             $content = (string) @file_get_contents($specPath);
-            if (preg_match('/^###\s+US-([A-Z]+)-\d+/m', $content, $m)) {
+            // #{2,4}: SPECs variam entre ### e #### por US (Cms usa ####); o parser
+            // canônico (US_HEADING_REGEX) usa #{2,4}, então casamos igual.
+            if (preg_match('/^#{2,4}\s+US-([A-Z]+)-\d+/m', $content, $m)) {
                 return $m[1]; // ex: "RB", "NFE", "COPI"
             }
         }
@@ -596,7 +598,8 @@ class TaskCrudService
             return 0;
         }
         $content = (string) @file_get_contents($specPath);
-        if (preg_match_all('/(?:^###|^-)\s+(?:\S+\s+)?' . preg_quote($prefixo, '/') . '(\d+)/m', $content, $matches)) {
+        // #{2,4} cobre ### E #### (Cms usa ####) — idem US_HEADING_REGEX do parser.
+        if (preg_match_all('/(?:^#{2,4}|^-)\s+(?:\S+\s+)?' . preg_quote($prefixo, '/') . '(\d+)/m', $content, $matches)) {
             return max(array_map('intval', $matches[1]));
         }
         return 0;

--- a/Modules/Jana/Tests/Feature/TaskRegistry/McpTasksOrphansCommandTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/McpTasksOrphansCommandTest.php
@@ -139,3 +139,20 @@ it('exit SUCCESS quando não há órfã, FAILURE quando há', function () {
     $this->artisan('mcp:tasks:orphans', ['--module' => '__TestOrphanCmd'])
         ->assertExitCode(1);
 });
+
+it('reconhece US declarada em heading #### (não vira falso-positivo de órfã)', function () {
+    // Regressão dos 70 falsos-positivos (2026-06-21): Cms usa "#### US-CMS-NNN" e o
+    // regex antigo (^###) não casava → toda US #### virava "órfã".
+    orphanWriteSpec('__TestOrphanCmd', "# SPEC\n\n#### US-ZZORPHCMD-001 — quatro hashes\n");
+
+    orphanSeed('US-ZZORPHCMD-001'); // declarada via #### → NÃO órfã
+    orphanSeed('US-ZZORPHCMD-099'); // não declarada em lugar nenhum → órfã
+
+    $ids = array_map(
+        fn ($o) => $o['task_id'],
+        (new McpTasksOrphansCommand())->detectarOrfas('__TestOrphanCmd', false),
+    );
+
+    expect($ids)->not->toContain('US-ZZORPHCMD-001')
+        ->and($ids)->toContain('US-ZZORPHCMD-099');
+});

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskCrudServiceCanonicalIdTest.php
@@ -222,3 +222,17 @@ it('nunca devolve um task_id que já existe no DB (guarda de colisão)', functio
     expect($next)->toBe('US-ZZORPH-015')
         ->and(DB::table('mcp_tasks')->where('task_id', $next)->exists())->toBeFalse();
 });
+
+it('conta US declarada em heading #### (4 hashes), não só ### (ex: Cms)', function () {
+    // Cms/SPEC.md usa "#### US-CMS-NNN". O regex antigo (^###\s+) não casava ####
+    // → maiorSequencialNoSpec voltava 0 (mascarado pelo termo do DB). Agora #{2,4}.
+    tcWriteSpec('__TestCanonicalA', "# SPEC\n\n#### US-ZZHASH-007 — quatro hashes\n");
+
+    $svc = new TaskCrudService();
+    $reflect = (new ReflectionClass(TaskCrudService::class))
+        ->getMethod('gerarProximoIdCanonical');
+    $reflect->setAccessible(true);
+
+    // prefixo ZZHASH detectado no heading #### + nSpec=007 → 008.
+    expect($reflect->invoke($svc, '__TestCanonicalA'))->toBe('US-ZZHASH-008');
+});


### PR DESCRIPTION
<!-- evidence-override: PR não toca runtime/infra-crítico (.htaccess/middleware/Kernel/routes/bootstrap). Só regex em TaskCrudService (service), McpTasksOrphansCommand (console) e testes. Sem superfície HTTP/rota nova. -->

## Bug (smoke pós-deploy do #3106 · 2026-06-21)

Rodando o novo `mcp:tasks:orphans` global contra o DB de prod, ele acusou **70 "órfãs" falsas** — todas US declaradas em heading `#### US-XX-NNN` (ex: `Cms/SPEC.md` usa 4 hashes). O regex `(?:^###|^-)\s+` só casava **3** hashes, então toda US de 4 hashes era vista como ausente do SPEC.

## Fix

Troca `^###` por `^#{2,4}` (idêntico ao `US_HEADING_REGEX` do parser canônico) em 3 pontos:

- **`McpTasksOrphansCommand::idsDeclaradosNosSpecs`** — o bug visível (70 falsos-positivos).
- **`TaskCrudService::maiorSequencialNoSpec`** — mesmo bug latente; estava mascarado pelo termo `max(nDb)`, mas para um módulo `####` com o DB atrás do SPEC ele subcontava o `nSpec`.
- **`TaskCrudService::detectarPrefixoSpec`** — caía no fallback `strtoupper` pra módulos `####` (coincidia em Cms; quebraria onde o prefixo curto ≠ nome do módulo).

## Test plan

- Casos novos: `####` no allocator (`gerarProximoIdCanonical`) + `####` no detector (não vira órfã). Lane sqlite roda ambos.
- Prova standalone (`preg_match_all`): `##`, `###`, `####` e bullets `- ` todos casam com o regex novo; o antigo perdia `##` e `####`.
- `php -l` limpo nos 4 arquivos.

Follow-up do [#3106](https://github.com/wagnerra23/oimpresso.com/pull/3106) (já mergeado + deployado no CT 100).

Refs: incidente US-RB-052 2026-06-20 · ADR 0264 · ADR 0144

🤖 Generated with [Claude Code](https://claude.com/claude-code)
