### PR TITLE
fix(jana): procedure_drift falso positivo — normalize ignora backticks do SHOW CREATE

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -543,10 +543,21 @@ class HealthCheckCommand extends Command
             $rows = DB::select('SHOW CREATE PROCEDURE refresh_brief_inputs_cache');
             $deployedSql = $rows[0]->{'Create Procedure'} ?? '';
 
+            // MySQL's SHOW CREATE PROCEDURE backtick-quotes the routine name +
+            // identifiers (`CREATE ... PROCEDURE `refresh_brief_inputs_cache`()`),
+            // while the migration source declares them bare (`CREATE PROCEDURE
+            // refresh_brief_inputs_cache()`). Backtick quoting is never semantic, so
+            // strip DEFINER first (its regex anchors on backticks) THEN drop the
+            // remaining backticks on both sides — otherwise identical DDL reads as
+            // drift forever (false positive US-COPI-092, caught in prod 2026-06-20).
             $normalize = static fn (string $sql): string => preg_replace(
                 '/\s+/',
                 ' ',
-                strtolower(preg_replace('/DEFINER\s*=\s*`[^`]*`@`[^`]*`\s*/i', '', trim($sql)))
+                strtolower(str_replace(
+                    '`',
+                    '',
+                    preg_replace('/DEFINER\s*=\s*`[^`]*`@`[^`]*`\s*/i', '', trim($sql))
+                ))
             );
 
             $drifted = md5($normalize($canonicalSql)) !== md5($normalize($deployedSql));

--- a/Modules/Jana/Tests/Feature/Smoke/ProcedureDriftSnapshotTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/ProcedureDriftSnapshotTest.php
@@ -22,10 +22,15 @@ uses(Tests\TestCase::class);
  * Refs: US-COPI-092, ADR 0094 §5, memory/proibicoes.md
  */
 
-/** Normaliza SQL para comparação: remove DEFINER, colapsa espaços, lowercase. */
+/** Normaliza SQL para comparação: remove DEFINER + backticks, colapsa espaços, lowercase. */
 function normalizeProcSql(string $sql): string
 {
+    // Strip DEFINER first (its regex anchors on backticks), then drop all remaining
+    // backticks: MySQL's SHOW CREATE backtick-quotes the routine name + identifiers,
+    // the migration source declares them bare. Quoting is never semantic drift —
+    // leaving the backticks made an unchanged procedure read as drift (US-COPI-092).
     $sql = preg_replace('/DEFINER\s*=\s*`[^`]*`@`[^`]*`\s*/i', '', $sql);
+    $sql = str_replace('`', '', $sql);
 
     return preg_replace('/\s+/', ' ', strtolower(trim($sql)));
 }

--- a/memory/sessions/2026-06-20-incidente-procedure-drift-false-positivo.md
+++ b/memory/sessions/2026-06-20-incidente-procedure-drift-false-positivo.md
@@ -1,0 +1,66 @@
+# Incidente — `procedure_drift = DRIFT` é falso positivo (backticks do SHOW CREATE)
+
+- **Data:** 2026-06-20 (achado 22:55 BRT via `php artisan jana:health-check` em prod Hostinger)
+- **Refs:** US-COPI-092 · [Modules/Jana/Console/Commands/HealthCheckCommand.php](../../Modules/Jana/Console/Commands/HealthCheckCommand.php) `::checkProcedureDrift` (Check 6)
+- **Tier 0:** banco de PRODUÇÃO. Investigação 100% READ-ONLY (nenhum ALTER/DROP/CREATE PROCEDURE).
+
+## Sintoma
+
+`jana:health-check` Check 6 reportou `procedure_drift = DRIFT` ("ALERTA: refresh_brief_inputs_cache divergiu da migration"). Interpretação esperada: ou edição manual da procedure em prod, ou migration não aplicada.
+
+## Diagnóstico (root cause): FALSO POSITIVO no próprio check
+
+A procedure **deployed em prod é byte-a-byte idêntica** à migration canônica `database/migrations/2026_05_07_120000_fix_brief_aggregator_in_flight_adrs_activity.php`. **Não há drift real** — a migration foi aplicada e o corpo bate.
+
+O DRIFT vem de um bug no `normalize()`:
+- `SHOW CREATE PROCEDURE` do MySQL devolve `CREATE DEFINER=\`…\`@\`…\` PROCEDURE \`refresh_brief_inputs_cache\`()` — nome da rotina **entre backticks**.
+- A migration declara `CREATE PROCEDURE refresh_brief_inputs_cache()` — nome **sem backticks**.
+- `normalize()` remove o `DEFINER=…@…` mas **deixa os backticks**. Resultado: `create procedure \`refresh_brief_inputs_cache\`()` ≠ `create procedure refresh_brief_inputs_cache()` → divergem no **char 17** (o backtick), e em mais nada.
+
+Backtick é só quoting de identificador (nunca é drift semântico). O mesmo bug está no snapshot test `Modules/Jana/Tests/Feature/Smoke/ProcedureDriftSnapshotTest.php::normalizeProcSql` — só não pegou porque o teste é `markTestSkipped` em SQLite/CI; o caminho MySQL só roda em prod/staging.
+
+### Prova (probe READ-ONLY em prod, replicando `checkProcedureDrift`)
+
+```
+=== CHECK REPLICA (current normalize) ===
+CHECK_RESULT=DRIFT
+CANON_LEN=3723 DEPLOY_LEN=3725          # diff = exatamente 2 chars = os 2 backticks
+CHECK_FIRST_DIFF_AT=17                  # char 17 = `refresh_brief_inputs_cache`
+CHECK_CANON_HEAD=create procedure refresh_brief_inputs_cache() begin declare v_active_cycle json; ...
+CHECK_DEPLOY_HEAD=create procedure `refresh_brief_inputs_cache`() begin declare v_active_cycle json; ...
+=== FIXED REPLICA (also strip backticks) ===
+FIXED_RESULT=OK
+FIXED_CANON_LEN=3721 FIXED_DEPLOY_LEN=3721
+FIXED_FIRST_DIFF_AT=3721 (of min 3721) # zero divergência: corpos idênticos
+```
+
+## Reconciliação (a correta)
+
+**NÃO** é migration de procedure (a procedure já está certa — rodar DDL em prod seria errado e desnecessário). O fix é **corrigir o `normalize()`**: tirar o DEFINER **primeiro** (a regex se ancora em backticks) e **depois** remover todos os backticks, dos dois lados. Aplicado em:
+- `HealthCheckCommand.php::checkProcedureDrift`
+- `ProcedureDriftSnapshotTest.php::normalizeProcSql`
+
+Com o fix, drift volta a significar drift de verdade (mudança de corpo via DDL fora de migration).
+
+## Achado secundário (incidente prod ATIVO, separado)
+
+Durante a repro, `php artisan jana:health-check` (e **qualquer** comando artisan) está **fatalando no boot** em prod:
+
+```
+Illuminate\Contracts\Container\BindingResolutionException
+Target class [Modules\Jana\Console\Commands\McpTasksOrphansCommand] does not exist.
+```
+
+Evidência (read-only):
+- Arquivo `Modules/Jana/Console/Commands/McpTasksOrphansCommand.php` **existe em disco** (deploy Jun 21 02:03 UTC ≈ 23:03 BRT — logo após a run das 22:55).
+- `grep -c McpTasksOrphansCommand vendor/composer/autoload_classmap.php` = **0** → classmap otimizado/authoritative **stale**.
+- Registrado em `Modules/Jana/Providers/JanaServiceProvider.php` (incidente US-RB-052, hoje) → o provider tenta resolver a classe no boot e estoura.
+
+Padrão idêntico ao incidente "prod 500 = classmap stale pós-deploy" (`git reset --hard` sem `composer dump-autoload`). **Impacto:** o cron diário `jana:health-check` (06:00 BRT) está quebrado até reconciliar o autoloader. **Remediação (precisa aprovação Wagner — Tier 0 prod):**
+
+```bash
+# após warm-up curl 5×, via receita SSH canônica (memory/reference/hostinger.md)
+ssh … "cd domains/oimpresso.com/public_html && /usr/local/bin/composer dump-autoload -o 2>&1 | tail -5"
+```
+
+(`dump-autoload` regenera só o autoloader, sem mexer em pacotes — baixo risco; mesmo assim é mudança em prod → escala pro Wagner por publication-policy.)


### PR DESCRIPTION
## Contexto

`php artisan jana:health-check` (Check 6 `procedure_drift`, US-COPI-092) reportou `DRIFT` em **produção** (Hostinger, 2026-06-20 22:55 BRT): _"ALERTA: refresh_brief_inputs_cache divergiu da migration"_.

## Root cause: falso positivo no próprio check

Investigação **read-only em prod** (SHOW CREATE PROCEDURE vs migration canônica `2026_05_07_120000`): a procedure deployed é **byte-a-byte idêntica** à migration. **Não há drift real.**

O `DRIFT` vem de um bug no `normalize()`:
- `SHOW CREATE PROCEDURE` devolve `CREATE DEFINER=…@… PROCEDURE ` + backtick + `refresh_brief_inputs_cache` + backtick + `()` — nome **entre backticks**.
- A migration declara `CREATE PROCEDURE refresh_brief_inputs_cache()` — nome **sem backticks**.
- `normalize()` removia o `DEFINER` mas **deixava os backticks** → strings divergem **só no char 17** (o backtick) e em mais nada.

Mesmo bug no snapshot test `ProcedureDriftSnapshotTest::normalizeProcSql` — nunca pegou porque o teste é `markTestSkipped` em SQLite/CI; o caminho MySQL só roda em prod/staging.

### Prova (probe read-only replicando `checkProcedureDrift` em prod)

```
CHECK_RESULT=DRIFT      CANON_LEN=3723  DEPLOY_LEN=3725   # diff = exatamente os 2 backticks
CHECK_FIRST_DIFF_AT=17  # char 17 = `refresh_brief_inputs_cache`
FIXED_RESULT=OK         FIXED_CANON_LEN=3721  FIXED_DEPLOY_LEN=3721  # corpos idênticos ao remover backticks
```

## Fix

Em `checkProcedureDrift` **e** `normalizeProcSql`: tira o `DEFINER` primeiro (a regex se ancora em backticks) e **depois** remove todos os backticks, dos dois lados. Quoting de identificador nunca é drift semântico. Com isso, `DRIFT` volta a significar mudança real de corpo (DDL fora de migration).

**Nenhum DDL em produção** — a procedure já está correta. Não foi criada migration de procedure (seria errado).

## Achado secundário (NÃO neste PR — precisa aprovação Wagner)

Durante a repro, **qualquer** comando artisan está fatalando no boot em prod:
`BindingResolutionException: Target class [Modules\Jana\Console\Commands\McpTasksOrphansCommand] does not exist`.
Arquivo existe em disco (deploy de hoje, US-RB-052) mas **ausente do `autoload_classmap.php`** (classmap stale). Cron diário `jana:health-check` quebrado até reconciliar. Remediação = `composer dump-autoload -o` em prod (Tier 0 → escala pro Wagner). Detalhe em `memory/sessions/2026-06-20-incidente-procedure-drift-false-positivo.md`.

Refs: US-COPI-092

🤖 Generated with [Claude Code](https://claude.com/claude-code)