### PR TITLE
fix(jana): agenda ProfileDistiller — job que faltava (COPI-26)

### DIFF
--- a/Modules/Jana/Console/Commands/ProfileDistillCommand.php
+++ b/Modules/Jana/Console/Commands/ProfileDistillCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use App\Business;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Services\Memoria\ProfileDistiller;
+
+/**
+ * jana:profile-distill — regenera o perfil compacto (`jana_business_profile`)
+ * de cada business via {@see ProfileDistiller} (MEM-S8-3, ADR 0037).
+ *
+ * RAIZ COPI-26 (incidente 2026-06-20): o `ProfileDistiller` existia desde abr/2026
+ * mas NUNCA foi agendado — `->destilar()` tinha ZERO call sites no codebase. As 3
+ * únicas linhas em prod (biz 1 WR2, 4 ROTA LIVRE, 164 MARTINHO) eram seeds one-off
+ * que envelheceram >7d e acendiam o check `profile_distiller_drift` no
+ * `jana:health-check`. A sentinela (graduada em L-OP-002) estava CORRETA — vigiava
+ * um job de manutenção que nunca rodava. Este comando é o job que faltava.
+ *
+ * O perfil é consumido por `ContextSnapshotService::montar()` (injeta `profile_text`
+ * como `observacoes` no system prompt da Jana) — perfil stale = assistente respondendo
+ * com narrativa comercial velha. Por isso o check é DURO.
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): itera business by business via loop
+ * EXPLÍCITO, passando `$businessId` pro distiller (que filtra por `business_id`).
+ * NUNCA cross-tenant. Mesmo padrão de `jana:retention-purge`.
+ *
+ * Custo: 1 chamada LLM/business (~200 tokens out @ gpt-4o-mini). ~76 biz ≈ $0,02/dia.
+ * Não escreve em `jana_mensagens`, então não conta pro check `custo_brain_b_24h`.
+ *
+ * Robustez: falha de UM business (LLM timeout, ctx vazio) NÃO aborta o batch — é
+ * contabilizada e logada; o próximo run diário (bem dentro da janela de 7d) re-tenta.
+ *
+ * Uso:
+ *   php artisan jana:profile-distill                  # todos os businesses
+ *   php artisan jana:profile-distill --business=4     # só ROTA LIVRE (backfill manual)
+ *   php artisan jana:profile-distill --only-stale     # só ausentes/stale (>7d)
+ *
+ * Schedule canon: daily 04:50 BRT (app/Console/Kernel.php) — antes do
+ * `jana:health-check` (06:00) reavaliar o check.
+ *
+ * @see Modules\Jana\Services\Memoria\ProfileDistiller
+ * @see Modules\Jana\Console\Commands\HealthCheckCommand::checkProfileDrift (check 5)
+ * @see Modules/Jana/LICOES-OPERACAO.md L-OP-002
+ */
+class ProfileDistillCommand extends Command
+{
+    protected $signature = 'jana:profile-distill
+                            {--business= : Limitar a business_id específico (default: itera todos)}
+                            {--only-stale : Regenera só profiles ausentes ou >7d sem regenerar}';
+
+    protected $description = 'Regenera jana_business_profile via ProfileDistiller (COPI-26 — job que faltava no scheduler)';
+
+    public function handle(ProfileDistiller $distiller): int
+    {
+        $businessIdArg = $this->option('business');
+        $onlyStale = (bool) $this->option('only-stale');
+
+        $businesses = $this->resolveBusinesses($businessIdArg !== null ? (string) $businessIdArg : null, $onlyStale);
+
+        if ($businesses->isEmpty()) {
+            $this->info('Nenhum business a regenerar' . ($onlyStale ? ' (--only-stale: tudo fresco <7d).' : '.'));
+
+            return self::SUCCESS;
+        }
+
+        $this->info('jana:profile-distill — ' . now()->toDateTimeString());
+        $this->line('  businesses : ' . $businesses->count() . ($onlyStale ? ' (só ausentes/stale)' : ''));
+        $this->newLine();
+
+        $rows = [];
+        $ok = 0;
+        $vazios = 0;
+        $falhas = 0;
+
+        foreach ($businesses as $bizId) {
+            $bizId = (int) $bizId;
+
+            try {
+                $r = $distiller->destilar($bizId);
+                $chars = mb_strlen((string) ($r['profile_text'] ?? ''));
+                $erro = $r['error'] ?? null;
+
+                if ($erro !== null) {
+                    $falhas++;
+                    $status = 'ERR: ' . mb_substr((string) $erro, 0, 26);
+                } elseif ($chars === 0) {
+                    // ctx null OU LLM devolveu vazio: o distiller NÃO bumpa gerado_em
+                    // nesse caminho, então a sentinela seguirá vendo este biz como
+                    // stale (correto — não escondemos falha persistente).
+                    $vazios++;
+                    $status = 'VAZIO (sem ctx/output)';
+                } else {
+                    $ok++;
+                    $status = 'OK';
+                }
+
+                $rows[] = [
+                    $bizId,
+                    (int) ($r['tokens_estimated'] ?? 0),
+                    (int) ($r['raw_context_tokens'] ?? 0),
+                    $chars,
+                    $status,
+                ];
+            } catch (\Throwable $e) {
+                $falhas++;
+                $rows[] = [$bizId, 0, 0, 0, 'EXC: ' . mb_substr($e->getMessage(), 0, 26)];
+                Log::channel('copiloto-ai')->error('jana:profile-distill — exceção num business', [
+                    'business_id' => $bizId,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        $this->table(['business_id', 'tok_est', 'raw_tok', 'chars', 'status'], $rows);
+        $this->newLine();
+        $this->info(sprintf(
+            'Total: %d ok · %d vazios · %d falhas · %d businesses',
+            $ok,
+            $vazios,
+            $falhas,
+            $businesses->count(),
+        ));
+
+        Log::channel('copiloto-ai')->info('jana:profile-distill — resumo', [
+            'ok' => $ok,
+            'vazios' => $vazios,
+            'falhas' => $falhas,
+            'total' => $businesses->count(),
+        ]);
+
+        return $falhas > 0 ? self::FAILURE : self::SUCCESS;
+    }
+
+    /**
+     * Multi-tenant Tier 0: resolve a lista de business_ids via loop EXPLÍCITO.
+     *
+     * @return Collection<int,int>
+     */
+    protected function resolveBusinesses(?string $businessIdArg, bool $onlyStale): Collection
+    {
+        if ($businessIdArg !== null && $businessIdArg !== '') {
+            return collect([(int) $businessIdArg]);
+        }
+
+        /** @var Collection<int,int> $todos */
+        $todos = Business::query()->orderBy('id')->pluck('id')->map(fn ($v) => (int) $v);
+
+        if (! $onlyStale) {
+            return $todos;
+        }
+
+        // Só os que NÃO têm profile fresco (<7d). Ausente do profile = stale.
+        // Espelha o critério de checkProfileDrift (gerado_em >= now-7d = fresco).
+        $frescos = DB::table('jana_business_profile')
+            ->where('gerado_em', '>=', now()->subDays(7))
+            ->pluck('business_id')
+            ->map(fn ($v) => (int) $v)
+            ->flip();
+
+        return $todos->reject(fn ($id) => $frescos->has($id))->values();
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -80,6 +80,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\DesignDossieCommand::class, // plano vectorized-badger PR-1 — dossiê de tela (read-view do curado, pré-aplicação)
                 \Modules\Jana\Console\Commands\DesignIngestZipCommand::class, // plano vectorized-badger PR-2 — ingestão de design-zip (prepare-only)
                 \Modules\Jana\Console\Commands\DesignMineRawCommand::class, // plano vectorized-badger PR-3 — minera raw→candidatos 🔍 (human-gated)
+                \Modules\Jana\Console\Commands\ProfileDistillCommand::class, // COPI-26 — job que faltava: regenera jana_business_profile (distiller nunca foi agendado; L-OP-002)
             ]);
         }
     }

--- a/Modules/Jana/Tests/Feature/ProfileDistillCommandTest.php
+++ b/Modules/Jana/Tests/Feature/ProfileDistillCommandTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Services\Memoria\ProfileDistiller;
+
+uses(Tests\TestCase::class);
+
+/**
+ * jana:profile-distill — COPI-26 (incidente 2026-06-20).
+ *
+ * Cobre a ORQUESTRAÇÃO que faltava (a causa-raiz: NADA iterava businesses chamando
+ * o distiller). Usa um ProfileDistiller fake (anonymous subclass) → ZERO chamada LLM.
+ *
+ * Invariantes:
+ *  001. default itera TODOS os businesses (cada um chamado 1×) + exit 0
+ *  002. --business=N regenera só aquele business (Tier 0 — não toca os outros)
+ *  003. --only-stale pula profiles frescos (<7d), regenera ausentes + stale
+ *  004. falha de UM business NÃO aborta o batch (exit FAILURE, demais processados)
+ *
+ * SQLite-friendly: schema sintético mínimo, sem FULLTEXT/JSON. Pattern dual-mode
+ * documentado em reference_tests_pest_canon.md (mesmo molde de RetentionPurgeCommandTest).
+ *
+ * @see Modules\Jana\Console\Commands\ProfileDistillCommand
+ * @see Modules\Jana\Services\Memoria\ProfileDistiller
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente — quarentena Onda 2 SDD floor.');
+    }
+
+    Schema::dropIfExists('jana_business_profile');
+    Schema::dropIfExists('business');
+
+    Schema::create('business', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->string('name', 191)->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('jana_business_profile', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->unique();
+        $t->text('profile_text');
+        $t->unsignedInteger('tokens_estimated')->default(0);
+        $t->unsignedInteger('raw_context_tokens')->default(0);
+        $t->timestamp('gerado_em')->nullable();
+        $t->timestamps();
+    });
+
+    DB::table('business')->insert([
+        ['id' => 1, 'name' => 'WR2 Sistemas'],
+        ['id' => 4, 'name' => 'ROTA LIVRE'],
+        ['id' => 99, 'name' => 'Outro tenant'],
+    ]);
+});
+
+afterEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('jana_business_profile');
+        Schema::dropIfExists('business');
+    }
+});
+
+/**
+ * Fake distiller: registra os business_ids chamados e escreve a row como o real
+ * (updateOrInsert bumpando gerado_em). `$throwFor` força exceção pra um biz (teste 004).
+ */
+function fakeDistiller(array $throwFor = []): ProfileDistiller
+{
+    return new class($throwFor) extends ProfileDistiller {
+        /** @var list<int> */
+        public array $called = [];
+
+        public function __construct(public array $throwFor = [])
+        {
+            // sem parent::__construct — não precisa de ContextSnapshotService no fake
+        }
+
+        public function destilar(int $businessId): array
+        {
+            $this->called[] = $businessId;
+
+            if (in_array($businessId, $this->throwFor, true)) {
+                throw new \RuntimeException("LLM timeout simulado biz {$businessId}");
+            }
+
+            $texto = "Perfil destilado do business {$businessId}.";
+            DB::table('jana_business_profile')->updateOrInsert(
+                ['business_id' => $businessId],
+                [
+                    'profile_text' => $texto,
+                    'tokens_estimated' => 10,
+                    'raw_context_tokens' => 20,
+                    'gerado_em' => now(),
+                    'updated_at' => now(),
+                    'created_at' => now(),
+                ],
+            );
+
+            return [
+                'profile_text' => $texto,
+                'tokens_estimated' => 10,
+                'raw_context_tokens' => 20,
+                'compression_ratio' => 2.0,
+            ];
+        }
+    };
+}
+
+it('ProfileDistill 001 — default itera TODOS os businesses (cada um 1×) + exit 0', function () {
+    $fake = fakeDistiller();
+    app()->instance(ProfileDistiller::class, $fake);
+
+    $exit = Artisan::call('jana:profile-distill');
+
+    expect($exit)->toBe(0)
+        ->and($fake->called)->toEqualCanonicalizing([1, 4, 99])
+        ->and(DB::table('jana_business_profile')->count())->toBe(3);
+
+    // Todas as rows ficaram frescas (gerado_em = agora).
+    $stale = DB::table('jana_business_profile')->where('gerado_em', '<', now()->subDays(7))->count();
+    expect($stale)->toBe(0);
+});
+
+it('ProfileDistill 002 — --business=4 regenera só ROTA LIVRE (Tier 0 — não toca os outros)', function () {
+    $fake = fakeDistiller();
+    app()->instance(ProfileDistiller::class, $fake);
+
+    $exit = Artisan::call('jana:profile-distill', ['--business' => '4']);
+
+    expect($exit)->toBe(0)
+        ->and($fake->called)->toBe([4])
+        ->and(DB::table('jana_business_profile')->where('business_id', 4)->exists())->toBeTrue()
+        ->and(DB::table('jana_business_profile')->where('business_id', 1)->exists())->toBeFalse()
+        ->and(DB::table('jana_business_profile')->where('business_id', 99)->exists())->toBeFalse();
+});
+
+it('ProfileDistill 003 — --only-stale pula frescos (<7d), regenera ausentes + stale', function () {
+    // biz=1 fresco (não deve ser tocado) · biz=4 stale (10d) · biz=99 ausente
+    DB::table('jana_business_profile')->insert([
+        ['business_id' => 1, 'profile_text' => 'fresco', 'gerado_em' => now()->subDay(), 'created_at' => now(), 'updated_at' => now()],
+        ['business_id' => 4, 'profile_text' => 'velho', 'gerado_em' => now()->subDays(10), 'created_at' => now()->subDays(10), 'updated_at' => now()->subDays(10)],
+    ]);
+
+    $fake = fakeDistiller();
+    app()->instance(ProfileDistiller::class, $fake);
+
+    $exit = Artisan::call('jana:profile-distill', ['--only-stale' => true]);
+
+    expect($exit)->toBe(0)
+        ->and($fake->called)->toEqualCanonicalizing([4, 99]) // biz=1 fresco NÃO foi chamado
+        ->and($fake->called)->not->toContain(1);
+
+    // biz=1 manteve o texto original (não regenerado).
+    expect(DB::table('jana_business_profile')->where('business_id', 1)->value('profile_text'))->toBe('fresco');
+});
+
+it('ProfileDistill 004 — falha de UM business não aborta o batch (exit FAILURE, demais processados)', function () {
+    $fake = fakeDistiller(throwFor: [4]); // biz=4 lança; 1 e 99 devem seguir
+    app()->instance(ProfileDistiller::class, $fake);
+
+    $exit = Artisan::call('jana:profile-distill');
+
+    expect($exit)->toBe(1) // FAILURE porque houve falha
+        ->and($fake->called)->toEqualCanonicalizing([1, 4, 99]); // todos tentados
+
+    // biz=1 e biz=99 foram persistidos apesar da exceção no biz=4.
+    expect(DB::table('jana_business_profile')->where('business_id', 1)->exists())->toBeTrue()
+        ->and(DB::table('jana_business_profile')->where('business_id', 99)->exists())->toBeTrue()
+        ->and(DB::table('jana_business_profile')->where('business_id', 4)->exists())->toBeFalse();
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -707,6 +707,31 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // COPI-26 fix (incidente 2026-06-20) — ProfileDistiller NUNCA foi agendado:
+        // `->destilar()` tinha ZERO call sites, então jana_business_profile só tinha
+        // 3 seeds one-off (biz 1/4/164) que envelheceram >7d e acendiam o check
+        // `profile_distiller_drift` no jana:health-check (06:00). A sentinela
+        // (L-OP-002) estava CORRETA — vigiava um job de manutenção que nunca rodava.
+        // Este schedule é o job que faltava.
+        //
+        // 04:50 BRT: DEPOIS de copiloto:seed-adrs (04:45) e jana:freshness-check (04:30),
+        // ANTES do jana:health-check (06:00) reavaliar o check. Bem dentro da janela 7d.
+        // Multi-tenant Tier 0 (ADR 0093): o command itera business by business EXPLÍCITO.
+        // ~76 chamadas LLM/dia (~$0,02). withoutOverlapping(15) cobre run lento (76 × ~3s).
+        $schedule->command('jana:profile-distill')
+            ->dailyAt('04:50')
+            ->timezone('America/Sao_Paulo')
+            ->name('jana-profile-distill-daily')
+            ->withoutOverlapping(15)
+            ->environments(['live'])
+            ->appendOutputTo(storage_path('logs/jana-profile-distill.log'))
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule jana:profile-distill FALHOU — jana_business_profile pode ficar ' .
+                    'STALE (profile_distiller_drift acende no jana:health-check 06:00)'
+                );
+            });
+
         // Sprint 1 — Daily Brief (ADR 0091, camada L7 da Constituição V2).
         // Gera o brief 6x/dia em horário comercial PT-BR (07/11/14/17/20/23h).
         // Custo médio: $0.05/run × 6 = $0.30/dia. Cap diário no command.


### PR DESCRIPTION
## Causa-raiz (incidente prod 2026-06-20 22:55 BRT)

`jana:health-check` acendeu `profile_distiller_drift = 3` (alvo 0). Investigação read-only:

**O `ProfileDistiller` (MEM-S8-3, ADR 0037) nunca foi agendado.** `->destilar()` tem **zero call sites** no codebase — nenhum Command, Job, Listener ou closure o invoca, e `git log -S 'destilar' -- app/Console/Kernel.php` é vazio (um schedule nunca existiu). A nota de sessão que dizia "PR #124 + schedule diário" era falsa: o commit `7ff8bc18d1` só corrigiu `Cache::tags`.

**Evidência de produção (Hostinger, read-only):**

| biz | nome | gerado_em | idade |
|---|---|---|---|
| 1 | WR2 Sistemas | 2026-05-06 | 45d |
| 4 | ROTA LIVRE (Larissa, piloto) | 2026-05-07 | 45d |
| 164 | MARTINHO CAÇAMBAS | 2026-05-14 | 37d |

- `total_profile_rows=3, stale_count=3` → são os 3 **únicos** profiles (de 76 businesses).
- Nos 3, `gerado_em == created_at == updated_at` → cada linha escrita **uma vez, nunca atualizada**.
- `grep ProfileDistiller storage/logs/` = **vazio** (nem sucesso nem erro) → o serviço nunca rodou em prod.

Não é "distiller parou" nem "job com erro": construíram o serviço **e** a sentinela (`profile_distiller_drift`, graduada em L-OP-002) mas **nunca o job que ela vigia**. O check estava correto ficando vermelho.

**Por que importa:** `ContextSnapshotService::montar` injeta `jana_business_profile.profile_text` como `observacoes` no system prompt da Jana (sem flag). Profile stale = assistente respondendo com narrativa comercial de 37–45 dias atrás (exatamente a degradação que L-OP-002 descreveu).

## Fix

- **novo `jana:profile-distill`** — itera business by business EXPLÍCITO (Tier 0 ADR 0093) chamando o distiller. Falha de um biz **não aborta** o batch (re-tenta no run diário, dentro da janela de 7d). Opções `--business=N` (backfill manual) e `--only-stale`.
- **schedule daily 04:50 BRT** no `Kernel.php` (`environments(['live'])`, `withoutOverlapping(15)`, `onFailure` log) — após `copiloto:seed-adrs` (04:45), antes do `jana:health-check` (06:00).
- **registra** o command no `JanaServiceProvider`.
- **Pest** cobrindo a orquestração que faltava (4 testes, fake distiller, **zero chamada LLM**): itera todos · `--business` targeted · `--only-stale` pula frescos · falha isolada não derruba o batch.

Escopo escolhido pelo Wagner: **todos os 76 businesses ativos**, diário. Custo ~\$0,02/dia (não escreve em `jana_mensagens`, não conta pro `custo_brain_b_24h`).

## Pós-merge / deploy

O primeiro cron 04:50 após deploy regenera os 3 stale + cria profile pros demais → `profile_distiller_drift` volta a 0 no health-check 06:00. (Merge/deploy = autoriza a escrita diária em prod — decisão do Wagner por publication-policy.)

> Nota: bug cosmético pré-existente fora de escopo — `ProfileDistiller` seta `created_at => now()` no caminho de UPDATE do `updateOrInsert` (sobrescreve a criação). Não bloqueia o fix; deixei para PR separado.

Refs: COPI-26, L-OP-002

🤖 Generated with [Claude Code](https://claude.com/claude-code)