### PR TITLE
fix(jana): spec_id_drift robustez — check tolera emoji `?` + parser captura sub-letra

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -618,7 +618,7 @@ class HealthCheckCommand extends Command
                     $taskId = "US-{$prefix}-" . str_pad((string) $n, 3, '0', STR_PAD_LEFT);
 
                     $dbRow = DB::table('mcp_tasks')->where('task_id', $taskId)->first();
-                    if ($dbRow && trim((string) $dbRow->title) !== $specTitle) {
+                    if ($dbRow && self::titleDriftKey((string) $dbRow->title) !== self::titleDriftKey($specTitle)) {
                         $hardDrifts[] = "{$taskId}";
                     }
                 }
@@ -644,6 +644,27 @@ class HealthCheckCommand extends Command
                 'message' => 'ERRO: ' . $e->getMessage(),
             ];
         }
+    }
+
+    /**
+     * Chave de comparação de title pro spec_id_drift.
+     *
+     * Tira o prefixo de não-letra/não-dígito (emoji de status, mid-dot `·`,
+     * pontuação) antes de comparar DB↔SPEC. Sem isso, 631/646 colisões eram
+     * falso-positivo: o título no `mcp_tasks` carrega um emoji de status no
+     * começo que o MySQL truncou pra `?` (coluna utf8mb3 × emoji 4-byte), e o
+     * parser do SPEC já come o emoji antes do `US-` — então `? Listar Budget`
+     * (DB) vs `Listar Budget` (SPEC) é a MESMA story, diferença só cosmética
+     * (incidente health-check 2026-06-20, prod = 646 alvo 0).
+     *
+     * Aplicado simetricamente nos dois lados: drift REAL difere no conteúdo
+     * alfanumérico (não só no enfeite inicial), então segue sendo pego — as 15
+     * colisões duras genuínas (RecurringBilling-001 ×9, TR-301..303, SELL-010,
+     * WA-002/010/045) continuam reportadas.
+     */
+    public static function titleDriftKey(string $title): string
+    {
+        return trim((string) preg_replace('/^[^\p{L}\p{N}]+/u', '', trim($title)));
     }
 
     /**

--- a/Modules/Jana/Services/TaskRegistry/TaskParserService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskParserService.php
@@ -48,8 +48,17 @@ use Modules\Jana\Entities\Mcp\McpTask;
  */
 class TaskParserService
 {
-    /** Regex pra heading de US: ###(#)? US-XXX-NNN[N] · Título */
-    public const US_HEADING_REGEX = '/^#{2,4}\s+(US-[A-Z0-9]+-\d{3,4})\s*[·\-:]?\s*(.*)$/m';
+    /**
+     * Regex pra heading de US: ###(#)? US-XXX-NNN[N][x] · Título
+     *
+     * O sufixo opcional `[a-z]?` captura o esquema de sub-letra (ex: US-WA-002b,
+     * US-WA-010b) como parte do task_id. Sem ele, `\d{3,4}` parava no dígito e
+     * `US-WA-002b` colapsava em `US-WA-002`, com o `b` vazando pro título
+     * (`b · …`) e sobrescrevendo o id-base canônico — origem das colisões
+     * WA-002/010/045 no spec_id_drift (incidente 2026-06-20). Só WhatsApp usa
+     * o esquema hoje; ids sem sufixo seguem inalterados.
+     */
+    public const US_HEADING_REGEX = '/^#{2,4}\s+(US-[A-Z0-9]+-\d{3,4}[a-z]?)\s*[·\-:]?\s*(.*)$/m';
 
     /**
      * Campos de "estado vivo" — ADR 0144.

--- a/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
@@ -173,3 +173,42 @@ test('ledger canônico Modules/Jana/LICOES-OPERACAO.md está todo graduado', fun
     expect($r['overdue'])->toBe([]);
     expect($r['malformed'])->toBe([]);
 });
+
+/**
+ * Check 7 — titleDriftKey: chave de comparação DB↔SPEC do spec_id_drift.
+ *
+ * Casos ancorados no CONTRATO (cosmético-inicial ≠ drift / divergência de
+ * conteúdo = drift) + nos dados REAIS do incidente prod 2026-06-20 (646 alvo 0),
+ * não derivados da implementação (anti-tautologia, proibicoes.md §5).
+ *
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand::titleDriftKey
+ */
+test('titleDriftKey: emoji corrompido "? " no DB não conta como drift (631 falso-pos)', function () {
+    // Caso real: mcp_tasks.title trunca emoji 4-byte pra `?` (utf8mb3); SPEC limpo.
+    expect(HealthCheckCommand::titleDriftKey('? Listar Budget'))
+        ->toBe(HealthCheckCommand::titleDriftKey('Listar Budget'));
+    expect(HealthCheckCommand::titleDriftKey('? Criar Journal Entry'))
+        ->toBe(HealthCheckCommand::titleDriftKey('Criar Journal Entry'));
+    // Prefixo simétrico em ambos os lados também colapsa.
+    expect(HealthCheckCommand::titleDriftKey('? [Epic] Models + migrations'))
+        ->toBe(HealthCheckCommand::titleDriftKey('[Epic] Models + migrations'));
+});
+
+test('titleDriftKey: colisão dura genuína continua diferente (15 reais não somem)', function () {
+    // RecurringBilling-001: 9 headers no 001; DB tem o "Listener", SPEC pede "Escopo 0".
+    expect(HealthCheckCommand::titleDriftKey('? Listener InvoicePaid em NfeBrasil'))
+        ->not->toBe(HealthCheckCommand::titleDriftKey('Escopo 0 — PaymentGateway + adapter Asaas'));
+    // SELL-010 duplicado dentro do mesmo SPEC.
+    expect(HealthCheckCommand::titleDriftKey('? Investigar State Machines existentes'))
+        ->not->toBe(HealthCheckCommand::titleDriftKey('FieldError por campo + auto-open details em erro'));
+    // WA: sub-letra vazada no título do DB (`b · …`) vs header canônico.
+    expect(HealthCheckCommand::titleDriftKey('b · Receber webhook Z-API'))
+        ->not->toBe(HealthCheckCommand::titleDriftKey('Receber webhook Meta + assinatura HMAC'));
+});
+
+test('titleDriftKey: títulos idênticos e variações de espaço são iguais', function () {
+    expect(HealthCheckCommand::titleDriftKey('Listar Core'))->toBe('Listar Core');
+    expect(HealthCheckCommand::titleDriftKey('  Listar Core  '))->toBe('Listar Core');
+    expect(HealthCheckCommand::titleDriftKey('Listar Core'))
+        ->not->toBe(HealthCheckCommand::titleDriftKey('Criar Core'));
+});

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskParserServiceTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskParserServiceTest.php
@@ -191,3 +191,28 @@ it('retorna empty se path nao existe', function () {
     $cand = $this->svc->parseSpec('/tmp/nao-existe-x99.md', 'X');
     expect($cand)->toHaveCount(0);
 });
+
+it('captura sub-letra como id distinto (US-WA-NNNx) — não colapsa no id-base', function () {
+    // Contrato: o esquema sub-letra do WhatsApp gera ids PRÓPRIOS, sem vazar a
+    // letra pro título. Antes da correção, US-WA-010b colapsava em US-WA-010 com
+    // título "b · Receber webhook Z-API" (colisão spec_id_drift 2026-06-20).
+    $spec = escreverSpec($this->tmp, <<<MD
+    ### US-WA-010 · Receber webhook Meta + assinatura HMAC
+
+    > owner: wagner · status: todo
+
+    canônica
+
+    ### US-WA-010b · Receber webhook Z-API
+
+    > owner: wagner · status: todo
+
+    variante
+    MD);
+
+    $cand = $this->svc->parseSpec($spec, 'Whatsapp');
+    expect($cand)->toHaveCount(2)
+        ->and($cand->pluck('task_id')->all())->toBe(['US-WA-010', 'US-WA-010b'])
+        ->and($cand[0]['title'])->toBe('Receber webhook Meta + assinatura HMAC')
+        ->and($cand[1]['title'])->toBe('Receber webhook Z-API'); // sem "b · " vazado
+});


### PR DESCRIPTION
Resolve o **spec_id_drift = 646** (incidente prod 2026-06-20). Investigação read-only: **631/646 falso-positivo** + **15 colisões reais**. Dois fixes Hostinger/git-side, mesmo incidente:

## 1. Check tolerante ao emoji corrompido (`HealthCheckCommand::titleDriftKey`)

`mcp_tasks.title` carrega prefixos cosméticos (`? ` = emoji truncado em dado histórico; coluna já é utf8mb4). O parser do SPEC come o emoji antes do `US-`, então o título fica limpo → `? Listar Budget` (DB) vs `Listar Budget` (SPEC) é a MESMA story. Novo `titleDriftKey()` tira o prefixo de não-letra/não-dígito **simetricamente** antes do `!==`.

**Verificado contra o dump real de prod: 646 → 15.** As 15 colisões duras genuínas seguem reportadas.

## 2. Parser captura sub-letra (`TaskParserService::US_HEADING_REGEX`)

`\d{3,4}` → `\d{3,4}[a-z]?`. Sem isso, `US-WA-010b` colapsava em `US-WA-010` com a letra vazando pro título (`b · …`) e sobrescrevendo o id-base — origem das colisões WA-002/010/045. Só WhatsApp usa o esquema (5 headers); ids sem sufixo seguem idênticos.

## Contexto da reconciliação

- As outras 12 colisões (RecurringBilling 9×001, SELL-010 dup, TR-301..303 cross-SPEC) vêm em [#3121](https://github.com/wagnerra23/oimpresso.com/pull/3121) (renumber SPEC).
- A higiene dos `?` no cache + a materialização dos renumbers acontece na **sync autoritativa (CT 100)** — o app Hostinger é **read-only** em `mcp_tasks` (`UPDATE denied`, confirmado), o webhook GitHub→MCP é quem escreve.

## Testes

Pest ancorado no contrato + dados reais do incidente (anti-tautologia, proibicoes.md §5): emoji-cosmético ≠ drift; divergência de conteúdo = drift; sub-letra = id próprio.

Refs: ADR 0134 · ADR 0144 · incidente jana:health-check 2026-06-20 spec_id_drift=646

🤖 Generated with [Claude Code](https://claude.com/claude-code)