### PR TITLE
fix(jana): ProfileDistiller não zera created_at em regen (COPI-26)

### DIFF
--- a/Modules/Jana/Services/Memoria/ProfileDistiller.php
+++ b/Modules/Jana/Services/Memoria/ProfileDistiller.php
@@ -91,19 +91,10 @@ class ProfileDistiller
                 now()->addDay()
             );
 
-            DB::table('jana_business_profile')->updateOrInsert(
-                ['business_id' => $businessId],
-                [
-                    'profile_text' => $profileText,
-                    'tokens_estimated' => (int) (mb_strlen($profileText) / 4),
-                    'raw_context_tokens' => $rawTokens,
-                    'gerado_em' => now(),
-                    'updated_at' => now(),
-                    'created_at' => now(),
-                ]
-            );
-
             $estTokens = (int) (mb_strlen($profileText) / 4);
+
+            $this->persistirProfile($businessId, $profileText, $estTokens, $rawTokens);
+
             $ratio = $rawTokens > 0 ? round($rawTokens / max(1, $estTokens), 2) : 0;
 
             Log::channel('copiloto-ai')->info('ProfileDistiller: gerado', [
@@ -132,6 +123,41 @@ class ProfileDistiller
                 'error' => $e->getMessage(),
             ];
         }
+    }
+
+    /**
+     * Persiste o profile destilado de forma idempotente SEM zerar `created_at`.
+     *
+     * `updateOrInsert($attrs, $values)` aplica `$values` nos dois caminhos (INSERT
+     * e UPDATE). Com `created_at => now()` no array, todo regen sobrescrevia a data
+     * real de 1ª criação — inócuo enquanto o distiller nunca rodava, mas o schedule
+     * diário (COPI-26, 04:50 BRT) zeraria `created_at = gerado_em` a cada noite.
+     * Aqui `created_at` só entra no caminho de INSERT; UPDATE preserva o original.
+     *
+     * Tier 0 multi-tenant (ADR 0093): filtro sempre por `business_id`.
+     */
+    protected function persistirProfile(int $businessId, string $profileText, int $estTokens, int $rawTokens): void
+    {
+        $values = [
+            'profile_text' => $profileText,
+            'tokens_estimated' => $estTokens,
+            'raw_context_tokens' => $rawTokens,
+            'gerado_em' => now(),
+            'updated_at' => now(),
+        ];
+
+        $query = DB::table('jana_business_profile')->where('business_id', $businessId);
+
+        if ($query->exists()) {
+            $query->update($values);
+
+            return;
+        }
+
+        DB::table('jana_business_profile')->insert($values + [
+            'business_id' => $businessId,
+            'created_at' => now(),
+        ]);
     }
 
     /**

--- a/Modules/Jana/Tests/Feature/ProfileDistillCommandTest.php
+++ b/Modules/Jana/Tests/Feature/ProfileDistillCommandTest.php
@@ -90,17 +90,10 @@ function fakeDistiller(array $throwFor = []): ProfileDistiller
             }
 
             $texto = "Perfil destilado do business {$businessId}.";
-            DB::table('jana_business_profile')->updateOrInsert(
-                ['business_id' => $businessId],
-                [
-                    'profile_text' => $texto,
-                    'tokens_estimated' => 10,
-                    'raw_context_tokens' => 20,
-                    'gerado_em' => now(),
-                    'updated_at' => now(),
-                    'created_at' => now(),
-                ],
-            );
+            // Delega à persistência REAL (herdada) — é o caminho que o COPI-26 fix
+            // corrige (created_at só no INSERT). Assim o teste 005 exercita o código
+            // de produção, não uma cópia da lógica dentro do fake.
+            $this->persistirProfile($businessId, $texto, 10, 20);
 
             return [
                 'profile_text' => $texto,
@@ -173,4 +166,25 @@ it('ProfileDistill 004 — falha de UM business não aborta o batch (exit FAILUR
     expect(DB::table('jana_business_profile')->where('business_id', 1)->exists())->toBeTrue()
         ->and(DB::table('jana_business_profile')->where('business_id', 99)->exists())->toBeTrue()
         ->and(DB::table('jana_business_profile')->where('business_id', 4)->exists())->toBeFalse();
+});
+
+it('ProfileDistill 005 — regen NÃO sobrescreve created_at original (COPI-26 data-quality)', function () {
+    $fake = fakeDistiller();
+    app()->instance(ProfileDistiller::class, $fake);
+
+    // 1ª geração: INSERT (created_at = data real de criação).
+    Artisan::call('jana:profile-distill', ['--business' => '4']);
+    $original = DB::table('jana_business_profile')->where('business_id', 4)->first();
+
+    // Relógio avança; o regen diário roda de novo (UPDATE da mesma row).
+    $this->travel(2)->days();
+    Artisan::call('jana:profile-distill', ['--business' => '4']);
+    $regen = DB::table('jana_business_profile')->where('business_id', 4)->first();
+
+    // created_at IMUTÁVEL (data de 1ª criação preservada); gerado_em/updated_at bumparam.
+    expect($regen->created_at)->toBe($original->created_at)
+        ->and($regen->gerado_em)->not->toBe($original->gerado_em)
+        ->and($regen->updated_at)->not->toBe($original->updated_at);
+
+    $this->travelBack();
 });


### PR DESCRIPTION
## Contexto

Follow-up de [#3115](https://github.com/wagnerra23/oimpresso.com/pull/3115) (merged), que ativou o schedule diário `jana:profile-distill` (04:50 BRT). Com o job rodando toda noite, um bug de data-quality em `ProfileDistiller` passa a morder.

## Bug

`destilarInternal()` persistia via `updateOrInsert(['business_id'=>...], [... 'created_at'=>now()])`. O `updateOrInsert($attrs, $values)` aplica `$values` nos **dois** caminhos (INSERT **e** UPDATE), então `created_at => now()` sobrescrevia a data real de 1ª criação a cada regeneração. Inócuo enquanto o distiller nunca rodava — mas o schedule diário zeraria `created_at = gerado_em` toda noite, perdendo a data de criação original do profile.

Impacto: cosmético / data-quality, baixo (não bloqueia nada).

## Fix

- Extrai `persistirProfile()`: `created_at` entra **só no caminho de INSERT**; o UPDATE preserva o original. `gerado_em`/`updated_at` continuam bumpando normalmente.
- **Tier 0 multi-tenant (ADR 0093):** filtro por `business_id` mantido em ambos os caminhos.
- Teste **005** no Pest novo confirma que `created_at` NÃO muda num 2º regen (com `travel(2)->days()`), enquanto `gerado_em`/`updated_at` mudam. O `fakeDistiller` agora delega à persistência real (`persistirProfile`) em vez de duplicar o `updateOrInsert` — assim o teste exercita o código de produção.

## Verificação local (SQLite :memory:)

- `php -l` limpo nos 2 arquivos.
- 5 testes verdes (21 assertions), incl. 005.
- **Mutation check:** reintroduzir `created_at => now()` no UPDATE quebra o 005 (`created_at` saltou 2026-06-20 → 2026-06-22); revertido. O teste morde de verdade.

Refs: COPI-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)