### PR TITLE
docs(inventory): SPEC marca Modules/{Inventory,Marketplaces} como inexistentes (catraca anti-ghost)

### DIFF
--- a/memory/requisitos/Inventory/SPEC.md
+++ b/memory/requisitos/Inventory/SPEC.md
@@ -408,7 +408,7 @@ Cruza com agente Marketplaces (sync ML/Shopee/Magalu).
 
 **Fluxo proposto:**
 1. `stock_movements` insertion → event `StockMovedEvent` (já pattern UPos)
-2. Listener `SyncToMarketplacesListener` (futuro Modules/Marketplaces) consome event
+2. Listener `SyncToMarketplacesListener` (futuro módulo Marketplaces — *planejado, não existe*) consome event
 3. Calcula novo qty_available_consolidated = sum(variation_location_details.qty_available) − sum(stock_reservations.active.qty)
 4. POST API ML/Shopee atualiza listing
 5. Webhook ML PEDIDO criado → cria sell + reserva imediata (idempotente per ext_order_id)
@@ -543,7 +543,7 @@ Cruza com agente Marketplaces (sync ML/Shopee/Magalu).
 - 🚫 Não removar `variations.combo_variations` JSON em V1 (compat legacy UPos POS Blade)
 - 🚫 Não permitir UPDATE/DELETE em `stock_movements` — triggers MySQL bloqueiam
 - 🚫 Não habilitar flags `enable_bom`/`enable_batch_tracking` em biz=4 (ROTA LIVRE) sem aviso prévio + canary 7d ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) cutover discipline)
-- 🚫 Não criar `Modules/Inventory` separado — Inventory é **camada cross-vertical** que vive em `app/Domain/Inventory/` (perto de `app/Domain/Fsm/`); módulos verticais USAM via service/contract
+- 🚫 Não criar um módulo `Inventory` separado em `Modules/` (*não existe — proibido por design*) — Inventory é **camada cross-vertical** que vive em `app/Domain/Inventory/` (perto de `app/Domain/Fsm/`); módulos verticais USAM via service/contract
 
 ---
 


### PR DESCRIPTION
## Por quê

A catraca anti-ghost `scripts/governance/knowledge-drift.mjs --check` (CI **anti-ghost ratchet (advisory)**) estava **vermelha no main** com 2 ghosts NOVOS:

```
FAIL Inventory: cita Modules/Inventory que NÃO existe e NÃO está no baseline.
FAIL Inventory: cita Modules/Marketplaces que NÃO existe e NÃO está no baseline.
```

Origem: `memory/requisitos/Inventory/SPEC.md` citava os literais `Modules/Inventory` e `Modules/Marketplaces`, mas **nenhum dos dois existe em disco** (não há `Modules/Inventory/` nem `Modules/Marketplaces/`). Sendo advisory, não bloqueava merge — mas pintava vermelho em **todo PR que mergeava main**, mascarando ghosts reais futuros.

## O quê

Reescreve as 2 únicas citações-ghost (linhas 411 e 546) para **não emitir o token `Modules/<Nome>`** que o regex da catraca (`/Modules\/([A-Z][A-Za-z0-9]+)/`) casa, anotando o status real de cada uma — conforme a própria instrução da catraca (*"Corrija o doc ou marque '(planejado — não existe)' — NUNCA adicione ao baseline"*):

| Linha | Antes | Depois |
|---|---|---|
| 411 | `(futuro Modules/Marketplaces)` | `(futuro módulo Marketplaces — *planejado, não existe*)` |
| 546 | `Não criar \`Modules/Inventory\` separado` | `Não criar um módulo \`Inventory\` separado em \`Modules/\` (*não existe — proibido por design*)` |

> Nota: a catraca não parseia o texto do marcador — ela casa o **literal** `Modules/<Nome>`. O que zera o ghost é deixar de emitir esse token; o marcador `(planejado/não existe)` fica pro leitor humano. Marketplaces é genuinamente futuro; Inventory é cross-vertical em `app/Domain/Inventory/` e **nunca** vira módulo (a própria SPEC já dizia isso).

As demais citações (`Modules/Vestuario`, `Modules/Manufacturing`, `Modules/NfeBrasil`) são módulos reais → intocadas.

## Garantias

- ✅ Escopo: **só** `memory/requisitos/Inventory/SPEC.md` (2 linhas).
- ✅ **Não** adiciona nada a `governance/knowledge-ghosts-baseline/` (33 ghosts legados intactos).
- ✅ Validação local: `node scripts/governance/knowledge-drift.mjs --check --baseline governance/knowledge-ghosts-baseline` → `0 NOVOS`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)