### PR TITLE
docs(inventory): remove 2 ghost-refs (Modules/Inventory + Modules/Marketplaces) da SPEC

### DIFF
--- a/memory/requisitos/Inventory/SPEC.md
+++ b/memory/requisitos/Inventory/SPEC.md
@@ -408,7 +408,7 @@ Cruza com agente Marketplaces (sync ML/Shopee/Magalu).
 
 **Fluxo proposto:**
 1. `stock_movements` insertion → event `StockMovedEvent` (já pattern UPos)
-2. Listener `SyncToMarketplacesListener` (futuro Modules/Marketplaces) consome event
+2. Listener `SyncToMarketplacesListener` (futuro módulo `Marketplaces` — planejado, não existe) consome event
 3. Calcula novo qty_available_consolidated = sum(variation_location_details.qty_available) − sum(stock_reservations.active.qty)
 4. POST API ML/Shopee atualiza listing
 5. Webhook ML PEDIDO criado → cria sell + reserva imediata (idempotente per ext_order_id)
@@ -543,7 +543,7 @@ Cruza com agente Marketplaces (sync ML/Shopee/Magalu).
 - 🚫 Não removar `variations.combo_variations` JSON em V1 (compat legacy UPos POS Blade)
 - 🚫 Não permitir UPDATE/DELETE em `stock_movements` — triggers MySQL bloqueiam
 - 🚫 Não habilitar flags `enable_bom`/`enable_batch_tracking` em biz=4 (ROTA LIVRE) sem aviso prévio + canary 7d ([ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) cutover discipline)
-- 🚫 Não criar `Modules/Inventory` separado — Inventory é **camada cross-vertical** que vive em `app/Domain/Inventory/` (perto de `app/Domain/Fsm/`); módulos verticais USAM via service/contract
+- 🚫 Não criar um módulo `Inventory` separado em `Modules/` — Inventory é **camada cross-vertical** que vive em `app/Domain/Inventory/` (perto de `app/Domain/Fsm/`); módulos verticais USAM via service/contract
 
 ---
 


### PR DESCRIPTION
## O quê

Reescreve 2 linhas de `memory/requisitos/Inventory/SPEC.md` pra **zerar a catraca anti-ghost** (`knowledge-drift.mjs`), que apontava 2 ghosts NOVOS:

```
FAIL Inventory: cita Modules/Inventory que NÃO existe e NÃO está no baseline.
FAIL Inventory: cita Modules/Marketplaces que NÃO existe e NÃO está no baseline.
```

```diff
-2. Listener `SyncToMarketplacesListener` (futuro Modules/Marketplaces) consome event
+2. Listener `SyncToMarketplacesListener` (futuro módulo `Marketplaces` — planejado, não existe) consome event

-- 🚫 Não criar `Modules/Inventory` separado — Inventory é **camada cross-vertical** ...
+- 🚫 Não criar um módulo `Inventory` separado em `Modules/` — Inventory é **camada cross-vertical** ...
```

## Por quê

`MOD_REF_RE = /Modules\/([A-Z][A-Za-z0-9]+)/g` casa **qualquer** literal `Modules/Xxx`. As duas citações eram intencionalmente sobre módulos **inexistentes** (um proibido por design — "não criar"; o outro só planejado). A própria mensagem da catraca manda: *"Corrija o doc … ou marque '(planejado — não existe)' — NUNCA adicione ao baseline."* A reescrita preserva o sentido e remove o token de path.

## Origem

Pré-existente na main, introduzido por [#3104](https://github.com/wagnerra23/oimpresso.com/pull/3104) (discovery Estoque). É advisory, então #3104 mergeou vermelho; apareceu na minha tela ao mergear main no [#3105](https://github.com/wagnerra23/oimpresso.com/pull/3105). Não é regressão deste fluxo — é limpeza da drift que já estava na main.

## Verificação

✅ `node scripts/governance/knowledge-drift.mjs --check --baseline governance/knowledge-ghosts-baseline` → **0 NOVOS · OK**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
