### PR TITLE
fix(jana): flag `u` no parser de US — raiz dos "? " no cache mcp_tasks

### DIFF
--- a/Modules/Jana/Services/TaskRegistry/TaskParserService.php
+++ b/Modules/Jana/Services/TaskRegistry/TaskParserService.php
@@ -57,8 +57,14 @@ class TaskParserService
      * (`b · …`) e sobrescrevendo o id-base canônico — origem das colisões
      * WA-002/010/045 no spec_id_drift (incidente 2026-06-20). Só WhatsApp usa
      * o esquema hoje; ids sem sufixo seguem inalterados.
+     *
+     * Flag `u` (UTF-8) é OBRIGATÓRIA: sem ela a classe `[·\-:]` é bytewise e
+     * casa só 1 dos 2 bytes do `·` (U+00B7 = C2 B7), deixando o B7 órfão grudar
+     * no começo do título → vira `?` ao gravar no MySQL. Era a RAIZ dos 751
+     * títulos `"? Listar Budget"` no cache `mcp_tasks` (incidente 2026-06-20).
+     * Com `u`, o `·` é consumido inteiro e o título sai limpo.
      */
-    public const US_HEADING_REGEX = '/^#{2,4}\s+(US-[A-Z0-9]+-\d{3,4}[a-z]?)\s*[·\-:]?\s*(.*)$/m';
+    public const US_HEADING_REGEX = '/^#{2,4}\s+(US-[A-Z0-9]+-\d{3,4}[a-z]?)\s*[·\-:]?\s*(.*)$/mu';
 
     /**
      * Campos de "estado vivo" — ADR 0144.

--- a/Modules/Jana/Tests/Feature/TaskRegistry/TaskParserServiceTest.php
+++ b/Modules/Jana/Tests/Feature/TaskRegistry/TaskParserServiceTest.php
@@ -216,3 +216,21 @@ it('captura sub-letra como id distinto (US-WA-NNNx) — não colapsa no id-base'
         ->and($cand[0]['title'])->toBe('Receber webhook Meta + assinatura HMAC')
         ->and($cand[1]['title'])->toBe('Receber webhook Z-API'); // sem "b · " vazado
 });
+
+it('título não carrega byte órfão do separador `·` (raiz dos "? " no cache)', function () {
+    // Contrato: o `·` (U+00B7 = 2 bytes C2 B7) é consumido INTEIRO. Sem a flag
+    // `u`, a classe bytewise comia só 1 byte e o B7 órfão grudava no título →
+    // virava `? Listar Budget` ao gravar (751 títulos poluídos, incidente 2026-06-20).
+    $spec = escreverSpec($this->tmp, <<<MD
+    ### US-ACCO-001 · Listar Budget
+
+    > owner: wagner · status: todo
+
+    desc
+    MD);
+
+    $title = $this->svc->parseSpec($spec, 'Accounting')->first()['title'];
+    expect($title)->toBe('Listar Budget')
+        ->and(bin2hex($title))->toBe('4c697374617220427564676574') // sem prefixo b7
+        ->and(bin2hex($title))->not->toContain('b7');
+});


### PR DESCRIPTION
## Raiz encontrada (não era o que se suspeitava)

Os **751 títulos `"? Listar Budget"`** no cache `mcp_tasks` (que geravam 631 falso-positivos no `spec_id_drift`) **não eram emoji corrompido** — são bug do parser.

`TaskParserService::US_HEADING_REGEX` rodava **sem a flag `u`**. A classe `[·\-:]` era tratada **byte a byte**, então casava só **1 dos 2 bytes** do `·` (`U+00B7` = `C2 B7`). O byte `B7` órfão grudava no começo do título → vira `?` ao gravar no MySQL.

Provado no CT 100 (read-only):
```
NO /u  : hex=b7204c697374... str=[� Listar Budget]
WITH /u: hex=4c697374...     str=[Listar Budget]   ✅
```

## Fix

`...$/m'` → `...$/mu'` (1 char). Com `u`, o `·` é consumido inteiro e o título sai limpo.

## Impacto + materialização

- Corrige **2 golden tests que já estavam vermelhos** (`'Pesquisa fiscal Tubarão'` vs `'� Pesquisa fiscal Tubarão'`). Eles passavam despercebidos porque a suite não roda limpa — há uma colisão **pré-existente e não-relacionada**: `makeWmChannel()` declarada em 2 arquivos de teste do Whatsapp (`HealthProbeChannelsCommandTest` + `WhatsmeowResubscribeEventsCommandTest`) → fatal `Cannot redeclare`. Vale um fix à parte.
- Novo teste trava a regressão por `bin2hex` (sem `b7` no título).
- O cache só fica limpo de fato na **próxima `mcp:tasks:sync` no CT 100** — que hoje está **bloqueada por um grant de DB faltando `INSERT`/`UPDATE`** no usuário `u906587222_oimpresso` (achado separado, precisa de DB-admin/hPanel).

Refs: incidente `jana:health-check` 2026-06-20 spec_id_drift · ADR 0134

🤖 Generated with [Claude Code](https://claude.com/claude-code)