### PR TITLE
feat(jana): write-canary no health-check — pega GRANT de escrita revogado

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -111,6 +111,7 @@ class HealthCheckCommand extends Command
             $this->checkWhatsappInboundCanary(),
             $this->checkMcpWebhookHealth2h(),
             $this->checkMemoriaRecallBackend(),
+            $this->checkDbWriteCanary(),
             $this->checkLessonLedgerGraduation(),
             $this->checkGovernancaGraduationRatio(),
             $this->checkProtocolFreshness(),
@@ -1127,6 +1128,99 @@ class HealthCheckCommand extends Command
                     . ') — chat degrada SEM memória. Checar Meilisearch/MCP CT 100.',
             ];
         }
+    }
+
+    /** Tabela-alvo do write-canary (check 10b). @see migration create_jana_health_write_canary_table. */
+    public const WRITE_CANARY_TABLE = 'jana_health_write_canary';
+
+    /** Mensagem-sentinela que força o rollback da transação de prova (não é erro real). */
+    private const WRITE_CANARY_ROLLBACK = '__jana_write_canary_rollback__';
+
+    /**
+     * Check 10b — DB write canary (incidente 2026-06-21 · GRANT INSERT revogado).
+     *
+     * Prova que o usuário de DB consegue ESCREVER. Nenhum outro check faz isso — são
+     * SELECTs (multi-tenant, PII, drift) ou degradam gracioso. Quando o usuário de prod
+     * `u906587222_oimpresso` perdeu INSERT/UPDATE no Hostinger (20/jun ~22:50), os 17
+     * checks seguiram VERDES enquanto TODA gravação do app falhava com MySQL 1142
+     * (~8.9k erros em 2h) — o anti-padrão "a suíte mente" que a auditoria de sentinelas
+     * (2026-06-20) caça. Este check fecha esse buraco.
+     *
+     * Mecânica: INSERT de prova numa tabela-alvo dedicada DENTRO de uma transação
+     * SEMPRE revertida — prova o privilégio sem persistir linha, sem tocar tabela de
+     * negócio nem disparar Observer. Check DURO: escrita morta derruba o exit code e
+     * dispara o ALERT do cron 06:00 — exatamente o que faltou no incidente.
+     *
+     * Driver-agnóstico (MySQL prod + SQLite CI). Skip gracioso se a tabela ainda não
+     * existe (pré-migração/instalação nova — ela própria precisa de CREATE, que o
+     * mesmo GRANT revoga; por isso o fix do grant vem ANTES do deploy deste guard).
+     */
+    protected function checkDbWriteCanary(): array
+    {
+        $name = 'db_write_canary';
+
+        try {
+            if (! \Illuminate\Support\Facades\Schema::hasTable(self::WRITE_CANARY_TABLE)) {
+                return [
+                    'name' => $name,
+                    'ok' => true,
+                    'value' => 'n/a',
+                    'threshold' => 'writable',
+                    'message' => 'Skipped (tabela canário ausente — pré-migração/instalação nova)',
+                ];
+            }
+
+            try {
+                DB::transaction(function (): void {
+                    DB::table(self::WRITE_CANARY_TABLE)->insert([
+                        'probe' => self::WRITE_CANARY_ROLLBACK,
+                        'pinged_at' => now(),
+                    ]);
+
+                    // Rollback intencional: a prova é o INSERT ter sido ACEITO; a linha
+                    // nunca persiste. Sentinela revertida pelo próprio DB::transaction.
+                    throw new \RuntimeException(self::WRITE_CANARY_ROLLBACK);
+                });
+            } catch (\Throwable $e) {
+                if ($e->getMessage() !== self::WRITE_CANARY_ROLLBACK) {
+                    throw $e; // falha REAL de escrita — trata no catch externo
+                }
+                // INSERT aceito e revertido → escrita OK.
+            }
+
+            return [
+                'name' => $name,
+                'ok' => true,
+                'value' => 'writable',
+                'threshold' => 'writable',
+                'message' => 'INSERT de prova aceito (revertido) — usuário de DB pode escrever',
+            ];
+        } catch (\Throwable $e) {
+            $denied = self::isWriteDenied($e->getMessage());
+
+            return [
+                'name' => $name,
+                'ok' => false,
+                'value' => $denied ? 'denied' : 'error',
+                'threshold' => 'writable',
+                'message' => $denied
+                    ? 'ALERTA Tier 0 ESCRITA: INSERT negado (' . mb_substr($e->getMessage(), 0, 90)
+                        . ') — usuário de DB sem privilégio de escrita; toda gravação do app falha. Restaurar GRANT INSERT/UPDATE no hPanel Hostinger.'
+                    : 'ERRO no canário de escrita: ' . mb_substr($e->getMessage(), 0, 90),
+            ];
+        }
+    }
+
+    /**
+     * Predicado puro: a mensagem de erro indica negação de privilégio de escrita?
+     * MySQL reporta GRANT faltando como `SQLSTATE[42000] ... 1142 ... command denied`
+     * (mascarado como "Syntax error or access violation"). Público + estático pra ser
+     * testável sem DB (mesmo padrão de allChecksOk / evaluateInboundFlow).
+     */
+    public static function isWriteDenied(string $message): bool
+    {
+        return str_contains($message, '1142')
+            || stripos($message, 'command denied') !== false;
     }
 
     /**

--- a/Modules/Jana/Database/Migrations/2026_06_21_000001_create_jana_health_write_canary_table.php
+++ b/Modules/Jana/Database/Migrations/2026_06_21_000001_create_jana_health_write_canary_table.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Tabela-alvo do write-canary do jana:health-check (incidente 2026-06-21).
+ *
+ * O sentinela de saúde NÃO tinha nenhum check que provasse PRIVILÉGIO DE ESCRITA —
+ * quando o usuário de DB de prod (`u906587222_oimpresso`) perdeu INSERT/UPDATE no
+ * Hostinger (GRANT revogado ~20/jun 22:50), os 17 checks seguiram VERDES enquanto
+ * toda gravação do app falhava com MySQL 1142 (~8.9k erros em 2h). Anti-padrão
+ * "a suíte mente" caçado pela auditoria de sentinelas (2026-06-20).
+ *
+ * Esta tabela é só o alvo de um INSERT de prova (em transação + rollback — nunca
+ * persiste linha). Sem dados de negócio → sem business_id (tabela de sistema, como
+ * jobs/migrations/mcp_audit_log).
+ *
+ * @see Modules\Jana\Console\Commands\HealthCheckCommand::checkDbWriteCanary()
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('jana_health_write_canary')) {
+            return;
+        }
+
+        Schema::create('jana_health_write_canary', function (Blueprint $table) {
+            $table->id();
+            $table->string('probe', 64);
+            $table->timestamp('pinged_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('jana_health_write_canary');
+    }
+};

--- a/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
@@ -63,6 +63,7 @@ test('cada check tem campos canonicos', function () {
         'whatsapp_media_pending_1h',
         'mcp_webhook_5xx_2h',
         'memoria_recall_backend',
+        'db_write_canary',
         'jana_lesson_ledger_graduation',
     ];
 

--- a/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
@@ -58,6 +58,25 @@ test('system-audit veredito: qualquer check ok=false derruba (sem advisory)', fu
     ]))->toBeTrue();
 });
 
+// ── 1b. write-canary: predicado de PRIVILÉGIO DE ESCRITA (incidente 2026-06-21) ──
+//
+// O GRANT INSERT revogado no Hostinger deixou os 17 checks verdes com prod sem
+// conseguir escrever. isWriteDenied distingue "negado por privilégio" (MySQL 1142)
+// de erro benigno — é o que faz o check db_write_canary MORDER no caso certo.
+
+test('isWriteDenied: 1142 / command denied = negação de escrita', function () {
+    expect(HealthCheckCommand::isWriteDenied(
+        'SQLSTATE[42000]: Syntax error or access violation: 1142 INSERT command denied to user'
+    ))->toBeTrue();
+    expect(HealthCheckCommand::isWriteDenied('INSERT command denied to user foo'))->toBeTrue();
+});
+
+test('isWriteDenied: erro benigno / sentinela de rollback NÃO é negação', function () {
+    expect(HealthCheckCommand::isWriteDenied('SQLSTATE[HY000]: server has gone away'))->toBeFalse();
+    expect(HealthCheckCommand::isWriteDenied('__jana_write_canary_rollback__'))->toBeFalse();
+    expect(HealthCheckCommand::isWriteDenied(''))->toBeFalse();
+});
+
 // ── 2. INTEGRAÇÃO: exit code == veredito (prova que NÃO é constante) ──────────
 
 /** Extrai o bloco JSON do output do comando (pode haver linhas de debug antes). */
@@ -77,6 +96,20 @@ test('jana:health-check: exit code BATE com o veredito dos checks', function () 
         ->contains(fn ($c) => ! ($c['ok'] ?? false) && ! ($c['advisory'] ?? false));
 
     expect($exit)->toBe($esperaFalha ? 1 : 0);
+});
+
+test('db_write_canary: escrita OK no DB de teste e NÃO persiste linha', function () {
+    Artisan::call('jana:health-check', ['--json' => true]);
+    $json = biteJson(Artisan::output());
+
+    $canary = collect($json['checks'])->firstWhere('name', 'db_write_canary');
+    expect($canary)->not->toBeNull();
+    // Tabela existe no CI (migration roda) → o INSERT de prova passa e é revertido.
+    expect($canary['ok'])->toBeTrue();
+    expect($canary['value'])->toBe('writable');
+
+    // Rollback de verdade: a prova nunca deixa linha pra trás.
+    expect(\Illuminate\Support\Facades\DB::table(HealthCheckCommand::WRITE_CANARY_TABLE)->count())->toBe(0);
 });
 
 test('jana:system-audit: exit code BATE com o veredito dos checks', function () {

--- a/memory/sessions/2026-06-21-incidente-grant-insert-revogado.md
+++ b/memory/sessions/2026-06-21-incidente-grant-insert-revogado.md
@@ -1,0 +1,80 @@
+---
+date: "2026-06-21"
+hour: "01:30 BRT"
+topic: "Incidente prod: GRANT INSERT/UPDATE revogado do usuário de DB (Hostinger) — 17 checks verdes com toda gravação morta; write-canary adicionado ao health-check"
+authors: [W, C]
+related_adrs:
+  - 0062-separacao-runtime-hostinger-ct100
+  - 0093-multi-tenant-isolation-tier-0
+outcomes:
+  - "Causa-raiz: usuário de DB de prod sem privilégio INSERT/UPDATE (MySQL 1142)"
+  - "Lacuna de detecção fechada: check db_write_canary (duro) no jana:health-check"
+---
+
+# Incidente — GRANT INSERT/UPDATE revogado em prod (2026-06-21)
+
+## Resumo
+
+Durante uma auditoria de saúde de rotina (`php artisan jana:health-check` ao vivo em
+prod via SSH), o gate falhou (exit 1) por `profile_distiller_drift = 3`. Ao investigar,
+descobri que o distiller falha em **76/76 businesses** — e a causa-raiz **não é o
+distiller**: o usuário de DB de produção **`u906587222_oimpresso` perdeu os privilégios
+`INSERT` e `UPDATE`** (e `CREATE`/`INDEX`). Toda gravação do app web no Hostinger falha
+com MySQL **1142** (`SQLSTATE[42000] ... command denied`), mascarado como "Syntax error
+or access violation".
+
+## Linha do tempo (BRT)
+
+- **20/jun ~22:45–22:50** — últimas escritas bem-sucedidas (`activity_log` 22:50,
+  `mcp_dual_brain_decisions` 22:45). Onset do bloqueio.
+- **20/jun 23:00** — primeiras negações no `laravel.log`.
+- **21/jun 01:03** — `jana:health-check` ao vivo: exit 1, mas só `profile_distiller_drift`
+  acende (sintoma), nada aponta pra escrita.
+- **21/jun ~01:1x** — diagnóstico: `SHOW GRANTS` confirma ausência de INSERT/UPDATE;
+  `mcp_dual_brain_decisions` acumulou **~8.377** negações; ~8.9k no total em ~2h.
+
+## Evidência
+
+```
+GRANT SELECT, DELETE, DROP, REFERENCES, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES,
+      EXECUTE, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, EVENT, TRIGGER,
+      ... ON `u906587222_oimpresso`.* TO `u906587222_oimpresso`@`localhost`
+```
+
+Sem `INSERT`, `UPDATE`, `CREATE`, `INDEX`. O grant é **database-wide** → atinge **todas**
+as tabelas uniformemente. Tabelas que ainda recebem escrita (`mcp_briefs` 23:02,
+`mcp_audit_log` 02:32) vêm de **outra conexão/usuário** (MCP server CT 100, runtime
+separado — [ADR 0062](../decisions/0062-separacao-runtime-hostinger-ct100.md)).
+
+Tabelas com negação registrada (amostra): `mcp_dual_brain_decisions` (8377), `jobs` (66 —
+**fila não enfileira**), `mcp_audit_log`/`error_groups` (131/131), `channel_health_snapshots`
+(60), `essentials_attendances` (13 — **ponto**), `woocommerce_sync_logs` (12), `channels`,
+`mcp_inbox`, `mcp_brief_inputs_cache`.
+
+## Por que passou despercebido (o buraco real)
+
+Os 17 checks do `jana:health-check` são **SELECTs** (multi-tenant, PII, drift) ou
+**degradam gracioso** quando uma tabela falta. **Nenhum** provava **privilégio de
+escrita**. Resultado: tudo verde com prod meio-morto — o anti-padrão **"a suíte mente"**
+(mesma classe da auditoria de sentinelas de 20/jun: monitor verde com o fluxo morto).
+
+## Correção
+
+1. **Grant (P0 — humano, hPanel):** o usuário não tem `GRANT OPTION` e não há root
+   MySQL no shared hosting; **só dá pra restaurar no hPanel Hostinger** (MySQL Databases
+   → privilégios de `u906587222_oimpresso` → ALL, ou ao menos INSERT/UPDATE/CREATE/INDEX),
+   ou via ticket. Tudo a jusante (distiller, ledger ADS) **auto-cura** depois.
+2. **Guard (este PR):** check **`db_write_canary`** (DURO) no `jana:health-check` —
+   INSERT de prova numa tabela dedicada (`jana_health_write_canary`) dentro de uma
+   transação **sempre revertida** (não persiste linha, não toca tabela de negócio).
+   Escrita morta passa a **derrubar o exit code + ALERT do cron 06:00**. Predicado puro
+   `isWriteDenied()` (1142/command denied) + bite-test. **Ordem:** o fix do grant vem
+   ANTES do deploy deste guard (a própria migration precisa de `CREATE`, que o mesmo
+   grant revoga).
+
+## Pendências
+
+- Reconciliar 3 IDs em `spec_id_drift` (US-WA-002/010/045 — título DB ≠ SPEC.md). **Bloqueado**
+  pelo grant (é `UPDATE mcp_tasks`) e precisa do MCP conectado. (US-RECURRINGBILLING-001 é
+  falso-positivo conhecido — `RecurringBilling/SPEC.md` linha 12 documenta o ID legado.)
+- Investigar **o que** revogou o grant ~22:50 (ação no hPanel? reset Hostinger? deploy?).


### PR DESCRIPTION
## Contexto — incidente 2026-06-21

Auditoria de saúde ao vivo em prod revelou que o usuário de DB `u906587222_oimpresso` **perdeu `INSERT`/`UPDATE`** no Hostinger (~20/jun 22:50). Toda gravação do app web falha com **MySQL 1142** (`command denied`, ~8.9k erros em 2h) — mas os **17 checks do `jana:health-check` seguiram VERDES**, porque todos são `SELECT` ou degradam gracioso. **Nenhum provava escrita.** Anti-padrão "a suíte mente".

> ⚠️ O fix do **GRANT** em si é humano (hPanel Hostinger → privilégios do usuário → ALL / INSERT+UPDATE+CREATE+INDEX). Este PR **não** corrige o grant — fecha a **lacuna de detecção** pra isso nunca mais passar batido.

## O que muda

- **`checkDbWriteCanary()`** (check DURO) — INSERT de prova numa tabela dedicada `jana_health_write_canary`, em transação **sempre revertida**: prova o privilégio de escrita sem persistir linha, sem tocar tabela de negócio nem disparar Observer. Escrita morta passa a **derrubar o exit code + ALERT do cron 06:00**.
- **`isWriteDenied()`** — predicado puro (1142 / `command denied`), testável sem DB.
- **migration** idempotente da tabela-alvo (tabela de sistema → sem `business_id`; com `down()`).
- **bite-test** (`isWriteDenied` + canário escreve e **não deixa lixo**) + **smoke** (presença na lista de checks duros).

## Ordem de deploy

O fix do **GRANT vem ANTES** deste deploy — a própria migration precisa de `CREATE`, que o mesmo grant revoga. O check degrada gracioso (skip) enquanto a tabela não existe.

## Teste

- `php -l` limpo nos 4 arquivos. Pest roda nos gates (vendor/ ausente no sub-worktree).
- Bite-test prova: canário `ok=true` / `value=writable` no DB de teste, e `count()==0` (rollback real).

Detalhes: [`memory/sessions/2026-06-21-incidente-grant-insert-revogado.md`](memory/sessions/2026-06-21-incidente-grant-insert-revogado.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)