### PR TITLE
feat(jana): db_storage_quota check + causa-raiz real (incidente 2026-06-21)

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -112,6 +112,7 @@ class HealthCheckCommand extends Command
             $this->checkMcpWebhookHealth2h(),
             $this->checkMemoriaRecallBackend(),
             $this->checkDbWriteCanary(),
+            $this->checkDbStorageQuota(),
             $this->checkLessonLedgerGraduation(),
             $this->checkGovernancaGraduationRatio(),
             $this->checkProtocolFreshness(),
@@ -1221,6 +1222,75 @@ class HealthCheckCommand extends Command
     {
         return str_contains($message, '1142')
             || stripos($message, 'command denied') !== false;
+    }
+
+    /** Cota de armazenamento do DB no plano (MB). Override via config jana.db_quota_mb. */
+    public const DB_QUOTA_MB_DEFAULT = 6144;
+
+    /**
+     * Check 10c — DB storage quota (a CAUSA do incidente 2026-06-21).
+     *
+     * O db_write_canary pega o SINTOMA (escrita morta); este pega a CAUSA antes dela
+     * acontecer. Ao bater a cota de disco do plano, o Hostinger AUTO-REVOGA
+     * INSERT/UPDATE/CREATE — toda escrita do ERP morre. Em 2026-06-21 a tabela
+     * mcp_memory_documents_history inflada (5 GB) levou o DB a 6180/6144 MB → escrita
+     * revogada por horas, com os 17 checks verdes. Este check acende ANTES (>= warnPct
+     * da cota), dando tempo de liberar espaço antes do provedor cortar.
+     *
+     * Mede só o DB da app — information_schema enxerga apenas as tabelas com
+     * privilégio; as bases legadas da conta (~300 MB estáticos) não entram, mas a app
+     * é a parte dominante e a que cresce. Cota/limiar via config (jana.db_quota_mb /
+     * jana.db_quota_warn_pct). Skip em não-MySQL (SQLite CI).
+     */
+    protected function checkDbStorageQuota(): array
+    {
+        $name = 'db_storage_quota';
+
+        if (DB::getDriverName() !== 'mysql') {
+            return [
+                'name' => $name, 'ok' => true, 'value' => 'n/a',
+                'threshold' => 'mysql only', 'message' => 'Skipped (driver não-MySQL)',
+            ];
+        }
+
+        try {
+            $quotaMb = (int) config('jana.db_quota_mb', self::DB_QUOTA_MB_DEFAULT);
+            $warnPct = (int) config('jana.db_quota_warn_pct', 90);
+            $usedMb = (float) (DB::selectOne(
+                'SELECT ROUND(SUM(data_length + index_length) / 1024 / 1024, 1) mb
+                   FROM information_schema.tables WHERE table_schema = DATABASE()'
+            )->mb ?? 0);
+            $pct = $quotaMb > 0 ? (int) round($usedMb / $quotaMb * 100) : 0;
+            $exceeded = self::dbQuotaExceeded($usedMb, $quotaMb, $warnPct);
+
+            return [
+                'name' => $name,
+                'ok' => ! $exceeded,
+                'value' => "{$usedMb}MB ({$pct}%)",
+                'threshold' => "< {$warnPct}% de {$quotaMb}MB",
+                'message' => $exceeded
+                    ? "ALERTA cota: DB em {$usedMb}MB ({$pct}% de {$quotaMb}MB) — ao bater 100% o Hostinger REVOGA INSERT/UPDATE e a escrita morre (incidente 2026-06-21). Liberar espaço / mover histórico pro CT 100."
+                    : "DB em {$usedMb}MB ({$pct}% da cota {$quotaMb}MB)",
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'name' => $name, 'ok' => false, 'value' => null,
+                'threshold' => 'measurable', 'message' => 'ERRO: ' . mb_substr($e->getMessage(), 0, 80),
+            ];
+        }
+    }
+
+    /**
+     * Predicado puro: o uso de disco do DB cruzou o limiar de alerta da cota?
+     * Testável sem DB (mesmo padrão de isWriteDenied / allChecksOk).
+     */
+    public static function dbQuotaExceeded(float $usedMb, int $quotaMb, int $warnPct = 90): bool
+    {
+        if ($quotaMb <= 0) {
+            return false;
+        }
+
+        return ($usedMb / $quotaMb * 100) >= $warnPct;
     }
 
     /**

--- a/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
@@ -64,6 +64,7 @@ test('cada check tem campos canonicos', function () {
         'mcp_webhook_5xx_2h',
         'memoria_recall_backend',
         'db_write_canary',
+        'db_storage_quota',
         'jana_lesson_ledger_graduation',
     ];
 

--- a/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/SentinelBiteTest.php
@@ -77,6 +77,14 @@ test('isWriteDenied: erro benigno / sentinela de rollback NÃO é negação', fu
     expect(HealthCheckCommand::isWriteDenied(''))->toBeFalse();
 });
 
+// db_storage_quota: a CAUSA do incidente (Hostinger revoga escrita ao bater a cota).
+test('dbQuotaExceeded: >= warnPct acende; abaixo não', function () {
+    expect(HealthCheckCommand::dbQuotaExceeded(5530.0, 6144, 90))->toBeTrue();   // ~90%
+    expect(HealthCheckCommand::dbQuotaExceeded(6180.0, 6144, 90))->toBeTrue();   // estourado (incidente)
+    expect(HealthCheckCommand::dbQuotaExceeded(816.0, 6144, 90))->toBeFalse();   // ~13% (pós-fix)
+    expect(HealthCheckCommand::dbQuotaExceeded(100.0, 0, 90))->toBeFalse();      // cota desconhecida = não alarma
+});
+
 // ── 2. INTEGRAÇÃO: exit code == veredito (prova que NÃO é constante) ──────────
 
 /** Extrai o bloco JSON do output do comando (pode haver linhas de debug antes). */

--- a/memory/sessions/2026-06-21-incidente-grant-insert-revogado.md
+++ b/memory/sessions/2026-06-21-incidente-grant-insert-revogado.md
@@ -6,9 +6,11 @@ authors: [W, C]
 related_adrs:
   - 0062-separacao-runtime-hostinger-ct100
   - 0093-multi-tenant-isolation-tier-0
+  - 0061-conhecimento-canonico-git-mcp-zero-automem
 outcomes:
-  - "Causa-raiz: usuário de DB de prod sem privilégio INSERT/UPDATE (MySQL 1142)"
-  - "Lacuna de detecção fechada: check db_write_canary (duro) no jana:health-check"
+  - "Causa-raiz: cota de disco do DB estourada (6180/6144 MB) → Hostinger auto-revogou INSERT/UPDATE"
+  - "Estouro por mcp_memory_documents_history (4.97 GB, over-versioning); dropada (git é canônico) → ALL PRIVILEGES auto-restaurado; DB 5788→816 MB"
+  - "Guards (PR #3125): db_write_canary + db_storage_quota (duros) no jana:health-check"
 ---
 
 # Incidente — GRANT INSERT/UPDATE revogado em prod (2026-06-21)
@@ -58,23 +60,51 @@ Os 17 checks do `jana:health-check` são **SELECTs** (multi-tenant, PII, drift) 
 escrita**. Resultado: tudo verde com prod meio-morto — o anti-padrão **"a suíte mente"**
 (mesma classe da auditoria de sentinelas de 20/jun: monitor verde com o fluxo morto).
 
-## Correção
+## Causa-raiz REAL (atualizado 2026-06-21)
 
-1. **Grant (P0 — humano, hPanel):** o usuário não tem `GRANT OPTION` e não há root
-   MySQL no shared hosting; **só dá pra restaurar no hPanel Hostinger** (MySQL Databases
-   → privilégios de `u906587222_oimpresso` → ALL, ou ao menos INSERT/UPDATE/CREATE/INDEX),
-   ou via ticket. Tudo a jusante (distiller, ledger ADS) **auto-cura** depois.
-2. **Guard (este PR):** check **`db_write_canary`** (DURO) no `jana:health-check` —
-   INSERT de prova numa tabela dedicada (`jana_health_write_canary`) dentro de uma
-   transação **sempre revertida** (não persiste linha, não toca tabela de negócio).
-   Escrita morta passa a **derrubar o exit code + ALERT do cron 06:00**. Predicado puro
-   `isWriteDenied()` (1142/command denied) + bite-test. **Ordem:** o fix do grant vem
-   ANTES do deploy deste guard (a própria migration precisa de `CREATE`, que o mesmo
-   grant revoga).
+O grant não foi "revogado por alguém" — foi **automático**. O DB bateu a **cota de disco
+do plano**: `6180 / 6144 MB` (100%+). Quando isso acontece, o **Hostinger auto-revoga
+INSERT/UPDATE/CREATE/INDEX** (deixa SELECT/DELETE/DROP pra dar como liberar espaço) e
+**re-restaura sozinho** assim que volta a ficar abaixo da cota.
+
+O que estourou a cota: **`mcp_memory_documents_history` = 4.97 GB** (296.586 linhas para
+1.042 docs atuais ≈ 285 versões/doc), inflada por over-versioning do sync git→MCP (grava
+snapshot a cada webhook). Sozinha era 85% do banco. Cada linha tem `git_sha` + `content_md`
+→ **redundante com o git**, fonte canônica das memórias ([ADR 0061](../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)).
+
+## Resolução (2026-06-21 ~09h BRT)
+
+1. `DROP TABLE _bkp_fin_titulos_20260602` (backup datado do resync num_uf, ~80 MB).
+2. `SHOW CREATE TABLE` salvo → `DROP TABLE mcp_memory_documents_history` (0.2s, libera
+   ~4.97 GB). DB: **5788 → 816 MB**.
+3. Hostinger **auto-restaurou `ALL PRIVILEGES`** no ato (confirma a causa-raiz).
+4. Tabela recriada **vazia** (DDL idêntico + FK `ON DELETE CASCADE`).
+5. `jana:profile-distill --only-stale` → **76 ok / 0 falha**; health-check **`ok: true`**
+   (profile_distiller_drift e spec_id_drift zerados).
+
+## Guards adicionados (PR #3125)
+
+- **`db_write_canary`** (DURO) — INSERT de prova em tabela dedicada (`jana_health_write_canary`),
+  transação sempre revertida (não persiste linha, não toca negócio). Pega o SINTOMA
+  (escrita morta) no cron 06:00. Predicado puro `isWriteDenied()` (1142/command denied).
+- **`db_storage_quota`** (DURO) — alerta quando o DB passa de `jana.db_quota_warn_pct`
+  (90%) da cota (`jana.db_quota_mb`, default 6144). Pega a CAUSA **antes** do provedor
+  cortar. Predicado puro `dbQuotaExceeded()`. Ambos com bite-tests.
+
+## Fase 2 — mover memória do MCP pro CT 100 (planejado)
+
+Arquiteturalmente os `mcp_memory_documents*` são dados do MCP server (CT 100, [ADR 0062](../decisions/0062-separacao-runtime-hostinger-ct100.md)),
+hoje no MySQL do Hostinger só por conexão remota — foi esse acoplamento que deixou o bloat
+da memória derrubar o ERP. Plano:
+1. Subir DB no CT 100 (storage do Proxmox, sem a cota apertada de shared hosting).
+2. Repointar a config de memória do MCP pro DB do CT 100.
+3. Corrigir o over-versioning (só gravar histórico quando `content_md` muda de fato).
+4. Retenção (N versões/doc OU ≤90d; o git já é o histórico de longo prazo).
+
+Refill atual é lento (~170 MB/semana → **meses** até reincomodar), então não é urgente.
 
 ## Pendências
 
-- Reconciliar 3 IDs em `spec_id_drift` (US-WA-002/010/045 — título DB ≠ SPEC.md). **Bloqueado**
-  pelo grant (é `UPDATE mcp_tasks`) e precisa do MCP conectado. (US-RECURRINGBILLING-001 é
-  falso-positivo conhecido — `RecurringBilling/SPEC.md` linha 12 documenta o ID legado.)
-- Investigar **o que** revogou o grant ~22:50 (ação no hPanel? reset Hostinger? deploy?).
+- Fase 2 (acima) — quando der.
+- `spec_id_drift` zerou sozinho pós-fix (provável efeito do parser #3124 + sync voltando);
+  monitorar. (US-RECURRINGBILLING-001 segue falso-positivo conhecido documentado em `RecurringBilling/SPEC.md`.)


### PR DESCRIPTION
## Contexto — fecha o ciclo do incidente 2026-06-21

Segue o #3125 (write-canary, já mergeado). A auditoria confirmou a **causa-raiz real**: o grant não foi revogado "por alguém" — o **DB bateu a cota de disco** do plano (`6180/6144 MB`) e o **Hostinger auto-revogou INSERT/UPDATE/CREATE** (re-restaura sozinho abaixo da cota). O estouro veio de `mcp_memory_documents_history` (**4.97 GB**, over-versioning do sync git→MCP; redundante com o git por [ADR 0061](memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)).

**Já resolvido em prod** (manual, via SSH): dropei a tabela → DB **5788 → 816 MB** → Hostinger devolveu `ALL PRIVILEGES` na hora → recriei vazia → health-check **`ok: true`**.

## O que muda aqui

- **`db_storage_quota`** (check DURO) — alerta quando o DB passa de `jana.db_quota_warn_pct` (90%) da cota (`jana.db_quota_mb`, default 6144). Onde o `db_write_canary` (#3125) pega o **sintoma** (escrita morta), este pega a **causa** *antes* do provedor cortar. Predicado puro `dbQuotaExceeded()` + bite-test + presença no smoke.
- **incident doc atualizado** — causa-raiz real + resolução + plano **Fase 2** (mover memória do MCP pro CT 100 + corrigir over-versioning + retenção).

## Notas

- O check mede o DB da app (information_schema só enxerga tabelas com privilégio); bases legadas (~300 MB estáticos) não contam, mas a app é a parte dominante/que cresce.
- Driver-agnóstico: skip em não-MySQL (SQLite CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)