### PR TITLE
feat(memory-health): Check L — ADR vivo-mas-proposto (integridade proposto×realizado)

### DIFF
--- a/scripts/governance/.memory-health-baseline.json
+++ b/scripts/governance/.memory-health-baseline.json
@@ -15,5 +15,19 @@
     "memory/requisitos/RecurringBilling/RUNBOOK-inter-pj.md": 1,
     "memory/research/clientes-legacy-officeimpresso/01-wr-sistemas/02-schema-real-2026-06-03.md": 1,
     "memory/research/clientes-legacy-officeimpresso/_COMO-ANALISAR.md": 1
-  }
+  },
+  "checkL": [
+    "0123-modules-arquivos-backbone",
+    "0124-curador-conhecimento-pipeline",
+    "0189-pageheader-canon-v3-1-cadastro-roxo",
+    "0236-scorecard-universal-entidade-arbitraria",
+    "0254-design-identity-grade-deterministico",
+    "0256-knowledge-survival-meia-vida-catraca-sentinela",
+    "0257-adr-status-lifecycle-kind-modelo-canonico",
+    "0258-processo-adr-estado-arte-indice-gerado-supersede-atomico",
+    "0286-channel-health-corroborado-por-mensagem-real",
+    "0291-distiller-modulo-verdade-contrato-emenda-0270-f3",
+    "0294-mcp-audit-log-hash-chain-tamper-evident",
+    "0295-bitemporal-event-time-memoria-jana"
+  ]
 }

--- a/scripts/governance/memory-health.mjs
+++ b/scripts/governance/memory-health.mjs
@@ -42,8 +42,9 @@ const STALE_MONTHS = 6; // doc canon parado > 6 meses = candidato a revisão
 // acima do teto por arquivo. Aceitos (ex: default Firebird "masterkey") ficam no baseline.
 const BASELINE_FILE = 'scripts/governance/.memory-health-baseline.json';
 const UPDATE_BASELINE = process.argv.includes('--update-baseline');
-const baseline = existsSync(join(ROOT, BASELINE_FILE)) ? JSON.parse(readFileSync(join(ROOT, BASELINE_FILE), 'utf8')) : { checkC: {} };
+const baseline = existsSync(join(ROOT, BASELINE_FILE)) ? JSON.parse(readFileSync(join(ROOT, BASELINE_FILE), 'utf8')) : { checkC: {}, checkL: [] };
 let checkCByFile = {};
+let checkLSlugs = []; // Check L (ADR vivo-mas-proposto): slugs detectados nesta run
 
 const fails = []; // 🔴 bloqueia CI
 const warns = []; // 🟡 só sinaliza
@@ -403,6 +404,47 @@ function checkSessionDecisionAnchor() {
   }
 }
 
+// ── Check L: ADR vivo-mas-proposto (proposto vs realizado) ──────────────────
+// "Declarado ≠ realizado": ADR com status proposto/rascunho cujo NÚMERO já é citado
+// por código que RODA (scripts/** ou .github/workflows/**) — o processo depende da
+// decisão, mas a metadata diz que ela não foi aceita. Ratchet (como Check C): os
+// offenders conhecidos ficam no baseline (.checkL); só ADR NOVO vivo-mas-proposto
+// acima do baseline 🔴 falha. Ratificar (proposto→aceito) tira do offender list
+// sozinho — o débito encolhe à vista. É o teste de integridade do proposto vs
+// realizado pedido por Wagner (2026-06-21). Refs: ADR 0256/0258.
+const UNRATIFIED_STATUS = new Set(['proposto', 'rascunho', 'proposed', 'draft']);
+function checkAdrVivoMasProposto() {
+  const dir = 'memory/decisions';
+  if (!exists(dir)) return;
+  // corpus = "código que roda". NÃO inclui memory/** (lá é doc, não execução) nem o
+  // próprio baseline (senão o grandfather vira citação circular auto-confirmante).
+  const isCode = (rel) => /\.(mjs|js|ts|php|json)$/.test(rel) && !rel.includes('.memory-health-baseline');
+  const corpusFiles = [
+    ...listFiles('scripts', isCode),
+    ...(exists('.github/workflows') ? listFiles('.github/workflows', (p) => /\.ya?ml$/.test(p)) : []),
+  ];
+  let corpus = '';
+  for (const f of corpusFiles) { try { corpus += '\n' + read(f); } catch {} }
+  for (const f of readdirSync(join(ROOT, dir))) {
+    const m = f.match(/^(\d{4})-.+\.md$/);
+    if (!m) continue;
+    const num = m[1];
+    let txt; try { txt = read(`${dir}/${f}`); } catch { continue; }
+    const st = (txt.match(/^status:\s*["']?([^\s"'#]+)/mi) || [])[1]?.toLowerCase();
+    if (!st || !UNRATIFIED_STATUS.has(st)) continue;
+    // citado como dependência viva: "ADR 0256" · "0256-slug" · "decisions/0256-"
+    const cited = new RegExp(`(ADR[ _-]?${num}\\b|\\b${num}-[a-z]|decisions/${num}-)`, 'i').test(corpus);
+    if (cited) checkLSlugs.push(f.replace(/\.md$/, ''));
+  }
+  if (UPDATE_BASELINE) return; // no modo update só capturamos; nada de fail
+  const grandfathered = new Set(baseline.checkL || []);
+  const novos = checkLSlugs.filter((slug) => !grandfathered.has(slug));
+  if (novos.length) {
+    fails.push({ check: 'L', kind: 'adr-vivo-mas-proposto', count: novos.length, sample: novos.slice(0, 15),
+      msg: `ADR(s) com status proposto/rascunho mas JÁ citado(s) por código que roda (scripts/** ou .github/workflows/**) — "proposto vs realizado": o processo já depende da decisão mas a metadata diz que não foi aceita. Ratifique (proposto→aceito via PR) ou corte a dependência. Se legítimo, rode --update-baseline. (ADR 0256 Check L · Wagner 2026-06-21)` });
+  }
+}
+
 // ── run ─────────────────────────────────────────────────────────────────────
 checkAdrCollisions();
 checkScorecardFantasma();
@@ -413,12 +455,13 @@ checkAntiResurrection();
 checkGatesRegistry();
 checkLidoFreshness();
 checkLicaoSemAssercao();
+checkAdrVivoMasProposto(); // Check L (fail-class) — proposto vs realizado
 try { checkPlanHealth(); } catch (e) { warns.push({ check: 'J', kind: 'plan-health-error', msg: 'plan-health falhou (não bloqueia): ' + e.message }); }
 try { checkSessionDecisionAnchor(); } catch (e) { warns.push({ check: 'K', kind: 'session-anchor-error', msg: 'session-anchor falhou (não bloqueia): ' + e.message }); }
 
 if (UPDATE_BASELINE) {
-  writeFileSync(join(ROOT, BASELINE_FILE), JSON.stringify({ checkC: checkCByFile }, null, 2) + '\n');
-  console.log(`✓ baseline atualizado: ${BASELINE_FILE} (${Object.keys(checkCByFile).length} arquivos com Check C aceitos)`);
+  writeFileSync(join(ROOT, BASELINE_FILE), JSON.stringify({ checkC: checkCByFile, checkL: checkLSlugs.slice().sort() }, null, 2) + '\n');
+  console.log(`✓ baseline atualizado: ${BASELINE_FILE} (Check C: ${Object.keys(checkCByFile).length} arquivos · Check L: ${checkLSlugs.length} ADRs vivo-mas-proposto grandfathered)`);
   process.exit(0);
 }
 


### PR DESCRIPTION
## O quê

Adiciona o **Check L** ao `memory-health.mjs` — a *garantia de integridade proposto×realizado* que faltava na malha de sentinelas.

Detecta a classe **"declarado ≠ realizado"**: ADR com `status: proposto`/`rascunho` cujo **número já é citado por código que roda** (`scripts/**` ou `.github/workflows/**`). Ou seja: o processo já depende da decisão, mas a metadata diz que ela não foi aceita. Nenhum check existente pegava isso — o Check E só pega grafia de enum errada, não status-válido-mas-stale-vs-realidade.

## Por quê

Auditoria de maturidade do processo (sessão 2026-06-21) achou o padrão em 3 áreas: *"mede tudo em estado-da-arte, governa nada"*. Rodando a própria sentinela ao vivo: estrutura sã (integrity-check 7/7), mas conteúdo drifado e **tudo advisory**. Os ADRs 0256/0258 — que **autorizam** a própria sentinela — estão `proposto` enquanto o código deles roda em CI. O crachá do vigia vencido.

## Como (ratchet, igual ao Check C)

- Os **12 offenders atuais** entram no baseline (`.memory-health-baseline.json` → `checkL`) como **dívida explícita e rastreada**.
- Só **ADR NOVO** vivo-mas-proposto acima do baseline **bloqueia o PR** (🔴 fail-class).
- **Ratificar** um ADR (`proposto→aceito`) tira ele do offender list sozinho — o débito encolhe à vista, sem editar o baseline.
- Corpus exclui `memory/**` (lá é doc) e o próprio baseline (evita auto-citação circular).

## Prova que morde (counterfactual)

```
sem baseline   → 🔴 [L] 12 offenders   (detecta + bloqueia)
baseline dos 12 → 0 🔴 fail · 5 🟡 warn (EXIT=0, grandfather ok)
```
O gate `memory-health.yml` roda **sem `--warn-only`** e dispara nos paths deste PR (`memory-health.mjs` + baseline), então é auto-validado no CI.

## Os 12 grandfathered (a ratificar fora deste PR)

`0123 0124 0189 0236 0254 0256 0257 0258 0286 0291 0294 0295` — cada um é decisão **já implementada e em uso** cujo status precisa virar `aceito` via PR de governança (ato seu).

## Follow-ups conhecidos (fora de escopo, 1 PR = 1 intent)

- [ ] Ratificar os 12 (`proposto→aceito`) — encolhe o baseline naturalmente.
- [ ] Título do ADR 0061 corrompido em YAML `!!binary` (em-dash mal-codificado) — repair mecânico, decidir append-only vs override consciente.
- [ ] Promover Check E (enum-drift, 56 hoje) de 🟡→🔴 após armar baseline.
- [ ] Guard anti-grandfather (Gap 2 do blueprint SDD) — impede afrouxar baseline no mesmo commit do código; cobre Check C e Check L de uma vez.

Refs: ADR 0256 · ADR 0258 · sessão 2026-06-21 (auditoria de maturidade do processo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
