### PR TITLE
feat(governance): baseline-tamper-guard — anti-grandfather (Gap 2 blueprint SDD)

### DIFF
--- a/.github/workflows/baseline-tamper-guard.yml
+++ b/.github/workflows/baseline-tamper-guard.yml
@@ -1,0 +1,34 @@
+name: Baseline tamper-guard (anti-grandfather)
+
+# Gap-2 do blueprint SDD (ADR 0256/0258). Impede AFROUXAR um baseline-ratchet
+# (subir teto / grandfatherar item) no MESMO PR que mete o código que o ratchet
+# deveria pegar — a regressão entraria verde (casos #2848, ghost 14→16).
+# Escape hatch consciente: `BASELINE-ABSORB: <motivo>` na mensagem de commit, OU
+# isolar a mudança de baseline num PR/commit só-de-baseline.
+#
+# Hoje guarda: scripts/governance/.memory-health-baseline.json (checkC + checkL).
+# Estender = adicionar o path + detector no GUARDED do script + o path neste trigger.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/governance/.memory-health-baseline.json'
+      - 'scripts/governance/baseline-tamper-guard.mjs'
+      - '.github/workflows/baseline-tamper-guard.yml'
+
+jobs:
+  guard:
+    name: baseline-tamper-guard (anti-grandfather)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # precisa da base p/ git show/diff/log do range do PR
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Run baseline tamper-guard
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/governance/baseline-tamper-guard.mjs

--- a/scripts/governance/baseline-tamper-guard.mjs
+++ b/scripts/governance/baseline-tamper-guard.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * baseline-tamper-guard.mjs — anti-grandfather (Gap 2 do blueprint SDD · ADR 0256/0258).
+ *
+ * Fecha o buraco que TODO ratchet-com-baseline compartilha: dá pra AFROUXAR o
+ * baseline (subir teto / grandfatherar item novo) NO MESMO PR que mete o código
+ * que o ratchet deveria pegar — a regressão entra verde. (Casos reais catalogados:
+ * MemCofre #2848, ghost 14→16, ambos mergearam verdes mascarados pelo baseline.)
+ *
+ * Regra: se um baseline guardado foi AFROUXADO em relação à base do PR E o PR
+ * também toca código (qualquer arquivo que NÃO seja um baseline guardado), FALHA
+ * 🔴 — a não ser que (a) algum commit do range carregue o marcador `BASELINE-ABSORB`
+ * (override consciente e auditável) OU (b) a mudança de baseline esteja ISOLADA
+ * (PR só toca baselines guardados = curadoria deliberada, nada de código pra mascarar).
+ *
+ * Base do diff: --base <ref> · env BASE_SHA · env GITHUB_BASE_REF (origin/<ref>) ·
+ *   fallback `git merge-base HEAD origin/main` · senão SKIP (sem base = nunca falha).
+ *
+ * Determinístico, sem LLM, sem deps. Roda em CI (PR toca baseline) e local.
+ * Uso: node scripts/governance/baseline-tamper-guard.mjs [--base <ref>]
+ */
+import { readFileSync, existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const argBase = (() => { const i = process.argv.indexOf('--base'); return i >= 0 ? process.argv[i + 1] : null; })();
+
+function git(cmd) {
+  try { return execSync(`git ${cmd}`, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim(); }
+  catch { return ''; }
+}
+const parseJson = (txt) => { try { return JSON.parse(txt); } catch { return null; } };
+
+// ── detectores de afrouxamento por schema de baseline ────────────────────────
+// Cada um recebe (base, head) já parseados e devolve lista de descrições do que
+// foi afrouxado (subiu teto / grandfatherou item novo). Vazio = nada afrouxou.
+function detectMemoryHealth(base, head) {
+  const out = [];
+  const b = base || {}, h = head || {};
+  const bC = b.checkC || {}, hC = h.checkC || {};
+  for (const [f, n] of Object.entries(hC)) {
+    const prev = bC[f] || 0;
+    if (n > prev) out.push(`checkC teto subiu: ${f} (${prev}→${n})`);
+  }
+  const bL = new Set(b.checkL || []);
+  for (const s of (h.checkL || [])) if (!bL.has(s)) out.push(`checkL grandfatherado novo: ${s}`);
+  return out;
+}
+
+// Mapa path→detector. Estender = adicionar o baseline + seu detector aqui
+// (e o path no trigger do workflow). Só guarda o que tem detector de schema:
+// afrouxamento genérico em formato heterogêneo daria falso-positivo.
+const GUARDED = {
+  'scripts/governance/.memory-health-baseline.json': detectMemoryHealth,
+};
+
+// ── resolver base do diff ─────────────────────────────────────────────────────
+function resolveBase() {
+  if (argBase) return argBase;
+  if (process.env.BASE_SHA) return process.env.BASE_SHA;
+  if (process.env.GITHUB_BASE_REF) {
+    git(`fetch origin ${process.env.GITHUB_BASE_REF} --depth=100`);
+    return `origin/${process.env.GITHUB_BASE_REF}`;
+  }
+  return git('merge-base HEAD origin/main') || null;
+}
+
+// ── run ────────────────────────────────────────────────────────────────────────
+const BASE = resolveBase();
+if (!BASE) {
+  console.log('baseline-tamper-guard: sem base determinável (não é PR / sem origin/main) — SKIP.');
+  process.exit(0);
+}
+
+const loosenings = [];
+for (const [path, detector] of Object.entries(GUARDED)) {
+  if (!existsSync(join(ROOT, path))) continue;
+  const baseTxt = git(`show ${BASE}:${path}`);
+  const base = baseTxt ? parseJson(baseTxt) : {}; // ausente na base = {} (tudo conta como novo)
+  const head = parseJson(readFileSync(join(ROOT, path), 'utf8'));
+  if (head === null) { console.error(`baseline-tamper-guard: ${path} não parseia como JSON.`); process.exit(1); }
+  for (const desc of detector(base, head)) loosenings.push(`${path} — ${desc}`);
+}
+
+if (!loosenings.length) {
+  console.log(`baseline-tamper-guard: nenhum baseline guardado afrouxado vs ${BASE}. ✓`);
+  process.exit(0);
+}
+
+// Houve afrouxamento — está pareado com código (suspeito) ou isolado/justificado?
+const changed = git(`diff --name-only ${BASE}..HEAD`).split('\n').map((s) => s.trim()).filter(Boolean);
+const guardedSet = new Set(Object.keys(GUARDED));
+const codeTouched = changed.filter((f) => !guardedSet.has(f));
+// Marcador só vale no commit que DE FATO toca um baseline guardado — não em
+// qualquer commit do range que mencione o token (senão o próprio commit que
+// implementa/documenta o guard auto-justificaria: falso-negativo "o gate se
+// auto-aceita"). E exige o token ancorado em início de linha (trailer), não em prosa.
+const guardedPaths = Object.keys(GUARDED).join(' ');
+const baselineCommits = git(`log ${BASE}..HEAD --format=%H -- ${guardedPaths}`).split('\n').filter(Boolean);
+let hasMarker = false;
+for (const sha of baselineCommits) {
+  if (/^[ \t]*BASELINE-ABSORB\b/m.test(git(`log -1 --format=%B ${sha}`))) { hasMarker = true; break; }
+}
+
+console.log(`baseline-tamper-guard: ${loosenings.length} afrouxamento(s) vs ${BASE}:`);
+loosenings.forEach((l) => console.log(`  - ${l}`));
+
+if (codeTouched.length && !hasMarker) {
+  console.error('\n✗ baseline-tamper-guard: baseline AFROUXADO no mesmo PR que toca código,');
+  console.error(`  sem o marcador \`BASELINE-ABSORB\`. ${codeTouched.length} arquivo(s) de código no diff:`);
+  codeTouched.slice(0, 10).forEach((f) => console.error(`     - ${f}`));
+  console.error('\n  Isso é o vetor que deixa regressão entrar verde (ex: #2848, ghost 14→16). Opções:');
+  console.error('   1. Isole a mudança de baseline num PR/commit SÓ de baseline (sem código), OU');
+  console.error('   2. Justifique conscientemente: inclua `BASELINE-ABSORB: <motivo>` na mensagem de commit.');
+  process.exit(1);
+}
+
+console.log(hasMarker
+  ? '\n✓ afrouxamento justificado por `BASELINE-ABSORB` (override consciente e auditável).'
+  : '\n✓ afrouxamento isolado (PR só toca baseline guardado — curadoria deliberada, sem código pra mascarar).');
+process.exit(0);

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -10,6 +10,10 @@
     }
   },
   "workflows": {
+    "baseline-tamper-guard.yml": {
+      "nome": "Baseline tamper-guard (anti-grandfather · afrouxar baseline + código no mesmo PR · ADR 0256/0258 · Gap-2 blueprint SDD)",
+      "classe": "gate"
+    },
     "jana-audit-chain-pest.yml": {
       "nome": "Jana audit-chain Pest (T5 · hash-chain mcp_audit_log lógica pura · ADR 0294)",
       "classe": "gate"


### PR DESCRIPTION
## O quê

Novo gate que fecha o buraco **compartilhado por todo ratchet-com-baseline** do projeto: hoje dá pra **afrouxar o baseline** (subir teto / grandfatherar item novo) **no mesmo PR que mete o código** que o ratchet deveria pegar — e a regressão entra **verde**. Casos reais catalogados: MemCofre #2848 e o ghost 14→16, ambos mergearam mascarados pelo próprio baseline.

É o **Gap 2** do `BLUEPRINT-SDD-ONDA1.md` e fecha o vetor de tampering do **Check C** e do **Check L** (este recém-armado no #3127).

## Regra

Se um baseline guardado foi **afrouxado** vs a base do PR **E** o PR também toca código (qualquer arquivo que não seja um baseline guardado) → 🔴 **FAIL**, a não ser que:
- **(a)** o commit que **de fato altera o baseline** carregue o marcador `BASELINE-ABSORB:` (override consciente e auditável), ou
- **(b)** a mudança de baseline esteja **isolada** (PR só toca baselines guardados — curadoria deliberada, nada de código pra mascarar).

O marcador só conta no **commit que toca o baseline** — não em qualquer commit do range que mencione o token (senão o próprio commit que implementa/documenta o guard se auto-justificaria; esse falso-negativo foi pego no teste e corrigido).

## Prova que morde (counterfactual)

```
A) afrouxa checkL + toca código, SEM marcador        → exit 1 (bloqueia) ✓
B) mesmo commit ganha `BASELINE-ABSORB: <motivo>`    → exit 0 (libera)   ✓
   sanity: só script/workflow/registry (sem afrouxar) → exit 0           ✓
```

## Escopo e arquitetura

- Guarda hoje: `scripts/governance/.memory-health-baseline.json` (checkC + checkL).
- Mapa `GUARDED` (path→detector) **extensível** — adicionar outro baseline = registrar path + detector de schema + path no trigger. (Há ~25 `*-baseline.json` no repo; cobrir os demais é follow-up, um detector por schema pra não dar falso-positivo.)
- `scripts/governance/baseline-tamper-guard.mjs` — determinístico, sem deps, sem LLM. Base do diff: `--base` · `BASE_SHA` · `GITHUB_BASE_REF` · fallback `merge-base origin/main` · senão **SKIP** (sem base nunca falha).
- `.github/workflows/baseline-tamper-guard.yml` — gate PR (fetch-depth 0, passa `base.sha`).
- `gates-registry.json` — entrada registrada (senão o memory-health Check G falha).

## ⚠️ Ordem de merge vs #3127

O #3127 **afrouxa o checkL** (grandfatherou os 12). Se este guard entrar **antes**, o #3127 seria bloqueado (afrouxamento + código, sem marcador). **Recomendo mergear o #3127 primeiro** — aí o checkL já está na base e deixa de ser "afrouxamento" pra este guard. (Alternativa: #3127 ganhar um commit `BASELINE-ABSORB:`.)

## Follow-ups

- [ ] Estender `GUARDED` aos outros baselines de ratchet (screen-grades, ui-lint, phpstan, foundation, no-mock…).
- [ ] ADR curta formalizando o gate (rationale já em BLUEPRINT-SDD-ONDA1 Gap 2).

Refs: ADR 0256 · ADR 0258 · BLUEPRINT-SDD-ONDA1 (Gap 2) · sessão 2026-06-21 (auditoria de maturidade do processo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
