### PR TITLE
feat(jana): jana:memory-history-prune — teto preventivo pra history bloat (Fase 2 · 1/2)

### DIFF
--- a/.github/ci-sqlite-pest.list
+++ b/.github/ci-sqlite-pest.list
@@ -18,6 +18,8 @@
 Modules/Jana/Tests/Feature/Ai/PrUiJudgeAgentTest.php
 Modules/Jana/Tests/Feature/Ai/UiJudgeRunMeasurementTest.php
 Modules/Jana/Tests/Feature/Mcp/McpAuthCostEstimateTest.php
+# Poda preventiva de mcp_memory_documents_history (incidente 2026-06-21 — 5 GB → cota → revogou escrita). Schema sintético, sqlite-safe.
+Modules/Jana/Tests/Feature/MemoryHistoryPruneCommandTest.php
 Modules/Jana/Tests/Feature/Mcp/TaskParserDetectaDivergenciaDescritivaTest.php
 Modules/Jana/Tests/Feature/Mcp/WorkLeaseServiceTest.php
 Modules/Jana/Tests/Feature/Mcp/PlanDriftCommandTest.php

--- a/Modules/Jana/Console/Commands/MemoryHistoryPruneCommand.php
+++ b/Modules/Jana/Console/Commands/MemoryHistoryPruneCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * jana:memory-history-prune — poda preventiva de mcp_memory_documents_history.
+ *
+ * CONTEXTO (incidente 2026-06-21): a tabela de histórico bitemporal das memórias
+ * é append-only — cada mudança real de um doc grava um snapshot do content_md
+ * inteiro (mediumtext). Docs "quentes" (CURRENT/TASKS/handoffs/CLAUDE) mudam a
+ * cada push e acumulam centenas de versões. SEM TETO, inflou pra 4.97 GB / 296k
+ * linhas, estourou a cota de disco do Hostinger e o provedor AUTO-REVOGOU a
+ * escrita do ERP. Foi dropada+recriada vazia; este comando impede a reincidência.
+ *
+ * PREVENTIVO (não é reclaim): roda diário e mantém a tabela pequena DESDE O
+ * INÍCIO. Por document_id preserva as últimas --keep versões E tudo dentro de
+ * --days; deleta só o que reprova AMBAS as defesas. O git é a fonte canônica de
+ * longo prazo (ADR 0061) — history antigo no DB é descartável.
+ *
+ * Tabela de SISTEMA (sem business_id) — cross-tenant intencional, igual
+ * mcp_audit_log / mcp_module_grades_history (ADR 0093 escopo plataforma).
+ *
+ * Driver-agnóstico (MySQL/MariaDB prod + SQLite CI): usa subquery correlacionada,
+ * sem window function. Skip gracioso se a tabela não existir.
+ *
+ * @see Modules\Jana\Entities\Mcp\McpMemoryDocumentHistory
+ * @see Modules\Jana\Console\Commands\RetentionPurgeCommand (molde)
+ */
+class MemoryHistoryPruneCommand extends Command
+{
+    protected $signature = 'jana:memory-history-prune
+                            {--keep=20 : Versões mais recentes a preservar por document_id}
+                            {--days=90 : Preservar tudo mais novo que N dias (defesa temporal)}
+                            {--chunk=2000 : Tamanho do lote de DELETE}
+                            {--dry-run : Apenas conta o que seria podado, não deleta}';
+
+    protected $description = 'Poda preventiva de mcp_memory_documents_history (mantém últimas N por doc + janela de X dias)';
+
+    private const TABLE = 'mcp_memory_documents_history';
+
+    public function handle(): int
+    {
+        if (! \Illuminate\Support\Facades\Schema::hasTable(self::TABLE)) {
+            $this->warn('Tabela ' . self::TABLE . ' ausente — nada a podar (pré-migração/dev).');
+
+            return self::SUCCESS;
+        }
+
+        $keep = max(1, (int) $this->option('keep'));
+        $days = max(1, (int) $this->option('days'));
+        $chunk = max(100, (int) $this->option('chunk'));
+        $dryRun = (bool) $this->option('dry-run');
+        $cutoff = Carbon::now()->subDays($days);
+
+        $this->info('jana:memory-history-prune — ' . now()->toDateTimeString());
+        $this->line("  keep (por doc): {$keep} · days (janela): {$days} (cutoff {$cutoff->toDateTimeString()})");
+        if ($dryRun) {
+            $this->warn('  [DRY-RUN] nada será deletado');
+        }
+
+        $totalBefore = (int) DB::table(self::TABLE)->count();
+
+        // Candidatos a DELETE: reprovam em AMBAS as defesas — estão FORA da janela
+        // de dias E já saíram do top-N do seu document_id (há >= keep versões mais
+        // novas). Desempate por id pra contagem determinística em changed_at igual.
+        $idsQuery = DB::table(self::TABLE . ' as h')
+            ->where('h.changed_at', '<', $cutoff)
+            ->whereRaw(
+                '(SELECT COUNT(*) FROM ' . self::TABLE . ' AS n
+                    WHERE n.document_id = h.document_id
+                      AND (n.changed_at > h.changed_at
+                           OR (n.changed_at = h.changed_at AND n.id > h.id))) >= ?',
+                [$keep],
+            )
+            ->select('h.id');
+
+        $matched = (clone $idsQuery)->count();
+
+        if ($matched === 0 || $dryRun) {
+            $this->info("Matched: {$matched} · total atual: {$totalBefore}" . ($dryRun ? ' (dry-run — nada deletado)' : ''));
+
+            return self::SUCCESS;
+        }
+
+        $ids = $idsQuery->pluck('id')->all();
+        $deleted = 0;
+        foreach (array_chunk($ids, $chunk) as $batch) {
+            $deleted += DB::table(self::TABLE)->whereIn('id', $batch)->delete();
+        }
+
+        $totalAfter = (int) DB::table(self::TABLE)->count();
+
+        Log::channel('copiloto-ai')->info('MemoryHistoryPrune concluído', [
+            'keep' => $keep,
+            'days' => $days,
+            'cutoff' => $cutoff->toIso8601String(),
+            'matched' => $matched,
+            'deleted' => $deleted,
+            'total_before' => $totalBefore,
+            'total_after' => $totalAfter,
+        ]);
+
+        $this->info(sprintf('Podadas: %d · antes: %d · depois: %d', $deleted, $totalBefore, $totalAfter));
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -72,6 +72,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\FreshnessCheckCommand::class, // GAP D7 #2 auditoria 2026-05-15 — freshness pipeline (4 níveis + drift + alert + reindex)
                 \Modules\Jana\Console\Commands\JanaDriftSentinelCommand::class, // Wave 23 §G2 — canary semanal drift Jana (faithfulness vs baseline)
                 \Modules\Jana\Console\Commands\RetentionPurgeCommand::class, // G1 P0 AUDIT-SENIOR-2026-05-25 — D7.d LGPD purge (Art. 16 + Art. 18 §VI)
+                \Modules\Jana\Console\Commands\MemoryHistoryPruneCommand::class, // incidente 2026-06-21 — poda preventiva de mcp_memory_documents_history (inflou 5 GB → cota → revogou escrita)
                 \Modules\Jana\Console\Commands\IndexRegenCommand::class, // regressão 2026-05-29 — gate integridade/priorização memory/INDEX.md (Tier 0 + links + contagens)
                 \Modules\Jana\Console\Commands\MeilisearchIndexSetupCommand::class, // 2026-05-29 — config-as-code dos embedders Meilisearch (Sprint 9b se perdeu)
                 \Modules\Jana\Console\Commands\ReconcileCommand::class, // ADR 0237 — jana:reconcile loop único (orquestra Reconcilers index/settings/content/deploy/eval)

--- a/Modules/Jana/Tests/Feature/MemoryHistoryPruneCommandTest.php
+++ b/Modules/Jana/Tests/Feature/MemoryHistoryPruneCommandTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * jana:memory-history-prune — poda preventiva de mcp_memory_documents_history
+ * (incidente 2026-06-21: tabela inflou pra 5 GB e derrubou prod por estourar a cota).
+ *
+ * Invariantes:
+ *  001. Preserva as últimas --keep versões por document_id (deleta as mais antigas).
+ *  002. Defesa temporal: tudo dentro de --days fica intocado, mesmo passando do top-N.
+ *  003. --dry-run não deleta nada.
+ *  004. Poda é POR document_id — não vaza entre docs.
+ *
+ * Dual-mode SQLite (pattern reference_tests_pest_canon): schema sintético mínimo.
+ * A query do comando é driver-agnóstica (subquery correlacionada, sem window fn).
+ *
+ * @see Modules\Jana\Console\Commands\MemoryHistoryPruneCommand
+ */
+beforeEach(function () {
+    if (DB::connection()->getDriverName() !== 'sqlite') {
+        test()->markTestSkipped('era-sqlite: schema sintético manual incompatível com MySQL persistente (quarentena Onda 2 SDD floor).');
+    }
+
+    Schema::dropIfExists('mcp_memory_documents_history');
+    Schema::create('mcp_memory_documents_history', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('document_id');
+        $t->string('slug', 200)->nullable();
+        $t->string('title', 250)->nullable();
+        $t->text('content_md')->nullable();
+        $t->timestamp('changed_at')->nullable();
+        $t->timestamp('created_at')->nullable();
+        $t->index(['document_id', 'changed_at'], 'mcp_mh_doc_changed_idx');
+    });
+});
+
+afterEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        Schema::dropIfExists('mcp_memory_documents_history');
+    }
+});
+
+/** Insere $n versões de um doc; changed_at = now()-($baseDays+i) dias (i=0 é a mais nova). */
+function seedHistory(int $documentId, int $n, int $baseDays): void
+{
+    $rows = [];
+    for ($i = 0; $i < $n; $i++) {
+        $rows[] = [
+            'document_id' => $documentId,
+            'slug' => "doc-{$documentId}",
+            'title' => "Doc {$documentId} v{$i}",
+            'content_md' => str_repeat('x', 100),
+            'changed_at' => now()->subDays($baseDays + $i),
+            'created_at' => now()->subDays($baseDays + $i),
+        ];
+    }
+    DB::table('mcp_memory_documents_history')->insert($rows);
+}
+
+it('MemoryHistoryPrune 001 — preserva as últimas --keep versões por doc', function () {
+    seedHistory(documentId: 1, n: 30, baseDays: 100); // 30 versões, todas > 90d
+
+    $exit = Artisan::call('jana:memory-history-prune', ['--keep' => 20, '--days' => 90]);
+    expect($exit)->toBe(0);
+
+    $restantes = DB::table('mcp_memory_documents_history')->where('document_id', 1)->count();
+    expect($restantes)->toBe(20); // 10 mais antigas podadas
+
+    // As preservadas são as 20 mais NOVAS (v0..v19); v20..v29 (as mais antigas) somem.
+    $titulos = DB::table('mcp_memory_documents_history')->where('document_id', 1)->pluck('title')->all();
+    expect($titulos)->toContain('Doc 1 v0')   // a mais nova — preservada
+        ->toContain('Doc 1 v19')               // 20ª mais nova — preservada
+        ->not->toContain('Doc 1 v20')          // 21ª — podada
+        ->not->toContain('Doc 1 v29');         // a mais antiga — podada
+});
+
+it('MemoryHistoryPrune 002 — janela de dias protege history quente (nada podado)', function () {
+    seedHistory(documentId: 1, n: 30, baseDays: 0); // 30 versões, todas dentro de 90d
+
+    $exit = Artisan::call('jana:memory-history-prune', ['--keep' => 20, '--days' => 90]);
+    expect($exit)->toBe(0);
+
+    // Todas dentro da janela → 0 podadas mesmo passando do top-20.
+    expect(DB::table('mcp_memory_documents_history')->where('document_id', 1)->count())->toBe(30);
+});
+
+it('MemoryHistoryPrune 003 — --dry-run não deleta nada', function () {
+    seedHistory(documentId: 1, n: 30, baseDays: 100);
+
+    $exit = Artisan::call('jana:memory-history-prune', ['--keep' => 20, '--days' => 90, '--dry-run' => true]);
+    expect($exit)->toBe(0);
+
+    expect(DB::table('mcp_memory_documents_history')->where('document_id', 1)->count())->toBe(30);
+});
+
+it('MemoryHistoryPrune 004 — poda é por document_id (não vaza entre docs)', function () {
+    seedHistory(documentId: 10, n: 25, baseDays: 100); // 25 antigas → perde 5
+    seedHistory(documentId: 20, n: 5, baseDays: 100);  // 5 antigas → top-N protege todas
+
+    $exit = Artisan::call('jana:memory-history-prune', ['--keep' => 20, '--days' => 90]);
+    expect($exit)->toBe(0);
+
+    expect(DB::table('mcp_memory_documents_history')->where('document_id', 10)->count())->toBe(20);
+    expect(DB::table('mcp_memory_documents_history')->where('document_id', 20)->count())->toBe(5);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -616,6 +616,28 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Defesa em profundidade — poda preventiva de mcp_memory_documents_history.
+        // Incidente 2026-06-21: o history append-only (snapshot do content inteiro por
+        // mudança) inflou pra 5 GB, estourou a cota do Hostinger e o provedor REVOGOU a
+        // escrita do ERP. Este cron mantém a tabela pequena DESDE O INÍCIO: por
+        // document_id preserva as últimas 20 versões + janela de 90d; o resto é
+        // descartável (git é a fonte canônica — ADR 0061). Sem flag de gate: é seguro
+        // e idempotente (não toca history quente). 03:20 BRT — sem disputa com
+        // retention-purge (03:00).
+        $schedule->command('jana:memory-history-prune')
+            ->dailyAt('03:20')
+            ->timezone('America/Sao_Paulo')
+            ->name('jana-memory-history-prune-daily')
+            ->withoutOverlapping(60)
+            ->environments(['live'])
+            ->appendOutputTo(storage_path('logs/jana-memory-history-prune.log'))
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule jana:memory-history-prune FALHOU — mcp_memory_documents_history ' .
+                    'pode voltar a inflar (investigar storage/logs/jana-memory-history-prune.log)'
+                );
+            });
+
         // MEM-FASE8 — esquecimento semanal (domingo 03:00).
         // Remove bloat (hits=0, >30d) + expirados (valid_until >90d) + órfãos MCP.
         // Soft-delete por padrão. Hard-delete LGPD só via comando manual com --hard.


### PR DESCRIPTION
## Fase 2 (1/2) — prevenir a reincidência do incidente 2026-06-21

A causa do estouro de cota (que fez o Hostinger revogar a escrita do ERP) foi a `mcp_memory_documents_history` **append-only sem teto**: cada mudança real de um doc grava um snapshot do `content_md` inteiro (mediumtext); docs quentes (CURRENT/TASKS/handoffs/CLAUDE) acumulam centenas de versões → 4.97 GB.

**Diagnóstico (verificado no código):** NÃO há bug de escrita espúria. O sync (`IndexarMemoryGitParaDb`) já deduplica por `content_md`, e `McpMemoryDocument::snapshotEAtualizar()` só grava history em mudança real. Faltava **retenção**.

## O que muda

- **`jana:memory-history-prune`** (diário 03:20 BRT) — por `document_id` preserva as últimas `--keep` (20) versões **+** janela `--days` (90); deleta só o que reprova AMBAS. Git é a fonte canônica de longo prazo ([ADR 0061](memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)). `--dry-run`, DELETE em lotes, skip se tabela ausente.
- Query **driver-agnóstica** (subquery correlacionada, sem window function) → roda em MariaDB prod **e** SQLite CI.
- Schedule no Kernel + registro no JanaServiceProvider. Sem flag de gate (poda é segura/idempotente — nunca toca history quente).
- **Pest** com 4 casos + entrada no `ci-sqlite-pest.list` → roda de verdade na lane SQLite.

## Validação

- `php -l` limpo nos 5 arquivos.
- **Lógica da query validada** contra SQLite in-memory nos 4 cenários (preserva-N, janela-protege, dry-run, isolamento-por-doc). Achado: a affinity do SQLite exige `keep` bound como **int** (`COUNT(*) >= '20'` texto é sempre falso) — que é exatamente o que o Laravel faz (`PDO::PARAM_INT`). Documentado.

## Preventivo, não reclaim

DELETE não devolve espaço InnoDB sem OPTIMIZE — mas aqui é **preventivo**: rodando diário desde já, a tabela nunca volta a inflar. O reclaim de uma vez (drop+recreate de 5 GB) já foi feito na resposta ao incidente.

Parte **2/2** (mover a memória do MCP pro CT 100) vem separada como **ADR proposta + runbook** — é decisão arquitetural que toca o MCP/recall vivo, então fica gated pra sua aprovação.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Infra Contract

<!-- evidence-override: mudança é um COMANDO AGENDADO (cron jana:memory-history-prune) + registro de Console command no JanaServiceProvider — não há rota/endpoint HTTP novo pra colar curl. Superfície de runtime validada por lint + Pest na lane SQLite + validação da query contra SQLite in-memory (4 cenários). -->

**Toca runtime crítico:** `app/Console/Kernel.php` (novo schedule diário) + `Modules/Jana/Providers/JanaServiceProvider.php` (registro de Console command). **Não há endpoint HTTP novo** — é um cron.

**Contrato:**
- `jana:memory-history-prune` agendado `dailyAt('03:20')` BRT, `environments(['live'])`, `withoutOverlapping(60)`, `onFailure` → ALERT em `copiloto-ai`. Slot 03:20 sem disputa com `jana:retention-purge` (03:00).
- **Sem flag de gate** (poda é segura/idempotente; preserva history quente; `--dry-run` disponível). Skip gracioso se a tabela não existir.
- **Reversível:** comando não-destrutivo de schema; remover o bloco do Kernel + a linha do ServiceProvider desfaz.
- **Validação:** `php -l` limpo (5 arquivos); lógica da query (subquery correlacionada) validada contra SQLite in-memory nos 4 cenários; Pest `MemoryHistoryPruneCommandTest` roda na lane `ci-sqlite-pest.list`. Comando idempotente — em prod o primeiro run só conta (tabela recém-recriada vazia).