### PR TITLE
fix(governance): mapeia colisão ADR 0294 no adr-alias-map (13→14)

### DIFF
--- a/governance/adr-alias-map.json
+++ b/governance/adr-alias-map.json
@@ -62,6 +62,10 @@
     "0246": [
       { "slug": "0246-sessao-2026-05-30-ds-harmonizacao", "hint": "harmonização DS sem perder qualidade + caminho v4.2" },
       { "slug": "0246-tipo-outros-default-migracoes-legacy", "hint": "tipo 'Outros' como default em migrações legacy" }
+    ],
+    "0294": [
+      { "slug": "0294-mcp-audit-log-hash-chain-tamper-evident", "hint": "mcp_audit_log tamper-evident por hash-chain SHA-256 (emenda 0084, padrão Ponto)" },
+      { "slug": "0294-metodo-dual-track-shapeup-catraca", "hint": "método de planejamento: dual-track + Shape Up travado por catraca" }
     ]
   }
 }


### PR DESCRIPTION
## O quê
Adiciona a colisão de número **0294** ao `governance/adr-alias-map.json`.

A 0294 era a **única das 14 colisões reais** de número de ADR ausente do alias-map (estava 13/14):
- `0294-mcp-audit-log-hash-chain-tamper-evident` — jana · mcp_audit_log tamper-evident por hash-chain SHA-256 (emenda 0084, padrão Ponto)
- `0294-metodo-dual-track-shapeup-catraca` — governance · dual-track + Shape Up travado por catraca

## Por quê
Origem: auditoria de saúde/integridade **2026-06-21** (dimensão *Ciclo de Vida de ADRs*). O índice gerado (`_INDEX-GENERATED.md`) já detectava a colisão 0294 a partir dos arquivos, mas o alias-map curado não tinha a entrada → dessincronia entre verdade-do-disco e mapa de desambiguação. Append-only respeitado (`_meta` intacto, nenhuma entrada removida).

## Validação
- JSON parseia; `collisions` 13 → 14, inclui 0294.
- `node scripts/governance/adr-index-generate.mjs`: `14 colisões · 0 alertas`, lista 0294 com os 2 slugs.
- Diff cirúrgico: **só** `governance/adr-alias-map.json`, +4 linhas, 0 removidas.

## Verificação adversarial (independente)
Verificador cético re-derivou as colisões do disco (301 ADRs → 14 colisões), reconciliou 1:1 com o alias-map (`MISSING: NONE · PHANTOM: NONE · slug-sets batem`), confirmou hints fiéis aos títulos reais e append-only preservado. **Aprovado.**

> **Caveat honesto (follow-up):** o `adr-index-generate.mjs` **não lê** o alias-map (o "0 alertas" é de integridade de supersessão), então **não há gate de CI** travando esse sync hoje — só a receita manual em `_meta.verify`. Candidato a follow-up: um check que falhe se `collisions` ≠ colisões auto-detectadas.

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
