### PR TITLE
fix(ci): comentário de regressão visual distingue enforcing de advisory

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -277,7 +277,9 @@ jobs:
             const body = [
               '## 📸 Visual Regression Detected',
               '',
-              'Screenshots têm diff > threshold contra baseline. Este check é REQUIRED — o PR não mergeia vermelho.',
+              'Screenshots têm diff > threshold contra baseline no **gate real** (Pest Browser smoke: telas públicas + auth-bridge + a11y axe + conformance). Esse check é **REQUIRED** — o PR não mergeia vermelho.',
+              '',
+              '> ℹ️ Distinção honesta: o **pixel-diff núcleo-6** (camada de diff de pixel das telas núcleo-6 — Onda Q4 · ADR 0261) é **ADVISORY** (`continue-on-error`) e **não bloqueia merge sozinho** — só vira enforcing após 2 verdes. Se a falha foi apenas dele, o veredito sai no log do step "Veredito advisory do pixel-diff", não neste comentário.',
               '',
               '### Como resolver',
               '1. Baixar artifact `screenshots-diff` deste workflow run',


### PR DESCRIPTION
## O quê
Torna **honesto** o comentário automático de PR do `visual-regression.yml`.

O texto antigo dizia genericamente: *"Screenshots têm diff > threshold... Este check é REQUIRED — o PR não mergeia vermelho."* — induzindo a crer que toda regressão visual bloqueia o merge.

## Por quê
Achado na auditoria de saúde/integridade **2026-06-21** (dimensão *Honestidade dos gates CI*). A realidade do workflow:
- **Enforcing (REQUIRED):** step `Run Pest Browser tests` (id `pest-browser`) — sem `continue-on-error` → falha = job vermelho = bloqueia.
- **ADVISORY:** step `Pixel-diff núcleo-6` (id `pixel-diff`) — `continue-on-error: true` (linha 233, Onda Q4 · ADR 0261) → **não bloqueia sozinho**.

O comentário só dispara em `failure() || pest-browser.fail` (gate real), mas o texto se vendia como se o pixel-diff também fosse bloqueante. Agora distingue os dois.

## Validação
- `python yaml.safe_load`: **YAML OK** (job `visual-regression`).
- Diff cirúrgico: **só** `.github/workflows/visual-regression.yml`, +3/−1, **apenas** texto dentro do array `body`. Nenhuma chave de lógica (`run`/`if`/`uses`/`continue-on-error`/`name`/`id`) alterada.

## Verificação adversarial (independente)
Verificador cético confirmou: escopo OK (22 steps == 22 steps, só `body` mudou), YAML parseia, e **todas as 4 afirmações batem com o comportamento real** (pest-browser sem continue-on-error = gate real; pixel-diff com continue-on-error:true = advisory; `if:` do comentário = `failure() || pest-browser.fail`; ADR 0261 e o step "Veredito advisory do pixel-diff" existem — nada inventado). **Aprovado sem ressalvas.**

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
