### PR TITLE
feat(governance): exceção append-only p/ migração legacy→canônico de frontmatter ADR (ADR 0297)

### DIFF
--- a/.github/workflows/governance-gate.yml
+++ b/.github/workflows/governance-gate.yml
@@ -112,8 +112,47 @@ jobs:
           echo "norm_ok=$ok" >> "$GITHUB_OUTPUT"
           if [ "$ok" = "1" ]; then echo "✓ Normalização cirúrgica validada (ADR 0257) — exceção aplicada."; fi
 
+      - name: Exceção — migração legacy→canônico de frontmatter de ADR (ADR 0297)
+        id: legacymig
+        if: steps.detect.outputs.adr_mod_count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Exceção append-only 0297 (emenda operacional de 0257): migração de
+          # frontmatter legacy→canônico (adr→slug/number/type, deciders→decided_by,
+          # date→decided_at, references→related, +authority). Protege a DECISÃO
+          # exigindo que o CORPO (tudo após o frontmatter) seja BYTE-IDÊNTICO.
+          # Sob label dedicado 'adr-legacy-schema-migration'.
+          labels=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels" --jq '.[].name' 2>/dev/null || echo "")
+          if ! echo "$labels" | grep -qFx "adr-legacy-schema-migration"; then
+            echo "legacymig_ok=0" >> "$GITHUB_OUTPUT"
+            echo "Label 'adr-legacy-schema-migration' ausente — exceção 0297 não aplica."
+            exit 0
+          fi
+          base_sha="${{ github.event.pull_request.base.sha }}"
+          # Corpo = tudo após o 2º fence '---' do frontmatter (preserva '---' do corpo).
+          body_of() { awk 'BEGIN{c=0} /^---$/ && c<2 {c++; next} c>=2 {print}' "$1"; }
+          ok=1
+          while IFS= read -r line; do
+            file=$(echo "$line" | sed -E 's/^M[[:space:]]+//')
+            [ -z "$file" ] && continue
+            if ! git show "$base_sha:$file" > /tmp/base_adr.md 2>/dev/null; then
+              echo "::warning::$file — sem versão na base; exceção 0297 é só pra migração de ADR existente."
+              ok=0; continue
+            fi
+            body_of /tmp/base_adr.md > /tmp/base_body.txt
+            body_of "$file" > /tmp/head_body.txt
+            if ! diff -q /tmp/base_body.txt /tmp/head_body.txt >/dev/null 2>&1; then
+              echo "::warning::$file — CORPO da decisão mudou; exceção 0297 exige corpo byte-idêntico (só frontmatter pode migrar)."
+              ok=0
+            fi
+          done < /tmp/adr_mod.txt
+          echo "legacymig_ok=$ok" >> "$GITHUB_OUTPUT"
+          if [ "$ok" = "1" ]; then echo "✓ Migração legacy→canônico validada (ADR 0297) — corpo intacto, exceção aplicada."; fi
+
       - name: Block ADR canon edits (append-only)
-        if: steps.detect.outputs.adr_renamed_count != '0' || (steps.detect.outputs.adr_mod_count != '0' && steps.norm.outputs.norm_ok != '1')
+        if: steps.detect.outputs.adr_renamed_count != '0' || (steps.detect.outputs.adr_mod_count != '0' && steps.norm.outputs.norm_ok != '1' && steps.legacymig.outputs.legacymig_ok != '1')
         run: |
           set -euo pipefail
           echo "::error::ADR CANON é append-only (Constituição Art. 3 + ADR 0095)."

--- a/memory/decisions/0297-excecao-append-only-migracao-legacy-frontmatter-adr.md
+++ b/memory/decisions/0297-excecao-append-only-migracao-legacy-frontmatter-adr.md
@@ -1,0 +1,99 @@
+---
+slug: 0297-excecao-append-only-migracao-legacy-frontmatter-adr
+number: 297
+title: "Exceção append-only: migração legacy→canônico de frontmatter de ADR sob label, corpo byte-idêntico (emenda 0257)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-06-21"
+module: governance
+kind: meta
+supersedes: []
+related:
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0095-skills-tiers-convencao-interna
+  - 0256-knowledge-survival-meia-vida-catraca-sentinela
+  - 0257-adr-status-lifecycle-kind-modelo-canonico
+  - 0258-processo-adr-estado-arte-indice-gerado-supersede-atomico
+---
+
+# ADR 0297 — Exceção append-only: migração legacy→canônico de frontmatter de ADR
+
+> **Emenda operacional da [ADR 0257](0257-adr-status-lifecycle-kind-modelo-canonico.md).** 0257 protege a
+> decisão e libera consertar a *etiqueta*, mas só criou exceção para `status/lifecycle/kind/authority`.
+> Esta ADR estende a mesma filosofia para o **rename de campos** dos ADRs pré-Constituição v2 (legacy),
+> com uma salvaguarda mais forte: o corpo da decisão tem que ser **byte-idêntico**.
+
+## Contexto
+
+Auditoria 2026-06-21 (sentinela `memory-health` Check L — integridade proposto×realizado, [ADR 0256](0256-knowledge-survival-meia-vida-catraca-sentinela.md))
+listou ADRs **vivo-mas-proposto**: decisões já realizadas em código mas com `status: proposed/proposto`.
+A maioria foi ratificada (proposto→aceito) sem atrito porque já estava em formato canônico.
+
+Sobraram **3 ADRs legacy** (`0123-modules-arquivos-backbone`, `0124-curador-conhecimento-pipeline`,
+`0189-pageheader-canon-v3-1-cadastro-roxo`) com frontmatter pré-canônico:
+`adr:` (em vez de `slug`+`number`+`type`), `deciders: [Wagner]` (em vez de `decided_by: [W]`),
+`date:` (em vez de `decided_at:`), `references:` (em vez de `related:`), `status: proposed`,
+`lifecycle: active`, e sem `authority`.
+
+**O deadlock estrutural:**
+- O gate `block-adr-edits` (`.github/workflows/governance-gate.yml`, Constituição Art. 3) só libera
+  edição de ADR existente sob o label `adr-metadata-normalization`, e mesmo assim apenas mudanças em
+  `status|lifecycle|kind|authority|superseded_by|supersedes` + itens de lista que começam com dígito.
+  Migrar `adr→slug/number/type`, `deciders→decided_by`, etc. cai **fora** dessa exceção → bloqueado.
+- O outro lado do torniquete: mudar **só** `status: proposed→aceito` (o que a exceção 0257 permite)
+  faz o `memory-schema-gate` revalidar o arquivo inteiro e **reprovar** por faltarem 6 campos
+  obrigatórios (`slug/number/type/authority/decided_by/decided_at`).
+
+Resultado: ADR legacy **não pode** virar schema-válido sem uma edição não-normalização, e edição
+não-normalização é bloqueada. Evidência de que a parede já travou alguém: `scripts/fix_adr_legacy_schema.py`
+existe, tem como `TARGETS` exatamente `0122..0126`, está hardcoded para um worktree antigo e **nunca landou**.
+
+## Decisão
+
+Adicionar uma **segunda exceção cirúrgica** ao gate `block-adr-edits`, sob o label dedicado
+**`adr-legacy-schema-migration`**, que libera a migração completa de frontmatter legacy→canônico
+**desde que o corpo da decisão seja byte-idêntico** entre a base e o HEAD do PR.
+
+Invariante (mais forte que a checagem por-linha da 0257):
+
+```
+corpo(base) ≡ corpo(head)   onde corpo = tudo após o 2º fence '---' do frontmatter
+```
+
+Se o corpo mudou um único byte, a exceção **não aplica** e o append-only bloqueia normalmente.
+Isso honra a Constituição Art. 3 ao pé da letra: **a decisão é imutável; só a etiqueta migra.**
+
+Implementação (step `legacymig` em `governance-gate.yml`): exige o label, extrai o corpo de cada ADR
+modificado via `awk` (preservando `---` do corpo), compara `base` vs `head` com `diff -q`, e só marca
+`legacymig_ok=1` se todos os corpos forem idênticos. O step de bloqueio passa a falhar apenas quando
+**nenhuma** das duas exceções (0257 metadados OU 0297 migração) se aplica.
+
+Regras de uso:
+- Label `adr-legacy-schema-migration` aplicado **conscientemente** no PR (mesma disciplina do label 0257).
+- 1 PR de migração ≠ PR de decisão nova (commit-discipline). A migração não pode alterar o corpo.
+- `rename` de arquivo continua **proibido** (ADR mantém número/slug = nome do arquivo).
+
+## Consequências
+
+**Positivas:**
+- Destrava a migração dos 3 ADRs legacy → fecha o débito do Check L de forma honesta (não no leitor).
+- Salvaguarda forte e simples (hash de corpo) — mais difícil de burlar que allowlist por-linha.
+- Os ADRs legacy entram no regime do `memory-schema-gate` (validados como os novos).
+
+**Negativas / riscos:**
+- Mais uma exceção no gate Tier-0 = mais superfície. Mitigado pelo label consciente + corpo-idêntico.
+- Não cobre ADRs cujo *corpo* também precise de normalização (raro; esses seguem o caminho supersede).
+
+## Alternativas consideradas
+
+1. **Superseder com ADR nova** (caminho que o próprio gate sugere): deixar os legacy imutáveis e criar
+   ADRs novas que os supersedem. Rejeitado: polui a numeração e duplica decisões **já realizadas** —
+   supersede é para mudar a decisão, não para corrigir a etiqueta.
+2. **Normalizar só no leitor** (como o `adr-index-generate` já faz com status/lifecycle): o débito do
+   Check L "some" sem tocar o arquivo. Rejeitado como solução única: o `memory-schema-gate` segue cego
+   a esses arquivos e a base canônica mantém duas gramáticas de frontmatter indefinidamente.
+3. **Ampliar a allowlist por-linha da 0257** para incluir os campos legacy. Rejeitado: frágil (cada
+   campo novo vira regex) e mais fácil de burlar que a checagem de corpo-idêntico.

--- a/memory/decisions/_INDEX-GENERATED.md
+++ b/memory/decisions/_INDEX-GENERATED.md
@@ -5,10 +5,10 @@
 > Status/lifecycle normalizados no leitor (ADR 0257) — não altera os arquivos (append-only).
 
 ## Resumo
-- **301** arquivos · **285** números únicos · máx **0295**
-- **ADRs ATIVOS (lifecycle ativo): 261** ← resposta única a "quantos ADRs ativos"
-- Por status: aceito 238 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
-- Por lifecycle: ativo 261 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
+- **302** arquivos · **286** números únicos · máx **0297**
+- **ADRs ATIVOS (lifecycle ativo): 262** ← resposta única a "quantos ADRs ativos"
+- Por status: aceito 239 · proposto 36 · superseded 23 · (vazio) 2 · rascunho 1 · recusado 1
+- Por lifecycle: ativo 262 · substituido 23 · (vazio) 8 · arquivado 6 · historical 3
 - Sem frontmatter (formato-tabela legado): 4 — 0126, 0128, 0246, 0247
 
 ## Colisões de número (14) — auto-detectadas
@@ -33,7 +33,7 @@ _(íntegra)_
 ## Recusadas (1) — o NÃO consultável
 - **0290** v0 'Fidelity Lock' (screenshot pareado em CI) — RECUSADO: fidelidade visual não  · recusada 2026-06-18 — Inviável + tautológico + backdoor de prosa (3 motivos na Decisão). REABRE só se surgir um check de fidelidade HERMÉTICO 
 
-## Todas as ADRs (301)
+## Todas as ADRs (302)
 | Nº | Status | Lifecycle | Kind | Título |
 |---|---|---|---|---|
 | 0001 | superseded | substituido | decision | Estender UltimatePOS em vez de build próprio ou fork |
@@ -337,3 +337,4 @@ _(íntegra)_
 | 0294 | aceito | ativo | decision | mcp_audit_log tamper-evident por hash-chain SHA-256 (cadeia global) — transplant |
 | 0294 | aceito | ativo | decision | Método de planejamento: dual-track + Shape Up travado por catraca (incubadora →  |
 | 0295 | aceito | ativo | decision | aceitar e implementar bi-temporal event-time na memoria Jana (ratifica desenho 0 |
+| 0297 | aceito | ativo | meta | Exceção append-only: migração legacy→canônico de frontmatter de ADR sob label, c |


### PR DESCRIPTION
## Por que (o deadlock)

A sentinela **Check L** (proposto×realizado, ADR 0256) listou ADRs *vivo-mas-proposto*. A maioria foi ratificada sem atrito (já eram canônicos). Sobraram **3 ADRs legacy** (`0123`, `0124`, `0189`) com frontmatter pré-Constituição v2 (`adr:`/`deciders:`/`date:`/`references:`/`proposed`/`active`, sem `authority`) que **não migram** pelos gates atuais:

- `block-adr-edits` (append-only, Art. 3) só libera `status|lifecycle|kind|authority|superseded_by|supersedes`. O rename `adr→slug/number/type`, `deciders→decided_by`, etc. cai **fora** → bloqueado.
- Mudar **só** o `status` faz o `memory-schema-gate` reprovar por **faltarem 6 campos obrigatórios**. E adicioná-los é bloqueado pelo append-only.

Deadlock real. Evidência de que já travou alguém: `scripts/fix_adr_legacy_schema.py` tem como TARGETS exatamente `0122..0126`, hardcoded a um worktree antigo, **nunca landou**.

## O que muda

Segunda exceção cirúrgica no `block-adr-edits`, sob o label **`adr-legacy-schema-migration`**, que libera a migração completa de frontmatter legacy→canônico **desde que o corpo da decisão seja byte-idêntico** entre base e HEAD:

```
corpo(base) ≡ corpo(head)   (corpo = tudo após o 2º fence '---')
```

Salvaguarda mais forte que a allowlist por-linha da 0257 (hash de corpo > regex por campo). Honra a Constituição Art. 3 ao pé da letra: **a decisão é imutável; só a etiqueta migra.** O bloqueio só dispara quando **nenhuma** das duas exceções (0257 metadados OU 0297 migração) aplica.

## Conteúdo
- `memory/decisions/0297-...md` — ADR Nygard (emenda operacional de 0257; alternativas consideradas: supersede / só-no-leitor / ampliar allowlist — todas rejeitadas com motivo).
- `.github/workflows/governance-gate.yml` — step `legacymig` + condição do bloqueio atualizada.
- `_INDEX-GENERATED.md` — regenerado (302 ADRs).

## Validação local
- `adr-index-generate --check` ✓ (índice em dia)
- YAML do gate parseia, steps `detect/norm/legacymig` ✓
- frontmatter 0297 completo + slugs válidos ✓
- lógica corpo-byte-idêntico testada contra os 3 ADRs do PR-2 → aprovaria os 3 (corpos 251/215/138 linhas idênticos)

## Sequência
**PR-1 de 2.** PR-2 (migração de 0123/0124/0189, status→aceito, fecha o débito do Check L) usa esta exceção e só pode mergear **depois** deste landar — `pull_request` roda o workflow da branch base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)