### PR TITLE
fix(docs): corrige 5 links internos quebrados (slug + profundidade)

### DIFF
--- a/.claude/rules/reuse-check.md
+++ b/.claude/rules/reuse-check.md
@@ -35,4 +35,4 @@ npm run reuse:check "<nome ou o que faz>"
 
 O gate `reuse-gate.yml` (CI) falha o PR em **duplicata NOVA** (ratchet, baseline em `scripts/reuse-duplicates-baseline.json`). Se a duplicata for legítima: `npm run reuse:baseline:write` consciente + justificativa no PR.
 
-Refs: `scripts/reuse-index.mjs` · MANUAL-CSS-JS #5 · [ADR 0240](../../memory/decisions/0240-task-ledger-evidencia-antifragilidade.md) (derivado>escrito).
+Refs: `scripts/reuse-index.mjs` · MANUAL-CSS-JS #5 · [ADR 0240](../../memory/decisions/0240-task-ledger-git-native-cowork-code.md) (derivado>escrito).

--- a/memory/requisitos/Auditoria/SPEC.md
+++ b/memory/requisitos/Auditoria/SPEC.md
@@ -36,9 +36,9 @@ Módulo de governança que reusa `spatie/laravel-activitylog` (já instalado) + 
 
 ## Stack
 
-- **`spatie/laravel-activitylog ^4.8`** — já em [composer.json:47](../../composer.json#L47)
+- **`spatie/laravel-activitylog ^4.8`** — já em [composer.json:47](../../../composer.json#L47)
 - Tabela `activity_log` — já existe + `business_id` (migrations 2019/2021/2023)
-- Padrão de configuração canônico do projeto: [Modules/Financeiro/Models/Titulo.php:28-35](../../Modules/Financeiro/Models/Titulo.php#L28) — `LogOptions::defaults()->logOnly([...])->logOnlyDirty()->dontSubmitEmptyLogs()->useLogName('domain.subdomain')`
+- Padrão de configuração canônico do projeto: [Modules/Financeiro/Models/Titulo.php:28-35](../../../Modules/Financeiro/Models/Titulo.php#L28) — `LogOptions::defaults()->logOnly([...])->logOnlyDirty()->dontSubmitEmptyLogs()->useLogName('domain.subdomain')`
 - Inertia v3 + React 19 (Pages padrão MWART, [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md))
 - Lib diff JSON: avaliar `react-diff-viewer-continued` na implementação (não decidido)
 
@@ -53,7 +53,7 @@ Backlog de user stories (US-AUDIT-*) organizado em 3 sub-sprints sequenciais.
 | US-AUDIT-001 | Trait `LogsActivity` em `App\Transaction` com `logOnly(['status','total_before_tax','final_total','contact_id','location_id','transaction_date','payment_status'])` + `useLogName('sales.transaction')`. Pest test: criar venda → entry em `activity_log` com `event=created` + `properties.attributes` preenchidas | p0 | 1.5h | — |
 | US-AUDIT-002 | Trait em `App\TransactionSellLine` + `App\TransactionPayment` (`logOnly` campos críticos: `quantity`, `unit_price_inc_tax`, `amount`, `method`). Pest: alterar pagamento → log com diff | p0 | 1h | US-AUDIT-001 |
 | US-AUDIT-003 | Trait em `App\Product` + `App\VariationLocationDetails` (estoque) — `logOnly(['sku','name','sell_price_inc_tax','enable_stock'])` no Product e `logOnly(['qty_available'])` no VLD. Pest: ajuste de estoque → log linha por VLD afetada | p1 | 1.5h | — |
-| US-AUDIT-004 | Trait em `App\Contact` com `logOnly(['name','email','mobile','contact_type','customer_group_id'])` — **`tax_number_1` NÃO entra** (PII LGPD). Pest assert: dump de log não contém CPF/CNPJ. Substitui `activity()->log('add_contact')` manual em [ContactController.php](../../app/Http/Controllers/ContactController.php) | p0 | 2h | — |
+| US-AUDIT-004 | Trait em `App\Contact` com `logOnly(['name','email','mobile','contact_type','customer_group_id'])` — **`tax_number_1` NÃO entra** (PII LGPD). Pest assert: dump de log não contém CPF/CNPJ. Substitui `activity()->log('add_contact')` manual em [ContactController.php](../../../app/Http/Controllers/ContactController.php) | p0 | 2h | — |
 
 **Subtotal Sprint 1 — ~6h IA-pair**
 

--- a/memory/requisitos/Repair/SPEC.md
+++ b/memory/requisitos/Repair/SPEC.md
@@ -115,7 +115,7 @@ Quando um IP faz mais de N requests/minuto
 Então recebe 429 Too Many Requests + log estruturado `repair.public_status.checked`
 ```
 
-**Implementação proposta (backlog Wave 4):** middleware `throttle:30,1` no grupo top-level que envolve `Route::get('/repair-status', ...)` e `Route::post('/post-repair-status', ...)` em [Modules/Repair/Routes/web.php](../../Modules/Repair/Routes/web.php) linhas 3-4. Hoje SEM throttle explícito — apenas throttle global Laravel via `RouteServiceProvider` (60 req/min padrão).
+**Implementação proposta (backlog Wave 4):** middleware `throttle:30,1` no grupo top-level que envolve `Route::get('/repair-status', ...)` e `Route::post('/post-repair-status', ...)` em [Modules/Repair/Routes/web.php](../../../Modules/Repair/Routes/web.php) linhas 3-4. Hoje SEM throttle explícito — apenas throttle global Laravel via `RouteServiceProvider` (60 req/min padrão).
 **Risco:** scraping massivo de OS expõe pattern de numeração + telefone redact incompleto.
 **Ver:** [PII-LGPD.md §"Pontos críticos"](PII-LGPD.md), [OBSERVABILITY.md §"repair_public_status_abuse"](OBSERVABILITY.md).
 **Testado em:** _(pendente — Pest test 31 requests retorna 429)_


### PR DESCRIPTION
## O quê
Corrige **5 links internos quebrados** em 3 docs vivos (não-canon):

| Arquivo | Defeito | Correção |
|---|---|---|
| `.claude/rules/reuse-check.md` | slug ADR 0240 defasado (alvo 404) | → `0240-task-ledger-git-native-cowork-code.md` |
| `memory/requisitos/Auditoria/SPEC.md` | 3 links repo-root com profundidade `../../` (caíam em `memory/`) | → `../../../` (composer.json, Titulo.php, ContactController.php) |
| `memory/requisitos/Repair/SPEC.md` | 1 link idem | → `../../../Modules/Repair/Routes/web.php` |

## Por quê
Achado na auditoria de saúde/integridade **2026-06-21** (batedor de links). Defeitos reais: os slugs/paths antigos retornavam 404.

## Validação
- Os **5 destinos novos resolvem** para arquivos reais (resolução relativa a partir do dir de cada doc: `.claude/rules/` = 2 níveis, `memory/requisitos/<Mod>/` = 3 níveis).
- Os **5 destinos antigos eram quebrados** em `origin/main` (confirmado).
- O link **correto** `[ADR 0104](../../decisions/0104-...)` (resolve p/ `memory/decisions/`) foi **preservado** — não virou `../../../`.
- Diff cirúrgico: 3 arquivos, 5↔5 linhas, **só texto de link**.

## Verificação adversarial (independente)
Verificador cético confirmou: escopo (3 arquivos, 5/5, zero conteúdo/decisão), todos os links novos resolvem, todos os velhos eram quebrados, link correto preservado, **nenhum corpo de ADR canon tocado** (append-only respeitado), e identidade do 0240 conferida no frontmatter (`number: 240`). **Aprovado.**

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
