### PR TITLE
feat(governance): gitleaks full-history scan + .gitleaks.toml (Onda 1 · segredos)

### DIFF
--- a/.github/workflows/gitleaks-history.yml
+++ b/.github/workflows/gitleaks-history.yml
@@ -1,0 +1,43 @@
+# Gitleaks — full git-history scan (4º portão do four-gate model · ADR 0215)
+#
+# O portão `secret-scan` (governance-gate-umbrella.yml) já cobre o DIFF do PR
+# (linhas novas). Este complementa com o **histórico completo** — pega segredo
+# que JÁ ESTÁ no git (dívida 2026-06-07: ~10 arquivos com valor em claro) e
+# qualquer um que tenha escapado antes do gate de PR existir.
+#
+# ADVISORY por design: `continue-on-error: true`. A dívida histórica não some
+# sem reescrever história (decisão do Wagner) — então a run NÃO fica vermelha
+# crônica; o relatório (step summary + artefato SARIF) é o sinal acionável.
+# Promoção a bloqueante/ratchet (falhar só em achado NOVO vs baseline) = follow-up.
+#
+# Config + allowlist: .gitleaks.toml na raiz (compartilhado com o scan de PR).
+
+name: Gitleaks — histórico completo (advisory)
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'   # toda segunda 09:00 UTC (06:00 BRT)
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  history-scan:
+    name: gitleaks detect (histórico completo)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # histórico inteiro (sem isto, scan parcial)
+
+      # Evento schedule/workflow_dispatch → gitleaks-action roda `detect` (full history).
+      # Lê .gitleaks.toml da raiz automaticamente. Licença não exigida (user account).
+      - name: Run gitleaks (full history detect)
+        uses: gitleaks/gitleaks-action@v2
+        continue-on-error: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
+          GITLEAKS_ENABLE_SUMMARY: "true"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,37 @@
+# gitleaks config — oimpresso
+# Compartilhado pelos dois portões gitleaks:
+#   - secret-scan (PR diff)         · .github/workflows/governance-gate-umbrella.yml
+#   - gitleaks-history (full scan)  · .github/workflows/gitleaks-history.yml
+# Completa o "four-gate model" da governança de segredos (ADR 0215, camada 1).
+#
+# REGRA: o allowlist abaixo cobre SÓ falso-positivo determinístico (lock files,
+# exemplos, fixtures). NÃO inclui arquivos que carregam segredo REAL — esses
+# DEVEM flagar pra rotação (ex: memory/_INDEX-SECRETS.md, dívida 2026-06-07).
+
+title = "oimpresso gitleaks"
+
+[extend]
+# Herda as ~170 regras default do gitleaks (AKIA, Bearer, PEM, etc).
+useDefault = true
+
+[allowlist]
+description = "Falsos-positivos conhecidos — NÃO mascara segredo real."
+
+# Arquivos de exemplo/template e lock files (nunca carregam segredo vivo).
+paths = [
+  '''\.env\.example$''',
+  '''\.env - Copia\.example$''',
+  '''\.env\.[a-z]+\.example$''',
+  '''(^|/)package-lock\.json$''',
+  '''(^|/)pnpm-lock\.yaml$''',
+  '''(^|/)composer\.lock$''',
+  '''(^|/)yarn\.lock$''',
+  '''(^|/).*\.(test|spec)\.(php|ts|tsx|mjs|js)$''',
+  '''(^|/)tests?/.*[Ff]ixtures?/''',
+  '''(^|/)scripts/legacy-migration/\.venv/''',
+]
+
+# Marcadores explícitos de valor fake em fixtures/docs (placeholder, exemplo).
+regexes = [
+  '''(?i)(example|exemplo|fake|dummy|placeholder|changeme|your[-_]?token|xxx+|<[a-z_]+>)''',
+]

--- a/scripts/governance/gates-registry.json
+++ b/scripts/governance/gates-registry.json
@@ -18,6 +18,10 @@
       "nome": "Jana audit-chain Pest (T5 · hash-chain mcp_audit_log lógica pura · ADR 0294)",
       "classe": "gate"
     },
+    "gitleaks-history.yml": {
+      "nome": "Gitleaks histórico completo (4º portão four-gate · full-history detect · advisory · ADR 0215)",
+      "classe": "automacao"
+    },
     "a11y-axe-gate.yml": {
       "nome": "A11y axe runtime (jsdom · componentes canon)",
       "classe": "gate"


### PR DESCRIPTION
## Onda 1 — frente segredos (4º portão do four-gate model)

A auditoria de maturidade (knowledge-arch, gap #2 P0) pedia "gitleaks + history-scan". **Verificado o estado real:** o gitleaks **já existe** pra PR-diff (`secret-scan` em `governance-gate-umbrella.yml`, advisory) e o pre-commit roda `secrets:scan --diff-only` — o dossiê estava parcialmente stale nesse ponto. O que **faltava** era o 3º portão: **scan do histórico completo**.

### O que entra
- **`.github/workflows/gitleaks-history.yml`** — `gitleaks detect` full-history (semanal + `workflow_dispatch`), **advisory** (`continue-on-error`). Pega a dívida que já está no git (2026-06-07, ~10 arquivos) + qualquer segredo anterior ao gate de PR. Relatório SARIF + step summary é o sinal acionável — não fica vermelho crônico (a dívida histórica não some sem reescrever história = decisão sua).
- **`.gitleaks.toml`** — config compartilhada pelos dois portões. `useDefault=true` + allowlist conservador (lock/example/fixtures). **NÃO allowlista `_INDEX-SECRETS.md`** de propósito — quero que a dívida flague.

### Fora de escopo (sua ação)
- **Rotação dos segredos vivos** (MinIO key, token Hostinger EXPIRED, 3 "falta Vault") — credencial externa, só você rotaciona. O history-scan vai te dar a lista exata.
- **Promover `secret-scan` a required** — calendário ADR 0271.

### Validação local
- YAML do workflow parseia (triggers schedule+dispatch, gitleaks-action@v2) ✓
- TOML do config parseia (useDefault + 10 paths + 1 regex allowlist) ✓

Parte de **Onda 1** dos gaps cruzados das 3 auditorias. Próximas frentes: refutador-no-baseline · sentinela transporte CT100→main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)