### PR TITLE
chore(governance): sanear anchored_dead Jana+NfeBrasil + placeholders (SA-A4 fatia 1/3)

### DIFF
--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -943,7 +943,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 **Quero** Langfuse v3 self-host em CT 100 (docker-compose: web + worker + ClickHouse + Postgres + Redis + MinIO) instrumentando 100% das chamadas LLM em prod (BriefDiarioAgent + kb-answer + recall + RAGAS gate)
 **Para** ter observability LLM real (trace + cost + latency + RAGAS metrics) — sem isso, claims de "95%+" são não-falsificáveis (princípio 4 Constituição v2). Destrava medição de R1 (reranker NDCG), K1 (time-decay impact), A1 (auto-summary ROI), RAGAS gate trend semanal
 
-**Implementado em:** `infra/ct100/langfuse/docker-compose.yml` (novo) + `Modules/Jana/Ai/Services/LangfuseClient.php` (já existe wrapper) instrumentado em `BriefDiarioAgent` + `KbAnswerService` + `MeilisearchDriver` + Console Command `jana:rag-eval` (RAGAS gate)
+**Implementado em:** _parcial_ · `Modules/Jana/Services/Telemetry/LangfuseClient.php` · `docker/langfuse/docker-compose.yml` · verificado@08c4a8f (2026-06-21) — wrapper + compose existem; falta instrumentar `BriefDiarioAgent`/`KbAnswerAgent`/`MeilisearchDriver` e subir stack CT 100 (DoD ainda aberto)
 
 **Definition of Done:**
 - [ ] Stack Langfuse v3 rodando CT 100 atrás Traefik HTTPS (subdomínio `langfuse.oimpresso.com` interno) — receita `proxmox-docker-host` skill
@@ -1004,7 +1004,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 **Quero** `MeilisearchDriver` retornar score composto (relevance × 0.6 + recency × 0.3 com half-life 90d + importance × 0.1) com decay rate 0 pra ADR `lifecycle: accepted` e 0.5 pra `historical`/superseded
 **Para** documentos canônicos recentes vencerem antigos no recall — fechando gap Knowledge R5 (0%→75%) que hoje mistura regras vigentes com revogadas em queries multi-dia
 
-**Implementado em:** `Modules/Jana/Services/Memoria/MeilisearchDriver.php` — novo método `applyTemporalScoring()` aplicado após reranker (US-COPI-107) na chain hybrid recall
+**Implementado em:** _pendente_ — método `applyTemporalScoring()` ainda não existe no `MeilisearchDriver`; depende de US-COPI-107 (reranker) e US-COPI-108 (Langfuse) pra medir ganho NDCG (status todo)
 
 **Definition of Done:**
 - [ ] Função composite `score = relevance×0.6 + recency_decay(age_days, lifecycle)×0.3 + importance×0.1` documentada
@@ -1035,7 +1035,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 **Quero** rota `/copiloto/admin/roadmap` com Gantt visual cronológico (SVAR React Gantt MIT) + sub-issues hierarchy view (parent_task_id) + drag-drop datas + filtro current cycle default
 **Para** fechar gap Viz (5%→70%) — listas markdown via tools MCP não mostram cronologia/dependências; Linear/Plane/GitHub Projects vão 5 anos à frente em viz
 
-**Implementado em:** novo `Modules/Jana/Http/Controllers/Admin/RoadmapController.php` + `Modules/Jana/Http/Resources/RoadmapTaskResource.php` + `resources/js/Pages/Admin/Roadmap/Index.tsx` + `_components/RoadmapGantt.tsx` + `_components/SubIssuesPanel.tsx` + `Index.charter.md`
+**Implementado em:** _parcial_ · `Modules/Jana/Http/Controllers/Admin/RoadmapController.php` · `resources/js/Pages/ProjectMgmt/Roadmap/Index.tsx` · verificado@08c4a8f (2026-06-21) — controller + página existem; falta RoadmapTaskResource + componentes Gantt SVAR (RoadmapGantt, SubIssuesPanel) + charter (Gantt visual não construído)
 
 **Definition of Done:**
 - [ ] npm dep `@svar-widgets/react-gantt` (MIT, ~80KB, React 19 nativo — rejeitado DHTMLX/Bryntum/Frappe por licença ou bundle)
@@ -1070,7 +1070,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 **Quero** tool MCP `handoff-draft` que lê `git log origin/main..HEAD` + `cycles-active` + `tasks-list status:doing` + `handoff-diff` (Onda 3) → 1 chamada `gpt-4o-mini` rascunha `.md` template canônico ADR 0130 que eu reviso + completo + Write final
 **Para** reduzir ~1h/dia que Wagner gasta escrevendo handoff manual (~10-20min × várias/dia) — fechar Handoff #4 auto-capture (30%→80%)
 
-**Implementado em:** novo `Modules/Jana/Mcp/Tools/HandoffDraftTool.php` (JSON-RPC schema: cycle_id?, since_hours? default 24, format? default md) + novo `Modules/Jana/Services/Handoff/HandoffDrafterService.php` + edit `Modules/Jana/Providers/OimpressoMcpServer.php` (registrar tool)
+**Implementado em:** `Modules/Jana/Mcp/Tools/HandoffDraftTool.php` · `Modules/Jana/Mcp/OimpressoMcpServer.php` · `Modules/Jana/Tests/Feature/Mcp/HandoffDraftToolTest.php` · verificado@08c4a8f (2026-06-21)
 
 **Definition of Done:**
 - [ ] Tool MCP `handoff-draft` exposta com schema documentado
@@ -1104,7 +1104,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 **Quero** workflow CI `memory-schema-lint.yml` matrix-strategy validando frontmatter de TODOS tipos `.md` canon (ADR + SPEC + RUNBOOK + session + handoff + charter) via JSON Schema 2020-12 + artisan command `jana:validate-memory` rodando daily 06:30 BRT pra detectar drift fora-de-PR
 **Para** fechar gap Knowledge S4 (40%→90%) — hoje só ADR é validado via `adr-lint.yml`; SPEC/RUNBOOK/session/handoff têm drift silencioso (ex: ADR sem `lifecycle:` passa, `decisions-search` devolve doc malformado)
 
-**Implementado em:** novos `memory/schemas/{adr,spec,runbook,session,handoff,charter}.schema.json` + `memory/schemas/README.md` + `.github/workflows/memory-schema-lint.yml` + `package.json` (root) com `remark-lint-frontmatter-schema` + novo `app/Console/Commands/Jana/ValidateMemorySchemas.php` artisan + edit `app/Console/Kernel.php` schedule
+**Implementado em:** `scripts/memory-schemas/adr.schema.json` · `scripts/memory-schemas/spec.schema.json` · `scripts/memory-schemas/runbook.schema.json` · `scripts/memory-schemas/session.schema.json` · `scripts/memory-schemas/handoff.schema.json` · `scripts/memory-schemas/charter.schema.json` · `scripts/memory-schemas/README.md` · `.github/workflows/memory-schema-gate.yml` · `Modules/Jana/Console/Commands/JanaValidateMemoryCommand.php` · verificado@08c4a8f (2026-06-21)
 
 **Definition of Done:**
 - [ ] 6 JSON Schemas 2020-12 declarados em `memory/schemas/` (adr, spec, runbook, session, handoff, charter) — required minimalista (só `title`, `type`, `decided_at`/`last_updated`), demais opcionais com defaults documentados

--- a/memory/requisitos/NfeBrasil/SPEC.md
+++ b/memory/requisitos/NfeBrasil/SPEC.md
@@ -37,7 +37,7 @@ na_justified:
 **Quero** subir certificado A1 (.pfx) com senha e o sistema validar + armazenar criptografado
 **Para** começar a emitir NFe sem expor cert na rede
 
-**Implementado em:** [`resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx`](../../../resources/js/Pages/NfeBrasil/Configuracao/Certificado.tsx) · [`Modules/NfeBrasil/Http/Controllers/CertificadoController.php`](../../../Modules/NfeBrasil/Http/Controllers/CertificadoController.php) · [`Modules/NfeBrasil/Services/CertificadoService.php`](../../../Modules/NfeBrasil/Services/CertificadoService.php)
+**Implementado em:** _parcial_ · [`Modules/NfeBrasil/Http/Controllers/CertificadoController.php`](../../../Modules/NfeBrasil/Http/Controllers/CertificadoController.php) · [`Modules/NfeBrasil/Services/CertificadoService.php`](../../../Modules/NfeBrasil/Services/CertificadoService.php) · verificado@08c4a8f (2026-06-21) — backend (upload + validação OpenSSL + cripto) pronto; falta a tela React de upload em Pages/NfeBrasil/Configuracao (não migrada)
 
 **Definition of Done:**
 - [x] FormRequest aceita `.pfx` ≤ 100KB + `senha` (não loga em audit log!)
@@ -60,7 +60,7 @@ na_justified:
 **Quero** clicar "Finalizar venda" no POS e o sistema emitir NFC-e em background, retornar DANFE imprimível em até 5s
 **Para** atender exigência fiscal sem fricção no balcão
 
-**Implementado em:** _[TODO — integração `/sells/create` finalizar + `resources/js/Pages/NfeBrasil/Emissao/Sucesso.tsx`]_
+**Implementado em:** _pendente_ — emissão NFC-e a partir de venda (job + listener) não construída; falta integração `/sells/create` + tela de sucesso em Pages/NfeBrasil/Emissao
 
 **Definition of Done:**
 - [ ] Listener escuta `App\Events\TransactionCompleted` (core) → dispatch job `EmitirNfceJob` na queue `nfe`
@@ -82,7 +82,7 @@ na_justified:
 **Quero** abrir nota emitida pela chave/número e baixar DANFE + XML
 **Para** reimprimir, enviar pra cliente, anexar em e-mail
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx`]_
+**Implementado em:** _pendente_ — tela de visualização/reimpressão (Pages/NfeBrasil/Emissoes/Show) não construída
 
 **Definition of Done:**
 - [ ] Mostra: chave acesso (44 dígitos formatado em 11 grupos), número, série, data emissão, valor, cStat, link DANFE PDF, link XML
@@ -101,7 +101,7 @@ na_justified:
 **Quero** cancelar uma NFC-e em até 24h ou NF-e em até 168h informando justificativa (15-255 chars)
 **Para** corrigir venda errada sem deixar rastro errado pra Receita
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx` (botão Cancelar)]_
+**Implementado em:** _pendente_ — cancelamento (serviço SEFAZ + botão na tela Emissoes/Show) não construído
 
 **Definition of Done:**
 - [ ] Valida prazo legal antes de chamar SEFAZ (NFC-e: 24h; NF-e: 168h)
@@ -122,7 +122,7 @@ na_justified:
 **Quero** enviar CCe pra corrigir erro não-monetário (ex: nome do destinatário errado, transportadora) sem cancelar e re-emitir
 **Para** evitar custo de re-emissão e manter histórico
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Emissoes/Show.tsx` (botão CCe)]_
+**Implementado em:** _pendente_ — Carta de Correção Eletrônica (serviço + botão CCe na tela Emissoes/Show) não construída
 
 **Definition of Done:**
 - [ ] Valida limite legal: máximo 20 CCe por NFe; correção 15-1000 chars; não permite mudar valor/quantidade/CNPJ
@@ -141,7 +141,7 @@ na_justified:
 **Quero** ativar contingência (EPEC pra NF-e, FS-DA pra NFC-e) e seguir vendendo offline
 **Para** não parar caixa quando SEFAZ está com problema
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Contingencia/Index.tsx`]_
+**Implementado em:** _pendente_ — modo contingência (EPEC/FS-DA + tela Pages/NfeBrasil/Contingencia) não construído
 
 **Definition of Done:**
 - [ ] Detecção automática: `SefazHealthCheck` ping a cada 30s → se 3 falhas seguidas, sugerir contingência
@@ -162,7 +162,7 @@ na_justified:
 **Quero** dashboard com KPIs (autorizadas hoje, rejeitadas, contingência ativa, cert vencendo) + lista de rejeições com cStat + sugestão de correção
 **Para** atacar rejeições antes de o cliente perceber
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Monitor/Index.tsx`]_
+**Implementado em:** _pendente_ — monitor de rejeições + status SEFAZ (tela Pages/NfeBrasil/Monitor) não construído
 
 **Definition of Done:**
 - [ ] KPIs: autorizadas (hoje/semana/mês), rejeitadas, em contingência, cert dias restantes
@@ -183,7 +183,7 @@ na_justified:
 **Quero** manifestar NFe recebida (Confirmação / Ciência / Desconhecimento / Operação não realizada)
 **Para** atender obrigação legal e gerar apropriação correta no DRE
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx`]_
+**Implementado em:** `Modules/NfeBrasil/Http/Controllers/ManifestacaoController.php` · `Modules/NfeBrasil/Services/Manifestacao/ManifestacaoService.php` · `resources/js/Pages/NfeBrasil/Manifestacao/Index.tsx` · `Modules/NfeBrasil/Tests/Feature/ManifestacaoControllerTest.php` · verificado@08c4a8f (2026-06-21)
 
 **Definition of Done:**
 - [ ] Lista NFes destinadas (consulta `WS-NFeDistribuicaoDFe` periódica) com status manifestação
@@ -202,7 +202,7 @@ na_justified:
 **Quero** baixar arquivo SPED Fiscal pronto pra ECF do mês de competência
 **Para** entregar obrigação contábil sem ligar pra Larissa
 
-**Implementado em:** _[TODO — `resources/js/Pages/NfeBrasil/Sped/Index.tsx`]_
+**Implementado em:** _pendente_ — geração SPED Fiscal/EFD (tela Pages/NfeBrasil/Sped) não construída
 
 **Definition of Done:**
 - [ ] Geração assíncrona via job (volume grande); progresso via broadcast

--- a/memory/requisitos/Vestuario/SPEC.md
+++ b/memory/requisitos/Vestuario/SPEC.md
@@ -170,7 +170,7 @@ ROTA LIVRE usa Asaas como adapter de boleto + extrato (Inter PJ planejado em US-
 ### US-VEST-009 · Sidebar/topnav adaptado por monitor 1280px `live`
 
 > **Área:** UX
-> **Implementado em:** [`Modules/Vestuario/Http/Controllers/DataController.php`](../../../Modules/Vestuario/Http/Controllers/DataController.php) **(a criar — hoje hooks vivem em DataController genérico via session)**
+> **Implementado em:** [`Modules/Vestuario/Http/Controllers/DataController.php`](../../../Modules/Vestuario/Http/Controllers/DataController.php) · verificado@08c4a8f (2026-06-21)
 
 **Definition of Done (em prod, em forma genérica):**
 - [x] Locale pt-BR DataTables global


### PR DESCRIPTION
## O que faz
Saneia os anchors spec↔código (gramática ADR 0273) de **Jana**, **NfeBrasil** e **Vestuario** no estado LIVE do `anchor-lint.mjs` — fatia 1/3 do item **P09 (SA-A4)**. Remove "mentiras detectáveis" (anchor apontando pra path inexistente) e placeholders legados `_[TODO]_`, sem inventar nenhum path (cada path novo passou por `existsSync@08c4a8f`).

### Jana (4 dead → 0, 1 placeholder → 0)
| US | Antes (path falso) | Depois | Estado |
|---|---|---|---|
| US-COPI-108 Langfuse | `Modules/Jana/Ai/Services/LangfuseClient.php` + `infra/ct100/langfuse/...` | `Modules/Jana/Services/Telemetry/LangfuseClient.php` + `docker/langfuse/docker-compose.yml` | `_parcial_` (falta instrumentação) |
| US-COPI-111 Roadmap | `Pages/Admin/Roadmap/Index.tsx` + Resource + Gantt | `RoadmapController.php` + `Pages/ProjectMgmt/Roadmap/Index.tsx` | `_parcial_` (falta Gantt SVAR) |
| US-COPI-112 handoff-draft | `Providers/OimpressoMcpServer.php` + `Services/Handoff/HandoffDrafterService.php` | `Mcp/Tools/HandoffDraftTool.php` + `Mcp/OimpressoMcpServer.php` + test | **anchored_ok** |
| US-COPI-113 schema CI | `memory/schemas/...` + `memory-schema-lint.yml` + `app/Console/.../ValidateMemorySchemas.php` | `scripts/memory-schemas/*.schema.json` + `memory-schema-gate.yml` + `JanaValidateMemoryCommand.php` | **anchored_ok** |
| US-COPI-110 temporal | placeholder (falso-positivo "méTODO") | `applyTemporalScoring()` não existe | `_pendente_` |

### NfeBrasil (1 dead + 8 placeholder → 0)
- **US-NFE-001** (cert A1) → `_parcial_`: Controller+Service reais; tela React não migrada.
- **US-NFE-008** (manifestação) → **anchored_ok**: Controller+Service+Page+test reais (tela já existe).
- **US-NFE-002/003/004/005/006/007/009** → `_pendente_`: telas/serviços não construídos.

### Vestuario (1 placeholder → 0)
- **US-VEST-009** → **anchored_ok**: `DataController.php` do módulo existe (a anotação `(a criar)` estava stale).

## DoD (desta fatia)
- [x] `anchored_dead` 15 → **10** (Jana+NfeBrasil zerados; restantes = MemCofre).
- [x] `placeholder` 22 → **12** (Jana+NfeBrasil+Vestuario zerados; restantes = PontoWr2).
- [x] Nenhum path inventado — todos `existsSync` true @08c4a8f (2026-06-21).
- [x] `anchor_coverage` 7% → 8.9% (propagado ao `sdd-scorecard`).
- [x] Frontmatter intacto (só corpo `**Implementado em:**` tocado) → memory-schema-gate ok.

## Counterfactual (prova de que o gate MORDE)
Após sanear, re-introduzi `Modules/Jana/Providers/OimpressoMcpServer.php` (path falso) em US-COPI-112 e rodei `node scripts/governance/anchor-lint.mjs --check` → **exit 1** com `💀 US-COPI-112`. Restaurei → **exit 0** para os 3 módulos. O `--check` (modo F2) não está cego.

## Verificação local
- `anchor-lint.mjs` (diff-aware) por módulo: Jana/NfeBrasil/Vestuario com `dead=0 placeholder=0`.
- `gate-selftest.mjs`: 10/10 catracas mordem.
- `sdd-scorecard.mjs`: anchor_coverage subiu (artefato gerado NÃO incluído neste PR pra não colidir com P03).

## Parte do roadmap SDD (P09)
Plano: `memory/requisitos/_Governanca/roadmap/P09-sa-a4-sanear-placeholders-anchored-dead.md`. Este item destrava **P10** (promover `anchor-lint --check` a gate required) — mas P09 só entrega estado-verde, NÃO liga o gate.

## Fatias restantes (PRs irmãos)
- **PR-B · MemCofre (10 dead)** — DECISÃO DE IDENTIDADE do Wagner. `memory/requisitos/MemCofre/SPEC.md` tem `status: arquivado`, é duplicado do módulo renomeado `MemCofre→SRS` (commit `8f7a51380e`), e `Modules/SRS/` está em `DEPRECATION-PLAN`. O `anchor-lint.mjs` NÃO filtra specs arquivados. Opções: (a) re-point pra `Modules/SRS/...` (morre de novo quando SRS for deletado); (b) `_pendente_` em massa; (c) **preferida** — adicionar skip de `status: arquivado` no lint (~3 linhas) + decidir destino do spec duplicado. **Não inventei nada — deixei pro Wagner decidir.**
- **PR-C · PontoWr2 (12 placeholder)** — backfill pros `Modules/Ponto/...` (rename `PontoWr2→Ponto` já concluído no código; pages mapeiam 1:1 às US). Regra DAG do plano-mãe (rename antes do backfill) satisfeita; sai em PR separado por ser módulo distinto e manter ≤300 linhas.

## Arquivos compartilhados / ordem de rebase
- **Colisão potencial com P03** no SPEC de Governance (`memory/requisitos/Governance/SPEC.md`) — este PR **NÃO toca** esse arquivo, então sem conflito direto. Se P03 mexer no `anchor-lint.mjs` ou no scorecard, rebasear este PR primeiro (ele só edita 3 SPECs de módulo).
- `governance/sdd-scorecard.json` deixado fora deste PR de propósito (artefato regenerável; evita colisão com P03/outros).

🤖 Generated with [Claude Code](https://claude.com/claude-code)