### PR TITLE
feat(governance): baseline-tamper-guard cobre +5 baselines (1/6→6/6) — Onda 1

### DIFF
--- a/.github/workflows/baseline-tamper-guard.yml
+++ b/.github/workflows/baseline-tamper-guard.yml
@@ -14,6 +14,11 @@ on:
     branches: [main]
     paths:
       - 'scripts/governance/.memory-health-baseline.json'
+      - '.conformance-baseline.json'
+      - '.fontramp-baseline.json'
+      - '.foundation-guard-baseline.json'
+      - '.dsih-baseline.json'
+      - '.scheme-baseline.json'
       - 'scripts/governance/baseline-tamper-guard.mjs'
       - '.github/workflows/baseline-tamper-guard.yml'
 

--- a/scripts/governance/baseline-tamper-guard.mjs
+++ b/scripts/governance/baseline-tamper-guard.mjs
@@ -49,11 +49,31 @@ function detectMemoryHealth(base, head) {
   return out;
 }
 
+// Ratchet homogêneo { "path": <nº de violações toleradas> }: afrouxar = teto
+// subiu numa key existente OU key nova grandfatherada com tolerância > 0.
+// Compartilhado pelos baselines de mesmo schema (conformance cor-crua, fontramp,
+// foundation-guard, dsih, scheme). Key removida ou teto que baixou = melhora (ok).
+function detectCountRatchet(base, head) {
+  const out = [];
+  const b = base || {}, h = head || {};
+  for (const [f, n] of Object.entries(h)) {
+    if (typeof n !== 'number') continue;
+    const prev = typeof b[f] === 'number' ? b[f] : 0;
+    if (n > prev) out.push(`teto subiu: ${f} (${prev}→${n})`);
+  }
+  return out;
+}
+
 // Mapa path→detector. Estender = adicionar o baseline + seu detector aqui
 // (e o path no trigger do workflow). Só guarda o que tem detector de schema:
 // afrouxamento genérico em formato heterogêneo daria falso-positivo.
 const GUARDED = {
   'scripts/governance/.memory-health-baseline.json': detectMemoryHealth,
+  '.conformance-baseline.json': detectCountRatchet,
+  '.fontramp-baseline.json': detectCountRatchet,
+  '.foundation-guard-baseline.json': detectCountRatchet,
+  '.dsih-baseline.json': detectCountRatchet,
+  '.scheme-baseline.json': detectCountRatchet,
 };
 
 // ── resolver base do diff ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Onda 1 — frente refutador-no-baseline

A auditoria SDD pedia "refutador no PR que mexe no baseline" (casos #2848, ghost 14→16 entraram verdes). **Verificado o estado real:** o mecanismo **já existe** — `baseline-tamper-guard` (#3128) impede afrouxar baseline + código no mesmo PR (escape consciente `BASELINE-ABSORB:`). **Mas guardava só 1 de 6 baselines** (`.memory-health-baseline.json`); os outros 5 ratchets podiam absorver regressão sem o guard pegar.

### O que entra
Estende a cobertura **1/6 → 6/6**. Os 5 baselines restantes têm **schema homogêneo** `{ "path": <nº violações toleradas> }` → 1 detector genérico **`detectCountRatchet`** (afrouxar = teto subiu numa key OU key nova grandfatherada com tolerância > 0) cobre todos:
- `.conformance-baseline.json` (cor-crua) · `.fontramp-baseline.json` · `.foundation-guard-baseline.json` · `.dsih-baseline.json` · `.scheme-baseline.json`

Workflow trigger ganha os 5 paths. `gates-registry.json` já tinha a entrada (não é workflow novo).

### Validação local
- `detectCountRatchet` — 6 casos: estável/teto-subiu/key-nova>0/key-nova=0/melhora/key-removida ✓
- smoke vs `origin/main` (sem mexer em baseline) → "nenhum afrouxado ✓" exit 0
- **e2e do catch**: afrouxei `.conformance` +5 + código no mesmo commit → guard FALHOU com a mensagem anti-grandfather + `process.exit(1)` ✓ (revertido)

Parte de **Onda 1**. Frente restante: sentinela transporte CT100→main (precisa de decisão de infra — vou trazer scoping).

🤖 Generated with [Claude Code](https://claude.com/claude-code)