### PR TITLE
fix(docs): corrige 12 links decisions/ com slug defasado em 5 SPECs

### DIFF
--- a/memory/requisitos/Brief/SPEC.md
+++ b/memory/requisitos/Brief/SPEC.md
@@ -48,4 +48,4 @@ BRIEFING.md mínimo existe como ponteiro pra ADR 0091 (cumpre regra Tier 0 "todo
 
 - **[ADR 0091](../../decisions/0091-daily-brief.md)** — Daily Brief (spec canônica, irreplaceable)
 - **[ADR 0153](../../decisions/0153-module-grade-rubrica-v1.md)** — Rubrica module-grade (origem do N/A justified)
-- **[ADR 0154](../../decisions/0154-na-justified-modules-infra.md)** — N/A justified em módulos de infra (limite 3 por módulo)
+- **[ADR 0154](../../decisions/0154-module-grade-v2-na-justificado.md)** — N/A justified em módulos de infra (limite 3 por módulo)

--- a/memory/requisitos/ComunicacaoVisual/SPEC.md
+++ b/memory/requisitos/ComunicacaoVisual/SPEC.md
@@ -50,7 +50,7 @@ ERP vertical brasileiro pra gráfica rápida e comunicação visual (lona, facha
 
 ### 6 saudáveis OfficeImpresso candidatos a migrar (piloto)
 
-Vargas, Extreme, Gold, Zoom, Fixar, Mhundo, Produart — todos em produção Delphi legacy WR Sistemas com R$ [redacted Tier 0]k–R$ [redacted Tier 0]M GMV/ano. Migration Factory ([ADR 0119](../../decisions/0119-migration-factory.md)) move cada um.
+Vargas, Extreme, Gold, Zoom, Fixar, Mhundo, Produart — todos em produção Delphi legacy WR Sistemas com R$ [redacted Tier 0]k–R$ [redacted Tier 0]M GMV/ano. Migration Factory ([ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md)) move cada um.
 
 ## 3. Capacidades core (User Stories)
 
@@ -161,7 +161,7 @@ Priorização: **P0** = bloqueia 1ª piloto migrado · **P1** = competitivo vs M
 - [ ] Relatório export Excel/PDF
 - [ ] Atende **dor #4 do top 10** (relatório margem por OS)
 
-**Concorrência:** **Calcgraf ✅** (único com pós-cálculo formal). Mubisys/Zênite/Visua ❌. **oimpresso pode entregar via Modules/Financeiro + Jana 3 ângulos** ([ADR 0052](../../decisions/0052-faturamento-3-angulos.md)).
+**Concorrência:** **Calcgraf ✅** (único com pós-cálculo formal). Mubisys/Zênite/Visua ❌. **oimpresso pode entregar via Modules/Financeiro + Jana 3 ângulos** ([ADR 0052](../../decisions/0052-contextonegocio-expor-multiplos-angulos.md)).
 
 ---
 
@@ -337,7 +337,7 @@ Priorização: **P0** = bloqueia 1ª piloto migrado · **P1** = competitivo vs M
 
 **DoD:**
 - [ ] Contexto vertical comvis: faturamento por categoria material, margem por cliente, OS atrasadas no PCP
-- [ ] 3 ângulos faturamento (recebido/faturado/orçado) — [ADR 0052](../../decisions/0052-faturamento-3-angulos.md)
+- [ ] 3 ângulos faturamento (recebido/faturado/orçado) — [ADR 0052](../../decisions/0052-contextonegocio-expor-multiplos-angulos.md)
 - [ ] Resposta com query SQL auditável anexa
 - [ ] Atende **dor #1 wedge** do research (transparência radical + IA)
 
@@ -386,7 +386,7 @@ Priorização: **P0** = bloqueia 1ª piloto migrado · **P1** = competitivo vs M
 ### US-COMVIS-017 · Importação massiva de clientes/produtos do legacy OfficeImpresso — **P0**
 
 > **Área:** Onboarding
-> **Reusa:** [Migration Factory ADR 0119](../../decisions/0119-migration-factory.md)
+> **Reusa:** [Migration Factory ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md)
 
 **Como** dono migrando do OfficeImpresso Delphi
 **Quero** trazer clientes (CPF/CNPJ + endereço + histórico OS) + produtos + saldos abertos AR/AP em 1 clique
@@ -547,7 +547,7 @@ Modules/ComunicacaoVisual/   ← a criar
 └── composer.json
 ```
 
-Frontend Inertia em `resources/js/Pages/ComunicacaoVisual/` seguindo Cockpit Pattern V2 ([ADR 0110](../../decisions/0110-cockpit-pattern-v2.md)) com `.charter.md` ao lado de cada Page (S4+).
+Frontend Inertia em `resources/js/Pages/ComunicacaoVisual/` seguindo Cockpit Pattern V2 ([ADR 0110](../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md)) com `.charter.md` ao lado de cada Page (S4+).
 
 ### 6.2 Extensions UltimatePOS
 
@@ -622,7 +622,7 @@ Todos com `business_id` indexado + FK + global scope (Tier 0 IRREVOGÁVEL).
 
 ## 8. Estratégia de migração — 6 saudáveis OfficeImpresso
 
-Base [Migration Factory ADR 0119](../../decisions/0119-migration-factory.md). Receita por cliente:
+Base [Migration Factory ADR 0119](../../decisions/0119-migration-factory-capacidade-institucional.md). Receita por cliente:
 
 | Etapa | Owner | Esforço |
 |---|---|---|
@@ -675,7 +675,7 @@ Quando snapshot financeiro de cada um estiver pronto, priorizar quem tem:
 11. ❌ **Cálculo m² em frontend** sem servidor validar — rule R-COMVIS-001: server-side authoritative pra evitar manipulação preço.
 12. ❌ **App mobile nativo M1-M6** — adiável 12m se Inertia/React mobile-first (Tailwind 4 responsive) + PWA cobrir o caso de uso "vendedor in-loco".
 13. ❌ **Onboarding sem wizard Jana** — gráficas pequenas não pagam consultor implantação. Jana detecta CNAE 1813 e pré-popula. Caso contrário, churn alto.
-14. ❌ **Esquecer `php artisan module:install` rotas obrigatórias** — RUNBOOK-criar-modulo §3 rotas Install (status, install, uninstall) senão botão fica sem ação ([ADR 0024](../../decisions/0024-module-install-routes-canonical.md)).
+14. ❌ **Esquecer `php artisan module:install` rotas obrigatórias** — RUNBOOK-criar-modulo §3 rotas Install (status, install, uninstall) senão botão fica sem ação ([ADR 0024](../../decisions/0024-instalacao-1-clique-modulos.md)).
 15. ❌ **Migrar 6 pilotos em paralelo** — escala humana 5 pessoas. Migration Factory rolling: 1 piloto por mês, depois 2/mês após M6 (curva aprendizado).
 
 ---

--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -1057,7 +1057,7 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 - ❌ Custom fields typed (JANA-10X-026 / Onda 6 P3)
 - ❌ Comentários inline timeline (next iter)
 
-**Refs:** [GAP-ANALYSIS §V1](GAP-ANALYSIS-91-100-2026-05-13.md) · [ONDA-5-DOSSIER §3](ONDA-5-DOSSIER-2026-05-13.md) · [SVAR React Gantt MIT](https://svar.dev/react/gantt/) · [SVAR Gantt 2.4 release](https://medium.com/@SvarWidgets/svar-gantt-2-4-a-modern-gantt-chart-library-for-react-svelte-under-the-mit-license-ae62f36a5dde) · [Linear roadmap timeline](https://linear.app/changelog/2021-05-27-linear-preview-roadmap-timeline) · [GitHub Projects Hierarchy GA mar/2026](https://github.blog/changelog/2026-03-19-hierarchy-view-in-github-projects-is-now-generally-available/) · [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) · [ADR 0110](../../decisions/0110-cockpit-layout-v2-padrao.md)
+**Refs:** [GAP-ANALYSIS §V1](GAP-ANALYSIS-91-100-2026-05-13.md) · [ONDA-5-DOSSIER §3](ONDA-5-DOSSIER-2026-05-13.md) · [SVAR React Gantt MIT](https://svar.dev/react/gantt/) · [SVAR Gantt 2.4 release](https://medium.com/@SvarWidgets/svar-gantt-2-4-a-modern-gantt-chart-library-for-react-svelte-under-the-mit-license-ae62f36a5dde) · [Linear roadmap timeline](https://linear.app/changelog/2021-05-27-linear-preview-roadmap-timeline) · [GitHub Projects Hierarchy GA mar/2026](https://github.blog/changelog/2026-03-19-hierarchy-view-in-github-projects-is-now-generally-available/) · [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) · [ADR 0110](../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
 
 ---
 

--- a/memory/requisitos/Mcp/SPEC.md
+++ b/memory/requisitos/Mcp/SPEC.md
@@ -69,14 +69,14 @@ related_adrs:
 
 ## 4. ADRs aplicáveis
 
-- [ADR 0053](../../decisions/0053-mcp-server-laravel-mcp.md) — MCP server laravel/mcp como entry point
+- [ADR 0053](../../decisions/0053-mcp-server-governanca-como-produto.md) — MCP server laravel/mcp como entry point
 - [ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) — Jira-style tasks via tools MCP
 - [ADR 0091](../../decisions/0091-daily-brief.md) — Daily Brief (brief-fetch Tier A always-on)
 - [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 isolation
 - [ADR 0094](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (princípio 2 tiered cost)
 - [ADR 0119](../../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md) — whats-active Tier 1
 - [ADR 0130](../../decisions/0130-handoff-append-only-mcp-first.md) — handoff append-only (event stream)
-- [ADR 0133](../../decisions/0133-system-health-audit.md) — System health audit canônico
+- [ADR 0133](../../decisions/0133-system-health-audit-canonico.md) — System health audit canônico
 
 ## 5. Notas
 

--- a/memory/requisitos/TeamMcp/SPEC.md
+++ b/memory/requisitos/TeamMcp/SPEC.md
@@ -19,7 +19,7 @@ related_adrs: [0053-mcp-server-governanca-como-produto, 0081-identity-mesh-mcp-a
 
 ## Missão
 
-Self-host equivalente ao Anthropic Team plan adaptado pra LGPD + custo + custom ([ADR 0059](../../decisions/0059-self-host-team-plan-anthropic-rejeitado.md)). Concentra governança: tokens MCP do time, Identity Mesh (mcp_actors), audit log append-only, webhooks git→DB, ingest Claude Code sessions, tools registry, Kanban tasks/cycles.
+Self-host equivalente ao Anthropic Team plan adaptado pra LGPD + custo + custom ([ADR 0059](../../decisions/0059-governanca-memoria-estilo-anthropic-team.md)). Concentra governança: tokens MCP do time, Identity Mesh (mcp_actors), audit log append-only, webhooks git→DB, ingest Claude Code sessions, tools registry, Kanban tasks/cycles.
 
 ## Tabelas owned (DB)
 


### PR DESCRIPTION
## O quê
Corrige **12 links `decisions/`** com slug defasado em **5 SPECs** (docs vivos):

| SPEC | Links | Exemplo |
|---|---:|---|
| `Brief` | 1 | `0154-na-justified-modules-infra` → `0154-module-grade-v2-na-justificado` |
| `ComunicacaoVisual` | 7 | `0119-migration-factory` → `…-capacidade-institucional` (3×); 0052, 0110, 0024 |
| `Jana` | 1 | `0110-cockpit-layout-v2-padrao` → `0110-cockpit-pattern-v2-canon-list-detail` |
| `Mcp` | 2 | `0053-mcp-server-laravel-mcp` → `…-governanca-como-produto`; `0133` |
| `TeamMcp` | 1 | `0059-self-host-team-plan-anthropic-rejeitado` → `…-governanca-memoria-estilo-anthropic-team` |

## Por quê
Achado na auditoria de saúde/integridade **2026-06-21** (batedor de links). ADRs foram renomeados; os links nos SPECs ficaram apontando pra slugs que não existem mais (404). Mesma classe segura do #3147.

## Validação
- Re-discovery: dos 13 links `decisions/` quebrados em SPECs, **12 corrigidos** → restam **0** (exceto `Connector:124`, um placeholder do autor com `...` + "(se existir)", deixado intacto de propósito).
- Os 12 destinos novos **resolvem** para arquivos reais; os 12 antigos eram **404** em `origin/main`.
- Diff cirúrgico: 5 arquivos, **12↔12 linhas, só slugs de link** (nenhuma US/prosa/DoD).

## Verificação adversarial (independente)
Verificador cético confirmou: escopo (5 SPECs, 12/12, zero conteúdo), 77/77 links `decisions/` resolvem pós-fix, **colisão 0119 mapeada ao ADR certo** (contexto = Migration Factory, não paralelismo), alvos não-inventados (frontmatter `number:` confere), **nenhum `memory/decisions/*.md` canon tocado**, e Connector preservado. **Aprovado.**

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)
