### PR TITLE
feat(charters): related_us canônico + lint + migra 3 legacy (P14)

### DIFF
--- a/resources/js/Pages/Financeiro/Advisor/Dashboard.charter.md
+++ b/resources/js/Pages/Financeiro/Advisor/Dashboard.charter.md
@@ -5,7 +5,7 @@ controller: Modules\Financeiro\Http\Controllers\Advisor\AdvisorPortalController@
 persona: eliana
 status: draft
 created: 2026-05-31
-us: US-FIN-037
+related_us: [US-FIN-037]
 onda: 31
 component: resources/js/Pages/Financeiro/Advisor/Dashboard.tsx
 owner: eliana

--- a/resources/js/Pages/Financeiro/Configuracoes/Contador.charter.md
+++ b/resources/js/Pages/Financeiro/Configuracoes/Contador.charter.md
@@ -5,7 +5,7 @@ module: Financeiro
 controller: Modules\Financeiro\Http\Controllers\AdvisorAccessController
 status: draft
 owner: eliana
-us: US-FIN-037
+related_us: [US-FIN-037]
 created: 2026-05-31
 page: /financeiro/configuracoes/contador
 component: resources/js/Pages/Financeiro/Configuracoes/Contador.tsx

--- a/resources/js/Pages/Jana/Painel.charter.md
+++ b/resources/js/Pages/Jana/Painel.charter.md
@@ -4,7 +4,7 @@ component: resources/js/Pages/Jana/Painel.tsx
 status: live
 versao: 1.0
 adrs: [0035, 0039, 0093, 0114]
-us: [US-JANA-PAINEL-001]
+related_us: [US-JANA-PAINEL-001]
 modulo: Jana
 rota: /jana/painel
 visual-canon: prototipo-ui/cowork-snapshot/chat-jana.jsx

--- a/scripts/governance/charter-us-lint.mjs
+++ b/scripts/governance/charter-us-lint.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+// charter-us-lint.mjs — lint do campo canônico `related_us` nos Page Charters
+// (resources/js/Pages/**/*.charter.md). Fecha a divergência #1 do roadmap SDD:
+// a metade "us:" do backfill foi re-escopada sem ADR — 148 charters, só 16 com
+// link de US e naming inconsistente (3 `us:` × 13 `related_us:`).
+//
+// O QUE FAZ:
+//   - Declara `related_us` como o ÚNICO campo canônico (alinhado a related_adrs).
+//   - Conta charters_sem_us (cobertura do join US→tela — fonte SA-A5/P10).
+//   - Flaga o campo legacy `us:` (regressão de naming — já migrado nos 3 legacy).
+//   - Valida o shape de cada slug contra o pattern do charter.schema.json.
+//
+// MODO --check (advisory-de-nascença, promovível a ratchet depois):
+//   exit 1 se um charter NOVO/TOCADO (git diff vs BASE, ou --files-from) NÃO tiver
+//   `related_us` válido. Charters pré-existentes (132 sem nada) NÃO bloqueiam —
+//   o backfill é lote IA futuro (roadmap SDD P10). Só morde o que nasce/muda agora.
+//
+// COUNTERFACTUAL (DoD): charter tocado sem related_us → --check exit 1;
+//                       charter tocado com related_us válido → --check exit 0.
+//
+// USO (raiz do repo):
+//   node scripts/governance/charter-us-lint.mjs            # relatório de cobertura (exit 0)
+//   node scripts/governance/charter-us-lint.mjs --json     # pro Daily Brief / agregador
+//   node scripts/governance/charter-us-lint.mjs --check    # morde charters NOVOS/tocados (CI/pre-commit)
+//   node scripts/governance/charter-us-lint.mjs --check --files-from=<arquivo>
+//                                                          # lista explícita de tocados (1 path/linha)
+// Node puro, sem deps, sem rede. Lê o pattern do próprio charter.schema.json (fonte única).
+
+import { readdirSync, readFileSync, existsSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+const JSON_OUT = process.argv.includes('--json');
+const CHECK = process.argv.includes('--check');
+const FILES_FROM = (process.argv.find((a) => a.startsWith('--files-from=')) || '').split('=')[1] || null;
+const BASE = process.env.BASE_REF || 'origin/main';
+
+const PAGES_DIR = 'resources/js/Pages';
+const SCHEMA_REL = 'scripts/memory-schemas/charter.schema.json';
+
+// --- pattern canônico de slug US — lido do schema (fonte única; sem hard-code divergente) ---
+function loadSlugPattern() {
+  const fallback = '^US-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$';
+  try {
+    const schema = JSON.parse(readFileSync(join(ROOT, SCHEMA_REL), 'utf8'));
+    const p = schema?.properties?.related_us?.items?.pattern;
+    return p || fallback;
+  } catch {
+    return fallback;
+  }
+}
+const SLUG_RE = new RegExp(loadSlugPattern());
+
+// --- walk recursivo: todos os *.charter.md sob Pages/ ---
+function walkCharters(dir, acc = []) {
+  if (!existsSync(dir)) return acc;
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) walkCharters(full, acc);
+    else if (e.isFile() && e.name.endsWith('.charter.md')) acc.push(full);
+  }
+  return acc;
+}
+
+// --- extrai frontmatter YAML (entre os --- iniciais) sem dep externa ---
+function frontmatter(body) {
+  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return m ? m[1] : '';
+}
+
+// Lê related_us (array inline `[A, B]`) OU o legacy us: (escalar OU array).
+// Retorna { hasRelated, relatedSlugs[], hasLegacyUs, legacySlugs[] }.
+function parseUsFields(fm) {
+  const lines = fm.split(/\r?\n/);
+  const grab = (key) => {
+    const re = new RegExp(`^${key}:\\s*(.+?)\\s*$`, 'i');
+    for (const l of lines) {
+      const mm = l.match(re);
+      if (mm) return mm[1].trim();
+    }
+    return null;
+  };
+  const toSlugs = (raw) => {
+    if (raw == null) return [];
+    const inner = raw.replace(/^\[/, '').replace(/\]$/, '');
+    return inner.split(',').map((s) => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+  };
+  const relatedRaw = grab('related_us');
+  const legacyRaw = grab('us');
+  return {
+    hasRelated: relatedRaw != null,
+    relatedSlugs: toSlugs(relatedRaw),
+    hasLegacyUs: legacyRaw != null,
+    legacySlugs: toSlugs(legacyRaw),
+  };
+}
+
+// --- conjunto de charters NOVOS/TOCADOS (pro --check) ---
+function touchedCharters() {
+  let names = [];
+  if (FILES_FROM && existsSync(FILES_FROM)) {
+    names = readFileSync(FILES_FROM, 'utf8').split(/\r?\n/);
+  } else {
+    try {
+      const out = execSync(`git diff --name-only --diff-filter=ACMR ${BASE}...HEAD`, {
+        cwd: ROOT, stdio: ['ignore', 'pipe', 'ignore'],
+      }).toString();
+      names = out.split(/\r?\n/);
+    } catch {
+      names = []; // sem git/sem base → --check vira no-op gracioso (não inventa bloqueio)
+    }
+  }
+  return new Set(
+    names.map((l) => l.trim()).filter((l) => l.endsWith('.charter.md')).map((l) => l.replace(/\\/g, '/'))
+  );
+}
+
+// --- análise ---
+const charters = walkCharters(join(ROOT, PAGES_DIR)).sort();
+const touched = CHECK ? touchedCharters() : new Set();
+
+let semUs = 0;
+let comUs = 0;
+const legacyKeyHits = []; // charters que ainda usam `us:` (regressão de naming)
+const invalidSlugHits = []; // charters com slug fora do pattern
+const blockers = []; // charters NOVOS/tocados sem related_us válido (mordem em --check)
+
+for (const abs of charters) {
+  const rel = abs.replace(ROOT, '').replace(/\\/g, '/').replace(/^\//, '');
+  const body = readFileSync(abs, 'utf8');
+  const f = parseUsFields(frontmatter(body));
+
+  const validSlugs = f.relatedSlugs.filter((s) => SLUG_RE.test(s));
+  const badSlugs = f.relatedSlugs.filter((s) => !SLUG_RE.test(s));
+  const hasValidRelated = f.hasRelated && validSlugs.length > 0;
+
+  if (hasValidRelated) comUs++; else semUs++;
+  if (f.hasLegacyUs) legacyKeyHits.push(rel);
+  if (badSlugs.length) invalidSlugHits.push({ charter: rel, slugs: badSlugs });
+
+  if (CHECK && touched.has(rel)) {
+    if (!f.hasRelated) {
+      blockers.push({ charter: rel, motivo: 'charter novo/tocado SEM related_us (declare a US que esta tela atende)' });
+    } else if (badSlugs.length) {
+      blockers.push({ charter: rel, motivo: `related_us com slug fora do padrão US-…: ${badSlugs.join(', ')}` });
+    } else if (validSlugs.length === 0) {
+      blockers.push({ charter: rel, motivo: 'related_us vazio (declare ao menos 1 slug US-…)' });
+    } else if (f.hasLegacyUs) {
+      blockers.push({ charter: rel, motivo: 'campo legacy `us:` presente — migre 100% pra related_us (zero divergência)' });
+    }
+  }
+}
+
+const total = charters.length;
+const coverage = total ? ((comUs / total) * 100).toFixed(1) : '0.0';
+
+if (JSON_OUT) {
+  console.log(JSON.stringify({
+    ok: CHECK ? blockers.length === 0 : true,
+    total_charters: total,
+    charters_com_us: comUs,
+    charters_sem_us: semUs,
+    cobertura_pct: Number(coverage),
+    legacy_us_key: legacyKeyHits,
+    slugs_invalidos: invalidSlugHits,
+    blockers,
+    mode: CHECK ? 'check' : 'report',
+  }, null, 2));
+  process.exit(CHECK && blockers.length ? 1 : 0);
+}
+
+console.log(`\n  charter-us-lint — ${total} charters · ${comUs} com related_us · ${semUs} sem (cobertura ${coverage}%)\n`);
+if (legacyKeyHits.length) {
+  console.log(`  🟡 ${legacyKeyHits.length} charter(s) ainda com campo legacy \`us:\` (canônico é related_us):`);
+  for (const c of legacyKeyHits) console.log(`     - ${c}`);
+}
+if (invalidSlugHits.length) {
+  console.log(`  🟡 ${invalidSlugHits.length} charter(s) com slug fora do padrão US-…:`);
+  for (const h of invalidSlugHits) console.log(`     - ${h.charter}: ${h.slugs.join(', ')}`);
+}
+if (!CHECK) {
+  console.log(`\n  ℹ Advisory de cobertura. ${semUs} charters sem related_us = lote IA futuro (roadmap SDD P10).`);
+  console.log('    --check só morde charters NOVOS/tocados (advisory-de-nascença).\n');
+  process.exit(0);
+}
+
+if (blockers.length) {
+  console.error(`\n  🔴 ${blockers.length} charter(s) NOVO(s)/tocado(s) sem related_us válido:`);
+  for (const b of blockers) console.error(`     - ${b.charter}: ${b.motivo}`);
+  console.error('\n  ✗ --check morde: charter que nasce/muda agora declara a US que atende.\n');
+  process.exit(1);
+}
+console.log('  ✓ --check: todos os charters NOVOS/tocados têm related_us válido.\n');
+process.exit(0);

--- a/scripts/memory-schemas/charter.schema.json
+++ b/scripts/memory-schemas/charter.schema.json
@@ -51,6 +51,16 @@
       "uniqueItems": true,
       "default": []
     },
+    "related_us": {
+      "type": "array",
+      "description": "Slugs de User Stories que esta tela atende — fonte do join US→tela (SA-A5/P10). CANÔNICO único (deprecou o `us:` ad-hoc de 3 charters legacy). OPCIONAL/grace-period: 132 charters ainda sem (backfill é lote IA futuro, roadmap SDD P10). Padrão alinhado a related_adrs: prefixo + cauda permissiva (tolera sufixos descritivos tipo -anexos/-aprovacao e variantes F3/CAIXA já em uso). Lint advisory de nascença via scripts/governance/charter-us-lint.mjs.",
+      "items": {
+        "type": "string",
+        "pattern": "^US-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$"
+      },
+      "uniqueItems": true,
+      "default": []
+    },
     "tier": {
       "type": "string",
       "enum": ["A", "B", "C"]


### PR DESCRIPTION
## O que faz

Fecha a **divergência #1** do roadmap SDD (`memory/requisitos/_Governanca/roadmap/_ROADMAP.md`): a metade `us:` do backfill de charters foi re-escopada/abandonada **sem ADR**. Hoje 16 de 148 charters têm link de US com naming **inconsistente** (3 usam `us:`, 13 usam `related_us:`); 132 sem nada. O `us:` validava só por `additionalProperties:true` (sem shape). Era a fonte do join **US→tela** pro SA-A5/P10.

Esta fatia entrega a **declaração canônica + migração dos 3 legacy + lint de nascença** — **não** o backfill dos 132 (isso é lote IA futuro, roadmap SDD P10).

1. **`charter.schema.json`** — declara `related_us` (array de slugs, `default []`, **OPCIONAL/grace-period**), alinhado a `related_adrs`. `additionalProperties` continua `true`.
2. **Migra os 3 legacy** `us:` → `related_us:` — `Financeiro/Advisor/Dashboard`, `Financeiro/Configuracoes/Contador`, `Jana/Painel`. **Zero divergência** `us:`/`related_us:` repo-wide (grep confirma 0 charters com `us:` restantes).
3. **`scripts/governance/charter-us-lint.mjs`** (zero-dep) — conta `charters_sem_us`; com `--check` dá **exit 1** se um charter **NOVO/tocado** não tiver `related_us` válido (advisory-de-nascença, promovível a ratchet). Lê o pattern do próprio schema (fonte única). Os `--json` alimentam brief/agregador.
4. **Sem workflow CI novo** → nada a registrar em `gates-registry.json` (Check [G] limpo). O lint roda local/pre-commit; promover a CT depois é 1 PR de promoção.

### Nota de pattern (decisão de engenharia)
O corpo da task sugeria `^US-[A-Z]{2,8}-[0-9]{3,4}$`, mas esse shape estrito **rejeita** `US-JANA-PAINEL-001` (alvo de migração obrigatório) **e** 4 dos 13 charters `related_us:` já existentes (`US-PG-F3-COBRANCA`, `US-FIN-050-anexos`, `US-FIN-055-aprovacao`, `US-FIN-014c`). Isso tornaria o campo schema-inválido contra dados reais e quebraria a própria migração. Adotei `^US-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+$` — mesma filosofia permissiva-na-cauda do `related_adrs` — que casa **100%** dos slugs canônicos reais e rejeita lixo (`FIN-037`, `US-FIN`, `US-037`).

## DoD (counterfactual — verificado local)

- Charter tocado **sem** `related_us` → `charter-us-lint --check` **exit 1** ✓
- Charter tocado **com** `related_us` válido → `--check` **exit 0** ✓
- Slug fora do padrão em charter tocado → **exit 1** ✓
- `--check` deste PR (vs `origin/main`) → **exit 0** (os 3 tocados têm slug válido — não auto-bloqueia) ✓
- `node scripts/governance/memory-health.mjs` → **0 🔴**, exit 0 ✓
- Zero `us:` charter restante repo-wide ✓
- Diff: 5 arquivos, 208+/3- = 211 linhas (≤300, 1 intent) ✓

## Counterfactual (por que importa)

Sem campo canônico, qualquer charter novo declara o link de US do jeito que quiser (`us:`, `related_us:`, ou nada) e o gate aceita — o join US→tela continua furado e o P10 (backfill IA) não tem alvo estável. Com `related_us` + lint de nascença, **todo charter que nasce/muda agora** é obrigado a declarar a US que atende (ou o `--check` morde), travando a divergência sem exigir o backfill pesado dos 132 de uma vez.

Parte do roadmap SDD (P14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)