### PR TITLE
feat(sdd): tripwire qualitativo do nightly (diff por-arquivo + classe de falha · P15)

### DIFF
--- a/scripts/tests/nightly-diff.mjs
+++ b/scripts/tests/nightly-diff.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+// nightly-diff.mjs — tripwire de regressão QUALITATIVA do nightly (ROADMAP-SDD P15).
+//
+// POR QUE (achado da avaliação adversarial 2026-06-21 + crítico de completude):
+// hoje só o `floor_count` AGREGADO é consumido (read-side sdd-scorecard.mjs). O floor é
+// a INTERSEÇÃO de 3 runs (floor-compute.mjs) — DE PROPÓSITO estável, mas isso MASCARA a
+// regressão de UMA noite: um arquivo de teste NOVO falhando, ou uma CLASSE de falha
+// (ex.: QueryException SQLSTATE[42S02]) explodindo, só entra no floor depois de 3 noites
+// — passa batido nesse meio-tempo. Este script faz o DIFF por-arquivo + por-classe entre
+// a noite N e N-1 e expõe {newly_failing_files, recovered_files, by_failure_class}.
+//
+// ANTI-PII (igual junit-summary.mjs, repo é PÚBLICO): a CLASSE de falha é derivada do
+// `type="..."` do <failure>/<error> do junit.xml (= nome FQ da exception, ESTÁVEL, sem
+// texto livre) + token SQLSTATE[XXXXX] quando a exception é de banco. NUNCA a mensagem.
+// O path do arquivo de teste já é público (vem do summary.json, que junit-summary já
+// publica). Frame de stack é OPCIONAL e, quando usado, só o basename:linha — nunca o
+// conteúdo. Default: NÃO extrai frame (só class+sqlstate) pra zero risco.
+//
+// ADVISORY POR CONSTRUÇÃO: este script SÓ COMPUTA o diff e o imprime. NÃO abre alerta
+// (gh issue / mcp_alertas). O caminho de alerta fica atrás do env NIGHTLY_DIFF_ALERT
+// (default OFF) — ligar SÓ após P03 estabilizar (US-GOV-021), senão é ruído de ambiente
+// (suíte era-sqlite ainda corrompe tabela CORE → falha de infra, não regressão real).
+//
+// Determinístico: para o MESMO par de runs, MESMO output (sem timestamp no corpo).
+// Espelha a estrutura de scripts/tests/floor-compute.mjs (validRuns + computeX + CLI guard).
+// Zero-dep (node >=18). Roda SEM CT100 (lê artefatos já materializados).
+//
+// USO:
+//   node scripts/tests/nightly-diff.mjs [--runs <dir>] [--out <file>]
+//     compara os 2 últimos runs VÁLIDOS de <dir> (cada um = pasta YYYYMMDD-HHMMSS com
+//     summary.json [+ junit.xml opcional p/ classe]).
+//   node scripts/tests/nightly-diff.mjs --n <summaryN.json> --prev <summaryN-1.json>
+//                                       [--junit-n <x.xml>] [--junit-prev <y.xml>] [--out <file>]
+//     compara 2 summary.json explícitos (modo usado pelo meta-teste e por CI ad-hoc).
+import { readdirSync, readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const arg = (k, d) => { const i = process.argv.indexOf(k); return i >= 0 ? process.argv[i + 1] : d; };
+
+// ── leitura de um "run" (summary.json + junit.xml opcional) ──────────────────
+// Aceita 2 formas: pasta de run (validRuns) OU caminhos explícitos (modo --n/--prev).
+function loadRun({ summaryPath, junitPath = null, ts = null }) {
+  if (!existsSync(summaryPath)) return null;
+  let s; try { s = JSON.parse(readFileSync(summaryPath, 'utf8')); } catch { return null; }
+  if (!s.coherent || !s.n_testcases || !Array.isArray(s.files)) return null;
+  const failingFiles = s.files
+    .filter((f) => (f.failed || 0) > 0 || (f.errors || 0) > 0)
+    .map((f) => f.file);
+  const xml = junitPath && existsSync(junitPath) ? safeRead(junitPath) : null;
+  return {
+    ts: ts || s.generated_at || null,
+    totals: s.totals || {},
+    failingFiles: [...new Set(failingFiles)].sort(),
+    failureClasses: xml ? extractFailureClasses(xml) : null,
+  };
+}
+function safeRead(p) { try { return readFileSync(p, 'utf8'); } catch { return null; } }
+
+// runs válidos de um diretório, em ordem cronológica (nome = YYYYMMDD-HHMMSS).
+// Espelha validRuns() do floor-compute.mjs; aqui também tenta casar o junit.xml ao lado.
+export function validRuns(runsDir) {
+  if (!existsSync(runsDir)) return [];
+  const names = readdirSync(runsDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && /^\d{8}-\d{6}$/.test(e.name))
+    .map((e) => e.name).sort();
+  const out = [];
+  for (const name of names) {
+    const dir = join(runsDir, name);
+    const run = loadRun({
+      summaryPath: join(dir, 'summary.json'),
+      junitPath: join(dir, 'junit.xml'),
+      ts: name,
+    });
+    if (run) out.push(run);
+  }
+  return out;
+}
+
+// ── CLASSE de falha ESTÁVEL a partir do junit.xml (anti-PII) ─────────────────
+// PHPUnit/Pest emitem <failure type="FQ\Exception\Class">msg</failure> (e <error type=...>).
+// O `type` é o nome FULLY-QUALIFIED da exception — ESTÁVEL e SEM texto de usuário.
+// Pra exceptions de banco (QueryException/PDOException), o SQLSTATE[XXXXX] no INÍCIO da
+// mensagem é um CÓDIGO estável (não-PII), então anexamos só ESSE token. Nada além disso
+// é lido da mensagem. Resultado: { "ExceptionClass": n } ou { "ExceptionClass#SQLSTATE[..]": n }.
+const FAIL_TAG_RE = /<(failure|error)\b([^>]*)>([\s\S]*?)<\/\1>/g;
+const SELFCLOSE_RE = /<(failure|error)\b([^>]*)\/>/g;
+const TYPE_RE = /\btype="([^"]*)"/;
+const SQLSTATE_RE = /SQLSTATE\[[0-9A-Z]{1,5}\]/; // ex.: SQLSTATE[42S02], SQLSTATE[HY000]
+
+function shortClass(fq) {
+  if (!fq) return '(sem-type)';
+  // só nome da classe (último segmento do namespace), preserva caracteres seguros.
+  const seg = fq.replace(/&amp;/g, '&').split(/[\\/]/).pop() || fq;
+  return seg.replace(/[^\w.+#-]/g, '') || '(sem-type)';
+}
+
+export function extractFailureClasses(xml) {
+  if (!xml) return {};
+  const counts = Object.create(null);
+  const bump = (attrs, body) => {
+    const t = (attrs.match(TYPE_RE) || [])[1] || null;
+    let key = shortClass(t);
+    // SQLSTATE é código estável — só esse token, NUNCA o resto da mensagem.
+    if (body) {
+      const m = body.match(SQLSTATE_RE);
+      if (m) key += `#${m[0]}`;
+    }
+    counts[key] = (counts[key] || 0) + 1;
+  };
+  for (const m of xml.matchAll(FAIL_TAG_RE)) bump(m[2], m[3]);
+  for (const m of xml.matchAll(SELFCLOSE_RE)) bump(m[2], '');
+  // ordena por chave pra output determinístico
+  const ordered = Object.create(null);
+  for (const k of Object.keys(counts).sort()) ordered[k] = counts[k];
+  return ordered;
+}
+
+// ── DIFF entre noite N e N-1 ─────────────────────────────────────────────────
+// newly_failing_files: falham em N e NÃO em N-1 (regressão por-arquivo de 1 noite).
+// recovered_files:     falhavam em N-1 e NÃO em N (sinal de melhora).
+// by_failure_class:    delta por classe estável { classe: { prev, curr, delta } }.
+// tripwire:            há regressão? (>=1 arquivo novo falhando OU >=1 classe inflando).
+export function diffRuns(curr, prev) {
+  if (!curr || !prev) {
+    return {
+      schema: 'nightly-diff/v1 (ROADMAP-SDD P15)',
+      comparable: false,
+      newly_failing_files: [], recovered_files: [], by_failure_class: {},
+      tripwire: false,
+      note: 'precisa de 2 runs validos (summary.json coherent + n_testcases>0); sem comparacao',
+    };
+  }
+  const cur = new Set(curr.failingFiles);
+  const pre = new Set(prev.failingFiles);
+  const newly = [...cur].filter((f) => !pre.has(f)).sort();
+  const recovered = [...pre].filter((f) => !cur.has(f)).sort();
+
+  const byClass = {};
+  if (curr.failureClasses || prev.failureClasses) {
+    const cc = curr.failureClasses || {};
+    const pc = prev.failureClasses || {};
+    for (const k of [...new Set([...Object.keys(cc), ...Object.keys(pc)])].sort()) {
+      const c = cc[k] || 0, p = pc[k] || 0;
+      if (c !== p) byClass[k] = { prev: p, curr: c, delta: c - p };
+    }
+  }
+  const classInflated = Object.values(byClass).some((d) => d.delta > 0);
+  const tripwire = newly.length > 0 || classInflated;
+  return {
+    schema: 'nightly-diff/v1 (ROADMAP-SDD P15)',
+    comparable: true,
+    runs: { curr: curr.ts, prev: prev.ts },
+    newly_failing_files: newly,
+    recovered_files: recovered,
+    by_failure_class: byClass,
+    tripwire,
+    note: tripwire
+      ? `regressao QUALITATIVA detectada: ${newly.length} arquivo(s) novo(s) falhando${classInflated ? ' + classe(s) de falha inflada(s)' : ''} (ADVISORY — alerta OFF; ligar so apos P03 estabilizar, US-GOV-021)`
+      : 'sem regressao por-arquivo nem por-classe entre as 2 noites (no-op)',
+  };
+}
+
+// ── alerta (DOCUMENTADO, atrás de flag DESLIGADO) ────────────────────────────
+// Caminho de alerta deliberadamente NÃO implementado/ligado. Quando P03 (US-GOV-021,
+// isolar os 18 corruptores era-sqlite) estabilizar, o nightly vai parar de gerar ruído
+// de ambiente; SÓ AÍ liga-se o alerta — setando NIGHTLY_DIFF_ALERT=1 e ligando o canal
+// (gh issue OU mcp_alertas) AQUI. Até lá, advisory puro (só imprime o diff).
+function maybeAlert(diff) {
+  if (process.env.NIGHTLY_DIFF_ALERT !== '1') return; // OFF por padrão (ligar só apos P03 — US-GOV-021)
+  if (!diff.tripwire) return;
+  // INTENCIONALMENTE NÃO-IMPLEMENTADO: ligar so apos P03 estabilizar (US-GOV-021).
+  // Esperado: abrir/atualizar gh issue OU mcp_alertas com newly_failing_files +
+  // by_failure_class (SEM mensagem — anti-PII; o diff já é anti-PII por construção).
+  console.error('[nightly-diff] NIGHTLY_DIFF_ALERT=1 mas canal de alerta nao ligado (P15: advisory ate P03 — US-GOV-021).');
+}
+
+// ── CLI (só quando executado direto; importável p/ teste) ────────────────────
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+const isMain = (() => { try { return realpathSync(process.argv[1]) === fileURLToPath(import.meta.url); } catch { return false; } })();
+if (isMain) {
+  const OUT = arg('--out', null);
+  let curr, prev;
+  const nPath = arg('--n', null);
+  if (nPath) {
+    // modo explícito: 2 summary.json (+ junit opcional)
+    curr = loadRun({ summaryPath: nPath, junitPath: arg('--junit-n', null), ts: 'N' });
+    prev = loadRun({ summaryPath: arg('--prev', null) ?? '', junitPath: arg('--junit-prev', null), ts: 'N-1' });
+  } else {
+    // modo diretório: 2 últimos runs válidos
+    const runs = validRuns(arg('--runs', '/opt/oimpresso-fullsuite/runs'));
+    curr = runs[runs.length - 1] || null;
+    prev = runs[runs.length - 2] || null;
+  }
+  const diff = diffRuns(curr, prev);
+  const json = JSON.stringify(diff, null, 2) + '\n';
+  if (OUT) writeFileSync(OUT, json, 'utf8');
+  console.log(json.trimEnd());
+  maybeAlert(diff);
+  // ADVISORY: nunca derruba o build (exit 0 sempre — alerta vem do canal, post-P03).
+  process.exit(0);
+}

--- a/scripts/tests/nightly-diff.test.mjs
+++ b/scripts/tests/nightly-diff.test.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Teste do tripwire qualitativo do nightly (ROADMAP-SDD P15). Importa diffRuns/
+// validRuns/extractFailureClasses (guard isMain garante que o import NÃO roda o CLI)
+// e prova as 2 condições que o crítico de completude exigiu:
+//   (a) noite com classe ESTÁVEL + mesmos arquivos → 0 tripwire (no-op);
+//   (b) noite com arquivo NOVO falhando OU classe de falha INFLADA → detecta.
+// Roda SEM CT100 (fixtures sintéticas em tmpdir). Espelha floor-compute.test.mjs.
+import { diffRuns, validRuns, extractFailureClasses } from './nightly-diff.mjs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const readXml = (dir) => readFileSync(join(dir, 'junit.xml'), 'utf8');
+
+let fails = 0;
+const ok = (c, m) => { if (c) console.log(`  ✓ ${m}`); else { console.error(`  ✗ ${m}`); fails++; } };
+
+const root = join(tmpdir(), `nightly-diff-test-${process.pid}`);
+
+// fixture de 1 run: summary.json (anti-PII, igual junit-summary) + junit.xml (fonte da classe).
+// failingFiles = files c/ failed>0||errors>0; classes = type="..." dos <failure>/<error>.
+const mkRun = (name, failingFiles, failures = []) => {
+  const d = join(root, name); mkdirSync(d, { recursive: true });
+  writeFileSync(join(d, 'summary.json'), JSON.stringify({
+    schema: 'junit-summary/v1', coherent: true, n_testcases: 50,
+    totals: { passed: 50 - failingFiles.length, failed: failingFiles.length, errors: 0, skipped: 0 },
+    files: failingFiles.map((f) => ({ file: f, tests: 1, passed: 0, failed: 1, errors: 0, skipped: 0 }))
+      .concat([{ file: 'tests/Feature/AlwaysGreenTest.php', tests: 1, passed: 1, failed: 0, errors: 0, skipped: 0 }]),
+  }, null, 2));
+  // junit.xml sintético com <failure type="..."> / <error type="...">
+  const cases = failures.map((fl) => {
+    const tag = fl.kind === 'error' ? 'error' : 'failure';
+    const body = fl.sqlstate ? `SQLSTATE[${fl.sqlstate}]: blah blah (NOME DA PESSOA aqui seria PII)` : 'Failed asserting that false is true.';
+    return `  <testcase name="t" file="${fl.file}::it x"><${tag} type="${fl.type}">${body}</${tag}></testcase>`;
+  }).join('\n');
+  writeFileSync(join(d, 'junit.xml'),
+    `<?xml version="1.0"?>\n<testsuites>\n<testsuite name="all" tests="50">\n${cases}\n</testsuite>\n</testsuites>\n`);
+};
+
+try {
+  // ── (a) 2 noites IDÊNTICAS → no-op (sem tripwire) ─────────────────────────
+  const failsA = [
+    { file: 'tests/Feature/FooTest.php', type: 'PHPUnit\\Framework\\ExpectationFailedException' },
+    { file: 'tests/Feature/BarTest.php', kind: 'error', type: 'Illuminate\\Database\\QueryException', sqlstate: '42S02' },
+  ];
+  mkRun('20260101-020000', ['tests/Feature/FooTest.php', 'tests/Feature/BarTest.php'], failsA);
+  mkRun('20260102-020000', ['tests/Feature/FooTest.php', 'tests/Feature/BarTest.php'], failsA);
+  const runs = validRuns(root);
+  ok(runs.length === 2, `2 runs válidos carregados — got ${runs.length}`);
+
+  const stable = diffRuns(runs[1], runs[0]);
+  ok(stable.comparable === true, 'noites estáveis: comparable');
+  ok(stable.tripwire === false, '(a) classe estável + mesmos arquivos → 0 tripwire (no-op)');
+  ok(stable.newly_failing_files.length === 0, '(a) nenhum arquivo novo falhando');
+  ok(Object.keys(stable.by_failure_class).length === 0, '(a) by_failure_class vazio (delta zero)');
+
+  // anti-PII: a classe extraída é só o nome curto da exception (+ SQLSTATE), nunca a msg
+  const cls = extractFailureClasses(
+    '<failure type="Illuminate\\Database\\QueryException">SQLSTATE[42S02]: Base table not found — segredo aqui</failure>');
+  ok(JSON.stringify(cls) === '{"QueryException#SQLSTATE[42S02]":1}',
+    `anti-PII: classe = QueryException#SQLSTATE[42S02] (sem msg livre) — got ${JSON.stringify(cls)}`);
+
+  // ── (b1) ARQUIVO NOVO no floor → detecta ──────────────────────────────────
+  mkRun('20260103-020000',
+    ['tests/Feature/FooTest.php', 'tests/Feature/BarTest.php', 'tests/Feature/NovoTest.php'],
+    failsA.concat([{ file: 'tests/Feature/NovoTest.php', type: 'PHPUnit\\Framework\\ExpectationFailedException' }]));
+  const r3 = validRuns(root);
+  const newFileDiff = diffRuns(r3[2], r3[1]);
+  ok(newFileDiff.tripwire === true, '(b) arquivo NOVO falhando → tripwire dispara');
+  ok(newFileDiff.newly_failing_files.includes('tests/Feature/NovoTest.php'),
+    '(b) NovoTest.php em newly_failing_files');
+  ok(newFileDiff.recovered_files.length === 0, '(b) nenhum recovered nesse passo');
+
+  // ── (b2) CLASSE INFLADA (mesmos arquivos) → detecta ───────────────────────
+  // N-1: 1 ExpectationFailed; N: 3 ExpectationFailed no MESMO arquivo (classe inflou 1→3).
+  const baseN1 = join(tmpdir(), `nd-inflate-prev-${process.pid}`);
+  const baseN = join(tmpdir(), `nd-inflate-curr-${process.pid}`);
+  const mk = (dir, n) => {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'summary.json'), JSON.stringify({
+      coherent: true, n_testcases: 50, totals: { failed: 1, errors: 0, skipped: 0 },
+      files: [{ file: 'tests/Feature/FlakyTest.php', failed: 1, errors: 0 }],
+    }));
+    const cases = Array.from({ length: n }, () =>
+      '  <testcase name="t" file="tests/Feature/FlakyTest.php::it x"><failure type="PHPUnit\\Framework\\ExpectationFailedException">Failed asserting</failure></testcase>').join('\n');
+    writeFileSync(join(dir, 'junit.xml'),
+      `<?xml version="1.0"?>\n<testsuites><testsuite name="all" tests="50">\n${cases}\n</testsuite></testsuites>\n`);
+  };
+  mk(baseN1, 1); mk(baseN, 3);
+  const inflated = diffRuns(
+    { ts: 'N', failingFiles: ['tests/Feature/FlakyTest.php'], failureClasses: extractFailureClasses(readXml(baseN)) },
+    { ts: 'N-1', failingFiles: ['tests/Feature/FlakyTest.php'], failureClasses: extractFailureClasses(readXml(baseN1)) });
+  ok(inflated.tripwire === true, '(b) classe INFLADA (1→3) com mesmos arquivos → tripwire dispara');
+  ok(inflated.newly_failing_files.length === 0, '(b) classe inflada sem arquivo novo: newly vazio');
+  ok(inflated.by_failure_class['ExpectationFailedException']?.delta === 2,
+    `(b) delta da classe = +2 — got ${JSON.stringify(inflated.by_failure_class)}`);
+  rmSync(baseN1, { recursive: true, force: true });
+  rmSync(baseN, { recursive: true, force: true });
+
+  // ── borda: <2 runs válidos → não comparável (não mente regressão) ─────────
+  ok(diffRuns(runs[0], null).comparable === false, '<2 runs → comparable=false (não mente tripwire)');
+  ok(diffRuns(runs[0], null).tripwire === false, '<2 runs → tripwire=false');
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+console.log(fails === 0 ? '\n  nightly-diff (ROADMAP-SDD P15): OK\n' : `\n  nightly-diff: ${fails} FALHA(S)\n`);
+process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
## O que faz

Adiciona um **tripwire de regressão QUALITATIVA do nightly** (advisory), o gap que o crítico de completude apontou no roadmap SDD P15.

Hoje só o `floor_count` **agregado** é consumido pelo read-side. O floor é a **interseção de 3 runs** (`floor-compute.mjs`) — estável de propósito, mas isso **mascara a regressão de UMA noite**: um arquivo de teste **novo** falhando, ou uma **classe** de falha (ex.: `QueryException#SQLSTATE[42S02]`) explodindo, só entra no floor depois de 3 noites e passa batido.

Dois arquivos novos (zero-dep, espelham `floor-compute.mjs` / `floor-compute.test.mjs`):

- `scripts/tests/nightly-diff.mjs` — dado 2 `summary.json` (noite N e N-1), computa `{newly_failing_files, recovered_files, by_failure_class, tripwire}`. A **classe de falha** é derivada do `type="..."` do `<failure>`/`<error>` do `junit.xml` (= nome FQ da exception, **estável**) + token `SQLSTATE[XXXXX]` quando é exception de banco. **Nunca a mensagem livre** → anti-PII por construção (igual `junit-summary.mjs`; repo é público).
- `scripts/tests/nightly-diff.test.mjs` — 14 asserts com fixtures sintéticas, roda **SEM CT100**.

**Alerta deliberadamente NÃO ligado**: o caminho (gh issue / mcp_alertas) fica atrás do env `NIGHTLY_DIFF_ALERT` (default OFF), com comentário inline *"ligar só apos P03 estabilizar (US-GOV-021)"* — senão vira ruído de ambiente era-sqlite (a suíte ainda corrompe tabela CORE → falha de infra, não regressão real).

Não cria workflow CI → **sem entrada nova** em `gates-registry.json` (Check [G] intacto).

## DoD (counterfactual)

- ✅ `node scripts/tests/nightly-diff.test.mjs` → 14/14 OK (sem CT100).
- ✅ **Counterfactual — classe inflada** (`1→3` no mesmo arquivo) → `tripwire: true`, `by_failure_class.ExpectationFailedException.delta === 2`.
- ✅ **Counterfactual — arquivo novo no floor** (`tests/B.php` aparece em N) → `tripwire: true`, `newly_failing_files: ["tests/B.php"]`.
- ✅ **2 noites idênticas** → `tripwire: false`, no-op (não alerta).
- ✅ **Anti-PII** provado: `<failure type="...QueryException">SQLSTATE[42S02]: ...segredo...</failure>` → chave `QueryException#SQLSTATE[42S02]` (mensagem livre descartada).
- ✅ `<2 runs válidos` → `comparable: false` / `tripwire: false` (não mente regressão).
- ✅ `node scripts/governance/memory-health.mjs` → **0 🔴**.

Parte do roadmap SDD (P15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)