### PR TITLE
feat(governance): sentinela transporte CT100→main — mcp_served_drift + index_freshness + escalonamento (Onda 1)

### DIFF
--- a/Modules/Governance/Config/config.php
+++ b/Modules/Governance/Config/config.php
@@ -80,7 +80,51 @@ return [
         \Modules\Governance\Services\Checkers\RoutesZombieChecker::class,        // ADR 0221
         \Modules\Governance\Services\Checkers\MeilisearchSettingsDriftChecker::class, // 2026-05-29 — embedder do índice se perdeu 2× (recall degrada)
         \Modules\Governance\Services\Checkers\DeployDriftChecker::class,         // 2026-05-29 — código deployado != main (1302-commits cego)
+        \Modules\Governance\Services\Checkers\McpServedDriftChecker::class,      // 2026-06-21 Onda 1 — commit servido por env remoto != main (CT100→main, ~19d cego)
+        \Modules\Governance\Services\Checkers\McpIndexFreshnessChecker::class,   // 2026-06-21 Onda 1 — índice mcp_memory_documents defasado vs git memory/
     ],
+
+    /*
+     * Onda 1 (sentinela transporte CT100→main) — envs que o McpServedDriftChecker
+     * consulta via GET <url>/api/mcp/version (ADR 0256) pra comparar o commit SERVIDO
+     * por cada um com GitHub main. Cada item: {nome, url} (sem trailing slash).
+     *
+     * Default cobre só o MCP público (mcp.oimpresso.com). Override por env
+     * GOVERNANCE_DEPLOY_DRIFT_ENVS (JSON: [{"nome":"...","url":"https://..."}]) —
+     * ex pra adicionar o app Hostinger quando ele expuser /api/mcp/version.
+     *
+     * Hostinger ≠ CT 100 (ADR 0062) — adicionar Hostinger só quando tiver endpoint próprio.
+     * Auth: Bearer config('copiloto.mcp.drift_token') (env MCP_DRIFT_TOKEN), o mesmo
+     * token dedicado do endpoint. Falha de rede/HTTP NÃO derruba o audit (finding low/info).
+     */
+    'deploy_drift_envs' => (function () {
+        $raw = env('GOVERNANCE_DEPLOY_DRIFT_ENVS');
+        if (is_string($raw) && trim($raw) !== '') {
+            $decoded = json_decode($raw, true);
+            if (is_array($decoded)) {
+                return $decoded;
+            }
+        }
+
+        return [
+            ['nome' => 'mcp', 'url' => 'https://mcp.oimpresso.com'],
+        ];
+    })(),
+
+    /*
+     * Onda 1 — lag máximo tolerado (horas) entre o último commit que tocou git memory/
+     * e o doc mais recente em mcp_memory_documents (McpIndexFreshnessChecker). Acima
+     * disso = índice defasado (sync IndexarMemoryGitParaDb falhou calado?). Default 6h.
+     */
+    'mcp_index_freshness_max_lag_hours' => env('GOVERNANCE_MCP_INDEX_FRESHNESS_MAX_LAG_HOURS', 6),
+
+    /*
+     * Onda 1 — escalonamento por persistência (trait PersistsDriftAlert). Se o MESMO
+     * drift segue ABERTO há mais de N dias, a severidade efetiva do alerta é elevada
+     * 1 nível (warn→high / high→critical) + flag escalated=true no metadata, pra que
+     * `governance:audit --notify` dispare alerta ATIVO em vez de só log diário. Default 3.
+     */
+    'drift_escalation_days' => env('GOVERNANCE_DRIFT_ESCALATION_DAYS', 3),
 
     /*
      * Allowlist multi-tenant: Models legítimos sem HasBusinessScope.

--- a/Modules/Governance/Services/Checkers/McpIndexFreshnessChecker.php
+++ b/Modules/Governance/Services/Checkers/McpIndexFreshnessChecker.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services\Checkers;
+
+use Illuminate\Support\Facades\Process;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\DriftCheckResult;
+use Modules\Governance\Services\DriftFinding;
+
+/**
+ * McpIndexFreshnessChecker — índice MCP (mcp_memory_documents) defasado vs git memory/ (Onda 1).
+ *
+ * Terceira perna da sentinela de transporte CT100→main: mesmo que o código deployado
+ * esteja em main (DeployDrift/McpServedDrift verdes), o ÍNDICE da memória pode ter
+ * parado de atualizar — o job IndexarMemoryGitParaDb (webhook GitHub OU cron 5min)
+ * pode falhar CALADO. Resultado: docs novos em memory/ existem no git mas as tools
+ * MCP (decisions-search/kb-answer) servem versão velha. Drift silencioso clássico.
+ *
+ * Compara:
+ *  - índice: `McpMemoryDocument::max('updated_at')` (doc mais recentemente indexado).
+ *  - git: timestamp do último commit que TOCOU `memory/` (`git log -1 --format=%cI -- memory/`).
+ *
+ * Se o índice está mais velho que o último commit de memory/ por > X horas (default 6,
+ * configurável via `governance.mcp_index_freshness_max_lag_hours`), finding high:
+ * "índice MCP defasado — IndexarMemoryGitParaDb pode ter falhado calado".
+ *
+ * Tolerância a falha: DB indisponível OU git indisponível (container sem binário) =
+ * finding info, sem throw. Determinístico, sem efeitos colaterais.
+ *
+ * Severity high · enforcement warn · cadence daily. System-level (sem business_id —
+ * tabela é repo-wide por ADR 0053; ADR 0093 §Exceção).
+ */
+final class McpIndexFreshnessChecker implements DriftChecker
+{
+    /** Lag default tolerado (h) entre commit de memory/ e índice. Override por config. */
+    private const DEFAULT_MAX_LAG_HOURS = 6;
+
+    /** Timeout do `git log` (s). Curto — sentinela não pendura o audit. */
+    private const GIT_TIMEOUT = 10;
+
+    public function name(): string
+    {
+        return 'mcp_index_freshness';
+    }
+
+    public function description(): string
+    {
+        return 'Índice MCP (mcp_memory_documents) defasado vs último commit em git memory/ (sync calado?)';
+    }
+
+    public function tags(): array
+    {
+        return ['tier_1', 'mcp', 'infra', 'transporte'];
+    }
+
+    public function severity(): string
+    {
+        return 'high';
+    }
+
+    public function enforcement(): string
+    {
+        return 'warn';
+    }
+
+    public function cadence(): string
+    {
+        return 'daily';
+    }
+
+    public function check(array $opts = []): DriftCheckResult
+    {
+        $start = microtime(true);
+
+        $maxLagHours = (int) config('governance.mcp_index_freshness_max_lag_hours', self::DEFAULT_MAX_LAG_HOURS);
+
+        $indexTs = $this->ultimoDocIndexado();
+        $gitTs = $this->ultimoCommitMemory();
+
+        $duration = (int) round((microtime(true) - $start) * 1000);
+
+        $findings = $this->analisar($indexTs, $gitTs, $maxLagHours);
+        $meta = [
+            'index_updated_at' => $indexTs?->toIso8601String(),
+            'git_memory_committed_at' => $gitTs?->toIso8601String(),
+            'max_lag_hours' => $maxLagHours,
+        ];
+
+        if ($findings === []) {
+            return DriftCheckResult::clean($this->name(), $duration, $meta);
+        }
+
+        return DriftCheckResult::drifted($this->name(), $findings, $duration, $meta);
+    }
+
+    /**
+     * Decide o finding a partir dos dois timestamps. Puro/testável (sem DB/git).
+     *
+     * @return DriftFinding[]
+     */
+    public function analisar(?\Carbon\CarbonInterface $indexTs, ?\Carbon\CarbonInterface $gitTs, int $maxLagHours): array
+    {
+        // Sem timestamp de git (binário ausente, repo raso) → info, não verificável.
+        if ($gitTs === null) {
+            return [new DriftFinding(
+                target: 'mcp_index',
+                target_type: 'index',
+                severity: 'info',
+                message: 'Não consegui ler o último commit de memory/ (git indisponível). Frescor do índice não verificável.',
+                evidence: ['git_memory_committed_at' => null],
+            )];
+        }
+
+        // Sem doc indexado (DB vazio ou indisponível) → info.
+        if ($indexTs === null) {
+            return [new DriftFinding(
+                target: 'mcp_index',
+                target_type: 'index',
+                severity: 'info',
+                message: 'Índice MCP vazio ou DB indisponível (mcp_memory_documents.max(updated_at) nulo). Frescor não verificável.',
+                evidence: ['index_updated_at' => null, 'git_memory_committed_at' => $gitTs->toIso8601String()],
+            )];
+        }
+
+        // Índice mais velho que o último commit de memory/ por mais que o lag tolerado.
+        $lagHoras = $gitTs->diffInHours($indexTs, false) * -1; // git - index, positivo se índice atrás
+        if ($indexTs->lt($gitTs) && $lagHoras > $maxLagHours) {
+            return [new DriftFinding(
+                target: 'mcp_index',
+                target_type: 'index',
+                severity: 'high',
+                message: sprintf(
+                    'Índice MCP defasado: último doc indexado em %s, mas memory/ tem commit em %s (%dh atrás do git, limite %dh). '
+                        .'IndexarMemoryGitParaDb pode ter falhado calado — checar webhook GitHub→MCP + cron 5min.',
+                    $indexTs->toIso8601String(),
+                    $gitTs->toIso8601String(),
+                    (int) round($lagHoras),
+                    $maxLagHours,
+                ),
+                evidence: [
+                    'index_updated_at' => $indexTs->toIso8601String(),
+                    'git_memory_committed_at' => $gitTs->toIso8601String(),
+                    'lag_hours' => (int) round($lagHoras),
+                    'max_lag_hours' => $maxLagHours,
+                ],
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * `McpMemoryDocument::max('updated_at')` tolerando DB indisponível/tabela ausente.
+     * Retorna null em qualquer falha (NUNCA throw).
+     */
+    private function ultimoDocIndexado(): ?\Carbon\CarbonInterface
+    {
+        try {
+            $max = \Modules\Jana\Entities\Mcp\McpMemoryDocument::max('updated_at');
+            if ($max === null || $max === '') {
+                return null;
+            }
+
+            return \Carbon\Carbon::parse($max);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Timestamp ISO-8601 do último commit que tocou `memory/` via `git log -1 --format=%cI`.
+     * null se git indisponível / sem commit / falha (NUNCA throw).
+     */
+    private function ultimoCommitMemory(): ?\Carbon\CarbonInterface
+    {
+        try {
+            $process = Process::path(base_path())
+                ->timeout(self::GIT_TIMEOUT)
+                ->run(['git', 'log', '-1', '--format=%cI', '--', 'memory/']);
+
+            if (! $process->successful()) {
+                return null;
+            }
+            $out = trim($process->output());
+            if ($out === '') {
+                return null;
+            }
+
+            return \Carbon\Carbon::parse($out);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/Modules/Governance/Services/Checkers/McpServedDriftChecker.php
+++ b/Modules/Governance/Services/Checkers/McpServedDriftChecker.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services\Checkers;
+
+use Illuminate\Support\Facades\Http;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\DriftCheckResult;
+use Modules\Governance\Services\DriftFinding;
+
+/**
+ * McpServedDriftChecker — commit SERVIDO por cada env != GitHub main (Onda 1).
+ *
+ * Fecha o gap de transporte CT100→main que o {@see DeployDriftChecker} (ADR 0216)
+ * marcou como follow-up: "Multi-env (Hostinger via /health) = follow-up; v1 cobre
+ * o ambiente onde roda (CT 100)". Incidente real que motivou: o container MCP ficou
+ * ~19 dias stale vs main e ninguém viu — handoff-pending/-ack inalcançáveis o tempo todo.
+ *
+ * Diferença do DeployDriftChecker:
+ *  - DeployDriftChecker: lê `.git/HEAD` LOCAL (o env ONDE o audit roda — CT 100).
+ *  - McpServedDriftChecker: CONSOME `GET /api/mcp/version` (ADR 0256) de uma lista de
+ *    envs REMOTOS (mcp.oimpresso.com etc.) e compara o commit servido por CADA UM
+ *    com main. Pega o stale de QUALQUER env, não só o local.
+ *
+ * Fonte de "main": REUTILIZA a mesma do DeployDriftChecker (arquivo gravado pelo
+ * webhook GitHub→MCP + fallback origin/main ref) — instancia o DeployDriftChecker e
+ * chama seus métodos públicos `latestMainSha`/`mesmoSha`. Zero duplicação da lógica
+ * de leitura de SHA (single source of truth — se a fonte de main mudar, muda nos dois).
+ *
+ * Auth: Bearer `config('copiloto.mcp.drift_token')` (env MCP_DRIFT_TOKEN) — o MESMO
+ * token dedicado que o endpoint /api/mcp/version espera (sem user, sem RBAC).
+ *
+ * Tolerância a falha: rede/HTTP fora do ar = finding low/info (NÃO derruba o audit,
+ * NUNCA throw). Determinístico, sem efeitos colaterais.
+ *
+ * Severity high (env stale = bug/feature ausente em prod, silencioso) · enforcement
+ * warn · cadence daily. System-level (sem business_id — ADR 0093 §Exceção repo-wide).
+ */
+final class McpServedDriftChecker implements DriftChecker
+{
+    /** Timeout por env (s). Curto de propósito — sentinela não pode pendurar o audit. */
+    private const HTTP_TIMEOUT = 8;
+
+    public function name(): string
+    {
+        return 'mcp_served_drift';
+    }
+
+    public function description(): string
+    {
+        return 'Commit servido por cada env (/api/mcp/version) != GitHub main (env stale silencioso)';
+    }
+
+    public function tags(): array
+    {
+        return ['tier_1', 'deploy', 'infra', 'transporte'];
+    }
+
+    public function severity(): string
+    {
+        return 'high';
+    }
+
+    public function enforcement(): string
+    {
+        return 'warn';
+    }
+
+    public function cadence(): string
+    {
+        return 'daily';
+    }
+
+    public function check(array $opts = []): DriftCheckResult
+    {
+        $start = microtime(true);
+
+        $deployChecker = new DeployDriftChecker();
+        $main = $deployChecker->latestMainSha(base_path());
+
+        $envs = $this->envs();
+        $token = (string) config('copiloto.mcp.drift_token', '');
+
+        $findings = [];
+        $metaEnvs = [];
+
+        foreach ($envs as $env) {
+            [$finding, $meta] = $this->verificarEnv($env, $main, $token, $deployChecker);
+            $metaEnvs[] = $meta;
+            if ($finding !== null) {
+                $findings[] = $finding;
+            }
+        }
+
+        $duration = (int) round((microtime(true) - $start) * 1000);
+        $meta = ['main' => $main, 'envs' => $metaEnvs];
+
+        if ($findings === []) {
+            return DriftCheckResult::clean($this->name(), $duration, $meta);
+        }
+
+        return DriftCheckResult::drifted($this->name(), $findings, $duration, $meta);
+    }
+
+    /**
+     * Lista de envs a checar — config NOVO `governance.deploy_drift_envs`.
+     * Cada item: ['nome' => string, 'url' => string] (sem trailing slash).
+     * Default cobre só o MCP público; overridable por env GOVERNANCE_DEPLOY_DRIFT_ENVS (JSON).
+     *
+     * @return array<int, array{nome: string, url: string}>
+     */
+    private function envs(): array
+    {
+        $raw = config('governance.deploy_drift_envs', []);
+        $out = [];
+        foreach ((array) $raw as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+            $nome = trim((string) ($item['nome'] ?? ''));
+            $url = rtrim(trim((string) ($item['url'] ?? '')), '/');
+            if ($nome === '' || $url === '') {
+                continue;
+            }
+            $out[] = ['nome' => $nome, 'url' => $url];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Bate em UM env, compara commit servido × main, decide o finding.
+     * Puro o suficiente pra testar com Http::fake. Nunca lança.
+     *
+     * @return array{0: ?DriftFinding, 1: array<string, mixed>}
+     */
+    private function verificarEnv(array $env, ?string $main, string $token, DeployDriftChecker $deployChecker): array
+    {
+        $nome = $env['nome'];
+        $url = $env['url'].'/api/mcp/version';
+
+        try {
+            $resp = Http::withToken($token)
+                ->timeout(self::HTTP_TIMEOUT)
+                ->acceptJson()
+                ->get($url);
+        } catch (\Throwable $e) {
+            // Rede caiu (DNS, conexão recusada, timeout transport) — info, não derruba.
+            return [
+                new DriftFinding(
+                    target: $nome,
+                    target_type: 'env',
+                    severity: 'info',
+                    message: "Não consegui contatar {$nome} ({$url}): {$e->getMessage()}. Drift do env não verificável agora.",
+                    evidence: ['env' => $nome, 'url' => $url, 'error' => $e->getMessage()],
+                ),
+                ['nome' => $nome, 'status' => 'unreachable', 'error' => $e->getMessage()],
+            ];
+        }
+
+        if (! $resp->successful()) {
+            // 401 (token errado), 500 (misconfigured), 5xx (env doente) — low, não derruba.
+            return [
+                new DriftFinding(
+                    target: $nome,
+                    target_type: 'env',
+                    severity: 'low',
+                    message: "{$nome} ({$url}) respondeu HTTP {$resp->status()} — commit servido não verificável "
+                        .'(token MCP_DRIFT_TOKEN errado? env doente?).',
+                    evidence: ['env' => $nome, 'url' => $url, 'http_status' => $resp->status()],
+                ),
+                ['nome' => $nome, 'status' => 'http_'.$resp->status()],
+            ];
+        }
+
+        $served = $this->extrairCommit($resp->json('commit'));
+        $deployedAt = $resp->json('deployed_at');
+
+        // Env respondeu mas sem commit (deployed_commit.txt = "unknown" no boot) → info.
+        if ($served === null) {
+            return [
+                new DriftFinding(
+                    target: $nome,
+                    target_type: 'env',
+                    severity: 'info',
+                    message: "{$nome} respondeu mas sem commit servido (deployed_commit.txt 'unknown'?). Reverifica no próximo boot.",
+                    evidence: ['env' => $nome, 'url' => $url, 'served' => null, 'deployed_at' => $deployedAt],
+                ),
+                ['nome' => $nome, 'status' => 'no_commit', 'deployed_at' => $deployedAt],
+            ];
+        }
+
+        // Main desconhecido (webhook ainda não gravou + sem origin/main ref) → info, não trava.
+        if ($main === null) {
+            return [
+                new DriftFinding(
+                    target: $nome,
+                    target_type: 'env',
+                    severity: 'info',
+                    message: "SHA de main desconhecido ainda — não dá pra comparar {$nome} ({$served}). Reverifica no próximo push.",
+                    evidence: ['env' => $nome, 'served' => $served, 'main' => null, 'deployed_at' => $deployedAt],
+                ),
+                ['nome' => $nome, 'status' => 'main_unknown', 'served' => $served, 'deployed_at' => $deployedAt],
+            ];
+        }
+
+        if (! $deployChecker->mesmoSha($served, $main)) {
+            $idade = $this->idadeHumana($deployedAt);
+            $sufixoIdade = $idade !== null ? " Servido há {$idade}." : '';
+
+            return [
+                new DriftFinding(
+                    target: $nome,
+                    target_type: 'env',
+                    severity: 'high',
+                    message: "{$nome} serve commit {$served} != GitHub main ({$main}).{$sufixoIdade} "
+                        .'Env stale — fazer deploy (ver RUNBOOK-transporte-sentinel + INFRA-ACESSO-CANON).',
+                    evidence: [
+                        'env' => $nome,
+                        'url' => $url,
+                        'served' => $served,
+                        'main' => $main,
+                        'deployed_at' => $deployedAt,
+                        'idade' => $idade,
+                    ],
+                ),
+                ['nome' => $nome, 'status' => 'drifted', 'served' => $served, 'deployed_at' => $deployedAt],
+            ];
+        }
+
+        return [null, ['nome' => $nome, 'status' => 'fresh', 'served' => $served, 'deployed_at' => $deployedAt]];
+    }
+
+    /** Normaliza/valida o commit vindo do JSON. null se ausente/inválido. */
+    private function extrairCommit(mixed $raw): ?string
+    {
+        if (! is_string($raw)) {
+            return null;
+        }
+        $sha = strtolower(trim($raw));
+
+        return preg_match('/^[0-9a-f]{7,40}$/', $sha) === 1 ? $sha : null;
+    }
+
+    /**
+     * Quanto tempo faz que o env deployou (string legível PT-BR), a partir do
+     * `deployed_at` ISO-8601 do /api/mcp/version. null se ausente/ilegível.
+     */
+    private function idadeHumana(mixed $deployedAt): ?string
+    {
+        if (! is_string($deployedAt) || trim($deployedAt) === '') {
+            return null;
+        }
+        try {
+            return \Carbon\Carbon::parse($deployedAt)->diffForHumans(now(), \Carbon\CarbonInterface::DIFF_ABSOLUTE);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/Modules/Governance/Services/Concerns/PersistsDriftAlert.php
+++ b/Modules/Governance/Services/Concerns/PersistsDriftAlert.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Governance\Services\Concerns;
 
+use Carbon\Carbon;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Modules\Governance\Services\DriftFinding;
@@ -31,6 +32,16 @@ trait PersistsDriftAlert
      *
      * Idempotência diária: 2x mesmo dia com mesmo (checker, target) NÃO duplica.
      * Dia seguinte com mesmo drift = NOVO alerta (não spam, mas mostra recorrência).
+     *
+     * Escalonamento por persistência (Onda 1 — sentinela transporte): se o MESMO drift
+     * (checker+target_type+target) já tem alerta-evento ABERTO há mais de N dias
+     * (`governance.drift_escalation_days`, default 3), a severidade EFETIVA do novo
+     * registro é elevada (warn→high / high→critical) e o metadata ganha `escalated=true`
+     * + `first_seen_at` + `dias_aberto`, pra que `governance:audit --notify` dispare um
+     * alerta ATIVO (Centrifugo) em vez de só persistir mais um diário ignorável.
+     *
+     * ADITIVO/retrocompatível: drift novo (sem histórico) segue o caminho de sempre,
+     * com `escalated=false`. Reusa `created_at` existente — sem coluna/migration nova.
      */
     public function persistirDriftAlert(
         string $checkerName,
@@ -55,22 +66,45 @@ trait PersistsDriftAlert
                 return (int) $existing;
             }
 
+            // Escalonamento: primeira ocorrência ABERTA deste MESMO drift (ignora o
+            // sufixo de data da chave — a chave é diária, então alerta de 4 dias atrás
+            // tem chave diferente; buscamos pelo prefixo chave/tipo + target estável).
+            $primeiraOcorrencia = $this->primeiraOcorrenciaAberta($checkerName, $finding, $targetHash);
+            $diasAberto = $primeiraOcorrencia !== null
+                ? (int) Carbon::parse($primeiraOcorrencia)->diffInDays(now())
+                : 0;
+            $limiteDias = (int) config('governance.drift_escalation_days', 3);
+            $escalated = $primeiraOcorrencia !== null && $diasAberto > $limiteDias;
+
+            $severityEfetiva = $escalated
+                ? $this->escalarSeveridade($finding->severity)
+                : $finding->severity;
+
+            $metadata = [
+                'checker' => $checkerName,
+                'target' => $finding->target,
+                'target_type' => $finding->target_type,
+                'severity' => $finding->severity,
+                'evidence' => $finding->evidence,
+                'detected_at' => now()->toIso8601String(),
+                // Escalonamento (Onda 1) — sempre presente; false no caso comum.
+                'escalated' => $escalated,
+            ];
+            if ($escalated) {
+                $metadata['severity_efetiva'] = $severityEfetiva;
+                $metadata['first_seen_at'] = Carbon::parse($primeiraOcorrencia)->toIso8601String();
+                $metadata['dias_aberto'] = $diasAberto;
+            }
+
             $id = DB::table('mcp_alertas_eventos')->insertGetId([
                 'user_id' => null,
                 'business_id' => $finding->business_id, // null = repo-wide per ADR 0093 §Exceção
                 'tipo' => "drift_{$checkerName}",
-                'severidade' => $this->mapSeveridadeToCanonical($finding->severity),
-                'titulo' => $this->buildAlertTitle($checkerName, $finding),
+                'severidade' => $this->mapSeveridadeToCanonical($severityEfetiva),
+                'titulo' => ($escalated ? '[ESCALADO] ' : '').$this->buildAlertTitle($checkerName, $finding),
                 'descricao' => $finding->message,
                 'chave_idempotencia' => $chave,
-                'metadata' => json_encode([
-                    'checker' => $checkerName,
-                    'target' => $finding->target,
-                    'target_type' => $finding->target_type,
-                    'severity' => $finding->severity,
-                    'evidence' => $finding->evidence,
-                    'detected_at' => now()->toIso8601String(),
-                ], JSON_UNESCAPED_UNICODE),
+                'metadata' => json_encode($metadata, JSON_UNESCAPED_UNICODE),
                 'status' => 'aberto',
                 'criado_em' => now(),
                 'created_at' => now(),
@@ -94,6 +128,44 @@ trait PersistsDriftAlert
         $shortTarget = mb_strimwidth($finding->target, 0, 80, '…');
 
         return sprintf('Drift [%s] — %s', $checkerName, $shortTarget);
+    }
+
+    /**
+     * `created_at` (string) da PRIMEIRA ocorrência ABERTA deste mesmo drift, ou null.
+     *
+     * "Mesmo drift" = mesmo tipo (`drift_<checker>`) + target_type + target estável
+     * (casado por `metadata->target` = $finding->target). NÃO usa a chave diária (que
+     * muda todo dia), por isso casa pelo target dentro do metadata. Pega o `created_at`
+     * mais antigo entre os abertos pra medir HÁ QUANTOS DIAS o drift persiste.
+     */
+    private function primeiraOcorrenciaAberta(string $checkerName, DriftFinding $finding, string $targetHash): ?string
+    {
+        try {
+            return DB::table('mcp_alertas_eventos')
+                ->where('tipo', "drift_{$checkerName}")
+                ->where('status', 'aberto')
+                ->where('chave_idempotencia', 'like', "drift_{$checkerName}:{$finding->target_type}:{$targetHash}:%")
+                ->min('created_at');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Eleva a severidade efetiva 1 nível no escalonamento por persistência:
+     * info→low→medium→warn→high→critical (warn é nível de checker, mapeado p/ high).
+     * 'critical' já é o teto. Mantém o input se desconhecido (defensivo).
+     */
+    private function escalarSeveridade(string $severity): string
+    {
+        return match (strtolower($severity)) {
+            'info' => 'low',
+            'low' => 'medium',
+            'medium' => 'high',
+            'warn', 'high' => 'critical',
+            'critical' => 'critical',
+            default => $severity,
+        };
     }
 
     /**

--- a/Modules/Governance/Tests/Feature/DriftAlertEscalationTest.php
+++ b/Modules/Governance/Tests/Feature/DriftAlertEscalationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Modules\Governance\Services\Concerns\PersistsDriftAlert;
+use Modules\Governance\Services\DriftFinding;
+
+uses(Tests\TestCase::class, RefreshDatabase::class);
+
+/**
+ * Escalonamento por persistência (Onda 1 — sentinela transporte) no trait
+ * PersistsDriftAlert. Drift novo → severidade base. Drift ABERTO há > N dias →
+ * severidade elevada (warn→high / high→critical) + flag escalated no metadata,
+ * pra que `governance:audit --notify` dispare alerta ATIVO em vez de só log diário.
+ *
+ * ADITIVO/retrocompatível: caso comum não muda; reusa created_at — sem migration.
+ */
+
+/** Classe-isca que expõe o trait pra testar o método público. */
+function persister(): object
+{
+    return new class
+    {
+        use PersistsDriftAlert;
+    };
+}
+
+function findingHigh(): DriftFinding
+{
+    return new DriftFinding(
+        target: 'mcp',
+        target_type: 'env',
+        severity: 'high',
+        message: 'mcp serve commit X != main Y',
+        evidence: ['served' => 'xxxxxxx', 'main' => 'yyyyyyy'],
+    );
+}
+
+beforeEach(function () {
+    config()->set('governance.drift_escalation_days', 3);
+    DB::table('mcp_alertas_eventos')->truncate();
+});
+
+it('alerta novo → severidade base, escalated=false', function () {
+    $id = persister()->persistirDriftAlert('mcp_served_drift', findingHigh());
+
+    $row = DB::table('mcp_alertas_eventos')->find($id);
+    $meta = json_decode($row->metadata, true);
+
+    expect($row->severidade)->toBe('high')           // high base → mapeia pra high
+        ->and($meta['escalated'])->toBeFalse()
+        ->and($row->titulo)->not->toContain('[ESCALADO]');
+});
+
+it('mesmo dia 2× → NÃO duplica (idempotência diária)', function () {
+    $id1 = persister()->persistirDriftAlert('mcp_served_drift', findingHigh());
+    $id2 = persister()->persistirDriftAlert('mcp_served_drift', findingHigh());
+
+    expect($id2)->toBe($id1)
+        ->and(DB::table('mcp_alertas_eventos')->count())->toBe(1);
+});
+
+it('drift ABERTO há > N dias → severidade elevada high→critical + escalated=true', function () {
+    // Semeia uma ocorrência ABERTA de 5 dias atrás com a MESMA assinatura (mesmo
+    // prefixo de chave) mas data antiga no sufixo — created_at controla a idade.
+    $finding = findingHigh();
+    $targetHash = substr(sha1($finding->target), 0, 12);
+    $diaAntigo = now()->subDays(5)->format('Y-m-d');
+    DB::table('mcp_alertas_eventos')->insert([
+        'user_id' => null,
+        'business_id' => null,
+        'tipo' => 'drift_mcp_served_drift',
+        'severidade' => 'high',
+        'titulo' => 'Drift [mcp_served_drift] — mcp',
+        'descricao' => 'antigo',
+        'chave_idempotencia' => "drift_mcp_served_drift:{$finding->target_type}:{$targetHash}:{$diaAntigo}",
+        'metadata' => json_encode(['escalated' => false]),
+        'status' => 'aberto',
+        'criado_em' => now()->subDays(5),
+        'created_at' => now()->subDays(5),
+        'updated_at' => now()->subDays(5),
+    ]);
+
+    // Hoje o mesmo drift reaparece → deve escalar.
+    $id = persister()->persistirDriftAlert('mcp_served_drift', $finding);
+
+    $row = DB::table('mcp_alertas_eventos')->find($id);
+    $meta = json_decode($row->metadata, true);
+
+    expect($row->severidade)->toBe('critical')        // high escalado → critical
+        ->and($meta['escalated'])->toBeTrue()
+        ->and($meta['severity_efetiva'])->toBe('critical')
+        ->and($meta['dias_aberto'])->toBeGreaterThan(3)
+        ->and($row->titulo)->toContain('[ESCALADO]');
+});
+
+it('drift ABERTO há < N dias → ainda não escala', function () {
+    $finding = findingHigh();
+    $targetHash = substr(sha1($finding->target), 0, 12);
+    $diaOntem = now()->subDays(1)->format('Y-m-d');
+    DB::table('mcp_alertas_eventos')->insert([
+        'user_id' => null,
+        'business_id' => null,
+        'tipo' => 'drift_mcp_served_drift',
+        'severidade' => 'high',
+        'titulo' => 'Drift [mcp_served_drift] — mcp',
+        'descricao' => 'ontem',
+        'chave_idempotencia' => "drift_mcp_served_drift:{$finding->target_type}:{$targetHash}:{$diaOntem}",
+        'metadata' => json_encode(['escalated' => false]),
+        'status' => 'aberto',
+        'criado_em' => now()->subDays(1),
+        'created_at' => now()->subDays(1),
+        'updated_at' => now()->subDays(1),
+    ]);
+
+    $id = persister()->persistirDriftAlert('mcp_served_drift', $finding);
+
+    $row = DB::table('mcp_alertas_eventos')->find($id);
+    $meta = json_decode($row->metadata, true);
+
+    expect($row->severidade)->toBe('high')
+        ->and($meta['escalated'])->toBeFalse();
+});

--- a/Modules/Governance/Tests/Feature/DriftAlertEscalationTest.php
+++ b/Modules/Governance/Tests/Feature/DriftAlertEscalationTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\DB;
 use Modules\Governance\Services\Concerns\PersistsDriftAlert;
 use Modules\Governance\Services\DriftFinding;
 
-uses(Tests\TestCase::class, RefreshDatabase::class);
+uses(Tests\TestCase::class, DatabaseTransactions::class);
 
 /**
  * Escalonamento por persistência (Onda 1 — sentinela transporte) no trait
@@ -40,7 +40,9 @@ function findingHigh(): DriftFinding
 
 beforeEach(function () {
     config()->set('governance.drift_escalation_days', 3);
-    DB::table('mcp_alertas_eventos')->truncate();
+    // delete() (DML, transaction-safe) em vez de truncate() — TRUNCATE dá implicit
+    // commit no MySQL e quebraria a isolação do DatabaseTransactions.
+    DB::table('mcp_alertas_eventos')->delete();
 });
 
 it('alerta novo → severidade base, escalated=false', function () {

--- a/Modules/Governance/Tests/Feature/McpIndexFreshnessCheckerTest.php
+++ b/Modules/Governance/Tests/Feature/McpIndexFreshnessCheckerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\Checkers\McpIndexFreshnessChecker;
+use Modules\Governance\Services\DriftFinding;
+
+uses(Tests\TestCase::class);
+
+/**
+ * McpIndexFreshnessChecker (Onda 1 — sentinela transporte) — índice MCP
+ * (mcp_memory_documents) defasado vs último commit em git memory/. Pega o sync
+ * IndexarMemoryGitParaDb falhando CALADO. analisar() é puro/testável (sem DB/git).
+ */
+
+it('implementa DriftChecker + registrado em governance.drift_checkers', function () {
+    expect(new McpIndexFreshnessChecker())->toBeInstanceOf(DriftChecker::class)
+        ->and((new McpIndexFreshnessChecker())->name())->toBe('mcp_index_freshness')
+        ->and((new McpIndexFreshnessChecker())->severity())->toBe('high')
+        ->and((new McpIndexFreshnessChecker())->enforcement())->toBe('warn')
+        ->and((new McpIndexFreshnessChecker())->cadence())->toBe('daily')
+        ->and((array) config('governance.drift_checkers'))->toContain(McpIndexFreshnessChecker::class);
+});
+
+it('analisar: índice mais novo que git memory/ → clean', function () {
+    $git = Carbon::parse('2026-06-20T10:00:00Z');
+    $index = Carbon::parse('2026-06-20T10:30:00Z'); // 30min depois — fresco
+    expect((new McpIndexFreshnessChecker())->analisar($index, $git, 6))->toBeEmpty();
+});
+
+it('analisar: índice atrás do git dentro do limite → clean', function () {
+    $git = Carbon::parse('2026-06-20T10:00:00Z');
+    $index = Carbon::parse('2026-06-20T06:00:00Z'); // 4h atrás, limite 6h → ok
+    expect((new McpIndexFreshnessChecker())->analisar($index, $git, 6))->toBeEmpty();
+});
+
+it('analisar: índice atrás do git > limite → drifted high', function () {
+    $git = Carbon::parse('2026-06-20T10:00:00Z');
+    $index = Carbon::parse('2026-06-19T20:00:00Z'); // 14h atrás, limite 6h → drift
+    $f = (new McpIndexFreshnessChecker())->analisar($index, $git, 6);
+    expect($f)->toHaveCount(1)
+        ->and($f[0])->toBeInstanceOf(DriftFinding::class)
+        ->and($f[0]->severity)->toBe('high')
+        ->and($f[0]->message)->toContain('Índice MCP defasado')
+        ->and($f[0]->message)->toContain('IndexarMemoryGitParaDb')
+        ->and($f[0]->evidence['lag_hours'])->toBe(14);
+});
+
+it('analisar: git indisponível → info, sem throw', function () {
+    $index = Carbon::parse('2026-06-20T10:00:00Z');
+    $f = (new McpIndexFreshnessChecker())->analisar($index, null, 6);
+    expect($f)->toHaveCount(1)
+        ->and($f[0]->severity)->toBe('info')
+        ->and($f[0]->message)->toContain('git indisponível');
+});
+
+it('analisar: índice vazio / DB indisponível → info', function () {
+    $git = Carbon::parse('2026-06-20T10:00:00Z');
+    $f = (new McpIndexFreshnessChecker())->analisar(null, $git, 6);
+    expect($f)->toHaveCount(1)
+        ->and($f[0]->severity)->toBe('info')
+        ->and($f[0]->message)->toContain('Índice MCP vazio');
+});

--- a/Modules/Governance/Tests/Feature/McpServedDriftCheckerTest.php
+++ b/Modules/Governance/Tests/Feature/McpServedDriftCheckerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\Checkers\DeployDriftChecker;
+use Modules\Governance\Services\Checkers\McpServedDriftChecker;
+use Modules\Governance\Services\DriftFinding;
+
+uses(Tests\TestCase::class);
+
+/**
+ * McpServedDriftChecker (Onda 1 — sentinela transporte CT100→main) — consome
+ * GET <env>/api/mcp/version (ADR 0256) e compara o commit SERVIDO com GitHub main.
+ * Fecha o "~19 dias stale e ninguém viu". Http::fake substitui a rede; a fonte de
+ * main reusa o DeployDriftChecker (arquivo do webhook), fakeada via config aqui.
+ */
+
+beforeEach(function () {
+    config()->set('copiloto.mcp.drift_token', 'fake-drift-token');
+    config()->set('governance.deploy_drift_envs', [
+        ['nome' => 'mcp', 'url' => 'https://mcp.test'],
+    ]);
+});
+
+it('implementa DriftChecker + registrado em governance.drift_checkers', function () {
+    expect(new McpServedDriftChecker())->toBeInstanceOf(DriftChecker::class)
+        ->and((new McpServedDriftChecker())->name())->toBe('mcp_served_drift')
+        ->and((new McpServedDriftChecker())->severity())->toBe('high')
+        ->and((new McpServedDriftChecker())->enforcement())->toBe('warn')
+        ->and((new McpServedDriftChecker())->cadence())->toBe('daily')
+        ->and((array) config('governance.drift_checkers'))->toContain(McpServedDriftChecker::class);
+});
+
+it('commit servido == main → clean (sem finding)', function () {
+    // Fonte de "main" reusada do DeployDriftChecker = arquivo do webhook (cross-process).
+    // Escrevemos no path canônico pra latestMainSha() devolver o SHA controlado.
+    $sha = 'abc1234def5678';
+    file_put_contents(DeployDriftChecker::shaFilePath(), $sha."\n");
+    Http::fake([
+        'mcp.test/api/mcp/version' => Http::response([
+            'service' => 'oimpresso-mcp',
+            'commit' => $sha,
+            'commit_short' => substr($sha, 0, 9),
+            'deployed_at' => now()->toIso8601String(),
+        ], 200),
+    ]);
+
+    $result = (new McpServedDriftChecker())->check();
+
+    expect($result->ok)->toBeTrue()
+        ->and($result->drift_count)->toBe(0);
+
+    @unlink(DeployDriftChecker::shaFilePath());
+});
+
+it('commit servido != main → drifted high', function () {
+    $main = 'aaaaaaa1111111';
+    file_put_contents(DeployDriftChecker::shaFilePath(), $main."\n");
+    Http::fake([
+        'mcp.test/api/mcp/version' => Http::response([
+            'service' => 'oimpresso-mcp',
+            'commit' => 'bbbbbbb2222222',
+            'commit_short' => 'bbbbbbb22',
+            'deployed_at' => now()->subDays(19)->toIso8601String(),
+        ], 200),
+    ]);
+
+    $result = (new McpServedDriftChecker())->check();
+
+    expect($result->ok)->toBeFalse()
+        ->and($result->drift_count)->toBe(1)
+        ->and($result->findings[0])->toBeInstanceOf(DriftFinding::class)
+        ->and($result->findings[0]->severity)->toBe('high')
+        ->and($result->findings[0]->target)->toBe('mcp')
+        ->and($result->findings[0]->message)->toContain('!= GitHub main')
+        ->and($result->findings[0]->evidence['served'])->toBe('bbbbbbb2222222');
+
+    @unlink(DeployDriftChecker::shaFilePath());
+});
+
+it('HTTP 500 → finding low, NÃO derruba o audit', function () {
+    file_put_contents(DeployDriftChecker::shaFilePath(), "aaaaaaa1111111\n");
+    Http::fake([
+        'mcp.test/api/mcp/version' => Http::response(['error' => 'Misconfigured'], 500),
+    ]);
+
+    $result = (new McpServedDriftChecker())->check();
+
+    expect($result->ok)->toBeFalse()
+        ->and($result->drift_count)->toBe(1)
+        ->and($result->findings[0]->severity)->toBe('low')
+        ->and($result->findings[0]->message)->toContain('HTTP 500');
+
+    @unlink(DeployDriftChecker::shaFilePath());
+});
+
+it('timeout/conexão recusada → finding info, sem throw', function () {
+    file_put_contents(DeployDriftChecker::shaFilePath(), "aaaaaaa1111111\n");
+    Http::fake(function () {
+        throw new \Illuminate\Http\Client\ConnectionException('Connection timed out');
+    });
+
+    $result = (new McpServedDriftChecker())->check();
+
+    expect($result->ok)->toBeFalse()
+        ->and($result->drift_count)->toBe(1)
+        ->and($result->findings[0]->severity)->toBe('info')
+        ->and($result->findings[0]->message)->toContain('Não consegui contatar');
+
+    @unlink(DeployDriftChecker::shaFilePath());
+});
+
+it('env respondeu sem commit (unknown no boot) → finding info', function () {
+    file_put_contents(DeployDriftChecker::shaFilePath(), "aaaaaaa1111111\n");
+    Http::fake([
+        'mcp.test/api/mcp/version' => Http::response([
+            'service' => 'oimpresso-mcp',
+            'commit' => null,
+            'commit_short' => null,
+            'deployed_at' => null,
+        ], 200),
+    ]);
+
+    $result = (new McpServedDriftChecker())->check();
+
+    expect($result->ok)->toBeFalse()
+        ->and($result->findings[0]->severity)->toBe('info')
+        ->and($result->findings[0]->message)->toContain('sem commit servido');
+
+    @unlink(DeployDriftChecker::shaFilePath());
+});

--- a/memory/requisitos/_Governanca/RUNBOOK-transporte-sentinel.md
+++ b/memory/requisitos/_Governanca/RUNBOOK-transporte-sentinel.md
@@ -1,0 +1,86 @@
+# RUNBOOK — Sentinela de transporte CT100→main (Onda 1)
+
+> Fecha o gap de freshness/drift entre o que está em **GitHub main** e o que cada
+> **env deployado** (MCP server / app) realmente serve. Incidente que motivou: o
+> container MCP ficou **~19 dias stale vs main** e ninguém viu (tools
+> handoff-pending/-ack inalcançáveis o tempo todo, silenciosamente).
+>
+> Estende o `DeployDriftChecker` (ADR 0216), que só cobria o ambiente ONDE o audit
+> roda (CT 100). Agora cobrimos envs REMOTOS + frescor do índice + escalonamento.
+
+## O que cada peça pega
+
+| Checker | name | Pega | Severity | Fonte |
+|---|---|---|---|---|
+| `DeployDriftChecker` (já existia) | `deploy_drift` | Código LOCAL (`.git/HEAD` do CT 100) != main | high | arquivo webhook + origin/main ref |
+| **`McpServedDriftChecker`** (novo) | `mcp_served_drift` | Commit **servido** por cada env remoto (`GET /api/mcp/version`) != main | high | `/api/mcp/version` (ADR 0256) × main |
+| **`McpIndexFreshnessChecker`** (novo) | `mcp_index_freshness` | Índice `mcp_memory_documents` defasado vs último commit em git `memory/` | high | `max(updated_at)` × `git log -1 -- memory/` |
+
+Os 3 rodam dentro do `governance:audit --all --notify` **já agendado** (Kernel daily 06:15 BRT).
+Não há workflow novo — nada a registrar em `scripts/governance/gates-registry.json`.
+
+## Como rodar manualmente
+
+```bash
+# Tudo (igual ao cron):
+php artisan governance:audit --all --notify
+
+# Só os checkers da sentinela de transporte:
+php artisan governance:audit --check=mcp_served_drift --json
+php artisan governance:audit --check=mcp_index_freshness --json
+
+# Pela tag (pega os 3 + futuros de transporte):
+php artisan governance:audit --tag=transporte --json
+```
+
+## Config (todas overridable por .env)
+
+| Chave (`config/governance.php`) | Env | Default | O quê |
+|---|---|---|---|
+| `deploy_drift_envs` | `GOVERNANCE_DEPLOY_DRIFT_ENVS` (JSON) | `[{nome:mcp, url:https://mcp.oimpresso.com}]` | Envs que o `mcp_served_drift` consulta |
+| `mcp_index_freshness_max_lag_hours` | `GOVERNANCE_MCP_INDEX_FRESHNESS_MAX_LAG_HOURS` | `6` | Lag tolerado (h) entre commit memory/ e índice |
+| `drift_escalation_days` | `GOVERNANCE_DRIFT_ESCALATION_DAYS` | `3` | Dias abertos antes de escalar a severidade |
+| `copiloto.mcp.drift_token` | `MCP_DRIFT_TOKEN` | — | Bearer do `/api/mcp/version` (mesmo da sentinela) |
+
+Adicionar o app **Hostinger** ao `mcp_served_drift` só quando ele expuser `/api/mcp/version`
+próprio — **Hostinger ≠ CT 100** (ADR 0062). Exemplo de override:
+
+```
+GOVERNANCE_DEPLOY_DRIFT_ENVS=[{"nome":"mcp","url":"https://mcp.oimpresso.com"},{"nome":"app","url":"https://oimpresso.com"}]
+```
+
+## Escalonamento por persistência (parte B)
+
+O trait `PersistsDriftAlert` grava cada finding em `mcp_alertas_eventos` com idempotência
+**diária**. Se o MESMO drift segue **aberto** há mais de `drift_escalation_days` dias, o
+novo registro é gravado com **severidade elevada** (`warn→high`, `high→critical`) e
+`metadata.escalated=true` + `first_seen_at` + `dias_aberto`, e o título ganha `[ESCALADO]`.
+Sem coluna/migration nova — reusa `created_at` da primeira ocorrência aberta.
+
+Efeito prático: o `--notify` (Centrifugo `governance:drift`) passa a tratar como **alerta
+ativo** (severidade alta/crítica) em vez de mais um log diário ignorável. É o que teria
+quebrado o silêncio de 19 dias.
+
+## Como reagir ao alerta
+
+1. **`mcp_served_drift` high** → um env serve commit != main.
+   - Ler o `evidence`: `env`, `served`, `main`, `deployed_at`, `idade`.
+   - É o env do CT 100 (MCP)? `git reset --hard origin/main` + `composer dump-autoload`
+     + reload octane (ver `INFRA-ACESSO-CANON`). Atenção ao incidente classmap stale
+     (deploy interrompido sem `composer dump-autoload` = 500 em toda rota).
+2. **`mcp_index_freshness` high** → índice da memória parou de atualizar.
+   - O job `IndexarMemoryGitParaDb` (webhook GitHub→MCP **ou** cron 5min) pode ter
+     falhado calado. Checar `storage/logs/laravel.log`, o webhook e o cron.
+   - Rodar o reindex manual do job e confirmar que `max(updated_at)` avança.
+3. **Findings `low`/`info`** (HTTP 500/401, timeout, git/DB indisponível) → **não** são
+   drift confirmado; são "não verificável agora". Não derrubam o audit. Se persistirem
+   dias seguidos, o escalonamento eleva e aí investigar (token errado? env morto?).
+
+## Notas de design / limites
+
+- Falha de rede/HTTP **nunca** lança exception que quebra o audit — vira finding low/info.
+- Os 3 checkers são **system-level** (sem `business_id`): `mcp_memory_documents` é
+  repo-wide (ADR 0053) e os envs/commits são da plataforma. ADR 0093 §Exceção repo-wide.
+- O `mcp_served_drift` reusa a MESMA fonte de "main" do `DeployDriftChecker`
+  (`DeployDriftChecker::latestMainSha`) — single source of truth, sem duplicação.
+- Token `MCP_DRIFT_TOKEN`: se vazar, revela só o SHA servido (sem user/RBAC) — ADR 0256.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6220,7 +6220,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 7
+			count: 10
 			path: Modules/Governance/Config/config.php
 
 		-


### PR DESCRIPTION
## Onda 1 — frente transporte CT100→main (A+B+C, aprovada por Wagner)

Fecha o gap que deixou o MCP ficar **19 dias stale** sem ninguém ver. Implementado por `audit-implement-expert` (worktree isolado), **revisado pelo agente pai** antes deste PR.

### A — `McpServedDriftChecker` (novo DriftChecker)
Consome o endpoint **`GET /api/mcp/version`** (que já existia, ADR 0256 — dedicado a sentinela externa) de cada env em `config('governance.deploy_drift_envs')`, compara o `commit` servido com main. **Reutiliza** `DeployDriftChecker::latestMainSha` (mesma fonte de main, zero duplicação). Falha de rede/HTTP → finding `low`/`info`, nunca throw. **Não inventa internals do MCP** (Tier-0).

### B — escalonamento por persistência (`PersistsDriftAlert`)
Drift que persiste **> N dias** (`governance.drift_escalation_days`, default 3) eleva severity (high→critical) + marca `escalated`/`first_seen_at`/`dias_aberto` no metadata + prefixa título `[ESCALADO]`, pra o `--notify` disparar alerta **ativo** em vez de só logar diário. **Aditivo/retrocompatível** (caso comum ganha só `escalated=false`; dedup diário intacto; sem migration — reusa `created_at`).

### C — `McpIndexFreshnessChecker` (novo DriftChecker)
`mcp_memory_documents.max(updated_at)` vs último commit em `memory/` (`git log -1`). Se o índice atrasa > `mcp_index_freshness_max_lag_hours` (default 6) → pega falha silenciosa do `IndexarMemoryGitParaDb`. DB/git fora → info, sem throw.

Os 3 rodam no `governance:audit --all --notify` já agendado (Kernel 06:15). Sem workflow novo, sem mexer em `gates-registry.json`.

## Revisão do agente pai (Tier-0)
- ✅ **Escalonamento casa o formato da chave**: query LIKE `drift_<checker>:<target_type>:<targetHash>:%` ≡ formato real da `chave_idempotencia` (confirmado no código). Não é falso-negativo.
- ✅ **Consume-only**: `McpServedDriftChecker` só faz `Http::get(.../api/mcp/version)` + reusa `latestMainSha`.
- ✅ **Trait change aditivo**: o `−10` é refactor do `json_encode` inline → variável; early-return de dedup intacto.

## Caveats pra o CI confirmar
- ⚠️ **`DriftAlertEscalationTest` (3 testes) não rodou local** — incompatibilidade ambiental do sqlite (migration `ALTER TABLE ... MODIFY ... ENUM` MySQL-only; o pré-existente `ScorecardSnapshotCommandTest` falha igual local). **Em CI (MySQL) deve passar** — conferir o verde nesse arquivo. Os 9 testes dos 2 checkers passaram local (Http::fake, 46 assertions).
- 🔧 **Janela de 3 dias é configurável** — GitOps best-practice 2026 sugere 1 dia útil pra prod; `drift_escalation_days` permite baixar sem deploy.

## Pendência sua
Definir os envs reais em `governance.deploy_drift_envs` (default `mcp.oimpresso.com`) + garantir `MCP_DRIFT_TOKEN` setado no ambiente onde o audit roda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)