### PR TITLE
chore(backlog): 6 US residuais da auditoria de saúde 2026-06-21

### DIFF
--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -1667,3 +1667,17 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 - Multi-tenant Tier 0: filtro `business_id` (ADR 0093).
 
 **Fonte:** memory/requisitos/_processo/BATCH-BACKLOG-34-2026-06-20.md (§Aprovação [W] 2026-06-20)
+
+### US-FIN-059 · Observers Sells/Compras→Financeiro: try/catch + report() (nunca propagar) + idealmente Job afterCommit
+
+> owner: — · priority: p1 · estimate: 3h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 (risco #5). Complementa `US-FIN-040` (health-check detecta gaps da bridge).
+
+**Achado:** `TransactionObserver` e `TransactionPaymentObserver` chamam o `TituloAutoService` **síncrono, SEM try/catch** (grep confirmou zero). Uma exceção no espelho Financeiro (deadlock de numeração, constraint, contact malformado) propaga pro `App\Transaction::save()` e **estoura o commit do core UltimatePOS** — exatamente o BUG-2 que bloqueou pagamentos da Larissa. Só o caminho CashRegister tem o try/catch protetor. Financeiro é módulo OPCIONAL derrubando o fluxo de venda do core.
+
+**Acceptance:**
+- Envolver as chamadas dos 2 Observers em try/catch que loga + `report()` e **nunca** propaga (espelhar o Listener do CashRegister).
+- Idealmente mover a sincronização para Job em fila `afterCommit`.
+- **Caveat antes de codar:** confirmar se o `save()` do core roda dentro de `DB::transaction` (se rodar, o rollback abrange o título e a severidade muda).

--- a/memory/requisitos/Governance/SPEC.md
+++ b/memory/requisitos/Governance/SPEC.md
@@ -460,3 +460,48 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 - Advisory → required conforme cadência.
 
 **Fonte:** memory/requisitos/_processo/BATCH-BACKLOG-34-2026-06-20.md (§Aprovação [W] 2026-06-20)
+
+### US-GOV-031 · MultiTenantScopeChecker em falso-clean (path Windows) + canário anti-falso-clean + promover guards Tier-0 a required
+
+> owner: — · priority: p1 · estimate: 5h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 (risco #3, ADR 0218). Distinto de `US-INFRA-032` (hardcodes business_id).
+
+**Achado:** o `MultiTenantScopeChecker` reporta `drift_count=0` por **bug de separador de path Windows-only** (`not_readable=217`). Não cega o CI Linux (`--diff-only` funciona lá), mas o daily `--all` que pegaria o backlog é não-bloqueante → backlog de models sem global scope fica invisível. Em paralelo, os guards Tier-0 (`WithoutGlobalScopes` + `business_id=4`) estavam **falhando no main** com `continue-on-error` (advisory reportando verde), e `business_id=4` (RotaLivre) reapareceu em fixtures.
+
+**Acceptance:**
+- Bug de path do checker corrigido (roda igual em Win/Linux).
+- Teste-canário anti-falso-clean: asserta `drift>0` contra fixture sem trait.
+- 4 violações dos guards corrigidas + `continue-on-error` removido (promover a required).
+- Triar models de tenant sem global scope (OficinaAuto/ComunicacaoVisual/Manufacturing/AssetManagement).
+
+### US-GOV-032 · Criar BRIEFING.md de memory/requisitos/_Governanca/ (front-door) antes de commitar o dir
+
+> owner: — · priority: p2 · estimate: 0.5h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 (batedor de governança).
+
+**Achado:** `memory/requisitos/_Governanca/` (trabalho em andamento) tem ≥2 `.md` e **não tem `BRIEFING.md`**. Quando o dir for commitado, ele entra no censo de módulos do `knowledge-drift` sem front-door → `front_door_coverage` cai de 100 → 98.6 e a **catraca armada do sdd-scorecard morde** (🔴). Todos os outros meta-dirs `_*` (`_DesignSystem`, `_Ideias`, `_processo`…) têm BRIEFING.
+
+**Acceptance:**
+- Criar `memory/requisitos/_Governanca/BRIEFING.md` (front-door auto-contido) junto/antes de commitar o dir.
+- Regenerar `governance/sdd-scorecard.json` (`node scripts/governance/sdd-scorecard.mjs`).
+- `--ratchet` volta a verde.
+
+### US-GOV-033 · Corrigir links internos residuais (corpos de ADR append-only + dead-links de alvo incerto)
+
+> owner: — · priority: p3 · estimate: 2h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 (batedor de links). Os links seguros em rules/SPECs já foram corrigidos (#3147, #3152). Restou o que NÃO é auto-fixável:
+
+**Achado:**
+- Corpos de ADR (append-only — precisam de bênção): `0250` (3 slugs defasados), `0253:123` (link 0013 aponta pro ADR errado → deveria ser o caminho UI `_DesignSystem/adr/ui/0013-...`), `0254` (slug 0209).
+- Dead-links de alvo incerto: `NfeBrasil/SPEC.md` → `app/Manifesto.php` (inexistente); `.claude/rules/README.md:11` → session-log inexistente; `Connector/SPEC.md:124` → placeholder `0021-...` com "(se existir)".
+- `memory/decisions/0296-...` (untracked): 2 links (slugs 0053/0084) — corrigir quando commitar.
+
+**Acceptance:**
+- Decidir alvo correto de cada item e corrigir.
+- Fixes em corpos de ADR só com aprovação (política append-only ADR 0094).

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -802,3 +802,34 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 - Suíte SQLite estável.
 
 **Fonte:** memory/requisitos/_processo/BATCH-BACKLOG-34-2026-06-20.md (§Aprovação [W] 2026-06-20)
+
+### US-INFRA-041 · Backup/DR de banco no deploy — mysqldump + cópia off-host + restore testado
+
+> owner: — · priority: p1 · estimate: 6h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 (risco #0 — o mais grave). Afina/supersede o vago `INFRA-5` (INF-008 backup pré-deploy "formalizar").
+
+**Achado:** o passo `Backup (arquivos + DB)` do `deploy.yml` faz só `tar czf` e **NÃO contém nenhum `mysqldump`** (grep: zero no deploy inteiro). Grava no **mesmo host** Hostinger (`~/`), sem cópia off-host, com `skip_backup:true` disponível como input, e **sem nenhum teste de restore**. Houve **incidente de cota de disco em 2026-06-21**. Resultado: RPO desconhecido, RTO não testado — perda de dados é o único risco pior que vazamento cross-tenant.
+
+**Acceptance:**
+- `deploy.yml` faz `mysqldump` do banco antes do deploy.
+- Cópia do dump para fora do host (storage externo / bucket).
+- ≥1 restore testado e documentado (RUNBOOK).
+- RPO/RTO definidos por escrito.
+- Hostinger ≠ CT 100 respeitado (ADR 0062).
+
+### US-INFRA-042 · Rotacionar segredos do repo público (MEILI_MASTER_KEY + token DNS Hostinger + 12 do incidente)
+
+> owner: — · priority: p1 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 (risco #1). Complementa `US-INFRA-011` (rotação senha MySQL) e os PRs #3148/#3151 (gitleaks full-history — que ESCANEIA, não rotaciona).
+
+**Achado:** o repo `wagnerra23/oimpresso.com` é **público**. A Meilisearch master key (controle admin total do search multi-tenant) está em arquivos rastreados no HEAD; o histórico append-only retém ela + token DNS Hostinger + os 12 segredos do incidente 2026-05-15. Editar o HEAD não resolve — git é append-only; a rotação é a única remediação real.
+
+**Acceptance:**
+- Rotacionar `MEILI_MASTER_KEY` no host + token DNS Hostinger + os 12 do incidente.
+- Atualizar status por item no `_INDEX-SECRETS.md`.
+- Avaliar tornar o repo privado.
+- Ativar `core.hooksPath .githooks` (pre-commit de segredos).

--- a/memory/requisitos/_BACKLOG-GENERATED.md
+++ b/memory/requisitos/_BACKLOG-GENERATED.md
@@ -2,24 +2,24 @@
 # Backlog indexado (gerado)
 
 > Fonte: as US-* dos `memory/requisitos/<Mod>/SPEC.md` (canon, ADR 0070). US abertas (status ∉ done/cancelled).
-> **744 tarefas abertas** em **45 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
+> **750 tarefas abertas** em **45 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
 
 ## Índice por módulo
 
 | Módulo | Abertas | doing | review | blocked | todo/backlog |
 |---|---:|---:|---:|---:|---:|
 | [`Jana`](#jana) | 58 | 2 | 0 | 0 | 55 |
-| [`Financeiro`](#financeiro) | 48 | 0 | 1 | 0 | 46 |
+| [`Financeiro`](#financeiro) | 49 | 0 | 1 | 0 | 47 |
 | [`OficinaAuto`](#oficinaauto) | 47 | 0 | 5 | 0 | 41 |
 | [`Whatsapp`](#whatsapp) | 47 | 1 | 2 | 0 | 44 |
+| [`Infra`](#infra) | 40 | 0 | 0 | 0 | 38 |
 | [`Sells`](#sells) | 39 | 0 | 0 | 0 | 39 |
-| [`Infra`](#infra) | 38 | 0 | 0 | 0 | 36 |
 | [`RecurringBilling`](#recurringbilling) | 35 | 0 | 0 | 0 | 35 |
 | [`NfeBrasil`](#nfebrasil) | 28 | 0 | 0 | 6 | 22 |
+| [`Governance`](#governance) | 25 | 0 | 2 | 0 | 23 |
 | [`Inventory`](#inventory) | 25 | 0 | 0 | 0 | 25 |
 | [`Marketplaces`](#marketplaces) | 25 | 0 | 0 | 0 | 25 |
 | [`Crm`](#crm) | 23 | 0 | 0 | 0 | 23 |
-| [`Governance`](#governance) | 22 | 0 | 2 | 0 | 20 |
 | [`Pcp`](#pcp) | 20 | 0 | 0 | 0 | 20 |
 | [`Vestuario`](#vestuario) | 20 | 0 | 0 | 0 | 20 |
 | [`Fiscal`](#fiscal) | 19 | 0 | 0 | 0 | 17 |
@@ -150,6 +150,7 @@
 - **US-FIN-045** — Wizard bank-first 2-step (banco → modo conexão) _(`p1`)_
 - **US-FIN-055** — Purgar coluna-fantasma transactions.total_remaining_amount (resto Financeiro + TituloAutoService) _(`p1`)_
 - **US-FIN-058** — Reparar 59 boletos órfãos + 3.372 fin_titulos com origem_id bug (Firebird) _(`p1`)_
+- **US-FIN-059** — Observers Sells/Compras→Financeiro: try/catch + report() (nunca propagar) + idealmente Job afterCommit _(`p1`)_
 - **US-FIN-018** — Boletos — Sheet Remessa/Retorno CNAB upload + processing _(`p2` · @wagner)_
 - **US-FIN-019** — Boletos — Drawer timeline cronológica rica via activity_log Spatie _(`p2` · @wagner)_
 - **US-FIN-020** — Boletos — Jobs automáticos cobrança (lembrete + ativa + protesto) _(`p2` · @wagner)_
@@ -306,6 +307,58 @@
 - **US-WA-307** — + Nova conversa (ContactPickerModal + template inicial + novo channel) _(`p2` · @wagner · sprint TBD)_
 - **US-WA-311** — Triagem automática no inbox — score + prioridade P1-P4 pro operador (L1) _(`p2` · @wagner · sprint TBD)_
 
+## Infra
+
+
+### todo
+
+- **US-INFRA-001** — GrowthBook self-hosted (feature flag system) _(`p0` · @wagner)_
+- **US-INFRA-014** — Install Larastan + phpstan.neon.dist nível 5 baseline _(`p0`)_
+- **US-INFRA-015** — Workflow phpstan-gate.yml — CI ratchet contra baseline _(`p0`)_
+- **US-INFRA-016** — LogContextMiddleware global — business_id/user_id/request_id em todo log _(`p0`)_
+- **US-INFRA-017** — PHPStan custom rule NoMissingTenantScope (T-AP-2 Tier 0) _(`p0`)_
+- **US-INFRA-020** — PHPStan custom rule NoSilentFallbackRule (R9 raiz) _(`p0`)_
+- **US-INFRA-022** — Install Laravel Wayfinder + Vite plugin + watch types _(`p0`)_
+- **US-INFRA-026** — Convenção markdown TASK[owner](Px) em audits _(`p0`)_
+- **US-INFRA-027** — Hook audit-creates-tasks.ps1 (PostToolUse Write) _(`p0`)_
+- **US-INFRA-002** — Client Signal — entidade + canal estruturado _(`p1` · @wagner)_
+- **US-INFRA-003** — APM full-stack — captura "lento aqui" automaticamente _(`p1` · @wagner)_
+- **US-INFRA-005** — S5 ADS adiantado (Risk + Confidence + Policy core) _(`p1` · @wagner)_
+- **US-INFRA-011** — Rotacionar senha MySQL Hostinger u906587222_oimpresso - exposicao sessao 2026-05-20 _(`p1` · @wagner)_
+- **US-INFRA-013** — Implementar contract-test-gate GH Action (ADR 0207) _(`p1` · sprint 2026-W22)_
+- **US-INFRA-018** — PHPStan custom rule NoInventedModel (T-AP-1) _(`p1`)_
+- **US-INFRA-019** — PHPStan custom rule NoNopMutationController (T-AP-13) _(`p1`)_
+- **US-INFRA-023** — Zod schemas em endpoints JSON não-Inertia _(`p1`)_
+- **US-INFRA-028** — Skill audit-to-backlog Tier B _(`p1`)_
+- **US-INFRA-029** — Workflow CI audit-orphan-check.yml — warning PR órfãos _(`p1`)_
+- **US-INFRA-031** — Resolver colisões de const/function globais em tests/Feature (bloqueia suíte Pest completa) _(`p1`)_
+- **US-INFRA-033** — Suíte Pest no staging falha em massa por testes fazerem Schema::create/dropIfExists cru em tabelas compartilhadas (vs clone MySQL) _(`p1`)_
+- **US-INFRA-041** — Backup/DR de banco no deploy — mysqldump + cópia off-host + restore testado _(`p1`)_
+- **US-INFRA-042** — Rotacionar segredos do repo público (MEILI_MASTER_KEY + token DNS Hostinger + 12 do incidente) _(`p1`)_
+- **US-INFRA-004** — Detecção automática de desvio (cron diário) _(`p2` · @wagner)_
+- **US-INFRA-006** — Tool MCP `whats-active` — agregar sessões doing + paths tocados (Tier 1 ADR 0119) _(`p2` · @wagner)_
+- **US-INFRA-007** — Skill Tier A `session-start-check` — alertar paths overlapping (ADR 0119) _(`p2` · @wagner)_
+- **US-INFRA-012** — Resolver migration order legacy pra visual-regression.yml sair de INFRA-ONLY (ADR 0108) _(`p2` · @wagner)_
+- **US-INFRA-021** — Catalogar AP-18 "Fallback default sem Log::warning" no LICOES_F3 _(`p2`)_
+- **US-INFRA-024** — PHPStan custom rule NoUntypedInertiaProps (R8 gate final) _(`p2`)_
+- **US-INFRA-025** — Catalogar AP-17 "Inertia props não tipadas" no LICOES_F3 _(`p2`)_
+- **US-INFRA-030** — health-check audits_with_orphan_findings — auditoria periódica _(`p2`)_
+- **US-INFRA-032** — Triar 11 hardcodes $businessId === N flagados pelo NoHardcodeBusinessIdInModulesTest (guard Tier 0 agora ativo) _(`p2`)_
+- **US-INFRA-035** — Item 7 ADR 0271 — fusão 4 gates de cor → 1 (executar ≥2026-06-18) _(`p2` · @claude)_
+- **US-INFRA-036** — CSS hex drift fase 2 — tokenizar 61 valores hex crus restantes _(`p2`)_
+- **US-INFRA-037** — Roadmap redução de CSS manual (~28k → ~20k linhas) _(`p2`)_
+- **US-INFRA-038** — SDD: promover os 3 steps de continue-on-error a required (gate-required) _(`p2`)_
+- **US-INFRA-039** — SDD KL E2/E3 — aplicar os 27 renames classe A _(`p2`)_
+- **US-INFRA-040** — SDD — burn-down dos 237 corruptores SQLite _(`p2`)_
+
+### in-progress
+
+- **US-INFRA-008** — Feature Flag Control (3 canais: Artisan/MCP/Painel) _(`p1` · @wagner)_
+
+### superseded
+
+- **US-INFRA-009** — Artisan command `feature:activate` via GrowthBook API ⚠️ **SUPERSEDED por US-INFRA-008** _(`p2` · @wagner)_
+
 ## Sells
 
 
@@ -350,56 +403,6 @@
 - **US-SELL-046** — Bug: viewMode `grade-avancada` órfão — middleware roteia 6 clientes legacy pra UI deletada _(`p2`)_
 - **US-SELL-048** — Higiene dos snapshots-grep Sells: DELETE/REWRITE por it() (não quarentena) — gated no nº do nightly C1 _(`p2`)_
 - **US-SELL-025** — Botões agrupamento rápido (1-click) · **P3 confirmado** _(`p3`)_
-
-## Infra
-
-
-### todo
-
-- **US-INFRA-001** — GrowthBook self-hosted (feature flag system) _(`p0` · @wagner)_
-- **US-INFRA-014** — Install Larastan + phpstan.neon.dist nível 5 baseline _(`p0`)_
-- **US-INFRA-015** — Workflow phpstan-gate.yml — CI ratchet contra baseline _(`p0`)_
-- **US-INFRA-016** — LogContextMiddleware global — business_id/user_id/request_id em todo log _(`p0`)_
-- **US-INFRA-017** — PHPStan custom rule NoMissingTenantScope (T-AP-2 Tier 0) _(`p0`)_
-- **US-INFRA-020** — PHPStan custom rule NoSilentFallbackRule (R9 raiz) _(`p0`)_
-- **US-INFRA-022** — Install Laravel Wayfinder + Vite plugin + watch types _(`p0`)_
-- **US-INFRA-026** — Convenção markdown TASK[owner](Px) em audits _(`p0`)_
-- **US-INFRA-027** — Hook audit-creates-tasks.ps1 (PostToolUse Write) _(`p0`)_
-- **US-INFRA-002** — Client Signal — entidade + canal estruturado _(`p1` · @wagner)_
-- **US-INFRA-003** — APM full-stack — captura "lento aqui" automaticamente _(`p1` · @wagner)_
-- **US-INFRA-005** — S5 ADS adiantado (Risk + Confidence + Policy core) _(`p1` · @wagner)_
-- **US-INFRA-011** — Rotacionar senha MySQL Hostinger u906587222_oimpresso - exposicao sessao 2026-05-20 _(`p1` · @wagner)_
-- **US-INFRA-013** — Implementar contract-test-gate GH Action (ADR 0207) _(`p1` · sprint 2026-W22)_
-- **US-INFRA-018** — PHPStan custom rule NoInventedModel (T-AP-1) _(`p1`)_
-- **US-INFRA-019** — PHPStan custom rule NoNopMutationController (T-AP-13) _(`p1`)_
-- **US-INFRA-023** — Zod schemas em endpoints JSON não-Inertia _(`p1`)_
-- **US-INFRA-028** — Skill audit-to-backlog Tier B _(`p1`)_
-- **US-INFRA-029** — Workflow CI audit-orphan-check.yml — warning PR órfãos _(`p1`)_
-- **US-INFRA-031** — Resolver colisões de const/function globais em tests/Feature (bloqueia suíte Pest completa) _(`p1`)_
-- **US-INFRA-033** — Suíte Pest no staging falha em massa por testes fazerem Schema::create/dropIfExists cru em tabelas compartilhadas (vs clone MySQL) _(`p1`)_
-- **US-INFRA-004** — Detecção automática de desvio (cron diário) _(`p2` · @wagner)_
-- **US-INFRA-006** — Tool MCP `whats-active` — agregar sessões doing + paths tocados (Tier 1 ADR 0119) _(`p2` · @wagner)_
-- **US-INFRA-007** — Skill Tier A `session-start-check` — alertar paths overlapping (ADR 0119) _(`p2` · @wagner)_
-- **US-INFRA-012** — Resolver migration order legacy pra visual-regression.yml sair de INFRA-ONLY (ADR 0108) _(`p2` · @wagner)_
-- **US-INFRA-021** — Catalogar AP-18 "Fallback default sem Log::warning" no LICOES_F3 _(`p2`)_
-- **US-INFRA-024** — PHPStan custom rule NoUntypedInertiaProps (R8 gate final) _(`p2`)_
-- **US-INFRA-025** — Catalogar AP-17 "Inertia props não tipadas" no LICOES_F3 _(`p2`)_
-- **US-INFRA-030** — health-check audits_with_orphan_findings — auditoria periódica _(`p2`)_
-- **US-INFRA-032** — Triar 11 hardcodes $businessId === N flagados pelo NoHardcodeBusinessIdInModulesTest (guard Tier 0 agora ativo) _(`p2`)_
-- **US-INFRA-035** — Item 7 ADR 0271 — fusão 4 gates de cor → 1 (executar ≥2026-06-18) _(`p2` · @claude)_
-- **US-INFRA-036** — CSS hex drift fase 2 — tokenizar 61 valores hex crus restantes _(`p2`)_
-- **US-INFRA-037** — Roadmap redução de CSS manual (~28k → ~20k linhas) _(`p2`)_
-- **US-INFRA-038** — SDD: promover os 3 steps de continue-on-error a required (gate-required) _(`p2`)_
-- **US-INFRA-039** — SDD KL E2/E3 — aplicar os 27 renames classe A _(`p2`)_
-- **US-INFRA-040** — SDD — burn-down dos 237 corruptores SQLite _(`p2`)_
-
-### in-progress
-
-- **US-INFRA-008** — Feature Flag Control (3 canais: Artisan/MCP/Painel) _(`p1` · @wagner)_
-
-### superseded
-
-- **US-INFRA-009** — Artisan command `feature:activate` via GrowthBook API ⚠️ **SUPERSEDED por US-INFRA-008** _(`p2` · @wagner)_
 
 ## RecurringBilling
 
@@ -478,6 +481,40 @@
 - **US-NFE-008** — Manifestar NF-e recebida (destinatário)
 - **US-NFE-009** — Gerar SPED Fiscal/EFD ICMS-IPI mensal
 - **US-NFE-010** — Cadastrar regra tributária por NCM (motor)
+
+## Governance
+
+
+### review
+
+- **US-GOV-018** — P0 Fase 2b: consertar harness de DB de teste do nightly (3 frentes) — não é "completar schema" _(`p0`)_
+- **US-GOV-020** — Frente C: migrate:fresh do nightly carrega dump incompleto (trigger DEFINER prod / privilégio) _(`p0`)_
+
+### todo
+
+- **US-GOV-011** — [ROI alto] Carregar extension OTel no Herd dev (+2-3pp em 36 módulos D9) _(`p0`)_
+- **US-GOV-012** — Investigar ScopedScorecardEvaluator não captura SATURATION markers Jana (gap 25pp grade real) _(`p1`)_
+- **US-GOV-015** — Zelador diário — piloto 14d (reconciliação + triagem por âncora + subtração de ruído) _(`p1` · @claude)_
+- **US-GOV-016** — Reestruturação SDD — Semana 0 (12 frentes paralelas) _(`p1` · @wagner)_
+- **US-GOV-017** — Reestruturação SDD — Fase 1+2 (medição real, backfill, burn-down) _(`p1` · @wagner)_
+- **US-GOV-019** — Re-triage eixo-FAILURE: 7 bugs (design) + 91 quarentena + 11 unclear _(`p1`)_
+- **US-GOV-031** — MultiTenantScopeChecker em falso-clean (path Windows) + canário anti-falso-clean + promover guards Tier-0 a required _(`p1`)_
+- **US-GOV-013** — Tornar o gate visual ADR 0108 (visual-regression) REAL — sair do stub _(`p2`)_
+- **US-GOV-028** — Governance sprint 2 cleanup — remover/atualizar 3 blocos legados do pre-commit _(`p2`)_
+- **US-GOV-029** — IA-OS onda 2 — promover anchor-gate de advisory a required _(`p2`)_
+- **US-GOV-030** — Screen-QA dim16 — adicionar workflow sentinela ausente no CI _(`p2`)_
+- **US-GOV-032** — Criar BRIEFING.md de memory/requisitos/_Governanca/ (front-door) antes de commitar o dir _(`p2`)_
+- **US-GOV-033** — Corrigir links internos residuais (corpos de ADR append-only + dead-links de alvo incerto) _(`p3`)_
+- **US-GOV-001** — Dashboard consolidado `/governance` ✅ DONE
+- **US-GOV-002** — Policies listagem + toggle ativo/inativo 🟡 PARCIAL
+- **US-GOV-003** — Audit log drill-down filtrável 🟡 PARCIAL
+- **US-GOV-004** — Drift alerts (Module Charter Art. 7) 🟡 PARCIAL
+- **US-GOV-005** — ActionGate middleware (modo warn/strict) ✅ DONE (warn)
+- **US-GOV-006** — Module Grade Dashboard `/governance/module-grades` ✅ DONE
+- **US-GOV-007** — Module Grade Drill-down + botão Evoluir ✅ DONE
+- **US-GOV-008** — CLI `php artisan module:grade` (machine-readable JSON) ✅ DONE
+- **US-GOV-009** — Cron daily snapshot histórico 90d ❌ BACKLOG
+- **US-GOV-010** — Integração ADS Brain B disparar agents auto ❌ BACKLOG
 
 ## Inventory
 
@@ -569,37 +606,6 @@
 - **US-CRM-061** — MWART tela Lead Show (drawer cockpit pattern V2 ADR 0110) · **P2** · 12H
 - **US-CRM-062** — MWART CrmDashboard com Recharts · **P2** · 10H
 - **US-CRM-077** — Pattern canon `officeimpresso_codigo` nos 3 importers de contacts (gap ADR 0200) · **P1** · 6H _(@felipe)_
-
-## Governance
-
-
-### review
-
-- **US-GOV-018** — P0 Fase 2b: consertar harness de DB de teste do nightly (3 frentes) — não é "completar schema" _(`p0`)_
-- **US-GOV-020** — Frente C: migrate:fresh do nightly carrega dump incompleto (trigger DEFINER prod / privilégio) _(`p0`)_
-
-### todo
-
-- **US-GOV-011** — [ROI alto] Carregar extension OTel no Herd dev (+2-3pp em 36 módulos D9) _(`p0`)_
-- **US-GOV-012** — Investigar ScopedScorecardEvaluator não captura SATURATION markers Jana (gap 25pp grade real) _(`p1`)_
-- **US-GOV-015** — Zelador diário — piloto 14d (reconciliação + triagem por âncora + subtração de ruído) _(`p1` · @claude)_
-- **US-GOV-016** — Reestruturação SDD — Semana 0 (12 frentes paralelas) _(`p1` · @wagner)_
-- **US-GOV-017** — Reestruturação SDD — Fase 1+2 (medição real, backfill, burn-down) _(`p1` · @wagner)_
-- **US-GOV-019** — Re-triage eixo-FAILURE: 7 bugs (design) + 91 quarentena + 11 unclear _(`p1`)_
-- **US-GOV-013** — Tornar o gate visual ADR 0108 (visual-regression) REAL — sair do stub _(`p2`)_
-- **US-GOV-028** — Governance sprint 2 cleanup — remover/atualizar 3 blocos legados do pre-commit _(`p2`)_
-- **US-GOV-029** — IA-OS onda 2 — promover anchor-gate de advisory a required _(`p2`)_
-- **US-GOV-030** — Screen-QA dim16 — adicionar workflow sentinela ausente no CI _(`p2`)_
-- **US-GOV-001** — Dashboard consolidado `/governance` ✅ DONE
-- **US-GOV-002** — Policies listagem + toggle ativo/inativo 🟡 PARCIAL
-- **US-GOV-003** — Audit log drill-down filtrável 🟡 PARCIAL
-- **US-GOV-004** — Drift alerts (Module Charter Art. 7) 🟡 PARCIAL
-- **US-GOV-005** — ActionGate middleware (modo warn/strict) ✅ DONE (warn)
-- **US-GOV-006** — Module Grade Dashboard `/governance/module-grades` ✅ DONE
-- **US-GOV-007** — Module Grade Drill-down + botão Evoluir ✅ DONE
-- **US-GOV-008** — CLI `php artisan module:grade` (machine-readable JSON) ✅ DONE
-- **US-GOV-009** — Cron daily snapshot histórico 90d ❌ BACKLOG
-- **US-GOV-010** — Integração ADS Brain B disparar agents auto ❌ BACKLOG
 
 ## Pcp
 


### PR DESCRIPTION
Registra no backlog dos módulos (Infra/Governance/Financeiro) os 6 itens **não-auto-fixáveis** da auditoria de saúde/integridade 2026-06-21 — os que dependem de ambiente PHP/Pest, produção, ou decisão humana (por isso não viraram PR de código nesta sessão).

| US | Prioridade | Item |
|---|---|---|
| US-INFRA-041 | p1 | Backup/DR: mysqldump + off-host + restore testado (risco #0) |
| US-INFRA-042 | p1 | Rotacionar segredos do repo público (risco #1) |
| US-GOV-031 | p1 | MultiTenantScopeChecker falso-clean + guards Tier-0 → required (risco #3) |
| US-FIN-059 | p1 | Observers Sells→Financeiro try/catch (risco #5) |
| US-GOV-032 | p2 | BRIEFING.md do _Governanca (anti-ratchet) |
| US-GOV-033 | p3 | Links internos residuais (ADR-body + dead-links) |

_BACKLOG-GENERATED.md regenerado (`tasks-index --check` verde). Sincroniza pro DB via webhook no merge (ADR 0070).

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)