### PR TITLE
chore(roadmap): atribui 4 US p1 ao CYCLE-SAUDE + 2 US estruturais (fecha furo do roadmap)

### DIFF
--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -1670,7 +1670,7 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 
 ### US-FIN-059 · Observers Sells/Compras→Financeiro: try/catch + report() (nunca propagar) + idealmente Job afterCommit
 
-> owner: — · priority: p1 · estimate: 3h · status: todo · type: story
+> owner: — · priority: p1 · estimate: 3h · status: todo · type: story · cycle: CYCLE-SAUDE
 > blocked_by: —
 
 **Origem:** auditoria de saúde/integridade 2026-06-21 (risco #5). Complementa `US-FIN-040` (health-check detecta gaps da bridge).

--- a/memory/requisitos/Governance/SPEC.md
+++ b/memory/requisitos/Governance/SPEC.md
@@ -463,7 +463,7 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 
 ### US-GOV-031 · MultiTenantScopeChecker em falso-clean (path Windows) + canário anti-falso-clean + promover guards Tier-0 a required
 
-> owner: — · priority: p1 · estimate: 5h · status: todo · type: story
+> owner: — · priority: p1 · estimate: 5h · status: todo · type: story · cycle: CYCLE-SAUDE
 > blocked_by: —
 
 **Origem:** auditoria de saúde/integridade 2026-06-21 (risco #3, ADR 0218). Distinto de `US-INFRA-032` (hardcodes business_id).

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -805,7 +805,7 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 
 ### US-INFRA-041 · Backup/DR de banco no deploy — mysqldump + cópia off-host + restore testado
 
-> owner: — · priority: p1 · estimate: 6h · status: todo · type: story
+> owner: — · priority: p1 · estimate: 6h · status: todo · type: story · cycle: CYCLE-SAUDE
 > blocked_by: —
 
 **Origem:** auditoria de saúde/integridade 2026-06-21 (risco #0 — o mais grave). Afina/supersede o vago `INFRA-5` (INF-008 backup pré-deploy "formalizar").
@@ -821,7 +821,7 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 
 ### US-INFRA-042 · Rotacionar segredos do repo público (MEILI_MASTER_KEY + token DNS Hostinger + 12 do incidente)
 
-> owner: — · priority: p1 · estimate: 1h · status: todo · type: story
+> owner: — · priority: p1 · estimate: 1h · status: todo · type: story · cycle: CYCLE-SAUDE
 > blocked_by: —
 
 **Origem:** auditoria de saúde/integridade 2026-06-21 (risco #1). Complementa `US-INFRA-011` (rotação senha MySQL) e os PRs #3148/#3151 (gitleaks full-history — que ESCANEIA, não rotaciona).
@@ -833,3 +833,31 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 - Atualizar status por item no `_INDEX-SECRETS.md`.
 - Avaliar tornar o repo privado.
 - Ativar `core.hooksPath .githooks` (pre-commit de segredos).
+
+
+### US-INFRA-043 · Sentinela tasks:unassigned — flag US todo sem cycle/owner (fecha furo do roadmap)
+
+> owner: — · priority: p2 · estimate: 5h · status: todo · type: story · cycle: CYCLE-SAUDE
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 — furo #2 (verificação adversarial). Hoje nenhum gate flaga US `status=todo` + `cycle_id`/`owner` NULL; só o `triage` (não-bloqueante, afogado em ~40 itens). O `mcp:tasks:orphans` mede a direção oposta (DB sem SPEC).
+
+**Achado:** toda US criada por `tasks-create` nasce `todo`/`unowned`/sem-cycle → invisível no roadmap (Jana filtra por `cycle_id`, ProjectMgmt por `epic_id`) e nada cobra a triagem. Foi exatamente o que aconteceu com as 6 US desta auditoria (PR #3164).
+
+**Acceptance:**
+- Comando `mcp:tasks:unassigned` (espelha `mcp:tasks:orphans` + `plan-health.mjs`): lista US `status=todo` AND (`cycle_id IS NULL` OR `owner IS NULL`) há > N dias.
+- Saída `--json` pro Daily Brief.
+- Opção de virar ratchet (exit 1) quando estabilizar.
+
+### US-INFRA-044 · Wire mcp:tasks:sync no CI (push de SPEC) — fecha drift SPEC↔DB
+
+> owner: — · priority: p2 · estimate: 4h · status: todo · type: story · cycle: CYCLE-SAUDE
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 — furo #3 (verificação adversarial). O `mcp:tasks:sync` é manual/server-side; nenhum workflow no CI o dispara. Resultado: drift SPEC↔DB real (ex.: US-GOV-001/005/006/007/008 com título "✅ DONE" mas status `todo` no DB).
+
+**Achado:** a cadeia SPEC→DB depende de sync no MCP server (CT 100) sem garantia/monitor no repo. O docblock do `McpTasksSyncCommand` diz "via webhook (futuro)".
+
+**Acceptance:**
+- Workflow `on: push: paths: 'memory/requisitos/**/SPEC.md'` que dispara `mcp:tasks:sync` (ou confirma/monitora o webhook server-side, como a mcp-drift-sentinel monitora código).
+- Rodar 1 `mcp:tasks:sync` full pra zerar o drift de status DONE/todo existente.

--- a/memory/requisitos/_BACKLOG-GENERATED.md
+++ b/memory/requisitos/_BACKLOG-GENERATED.md
@@ -2,7 +2,7 @@
 # Backlog indexado (gerado)
 
 > Fonte: as US-* dos `memory/requisitos/<Mod>/SPEC.md` (canon, ADR 0070). US abertas (status ∉ done/cancelled).
-> **750 tarefas abertas** em **45 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
+> **752 tarefas abertas** em **45 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
 
 ## Índice por módulo
 
@@ -12,7 +12,7 @@
 | [`Financeiro`](#financeiro) | 49 | 0 | 1 | 0 | 47 |
 | [`OficinaAuto`](#oficinaauto) | 47 | 0 | 5 | 0 | 41 |
 | [`Whatsapp`](#whatsapp) | 47 | 1 | 2 | 0 | 44 |
-| [`Infra`](#infra) | 40 | 0 | 0 | 0 | 38 |
+| [`Infra`](#infra) | 42 | 0 | 0 | 0 | 40 |
 | [`Sells`](#sells) | 39 | 0 | 0 | 0 | 39 |
 | [`RecurringBilling`](#recurringbilling) | 35 | 0 | 0 | 0 | 35 |
 | [`NfeBrasil`](#nfebrasil) | 28 | 0 | 0 | 6 | 22 |
@@ -350,6 +350,8 @@
 - **US-INFRA-038** — SDD: promover os 3 steps de continue-on-error a required (gate-required) _(`p2`)_
 - **US-INFRA-039** — SDD KL E2/E3 — aplicar os 27 renames classe A _(`p2`)_
 - **US-INFRA-040** — SDD — burn-down dos 237 corruptores SQLite _(`p2`)_
+- **US-INFRA-043** — Sentinela tasks:unassigned — flag US todo sem cycle/owner (fecha furo do roadmap) _(`p2`)_
+- **US-INFRA-044** — Wire mcp:tasks:sync no CI (push de SPEC) — fecha drift SPEC↔DB _(`p2`)_
 
 ### in-progress
 


### PR DESCRIPTION
Fecha o **furo** confirmado pela verificação adversarial: as 6 US da auditoria (#3164) entraram no **backlog** mas ficaram **invisíveis no roadmap** porque `cycle_id`/`epic_id` eram NULL (Jana filtra por cycle ativo, ProjectMgmt por epic).

**O que faz:**
- Cria **CYCLE-SAUDE** "Saúde & Integridade" (id=12, planning, 4 goals) — não contamina o CYCLE-08 (Receita).
- Atribui `cycle: CYCLE-SAUDE` às 4 p1: US-INFRA-041, US-INFRA-042, US-GOV-031, US-FIN-059.
- Adiciona 2 US estruturais (também no CYCLE-SAUDE) que fecham os outros furos:
  - **US-INFRA-043** — sentinela `tasks:unassigned` (furo #2: nada flaga US todo/sem-cycle/sem-owner).
  - **US-INFRA-044** — wire `mcp:tasks:sync` no CI (furo #3: drift SPEC↔DB, sync só manual).
- Regenera `_BACKLOG-GENERATED.md` (`tasks-index --check` verde).

`cycle`/`epic` não são live-state (ADR 0144) → aplicados no sync mesmo em tasks existentes (TaskParserService L234-235/L381-382). Pós-merge: o webhook seta `cycle_id` e as 4 p1 passam a aparecer no roadmap filtrando CYCLE-SAUDE.

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)