### PR TITLE
fix(roadmap): project: COPI nos 3 SPECs — destrava cycle_id (fecha furo #6 do pipeline)

### DIFF
--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -3,6 +3,7 @@ slug: financeiro
 title: "Especificação funcional — Financeiro"
 type: spec
 module: Financeiro
+project: COPI
 status: ativo
 related_adrs:
   - 0154-rubrica-module-grade-v2

--- a/memory/requisitos/Governance/SPEC.md
+++ b/memory/requisitos/Governance/SPEC.md
@@ -2,6 +2,7 @@
 lifecycle: active
 owner: [W]
 module: Governance
+project: COPI
 status: ativo
 authority: canonical
 version: "1.0"

--- a/memory/requisitos/Infra/SPEC.md
+++ b/memory/requisitos/Infra/SPEC.md
@@ -3,6 +3,7 @@ slug: infra
 title: "Especificação funcional — Infra (loop de governança fechado)"
 type: spec
 module: Infra
+project: COPI
 status: ativo
 owner: wagner
 version: "1.2"
@@ -861,3 +862,22 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 **Acceptance:**
 - Workflow `on: push: paths: 'memory/requisitos/**/SPEC.md'` que dispara `mcp:tasks:sync` (ou confirma/monitora o webhook server-side, como a mcp-drift-sentinel monitora código).
 - Rodar 1 `mcp:tasks:sync` full pra zerar o drift de status DONE/todo existente.
+
+
+### US-INFRA-045 · Pipeline task→roadmap furada: cycle/epic não resolvem sem project: no SPEC + sem tool de atribuição
+
+> owner: — · priority: p2 · estimate: 4h · status: todo · type: story · cycle: CYCLE-SAUDE
+> blocked_by: —
+
+**Origem:** auditoria de saúde/integridade 2026-06-21 — furo #6 (verificação adversarial, 2ª rodada).
+
+**Achado:** a cadeia tasks-create→SPEC→sync→roadmap tem 3 buracos:
+1. `TaskParserService::resolveCycleId/resolveEpicId` retornam NULL se o SPEC não tem `project:` no frontmatter (L208 + L571). 55 de 57 SPECs não tinham `project:` → US nasce com project_id/cycle_id/epic_id NULL e nunca entra no roadmap. (Mitigado nos 3 SPECs de saúde com `project: COPI`, mas é sistêmico.)
+2. Não há tool MCP pra atribuir cycle/epic a US existente (`tasks-update` não tem o campo; sem `tasks-move`).
+3. Roadmap Jana só mostra o cycle ATIVO; ProjectMgmt só mostra US com `epic_id`. US em cycle `planning` / sem epic ficam invisíveis.
+
+**Acceptance:**
+- Fallback de project default no parser (ex.: COPI) OU exigir `project:` em todo SPEC (gate de schema).
+- Tool/canal pra atribuir cycle/epic a US existente.
+- RUNBOOK do caminho canônico "US → roadmap".
+- Pareia com US-INFRA-043 (sentinela unassigned) + US-INFRA-044 (sync no CI).

--- a/memory/requisitos/_BACKLOG-GENERATED.md
+++ b/memory/requisitos/_BACKLOG-GENERATED.md
@@ -2,7 +2,7 @@
 # Backlog indexado (gerado)
 
 > Fonte: as US-* dos `memory/requisitos/<Mod>/SPEC.md` (canon, ADR 0070). US abertas (status ∉ done/cancelled).
-> **752 tarefas abertas** em **45 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
+> **753 tarefas abertas** em **45 módulos**. Regenera com `node scripts/governance/tasks-index-generate.mjs --write`.
 
 ## Índice por módulo
 
@@ -12,7 +12,7 @@
 | [`Financeiro`](#financeiro) | 49 | 0 | 1 | 0 | 47 |
 | [`OficinaAuto`](#oficinaauto) | 47 | 0 | 5 | 0 | 41 |
 | [`Whatsapp`](#whatsapp) | 47 | 1 | 2 | 0 | 44 |
-| [`Infra`](#infra) | 42 | 0 | 0 | 0 | 40 |
+| [`Infra`](#infra) | 43 | 0 | 0 | 0 | 41 |
 | [`Sells`](#sells) | 39 | 0 | 0 | 0 | 39 |
 | [`RecurringBilling`](#recurringbilling) | 35 | 0 | 0 | 0 | 35 |
 | [`NfeBrasil`](#nfebrasil) | 28 | 0 | 0 | 6 | 22 |
@@ -352,6 +352,7 @@
 - **US-INFRA-040** — SDD — burn-down dos 237 corruptores SQLite _(`p2`)_
 - **US-INFRA-043** — Sentinela tasks:unassigned — flag US todo sem cycle/owner (fecha furo do roadmap) _(`p2`)_
 - **US-INFRA-044** — Wire mcp:tasks:sync no CI (push de SPEC) — fecha drift SPEC↔DB _(`p2`)_
+- **US-INFRA-045** — Pipeline task→roadmap furada: cycle/epic não resolvem sem project: no SPEC + sem tool de atribuição _(`p2`)_
 
 ### in-progress
 


### PR DESCRIPTION
A verificação adversarial provou que o `cycle: CYCLE-SAUDE` do #3165 era **no-op no DB**: `TaskParserService::resolveCycleId` (L571 `if (! \$projectId) return null`) precisa de project_id, que só vem do frontmatter `project:` (L208) — **ausente nos 3 SPECs** (55/57 SPECs sem ele).

**Fix:** adiciona `project: COPI` ao frontmatter de Infra/Governance/Financeiro → o sync passa a resolver `cycle_id=CYCLE-SAUDE` pras 6 US de saúde (cycle/project não são live-state · ADR 0144 · aplicados em tasks existentes).

**+ US-INFRA-045** registra o gap sistêmico (project default no parser + tool de atribuição cycle/epic + roadmap visibility), pareada com US-INFRA-043/044.

**Escopo:** broad por design — todas as US dos 3 SPECs ganham project_id=COPI (correto: são tarefas COPI). `_BACKLOG-GENERATED` regenerado (`tasks-index --check` verde).

**Caveat (camada 1, escolha do Wagner):** roadmap Jana default mostra o cycle ATIVO (CYCLE-08); CYCLE-SAUDE é `planning` → as 6 aparecem **ao selecionar CYCLE-SAUDE**. Default-visível + ProjectMgmt (por epic) ficam diferidos em US-INFRA-045.

Refs: auditoria-saude-2026-06-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)