### PR TITLE
docs(ds): backfill changelog [0.6.15]→[0.7.3] — ~80 PRs de DS do gap 11→21/jun

### DIFF
--- a/memory/requisitos/_DesignSystem/CHANGELOG.md
+++ b/memory/requisitos/_DesignSystem/CHANGELOG.md
@@ -1,10 +1,65 @@
 ---
 status: ativo
-last_reviewed: "2026-06-06"
+last_reviewed: "2026-06-21"
 next_review: "2026-09-06"
 ---
 
 # Changelog · Design System
+
+> **Nota de backfill (2026-06-21):** as entradas **[0.6.15]–[0.7.3]** consolidam de uma vez o período **11→21/jun**, que ficou sem registro enquanto o changelog era atualizado à mão. Reconstruídas a partir dos PRs realmente mergeados (fonte: GitHub) — ~80 PRs de DS que tinham ficado invisíveis. O detalhe fino (Added/Changed por PR, "Não regrediu") pode ser enriquecido depois; o objetivo aqui é que **nenhum PR de DS fique fora do registro**.
+
+## [0.7.3] - 2026-06-21 · catracas visuais afinadas
+
+### Changed
+- `design-index-gate` always-run + short-circuit (required-readiness, ADR 0282) (#3114)
+- Comentário de regressão visual distingue enforcing × advisory (#3136)
+- `casos.md`: reconcilia 4 violações ratchet herdadas da branch feat (ADR 0264) (#3102)
+
+## [0.7.2] - 2026-06-17/19 · pipeline de design zero-paste + Contrato de Tela + mobile shell
+
+### Added
+- **Pipeline de handoff Cowork→git sem colar** (ADR 0283/0285): carteiro/publisher/inbox + write-path com review-gate (#2876 #2913 #2921 #2929 #2935)
+- **Ferramental de ingestão de design** (Jana): `design:dossie`, `design:ingest-zip`, `DesignIngestPlanner`, `design:mine-raw`, cowork-map (#3032 #3033 #3034 #3036 #3037 #3039 #3040 #3042)
+- **Catraca Contrato de Tela** — fidelidade visual + resolução de escopo + não-vazamento Tier 0 (ADR 0286) (#2973 #2986 #2992 #2993 #2999)
+- **Catraca Viva F1** — gate de tela órfã/morta (#2943)
+- **Design Request Ledger** + ADR 0293 (governança da decisão de design: responsável + registro + retorno) (#2980 #2988 #3043)
+
+### Changed
+- **Shell**: sidebar vira drawer flutuante no mobile ≤768px (#2887 #2889)
+- `font-ramp` migration — sells/cockpit/fiscal CSS (FORJA-140) (#2870)
+- Apaga `prototipo-ui/_BACKUP-NAO-USAR` (1082 arquivos, peso morto) (#2977)
+
+## [0.7.1] - 2026-06-16 · dark mode real + redesign fiel ao Cowork (Caixa / Forja / Financeiro)
+
+### Added
+- **Dark mode real** por `[data-theme=dark]` (não só `.dark`) (ADR 0281) (#2826 #2818 #2846 #3044)
+- **Caixa Unificada / Atendimento** — redesign fiel ao protótipo Cowork: bolhas/timestamp/fundo, SLA pill 4 estados + dot, Contexto recolhível (trilho 44px), composer discreto, Saldo+Histórico do cliente, reconectar canal via QR in-place, ChannelHealthBanner (#2818 #2822 #2838 #2839 #2841 #2845 #2849 #2850 #2852 #2858 #2859 #2860 #2963 #2974)
+- **Forja / TeamMcp** — hub único (fusão) + re-skin DS v6 conservador + 5 abas do cockpit (Tasks, CcSessions, Scorecard, Triagem) (#2819 #2821 #2823 #2824 #2840 #2843 #2848 #2853 #2857)
+
+### Changed
+- **Financeiro Unificado** bate pixel com o gabarito Cowork: hero KPI vira claro, header → `<PageHeader>` canon v3.8 + primary roxo, drawer F3 (#2584 #2844 #2851 #2856 #2863 #2947)
+- `reuse`: dedup `fmtRelative` canônico em `@/Lib/datetime-br` (#2831 #2832 #2835)
+
+## [0.7.0] - 2026-06-12/13 · Elevação do Design System (Onda M1)
+
+> Auditoria sênior graduou o DS em 61/100 (14 dimensões vs Linear/Stripe/Vercel/Radix/Polaris). Onda M1 = "consolidar a fundação".
+
+### Added
+- **Tokens oklch** extraídos da tela-ouro + unifica hsl→oklch nos neutros legacy (pixel-idêntico provado) (#2639 #2651)
+- **Tokens de motion** (`--duration-*` / `--ease-*`) (#2645)
+- **Camada canônica consome o DS** — badge/KpiCard/EmptyState/StatusBadge tokenizam status + catraca `ds-canon-color-guard` (#2641 #2643)
+- **DS Rollout + Ledger de Conformidade** (censo `ds-ledger.mjs`) (#2621)
+
+### Changed
+- **Adoção em massa**: 329 tokenizações verificadas por adversário (132 arquivos, 32 módulos) (#2666)
+- **Cliente "tela-linda"**: Pills tokeniza ESTADO preservando CATEGORIA + 9 componentes limpo-semânticos (#2655 #2660 #2626)
+
+## [0.6.15] - 2026-06-11 · fecho do thread "árvore de componentes" + casos-gate (Onda Q2)
+
+### Added
+- **ADR 0272 aceita** — árvore canônica de componentes (#2552)
+- **casos-gate**: ratchet só-desce do baseline de cobertura + manifestos de UC + runner parcial não apaga prova alheia (#2565 #2566 #2567 #2568)
+- **visual-regression** required-readiness (always-run + skip-as-pass) (#2553)
 
 ## [0.6.14] - 2026-06-11 · DELETE shim MercosulPlate (ADR 0251 cumprida — fonte única shared/)
 


### PR DESCRIPTION
Reconstrói o changelog do **Design System** (10 dias sem registro desde `[0.6.14]` 11/jun). Cruzando 589 PRs mergeados contra o `gh`, **~80 PRs de DS/UI ficaram fora**.

**5 entradas novas** (PRs realmente mergeados):
- **[0.7.3]** catracas visuais (design-index #3114, visual-reg #3136, casos #3102)
- **[0.7.2]** pipeline design zero-paste + Contrato de Tela (ADR 0286) + mobile shell
- **[0.7.1]** dark mode real (ADR 0281) + redesign Cowork Caixa/Forja/Financeiro
- **[0.7.0]** Elevação do DS — Onda M1 (oklch/motion/adoção em massa)
- **[0.6.15]** árvore de componentes ADR 0272 + casos-gate Q2

Só toca `_DesignSystem/CHANGELOG.md`. Backlog→cycle fechado em paralelo (#3165); este é a metade do **changelog**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)