### PR TITLE
feat(governance): US-GOV-042 — anchor-lint status:arquivado + MemCofre/SRS (A3 do sweep)

### DIFF
--- a/memory/requisitos/Governance/SPEC.md
+++ b/memory/requisitos/Governance/SPEC.md
@@ -586,3 +586,13 @@ labels: `plano-perdido`, `backlog-2026-06-20`
 **Problema:** `M governance/sdd-scorecard.json` não-commitado mostra full_suite=274 (engana a leitura; o HEAD diz not_yet_measured). Atrapalhou o planejamento desta sessão.
 **Fix:** quem é dono do working-tree decide: `git checkout` (descartar) OU commitar o valor correto via o job de P01/#3142. NÃO tocar cego.
 **Acceptance:** working-tree limpo ou o 274 reconciliado pelo commit-back. Refs: ROADMAP-SDD
+
+### US-GOV-042 · anchor-lint pula status:arquivado + decidir destino do SPEC duplicado MemCofre/SRS
+
+> owner: — · priority: p2 · estimate: 1h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** sweep do mês 2026-06-21 (PR #3149, bloco "PR-B · MemCofre (10 dead)").
+**Problema:** `anchor-lint.mjs` não filtra specs `status: arquivado`; `memory/requisitos/MemCofre/SPEC.md` é duplicado do módulo renomeado MemCofre→SRS (em DEPRECATION-PLAN) → 10 anchors mortos perenes.
+**Fix:** lint pula `status: arquivado` (~3 linhas) + decisão de identidade sobre o SPEC duplicado (re-point pra SRS vs delete).
+**Acceptance:** `anchor-lint --json` não conta os 10 dead do MemCofre; SPEC duplicado resolvido. Refs: ROADMAP-SDD (sweep do mês)


### PR DESCRIPTION
Item A3 (LIMPO) do sweep de roadmap do mês 2026-06-21. anchor-lint não filtra specs `status: arquivado` → o SPEC duplicado MemCofre/SRS (módulo renomeado, em DEPRECATION-PLAN) deixa 10 dead anchors perenes. Origem: bloco PR-B do #3149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)