### PR TITLE
fix(governance): isenção roadmap no allMdLive — fecha o anti-ghost vermelho (de verdade)

### DIFF
--- a/scripts/governance/knowledge-drift.mjs
+++ b/scripts/governance/knowledge-drift.mjs
@@ -64,6 +64,7 @@ function allMdLive(dir) {
     const p = join(dir, e.name);
     if (e.isDirectory()) {
       if (e.name === 'adr') continue; // hard-skip append-only — espelha ghost-fix.mjs:60-61
+      if (e.name === 'roadmap' && p.includes('_Governanca')) continue; // US-GOV-035: planos do roadmap citam módulos legados/renomeados em contexto de planejamento (não ghost vivo)
       out.push(...allMdLive(p));
     } else if (e.name.endsWith('.md')) out.push(p);
   }


### PR DESCRIPTION
**Conserta o vermelho do `anti-ghost ratchet` que voltou** — inclusive no próprio `main`.

**O que aconteceu:** o #3175 pôs a isenção de `_Governanca/roadmap/` no `allMd()`. Mas o #3155 (mergeado em paralelo) **refatorou o ratchet pra usar `allMdLive()`** e **abaixou o piso de ghosts (33→14)**. Resultado: a isenção ficou numa função que o `--check` não usa, e o gate ficou vermelho no main (5 NOVOS: `Governance:MemCofre` — já resolvido pelo #3175 — + 4 do `_Governanca/roadmap/`).

**Fix:** adiciona o skip de `_Governanca/roadmap/` ao **`allMdLive()`** (a função que o ratchet de fato usa), ao lado do skip de `adr` que já existia.

**Verificado contra o main ATUAL:** `4 NOVOS` → **`0 NOVOS · OK`** ✓. Diff = 1 linha.

Refs: auditoria-saude-2026-06-21 · US-GOV-035

🤖 Generated with [Claude Code](https://claude.com/claude-code)
